### PR TITLE
fix(aiohttp): sanitize non-ASCII response headers before passing to httpx

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -339,9 +339,29 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                 # Re-raise if it's a different RuntimeError
                 raise
 
+        # Sanitize response headers: aiohttp decodes header values into
+        # Python str that may contain non-ASCII characters (e.g. Chinese
+        # text in Volcengine Ark's x-tos-expiration header).
+        # httpx.Headers normalizes values via value.encode("ascii") which
+        # raises UnicodeEncodeError for such headers.  For non-ASCII
+        # values, we pass the UTF-8 encoded bytes directly to httpx,
+        # which stores them as-is and avoids the str->ascii encoding
+        # step.  When later accessed via response.headers[key], httpx
+        # decodes the stored bytes (typically with latin-1), so
+        # multi-byte UTF-8 sequences may appear garbled — but the
+        # request completes successfully instead of crashing.
+        sanitized_headers: typing.List[typing.Any] = []
+        for key, value in response.headers.items():
+            try:
+                value.encode("ascii")
+                sanitized_headers.append((key, value))
+            except UnicodeEncodeError:
+                # Pass as bytes so httpx skips the str→ascii encoding step
+                sanitized_headers.append((key, value.encode("utf-8")))
+
         return httpx.Response(
             status_code=response.status,
-            headers=response.headers,
+            headers=sanitized_headers,  # type: ignore[arg-type]
             stream=AiohttpResponseStream(response),
             request=request,
         )

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -558,3 +558,78 @@ async def test_handle_session_closed_during_request():
     assert counts["requests"] == 2  # First request failed, second succeeded
     assert counts["sessions"] == 2  # Created 2 sessions for retry
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_handle_async_request_non_ascii_headers():
+    """
+    Regression test for issue #26548: aiohttp transport fails when
+    response headers contain non-ASCII characters.
+
+    aiohttp decodes header values into Python str with non-ASCII
+    characters (e.g. Chinese text in Volcengine Ark's x-tos-expiration
+    header).  httpx.Headers tries to encode values as ASCII and raises
+    UnicodeEncodeError.  The fix sanitizes non-ASCII values before
+    passing them to httpx.Response.
+    """
+
+    class MockSession:
+        def __init__(self):
+            self.closed = False
+            try:
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = None
+
+        def request(self, *args, **kwargs):
+            class Resp:
+                status = 200
+                # Simulate aiohttp returning non-ASCII header values
+                headers = {
+                    "content-type": "application/octet-stream",
+                    "x-tos-expiration": 'expiry-date="Fri, 23 Oct 2026", rule-id="180day自动清理"',
+                    "x-ark-message": "视频生成成功",
+                }
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *args):
+                    pass
+
+                @property
+                def content(self):
+                    class C:
+                        async def iter_chunked(self, size):
+                            yield b"ok"
+
+                    return C()
+
+            return Resp()
+
+    transport = LiteLLMAiohttpTransport(client=lambda: MockSession())  # type: ignore
+    request = httpx.Request("GET", "http://example.com/asset")
+
+    # This should NOT raise UnicodeEncodeError
+    response = await transport.handle_async_request(request)
+
+    assert response.status_code == 200
+
+    # ASCII-safe headers should be preserved as-is
+    assert response.headers["content-type"] == "application/octet-stream"
+
+    # Non-ASCII headers should be present (not crash the request)
+    assert "x-tos-expiration" in response.headers
+    assert "x-ark-message" in response.headers
+
+    # Verify ASCII portions of non-ASCII headers are preserved
+    tos_value = response.headers["x-tos-expiration"]
+    assert "180day" in tos_value  # ASCII portion preserved
+    assert "rule-id" in tos_value  # ASCII portion preserved
+
+    # Verify non-ASCII content is preserved as UTF-8 bytes in the
+    # raw header value (httpx stores the bytes we passed through).
+    # The raw bytes should contain the original UTF-8 encoded Chinese.
+    raw_headers = dict(response.headers.raw)
+    assert "自动清理".encode("utf-8") in raw_headers[b"x-tos-expiration"]
+    assert "视频生成成功".encode("utf-8") in raw_headers[b"x-ark-message"]


### PR DESCRIPTION
## Relevant issues

Fixes #26548

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` 

## Screenshots / Proof of Fix

All 16 tests pass (15 existing + 1 new regression test):

    tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
    ✅ test_aclose_closes_owned_session PASSED
    ✅ test_aclose_does_not_close_shared_session PASSED
    ✅ test_aiohttp_response_stream_normal_flow PASSED
    ✅ test_client_payload_error_graceful_handling PASSED
    ✅ test_handle_async_request_non_ascii_headers PASSED  ← NEW
    ✅ test_handle_async_request_proxy_cache_per_host PASSED
    ✅ test_handle_async_request_sock_read_timeout_triggers PASSED
    ✅ test_handle_async_request_streaming_does_not_timeout_on_total_duration PASSED
    ✅ test_handle_async_request_uses_env_proxy PASSED
    ✅ test_handle_async_request_uses_env_proxy_per_url PASSED
    ✅ test_handle_closed_session_before_request PASSED
    ✅ test_handle_session_closed_during_request PASSED
    ✅ test_owns_session_defaults_to_true PASSED
    ✅ test_timeout_exception_gets_mapped PASSED
    ✅ test_transfer_encoding_error_no_httpx_read_error PASSED
    ✅ test_unknown_aiohttp_exception_gets_mapped PASSED
    16 passed in 1.59s

## Type

🐛 Bug Fix

## Changes

**Problem:** `LiteLLMAiohttpTransport.handle_async_request` crashes with `UnicodeEncodeError` when the upstream server returns response headers containing non-ASCII characters (e.g. Chinese text). `aiohttp` decodes header values into Python `str` with non-ASCII characters, but `httpx.Headers` normalizes values via `value.encode("ascii")` which raises `UnicodeEncodeError`.

This affects providers returning localized response headers, such as Volcengine Ark's `x-tos-expiration` header containing Chinese text like `rule-id="180day自动清理"`.

**Fix (in `aiohttp_transport.py`):**

- Added header sanitization loop before constructing `httpx.Response`
- For each response header, try ASCII encoding first (fast path for normal headers)
- If `UnicodeEncodeError` is raised, encode the value as UTF-8 bytes and pass to httpx directly (bypasses the `str→ascii` encoding step)
- ASCII-safe headers pass through unchanged (zero overhead for common case)

**Test (in `test_aiohttp_transport.py`):**

- `test_handle_async_request_non_ascii_headers` — simulates aiohttp returning Chinese characters in `x-tos-expiration` and `x-ark-message` headers, verifies the response is constructed successfully without crashing
