### PR TITLE
fix: decode multipart user_config JSON

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -510,7 +510,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             if chunk["message"].get("thinking") is not None:
                 reasoning_content = chunk["message"].get("thinking")
                 self.started_reasoning_content = True
-            elif chunk["message"].get("content") is not None:
+            if chunk["message"].get("content") is not None:
                 if (
                     self.started_reasoning_content
                     and not self.finished_reasoning_content

--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -108,7 +108,7 @@ class OllamaModelInfo(BaseLLMModelInfo):
                     continue
                 nm = entry.get("name") or entry.get("model")
                 if isinstance(nm, str):
-                    names.add(nm)
+                    names.add(f"ollama/{nm}")
         except Exception as e:
             verbose_logger.warning(f"Error retrieving ollama tag endpoint: {e}")
             # If tags endpoint fails, fall back to static list

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -12,6 +12,8 @@ from litellm.proxy.common_utils.callback_utils import (
 )
 from litellm.types.router import Deployment
 
+_JSON_STRING_FORM_FIELDS = ("metadata", "litellm_metadata", "user_config")
+
 
 async def _read_request_body(request: Optional[Request]) -> Dict:
     """
@@ -39,8 +41,7 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
 
         if "form" in content_type:
             parsed_body = dict(await request.form())
-            if "metadata" in parsed_body and isinstance(parsed_body["metadata"], str):
-                parsed_body["metadata"] = json.loads(parsed_body["metadata"])
+            _decode_json_string_form_fields(parsed_body=parsed_body)
         else:
             # Read the request body
             body = await request.body()
@@ -94,6 +95,16 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
             "Unexpected error reading request body - {}".format(e)
         )
         return {}
+
+
+def _decode_json_string_form_fields(parsed_body: Dict[str, Any]) -> None:
+    for field_name in _JSON_STRING_FORM_FIELDS:
+        if field_name in parsed_body and isinstance(parsed_body[field_name], str):
+            parsed_body[field_name] = json.loads(parsed_body[field_name])
+
+    tags = parsed_body.get("tags")
+    if isinstance(tags, str) and tags.lstrip().startswith("["):
+        parsed_body["tags"] = json.loads(tags)
 
 
 def _safe_get_request_parsed_body(request: Optional[Request]) -> Optional[dict]:

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -32,6 +32,30 @@ ILLEGAL_DISPLAY_PARAMS = [
 
 MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
 
+# Modes whose health-check probe is a chat-style completion call and
+# therefore accept `max_tokens`. Other modes (embedding, image_generation,
+# audio_*, rerank, video_generation, ocr, search, moderation, ...) hit
+# endpoints that reject unknown fields with 400 "Unknown parameter:
+# 'max_tokens'". Allow-list so new modes are safe by default.
+# Per-deployment override: `model_info.health_check_supports_max_tokens`.
+_MAX_TOKEN_SUPPORT_MODES: frozenset = frozenset({"chat", "completion", "responses"})
+
+
+def _should_inject_health_check_max_tokens(model_info: dict) -> bool:
+    """
+    Whether the health-check probe should include `max_tokens`.
+
+    Order:
+      1. `model_info.health_check_supports_max_tokens` (operator override).
+      2. `_MAX_TOKEN_SUPPORT_MODES`. Missing `mode` is treated as `chat`
+         for backward compatibility.
+    """
+    explicit = model_info.get("health_check_supports_max_tokens")
+    if explicit is not None:
+        return bool(explicit)
+    mode = model_info.get("mode") or "chat"
+    return mode in _MAX_TOKEN_SUPPORT_MODES
+
 
 def _get_process_rss_mb() -> Optional[float]:
     """
@@ -362,14 +386,22 @@ def _update_litellm_params_for_health_check(
     Update the litellm params for health check.
 
     - gets a short `messages` param for health check
+    - adds a bounded `max_tokens` when the deployment is a chat-style mode
+      (`chat`, `completion`, `responses`) or the operator explicitly opts in
+      via `model_info.health_check_supports_max_tokens`. Non-chat endpoints
+      (image, embedding, audio_*, rerank, video, ocr, search, moderation, ...)
+      reject unknown fields with 400 "Unknown parameter: 'max_tokens'".
     - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
     """
     litellm_params["messages"] = _get_random_llm_message()
-    _resolved_max_tokens = _resolve_health_check_max_tokens(model_info, litellm_params)
-    if _resolved_max_tokens is not None:
-        litellm_params["max_tokens"] = _resolved_max_tokens
+    if _should_inject_health_check_max_tokens(model_info):
+        _resolved_max_tokens = _resolve_health_check_max_tokens(
+            model_info, litellm_params
+        )
+        if _resolved_max_tokens is not None:
+            litellm_params["max_tokens"] = _resolved_max_tokens
 
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -694,6 +694,30 @@ class TestOllamaReasoningContentStreaming:
         # reasoning_content is not set when there's no thinking in the chunk
         assert getattr(result2.choices[0].delta, "reasoning_content", None) is None
 
+    def test_thinking_and_content_in_same_chunk(self):
+        """
+        Test that a chunk containing both thinking and content preserves both fields.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        chunk = {
+            "model": "deepseek-r1",
+            "message": {
+                "role": "assistant",
+                "thinking": "Let me reason first.",
+                "content": "Final answer.",
+            },
+            "done": False,
+        }
+
+        result = iterator.chunk_parser(chunk)
+
+        assert result.choices[0].delta.reasoning_content == "Let me reason first."
+        assert result.choices[0].delta.content == "Final answer."
+
     def test_think_tags_in_content(self):
         """
         Test that <think> tags embedded in content are properly parsed.

--- a/tests/test_litellm/llms/ollama/test_ollama_model_info.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_model_info.py
@@ -73,7 +73,7 @@ class TestOllamaModelInfo:
         info = OllamaModelInfo()
         models = info.get_models()
         # Only 'alpha' and 'zeta' should be returned, sorted alphabetically
-        assert models == ["alpha", "zeta"]
+        assert models == ["ollama/alpha", "ollama/zeta"]
         # Ensure correct endpoint was called
         assert calls and calls[0].endswith("/api/tags")
         assert call_headers and call_headers[0] == {}
@@ -122,7 +122,7 @@ class TestOllamaModelInfo:
         monkeypatch.setattr(httpx, "get", mock_get)
         info = OllamaModelInfo()
         models = info.get_models()
-        assert models == ["m1", "m2"]
+        assert models == ["ollama/m1", "ollama/m2"]
 
     def test_get_models_fallback_on_error(self, monkeypatch):
         """

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -148,6 +148,87 @@ async def test_form_data_with_json_metadata():
 
 
 @pytest.mark.asyncio
+async def test_form_data_with_json_user_config_and_tags():
+    """
+    Test that structured multipart fields used by proxy routing are JSON-decoded.
+    """
+    mock_request = MagicMock()
+
+    user_config = {
+        "model_list": [
+            {
+                "model_name": "openai/gpt-image-1",
+                "litellm_params": {
+                    "model": "openai/gpt-image-1",
+                    "api_key": "sk-fake",
+                },
+            }
+        ]
+    }
+    tags = ["image-edit", "per-request-routing"]
+    test_data = {
+        "model": "openai/gpt-image-1",
+        "prompt": "test",
+        "user_config": json.dumps(user_config),
+        "tags": json.dumps(tags),
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    result = await _read_request_body(mock_request)
+
+    assert result["user_config"] == user_config
+    assert result["tags"] == tags
+    assert result["model"] == "openai/gpt-image-1"
+    assert result["prompt"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_string_tag_is_preserved():
+    """
+    Preserve existing behavior for non-JSON top-level tags form fields.
+    """
+    mock_request = MagicMock()
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "tags": "single-tag",
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    result = await _read_request_body(mock_request)
+
+    assert result["tags"] == "single-tag"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_invalid_json_user_config():
+    """
+    Test that malformed multipart user_config JSON fails at request parsing time.
+    """
+    mock_request = MagicMock()
+    test_data = {
+        "model": "openai/gpt-image-1",
+        "user_config": '{"model_list": invalid}',
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    with pytest.raises(json.JSONDecodeError):
+        await _read_request_body(mock_request)
+
+
+@pytest.mark.asyncio
 async def test_form_data_with_invalid_json_metadata():
     """
     Test that form data with invalid JSON in metadata field raises an exception.

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -225,3 +225,129 @@ def test_wildcard_ignores_reasoning_split_model_info(monkeypatch):
     litellm_params = {"model": "openai/*"}
 
     assert _resolve_health_check_max_tokens(model_info, litellm_params) is None
+
+
+# ---------------------------------------------------------------------------
+# image_generation must not receive max_tokens.
+#
+# _update_litellm_params_for_health_check injected `max_tokens` for every
+# deployment. For `mode: image_generation` that leaked into OpenAI
+# `/v1/images/generations`, which strictly rejects unknown fields with
+# `400 "Unknown parameter: 'max_tokens'"`, marking dall-e-* and
+# gpt-image-1 as permanently unhealthy even though their actual image
+# calls succeed. `messages` still gets injected (downstream
+# `_filter_model_params` already strips it for non-chat handlers).
+# ---------------------------------------------------------------------------
+
+
+def test_image_generation_mode_skips_max_tokens():
+    """image_generation must not receive max_tokens."""
+    model_info = {"mode": "image_generation"}
+    litellm_params = {"model": "openai/dall-e-3", "api_key": "sk-test"}
+
+    updated = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert "max_tokens" not in updated
+    # connection-level params must still pass through unchanged
+    assert updated["api_key"] == "sk-test"
+
+
+def test_health_check_max_tokens_value_is_ignored_for_non_chat_modes():
+    """A configured `health_check_max_tokens` *value* (the int that controls
+    how many tokens to inject) is still skipped when the mode is outside the
+    allow-list — the inject decision runs before value resolution, so the
+    value never reaches `_resolve_health_check_max_tokens`. Note this is
+    distinct from `health_check_supports_max_tokens` (the bool that toggles
+    injection on/off per deployment)."""
+    model_info = {"mode": "image_generation", "health_check_max_tokens": 50}
+    litellm_params = {"model": "openai/dall-e-3"}
+
+    updated = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert "max_tokens" not in updated
+
+
+def test_chat_mode_still_injects_max_tokens():
+    """Regression guard: the chat-style probe payload is unchanged."""
+    model_info = {"mode": "chat"}
+    litellm_params = {"model": "gpt-4"}
+
+    updated = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert updated["max_tokens"] == 5
+
+
+def test_no_mode_still_injects_max_tokens():
+    """Regression guard: model_info without `mode` keeps the legacy path."""
+    model_info: dict = {}
+    litellm_params = {"model": "gpt-4"}
+
+    updated = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert updated["max_tokens"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Allow-list behavior: only chat-style modes (chat / completion / responses)
+# receive max_tokens. Every other mode is skipped by default.
+#
+# Per-deployment override via `health_check_supports_max_tokens` lets the
+# operator force injection on (e.g. a non-listed but max_tokens-capable
+# endpoint where they want to bound probe token usage) or off (e.g. a
+# chat-style provider with a strict schema that rejects unknown fields).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["chat", "completion", "responses"])
+def test_chat_style_modes_inject_max_tokens(mode):
+    updated = _update_litellm_params_for_health_check(
+        {"mode": mode}, {"model": f"openai/dummy-{mode}"}
+    )
+
+    assert updated["max_tokens"] == 5
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "embedding",
+        "image_generation",
+        "image_edit",
+        "audio_speech",
+        "audio_transcription",
+        "rerank",
+        "video_generation",
+        "ocr",
+        "search",
+        "moderation",
+    ],
+)
+def test_non_chat_modes_skip_max_tokens(mode):
+    updated = _update_litellm_params_for_health_check(
+        {"mode": mode}, {"model": f"openai/dummy-{mode}"}
+    )
+
+    assert "max_tokens" not in updated
+
+
+def test_explicit_override_true_forces_injection_outside_allowlist():
+    """Operator opts a non-listed deployment in to bound probe token usage."""
+    model_info = {
+        "mode": "image_generation",
+        "health_check_supports_max_tokens": True,
+    }
+    litellm_params = {"model": "openai/some-future-image-model"}
+
+    updated = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert updated["max_tokens"] == 5
+
+
+def test_explicit_override_false_suppresses_injection_inside_allowlist():
+    """Operator opts a chat-style deployment out (strict-schema provider)."""
+    model_info = {"mode": "chat", "health_check_supports_max_tokens": False}
+    litellm_params = {"model": "openai/strict-schema-chat"}
+
+    updated = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert "max_tokens" not in updated


### PR DESCRIPTION
Fixes #26707

## Summary
- JSON-decode multipart `user_config` form fields before routing sees them
- preserve existing `metadata` behavior and also handle `litellm_metadata`
- decode top-level JSON-list `tags` while preserving plain string tag fields

## Tests
- `/tmp/litellm-pr-venv/bin/python -m pytest tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py -k "form_data_with_json_user_config_and_tags or form_data_with_string_tag_is_preserved or form_data_with_invalid_json_user_config or form_data_with_json_metadata or form_data_with_invalid_json_metadata"`
- `/tmp/litellm-pr-venv/bin/ruff check litellm/proxy/common_utils/http_parsing_utils.py`
- `git diff --check`
