### PR TITLE
feat(responses): support cursor-based stream resume on retrieve

### DIFF
--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -249,18 +249,29 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
         """
-        Transform the get response API request into a URL and data
+        Transform the get response API request into a URL and data.
 
-        OpenAI API expects the following request
-        - GET /v1/responses/{response_id}
+        Azure OpenAI follows the same shape as OpenAI for retrieve:
+        - GET /openai/responses/{response_id}?api-version=...
+
+        For cursor-based stream resume, Azure also accepts ``stream`` and
+        ``starting_after`` as query parameters (verified empirically against
+        api-version 2025-04-01-preview); we surface them via the returned
+        ``data`` dict so the HTTP layer can attach them.
         """
         get_url = self._construct_url_for_response_id_in_path(
             api_base=api_base, response_id=response_id
         )
         data: Dict = {}
-        verbose_logger.debug(f"get response url={get_url}")
+        if stream:
+            data["stream"] = "true"
+        if starting_after is not None:
+            data["starting_after"] = starting_after
+        verbose_logger.debug(f"get response url={get_url} data={data}")
         return get_url, data
 
     def transform_list_input_items_request(

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -165,7 +165,18 @@ class BaseResponsesAPIConfig(ABC):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
+        """
+        Build the URL and query params for ``GET /v1/responses/{response_id}``.
+
+        ``stream`` and ``starting_after`` enable cursor-based stream resume per
+        the OpenAI Responses API. Implementations that do not support resume
+        should ignore these arguments. Implementations that do support resume
+        should put ``stream`` and ``starting_after`` into the returned ``data``
+        dict so the underlying HTTP layer attaches them as query parameters.
+        """
         pass
 
     @abstractmethod

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -486,6 +486,8 @@ class AsyncHTTPHandler:
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         follow_redirects: Optional[bool] = None,
+        stream: bool = False,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ):
         # Set follow_redirects to UseClientDefault if None
         _follow_redirects = (
@@ -494,6 +496,24 @@ class AsyncHTTPHandler:
 
         params = params or {}
         params.update(HTTPHandler.extract_query_params(url))
+
+        if stream:
+            # Build and send an open SSE-style stream request. Caller is
+            # responsible for iterating ``response.aiter_lines()`` and
+            # eventually awaiting ``response.aclose()`` to release the
+            # underlying connection back to the pool.
+            req = self.client.build_request(
+                "GET",
+                url,
+                params=params,
+                headers=headers,
+                timeout=timeout if timeout is not None else self.timeout,
+            )
+            response = await self.client.send(
+                req, stream=True, follow_redirects=_follow_redirects
+            )
+            response.raise_for_status()
+            return response
 
         response = await self.client.get(
             url, params=params, headers=headers, follow_redirects=_follow_redirects  # type: ignore

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2624,10 +2624,25 @@ class BaseLLMHTTPHandler:
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
         shared_session: Optional["ClientSession"] = None,
-    ) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
+        stream: bool = False,
+        starting_after: Optional[int] = None,
+        litellm_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Union[
+        ResponsesAPIResponse,
+        BaseResponsesAPIStreamingIterator,
+        Coroutine[
+            Any, Any, Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]
+        ],
+    ]:
         """
         Get a response by ID
-        Uses GET /v1/responses/{response_id} endpoint in the responses API
+        Uses GET /v1/responses/{response_id} endpoint in the responses API.
+
+        When ``stream=True``, performs cursor-based stream resume per the OpenAI
+        Responses API spec — equivalent to
+        ``client.responses.retrieve(response_id, stream=True, starting_after=N)``
+        on the OpenAI Python SDK. The provider must support resume; OpenAI and
+        Azure OpenAI (api-version 2025-04-01-preview) are known to support it.
         """
         if _is_async:
             return self.async_get_responses(
@@ -2641,6 +2656,9 @@ class BaseLLMHTTPHandler:
                 timeout=timeout,
                 client=client,
                 shared_session=shared_session,
+                stream=stream,
+                starting_after=starting_after,
+                litellm_metadata=litellm_metadata,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -2667,6 +2685,8 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             litellm_params=litellm_params,
             headers=headers,
+            stream=stream,
+            starting_after=starting_after,
         )
 
         ## LOGGING
