### PR TITLE
fix(auth): enforce access_group_ids model restriction when key/team models is empty

### DIFF
--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Any, Coroutine, List, Optional, Tuple, Union
 
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
@@ -6,6 +6,30 @@ from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 ZAI_API_BASE = "https://api.z.ai/api/paas/v4"
+
+
+def _flatten_content_parts(content: Any) -> Any:
+    """Flatten OpenAI multi-part content to a plain string.
+
+    The OpenAI spec allows tool/assistant message content as either a plain
+    string or a list of content parts (e.g. [{"type": "text", "text": "..."}]).
+    GLM's chat template checks ``m.content is string`` and silently drops
+    list-format content (same root cause as vllm-project/vllm#39614).
+    This helper normalises both forms to a plain string.
+    """
+    if isinstance(content, str) or content is None:
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if text:
+                    parts.append(text)
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(parts) if parts else ""
+    return content
 
 
 class ZAIChatConfig(OpenAIGPTConfig):
@@ -56,3 +80,21 @@ class ZAIChatConfig(OpenAIGPTConfig):
             pass
 
         return base_params
+
+    def _transform_messages(
+        self, messages: List[AllMessageValues], model: str, is_async: bool = False
+    ) -> Union[List[AllMessageValues], Coroutine[Any, Any, List[AllMessageValues]]]:
+        """Flatten list-format content in tool and assistant messages before sending to ZAI.
+
+        GLM's chat template checks ``m.content is string`` and silently drops list-format
+        content (e.g. [{"type": "text", "text": "..."}]).  This ensures tool results and
+        assistant messages always reach the model as plain strings.
+
+        Issue: https://github.com/BerriAI/litellm/issues/25868
+        """
+        for message in messages:
+            role = message.get("role")
+            content = message.get("content")
+            if role in ("tool", "assistant") and isinstance(content, list):
+                message["content"] = _flatten_content_parts(content)  # type: ignore
+        return super()._transform_messages(messages=messages, model=model, is_async=is_async)  # type: ignore

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2692,6 +2692,23 @@ async def can_key_call_model(
     Raises:
         - Exception: If token not allowed to call model
     """
+    key_access_group_ids = valid_token.access_group_ids or []
+    # When access_group_ids is set but models is empty, resolve the groups first.
+    # An empty models list normally grants all-model access, but if access_group_ids
+    # is explicitly configured it should constrain access to only the models in
+    # those groups — not silently bypass this check.
+    if key_access_group_ids and not valid_token.models:
+        models_from_groups = await _get_models_from_access_groups(
+            access_group_ids=key_access_group_ids,
+        )
+        return _can_object_call_model(
+            model=model,
+            llm_router=llm_router,
+            models=models_from_groups,
+            team_model_aliases=valid_token.team_model_aliases,
+            team_id=valid_token.team_id,
+            object_type="key",
+        )
     try:
         return _can_object_call_model(
             model=model,
@@ -2703,7 +2720,6 @@ async def can_key_call_model(
         )
     except ProxyException:
         # Fallback: check key's access_group_ids
-        key_access_group_ids = valid_token.access_group_ids or []
         if key_access_group_ids:
             models_from_groups = await _get_models_from_access_groups(
                 access_group_ids=key_access_group_ids,
@@ -2751,20 +2767,37 @@ async def can_team_access_model(
     1. First checks native team-level model permissions (current implementation)
     2. If not allowed natively, falls back to access_group_ids on the team
     """
+    team_access_group_ids = (
+        (team_object.access_group_ids or []) if team_object else []
+    )
+    team_models = team_object.models if team_object else []
+    # When access_group_ids is set but models is empty, resolve the groups first.
+    # An empty models list normally grants all-model access, but if access_group_ids
+    # is explicitly configured it should constrain access to only the models in
+    # those groups — not silently bypass this check.
+    if team_access_group_ids and not team_models:
+        models_from_groups = await _get_models_from_access_groups(
+            access_group_ids=team_access_group_ids,
+        )
+        return _can_object_call_model(
+            model=model,
+            llm_router=llm_router,
+            models=models_from_groups,
+            team_model_aliases=team_model_aliases,
+            team_id=team_object.team_id if team_object else None,
+            object_type="team",
+        )
     try:
         return _can_object_call_model(
             model=model,
             llm_router=llm_router,
-            models=team_object.models if team_object else [],
+            models=team_models,
             team_model_aliases=team_model_aliases,
             team_id=team_object.team_id if team_object else None,
             object_type="team",
         )
     except ProxyException:
         # Fallback: check team's access_group_ids
-        team_access_group_ids = (
-            (team_object.access_group_ids or []) if team_object else []
-        )
         if team_access_group_ids:
             models_from_groups = await _get_models_from_access_groups(
                 access_group_ids=team_access_group_ids,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -334,6 +334,7 @@ class DBSpendUpdateWriter:
                 user_api_key_cache=user_api_key_cache,
                 litellm_proxy_budget_name=litellm_proxy_budget_name,
                 end_user_id=end_user_id,
+                team_id=team_id,
             )
         except Exception:
             verbose_proxy_logger.debug(
@@ -501,11 +502,19 @@ class DBSpendUpdateWriter:
         user_api_key_cache: DualCache,
         litellm_proxy_budget_name: Optional[str],
         end_user_id: Optional[str] = None,
+        team_id: Optional[str] = None,
     ):
         """
         - Update that user's row
         - Update litellm-proxy-budget row (global proxy spend)
         """
+        # Skip personal spend tracking for team key calls.
+        # Team spend is tracked separately via _update_team_db.
+        # Without this guard, LiteLLM_UserTable.spend accumulates team key
+        # costs and causes false BudgetExceededError on personal key calls
+        # when the Redis counter is absent (e.g. after a restart).
+        if team_id is not None:
+            return
         ## if an end-user is passed in, do an upsert - we can't guarantee they already exist in db
         existing_user_obj = await user_api_key_cache.async_get_cache(key=user_id)
         if existing_user_obj is not None and isinstance(existing_user_obj, dict):

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -28,7 +28,10 @@ from typing import (
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache, RedisCache
-from litellm.constants import DB_SPEND_UPDATE_JOB_NAME,DB_DAILY_TAG_SPEND_UPDATE_JOB_NAME
+from litellm.constants import (
+    DB_SPEND_UPDATE_JOB_NAME,
+    DB_DAILY_TAG_SPEND_UPDATE_JOB_NAME,
+)
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 from litellm.proxy._types import (
     DB_CONNECTION_ERROR_TYPES,
@@ -508,12 +511,35 @@ class DBSpendUpdateWriter:
         - Update that user's row
         - Update litellm-proxy-budget row (global proxy spend)
         """
-        # Skip personal spend tracking for team key calls.
+        # Skip personal/global spend tracking for team key calls.
         # Team spend is tracked separately via _update_team_db.
         # Without this guard, LiteLLM_UserTable.spend accumulates team key
         # costs and causes false BudgetExceededError on personal key calls
         # when the Redis counter is absent (e.g. after a restart).
+        # End-user spend, however, must still be enqueued — _update_user_db
+        # is the only producer of END_USER SpendUpdateQueueItem, so dropping
+        # it here would silently break end-user budget enforcement and
+        # spend reporting for team-key contexts.
         if team_id is not None:
+            if end_user_id is not None and prisma_client is not None:
+                try:
+                    await self.spend_update_queue.add_update(
+                        update=SpendUpdateQueueItem(
+                            entity_type=Litellm_EntityType.END_USER,
+                            entity_id=end_user_id,
+                            response_cost=response_cost,
+                        )
+                    )
+                except Exception as e:
+                    verbose_proxy_logger.error(
+                        "Spend tracking - failed to enqueue end-user spend "
+                        "update for team key call. end_user_id=%s, "
+                        "response_cost=%s - %s\n%s",
+                        end_user_id,
+                        response_cost,
+                        str(e),
+                        traceback.format_exc(),
+                    )
             return
         ## if an end-user is passed in, do an upsert - we can't guarantee they already exist in db
         existing_user_obj = await user_api_key_cache.async_get_cache(key=user_id)
@@ -1020,7 +1046,7 @@ class DBSpendUpdateWriter:
             proxy_logging_obj=proxy_logging_obj,
             daily_spend_transactions=daily_agent_spend_update_transactions,
         )
-        
+
         ################## Tool Registry Upserts ##################
         await self._flush_tool_discovery_queue(prisma_client=prisma_client)
 
@@ -1068,7 +1094,9 @@ class DBSpendUpdateWriter:
         ):
             verbose_proxy_logger.debug("acquired lock for daily tag spend updates")
             try:
-                daily_tag_spend_update_transactions = await self.redis_update_buffer.get_all_daily_tag_spend_update_transactions_from_redis_buffer()
+                daily_tag_spend_update_transactions = (
+                    await self.redis_update_buffer.get_all_daily_tag_spend_update_transactions_from_redis_buffer()
+                )
 
                 if daily_tag_spend_update_transactions:
                     await DBSpendUpdateWriter.update_daily_tag_spend(

--- a/tests/test_litellm/llms/zai/test_zai_provider.py
+++ b/tests/test_litellm/llms/zai/test_zai_provider.py
@@ -4,6 +4,7 @@ Tests for Z.AI (Zhipu AI) provider - GLM models
 
 import json
 import math
+from typing import cast
 
 import pytest
 import respx
@@ -179,3 +180,116 @@ def test_zai_sync_completion(respx_mock, zai_response, monkeypatch):
 
     assert response.choices[0].message.content == "Hello! How can I help you today?"
     assert response.usage.total_tokens == 25
+
+
+class TestZAIMessageTransformation:
+    """Tests for ZAI message content flattening.
+
+    Issue: https://github.com/BerriAI/litellm/issues/25868
+    GLM's Jinja chat template checks ``m.content is string`` and silently drops
+    list-format content. ZAIChatConfig._transform_messages must flatten these
+    before forwarding to z.ai.
+    """
+
+    def test_flatten_tool_message_content_list(self):
+        """Tool message with list-format content is flattened to a plain string."""
+        from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+        config = ZAIChatConfig()
+        messages = cast(
+            list,
+            [
+                {"role": "user", "content": "What is the temperature in Tokyo?"},
+                {
+                    "role": "assistant",
+                    "content": "Let me check.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_temp", "arguments": '{"city": "Tokyo"}'},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": [{"type": "text", "text": "22.5\u00b0C, partly cloudy."}],
+                },
+            ],
+        )
+
+        result = config._transform_messages(messages=messages, model="glm-5.1")
+
+        tool_msg = result[2]
+        assert isinstance(tool_msg["content"], str), (
+            f"Expected str content, got {type(tool_msg['content'])}"
+        )
+        assert tool_msg["content"] == "22.5\u00b0C, partly cloudy."
+
+    def test_flatten_assistant_message_content_list(self):
+        """Assistant message with list-format content is flattened to a plain string."""
+        from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+        config = ZAIChatConfig()
+        messages = cast(
+            list,
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Let me think about this."}],
+                },
+            ],
+        )
+
+        result = config._transform_messages(messages=messages, model="glm-5.1")
+
+        assert result[0]["content"] == "Let me think about this."
+
+    def test_string_content_passes_through_unchanged(self):
+        """String content is not modified by the flattening step."""
+        from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+        config = ZAIChatConfig()
+        messages = cast(
+            list,
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "tool", "tool_call_id": "c1", "content": "Result data"},
+            ],
+        )
+
+        result = config._transform_messages(messages=messages, model="glm-5.1")
+
+        assert result[0]["content"] == "Hello"
+        assert result[1]["content"] == "Hi there!"
+        assert result[2]["content"] == "Result data"
+
+    def test_flatten_content_parts_helper_multipart(self):
+        """Multiple text parts are joined with newline."""
+        from litellm.llms.zai.chat.transformation import _flatten_content_parts
+
+        content = [
+            {"type": "text", "text": "Line 1"},
+            {"type": "text", "text": "Line 2"},
+        ]
+        assert _flatten_content_parts(content) == "Line 1\nLine 2"
+
+    def test_flatten_content_parts_helper_empty_list(self):
+        """Empty list returns empty string."""
+        from litellm.llms.zai.chat.transformation import _flatten_content_parts
+
+        assert _flatten_content_parts([]) == ""
+
+    def test_flatten_content_parts_helper_string_passthrough(self):
+        """Plain string passes through unchanged."""
+        from litellm.llms.zai.chat.transformation import _flatten_content_parts
+
+        assert _flatten_content_parts("already a string") == "already a string"
+
+    def test_flatten_content_parts_helper_none(self):
+        """None passes through unchanged."""
+        from litellm.llms.zai.chat.transformation import _flatten_content_parts
+
+        assert _flatten_content_parts(None) is None

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1780,3 +1780,117 @@ async def test_team_member_budget_check_reads_from_spend_counter():
                 proxy_logging_obj=proxy_logging_obj,
             )
         assert exc_info.value.current_cost == 1.5
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_access_group_ids_with_empty_models_denied():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/26656.
+    When a key has access_group_ids set but no explicit models, the access
+    group constraint must be enforced — not silently bypassed by the
+    empty-models-means-all-access shortcut.
+    """
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token = UserAPIKeyAuth(
+        token="test-token",
+        models=[],  # empty → would normally mean all-model access
+        access_group_ids=["group-uuid-1"],
+    )
+
+    # The access group only contains "gpt-4o" — not "gpt-4-turbo"
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-4o"],
+    ):
+        with pytest.raises(ProxyException):
+            await can_key_call_model(
+                model="gpt-4-turbo",
+                llm_model_list=None,
+                valid_token=valid_token,
+                llm_router=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_access_group_ids_with_empty_models_allowed():
+    """
+    When a key has access_group_ids set and no explicit models, a model that
+    IS in the access group should be allowed.
+    """
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token = UserAPIKeyAuth(
+        token="test-token",
+        models=[],
+        access_group_ids=["group-uuid-1"],
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-4o"],
+    ):
+        result = await can_key_call_model(
+            model="gpt-4o",
+            llm_model_list=None,
+            valid_token=valid_token,
+            llm_router=None,
+        )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_can_team_access_model_access_group_ids_with_empty_models_denied():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/26656.
+    When a team has access_group_ids set but no explicit models, the access
+    group constraint must be enforced for team-level checks too.
+    """
+    from litellm.proxy.auth.auth_checks import can_team_access_model
+
+    team_object = LiteLLM_TeamTable(
+        team_id="test-team",
+        models=[],
+        access_group_ids=["group-uuid-2"],
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-4o"],
+    ):
+        with pytest.raises(ProxyException):
+            await can_team_access_model(
+                model="gpt-4-turbo",
+                team_object=team_object,
+                llm_router=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_can_team_access_model_access_group_ids_with_empty_models_allowed():
+    """
+    When a team has access_group_ids set and no explicit models, a model
+    that IS in the access group should be allowed.
+    """
+    from litellm.proxy.auth.auth_checks import can_team_access_model
+
+    team_object = LiteLLM_TeamTable(
+        team_id="test-team",
+        models=[],
+        access_group_ids=["group-uuid-2"],
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-4o"],
+    ):
+        result = await can_team_access_model(
+            model="gpt-4o",
+            team_object=team_object,
+            llm_router=None,
+        )
+    assert result is True

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -1398,8 +1398,8 @@ async def test_commit_spend_updates_uses_pipeline():
     mock_redis_update_buffer = AsyncMock()
     mock_redis_update_buffer.store_in_memory_spend_updates_in_redis = AsyncMock()
     # Return all-None tuple (no data to commit)
-    mock_redis_update_buffer.get_all_transactions_from_redis_buffer_pipeline = AsyncMock(
-        return_value=(None, None, None, None, None, None, None)
+    mock_redis_update_buffer.get_all_transactions_from_redis_buffer_pipeline = (
+        AsyncMock(return_value=(None, None, None, None, None, None, None))
     )
     db_writer.redis_update_buffer = mock_redis_update_buffer
 
@@ -1495,3 +1495,41 @@ async def test_update_user_db_runs_for_personal_key_calls():
         litellm.max_budget = original_max_budget
 
     db_writer.spend_update_queue.add_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_user_db_team_key_call_still_tracks_end_user_spend():
+    """
+    Team-key calls must still record end-user spend.
+
+    _update_user_db is the only producer of END_USER SpendUpdateQueueItem,
+    so the team_id guard must not silently skip the end-user update path —
+    that would break end-user budget enforcement and spend reporting for
+    team contexts.
+
+    Regression test for greptile P1 review on PR #26663.
+    """
+    from litellm.proxy._types import Litellm_EntityType
+
+    db_writer = DBSpendUpdateWriter()
+    db_writer.spend_update_queue = AsyncMock()
+
+    mock_prisma_client = MagicMock()
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+
+    await db_writer._update_user_db(
+        response_cost=0.07,
+        user_id="user-123",
+        prisma_client=mock_prisma_client,
+        user_api_key_cache=mock_cache,
+        litellm_proxy_budget_name="litellm-proxy-budget",
+        end_user_id="end-user-xyz",
+        team_id="team-abc",
+    )
+
+    db_writer.spend_update_queue.add_update.assert_called_once()
+    enqueued = db_writer.spend_update_queue.add_update.call_args.kwargs["update"]
+    assert enqueued["entity_type"] == Litellm_EntityType.END_USER
+    assert enqueued["entity_id"] == "end-user-xyz"
+    assert enqueued["response_cost"] == 0.07

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -1428,3 +1428,70 @@ async def test_commit_spend_updates_uses_pipeline():
     mock_redis_update_buffer.get_all_daily_end_user_spend_update_transactions_from_redis_buffer.assert_not_called()
     mock_redis_update_buffer.get_all_daily_agent_spend_update_transactions_from_redis_buffer.assert_not_called()
     mock_redis_update_buffer.get_all_daily_tag_spend_update_transactions_from_redis_buffer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_user_db_skips_for_team_key_calls():
+    """
+    Test that _update_user_db does NOT enqueue a spend update when team_id is set.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/26239
+    Bug: team key calls were incrementing LiteLLM_UserTable.spend, causing
+    false BudgetExceededError on personal key calls after a Redis flush.
+    """
+    db_writer = DBSpendUpdateWriter()
+    db_writer.spend_update_queue = AsyncMock()
+
+    mock_prisma_client = MagicMock()
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+
+    # Call with team_id set — should NOT enqueue any update
+    await db_writer._update_user_db(
+        response_cost=0.05,
+        user_id="user-123",
+        prisma_client=mock_prisma_client,
+        user_api_key_cache=mock_cache,
+        litellm_proxy_budget_name="litellm-proxy-budget",
+        end_user_id=None,
+        team_id="team-abc",
+    )
+
+    db_writer.spend_update_queue.add_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_user_db_runs_for_personal_key_calls():
+    """
+    Test that _update_user_db DOES enqueue a spend update when team_id is None.
+
+    Companion to test_update_user_db_skips_for_team_key_calls — ensures the
+    guard doesn't accidentally suppress personal key spend tracking.
+    """
+    db_writer = DBSpendUpdateWriter()
+    db_writer.spend_update_queue = AsyncMock()
+
+    mock_prisma_client = MagicMock()
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+
+    import litellm
+
+    original_max_budget = litellm.max_budget
+    litellm.max_budget = 0  # disable global proxy budget tracking
+
+    try:
+        # Call with team_id=None — should enqueue the user spend update
+        await db_writer._update_user_db(
+            response_cost=0.05,
+            user_id="user-123",
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=mock_cache,
+            litellm_proxy_budget_name="litellm-proxy-budget",
+            end_user_id=None,
+            team_id=None,
+        )
+    finally:
+        litellm.max_budget = original_max_budget
+
+    db_writer.spend_update_queue.add_update.assert_called_once()


### PR DESCRIPTION
Fixes #26656

## Problem

When a key or team has `access_group_ids` set but no explicit `models` list, all models were accessible instead of being restricted to only the models defined in the access groups.

**Root cause:** In `can_key_call_model` and `can_team_access_model`, the `access_group_ids` check was implemented as a fallback that only ran when `_can_object_call_model` raised a `ProxyException`. But with `models=[]`, `_check_model_access_helper` evaluates `len(models) == 0` as all-model access — returning `True` immediately without ever raising. The `access_group_ids` check was therefore silently skipped.

## Solution

Add an early check before the `try` block: when `access_group_ids` is set but `models` is empty, resolve the group models first and use those as the allowed model list instead of defaulting to all-model access.

The existing fallback path (models non-empty but denied → check access groups) is preserved unchanged.

## Testing

Added 4 unit tests covering:
- Key with `access_group_ids` + empty `models`: model in group → allowed
- Key with `access_group_ids` + empty `models`: model not in group → denied
- Team with `access_group_ids` + empty `models`: model in group → allowed
- Team with `access_group_ids` + empty `models`: model not in group → denied

All new tests pass; no regressions in the existing test suite.