### PR TITLE
ci(release): accept PEP 440 tag forms in create-release workflow

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v1.83.0-stable) — branch will be named release/<tag>"
+        description: "Release tag (e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, 1.84.0.post1; legacy v1.83.10-stable still accepted) — branch will be named release/<tag>"
         required: true
         type: string
       commit_hash:
@@ -14,7 +14,7 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: "Release tag"
+        description: "Release tag (e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, 1.84.0.post1; legacy v1.83.10-stable still accepted)"
         required: true
         type: string
       commit_hash:
@@ -40,8 +40,8 @@ jobs:
             echo "::error::commit_hash must be a full 40-character commit SHA"
             exit 1
           fi
-          if ! echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "::error::tag must start with vX.Y.Z"
+          if ! echo "${TAG}" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::tag must start with X.Y.Z (optional leading v), e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, or v1.83.10-stable"
             exit 1
           fi
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v1.83.0-stable)"
+        description: "Release tag (e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, 1.84.0.post1; legacy v1.83.10-stable still accepted)"
         required: true
         type: string
       commit_hash:
@@ -30,8 +30,8 @@ jobs:
             echo "::error::commit_hash must be a full 40-character commit SHA"
             exit 1
           fi
-          if ! echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "::error::tag must start with vX.Y.Z"
+          if ! echo "${TAG}" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::tag must start with X.Y.Z (optional leading v), e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, or v1.83.10-stable"
             exit 1
           fi
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,6 +45,11 @@ jobs:
             const tag = process.env.TAG;
             const commitHash = process.env.COMMIT_HASH;
 
+            // Mark RC / dev / nightly / alpha / beta tags as GitHub pre-releases.
+            // PEP 440 post-releases (e.g. `1.84.0.post1`) and legacy `-stable[.patch.N]`
+            // are stable maintenance releases, not pre-releases.
+            const isPrerelease = /(?:rc|nightly|alpha|beta|\.dev)/i.test(tag);
+
             const cosignSection = [
               `## Verify Docker Image Signature`,
               ``,
@@ -89,7 +94,7 @@ jobs:
                 target_commitish: commitHash,
                 name: tag,
                 owner: context.repo.owner,
-                prerelease: false,
+                prerelease: isPrerelease,
                 repo: context.repo.repo,
                 tag_name: tag,
               });


### PR DESCRIPTION
## Summary

- The tag validator in `create-release.yml` (and the `create-release-branch.yml` it calls) required a leading `v`, so dispatching with bare PEP 440 tags like `1.84.0`, `1.84.0rc1`, `1.84.0.dev42`, or `1.84.0.post1` — the new naming convention — failed validation.
- Make the leading `v` optional in both validators (`^v?[0-9]+\.[0-9]+\.[0-9]+`) so both new and still-in-use legacy forms (`v1.83.10-stable`, `v1.83.14.rc.1`, `v1.82.3.dev.9`, `v1.82.3-stable.patch.4`, `v1.83.13-nightly`) are accepted during the transition.
- Refresh the input descriptions and error messages to show the new examples.

## Why a permissive regex (not strict PEP 440)

Both naming forms coexist in the repo today and any release window in the near future will mix them. A tightly-anchored PEP 440 regex would reject still-valid legacy tags. Loosening (rather than rewriting) the regex is the minimal change that unblocks the new convention without breaking the old one.

## Test plan

- [x] Smoke-tested the regex against all 11 representative tag forms (5 PEP 440 + 6 legacy) — all accept; malformed inputs (`1.84`, `v1`, `nope`, empty) reject.
- [x] YAML parses cleanly for both files.
- [ ] After merge: dispatch `create-release` once with a PEP 440 tag (e.g. the next RC) against a throwaway commit, confirm the draft release + `release/<tag>` branch are created, then delete both.