### PR TITLE
fix(ui): stop page.tsx prefetch from overwriting teams table pagination

### DIFF
--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -533,8 +533,6 @@ function CreateKeyPageContent() {
                     />
                   ) : page == "teams" ? (
                     <OldTeams
-                      teams={teams}
-                      setTeams={setTeams}
                       accessToken={accessToken}
                       userID={userID}
                       userRole={userRole}

--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchAvailableModelsForTeamOrKey } from "./key_team_helpers/fetch_available_models_team_key";
 import { fetchMCPAccessGroups, getGuardrailsList, teamCreateCall } from "./networking";
+import { teamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import OldTeams from "./OldTeams";
 
 const mockTeamInfoView = vi.fn();
@@ -128,6 +129,16 @@ const createQueryClient = () => {
 const renderWithQueryClient = (component: React.ReactElement) => {
   const queryClient = createQueryClient();
   return render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>);
+};
+
+const mockTeamsResponse = (teams: any[]) => {
+  vi.mocked(teamListCall).mockResolvedValueOnce({
+    teams,
+    total: teams.length,
+    page: 1,
+    page_size: 10,
+    total_pages: teams.length > 0 ? 1 : 0,
+  });
 };
 
 describe("OldTeams - handleCreate organization handling", () => {
@@ -349,27 +360,26 @@ describe("OldTeams - handleCreate organization handling", () => {
 
   it("should clear the delete modal when the cancel button is clicked", async () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
+    mockTeamsResponse([
+      {
+        team_id: "1",
+        team_alias: "Test Team",
+        organization_id: "org-123",
+        models: ["gpt-4"],
+        max_budget: 100,
+        budget_duration: "1d",
+        tpm_limit: 1000,
+        rpm_limit: 1000,
+        created_at: new Date().toISOString(),
+        keys: [],
+        members_with_roles: [],
+        spend: 0,
+      },
+    ]);
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -395,10 +405,8 @@ describe("OldTeams - empty state", () => {
   it("should display empty state message when teams array is empty", async () => {
     renderWithQueryClient(
       <OldTeams
-        teams={[]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -414,10 +422,8 @@ describe("OldTeams - empty state", () => {
   it("should display empty state message when teams is null", async () => {
     renderWithQueryClient(
       <OldTeams
-        teams={null}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -431,27 +437,26 @@ describe("OldTeams - empty state", () => {
   });
 
   it("should not display empty state when teams array has items", async () => {
+    mockTeamsResponse([
+      {
+        team_id: "1",
+        team_alias: "Test Team",
+        organization_id: "org-123",
+        models: ["gpt-4"],
+        max_budget: 100,
+        budget_duration: "1d",
+        tpm_limit: 1000,
+        rpm_limit: 1000,
+        created_at: new Date().toISOString(),
+        keys: [],
+        members_with_roles: [],
+        spend: 0,
+      },
+    ]);
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -602,27 +607,26 @@ describe("OldTeams - premium props", () => {
   });
 
   it("passes premiumUser flag to TeamInfoView", async () => {
+    mockTeamsResponse([
+      {
+        team_id: "team-123456789",
+        team_alias: "Premium Team",
+        organization_id: "org-123",
+        models: ["gpt-4"],
+        max_budget: 100,
+        budget_duration: "1d",
+        tpm_limit: 1000,
+        rpm_limit: 1000,
+        created_at: new Date().toISOString(),
+        keys: [],
+        members_with_roles: [],
+        spend: 0,
+      },
+    ]);
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "team-123456789",
-            team_alias: "Premium Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -650,25 +654,8 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
   it("should show Default Team Settings tab for Admin role", () => {
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -681,25 +668,8 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
   it("should show Default Team Settings tab for proxy_admin role", () => {
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="proxy_admin"
         organizations={[]}
@@ -712,25 +682,8 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
   it("should not show Default Team Settings tab for proxy_admin_viewer role", () => {
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="proxy_admin_viewer"
         organizations={[]}
@@ -743,25 +696,8 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
   it("should not show Default Team Settings tab for Admin Viewer role", () => {
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin Viewer"
         organizations={[]}
@@ -794,10 +730,8 @@ describe("OldTeams - access_group_ids in team create", () => {
   it("should pass access_group_ids to teamCreateCall when creating team", async () => {
     renderWithQueryClient(
       <OldTeams
-        teams={[]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[{ organization_id: "org-1", organization_alias: "Org 1", models: [], members: [] }]}
@@ -858,10 +792,8 @@ describe("OldTeams - models dropdown options", () => {
 
     renderWithQueryClient(
       <OldTeams
-        teams={[]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -913,28 +845,27 @@ describe("OldTeams - organization alias display", () => {
     ];
 
     mockUseOrganizations.mockReturnValue({ data: mockOrganizations });
+    mockTeamsResponse([
+      {
+        team_id: "1",
+        team_alias: "Test Team",
+        organization_id: "org-123",
+        models: ["gpt-4"],
+        max_budget: 100,
+        budget_duration: "1d",
+        tpm_limit: 1000,
+        rpm_limit: 1000,
+        created_at: new Date().toISOString(),
+        keys: [],
+        members_with_roles: [],
+        spend: 0,
+      },
+    ]);
 
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-123",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={mockOrganizations}
@@ -949,28 +880,27 @@ describe("OldTeams - organization alias display", () => {
 
   it("should display organization id when alias is not found", async () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
+    mockTeamsResponse([
+      {
+        team_id: "1",
+        team_alias: "Test Team",
+        organization_id: "org-unknown",
+        models: ["gpt-4"],
+        max_budget: 100,
+        budget_duration: "1d",
+        tpm_limit: 1000,
+        rpm_limit: 1000,
+        created_at: new Date().toISOString(),
+        keys: [],
+        members_with_roles: [],
+        spend: 0,
+      },
+    ]);
 
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: "org-unknown",
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}
@@ -984,28 +914,27 @@ describe("OldTeams - organization alias display", () => {
 
   it("should display N/A when organization_id is null", async () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
+    mockTeamsResponse([
+      {
+        team_id: "1",
+        team_alias: "Test Team",
+        organization_id: null as any,
+        models: ["gpt-4"],
+        max_budget: 100,
+        budget_duration: "1d",
+        tpm_limit: 1000,
+        rpm_limit: 1000,
+        created_at: new Date().toISOString(),
+        keys: [],
+        members_with_roles: [],
+        spend: 0,
+      },
+    ]);
 
     renderWithQueryClient(
       <OldTeams
-        teams={[
-          {
-            team_id: "1",
-            team_alias: "Test Team",
-            organization_id: null as any,
-            models: ["gpt-4"],
-            max_budget: 100,
-            budget_duration: "1d",
-            tpm_limit: 1000,
-            rpm_limit: 1000,
-            created_at: new Date().toISOString(),
-            keys: [],
-            members_with_roles: [],
-            spend: 0,
-          },
-        ]}
         searchParams={{}}
         accessToken="test-token"
-        setTeams={vi.fn()}
         userID="user-123"
         userRole="Admin"
         organizations={[]}

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -62,10 +62,8 @@ import NumericalInput from "./shared/numerical_input";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 
 interface TeamProps {
-  teams: Team[] | null;
   searchParams: any;
   accessToken: string | null;
-  setTeams: React.Dispatch<React.SetStateAction<Team[] | null>>;
   userID: string | null;
   userRole: string | null;
   organizations: Organization[] | null;
@@ -174,10 +172,8 @@ const getOrganizationAlias = (
 
 // @deprecated
 const Teams: React.FC<TeamProps> = ({
-  teams,
   searchParams,
   accessToken,
-  setTeams,
   userID,
   userRole,
   organizations,
@@ -185,6 +181,7 @@ const Teams: React.FC<TeamProps> = ({
 }) => {
   console.log(`organizations: ${JSON.stringify(organizations)}`);
   const { data: organizationsData } = useOrganizations();
+  const [teams, setTeams] = useState<Team[] | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);


### PR DESCRIPTION
# PR: fix(ui): stop page.tsx prefetch from overwriting teams table pagination

> **Branch**: `Bytechoreographer:fix/teams-table-pagination`
> **Target**: `BerriAI:litellm_internal_staging`

---

## Relevant issues

<!-- No open issue; bug reproduced locally on `?page=teams` with more than 10 teams in the proxy DB. -->

## Pre-Submission checklist

- [x] Updated tests in `ui/litellm-dashboard/src/components/OldTeams.test.tsx` (30/30 pass)
- [x] `npx vitest run src/components/OldTeams.test.tsx` passes for affected file
- [x] Scope is isolated: two source files changed, one test file updated
- [x] Comment `@greptileai` and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Reproduction

Open `http://localhost:3000/?page=teams` with more than 10 teams in the
proxy DB. The page shows the correct 10-per-page table briefly, then
visibly flashes to a list of up to 100 teams — defeating the pagination
control in the top-right.

Network tab shows two requests, in this order:

```
GET /v2/team/list?page=1&page_size=10&sort_by=created_at&sort_order=desc
GET /v2/team/list?page=1&page_size=100
```

### Root cause — two effects fighting over the same `teams` state

Two independent `useEffect`s write to the same top-level `teams` state
declared in `src/app/page.tsx`:

1. **`OldTeams.tsx`** owns the teams page and its server-side
   pagination. On mount it calls `fetchTeamsV2()` with
   `page_size=10, sort_by=created_at, sort_order=desc` and calls
   `setTeams(response.teams)` — where `setTeams` is inherited via props
   from the top-level state in `page.tsx`.

2. **`src/app/page.tsx`** has a separate effect that runs when
   `accessToken`, `userID`, and `userRole` all become truthy:

   ```ts
   useEffect(() => {
     ...
     if (accessToken && userID && userRole) {
       v2TeamListCall(accessToken, 1, 100, {...})
         .then(response => setTeams(response.teams ?? []))
     }
     ...
   }, [accessToken, userID, userRole]);
   ```

   This writes up to 100 teams into the **same** top-level state.

Because JWT decoding is async, the three deps resolve in separate
renders, so this effect typically fires a moment **after** `OldTeams`
has already populated the state with its paginated 10 rows. The 100-row
response then clobbers the paginated view — exactly the flash users see.

The prefetch in `page.tsx` is not specific to the teams page: it also
seeds team dropdowns on other pages (api-keys, models, users, agents,
new_usage). But it has no business driving the state that backs the
paginated teams table.

### Fix — move teams state into `OldTeams`

Make `OldTeams` own its own `teams` list locally. The parent no longer
passes `teams` / `setTeams` into it, so the parent's prefetch can't
stomp on the paginated view.

```tsx
// Before — OldTeams.tsx
interface TeamProps {
  teams: Team[] | null;
  setTeams: React.Dispatch<React.SetStateAction<Team[] | null>>;
  // ...
}

// After
interface TeamProps {
  // teams / setTeams removed
}

const Teams: React.FC<TeamProps> = ({ ... }) => {
  const [teams, setTeams] = useState<Team[] | null>(null);
  // ...
};
```

```tsx
// Before — src/app/page.tsx
<OldTeams
  teams={teams}
  setTeams={setTeams}
  accessToken={accessToken}
  // ...
/>

// After
<OldTeams
  accessToken={accessToken}
  // ...
/>
```

The top-level `[teams, setTeams]` in `page.tsx` and its `v2TeamListCall`
prefetch are kept unchanged — other pages that still read the top-level
`teams` (UserDashboard, OldModelDashboard, ViewUserDashboard,
AgentsPanel, NewUsagePage) continue to work.

### Why not just remove the `page.tsx` prefetch?

That would also work for this specific symptom, but the top-level
`teams` is consumed by five other panels as seed data for dropdowns
and selectors. Deleting the prefetch would leave those panels empty
on first paint. Isolating the teams-page state from the shared state
fixes the bug without affecting any other consumer.

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/OldTeams.tsx` | Drop `teams` / `setTeams` from `TeamProps`; add local `useState<Team[] \| null>`. The three existing `setTeams(...)` call sites now write to local state with no change to their bodies. |
| `ui/litellm-dashboard/src/app/page.tsx` | Stop passing `teams` / `setTeams` into `<OldTeams>`. Top-level `teams` state and the `v2TeamListCall(accessToken, 1, 100, ...)` prefetch are preserved for other consumers. |
| `ui/litellm-dashboard/src/components/OldTeams.test.tsx` | Import `teamListCall` from `@/app/(dashboard)/hooks/teams/useTeams`; add `mockTeamsResponse(teams)` helper that queues `v2TeamListCall` to return the given list; remove the `teams={...}` / `setTeams={vi.fn()}` props from all 15 render sites; tests that need a populated table now call `mockTeamsResponse([...])` before rendering. |

### Test results

```
$ npx vitest run src/components/OldTeams.test.tsx
 ✓ src/components/OldTeams.test.tsx (30 tests) 41499ms
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

### Before / After behavior

| Scenario | Before | After |
|---|---|---|
| Landing on `?page=teams` with >10 teams | Shows 10 rows, flashes to up to 100 | Shows 10 rows, stays at 10 |
| Paginating, sorting, filtering | Occasionally reset by parent prefetch | Controlled entirely by OldTeams |
| Other pages that consume top-level `teams` (api-keys, models, users, agents, new_usage) | Works | Unchanged |
