### PR TITLE
fix(github-copilot): invalidate stale access token on 401 and re-acquire

### DIFF
--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -153,10 +153,11 @@ class Authenticator:
         """
         Refresh the API key using the access token.
 
-        On a 401 response the cached access token is deleted and a fresh
-        token is acquired before retrying. If re-acquisition succeeds the
-        invalidation is not repeated; if it fails each subsequent 401
-        re-attempts.
+        On a 401 response, the retry loop drains with the stale token by
+        default, matching pre-recovery behavior. When
+        ``GITHUB_COPILOT_ENABLE_AUTH_RECOVERY=true``, the cached access token
+        is deleted and a fresh token is acquired before retrying. Invalidation
+        runs at most once per call.
 
         Returns:
             Dict[str, Any]: The API key information including token and expiration.
@@ -194,6 +195,10 @@ class Authenticator:
                     result = self._invalidate_and_reacquire_token()
                     token_invalidated = True
                     if result is None:
+                        verbose_logger.info(
+                            "Token invalidation did not yield a fresh token; "
+                            "remaining retries will reuse the stale token."
+                        )
                         continue
                     access_token = result
             except Exception as e:
@@ -208,15 +213,32 @@ class Authenticator:
         """
         Delete the cached access token and re-acquire via device-flow login.
 
+        When ``GITHUB_COPILOT_ENABLE_AUTH_RECOVERY`` is unset or not
+        ``"true"``, this returns ``None`` immediately. That preserves the
+        pre-recovery behavior of failing fast on a 401 without printing a
+        device-flow prompt or blocking on user interaction.
+
         Returns:
-            The fresh access token, or None if either the file deletion or
-            re-acquisition failed (the caller should continue to the next
-            retry with the existing token).
+            The fresh access token, or None if auth recovery is disabled, the
+            file deletion failed, or re-acquisition failed (the caller
+            should continue to the next retry with the existing token).
         """
+        auth_recovery_enabled = (
+            os.getenv("GITHUB_COPILOT_ENABLE_AUTH_RECOVERY", "false").lower() == "true"
+        )
+        if not auth_recovery_enabled:
+            verbose_logger.info(
+                "Skipping access-token recovery: "
+                "GITHUB_COPILOT_ENABLE_AUTH_RECOVERY is not set."
+            )
+            return None
         try:
             os.remove(self.access_token_file)
-        except OSError:
-            verbose_logger.warning("Failed to delete cached access token file")
+        except OSError as e:
+            verbose_logger.warning(
+                f"Failed to delete cached access token file "
+                f"{self.access_token_file}: {repr(e)}"
+            )
             return None
         try:
             return self.get_access_token()

--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -126,7 +126,7 @@ class Authenticator:
                 message=f"Failed to save API key: {str(e)}",
                 status_code=500,
             )
-        except RefreshAPIKeyError as e:
+        except (RefreshAPIKeyError, GetAccessTokenError) as e:
             raise GetAPIKeyError(
                 message=f"Failed to refresh API key: {str(e)}",
                 status_code=401,
@@ -153,6 +153,11 @@ class Authenticator:
         """
         Refresh the API key using the access token.
 
+        On a 401 response the cached access token is deleted and a fresh
+        token is acquired before retrying. If re-acquisition succeeds the
+        invalidation is not repeated; if it fails each subsequent 401
+        re-attempts.
+
         Returns:
             Dict[str, Any]: The API key information including token and expiration.
 