@@ -2705,9 +2725,17 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         shared_session: Optional["ClientSession"] = None,
-    ) -> ResponsesAPIResponse:
+        stream: bool = False,
+        starting_after: Optional[int] = None,
+        litellm_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]:
         """
-        Async version of get_responses
+        Async version of get_responses.
+
+        When ``stream=True``, returns a :class:`ResponsesAPIStreamingIterator`
+        that yields :class:`ResponsesAPIStreamingResponse` events parsed from
+        the upstream SSE stream — enabling cursor-based stream resume per the
+        OpenAI Responses API spec.
         """
         if client is None or not isinstance(client, AsyncHTTPHandler):
             verbose_logger.debug(
@@ -2738,6 +2766,8 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             litellm_params=litellm_params,
             headers=headers,
+            stream=stream,
+            starting_after=starting_after,
         )
 
         ## LOGGING
@@ -2752,6 +2782,34 @@ class BaseLLMHTTPHandler:
         )
 
         try:
+            if stream:
+                # Open an SSE-style stream against the retrieve endpoint and
+                # wrap it in the same iterator used for streaming POSTs so
+                # parsing, hooks, and logging stay uniform across paths.
+                response = await async_httpx_client.get(
+                    url=url,
+                    headers=headers,
+                    params=data,
+                    stream=True,
+                    timeout=timeout,
+                )
+                request_context: Dict[str, Any] = {
+                    "response_id": response_id,
+                    "stream": True,
+                    "starting_after": starting_after,
+                    "litellm_params": dict(litellm_params),
+                }
+                return ResponsesAPIStreamingIterator(
+                    response=response,
+                    model="",
+                    logging_obj=logging_obj,
+                    responses_api_provider_config=responses_api_provider_config,
+                    litellm_metadata=litellm_metadata,
+                    custom_llm_provider=custom_llm_provider,
+                    request_data=request_context,
+                    call_type=CallTypes.aresponses.value,
+                )
+
             response = await async_httpx_client.get(
                 url=url, headers=headers, params=data
             )

--- a/litellm/llms/manus/responses/transformation.py
+++ b/litellm/llms/manus/responses/transformation.py
@@ -261,6 +261,8 @@ class ManusResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
         """
         Transform the get response API request into a URL and data.
@@ -269,6 +271,10 @@ class ManusResponsesAPIConfig(OpenAIResponsesAPIConfig):
         - GET /v1/responses/{response_id}
 
         Reference: https://open.manus.im/docs/openai-compatibility
+
+        Cursor-based stream resume (``stream`` / ``starting_after``) is not
+        supported by Manus; the arguments are accepted for signature parity
+        with the base class and silently ignored.
         """
         url = f"{api_base}/{response_id}"
         data: Dict = {}

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -450,15 +450,25 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
         """
-        Transform the get response API request into a URL and data
+        Transform the get response API request into a URL and data.
 
         OpenAI API expects the following request
         - GET /v1/responses/{response_id}
+
+        For cursor-based stream resume, OpenAI accepts ``stream`` and
+        ``starting_after`` as query parameters; we surface them via the
+        returned ``data`` dict so the HTTP layer can attach them.
         """
         url = f"{api_base}/{response_id}"
         data: Dict = {}
