### PR TITLE
feat: add Astraflow (ModelVerse) provider support

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -763,6 +763,8 @@ openai_compatible_endpoints: List = [
     "https://ai-gateway.vercel.sh/v1",
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
+    "api-us-ca.umodelverse.ai/v1",
+    "api.modelverse.cn/v1",
 ]
 
 
@@ -821,6 +823,8 @@ openai_compatible_providers: List = [
     "clarifai",
     "docker_model_runner",
     "ragflow",
+    "astraflow",  # Astraflow (ModelVerse) Global node - JSON-configured provider
+    "astraflow-cn",  # Astraflow (ModelVerse) China node - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: List = (
     [  # providers that support `/v1/completions`

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -95,6 +95,14 @@
     "base_url": "https://llm-gateway.assemblyai.com/v1",
     "api_key_env": "ASSEMBLYAI_API_KEY"
   },
+  "astraflow": {
+    "base_url": "https://api-us-ca.umodelverse.ai/v1",
+    "api_key_env": "ASTRAFLOW_API_KEY"
+  },
+  "astraflow-cn": {
+    "base_url": "https://api.modelverse.cn/v1",
+    "api_key_env": "ASTRAFLOW_CN_API_KEY"
+  },
   "charity_engine": {
     "base_url": "https://api.charityengine.services/remotejobs/v2/inference",
     "api_key_env": "CHARITY_ENGINE_API_KEY",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3332,6 +3332,8 @@ class LlmProviders(str, Enum):
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"
 
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow-cn"
 
 # Create a set of all provider values for quick lookup
 LlmProvidersSet = {provider.value for provider in LlmProviders}


### PR DESCRIPTION
## Add Astraflow (UCloud ModelVerse) Provider Support

This PR integrates **Astraflow (UCloud ModelVerse)** — an OpenAI-compatible AI model aggregation platform — as two independent regional providers:

| Provider slug | Region | Base URL | API Key env var |
|---|---|---|---|
| `astraflow` | Global (US/CA) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| `astraflow-cn` | China | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

ModelVerse supports DeepSeek, GPT-4, Claude, and many other models via a unified OpenAI-compatible API.

---

### Changes

#### 1. `litellm/llms/openai_like/providers.json`
Registers both regional providers via the JSON-based provider config system.

#### 2. `litellm/types/utils.py`
Adds `ASTRAFLOW` and `ASTRAFLOW_CN` to the `LlmProviders` enum so the providers appear in `litellm.provider_list`.

#### 3. `litellm/constants.py`
Adds both slugs to `openai_compatible_providers` (and their base URLs to `openai_compatible_endpoints`) to enable automatic provider detection from `api_base`.

---

### Usage

```python
import litellm

# Global node (US/CA)
response = litellm.completion(
    model="astraflow/claude-3-5-haiku-20241022",
    messages=[{"role": "user", "content": "Hello!"}],
    api_key="your-ASTRAFLOW_API_KEY",
)

# China node
response = litellm.completion(
    model="astraflow-cn/deepseek-ai/DeepSeek-V3",
    messages=[{"role": "user", "content": "你好！"}],
    api_key="your-ASTRAFLOW_CN_API_KEY",
)
```

Or via environment variables:
```bash
export ASTRAFLOW_API_KEY="sk-..."
export ASTRAFLOW_CN_API_KEY="sk-..."
```

```python
response = litellm.completion(
    model="astraflow/claude-3-5-haiku-20241022",
    messages=[{"role": "user", "content": "Hello!"}],
)
```