@@ -160,13 +165,14 @@ class Authenticator:
             RefreshAPIKeyError: If unable to refresh the API key.
         """
         access_token = self.get_access_token()
-        headers = self._get_github_headers(access_token)
         api_key_url = os.getenv(
             "GITHUB_COPILOT_API_KEY_URL", DEFAULT_GITHUB_API_KEY_URL
         )
+        token_invalidated = False
 
         max_retries = 3
         for attempt in range(max_retries):
+            headers = self._get_github_headers(access_token)
             try:
                 sync_client = _get_httpx_client()
                 response = sync_client.get(api_key_url, headers=headers)
@@ -184,6 +190,12 @@ class Authenticator:
                 verbose_logger.error(
                     f"HTTP error refreshing API key (attempt {attempt+1}/{max_retries}): {str(e)}"
                 )
+                if e.response.status_code == 401 and not token_invalidated:
+                    result = self._invalidate_and_reacquire_token()
+                    token_invalidated = True
+                    if result is None:
+                        continue
+                    access_token = result
             except Exception as e:
                 verbose_logger.error(f"Unexpected error refreshing API key: {str(e)}")
 
@@ -191,6 +203,28 @@ class Authenticator:
             message="Failed to refresh API key after maximum retries",
             status_code=401,
         )
+
+    def _invalidate_and_reacquire_token(self) -> Optional[str]:
+        """
+        Delete the cached access token and re-acquire via device-flow login.
+
+        Returns:
+            The fresh access token, or None if either the file deletion or
+            re-acquisition failed (the caller should continue to the next
+            retry with the existing token).
+        """
+        try:
+            os.remove(self.access_token_file)
+        except OSError:
+            verbose_logger.warning("Failed to delete cached access token file")
+            return None
+        try:
+            return self.get_access_token()
+        except (GetAccessTokenError, GetDeviceCodeError) as e:
+            verbose_logger.warning(
+                f"Failed to re-acquire access token after 401: {str(e)}"
+            )
+            return None
 
     def _ensure_token_dir(self) -> None:
         """Ensure the token directory exists."""

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py
@@ -1,6 +1,5 @@
 import json
 import os
-import time
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -9,7 +8,6 @@ import pytest
 
 from litellm.llms.github_copilot.authenticator import Authenticator
 from litellm.llms.github_copilot.common_utils import (
-    APIKeyExpiredError,
     GetAccessTokenError,
     GetAPIKeyError,
     GetDeviceCodeError,
@@ -108,7 +106,7 @@ class TestGitHubCopilotAuthenticator:
         with (
             patch.object(authenticator, "_login", return_value=mock_token),
             patch("builtins.open", mock_open()),
-            patch("builtins.open", side_effect=IOError) as mock_read,
+            patch("builtins.open", side_effect=IOError),
         ):
             token = authenticator.get_access_token()
             assert token == mock_token
@@ -153,7 +151,7 @@ class TestGitHubCopilotAuthenticator:
         with (
             patch("builtins.open", mock_open(read_data=mock_expired_data)),
             patch.object(authenticator, "_refresh_api_key", return_value=mock_new_data),
-            patch("json.dump") as mock_json_dump,
+            patch("json.dump"),
         ):
             api_key = authenticator.get_api_key()
             assert api_key == "new-api-key"
@@ -374,6 +372,7 @@ class TestGitHubCopilotAuthenticator:
         ]
 
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator,
                 "get_access_token",
@@ -404,6 +403,7 @@ class TestGitHubCopilotAuthenticator:
         mock_client.get.return_value = self._make_failing_response(http_401)
 
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator,
                 "get_access_token",
@@ -448,6 +448,7 @@ class TestGitHubCopilotAuthenticator:
         ]
 
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator,
                 "get_access_token",
@@ -511,6 +512,7 @@ class TestGitHubCopilotAuthenticator:
             message="device flow failed", status_code=401
         )
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator,
                 "get_access_token",
@@ -542,6 +544,7 @@ class TestGitHubCopilotAuthenticator:
 
         reacquire_err = GetDeviceCodeError(message="no device code", status_code=400)
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator,
                 "get_access_token",
@@ -571,6 +574,7 @@ class TestGitHubCopilotAuthenticator:
         mock_client.get.return_value = self._make_failing_response(http_401)
 
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator, "get_access_token", return_value="stale-token"
             ) as mock_get_token,
@@ -628,6 +632,7 @@ class TestGitHubCopilotAuthenticator:
         ]
 
         with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ENABLE_AUTH_RECOVERY": "true"}),
             patch.object(
                 authenticator,
                 "get_access_token",
@@ -678,8 +683,8 @@ class TestGitHubCopilotAuthenticator:
             assert mock_client.get.call_count == 3
 
     def test_get_api_key_catches_access_token_error(self, authenticator):
-        """get_api_key catches GetAccessTokenError from _refresh_api_key and
-        wraps it in GetAPIKeyError (B2 fix)."""
+        """get_api_key catches GetAccessTokenError from _refresh_api_key
+        and wraps it in GetAPIKeyError."""
         with (
             patch("builtins.open", side_effect=IOError),
             patch.object(
@@ -692,3 +697,36 @@ class TestGitHubCopilotAuthenticator:
         ):
             with pytest.raises(GetAPIKeyError, match="refresh API key"):
                 authenticator.get_api_key()
+
+    def test_refresh_api_key_401_default_no_auth_recovery(self, authenticator):
+        """By default, a 401 does NOT delete the
+        cached token or run device flow. The retry loop drains with the
+        stale token and raises RefreshAPIKeyError, matching pre-fix behavior.
+        Recovery is opt-in via GITHUB_COPILOT_ENABLE_AUTH_RECOVERY=true."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_401)
+
+        env_without_var = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "GITHUB_COPILOT_ENABLE_AUTH_RECOVERY"
+        }
+        with (
+            patch.dict(os.environ, env_without_var, clear=True),
+            patch.object(authenticator, "get_access_token", return_value="stale-token"),
+            patch("os.remove") as mock_remove,
+            patch.object(authenticator, "_get_device_code") as mock_device_code,
+            patch.object(authenticator, "_poll_for_access_token") as mock_poll,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            mock_remove.assert_not_called()
+            mock_device_code.assert_not_called()
+            mock_poll.assert_not_called()
+            assert mock_client.get.call_count == 3

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, mock_open, patch
 
+import httpx
 import pytest
 
 from litellm.llms.github_copilot.authenticator import Authenticator
@@ -35,6 +36,30 @@ class TestGitHubCopilotAuthenticator:
         mock_client.post.return_value = mock_response
         mock_response.raise_for_status.return_value = None
         return mock_client, mock_response
+
+    @staticmethod
+    def _make_http_error(status_code: int, message: str = "") -> httpx.HTTPStatusError:
+        """Build an ``httpx.HTTPStatusError`` with the given status code."""
+        msg = message or f"{status_code} Error"
+        request = MagicMock(spec=httpx.Request)
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = status_code
+        return httpx.HTTPStatusError(msg, request=request, response=response)
+
+    @staticmethod
+    def _make_failing_response(error: httpx.HTTPStatusError) -> MagicMock:
+        """Return a mock response whose ``raise_for_status`` throws *error*."""
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = error
+        return resp
+
+    @staticmethod
+    def _make_success_response(payload: dict) -> MagicMock:
+        """Return a mock response that succeeds with *payload*."""
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = payload
+        return resp
 
     def test_init(self):
         """Test the initialization of the authenticator."""
@@ -255,12 +280,19 @@ class TestGitHubCopilotAuthenticator:
             "user_code": "UC",
             "verification_uri": "https://example.com",
         }