+        if stream:
+            data["stream"] = "true"
+        if starting_after is not None:
+            data["starting_after"] = starting_after
         return url, data
 
     def transform_get_response_api_response(

--- a/litellm/llms/volcengine/responses/transformation.py
+++ b/litellm/llms/volcengine/responses/transformation.py
@@ -332,7 +332,12 @@ class VolcEngineResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
+        # Volcengine does not support cursor-based stream resume on retrieve;
+        # ``stream`` and ``starting_after`` are accepted for signature parity
+        # with the base class and silently ignored.
         url = f"{api_base}/{response_id}"
         data: Dict = {}
         return url, data

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -527,6 +527,28 @@ async def get_response(
     # Normal provider response flow
     data = await _read_request_body(request=request)
     data["response_id"] = response_id
+
+    # Read cursor-based stream resume params from the query string. The
+    # OpenAI Python SDK sends ``client.responses.retrieve(id, stream=True,
+    # starting_after=N)`` as ``GET .../responses/{id}?stream=true&starting_after=N``
+    # — these never appear in the request body for a GET. Without this we
+    # silently drop them and return the cached non-stream response.
+    query_stream = request.query_params.get("stream")
+    if query_stream is not None and query_stream.lower() in ("true", "1"):
+        data["stream"] = True
+    query_starting_after = request.query_params.get("starting_after")
+    if query_starting_after is not None:
+        try:
+            data["starting_after"] = int(query_starting_after)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Query parameter 'starting_after' must be an integer "
+                    f"sequence number, got {query_starting_after!r}."
+                ),
+            )
+
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
         return await processor.base_process_llm_request(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1365,19 +1365,31 @@ async def aget_responses(
     timeout: Optional[Union[float, httpx.Timeout]] = None,
     # LiteLLM specific params,
     custom_llm_provider: Optional[str] = None,
+    stream: bool = False,
+    starting_after: Optional[int] = None,
     **kwargs,
-) -> ResponsesAPIResponse:
+) -> Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]:
     """
     Async: Fetch a response by its ID.
 
-    GET /v1/responses/{response_id} endpoint in the responses API
+    GET /v1/responses/{response_id} endpoint in the responses API.
 
     Args:
         response_id: The ID of the response to fetch.
         custom_llm_provider: Optional provider name. If not specified, will be decoded from response_id.
+        stream: When ``True``, opens an SSE stream to resume the response from
+            ``starting_after`` and returns a streaming iterator instead of a
+            single :class:`ResponsesAPIResponse`. Equivalent to the OpenAI
+            Python SDK call
+            ``client.responses.retrieve(id, stream=True, starting_after=N)``.
+        starting_after: The last ``sequence_number`` the caller has already
+            received from the original stream. Only meaningful when
+            ``stream=True``.
 
     Returns:
-        The response object with complete information about the stored response.
+        The response object with complete information about the stored
+        response, or a :class:`ResponsesAPIStreamingIterator` when
+        ``stream=True``.
     """
     local_vars = locals()
     try:
@@ -1403,6 +1415,8 @@ async def aget_responses(
             extra_query=extra_query,
             extra_body=extra_body,
             timeout=timeout,
+            stream=stream,
+            starting_after=starting_after,
             **kwargs,
         )
 
@@ -1444,19 +1458,30 @@ def get_responses(
     timeout: Optional[Union[float, httpx.Timeout]] = None,
     # LiteLLM specific params,
     custom_llm_provider: Optional[str] = None,
+    stream: bool = False,
+    starting_after: Optional[int] = None,
     **kwargs,
-) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
+) -> Union[
+    ResponsesAPIResponse,
+    BaseResponsesAPIStreamingIterator,
+    Coroutine[Any, Any, Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]],
+]:
     """
     Fetch a response by its ID.
 
-    GET /v1/responses/{response_id} endpoint in the responses API
+    GET /v1/responses/{response_id} endpoint in the responses API.
 
     Args:
         response_id: The ID of the response to fetch.
         custom_llm_provider: Optional provider name. If not specified, will be decoded from response_id.
+        stream: When ``True``, opens an SSE stream to resume the response from
+            ``starting_after``. Returns a streaming iterator instead of a
+            single :class:`ResponsesAPIResponse`.
+        starting_after: The last ``sequence_number`` already received by the
+            caller. Only meaningful when ``stream=True``.
 
     Returns:
-        The response object with complete information about the stored response.
+        The response object, or a streaming iterator when ``stream=True``.
     """
     local_vars = locals()
     try:
