### PR TITLE
Add gateway-managed conversation IDs for the Responses API

### DIFF
--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -266,6 +266,53 @@ class ResponsesSessionHandler:
         return False
 
     @staticmethod
+    async def get_chat_completion_message_history_for_session_id(
+        session_id: str,
+    ) -> ChatCompletionSession:
+        from litellm.responses.litellm_completion_transformation.transformation import (
+            ChatCompletionSession,
+        )
+
+        all_spend_logs: List[SpendLogsPayload] = (
+            await ResponsesSessionHandler.get_all_spend_logs_for_session_id(session_id)
+        )
+
+        chat_completion_message_history: List[
+            Union[
+                AllMessageValues,
+                GenericChatCompletionMessage,
+                ChatCompletionMessageToolCall,
+                ChatCompletionResponseMessage,
+                Message,
+            ]
+        ] = []
+        for spend_log in all_spend_logs:
+            chat_completion_message_history = await ResponsesSessionHandler.extend_chat_completion_message_with_spend_log_payload(
+                spend_log=spend_log,
+                chat_completion_message_history=chat_completion_message_history,
+            )
+
+        return ChatCompletionSession(
+            messages=chat_completion_message_history,
+            litellm_session_id=session_id,
+        )
+
+    @staticmethod
+    async def get_all_spend_logs_for_session_id(
+        session_id: str,
+    ) -> List[SpendLogsPayload]:
+        from litellm.proxy.proxy_server import prisma_client
+
+        if prisma_client is None:
+            return []
+
+        spend_logs = await prisma_client.db.litellm_spendlogs.find_many(
+            where={"session_id": session_id},
+            order={"endTime": "asc"},
+        )
+        return cast(List[SpendLogsPayload], spend_logs)
+
+    @staticmethod
     async def get_all_spend_logs_for_previous_response_id(
         previous_response_id: str,
     ) -> List[SpendLogsPayload]:

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -518,6 +518,13 @@ async def aresponses(
             kwargs.pop("prompt_id", None)
             kwargs["_async_prompt_merged_params"] = merged_optional_params
 
+        (
+            input,
+            kwargs,
+            _litellm_conversation_id,
+            _litellm_conversation_pre_call_input,
+        ) = await _apply_litellm_managed_conversation(input=input, kwargs=kwargs)
+
         func = partial(
             responses,
             input=input,
@@ -575,6 +582,12 @@ async def aresponses(
                 f"Got an unexpected None response from the Responses API: {response}"
             )
 
+        await _record_litellm_managed_conversation(
+            response=response,
+            conversation_id=_litellm_conversation_id,
+            pre_call_input=_litellm_conversation_pre_call_input,
+        )
+
         return response
     except Exception as e:
         raise litellm.exception_type(
@@ -584,6 +597,95 @@ async def aresponses(
             completion_kwargs=local_vars,
             extra_kwargs=kwargs,
         )
+
+
+async def _apply_litellm_managed_conversation(
+    input: Union[str, ResponseInputParam],
+    kwargs: Dict[str, Any],
+) -> tuple[
+    Union[str, ResponseInputParam],
+    Dict[str, Any],
+    Optional[str],
+    Optional[List[Dict[str, Any]]],
+]:
+    from litellm.llms.openai.responses.count_tokens.transformation import (
+        OpenAICountTokensConfig,
+    )
+    from litellm.responses.litellm_completion_transformation.session_handler import (
+        ResponsesSessionHandler,
+    )
+    from litellm.responses.utils import (
+        get_cached_conversation_items,
+        is_litellm_conversation_id,
+    )
+
+    extra_body = kwargs.get("extra_body") or {}
+    conversation_id = kwargs.pop("conversation", None) or extra_body.pop(
+        "conversation", None
+    )
+
+    if not is_litellm_conversation_id(conversation_id):
+        if conversation_id is not None:
+            kwargs["conversation"] = conversation_id
+        return input, kwargs, None, None
+
+    kwargs["litellm_session_id"] = conversation_id
+
+    history_input_items: List[Dict[str, Any]] = []
+    cached = await get_cached_conversation_items(conversation_id)
+    if cached:
+        history_input_items = list(cached)
+    else:
+        session = await ResponsesSessionHandler.get_chat_completion_message_history_for_session_id(
+            session_id=conversation_id
+        )
+        history_messages = session.get("messages") or []
+        if history_messages:
+            replayed, _ = OpenAICountTokensConfig.messages_to_responses_input(
+                messages=cast(List[Dict[str, Any]], history_messages)
+            )
+            history_input_items = list(replayed)
+
+    if isinstance(input, str):
+        new_input_items: List[Dict[str, Any]] = history_input_items + [
+            {"role": "user", "content": input}
+        ]
+    else:
+        new_input_items = history_input_items + list(input or [])
+
+    if not history_input_items:
+        return input, kwargs, conversation_id, list(new_input_items)
+
+    return (
+        cast(Union[str, ResponseInputParam], new_input_items),
+        kwargs,
+        conversation_id,
+        list(new_input_items),
+    )
+
+
+async def _record_litellm_managed_conversation(
+    response: Any,
+    conversation_id: Optional[str],
+    pre_call_input: Optional[List[Dict[str, Any]]],
+) -> None:
+    from litellm.responses.utils import set_cached_conversation_items
+
+    if not conversation_id or pre_call_input is None:
+        return
+    if not isinstance(response, ResponsesAPIResponse):
+        return
+
+    output = getattr(response, "output", None) or []
+    serialized_output: List[Dict[str, Any]] = []
+    for item in output:
+        if hasattr(item, "model_dump"):
+            serialized_output.append(item.model_dump(exclude_none=True))
+        elif isinstance(item, dict):
+            serialized_output.append(item)
+
+    full_transcript = list(pre_call_input) + serialized_output
+    await set_cached_conversation_items(conversation_id, full_transcript)
 
 
 def _apply_prompt_management_to_responses_call(

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -24,6 +24,8 @@ from litellm.types.llms.openai import (
     ResponsesAPIResponse,
     ResponseText,
 )
+from litellm.caching.dual_cache import DualCache
+from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.types.responses.main import DecodedResponseId
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
@@ -31,6 +33,72 @@ from litellm.types.utils import (
     SpecialEnums,
     Usage,
 )
+
+LITELLM_CONVERSATION_ID_PREFIX = "litellm_conv_id_"
+
+
+def is_litellm_conversation_id(conversation_id: Optional[str]) -> bool:
+    return isinstance(conversation_id, str) and conversation_id.startswith(
+        LITELLM_CONVERSATION_ID_PREFIX
+    )
+
+
+_LITELLM_CONVERSATION_TTL_SECONDS = 3600
+_LITELLM_CONVERSATION_CACHE: Optional[DualCache] = None
+_LITELLM_CONVERSATION_REDIS_REF: Optional[Any] = None
+
+
+def _get_conversation_cache() -> DualCache:
+    global _LITELLM_CONVERSATION_CACHE, _LITELLM_CONVERSATION_REDIS_REF
+    redis_cache: Optional[Any] = None
+    try:
+        from litellm.proxy import proxy_server
+
+        redis_cache = getattr(proxy_server, "redis_usage_cache", None)
+    except Exception:
+        redis_cache = None
+
+    if (
+        _LITELLM_CONVERSATION_CACHE is None
+        or _LITELLM_CONVERSATION_REDIS_REF is not redis_cache
+    ):
+        _LITELLM_CONVERSATION_CACHE = DualCache(
+            in_memory_cache=InMemoryCache(
+                max_size_in_memory=10000,
+                default_ttl=_LITELLM_CONVERSATION_TTL_SECONDS,
+                max_size_per_item=2048,
+            ),
+            redis_cache=redis_cache,
+            default_in_memory_ttl=_LITELLM_CONVERSATION_TTL_SECONDS,
+            default_redis_ttl=_LITELLM_CONVERSATION_TTL_SECONDS,
+        )
+        _LITELLM_CONVERSATION_REDIS_REF = redis_cache
+    return _LITELLM_CONVERSATION_CACHE
+
+
+def _conversation_cache_key(conversation_id: str) -> str:
+    return f"litellm_conversation:{conversation_id}"
+
+
+async def get_cached_conversation_items(
+    conversation_id: str,
+) -> Optional[List[Dict[str, Any]]]:
+    cache = _get_conversation_cache()
+    cached = await cache.async_get_cache(key=_conversation_cache_key(conversation_id))
+    if isinstance(cached, list):
+        return cached
+    return None
+
+
+async def set_cached_conversation_items(
+    conversation_id: str, items: List[Dict[str, Any]]
+) -> None:
+    cache = _get_conversation_cache()
+    await cache.async_set_cache(
+        key=_conversation_cache_key(conversation_id),
+        value=items,
+        ttl=_LITELLM_CONVERSATION_TTL_SECONDS,
+    )
 
 
 class ResponsesAPIRequestUtils:

--- a/tests/openai_endpoints_tests/test_e2e_litellm_conversation_id.py
+++ b/tests/openai_endpoints_tests/test_e2e_litellm_conversation_id.py
@@ -1,0 +1,238 @@
+"""
+E2E contract tests for LiteLLM-managed conversation IDs over the Responses API.
+
+Any implementation that supports gateway-managed conversation state via the
+`litellm_conv_id_<uuid>` prefix on the Responses API `conversation` field MUST
+pass these tests.
+
+Behavior under test
+-------------------
+1. A first `/v1/responses` call with `conversation="litellm_conv_id_<uuid>"`
+   succeeds and is recorded against the gateway's spend logs under
+   `session_id = "litellm_conv_id_<uuid>"`.
+2. A second `/v1/responses` call reusing the same conversation id succeeds and
+   is recorded against the same `session_id`. The model receives prior turn
+   history (we assert that follow-up referencing turn 1 works without resending
+   the original prompt).
+3. `GET /spend/logs/session/ui?session_id=litellm_conv_id_<uuid>` returns BOTH
+   request rows, ordered, and tagged with the conversation id as `session_id`.
+
+These tests run against a live proxy at http://0.0.0.0:4000 with master key
+`sk-1234`, matching the rest of `tests/openai_endpoints_tests/`.
+"""
+
+import time
+import uuid
+
+import httpx
+import pytest
+from openai import OpenAI
+
+PROXY_BASE_URL = "http://0.0.0.0:4000"
+MASTER_KEY = "sk-1234"
+LITELLM_CONV_PREFIX = "litellm_conv_id_"
+TEST_MODEL = "fast"
+
+
+def _generate_key() -> str:
+    """Mint a virtual key for the test so spend logs are attributable."""
+    response = httpx.post(
+        f"{PROXY_BASE_URL}/key/generate",
+        headers={
+            "Authorization": f"Bearer {MASTER_KEY}",
+            "Content-Type": "application/json",
+        },
+        json={},
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Key generation failed: status={response.status_code} body={response.text}"
+        )
+    return response.json()["key"]
+
+
+def _get_test_client() -> OpenAI:
+    return OpenAI(api_key=_generate_key(), base_url=PROXY_BASE_URL)
+
+
+def _new_conversation_id() -> str:
+    return f"{LITELLM_CONV_PREFIX}{uuid.uuid4()}"
+
+
+def _fetch_session_logs(session_id: str) -> dict:
+    """
+    Read all spend logs for a session via the existing
+    /spend/logs/session/ui endpoint. Uses the master key so we can see
+    every row regardless of which virtual key wrote it.
+    """
+    response = httpx.get(
+        f"{PROXY_BASE_URL}/spend/logs/session/ui",
+        params={"session_id": session_id, "page": 1, "page_size": 100},
+        headers={"Authorization": f"Bearer {MASTER_KEY}"},
+        timeout=30.0,
+    )
+    assert response.status_code == 200, (
+        f"Expected 200 from /spend/logs/session/ui, got {response.status_code}: "
+        f"{response.text}"
+    )
+    return response.json()
+
+
+def _wait_for_logs(session_id: str, expected_count: int, timeout_s: float = 30.0) -> dict:
+    """
+    Spend logs are written asynchronously after the request returns. Poll
+    /spend/logs/session/ui until we see at least `expected_count` rows for
+    this session_id, or fail.
+    """
+    deadline = time.time() + timeout_s
+    last_payload: dict = {}
+    while time.time() < deadline:
+        last_payload = _fetch_session_logs(session_id)
+        if last_payload.get("total", 0) >= expected_count:
+            return last_payload
+        time.sleep(1.0)
+    raise AssertionError(
+        f"Timed out waiting for {expected_count} spend logs for "
+        f"session_id={session_id}. Last payload: {last_payload}"
+    )
+
+
+@pytest.mark.flaky(retries=3, delay=2)
+def test_litellm_conversation_id_persists_across_responses_calls():
+    """
+    The contract:
+
+    - Two /v1/responses calls sharing the same `litellm_conv_id_<uuid>` value in
+      the `conversation` field must both succeed.
+    - Both calls must land in LiteLLM_SpendLogs with session_id equal to that
+      conversation id.
+    - The conversation id must NOT be forwarded to the upstream provider as the
+      provider's own conversation id (i.e. responses still come back with their
+      own provider-issued response ids, not the litellm_conv_id_).
+    """
+    client = _get_test_client()
+    conversation_id = _new_conversation_id()
+
+    response_1 = client.responses.create(
+        model=TEST_MODEL,
+        input="Remember the number 42. Just acknowledge with the word 'ok'.",
+        extra_body={"conversation": conversation_id},
+    )
+    assert response_1 is not None, "first response was None"
+    assert hasattr(response_1, "id"), "first response missing id"
+    assert isinstance(response_1.id, str) and len(response_1.id) > 0
+    assert not response_1.id.startswith(LITELLM_CONV_PREFIX), (
+        "Provider response id must not be the gateway-minted conversation id; "
+        f"got {response_1.id!r}"
+    )
+
+    response_2 = client.responses.create(
+        model=TEST_MODEL,
+        input="What number did I just ask you to remember? Reply with only the digits.",
+        extra_body={"conversation": conversation_id},
+    )
+    assert response_2 is not None, "second response was None"
+    assert hasattr(response_2, "id"), "second response missing id"
+    assert response_2.id != response_1.id, (
+        "Each call must produce a distinct provider response id even when "
+        "sharing the same conversation."
+    )
+
+    payload = _wait_for_logs(session_id=conversation_id, expected_count=2)
+
+    assert payload["total"] >= 2, (
+        f"Expected at least 2 spend log rows for session_id={conversation_id}, "
+        f"got total={payload['total']}. Payload: {payload}"
+    )
+
+    rows = payload["data"]
+    session_ids = {row.get("session_id") for row in rows}
+    assert session_ids == {conversation_id}, (
+        f"Every spend log for this session must carry session_id="
+        f"{conversation_id!r}; got {session_ids!r}"
+    )
+
+    call_types = [row.get("call_type") for row in rows]
+    assert all(ct in {"aresponses", "responses"} for ct in call_types), (
+        f"All rows should be Responses API calls; got call_types={call_types}"
+    )
+
+    sorted_rows = sorted(rows, key=lambda r: r.get("startTime") or "")
+    assert sorted_rows[0]["startTime"] <= sorted_rows[-1]["startTime"]
+
+
+@pytest.mark.flaky(retries=3, delay=2)
+def test_litellm_conversation_id_history_is_replayed_to_model():
+    """
+    The model must be able to answer a follow-up question that ONLY makes sense
+    if turn-1 history was replayed to it. This exercises the read side of the
+    feature (history reconstruction from spend logs keyed by session_id).
+
+    We avoid asserting on exact model output (flaky) and instead assert that
+    the model produced a non-empty response containing the expected token,
+    which is a strong signal that prior context was injected.
+    """
+    client = _get_test_client()
+    conversation_id = _new_conversation_id()
+
+    secret_token = "PURPLE-OWL-7821"
+
+    client.responses.create(
+        model=TEST_MODEL,
+        input=(
+            f"You are participating in a memory test. The secret token is "
+            f"{secret_token}. Acknowledge with the word 'noted'."
+        ),
+        extra_body={"conversation": conversation_id},
+    )
+
+    follow_up = client.responses.create(
+        model=TEST_MODEL,
+        input="Repeat the secret token I gave you earlier, exactly, with no other text.",
+        extra_body={"conversation": conversation_id},
+    )
+
+    output_text = ""
+    if hasattr(follow_up, "output_text") and follow_up.output_text:
+        output_text = follow_up.output_text
+    elif hasattr(follow_up, "output") and follow_up.output:
+        for item in follow_up.output:
+            for content in getattr(item, "content", []) or []:
+                text_val = getattr(content, "text", None)
+                if isinstance(text_val, str):
+                    output_text += text_val
+
+    assert secret_token in output_text, (
+        f"Follow-up call did not see prior conversation history. "
+        f"Expected output to contain {secret_token!r}, got: {output_text!r}"
+    )
+
+
+@pytest.mark.flaky(retries=3, delay=2)
+def test_non_litellm_conversation_id_is_not_intercepted():
+    """
+    Conversation ids that do NOT start with `litellm_conv_id_` must pass through
+    untouched. The gateway must not write a spend-log session_id matching some
+    arbitrary upstream conversation id, because doing so would silently leak
+    cross-customer history.
+    """
+    client = _get_test_client()
+    foreign_conversation_id = f"conv_{uuid.uuid4().hex}"
+
+    try:
+        client.responses.create(
+            model=TEST_MODEL,
+            input="ping",
+            extra_body={"conversation": foreign_conversation_id},
+        )
+    except Exception:
+        # Some providers reject unknown conversation ids. That's fine for this
+        # test; we only care that the gateway didn't claim ownership of the id.
+        pass
+
+    payload = _fetch_session_logs(session_id=foreign_conversation_id)
+    assert payload["total"] == 0, (
+        f"Foreign conversation id {foreign_conversation_id!r} must not be "
+        f"written as a spend-log session_id by the gateway. Got "
+        f"total={payload['total']}: {payload}"
+    )


### PR DESCRIPTION
## Summary

Adds support for gateway-managed conversation state on the Responses API. When a `/v1/responses` request includes `conversation` prefixed with `litellm_conv_id_`, the proxy:

1. Sets `LiteLLM_SpendLogs.session_id` to the conversation id, so every turn is queryable via the existing `/spend/logs/session/ui?session_id=...` endpoint.
2. Replays prior turns to the model on follow-up calls. Reads come from a `DualCache` (in-memory + Redis when configured) populated by each successful response, with a spend-logs fallback when the cache misses (handles process restarts and cache eviction).
3. Strips the synthetic id from the request body so it is never forwarded to the upstream provider.

Foreign `conversation` ids (anything not prefixed) pass through untouched to whichever provider the request routes to.

### Why this design

- **No new tables, no new endpoints, no new migrations.** Reuses `LiteLLM_SpendLogs.session_id` (already indexed) and the existing `/spend/logs/session/ui` route for retrieval.
- **Race-resistant.** Spend logs are flushed asynchronously (~12s in dev). The `DualCache` short-circuits this for the common back-to-back agentic loop pattern.
- **Multi-worker correct when Redis is configured.** Without Redis, falls back to in-memory only — degrades to the same baseline as the existing `previous_response_id` flow.

### Files changed

| File | Purpose |
|---|---|
| `litellm/responses/utils.py` | `LITELLM_CONVERSATION_ID_PREFIX`, helper, lazy `DualCache` getter (Redis + in-memory) |
| `litellm/responses/main.py` | `_apply_litellm_managed_conversation` pre-call hook + `_record_litellm_managed_conversation` post-call cache writer in `aresponses` |
| `litellm/responses/litellm_completion_transformation/session_handler.py` | `get_chat_completion_message_history_for_session_id` (Prisma `find_many` per CLAUDE.md guidance) |
| `tests/openai_endpoints_tests/test_e2e_litellm_conversation_id.py` | E2E contract tests (3 cases) |

## Test plan

- [x] `tests/openai_endpoints_tests/test_e2e_litellm_conversation_id.py` — 3/3 passing against a live proxy
  - `test_litellm_conversation_id_persists_across_responses_calls` — both calls land in spend logs with the conv id as `session_id`, distinct provider response ids, retrievable via `/spend/logs/session/ui`
  - `test_litellm_conversation_id_history_is_replayed_to_model` — secret token planted in turn 1 is recalled in turn 2 (proves replay works)
  - `test_non_litellm_conversation_id_is_not_intercepted` — foreign-prefixed ids must not be claimed by the gateway
- [x] Unit smoke test verifying `DualCache` Redis branch with a fake `RedisCache`: writes hit Redis, cross-worker reads return Redis value after wiping in-memory layer
- [x] `uv run black` + `uv run ruff check` clean on changed files
- [ ] Reviewer to confirm behavior with a live Redis instance in CI

## Known limitations (documented honestly)

- **Async-only.** The hook lives in `aresponses`. Direct sync `litellm.responses(...)` calls with `conversation=...` are not intercepted. The proxy is async-only, so this covers the proxy path.
- **No item-level mutation.** No CRUD on individual conversation items — by design (out of scope; spend logs are append-only).
- **No per-key auth scoping.** Same posture as `previous_response_id` today (`session_handler.get_all_spend_logs_for_previous_response_id` does no per-key filtering). Worth tightening separately for both flows.
- **Multi-worker without Redis is best-effort.** Falls back to spend-logs DB on cross-worker miss, which then races with the ~12s async flush. Configure Redis to make multi-worker correct.


Made with [Cursor](https://cursor.com)