-        with patch.dict(os.environ, {"GITHUB_COPILOT_DEVICE_CODE_URL": custom_url}), \
-             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client):
+        with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_DEVICE_CODE_URL": custom_url}),
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
             authenticator._get_device_code()
             assert mock_client.post.call_args[0][0] == custom_url
 
-    def test_get_device_code_with_custom_client_id(self, authenticator, mock_http_client):
+    def test_get_device_code_with_custom_client_id(
+        self, authenticator, mock_http_client
+    ):
         """GITHUB_COPILOT_CLIENT_ID env var must appear as client_id in the device-code request body."""
         mock_client, mock_response = mock_http_client
         custom_id = "custom_client_id"
@@ -269,30 +301,49 @@ class TestGitHubCopilotAuthenticator:
             "user_code": "UC",
             "verification_uri": "https://example.com",
         }
-        with patch.dict(os.environ, {"GITHUB_COPILOT_CLIENT_ID": custom_id}), \
-             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client):
+        with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_CLIENT_ID": custom_id}),
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
             authenticator._get_device_code()
             assert mock_client.post.call_args[1]["json"]["client_id"] == custom_id
 
-    def test_poll_for_access_token_with_custom_url(self, authenticator, mock_http_client):
+    def test_poll_for_access_token_with_custom_url(
+        self, authenticator, mock_http_client
+    ):
         """GITHUB_COPILOT_ACCESS_TOKEN_URL env var must be used by _poll_for_access_token at call time."""
         mock_client, mock_response = mock_http_client
         custom_url = "https://custom.example.com/token"
         mock_response.json.return_value = {"access_token": "tok"}
