### PR TITLE
fix(http_handler): handle RequestNotRead in MaskedHTTPStatusError for multipart uploads

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -387,11 +387,16 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
             if k.lower() not in ("content-encoding", "content-length")
         }
 
+        try:
+            request_content = original_error.request.content
+        except httpx.RequestNotRead:
+            request_content = b""
+
         masked_request = httpx.Request(
             method=original_error.request.method,
             url=masked_url,
             headers=original_error.request.headers,
-            content=original_error.request.content,
+            content=request_content,
         )
 
         super().__init__(

--- a/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
+++ b/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
@@ -104,6 +104,31 @@ class TestMaskedHTTPStatusError:
         # The attached request must be the masked one, not the original.
         assert "KEY_X" not in str(req.url)
 
+    def test_handles_streaming_request_content(self):
+        """MaskedHTTPStatusError must not crash when request body is streamed."""
+        streaming_request = httpx.Request(
+            "POST",
+            "https://api.openai.com/v1/images/edits?key=SECRET_KEY",
+            stream=httpx.ByteStream(b"multipart-data"),
+        )
+        response = httpx.Response(
+            400,
+            request=streaming_request,
+            content=b'{"error": "bad request"}',
+        )
+        orig = httpx.HTTPStatusError(
+            message="400 Bad Request",
+            request=streaming_request,
+            response=response,
+        )
+
+        masked = MaskedHTTPStatusError(orig)
+
+        assert masked.status_code == 400
+        assert masked.response.status_code == 400
+        assert masked.response.request is not None
+        assert "SECRET_KEY" not in str(masked.request.url)
+
     def test_strips_content_encoding_to_avoid_double_decode(self):
         """If the upstream response declared Content-Encoding (e.g. gzip),
         the rebuilt Response must not carry that header over — otherwise httpx


### PR DESCRIPTION
## Summary

Fixes #26552 — `/v1/images/edits` with `image` + `mask` fails with `httpx.RequestNotRead` ("Attempted to access streaming request content, without having called `read()`").

## Root Cause

When a multipart file upload (e.g. image edits with a mask) triggers an upstream HTTP error, `MaskedHTTPStatusError.__init__` tries to access `original_error.request.content` to reconstruct a masked request for error reporting. For streaming/multipart requests, httpx never buffers the request body, so `.content` raises `httpx.RequestNotRead` — completely masking the real upstream error (e.g. OpenAI 400/422) with a confusing internal traceback.

**Bug location**: `litellm/llms/custom_httpx/http_handler.py` — `MaskedHTTPStatusError.__init__`

```python
# Before (crashes on multipart requests):
masked_request = httpx.Request(
    ...
    content=original_error.request.content,  # raises RequestNotRead for streaming bodies
)

# After (safe fallback to empty bytes for error-reporting purposes):
try:
    request_content = original_error.request.content
except httpx.RequestNotRead:
    request_content = b""

masked_request = httpx.Request(
    ...
    content=request_content,
)
```

The same `httpx.RequestNotRead` pattern is already handled elsewhere in the codebase (`aiohttp_transport.py:258-262`). The fallback here is `b""` rather than `request.stream` because `MaskedHTTPStatusError` is only used for error reporting — it doesn't need to forward the body.

## Impact

This bug affects **all** multipart/file-upload endpoints (image edits, audio transcriptions, file uploads) whenever the upstream API returns any HTTP error. The real error is completely hidden from users.

## Changes

- `litellm/llms/custom_httpx/http_handler.py` — wrap `original_error.request.content` in `try/except httpx.RequestNotRead`, fall back to `b""`
- `tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py` — add `test_handles_streaming_request_content` to `TestMaskedHTTPStatusError` (TDD: written as failing test first, then fixed)

## Testing

```
uv run pytest tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py -vv
# 28 passed, 0 failed
```