### PR TITLE
Security: gate skills auto-execution and guardrail exec() behind env vars

### DIFF
--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2071,6 +2071,14 @@ async def test_custom_code_guardrail(
             detail="Admin access required to test custom code guardrails",
         )
 
+    if os.getenv("LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS", "").lower() != "true":
+        return TestCustomCodeGuardrailResponse(
+            success=False,
+            error="Custom code guardrails are disabled by default. "
+            "Set LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS=true to enable.",
+            error_type="compilation",
+        )
+
     EXECUTION_TIMEOUT_SECONDS = 5
 
     try:

--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/custom_code_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/custom_code_guardrail.py
@@ -35,6 +35,7 @@ Example: block when response rejects the user (input_type response only):
 """
 
 import asyncio
+import os
 import threading
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, cast
 
@@ -143,8 +144,17 @@ class CustomCodeGuardrail(CustomGuardrail):
         """Returns the config model for the UI."""
         return CustomCodeGuardrailConfigModel
 
+    @staticmethod
+    def _require_custom_code_enabled() -> None:
+        if os.getenv("LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS", "").lower() != "true":
+            raise CustomCodeCompilationError(
+                "Custom code guardrails are disabled by default. "
+                "Set LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS=true to enable."
+            )
+
     def _do_compile(self) -> None:
         """Internal compilation method without lock. Expected to run inside _compile_lock."""
+        self._require_custom_code_enabled()
         exec_globals = build_sandbox_globals()
         compiled = compile_sandboxed(self.custom_code)
         exec(compiled, exec_globals)  # noqa: S102

--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -24,7 +24,6 @@ PROXY_HOOKS = {
     "parallel_request_limiter": _PROXY_MaxParallelRequestsHandler_v3,
     "cache_control_check": _PROXY_CacheControlCheck,
     "responses_id_security": ResponsesIDSecurity,
-    "litellm_skills": SkillsInjectionHook,
     "max_iterations_limiter": _PROXY_MaxIterationsHandler,
     "max_budget_per_session_limiter": _PROXY_MaxBudgetPerSessionHandler,
 }
@@ -32,6 +31,9 @@ PROXY_HOOKS = {
 ## FEATURE FLAG HOOKS ##
 if os.getenv("LEGACY_MULTI_INSTANCE_RATE_LIMITING", "false").lower() == "true":
     PROXY_HOOKS["parallel_request_limiter"] = _PROXY_MaxParallelRequestsHandler
+
+if os.getenv("LITELLM_ENABLE_SKILLS", "false").lower() == "true":
+    PROXY_HOOKS["litellm_skills"] = SkillsInjectionHook
 
 
 ### update PROXY_HOOKS with ENTERPRISE_PROXY_HOOKS ###

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_response_rejection_guardrail_code.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_response_rejection_guardrail_code.py
@@ -9,6 +9,11 @@ from litellm.proxy.guardrails.guardrail_hooks.custom_code import (
 )
 
 
+@pytest.fixture(autouse=True)
+def enable_custom_code_guardrails(monkeypatch):
+    monkeypatch.setenv("LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS", "true")
+
+
 @pytest.fixture
 def response_rejection_guardrail():
     """Guardrail instance using the response-rejection custom code."""

--- a/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
+++ b/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
@@ -1,9 +1,16 @@
+import os
+
 import pytest
 
 from litellm.proxy.guardrails.guardrail_hooks.custom_code.custom_code_guardrail import (
     CustomCodeCompilationError,
     CustomCodeGuardrail,
 )
+
+
+@pytest.fixture(autouse=True)
+def enable_custom_code_guardrails(monkeypatch):
+    monkeypatch.setenv("LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS", "true")
 
 
 # str.mro() + generator gi_code + code.replace(co_names=...) + __setattr__


### PR DESCRIPTION
Fixes two critical security findings:

1. Skills auto-execution: Removed SkillsInjectionHook from default proxy hooks; now only loads when LITELLM_ENABLE_SKILLS=true is explicitly set.
2. Guardrail exec(): Gated exec() in CustomCodeGuardrail and the test endpoint behind LITELLM_ENABLE_CUSTOM_CODE_GUARDRAILS=true.

Related tests updated and passing.
