### PR TITLE
fix(ui): add Your Usage view for admin users on usage page

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -169,8 +169,8 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
     }
   }, [isAdmin, userID]);
 
-  // For non-admins, always pass their own user_id
-  const effectiveUserId = isAdmin ? selectedUserId : userID || null;
+  // For non-admins or "my-usage" view, always pass their own user_id
+  const effectiveUserId = usageView === "my-usage" || !isAdmin ? userID || null : selectedUserId;
 
   const startTime = useMemo(() => (dateValue.from ? new Date(dateValue.from) : null), [dateValue.from]);
   const endTime = useMemo(() => (dateValue.to ? new Date(dateValue.to) : null), [dateValue.to]);
@@ -477,10 +477,10 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
               }
             />
           )}
-          {/* Your Usage Panel */}
-          {usageView === "global" && (
+          {/* Your Usage / Global Usage Panel */}
+          {(usageView === "global" || usageView === "my-usage") && (
             <>
-              {isAdmin && (
+              {isAdmin && usageView === "global" && (
                 <div className="mb-4">
                   <Text className="mb-2">Filter by user</Text>
                   <Select

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsageViewSelect/UsageViewSelect.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsageViewSelect/UsageViewSelect.tsx
@@ -11,7 +11,7 @@ import {
 } from "@ant-design/icons";
 import { Badge, Select } from "antd";
 import React from "react";
-export type UsageOption = "global" | "organization" | "team" | "customer" | "tag" | "agent" | "user" | "user-agent-activity";
+export type UsageOption = "global" | "my-usage" | "organization" | "team" | "customer" | "tag" | "agent" | "user" | "user-agent-activity";
 export interface UsageViewSelectProps {
   value: UsageOption;
   onChange: (value: UsageOption) => void;
@@ -42,6 +42,13 @@ const OPTIONS: OptionConfig[] = [
     descriptionForAdmin: "View usage across all resources",
     descriptionForNonAdmin: "View your usage",
     icon: <GlobalOutlined style={{ fontSize: "16px" }} />,
+  },
+  {
+    value: "my-usage",
+    label: "Your Usage",
+    description: "View your own usage",
+    icon: <UserOutlined style={{ fontSize: "16px" }} />,
+    adminOnly: true,
   },
   {
     value: "organization",


### PR DESCRIPTION
## Relevant issues

Fixes bug: admin users logged in with proxy_admin role lost access to their own personal usage view — they only see the global usage page and had to manually search for themselves in the user filter dropdown.

## Changes

Added a new **"Your Usage"** option (admin-only) to the usage view selector.

- `UsageViewSelect.tsx`: added `"my-usage"` to the `UsageOption` type + new admin-only entry with `UserOutlined` icon
- `UsagePageView.tsx`: when `usageView === "my-usage"`, `effectiveUserId` resolves to the logged-in admin's own user ID; the "Filter by user" dropdown is hidden in this view

No backend changes needed — the existing `userDailyActivityAggregatedCall` already filters by user_id when one is passed.

## Screenshots

**Admin default — Global Usage with filter dropdown:**

<img width="1200" height="896" alt="admin-usage-global-default" src="https://github.com/user-attachments/assets/40e18a38-84d1-4b6d-ae9d-a70500ad3a18" />


**Dropdown now shows "Your Usage" option for admins:**
<img width="1200" height="896" alt="admin-dropdown-open" src="https://github.com/user-attachments/assets/27d26892-fa27-416e-aae5-f104826a318b" />


**After selecting "Your Usage" — scoped to admin's own spend, filter hidden:**

<img width="1200" height="896" alt="admin-your-usage-view" src="https://github.com/user-attachments/assets/11932172-f0b8-4c11-a59d-339aa9f5ae72" />


## Pre-Submission checklist

- [x] Manually tested on dev server as `proxy_admin` user
- [x] Verified Global Usage still works (filter dropdown reappears when switching back)
- [x] Non-admin flow unchanged

## CI

- [ ] LiteLLM team to run

## Type

- [x] Bug fix

## Files changed

- `ui/litellm-dashboard/src/components/UsagePage/components/UsageViewSelect/UsageViewSelect.tsx`
- `ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx`