### PR TITLE
[Fix] Route end-user, tag, team-membership, and org spend through the cross-pod counter

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -656,12 +656,19 @@ async def common_checks(  # noqa: PLR0915
             and end_user_object.litellm_budget_table is not None
         ):
             end_user_budget = end_user_object.litellm_budget_table.max_budget
-            if end_user_budget is not None and end_user_object.spend > end_user_budget:
-                raise litellm.BudgetExceededError(
-                    current_cost=end_user_object.spend,
-                    max_budget=end_user_budget,
-                    message=f"ExceededBudget: End User={end_user_object.user_id} over budget. Spend={end_user_object.spend}, Budget={end_user_budget}",
+            if end_user_budget is not None:
+                from litellm.proxy.proxy_server import get_current_spend
+
+                end_user_spend = await get_current_spend(
+                    counter_key=f"spend:end_user:{end_user_object.user_id}",
+                    fallback_spend=end_user_object.spend or 0.0,
                 )
+                if end_user_spend > end_user_budget:
+                    raise litellm.BudgetExceededError(
+                        current_cost=end_user_spend,
+                        max_budget=end_user_budget,
+                        message=f"ExceededBudget: End User={end_user_object.user_id} over budget. Spend={end_user_spend}, Budget={end_user_budget}",
+                    )
 
     _enforce_user_param_check(general_settings, request, request_body, route)
     _reject_clientside_metadata_tags_check(general_settings, request_body, route)
@@ -3813,6 +3820,9 @@ async def _tag_max_budget_check(
         proxy_logging_obj=proxy_logging_obj,
     )
 
+    # Read spend from cross-pod counter (Redis-first) or cached object (fallback)
+    from litellm.proxy.proxy_server import get_current_spend
+
     # Check budget for each tag
     for tag_name in tags:
         tag_object = tag_objects.get(tag_name)
@@ -3823,14 +3833,18 @@ async def _tag_max_budget_check(
         if (
             tag_object.litellm_budget_table is not None
             and tag_object.litellm_budget_table.max_budget is not None
-            and tag_object.spend is not None
-            and tag_object.spend > tag_object.litellm_budget_table.max_budget
         ):
-            raise litellm.BudgetExceededError(
-                current_cost=tag_object.spend,
-                max_budget=tag_object.litellm_budget_table.max_budget,
-                message=f"Budget has been exceeded! Tag={tag_name} Current cost: {tag_object.spend}, Max budget: {tag_object.litellm_budget_table.max_budget}",
+            tag_max_budget = tag_object.litellm_budget_table.max_budget
+            tag_spend = await get_current_spend(
+                counter_key=f"spend:tag:{tag_name}",
+                fallback_spend=(tag_object.spend or 0.0),
             )
+            if tag_spend > tag_max_budget:
+                raise litellm.BudgetExceededError(
+                    current_cost=tag_spend,
+                    max_budget=tag_max_budget,
+                    message=f"Budget has been exceeded! Tag={tag_name} Current cost: {tag_spend}, Max budget: {tag_max_budget}",
+                )
 
 
 def is_model_allowed_by_pattern(model: str, allowed_model_pattern: str) -> bool:

--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -35,6 +35,8 @@ class SpendCounterReseed:
         spend:team_member:{uid}:{tid}     -> LiteLLM_TeamMembership.spend
         spend:user:{user_id}              -> LiteLLM_UserTable.spend
         spend:org:{org_id}                -> LiteLLM_OrganizationTable.spend
+        spend:end_user:{end_user_id}      -> LiteLLM_EndUserTable.spend
+        spend:tag:{tag_name}              -> LiteLLM_TagTable.spend
     """
 
     _locks: ClassVar["OrderedDict[str, asyncio.Lock]"] = OrderedDict()
@@ -101,6 +103,16 @@ class SpendCounterReseed:
                 org_id = counter_key[len("spend:org:") :]
                 row = await prisma_client.db.litellm_organizationtable.find_unique(
                     where={"organization_id": org_id}
+                )
+            elif counter_key.startswith("spend:end_user:"):
+                end_user_id = counter_key[len("spend:end_user:") :]
+                row = await prisma_client.db.litellm_endusertable.find_unique(
+                    where={"user_id": end_user_id}
+                )
+            elif counter_key.startswith("spend:tag:"):
+                tag_name = counter_key[len("spend:tag:") :]
+                row = await prisma_client.db.litellm_tagtable.find_unique(
+                    where={"tag_name": tag_name}
                 )
             else:
                 return None

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -214,6 +214,8 @@ class _ProxyDBLogger(CustomLogger):
                         user_id=user_id,
                         response_cost=response_cost,
                         org_id=org_id,
+                        end_user_id=end_user_id,
+                        tags=tags,
                     )
 
                     # update cache (fire-and-forget for backward compat:
@@ -227,6 +229,7 @@ class _ProxyDBLogger(CustomLogger):
                             team_id=team_id,
                             parent_otel_span=parent_otel_span,
                             tags=tags,
+                            org_id=org_id,
                         )
                     )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1816,6 +1816,8 @@ async def increment_spend_counters(
     user_id: Optional[str],
     response_cost: Optional[float],
     org_id: Optional[str] = None,
+    end_user_id: Optional[str] = None,
+    tags: Optional[List[str]] = None,
 ):
     """
     Atomically increment spend counters for budget enforcement.
@@ -1916,6 +1918,23 @@ async def increment_spend_counters(
             increment=response_cost,
         )
 
+    if end_user_id is not None:
+        await _init_and_increment_spend_counter(
+            counter_key=f"spend:end_user:{end_user_id}",
+            source_cache_key=f"end_user_id:{end_user_id}",
+            increment=response_cost,
+        )
+
+    if tags is not None:
+        for tag_name in tags:
+            if not tag_name or not isinstance(tag_name, str):
+                continue
+            await _init_and_increment_spend_counter(
+                counter_key=f"spend:tag:{tag_name}",
+                source_cache_key=f"tag:{tag_name}",
+                increment=response_cost,
+            )
+
 
 async def _init_and_increment_spend_counter(
     counter_key: str,
@@ -1971,6 +1990,7 @@ async def update_cache(  # noqa: PLR0915
     response_cost: Optional[float],
     parent_otel_span: Optional[Span],  # type: ignore
     tags: Optional[List[str]] = None,
+    org_id: Optional[str] = None,
 ):
     """
     Use this to update the cache with new user spend.
@@ -2203,6 +2223,80 @@ async def update_cache(  # noqa: PLR0915
                 traceback.format_exc(),
             )
 
+    ### UPDATE TEAM MEMBERSHIP SPEND ###
+    async def _update_team_membership_cache():
+        if user_id is None or team_id is None or response_cost is None:
+            return
+
+        _key = f"team_membership:{user_id}:{team_id}"
+        try:
+            existing_membership_obj = await user_api_key_cache.async_get_cache(key=_key)
+            if existing_membership_obj is None:
+                # do nothing if membership not in api key cache
+                return
+
+            if isinstance(existing_membership_obj, dict):
+                existing_spend = existing_membership_obj.get("spend", 0) or 0
+            else:
+                existing_spend = getattr(existing_membership_obj, "spend", 0) or 0
+
+            new_spend = existing_spend + response_cost
+
+            if isinstance(existing_membership_obj, dict):
+                existing_membership_obj["spend"] = new_spend
+                values_to_update_in_cache.append((_key, existing_membership_obj))
+            else:
+                existing_membership_obj.spend = new_spend
+                values_to_update_in_cache.append((_key, existing_membership_obj))
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update team membership spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "user_id=%s, team_id=%s, response_cost=%s - %s\n%s",
+                user_id,
+                team_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
+            )
+
+    ### UPDATE ORG SPEND ###
+    async def _update_org_cache():
+        if org_id is None or response_cost is None:
+            return
+
+        try:
+            for cache_key in (f"org_id:{org_id}", f"org_id:{org_id}:with_budget"):
+                existing_org_obj = await user_api_key_cache.async_get_cache(
+                    key=cache_key
+                )
+                if existing_org_obj is None:
+                    continue
+
+                if isinstance(existing_org_obj, dict):
+                    existing_spend = existing_org_obj.get("spend", 0) or 0
+                else:
+                    existing_spend = getattr(existing_org_obj, "spend", 0) or 0
+
+                new_spend = existing_spend + response_cost
+
+                if isinstance(existing_org_obj, dict):
+                    existing_org_obj["spend"] = new_spend
+                    values_to_update_in_cache.append((cache_key, existing_org_obj))
+                else:
+                    existing_org_obj.spend = new_spend
+                    values_to_update_in_cache.append((cache_key, existing_org_obj))
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update organization spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "org_id=%s, response_cost=%s - %s\n%s",
+                org_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
+            )
+
     ### UPDATE TAG SPEND ###
     async def _update_tag_cache():
         """
@@ -2266,6 +2360,12 @@ async def update_cache(  # noqa: PLR0915
 
     if team_id is not None:
         await _update_team_cache()
+
+    if user_id is not None and team_id is not None:
+        await _update_team_membership_cache()
+
+    if org_id is not None:
+        await _update_org_cache()
 
     if tags is not None:
         await _update_tag_cache()

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1926,14 +1926,17 @@ async def increment_spend_counters(
         )
 
     if tags is not None:
-        for tag_name in tags:
-            if not tag_name or not isinstance(tag_name, str):
-                continue
-            await _init_and_increment_spend_counter(
+        tag_tasks = [
+            _init_and_increment_spend_counter(
                 counter_key=f"spend:tag:{tag_name}",
                 source_cache_key=f"tag:{tag_name}",
                 increment=response_cost,
             )
+            for tag_name in tags
+            if tag_name and isinstance(tag_name, str)
+        ]
+        if tag_tasks:
+            await asyncio.gather(*tag_tasks)
 
 
 async def _init_and_increment_spend_counter(
@@ -2265,8 +2268,8 @@ async def update_cache(  # noqa: PLR0915
         if org_id is None or response_cost is None:
             return
 
-        try:
-            for cache_key in (f"org_id:{org_id}", f"org_id:{org_id}:with_budget"):
+        for cache_key in (f"org_id:{org_id}", f"org_id:{org_id}:with_budget"):
+            try:
                 existing_org_obj = await user_api_key_cache.async_get_cache(
                     key=cache_key
                 )
@@ -2286,16 +2289,17 @@ async def update_cache(  # noqa: PLR0915
                 else:
                     existing_org_obj.spend = new_spend
                     values_to_update_in_cache.append((cache_key, existing_org_obj))
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "Spend tracking - failed to update organization spend in cache. "
-                "Budget enforcement may use stale spend values. "
-                "org_id=%s, response_cost=%s - %s\n%s",
-                org_id,
-                response_cost,
-                str(e),
-                traceback.format_exc(),
-            )
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    "Spend tracking - failed to update organization spend in cache. "
+                    "Budget enforcement may use stale spend values. "
+                    "org_id=%s, cache_key=%s, response_cost=%s - %s\n%s",
+                    org_id,
+                    cache_key,
+                    response_cost,
+                    str(e),
+                    traceback.format_exc(),
+                )
 
     ### UPDATE TAG SPEND ###
     async def _update_tag_cache():


### PR DESCRIPTION
## Summary
- Extend `increment_spend_counters` to cover end-user and tag spend so they go through the same atomic in-memory + Redis counter pipeline as keys, teams, users, team-members, and orgs.
- Switch the end-user budget check (`auth_checks._check_end_user_budget` site) and `_tag_max_budget_check` to read via `get_current_spend()` from those counters, falling back to the cached object only when both the counter and the DB are unavailable.
- Add `_update_team_membership_cache` and `_update_org_cache` in `update_cache()` so the `team_membership:{user_id}:{team_id}` and `org_id:{org_id}` secondary caches stay current — the counter-reseed fallback now has a non-stale source on cold pods.
- Teach `SpendCounterReseed.from_db` to recognize `spend:end_user:` and `spend:tag:` prefixes, reseeding from `LiteLLM_EndUserTable` and `LiteLLM_TagTable` respectively.
- Forward `end_user_id`, `tags`, and `org_id` from the cost callback into both pipelines.
- Follow-up: tag counter increments now run concurrently via `asyncio.gather`, and `_update_org_cache`'s try/except is per cache key so one key's failure doesn't skip the other.

## Test plan
- [x] `uv run pytest tests/test_litellm/proxy/db/test_db_spend_update_writer.py -q` — 31 passed
- [x] `uv run pytest tests/test_litellm/proxy/auth/test_auth_checks.py -q` — 76 passed
- [x] `uv run pytest tests/test_litellm/proxy/auth/test_organization_budget_enforcement.py tests/test_litellm/proxy/auth/test_team_member_budget.py tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py -q` — 13 passed
- [x] `uv run pytest tests/test_litellm/proxy/test_proxy_server.py -q -k "spend or cache or counter or reseed"` — 18 passed
- [x] `uv run pytest tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py -q` — 13 passed
- [x] End-to-end: end-user with `max_budget=$0.0001`, sequential follow-up after burst is blocked with `BudgetExceededError(spend≈0.00121, budget=0.0001)`.
- [x] End-to-end: tag with `max_budget=$0.0001` (key carrying `allow_client_tags: true`), 1st call 200, 2nd call blocked with `Budget has been exceeded! Tag=… Current cost: 0.00011, Max budget: 0.0001`.
- [x] Adjacency: master-key `/v1/chat/completions` with and without `user` parameter — both 200.