### PR TITLE
remove /ui/chat page

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
@@ -853,14 +853,11 @@ async def project_info(
         is_team_member = False
 
         if project.team_id and user_api_key_dict.user_id:
-            team = await prisma_client.db.litellm_teamtable.find_unique(
-                where={"team_id": project.team_id}
+            user_row = await prisma_client.db.litellm_usertable.find_unique(
+                where={"user_id": user_api_key_dict.user_id}
             )
-            if team:
-                is_team_member = (
-                    user_api_key_dict.user_id in team.admins
-                    or user_api_key_dict.user_id in team.members
-                )
+            if user_row and user_row.teams:
+                is_team_member = project.team_id in user_row.teams
 
         if not (is_admin or is_team_member):
             raise HTTPException(
@@ -911,17 +908,15 @@ async def list_projects(
                 include={"litellm_budget_table": True, "object_permission": True}
             )
         else:
-            # Get projects for teams the user belongs to
-            user_teams = await prisma_client.db.litellm_teamtable.find_many(
-                where={
-                    "OR": [
-                        {"members": {"has": user_api_key_dict.user_id}},
-                        {"admins": {"has": user_api_key_dict.user_id}},
-                    ]
-                }
-            )
-
-            team_ids = [team.team_id for team in user_teams]
+            # Get team IDs from the user's own record — litellm_usertable.teams
+            # is the authoritative membership list (populated by team_member_add).
+            team_ids: List[str] = []
+            if user_api_key_dict.user_id:
+                user_row = await prisma_client.db.litellm_usertable.find_unique(
+                    where={"user_id": user_api_key_dict.user_id}
+                )
+                if user_row and user_row.teams:
+                    team_ids = user_row.teams
 
             projects = await prisma_client.db.litellm_projecttable.find_many(
                 where={"team_id": {"in": team_ids}},

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -665,6 +665,8 @@ class LiteLLMRoutes(enum.Enum):
             "/models/{model_id}",
             "/guardrails/list",
             "/v2/guardrails/list",
+            "/project/list",
+            "/project/info",
         ]
         + spend_tracking_routes
         + key_management_routes

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
@@ -6,7 +6,7 @@ import {
   deriveErrorMessage,
   handleError,
 } from "@/components/networking";
-import { all_admin_roles } from "@/utils/roles";
+import { all_admin_roles, internalUserRoles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -82,6 +82,8 @@ export const useProjects = () => {
     queryKey: projectKeys.list({}),
     queryFn: async () => fetchProjects(accessToken!),
     enabled:
-      Boolean(accessToken) && all_admin_roles.includes(userRole || ""),
+      Boolean(accessToken) &&
+      (all_admin_roles.includes(userRole || "") ||
+        internalUserRoles.includes(userRole || "")),
   });
 };


### PR DESCRIPTION
## Relevant issues

 users can still access the old chat UI at `/ui/chat` even after it was removed from the swagger/main navigation.

## Pre-Submission checklist

- [ ] No tests needed (UI source deletion only; the page no longer exists in the next build)

## Type

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Changes

- Deletes `src/app/chat/page.tsx` (the Next.js route for `/ui/chat`)
- Deletes `src/components/chat/` (8 component files only used by that route)

The static build in `_experimental/out/` still has the old `chat/index.html` — that will be cleared the next time the UI is rebuilt and the output is committed.