### PR TITLE
fix(ui): correct npm min-release-age values

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/litellm-js/proxy/.npmrc
+++ b/litellm-js/proxy/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/litellm-js/spend-logs/.npmrc
+++ b/litellm-js/spend-logs/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/tests/proxy_admin_ui_tests/.npmrc
+++ b/tests/proxy_admin_ui_tests/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc
+++ b/tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/ui/litellm-dashboard/.npmrc
+++ b/ui/litellm-dashboard/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3


### PR DESCRIPTION
The dashboard and related npmrc files used min-release-age=3d, which breaks npm installs in environments that validate the config value strictly. This change switches those files to min-release-age=3, matching the merged fix from PR #25058. Verified with npm config get min-release-age and npm ci --dry-run in ui/litellm-dashboard.