@@ -1522,6 +1547,9 @@ def get_responses(
             _is_async=_is_async,
             client=kwargs.get("client"),
             shared_session=kwargs.get("shared_session"),
+            stream=stream,
+            starting_after=starting_after,
+            litellm_metadata=kwargs.get("litellm_metadata"),
         )
 
         # Update the responses_api_response_id with the model_id

--- a/tests/test_litellm/responses/test_get_responses_stream_resume.py
+++ b/tests/test_litellm/responses/test_get_responses_stream_resume.py
@@ -1,0 +1,175 @@
+"""
+Tests for cursor-based stream resume on the Responses API retrieve endpoint.
+
+Covers the GET /v1/responses/{response_id}?stream=true&starting_after=N flow:
+
+- Provider transforms (OpenAI, Azure) put ``stream`` and ``starting_after``
+  into the returned ``data`` dict so the HTTP layer attaches them as query
+  params.
+- Provider transforms that do not support resume (Volcengine, Manus) accept
+  the new arguments without breaking (signature parity with the base class).
+- The async core dispatcher ``litellm.aget_responses(stream=True, ...)``
+  returns a streaming iterator instead of a non-streaming
+  :class:`ResponsesAPIResponse`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from litellm.llms.azure.responses.transformation import AzureOpenAIResponsesAPIConfig
+from litellm.llms.manus.responses.transformation import ManusResponsesAPIConfig
+from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+from litellm.llms.volcengine.responses.transformation import VolcEngineResponsesAPIConfig
+from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+from litellm.types.router import GenericLiteLLMParams
+
+
+# ---------------------------------------------------------------------------
+# Provider transform tests
+# ---------------------------------------------------------------------------
+
+
+def _params() -> GenericLiteLLMParams:
+    return GenericLiteLLMParams(api_base="https://api.openai.com/v1/responses")
+
+
+def test_openai_transform_includes_stream_and_starting_after() -> None:
+    config = OpenAIResponsesAPIConfig()
+    url, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://api.openai.com/v1/responses",
+        litellm_params=_params(),
+        headers={},
+        stream=True,
+        starting_after=42,
+    )
+    assert url == "https://api.openai.com/v1/responses/resp_abc"
+    assert data == {"stream": "true", "starting_after": 42}
+
+
+def test_openai_transform_omits_resume_args_when_not_set() -> None:
+    config = OpenAIResponsesAPIConfig()
+    url, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://api.openai.com/v1/responses",
+        litellm_params=_params(),
+        headers={},
+    )
+    assert url == "https://api.openai.com/v1/responses/resp_abc"
+    assert data == {}
+
+
+def test_azure_transform_includes_stream_and_starting_after() -> None:
+    config = AzureOpenAIResponsesAPIConfig()
+    url, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://example.openai.azure.com/openai/responses?api-version=2025-04-01-preview",
+        litellm_params=GenericLiteLLMParams(
+            api_base="https://example.openai.azure.com/",
+            api_version="2025-04-01-preview",
+        ),
+        headers={},
+        stream=True,
+        starting_after=6,
+    )
+    # URL must contain the response_id; query params live in ``data``.
+    assert "resp_abc" in url
+    assert data == {"stream": "true", "starting_after": 6}
+
+
+def test_volcengine_transform_accepts_resume_args_without_using_them() -> None:
+    config = VolcEngineResponsesAPIConfig()
+    _, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://example.volces.com/v1/responses",
+        litellm_params=_params(),
+        headers={},
+        stream=True,
+        starting_after=10,
+    )
+    # Volcengine does not support resume; args are silently ignored.
+    assert data == {}
+
+
+def test_manus_transform_accepts_resume_args_without_using_them() -> None:
+    config = ManusResponsesAPIConfig()
+    _, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://api.manus.im/v1/responses",
+        litellm_params=_params(),
+        headers={},
+        stream=True,
+        starting_after=10,
+    )
+    assert data == {}
+
+
+# ---------------------------------------------------------------------------
+# Core dispatcher streaming test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aget_responses_stream_returns_streaming_iterator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``litellm.aget_responses(stream=True, starting_after=N)`` must return a
+    :class:`ResponsesAPIStreamingIterator` rather than a single
+    :class:`ResponsesAPIResponse`. We stub out the underlying HTTP client to
+    keep the test offline and assert on the wiring (URL params + iterator
+    type).
+    """
+    import litellm
+    from litellm.llms.custom_httpx import llm_http_handler as handler_module
+
+    captured: dict[str, Any] = {}
+
+    async def fake_get(
+        url: str,
+        headers: dict | None = None,
+        params: dict | None = None,
+        stream: bool = False,
+        timeout: Any = None,
+        **_: Any,
+    ) -> httpx.Response:
+        captured["url"] = url
+        captured["params"] = params
+        captured["stream"] = stream
+        # An empty SSE-style body — the iterator can be constructed from any
+        # httpx.Response with ``aiter_lines``; we only care about wiring here.
+        return httpx.Response(
+            status_code=200,
+            content=b"",
+            request=httpx.Request("GET", url),
+        )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr(
+        handler_module,
+        "get_async_httpx_client",
+        lambda *a, **kw: fake_client,
+    )
+
+    response_id = (
+        "resp_test_stream_resume_with_a_long_enough_id_to_satisfy_validators"
+    )
+    result = await litellm.aget_responses(
+        response_id=response_id,
+        stream=True,
+        starting_after=6,
+        custom_llm_provider="openai",
+        api_key="sk-test",
+        api_base="https://api.openai.com/v1/responses",
+    )
+
+    assert isinstance(result, ResponsesAPIStreamingIterator)
+    assert captured["stream"] is True
+    assert captured["params"] == {"stream": "true", "starting_after": 6}
+    assert response_id in captured["url"]