-        with patch.dict(os.environ, {"GITHUB_COPILOT_ACCESS_TOKEN_URL": custom_url}), \
-             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client), \
-             patch("time.sleep"):
+        with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_ACCESS_TOKEN_URL": custom_url}),
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+            patch("time.sleep"),
+        ):
             authenticator._poll_for_access_token("dc")
             assert mock_client.post.call_args[0][0] == custom_url
 
-    def test_poll_for_access_token_with_custom_client_id(self, authenticator, mock_http_client):
+    def test_poll_for_access_token_with_custom_client_id(
+        self, authenticator, mock_http_client
+    ):
         """GITHUB_COPILOT_CLIENT_ID env var must appear as client_id in the polling request body."""
         mock_client, mock_response = mock_http_client
         custom_id = "custom_client_id"
         mock_response.json.return_value = {"access_token": "tok"}
-        with patch.dict(os.environ, {"GITHUB_COPILOT_CLIENT_ID": custom_id}), \
-             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client), \
-             patch("time.sleep"):
+        with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_CLIENT_ID": custom_id}),
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+            patch("time.sleep"),
+        ):
             authenticator._poll_for_access_token("dc")
             assert mock_client.post.call_args[1]["json"]["client_id"] == custom_id
 
@@ -301,9 +352,343 @@ class TestGitHubCopilotAuthenticator:
         mock_client, mock_response = mock_http_client
         custom_url = "https://custom.example.com/api-key"
         mock_response.json.return_value = {"token": "api-tok", "expires_at": 9999999999}
-        with patch.dict(os.environ, {"GITHUB_COPILOT_API_KEY_URL": custom_url}), \
-             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client), \
-             patch.object(authenticator, "get_access_token", return_value="access-tok"):
+        with (
+            patch.dict(os.environ, {"GITHUB_COPILOT_API_KEY_URL": custom_url}),
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+            patch.object(authenticator, "get_access_token", return_value="access-tok"),
+        ):
             authenticator._refresh_api_key()
             assert mock_client.get.call_args[0][0] == custom_url
 
