### PR TITLE
fix(projects): non-admin users can now see their projects

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
@@ -853,14 +853,13 @@ async def project_info(
         is_team_member = False
 
         if project.team_id and user_api_key_dict.user_id:
-            team = await prisma_client.db.litellm_teamtable.find_unique(
-                where={"team_id": project.team_id}
+            # Membership is written to LiteLLM_UserTable.teams by team_member_add.
+            # team.admins and team.members are never populated by that path.
+            user_row = await prisma_client.db.litellm_usertable.find_unique(
+                where={"user_id": user_api_key_dict.user_id}
             )
-            if team:
-                is_team_member = (
-                    user_api_key_dict.user_id in team.admins
-                    or user_api_key_dict.user_id in team.members
-                )
+            user_teams = user_row.teams if (user_row and user_row.teams) else []
+            is_team_member = project.team_id in user_teams
 
         if not (is_admin or is_team_member):
             raise HTTPException(
@@ -911,17 +910,14 @@ async def list_projects(
                 include={"litellm_budget_table": True, "object_permission": True}
             )
         else:
-            # Get projects for teams the user belongs to
-            user_teams = await prisma_client.db.litellm_teamtable.find_many(
-                where={
-                    "OR": [
-                        {"members": {"has": user_api_key_dict.user_id}},
-                        {"admins": {"has": user_api_key_dict.user_id}},
-                    ]
-                }
-            )
-
-            team_ids = [team.team_id for team in user_teams]
+            # Membership is written to LiteLLM_UserTable.teams by team_member_add.
+            # LiteLLM_TeamTable.members and .admins are never populated by that path.
+            team_ids: list[str] = []
+            if user_api_key_dict.user_id:
+                user_row = await prisma_client.db.litellm_usertable.find_unique(
+                    where={"user_id": user_api_key_dict.user_id}
+                )
+                team_ids = user_row.teams if (user_row and user_row.teams) else []
 
             projects = await prisma_client.db.litellm_projecttable.find_many(
                 where={"team_id": {"in": team_ids}},

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -697,6 +697,9 @@ class LiteLLMRoutes(enum.Enum):
         # Team guardrail submissions - endpoint scopes results to caller's teams (non-admin)
         "/guardrails/submissions",
         "/guardrails/submissions/{guardrail_id}",
+        # Project routes - endpoint scopes results to caller's teams (non-admin)
+        "/project/list",
+        "/project/info",
     ]  # routes that manage their own allowed/disallowed logic
 
     ## Org Admin Routes ##

--- a/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
+++ b/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
@@ -864,3 +864,83 @@ def test_litellm_project_table_has_timestamp_fields():
     fields = LiteLLM_ProjectTable.model_fields
     assert "created_at" in fields, "LiteLLM_ProjectTable must have created_at field"
     assert "updated_at" in fields, "LiteLLM_ProjectTable must have updated_at field"
+
+
+def test_project_routes_in_self_managed_routes():
+    """
+    /project/list and /project/info must appear in self_managed_routes so that
+    non-admin callers reach the endpoint (which enforces its own membership check)
+    instead of being rejected with 401 by the framework.
+    """
+    from litellm.proxy._types import LiteLLMRoutes
+
+    routes = LiteLLMRoutes.self_managed_routes.value
+    assert "/project/list" in routes, "/project/list missing from self_managed_routes"
+    assert "/project/info" in routes, "/project/info missing from self_managed_routes"
+
+
+@pytest.mark.asyncio
+async def test_list_projects_internal_user_queries_user_table_teams():
+    """
+    list_projects for a non-admin user must look up team membership via
+    LiteLLM_UserTable.teams, not LiteLLM_TeamTable.members which is always empty.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm_enterprise.proxy.management_endpoints.project_endpoints import (
+        list_projects,
+    )
+
+    user_id = "user-abc"
+    team_id = "team-xyz"
+
+    fake_user = MagicMock()
+    fake_user.teams = [team_id]
+
+    fake_project = MagicMock()
+    fake_project.model_dump.return_value = {
+        "project_id": "proj-1",
+        "project_alias": "p1",
+        "team_id": team_id,
+        "created_by": "admin",
+        "updated_by": "admin",
+        "created_at": None,
+        "updated_at": None,
+        "models": [],
+        "spend": 0.0,
+        "blocked": False,
+        "budget_id": None,
+        "description": None,
+        "metadata": None,
+        "model_spend": None,
+        "model_rpm_limit": None,
+        "model_tpm_limit": None,
+        "object_permission_id": None,
+        "litellm_budget_table": None,
+        "object_permission": None,
+    }
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=fake_user)
+    mock_prisma.db.litellm_projecttable.find_many = AsyncMock(
+        return_value=[fake_project]
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        response = await list_projects(
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.INTERNAL_USER,
+                api_key="sk-user",
+                user_id=user_id,
+            ),
+        )
+
+    # Must have queried LiteLLM_UserTable by user_id, not LiteLLM_TeamTable
+    mock_prisma.db.litellm_usertable.find_unique.assert_called_once_with(
+        where={"user_id": user_id}
+    )
+    mock_prisma.db.litellm_teamtable.find_many.assert_not_called()
+    # Projects filtered by the team_ids from user's teams list
+    call_kwargs = mock_prisma.db.litellm_projecttable.find_many.call_args[1]
+    assert call_kwargs["where"]["team_id"]["in"] == [team_id]
+    assert len(response) == 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useProjects.ts
@@ -6,7 +6,6 @@ import {
   deriveErrorMessage,
   handleError,
 } from "@/components/networking";
-import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -76,12 +75,11 @@ const fetchProjects = async (
 // ── Hook ─────────────────────────────────────────────────────────────────────
 
 export const useProjects = () => {
-  const { accessToken, userRole } = useAuthorized();
+  const { accessToken } = useAuthorized();
 
   return useQuery<ProjectResponse[]>({
     queryKey: projectKeys.list({}),
     queryFn: async () => fetchProjects(accessToken!),
-    enabled:
-      Boolean(accessToken) && all_admin_roles.includes(userRole || ""),
+    enabled: Boolean(accessToken),
   });
 };


### PR DESCRIPTION
## Relevant issues

Closes the regression where internal users/team members got a 401 on `/project/list` and `/project/info` and the projects dropdown never loaded for non-admin users.

## Changes

- **`litellm/proxy/_types.py`** — add `/project/list` and `/project/info` to `self_managed_routes`. These were missing entirely, so any non-admin caller hit a 401 before reaching the handler. They belong in `self_managed_routes` (not `internal_user_routes`) because the endpoints enforce their own membership check.

- **`project_endpoints.py`** — `project_info` and `list_projects` were checking `LiteLLM_TeamTable.admins`/`.members` which `team_member_add` never populates. Actual membership lives in `LiteLLM_UserTable.teams` (pushed to by `add_new_member` on every team join). Both handlers now fetch the user row from `LiteLLM_UserTable` and derive reachable `team_ids` from `.teams`.

- **`useProjects.ts`** — removed the `all_admin_roles` gate from the `enabled` condition. Access control belongs on the server; the hook should fire for any authenticated user.

## Pre-Submission checklist

- [x] Added tests in `tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py`
- [x] `make test-unit` passes locally

## Type

Bug fix

## Tests

Two new unit tests (no DB required):
- `test_project_routes_in_self_managed_routes` — asserts both routes appear in the allowlist
- `test_list_projects_internal_user_queries_user_table_teams` — mocks prisma and verifies `litellm_usertable` is queried (never `litellm_teamtable.find_many`)