### PR TITLE
fix(proxy): block /ui/* routes when DISABLE_ADMIN_UI=true

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -302,6 +302,7 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
+from litellm.proxy.common_utils.admin_ui_utils import admin_ui_disabled
 from litellm.proxy.common_utils.html_forms.ui_login import build_ui_login_form
 from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
@@ -1454,7 +1455,19 @@ try:
     )
     # print(f"mounted _next at {server_root_path}/ui/_next")
 
-    app.mount("/ui", StaticFiles(directory=ui_path, html=True), name="ui")
+    _disable_admin_ui = str_to_bool(os.getenv("DISABLE_ADMIN_UI", "false")) is True
+    if _disable_admin_ui:
+
+        @app.get("/ui/{path:path}")
+        async def ui_disabled_path(path: str):
+            return admin_ui_disabled()
+
+        @app.get("/ui")
+        async def ui_disabled_root():
+            return admin_ui_disabled()
+
+    else:
+        app.mount("/ui", StaticFiles(directory=ui_path, html=True), name="ui")
 
     def _restructure_ui_html_files(ui_root: str) -> None:
         """Ensure each exported HTML route is available as <route>/index.html."""


### PR DESCRIPTION
## What

When `DISABLE_ADMIN_UI=true`, all `/ui/*` routes (including `/ui/chat`) now return the \"Admin UI Disabled\" page instead of serving the static Next.js bundle.

## Why

`DISABLE_ADMIN_UI=true` gated the `/login` and SSO route handlers but left the `StaticFiles` mount at `/ui` unconditional. Users who knew the URL `https://<host>/ui/chat` could navigate directly to the full Chat UI, bypassing the intended restriction entirely.

## Plan

https://gist.github.com/ishaan-berri/7bca506f25632b2f98c4262c77f8b089

## Changes

`litellm/proxy/proxy_server.py` — import `admin_ui_disabled` at the top; wrap the `app.mount("/ui", StaticFiles(...))` in a conditional. When `DISABLE_ADMIN_UI=true`, register `GET /ui/{path:path}` and `GET /ui` routes that return the existing disabled HTML response. When false/unset, behavior is unchanged.

## Testing

### Before (broken state)

`/ui/chat` returns HTTP 200 with the full Chat UI despite `DISABLE_ADMIN_UI=true`:

![BROKEN: /ui/chat returns 200 despite DISABLE_ADMIN_UI=true](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-cf3dabaa/task-cf3dabaa_before_ann.png)

![BROKEN: browser shows Chat UI despite DISABLE_ADMIN_UI=true](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-cf3dabaa/task-cf3dabaa_before_browser_ann.png)

### After (fixed state)

`/ui/chat` and `/ui/` now return the "Admin UI Disabled" page:

![FIXED: all /ui/* routes return disabled page](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-cf3dabaa/task-cf3dabaa_qa_api_1_ann.png)

![FIXED: browser shows Admin UI Disabled page at /ui/chat](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-cf3dabaa/task-cf3dabaa_qa_browser_ann.png)