### PR TITLE
fix(test): scope ERROR log assertion to LiteLLM logger in test_model_alias_map

### DIFF
--- a/tests/local_testing/test_model_alias_map.py
+++ b/tests/local_testing/test_model_alias_map.py
@@ -30,10 +30,9 @@ def test_model_alias_map(caplog):
         )
         print(response.model)
 
-        captured_logs = [rec.levelname for rec in caplog.records]
-
-        for log in captured_logs:
-            assert "ERROR" not in log
+        for rec in caplog.records:
+            if rec.levelname == "ERROR" and rec.name.startswith("LiteLLM"):
+                pytest.fail(f"Unexpected litellm ERROR log: {rec.getMessage()}")
 
         assert "llama-3.1-8b-instant" in response.model
     except litellm.ServiceUnavailableError:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Fixes a flaky test caused by unrelated `asyncio` ERROR records leaking into `caplog`.

## Linear ticket

Resolves LIT-2655

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test
🐛 Bug Fix

## Changes

`tests/local_testing/test_model_alias_map.py` was asserting that no record in `caplog` had `levelname == "ERROR"`. This makes the test sensitive to ERROR logs emitted by *anything* that ran in the same process — most notably `asyncio` records like `Unclosed client session` / `Unclosed connector` from background tasks in other tests / observability integrations. Those records have `rec.name == "asyncio"`, not `"LiteLLM"`, so they have nothing to do with the code under test, but they still flunked this assertion intermittently.

The fix narrows the assertion to records emitted by LiteLLM loggers:

```python
for rec in caplog.records:
    if rec.levelname == "ERROR" and rec.name.startswith("LiteLLM"):
        pytest.fail(f"Unexpected litellm ERROR log: {rec.getMessage()}")
```

This preserves the original intent of the test (no ERROR logs from LiteLLM during a successful aliased completion) without coupling it to unrelated async cleanup noise.

The underlying `Unclosed ClientSession` warnings are real bugs and worth fixing separately, but they're out of scope for this targeted test fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777434410777679?thread_ts=1777434410.777679&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-60cdd03f-2f7b-5da4-96e6-85b7737dc5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60cdd03f-2f7b-5da4-96e6-85b7737dc5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