+    def test_refresh_api_key_401_invalidates_and_retries(self, authenticator):
+        """A 401 deletes the cached token, re-acquires, and retries with the
+        fresh token in the Authorization header."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [
+            self._make_failing_response(http_401),
+            self._make_success_response({"token": "new-api-key", "expires_at": 99999}),
+        ]
+
+        with (
+            patch.object(
+                authenticator,
+                "get_access_token",
+                side_effect=["stale-token", "fresh-token"],
+            ),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            result = authenticator._refresh_api_key()
+
+            assert result == {"token": "new-api-key", "expires_at": 99999}
+            mock_remove.assert_called_once_with(authenticator.access_token_file)
+
+            # Verify stale token on first call, fresh on second
+            first_headers = mock_client.get.call_args_list[0][1]["headers"]
+            assert first_headers["authorization"] == "token stale-token"
+            second_headers = mock_client.get.call_args_list[1][1]["headers"]
+            assert second_headers["authorization"] == "token fresh-token"
+
+    def test_refresh_api_key_401_invalidates_only_once(self, authenticator):
+        """Persistent 401s delete the token exactly once; remaining retries
+        use the fresh token until exhaustion."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_401)
+
+        with (
+            patch.object(
+                authenticator,
+                "get_access_token",
+                side_effect=["stale-token", "fresh-token"],
+            ),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            mock_remove.assert_called_once_with(authenticator.access_token_file)
+            assert mock_client.get.call_count == 3
+
+            # Attempt 1 used stale token, attempts 2+3 used fresh token
+            assert (
+                mock_client.get.call_args_list[0][1]["headers"]["authorization"]
+                == "token stale-token"
+            )
+            assert (
+                mock_client.get.call_args_list[1][1]["headers"]["authorization"]
+                == "token fresh-token"
+            )
+            assert (
+                mock_client.get.call_args_list[2][1]["headers"]["authorization"]
+                == "token fresh-token"
+            )
+
+    def test_refresh_api_key_401_on_second_attempt(self, authenticator):
+        """A 401 on attempt 2 (after a 500 on attempt 1) still deletes the
+        token and retries with a fresh one."""
+        http_500 = self._make_http_error(500, "500 Internal Server Error")
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [
+            self._make_failing_response(http_500),
+            self._make_failing_response(http_401),
+            self._make_success_response({"token": "recovered", "expires_at": 99999}),
+        ]
+
+        with (
+            patch.object(
+                authenticator,
+                "get_access_token",
+                side_effect=["stale-token", "fresh-token"],
+            ),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            result = authenticator._refresh_api_key()
+
+            assert result == {"token": "recovered", "expires_at": 99999}
+            mock_remove.assert_called_once()
+
+            # Attempts 1 (500) and 2 (401) used stale token
+            assert (
+                mock_client.get.call_args_list[0][1]["headers"]["authorization"]
+                == "token stale-token"
+            )
+            assert (
+                mock_client.get.call_args_list[1][1]["headers"]["authorization"]
+                == "token stale-token"
+            )
+            # Attempt 3 used fresh token after invalidation
+            assert (
+                mock_client.get.call_args_list[2][1]["headers"]["authorization"]
+                == "token fresh-token"
+            )
+
+    def test_refresh_api_key_non_401_does_not_invalidate(self, authenticator):
+        """Non-401 HTTP errors do NOT trigger token invalidation."""
+        http_500 = self._make_http_error(500, "500 Internal Server Error")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_500)
+
+        with (
+            patch.object(authenticator, "get_access_token", return_value="mock-token"),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            mock_remove.assert_not_called()
+            assert mock_client.get.call_count == 3
+
+    def test_refresh_api_key_401_reacquire_fails_raises_cleanly(self, authenticator):
+        """When device flow fails after token deletion, the file is already
+        gone so token_invalidated is set True — no further invalidation
+        attempts. The loop exhausts and raises RefreshAPIKeyError."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_401)
+
+        reacquire_err = GetAccessTokenError(
+            message="device flow failed", status_code=401
+        )
+        with (
+            patch.object(
+                authenticator,
+                "get_access_token",
+                side_effect=["stale-token", reacquire_err],
+            ),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            assert mock_client.get.call_count == 3
+            # File deleted once on first 401; no re-attempts (file already gone)
+            mock_remove.assert_called_once()
+            # All 3 attempts used the stale token (re-acquire never succeeded)
+            for call in mock_client.get.call_args_list:
+                assert call[1]["headers"]["authorization"] == "token stale-token"
+
+    def test_refresh_api_key_401_reacquire_device_code_error(self, authenticator):
+        """When get_access_token raises GetDeviceCodeError after token
+        deletion, the file is already gone so token_invalidated is set True
+        — no further invalidation attempts."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_401)
+
+        reacquire_err = GetDeviceCodeError(message="no device code", status_code=400)
+        with (
+            patch.object(
+                authenticator,
+                "get_access_token",
+                side_effect=["stale-token", reacquire_err],
+            ),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            mock_remove.assert_called_once()
+            assert mock_client.get.call_count == 3
+            for call in mock_client.get.call_args_list:
+                assert call[1]["headers"]["authorization"] == "token stale-token"
+
+    def test_refresh_api_key_401_os_remove_fails(self, authenticator):
+        """When os.remove raises OSError (e.g. permission denied), the code
+        sets token_invalidated=True, skips re-acquire (file still has stale
+        token), and continues the retry loop without re-entering the 401
+        block on subsequent attempts."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_401)
+
+        with (
+            patch.object(
+                authenticator, "get_access_token", return_value="stale-token"
+            ) as mock_get_token,
+            patch(
+                "os.remove", side_effect=PermissionError("Permission denied")
+            ) as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            assert mock_client.get.call_count == 3
+            # os.remove attempted only once — token_invalidated set on failure
+            mock_remove.assert_called_once()
+            # get_access_token called only once (initial), never for re-acquire
+            mock_get_token.assert_called_once()
+            # All attempts used stale token since file was never deleted
+            for call in mock_client.get.call_args_list:
+                assert call[1]["headers"]["authorization"] == "token stale-token"
+
+    def test_refresh_api_key_403_does_not_invalidate(self, authenticator):
+        """A 403 (Forbidden) does NOT trigger token invalidation — only 401."""
+        http_403 = self._make_http_error(403, "403 Forbidden")
+        mock_client = MagicMock()
+        mock_client.get.return_value = self._make_failing_response(http_403)
+
+        with (
+            patch.object(authenticator, "get_access_token", return_value="mock-token"),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            mock_remove.assert_not_called()
+            assert mock_client.get.call_count == 3
+
+    def test_refresh_api_key_401_then_500_uses_fresh_token(self, authenticator):
+        """After a 401 triggers invalidation and re-acquire succeeds, a
+        subsequent 500 does NOT re-trigger invalidation and retries with
+        the fresh token."""
+        http_401 = self._make_http_error(401, "401 Unauthorized")
+        http_500 = self._make_http_error(500, "500 Internal Server Error")
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [
+            self._make_failing_response(http_401),
+            self._make_failing_response(http_500),
+            self._make_success_response({"token": "recovered", "expires_at": 99999}),
+        ]
+
+        with (
+            patch.object(
+                authenticator,
+                "get_access_token",
+                side_effect=["stale-token", "fresh-token"],
+            ),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            result = authenticator._refresh_api_key()
+
+            assert result == {"token": "recovered", "expires_at": 99999}
+            mock_remove.assert_called_once_with(authenticator.access_token_file)
+            # Attempt 1 used stale, attempts 2+3 used fresh (even though attempt 2 was a 500)
+            assert (
+                mock_client.get.call_args_list[0][1]["headers"]["authorization"]
+                == "token stale-token"
+            )
+            assert (
+                mock_client.get.call_args_list[1][1]["headers"]["authorization"]
+                == "token fresh-token"
+            )
+            assert (
+                mock_client.get.call_args_list[2][1]["headers"]["authorization"]
+                == "token fresh-token"
+            )
+
+    def test_refresh_api_key_connection_error_does_not_invalidate(self, authenticator):
+        """A non-HTTP exception (e.g. ConnectionError) is caught by the
+        broad except Exception branch and does not trigger invalidation."""
+        mock_client = MagicMock()
+        mock_client.get.side_effect = ConnectionError("Connection refused")
+
+        with (
+            patch.object(authenticator, "get_access_token", return_value="mock-token"),
+            patch("os.remove") as mock_remove,
+            patch(
+                "litellm.llms.github_copilot.authenticator._get_httpx_client",
+                return_value=mock_client,
+            ),
+        ):
+            with pytest.raises(RefreshAPIKeyError):
+                authenticator._refresh_api_key()
+
+            mock_remove.assert_not_called()
+            assert mock_client.get.call_count == 3
+
+    def test_get_api_key_catches_access_token_error(self, authenticator):
+        """get_api_key catches GetAccessTokenError from _refresh_api_key and
+        wraps it in GetAPIKeyError (B2 fix)."""
+        with (
+            patch("builtins.open", side_effect=IOError),
+            patch.object(
+                authenticator,
+                "_refresh_api_key",
+                side_effect=GetAccessTokenError(
+                    message="device flow timeout", status_code=401
+                ),
+            ),
+        ):
+            with pytest.raises(GetAPIKeyError, match="refresh API key"):
+                authenticator.get_api_key()


### PR DESCRIPTION
## Summary

When `_refresh_api_key()` receives a 401 from `api.github.com/copilot_internal/v2/token`, delete the cached `access-token` file and re-acquire a fresh OAuth token before retrying. This recovers from stale tokens (machine sleep/wake, server-side revocation) without manual intervention.

The recovery path is opt-in via `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY=true`. By default, behavior is unchanged: a 401 propagates to the caller and the cached token is left in place, preserving fast-fail semantics for headless proxy/CI deployments.

Fixes #25312

Docs: BerriAI/litellm-docs#45

## Root Cause

After a machine sleep/wake cycle (or any scenario where the GitHub OAuth access token becomes invalid server-side), `_refresh_api_key()` retries 3 times with the same stale token read from disk, fails, and raises `RefreshAPIKeyError`. The router retries the full request, which reads the same dead token again via `get_access_token()`. Every request fails until the proxy is manually restarted or `~/.config/litellm/github_copilot/` is deleted by hand.

There is no code path from "GitHub returned 401" to "delete stale token and re-authenticate." The `get_access_token()` method trusts whatever is on disk and has no force-refresh mechanism.

## Design Decisions

**Why opt-in?** Device flow requires an interactive terminal. Enabling recovery unconditionally would break headless proxy/server deployments by blocking on a device-code prompt no human can answer. `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY` defaults to `false`, so existing deployments preserve the previous fast-fail behavior; interactive users who want the recovery loop opt in explicitly.

**Why file deletion?** `get_access_token()` has no force-refresh parameter. The only way to trigger re-authentication is to remove the cached file so the method falls through to the device-flow login.

**Why invalidate at most once?** A `token_invalidated` flag scoped to each `_refresh_api_key()` invocation prevents repeated invalidation. The flag is set `True` when (a) `get_access_token()` succeeds after file deletion, or (b) `os.remove()` itself fails (the stale file still exists, so re-acquire would just re-read it — retrying is pointless). If re-acquisition fails but the file was successfully deleted, the flag stays `False` so subsequent 401s re-attempt invalidation, giving transient failures another chance.

**Why no lock?** The authenticator uses a sync httpx client, so this code runs on a single thread per call. A `threading.Lock` would not help with multi-worker deployments (separate processes), and adds complexity for a concurrency scenario that does not arise in practice.

## Changes

**`litellm/llms/github_copilot/authenticator.py`**

- `_invalidate_and_reacquire_token()` *(new)*: When `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY` is unset/false, returns `None` immediately without touching the cached token. When enabled, deletes the cached access token file and calls `get_access_token()` to re-acquire via device-flow login. Returns the fresh token on success, or `None` if either `os.remove()` or re-acquisition fails.
- `_refresh_api_key()`: On a 401, delegates to `_invalidate_and_reacquire_token()` and sets `token_invalidated = True` to prevent re-entry. If the helper returns a fresh token, it replaces the current one; if it returns `None` (recovery disabled, file deletion failed, or re-acquire failed), the loop continues with the existing token. Headers are rebuilt inside the retry loop so the refreshed token is used on the next iteration.
- `get_api_key()`: Now catches `GetAccessTokenError` alongside `RefreshAPIKeyError` when calling `_refresh_api_key()`. Previously a `GetAccessTokenError` from a failed device flow would escape as an unhandled exception.

**`tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py`**

19 existing tests preserved. 12 new tests added (31 total), covering both the default (recovery disabled) path and the opt-in recovery path:

| Test | What it covers |
|------|---------------|
| `test_refresh_api_key_401_invalidates_and_retries` | Recovery enabled: 401 triggers file deletion; stale token on first call, fresh on second |
| `test_refresh_api_key_401_invalidates_only_once` | Recovery enabled: persistent 401s delete the file exactly once; header assertions on all 3 attempts |
| `test_refresh_api_key_401_on_second_attempt` | Recovery enabled: 500 on attempt 1, 401 on attempt 2 still triggers invalidation |
| `test_refresh_api_key_non_401_does_not_invalidate` | 500 errors do not touch the token file |
| `test_refresh_api_key_401_reacquire_fails_raises_cleanly` | Recovery enabled, device flow fails: `token_invalidated` stays False, each 401 re-attempts invalidation, stale token reused on all attempts |
| `test_refresh_api_key_401_reacquire_device_code_error` | Recovery enabled, `GetDeviceCodeError` during re-acquisition: same retry-invalidation behavior |
| `test_refresh_api_key_401_os_remove_fails` | Recovery enabled, `os.remove` permission error: flag set, no re-acquire, stale token on all attempts |
| `test_refresh_api_key_403_does_not_invalidate` | 403 does not trigger invalidation — only 401 |
| `test_refresh_api_key_401_then_500_uses_fresh_token` | Recovery enabled: after 401 recovery, a subsequent 500 uses the fresh token and does not re-trigger invalidation |
| `test_refresh_api_key_connection_error_does_not_invalidate` | Non-HTTP exception (ConnectionError) caught by broad except, no invalidation |
| `test_get_api_key_catches_access_token_error` | `get_api_key` catches `GetAccessTokenError` from `_refresh_api_key` |
| `test_refresh_api_key_401_recovery_disabled_by_default` | Recovery disabled (default): 401 does not delete the cached token file or re-enter device flow |

## Backwards Compatibility

No breaking changes. With `GITHUB_COPILOT_ENABLE_AUTH_RECOVERY` unset (default), behavior is identical to before this PR for all responses: a 401 propagates to the caller, the cached token is left in place, and there is no device-flow prompt. The recovery side effect (file deletion + device-flow re-authentication) only runs when the flag is explicitly enabled, and is equivalent to the manual workaround users already perform.

## Test Plan

- [x] All 31 authenticator tests pass (19 existing + 12 new): `python3 -m pytest tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py -v`
