### PR TITLE
fix(proxy): scope v1 /team/list teams via user.teams

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4145,6 +4145,7 @@ async def _authorize_and_filter_teams(
     """
     is_proxy_admin = _user_has_admin_view(user_api_key_dict)
     allowed_org_ids: Optional[List[str]] = None
+    caller_user = None
 
     if not is_proxy_admin:
         # Check if user is an org admin (even for own queries, so they see org teams)
@@ -4203,24 +4204,34 @@ async def _authorize_and_filter_teams(
         # Regular users are scoped to the canonical team ids on their user row.
         # This mirrors /v2/team/list and avoids exposing teams from stale
         # members_with_roles entries.
-        try:
-            target_user = await get_user_object(
-                user_id=user_id,
-                prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
-                user_id_upsert=False,
-                proxy_logging_obj=proxy_logging_obj,
-            )
-        except ValueError:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": f"User not found, passed user_id={user_id}"},
-            )
-        if target_user is None:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": f"User not found, passed user_id={user_id}"},
-            )
+        #
+        # Reuse caller_user when listing own teams — already loaded above for
+        # org-admin detection — to avoid a second get_user_object round-trip.
+        if (
+            caller_user is not None
+            and user_api_key_dict.user_id is not None
+            and user_id == user_api_key_dict.user_id
+        ):
+            target_user = caller_user
+        else:
+            try:
+                target_user = await get_user_object(
+                    user_id=user_id,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    user_id_upsert=False,
+                    proxy_logging_obj=proxy_logging_obj,
+                )
+            except ValueError:
+                raise HTTPException(
+                    status_code=404,
+                    detail={"error": f"User not found, passed user_id={user_id}"},
+                )
+            if target_user is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail={"error": f"User not found, passed user_id={user_id}"},
+                )
         user_team_ids = target_user.teams or []
         if not user_team_ids:
             return []

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4147,12 +4147,6 @@ async def _authorize_and_filter_teams(
     allowed_org_ids: Optional[List[str]] = None
 
     if not is_proxy_admin:
-        is_own_query = (
-            user_id is not None
-            and user_api_key_dict.user_id is not None
-            and user_api_key_dict.user_id == user_id
-        )
-
         # Check if user is an org admin (even for own queries, so they see org teams)
         if user_api_key_dict.user_id is not None:
             caller_user = await get_user_object(
@@ -4172,15 +4166,23 @@ async def _authorize_and_filter_teams(
                 if not allowed_org_ids:
                     allowed_org_ids = None
 
-        if allowed_org_ids is None and not is_own_query:
-            raise HTTPException(
-                status_code=401,
-                detail={
-                    "error": "Only admin users can query all teams/other teams. Your user role={}".format(
-                        user_api_key_dict.user_role
-                    )
-                },
+        if allowed_org_ids is None:
+            if user_id is None:
+                user_id = user_api_key_dict.user_id
+            is_own_query = (
+                user_id is not None
+                and user_api_key_dict.user_id is not None
+                and user_api_key_dict.user_id == user_id
             )
+            if not is_own_query:
+                raise HTTPException(
+                    status_code=401,
+                    detail={
+                        "error": "Only admin users can query all teams/other teams. Your user role={}".format(
+                            user_api_key_dict.user_role
+                        )
+                    },
+                )
 
     if allowed_org_ids is not None:
         # Org admin: query DB for teams in their orgs
@@ -4198,16 +4200,36 @@ async def _authorize_and_filter_teams(
             and any(m.get("user_id") == user_id for m in team.members_with_roles)
         ]
     elif user_id:
-        # Regular user: fetch all and filter by membership (Prisma can't filter JSON arrays)
-        response = await prisma_client.db.litellm_teamtable.find_many(
-            include={"litellm_model_table": True}
+        # Regular users are scoped to the canonical team ids on their user row.
+        # This mirrors /v2/team/list and avoids exposing teams from stale
+        # members_with_roles entries.
+        try:
+            target_user = await get_user_object(
+                user_id=user_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                user_id_upsert=False,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except ValueError:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": f"User not found, passed user_id={user_id}"},
+            )
+        if target_user is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": f"User not found, passed user_id={user_id}"},
+            )
+        user_team_ids = target_user.teams or []
+        if not user_team_ids:
+            return []
+        return list(
+            await prisma_client.db.litellm_teamtable.find_many(
+                where={"team_id": {"in": user_team_ids}},
+                include={"litellm_model_table": True},
+            )
         )
-        return [
-            team
-            for team in response
-            if team.members_with_roles
-            and any(m.get("user_id") == user_id for m in team.members_with_roles)
-        ]
     else:
         # Proxy admin: all teams
         return list(

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2259,6 +2259,224 @@ async def test_bulk_team_member_add_no_db_connection():
 
 
 @pytest.mark.asyncio
+async def test_list_team_v1_internal_user_scoped_to_user_table_teams():
+    """
+    Test that v1 /team/list scopes internal users to the canonical teams on
+    LiteLLM_UserTable.teams, matching /v2/team/list behavior.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user_123",
+    )
+    mock_user = LiteLLM_UserTable(
+        user_id="internal_user_123",
+        teams=["allowed_team"],
+    )
+
+    mock_team = Mock()
+    mock_team.team_id = "allowed_team"
+    mock_team.model_dump.return_value = {
+        "team_id": "allowed_team",
+        "team_alias": "Allowed Team",
+        "members_with_roles": [
+            {"user_id": "internal_user_123", "role": "user"},
+        ],
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.user_api_key_cache"),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj"),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+    ):
+        mock_db = Mock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=[])
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+
+        result = await list_team(
+            http_request=mock_request,
+            user_id="internal_user_123",
+            organization_id=None,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        assert len(result) == 1
+        assert result[0].team_id == "allowed_team"
+        team_query = mock_db.litellm_teamtable.find_many.call_args.kwargs
+        assert team_query["where"] == {"team_id": {"in": ["allowed_team"]}}
+
+
+@pytest.mark.asyncio
+async def test_list_team_v1_internal_user_without_user_id_scopes_to_self():
+    """
+    Test that v1 /team/list auto-scopes internal users without an explicit
+    user_id to their own user_id instead of listing all teams.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user_123",
+    )
+    mock_user = LiteLLM_UserTable(
+        user_id="internal_user_123",
+        teams=["self_team"],
+    )
+
+    mock_team = Mock()
+    mock_team.team_id = "self_team"
+    mock_team.model_dump.return_value = {
+        "team_id": "self_team",
+        "team_alias": "Self Team",
+        "members_with_roles": [
+            {"user_id": "internal_user_123", "role": "user"},
+        ],
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.user_api_key_cache"),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj"),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+    ):
+        mock_db = Mock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=[])
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+
+        result = await list_team(
+            http_request=mock_request,
+            user_id=None,
+            organization_id=None,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        assert len(result) == 1
+        assert result[0].team_id == "self_team"
+        team_query = mock_db.litellm_teamtable.find_many.call_args.kwargs
+        assert team_query["where"] == {"team_id": {"in": ["self_team"]}}
+
+
+@pytest.mark.asyncio
+async def test_list_team_v1_internal_user_cannot_query_other_user():
+    """
+    Test that v1 /team/list rejects internal users querying another user's teams.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from fastapi import HTTPException, Request
+
+    from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user_123",
+    )
+    mock_user = LiteLLM_UserTable(
+        user_id="internal_user_123",
+        teams=["team_1"],
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.user_api_key_cache"),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj"),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+    ):
+        mock_prisma_client.db = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_team(
+                http_request=mock_request,
+                user_id="other_user_456",
+                organization_id=None,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        assert exc_info.value.status_code == 401
+        assert "Only admin users can query all teams/other teams" in str(
+            exc_info.value.detail
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_team_v1_proxy_admin_can_query_all_teams():
+    """
+    Test that v1 /team/list keeps proxy admin behavior unchanged.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_123",
+    )
+
+    mock_team = Mock()
+    mock_team.team_id = "team_1"
+    mock_team.model_dump.return_value = {
+        "team_id": "team_1",
+        "team_alias": "Team 1",
+        "members_with_roles": [],
+    }
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        mock_db = Mock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=[])
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+
+        result = await list_team(
+            http_request=mock_request,
+            user_id=None,
+            organization_id=None,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        assert len(result) == 1
+        assert result[0].team_id == "team_1"
+        team_query = mock_db.litellm_teamtable.find_many.call_args.kwargs
+        assert "where" not in team_query
+
+
+@pytest.mark.asyncio
 async def test_list_team_v2_security_check_non_admin_user():
     """
     Test that list_team_v2 properly checks route permissions for non-admin users.

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -4,10 +4,10 @@ import os
 import sys
 from datetime import datetime, timezone
 from typing import Optional, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 
 from litellm._uuid import uuid
@@ -44,6 +44,7 @@ from litellm.proxy.management_endpoints.team_endpoints import (
     _verify_team_access,
     delete_team,
     list_available_teams,
+    list_team,
     router,
     team_member_add_duplication_check,
     team_member_delete,
@@ -2264,13 +2265,6 @@ async def test_list_team_v1_internal_user_scoped_to_user_table_teams():
     Test that v1 /team/list scopes internal users to the canonical teams on
     LiteLLM_UserTable.teams, matching /v2/team/list behavior.
     """
-    from unittest.mock import AsyncMock, Mock, patch
-
-    from fastapi import Request
-
-    from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
-    from litellm.proxy.management_endpoints.team_endpoints import list_team
-
     mock_request = Mock(spec=Request)
     mock_user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.INTERNAL_USER,
@@ -2326,13 +2320,6 @@ async def test_list_team_v1_internal_user_without_user_id_scopes_to_self():
     Test that v1 /team/list auto-scopes internal users without an explicit
     user_id to their own user_id instead of listing all teams.
     """
-    from unittest.mock import AsyncMock, Mock, patch
-
-    from fastapi import Request
-
-    from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
-    from litellm.proxy.management_endpoints.team_endpoints import list_team
-
     mock_request = Mock(spec=Request)
     mock_user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.INTERNAL_USER,
@@ -2387,13 +2374,6 @@ async def test_list_team_v1_internal_user_cannot_query_other_user():
     """
     Test that v1 /team/list rejects internal users querying another user's teams.
     """
-    from unittest.mock import AsyncMock, Mock, patch
-
-    from fastapi import HTTPException, Request
-
-    from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
-    from litellm.proxy.management_endpoints.team_endpoints import list_team
-
     mock_request = Mock(spec=Request)
     mock_user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.INTERNAL_USER,
@@ -2435,13 +2415,6 @@ async def test_list_team_v1_proxy_admin_can_query_all_teams():
     """
     Test that v1 /team/list keeps proxy admin behavior unchanged.
     """
-    from unittest.mock import AsyncMock, Mock, patch
-
-    from fastapi import Request
-
-    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
-    from litellm.proxy.management_endpoints.team_endpoints import list_team
-
     mock_request = Mock(spec=Request)
     mock_user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN,
@@ -7101,19 +7074,6 @@ async def test_list_team_v1_batches_key_queries():
     Test that list_team fetches all keys in a single batched query
     instead of issuing one query per team (N+1).
     """
-    from unittest.mock import AsyncMock, MagicMock, Mock, patch
-
-    from fastapi import Request
-
-    from litellm.proxy._types import (
-        LiteLLM_TeamMembership,
-        LiteLLM_TeamTable,
-        LitellmUserRoles,
-        TeamListResponseObject,
-        UserAPIKeyAuth,
-    )
-    from litellm.proxy.management_endpoints.team_endpoints import list_team
-
     mock_request = Mock(spec=Request)
 
     mock_user_api_key_dict = UserAPIKeyAuth(


### PR DESCRIPTION
## Linear ticket

Resolves LIT-2533

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
**Before**

- **Membership source:** For internal / non–org-admin callers, v1 **`GET /team/list`** effectively decided “is this user in this team?” by scanning each team’s **`members_with_roles`** (user appears in that list → team included).
- **Mismatch:** **`/v2/team/list`** and the user row use **`LiteLLM_UserTable.teams`** as the canonical team-id list. If the team row still listed the user in **`members_with_roles`** but the user row no longer had that **`team_id`** in **`teams`** (stale team roster), **v1 could still return that team** while **v2 did not**.
- **Missing `user_id`:** Calling **`/team/list`** without **`user_id`** could fall through authorization in a way that did not reliably mean “only my teams” for non-admins.

**After**

- **Same rule as v2:** For that caller class, teams are loaded only for **`team_id`s in `target_user.teams`** (after resolving **`user_id`**, defaulting to the caller when omitted). No inference from **`members_with_roles`** on this path.
- **Aligned lists:** **`GET /team/list`** and **`/v2/team/list`** return the **same set of team ids** for the same user when **`UserTable.teams`** is the source of truth.
- **Stricter default:** Omitting **`user_id`** no longer risks a non-admin path that looks like listing beyond “me”; **`user_id`** is treated as the caller for authorization/filtering.

**What’s different now (one line):** v1 team visibility for regular users follows **`UserTable.teams`**, not **`members_with_roles`**, so stale roster rows on **`LiteLLM_TeamTable`** cannot inflate v1 relative to v2.

## Type

🐛 Bug Fix  
✅ Test

## Changes

- **`_authorize_and_filter_teams`** (`team_endpoints.py`): For callers who are **not** org-admins and pass (or default to) a **`user_id`**, resolve teams via **`get_user_object`** and **`LiteLLM_UserTable.teams`**, then **`find_many`** on **`litellm_teamtable`** by those ids — same conceptual rule as **`/v2/team/list`**, avoiding leaks from stale **`members_with_roles`**.
- Same helper: When **`allowed_org_ids`** is unset and **`user_id`** was **`None`**, set **`user_id`** to the caller’s id so internal users do not get an unintended “list others” code path.
- **Org-admin behavior unchanged:** When **`allowed_org_ids`** is set and **`user_id`** is provided, org teams are still filtered with **`members_with_roles`** + **`any(m.get("user_id") == user_id)`** (scoped org-admin listing).
- **Tests** (`test_team_endpoints.py`): Mocked coverage for v1 list alignment with canonical **`user.teams`**, missing-**`user_id`** injection, and existing v2 security cases remain relevant.


**Out of scope (explicit):** No change to response shape beyond which teams are returned; no stripping of **`keys`** / **`team_memberships`** from v1 in this PR.