### PR DESCRIPTION
## Relevant issues

Adds end-to-end support for cursor-based stream resume on the Responses API
retrieve endpoint — i.e. proxying
`client.responses.retrieve(response_id, stream=True, starting_after=N)` from
the OpenAI Python SDK through the LiteLLM gateway to the underlying
provider.

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/responses/test_get_responses_stream_resume.py` (6 new test cases)
- [x] My PR passes the relevant unit tests locally (`tests/test_litellm/responses/`, `tests/test_litellm/llms/custom_httpx/`, `tests/test_litellm/proxy/response_api_endpoints/`, `tests/test_litellm/proxy/test_route_llm_request.py` — 372+ tests pass)
- [x] My PR's scope is isolated: it only adds resume support to the existing retrieve path; no behavior change for callers that don't pass `stream=True`.

## Type

- Feature

## Why

Today, calling `client.responses.retrieve(response_id, stream=True, starting_after=N)`
through the LiteLLM proxy returns 200 OK with an empty body — a silent no-op.
The reasons:

1. The proxy GET handler (`litellm/proxy/response_api_endpoints/endpoints.py::get_response`)
   only reads the request **body** (which is empty for a GET) and ignores
   the OpenAI SDK's `?stream=true&starting_after=N` query parameters.
2. The core `litellm.aget_responses` has no `stream` or `starting_after`
   parameters, and `starting_after` was not referenced anywhere in the Python
   codebase.
3. The provider transforms (`transform_get_response_api_request`) build a
   plain `GET /v1/responses/{id}` URL with no resume query params.

OpenAI and Azure OpenAI (`api-version=2025-04-01-preview`) both natively
support cursor-based stream resume on this endpoint — verified empirically
by hitting Azure directly. This PR wires it through LiteLLM.

## What

Five surgical, backward-compatible changes:

| Layer | File | Change |
| --- | --- | --- |
| Base config | `litellm/llms/base_llm/responses/transformation.py` | Add optional `stream: bool = False` and `starting_after: Optional[int] = None` to abstract `transform_get_response_api_request`. |
| OpenAI / Azure transforms | `litellm/llms/openai/responses/transformation.py`, `litellm/llms/azure/responses/transformation.py` | Surface `stream=true` and `starting_after` via the returned `data` dict so the HTTP layer attaches them as query params. |
| Volcengine / Manus transforms | `litellm/llms/volcengine/responses/transformation.py`, `litellm/llms/manus/responses/transformation.py` | Accept the new args for signature parity but ignore them (resume not supported there). |
| Async HTTP handler | `litellm/llms/custom_httpx/http_handler.py` | `AsyncHTTPHandler.get` learns to open an SSE-style stream via `client.send(req, stream=True)` so callers can iterate `response.aiter_lines()`. |
| Responses HTTP handler | `litellm/llms/custom_httpx/llm_http_handler.py` | `async_get_responses` returns a `ResponsesAPIStreamingIterator` (the same iterator class used for streaming POSTs) when `stream=True`. |
| Core dispatcher | `litellm/responses/main.py` | `aget_responses` / `get_responses` accept `stream` / `starting_after` and forward them down the stack. |
| Proxy GET handler | `litellm/proxy/response_api_endpoints/endpoints.py` | `get_response` reads `stream` and `starting_after` from `request.query_params` and injects them into `data`, so the existing streaming branch in `base_process_llm_request` returns a `text/event-stream` response. |

The existing `select_data_generator` / `async_data_generator` infrastructure
in the proxy already handles SSE serialization for `BaseModel` chunks, so
the streaming retrieve path returns a valid `text/event-stream` response
without any new generator code.

## Tests

New: `tests/test_litellm/responses/test_get_responses_stream_resume.py`

- `test_openai_transform_includes_stream_and_starting_after`
- `test_openai_transform_omits_resume_args_when_not_set`
- `test_azure_transform_includes_stream_and_starting_after`
- `test_volcengine_transform_accepts_resume_args_without_using_them`
- `test_manus_transform_accepts_resume_args_without_using_them`
- `test_aget_responses_stream_returns_streaming_iterator` (offline, monkeypatches `httpx`)

Existing test suites pass unchanged (responses, custom_httpx, proxy
response_api_endpoints, proxy route_llm_request).

## Screenshots / Proof of Fix

End-to-end smoke test against an Azure-backed LiteLLM proxy
(`gpt-5-mini`, US-West, `api-version=2025-04-01-preview`):

**Before this PR** (LiteLLM v1.83.13-nightly, v1.83.0-nightly, v1.82.6 — all
identical):

```json
{
  "primary_event_count": 8,
  "primary_last_seq": 6,
  "resume_event_count": 0,
  "resume_first_seq": null,
  "saw_completed": false,
  "completion_status": null,
  "final_text_len": 0
}
```

**After this PR** (same Azure backend, same prompt):

```json
{
  "primary_event_count": 8,
  "primary_last_seq": 6,
  "resume_event_count": 326,
  "resume_first_seq": 7,
  "resume_first_event_type": "response.output_text.delta",
  "saw_completed": true,
  "completion_status": "completed",
  "final_text_len": 1944
}
```

The cut-and-resume stitches into a coherent 1944-character response that
ends on `response.completed` with `status=completed`.

## Backward compatibility

All new parameters default to "off" (`stream=False`, `starting_after=None`).
Callers that don't pass them see no behavior change. Provider transforms
that inherit the old signature now receive two new optional kwargs;
`base_llm/responses/transformation.py` is the only abstract method
signature that changed, and all four in-tree implementations are updated
in this PR.
