### PR TITLE
fix(azure_ai): use correct 'input_image' key for FLUX.2-pro image editing

### DIFF
--- a/litellm/llms/azure_ai/image_edit/flux2_transformation.py
+++ b/litellm/llms/azure_ai/image_edit/flux2_transformation.py
@@ -112,7 +112,7 @@ class AzureFoundryFlux2ImageEditConfig(OpenAIImageEditConfig):
         # Build request body with required params
         request_body: Dict[str, Any] = {
             "prompt": prompt,
-            "image": image_b64,
+            "input_image": image_b64,
             "model": model,
         }
 


### PR DESCRIPTION
## Problem

When calling the Azure AI FLUX.2-pro image editing endpoint, litellm sends the base64-encoded image under the JSON key `"image"`, but the Black Forest Labs API actually expects the key `"input_image"`.

**Why this is hard to detect:** The API silently ignores the unknown `"image"` field and returns a response without error — it simply processes the request as if no input image was provided. There is no validation error to alert the caller.

## Fix

Changed the key in the request body from `"image"` to `"input_image"` in `AzureFoundryFlux2ImageEditConfig.transform_request_body()`.

**File:** `litellm/llms/azure_ai/image_edit/flux2_transformation.py` (line ~115)

```python
# Before
request_body: Dict[str, Any] = {
    "prompt": prompt,
    "image": image_b64,   # ❌ wrong key — silently ignored by API
    "model": model,
}

# After
request_body: Dict[str, Any] = {
    "prompt": prompt,
    "input_image": image_b64,   # ✅ correct key per BFL API spec
    "model": model,
}
```

## References

- Issue: #26698
- [Azure AI Foundry FLUX Guide](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/flux-image-generation)
- [Black Forest Labs Image Editing API Docs](https://api.bfl.ml/docs) — specifies `input_image` as the required field name for the source image

## Testing

Verified manually that the correct key is now sent in the JSON body when using `litellm.image_edit()` with an Azure AI FLUX.2-pro deployment.

Fixes #26698