### PR TITLE
fix(projects): internal users can see projects in Create Key dialog

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
@@ -853,14 +853,13 @@ async def project_info(
         is_team_member = False
 
         if project.team_id and user_api_key_dict.user_id:
-            team = await prisma_client.db.litellm_teamtable.find_unique(
-                where={"team_id": project.team_id}
+            # Membership is stored in LiteLLM_UserTable.teams, not in the
+            # team table's members/admins columns which are never populated.
+            user_row = await prisma_client.db.litellm_usertable.find_unique(
+                where={"user_id": user_api_key_dict.user_id}
             )
-            if team:
-                is_team_member = (
-                    user_api_key_dict.user_id in team.admins
-                    or user_api_key_dict.user_id in team.members
-                )
+            user_teams = user_row.teams if (user_row and user_row.teams) else []
+            is_team_member = project.team_id in user_teams
 
         if not (is_admin or is_team_member):
             raise HTTPException(
@@ -911,17 +910,14 @@ async def list_projects(
                 include={"litellm_budget_table": True, "object_permission": True}
             )
         else:
-            # Get projects for teams the user belongs to
-            user_teams = await prisma_client.db.litellm_teamtable.find_many(
-                where={
-                    "OR": [
-                        {"members": {"has": user_api_key_dict.user_id}},
-                        {"admins": {"has": user_api_key_dict.user_id}},
-                    ]
-                }
-            )
-
-            team_ids = [team.team_id for team in user_teams]
+            # Membership is written to LiteLLM_UserTable.teams by team_member_add,
+            # not to LiteLLM_TeamTable.members which is always empty.
+            team_ids: list[str] = []
+            if user_api_key_dict.user_id:
+                user_row = await prisma_client.db.litellm_usertable.find_unique(
+                    where={"user_id": user_api_key_dict.user_id}
+                )
+                team_ids = user_row.teams if (user_row and user_row.teams) else []
 
             projects = await prisma_client.db.litellm_projecttable.find_many(
                 where={"team_id": {"in": team_ids}},

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -665,6 +665,8 @@ class LiteLLMRoutes(enum.Enum):
             "/models/{model_id}",
             "/guardrails/list",
             "/v2/guardrails/list",
+            "/project/list",
+            "/project/info",
         ]
         + spend_tracking_routes
         + key_management_routes

--- a/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
+++ b/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
@@ -801,7 +801,9 @@ async def test_list_projects_returns_timestamps():
     from datetime import datetime, timezone
     from unittest.mock import AsyncMock, MagicMock, patch
 
-    from litellm_enterprise.proxy.management_endpoints.project_endpoints import list_projects
+    from litellm_enterprise.proxy.management_endpoints.project_endpoints import (
+        list_projects,
+    )
     from litellm.proxy._types import LiteLLM_ProjectTable
 
     now = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
@@ -864,3 +866,81 @@ def test_litellm_project_table_has_timestamp_fields():
     fields = LiteLLM_ProjectTable.model_fields
     assert "created_at" in fields, "LiteLLM_ProjectTable must have created_at field"
     assert "updated_at" in fields, "LiteLLM_ProjectTable must have updated_at field"
+
+
+def test_project_routes_in_internal_user_routes():
+    """
+    /project/list and /project/info must appear in internal_user_routes so that
+    internal_user role callers are not rejected with 401.
+    """
+    from litellm.proxy._types import LiteLLMRoutes
+
+    routes = LiteLLMRoutes.internal_user_routes.value
+    assert "/project/list" in routes, "/project/list missing from internal_user_routes"
+    assert "/project/info" in routes, "/project/info missing from internal_user_routes"
+
+
+@pytest.mark.asyncio
+async def test_list_projects_internal_user_queries_user_table_teams():
+    """
+    list_projects for a non-admin user must look up team membership via
+    LiteLLM_UserTable.teams, not LiteLLM_TeamTable.members which is always empty.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm_enterprise.proxy.management_endpoints.project_endpoints import (
+        list_projects,
+    )
+
+    user_id = "user-abc"
+    team_id = "team-xyz"
+
+    fake_user = MagicMock()
+    fake_user.teams = [team_id]
+
+    fake_project = MagicMock()
+    fake_project.model_dump.return_value = {
+        "project_id": "proj-1",
+        "project_alias": "p1",
+        "team_id": team_id,
+        "created_by": "admin",
+        "updated_by": "admin",
+        "created_at": None,
+        "updated_at": None,
+        "models": [],
+        "spend": 0.0,
+        "blocked": False,
+        "budget_id": None,
+        "description": None,
+        "metadata": None,
+        "model_spend": None,
+        "model_rpm_limit": None,
+        "model_tpm_limit": None,
+        "object_permission_id": None,
+        "litellm_budget_table": None,
+        "object_permission": None,
+    }
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=fake_user)
+    mock_prisma.db.litellm_projecttable.find_many = AsyncMock(
+        return_value=[fake_project]
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        response = await list_projects(
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.INTERNAL_USER,
+                api_key="sk-user",
+                user_id=user_id,
+            ),
+        )
+
+    # Must have queried LiteLLM_UserTable by user_id
+    mock_prisma.db.litellm_usertable.find_unique.assert_called_once_with(
+        where={"user_id": user_id}
+    )
+    # Projects filtered by team_id values from user's teams list
+    call_kwargs = mock_prisma.db.litellm_projecttable.find_many.call_args[1]
+    assert call_kwargs["where"]["team_id"]["in"] == [team_id]
+    assert len(response) == 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
@@ -6,7 +6,6 @@ import {
   deriveErrorMessage,
   handleError,
 } from "@/components/networking";
-import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -76,12 +75,11 @@ const fetchProjects = async (
 // ── Hook ─────────────────────────────────────────────────────────────────────
 
 export const useProjects = () => {
-  const { accessToken, userRole } = useAuthorized();
+  const { accessToken } = useAuthorized();
 
   return useQuery<ProjectResponse[]>({
     queryKey: projectKeys.list({}),
     queryFn: async () => fetchProjects(accessToken!),
-    enabled:
-      Boolean(accessToken) && all_admin_roles.includes(userRole || ""),
+    enabled: Boolean(accessToken),
   });
 };


### PR DESCRIPTION
## Relevant issues

Fixes a three-layer bug where internal users (and team members) could never see projects in the Create Key dialog, even when their team had associated projects.

## What was broken

**Bug 1 — UI hook gated on admin role** (`useProjects.ts`)
The `useQuery` `enabled` flag was `Boolean(accessToken) && all_admin_roles.includes(userRole)`. `internal_user` is not in `all_admin_roles`, so the `/project/list` request was never fired. Fixed: removed the role gate, only check `Boolean(accessToken)`.

**Bug 2 — Route not in allowlist** (`_types.py`)
`/project/list` and `/project/info` were missing from `internal_user_routes`. Any non-admin caller got a 401 before reaching the handler. Fixed: added both routes.

**Bug 3 — Membership lookup queried wrong column** (`project_endpoints.py`)
`list_projects` queried `LiteLLM_TeamTable.members` to find what teams a user is in. That column is never populated — actual membership is written to `LiteLLM_UserTable.teams` by `team_member_add`. Same issue in `project_info`'s membership check. Fixed: fetch `LiteLLM_UserTable` for the calling user and use its `teams` array.

## Pre-Submission checklist

- [x] Unit tests added in `tests/enterprise/.../test_project_endpoints_prisma.py`
- [x] UI validated: internal user in team sees project in Create Key dropdown (GET /project/list => 200, project appears)
- [x] Non-member user returns empty list (not 401, not the other user's projects)
- [x] Admin access unaffected
- [x] Black formatting applied

## Type

Bug fix

## Changes

- `litellm/proxy/_types.py` — add `/project/list` and `/project/info` to `internal_user_routes`
- `enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py` — use `LiteLLM_UserTable.teams` for membership in `list_projects` and `project_info`
- `ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts` — remove `all_admin_roles` gate from `useQuery` enabled condition
- `tests/enterprise/.../test_project_endpoints_prisma.py` — two new regression guards