### PR TITLE
[Fix] UI - Allow Proxy Admin Viewer to access /api-keys page

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/proxy-admin-viewer/api-keys-access.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/proxy-admin-viewer/api-keys-access.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import {
+  ADMIN_VIEWER_STORAGE_PATH,
+  E2E_INTERNAL_USER_KEY_ALIAS,
+} from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage } from "../../helpers/navigation";
+
+test.describe("Proxy Admin Viewer - Keys (read-only)", () => {
+  test.use({ storageState: ADMIN_VIEWER_STORAGE_PATH });
+
+  test("Sees the keys table without an Access Denied gate", async ({ page }) => {
+    await navigateToPage(page, Page.ApiKeys);
+
+    // Hard entry-level gate is gone.
+    await expect(page.getByText("Access Denied")).toHaveCount(0);
+    await expect(
+      page.getByText("Ask your proxy admin for access to create keys"),
+    ).toHaveCount(0);
+
+    // Admin viewer has the same all-keys view as proxy admin
+    // (backend use_substring_matching path).
+    await expect(page.getByText(E2E_INTERNAL_USER_KEY_ALIAS)).toBeVisible({ timeout: 10_000 });
+
+    // rolesWithWriteAccess guard hides the create affordance.
+    await expect(page.getByRole("button", { name: /Create New Key/i })).toHaveCount(0);
+  });
+
+  test("Can open a key detail view but cannot regenerate / delete / edit", async ({ page }) => {
+    await navigateToPage(page, Page.ApiKeys);
+
+    // Open the detail view of one of the seeded keys.
+    const keyRow = page.locator("tr", { hasText: E2E_INTERNAL_USER_KEY_ALIAS });
+    await expect(keyRow).toBeVisible({ timeout: 10_000 });
+    await keyRow.locator("button").first().click();
+
+    // Detail view loaded.
+    await expect(page.getByText("Back to Keys")).toBeVisible({ timeout: 10_000 });
+
+    // No write affordances on the detail view.
+    await expect(page.getByRole("button", { name: "Regenerate Key" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Delete Key" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Edit Settings" })).toHaveCount(0);
+  });
+});

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -324,9 +324,6 @@ function CreateKeyPageContent() {
       if (decoded.user_role) {
         const formattedUserRole = formatUserRole(decoded.user_role);
         setUserRole(formattedUserRole);
-        if (formattedUserRole == "Admin Viewer") {
-          setPage("usage");
-        }
       }
 
       if (decoded.user_email) {

--- a/ui/litellm-dashboard/src/components/user_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import React from "react";
 import { renderWithProviders } from "../../tests/test-utils";
 
@@ -136,5 +136,26 @@ describe("UserDashboard beforeunload listener", () => {
       ([event]) => event === "beforeunload",
     );
     expect(removeCalls).toHaveLength(1);
+  });
+});
+
+describe("UserDashboard role-based rendering", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the keys page (no Access Denied screen) for proxy_admin_viewer", () => {
+    renderDashboard({ userRole: "Admin Viewer" });
+
+    expect(screen.queryByText("Access Denied")).toBeNull();
+    expect(screen.queryByText("Ask your proxy admin for access to create keys")).toBeNull();
+    expect(screen.getByTestId("virtual-keys-table-mock")).toBeInTheDocument();
+  });
+
+  it("renders the keys page for proxy_admin", () => {
+    renderDashboard({ userRole: "Admin" });
+
+    expect(screen.queryByText("Access Denied")).toBeNull();
+    expect(screen.getByTestId("virtual-keys-table-mock")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -317,16 +317,6 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
     setUserRole("App Owner");
   }
 
-  if (userRole && userRole == "Admin Viewer") {
-    const { Title, Paragraph } = Typography;
-    return (
-      <div>
-        <Title level={1}>Access Denied</Title>
-        <Paragraph>Ask your proxy admin for access to create keys</Paragraph>
-      </div>
-    );
-  }
-
   console.log("inside user dashboard, selected team", selectedTeam);
   console.log("All cookies after redirect:", document.cookie);
   return (


### PR DESCRIPTION
## Relevant issues

Fixes #26689

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### AS-IS

<img width="1267" height="888" alt="스크린샷 2026-04-28 오후 8 23 16" src="https://github.com/user-attachments/assets/33337057-a525-4e83-8e57-970b5c36f4c9" />


### TO-BE

<img width="1267" height="888" alt="스크린샷 2026-04-28 오후 8 09 41" src="https://github.com/user-attachments/assets/791a7d7c-481a-457f-8712-9fd2e5ee7358" />

## Type

🐛 Bug Fix

## Changes
Remove the entry-level "Access Denied" gate in ui/litellm-dashboard/src/components/user_dashboard.tsx that was hard-blocking proxy_admin_viewer from /ui/?page=api-keys. 

The backend (admin_viewer_routes, route_checks, key handler) already allows /key/list and /key/info for this role, and component-level guards (rolesWithWriteAccess in ui/litellm-dashboard/src/utils/roles.ts) already hide Create / Edit / Delete affordances — so the gate was redundant and inconsistent with the role's documented intent.


There's a useEffect that was forcing page to "usage" for Admin Viewer right after JWT decode, so even if you went to /ui?page=api-keys it would silently rewrite the URL. 

That was probably a workaround for the Access Denied screen (push viewers somewhere they can actually see something). 

Now that the gate is gone, viewers can stay on the keys page in read-only mode, so the redirect isn't needed anymore. also the e2e below would fail without removing it.

### Tests

- vitest: UserDashboard renders the keys table for both Admin Viewer and proxy_admin (no Access Denied screen).
- e2e: 
  - as proxy_admin_viewer, /ui?page=api-keys shows the keys table, other users' seeded keys are visible (admin scope), and the Create New Key button is hidden
  - clicking into a key detail view works, but Regenerate Key / Delete Key / Edit Settings buttons are hidden.