### PR TITLE
chore(tests): source live Bedrock Anthropic model from env var

### DIFF
--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -475,7 +475,7 @@ def test_bedrock_claude_3(image_url):
             ],
         }
         response: ModelResponse = completion(
-            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
             num_retries=3,
             **data,
         )  # type: ignore
@@ -602,7 +602,7 @@ def test_bedrock_claude_3_tool_calling():
             }
         ]
         response: ModelResponse = completion(
-            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
             messages=messages,
             tools=tools,
             tool_choice="auto",
@@ -630,7 +630,7 @@ def test_bedrock_claude_3_tool_calling():
         )
         # In the second response, Claude should deduce answer from tool results
         second_response = completion(
-            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
             messages=messages,
             tools=tools,
             tool_choice="auto",
@@ -939,7 +939,7 @@ def test_bedrock_tool_calling():
     """
     litellm.set_verbose = True
     response = litellm.completion(
-        model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+        model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
         fallbacks=["bedrock/meta.llama3-1-8b-instruct-v1:0"],
         messages=[
             {
@@ -2887,7 +2887,7 @@ async def test_bedrock_stream_thinking_content_openwebui():
     ```
     """
     response = await litellm.acompletion(
-        model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
         messages=[{"role": "user", "content": "Hello who is this?"}],
         stream=True,
         max_tokens=1080,

--- a/tests/local_testing/test_exceptions.py
+++ b/tests/local_testing/test_exceptions.py
@@ -471,7 +471,7 @@ def test_completion_bedrock_invalid_role_exception():
     try:
         litellm.set_verbose = True
         response = completion(
-            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
             messages=[{"role": "very-bad-role", "content": "hello"}],
         )
         print(f"response: {response}")

--- a/tests/local_testing/test_function_calling.py
+++ b/tests/local_testing/test_function_calling.py
@@ -155,11 +155,13 @@ def test_aaparallel_function_call(model):
 # test_parallel_function_call()
 
 
+# $BEDROCK_ANTHROPIC_MODEL holds the full bedrock-prefixed model path, set in
+# CircleCI project env vars. EOL bumps are a CI UI change. Required to be set.
 @pytest.mark.parametrize(
     "model",
     [
         "anthropic/claude-4-sonnet-20250514",
-        "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        os.environ["BEDROCK_ANTHROPIC_MODEL"],
     ],
 )
 @pytest.mark.flaky(retries=3, delay=1)

--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -1241,7 +1241,7 @@ def test_bedrock_claude_3_streaming():
     try:
         litellm.set_verbose = True
         response: ModelResponse = completion(  # type: ignore
-            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            model=os.environ["BEDROCK_ANTHROPIC_MODEL"],
             messages=messages,
             max_tokens=10,  # type: ignore
             stream=True,

--- a/tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py
@@ -21,6 +21,9 @@ from base_anthropic_messages_prompt_caching_test import (
     BaseAnthropicMessagesPromptCachingTest,
 )
 
+# $BEDROCK_ANTHROPIC_{CONVERSE,INVOKE}_MODEL hold the full route-prefixed
+# model paths, set in CircleCI project env vars. EOL bumps are a CI UI change.
+
 
 class TestBedrockConversePromptCaching(BaseAnthropicMessagesPromptCachingTest):
     """
@@ -31,7 +34,7 @@ class TestBedrockConversePromptCaching(BaseAnthropicMessagesPromptCachingTest):
     """
 
     def get_model(self) -> str:
-        return "bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        return os.environ["BEDROCK_ANTHROPIC_CONVERSE_MODEL"]
 
 
 class TestBedrockInvokePromptCaching(BaseAnthropicMessagesPromptCachingTest):
@@ -43,4 +46,4 @@ class TestBedrockInvokePromptCaching(BaseAnthropicMessagesPromptCachingTest):
     """
 
     def get_model(self) -> str:
-        return "bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        return os.environ["BEDROCK_ANTHROPIC_INVOKE_MODEL"]

--- a/tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py
+++ b/tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py
@@ -24,7 +24,7 @@ async def test_bedrock_sonnet_4_5_with_advanced_tool_use_beta_header():
     """
     litellm._turn_on_debug()
     response = await litellm.anthropic.messages.acreate(
-        model="bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        model=os.environ["BEDROCK_ANTHROPIC_INVOKE_MODEL"],
         messages=[{"role": "user", "content": "What is 2+2?"}],
         max_tokens=100,
         provider_specific_header={


### PR DESCRIPTION
## Summary

- Centralize the Bedrock Anthropic model IDs used by live tests behind 3 env vars (one per route prefix). Each env var holds a full, copy-pasteable model path. EOL bumps become CircleCI UI changes, no PR.
- **Motivation:** PR #26721 had to touch 16 files when AWS EOL'd Claude 3.7 Sonnet on Bedrock, then a follow-up commit had to swap Claude 3.5 Sonnet v2 (also EOL on 2026-03-01) for Sonnet 4.5. AWS is rolling out EOLs continuously; this PR makes that maintenance trivial.
- **Scope:** only live tests are migrated:
  - `tests/local_testing/test_function_calling.py::test_aaparallel_function_call_with_anthropic_thinking` (Bedrock parametrize entry)
  - `tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py` (`TestBedrockConversePromptCaching` and `TestBedrockInvokePromptCaching`)
- Mocked transformation tests (~10 files) intentionally keep their hardcoded model IDs. The string is opaque in those tests — it never reaches AWS, so EOLs don't break them.
- **No fallback default.** Test files fail loud at collection time with `KeyError` if any env var is missing. Avoids the dead-code trap of an unused fallback (see existing precedents `BEDROCK_TEST_MODEL`, `LITELLM_PROXY_RESPONSES_MODEL` which silently default forever).

## Required before merge

Add the following 3 env vars to https://app.circleci.com/settings/project/github/BerriAI/litellm/environment-variables. Without all 3, CI will fail at collection.

| Env var | Value |
|---|---|
| `BEDROCK_ANTHROPIC_MODEL` | `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
| `BEDROCK_ANTHROPIC_CONVERSE_MODEL` | `bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
| `BEDROCK_ANTHROPIC_INVOKE_MODEL` | `bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0` |

Local dev requires `export`ing all 3 (or setting via `.envrc`/`.env`).

## Test plan

- [x] Verified locally: without env vars → `KeyError` at collection (loud failure). With all 3 set → parametrize ID and `get_model()` resolve to the override values.
- [x] All 3 CircleCI UI env vars set before merge.
- [x] CI passes.

## How to bump after future EOLs

Edit the 3 CircleCI UI values (all visible together alphabetically). No code change, no PR. If you forget one, CI surfaces the EOL 404 from the un-bumped one — self-correcting.