### PR TITLE
feat(responses): support cursor-based stream resume on retrieve

### DIFF
--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -249,18 +249,29 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
         """
-        Transform the get response API request into a URL and data
+        Transform the get response API request into a URL and data.
 
-        OpenAI API expects the following request
-        - GET /v1/responses/{response_id}
+        Azure OpenAI follows the same shape as OpenAI for retrieve:
+        - GET /openai/responses/{response_id}?api-version=...
+
+        For cursor-based stream resume, Azure also accepts ``stream`` and
+        ``starting_after`` as query parameters (verified empirically against
+        api-version 2025-04-01-preview); we surface them via the returned
+        ``data`` dict so the HTTP layer can attach them.
         """
         get_url = self._construct_url_for_response_id_in_path(
             api_base=api_base, response_id=response_id
         )
         data: Dict = {}
-        verbose_logger.debug(f"get response url={get_url}")
+        if stream:
+            data["stream"] = "true"
+        if starting_after is not None:
+            data["starting_after"] = starting_after
+        verbose_logger.debug(f"get response url={get_url} data={data}")
         return get_url, data
 
     def transform_list_input_items_request(

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -165,7 +165,18 @@ class BaseResponsesAPIConfig(ABC):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
+        """
+        Build the URL and query params for ``GET /v1/responses/{response_id}``.
+
+        ``stream`` and ``starting_after`` enable cursor-based stream resume per
+        the OpenAI Responses API. Implementations that do not support resume
+        should ignore these arguments. Implementations that do support resume
+        should put ``stream`` and ``starting_after`` into the returned ``data``
+        dict so the underlying HTTP layer attaches them as query parameters.
+        """
         pass
 
     @abstractmethod

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -337,6 +337,14 @@ async def _safe_aread_response(response: httpx.Response) -> bytes:
         return b""
 
 
+async def _safe_aclose_response(response: httpx.Response) -> None:
+    """Safely close an async response, ignoring transport cleanup failures."""
+    try:
+        await response.aclose()
+    except Exception:
+        pass
+
+
 def _safe_read_response(response: httpx.Response) -> bytes:
     """Safely read sync response body, falling back to empty bytes on errors."""
     try:
@@ -357,7 +365,10 @@ def _raise_masked_sync_error(e: httpx.HTTPStatusError, stream: bool) -> None:
 async def _raise_masked_async_error(e: httpx.HTTPStatusError, stream: bool) -> None:
     """Raise a MaskedHTTPStatusError for async HTTP handlers."""
     if stream:
-        _body = mask_sensitive_info(await _safe_aread_response(e.response))
+        try:
+            _body = mask_sensitive_info(await _safe_aread_response(e.response))
+        finally:
+            await _safe_aclose_response(e.response)
         raise MaskedHTTPStatusError(e, message=_body, text=_body) from None
     _text = mask_sensitive_info(_safe_get_response_text(e.response))
     raise MaskedHTTPStatusError(e, message=_text, text=_text) from None
@@ -512,7 +523,10 @@ class AsyncHTTPHandler:
             response = await self.client.send(
                 req, stream=True, follow_redirects=_follow_redirects
             )
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                await _raise_masked_async_error(e, stream=True)
             return response
 
         response = await self.client.get(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -486,6 +486,8 @@ class AsyncHTTPHandler:
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         follow_redirects: Optional[bool] = None,
+        stream: bool = False,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ):
         # Set follow_redirects to UseClientDefault if None
         _follow_redirects = (
@@ -494,6 +496,24 @@ class AsyncHTTPHandler:
 
         params = params or {}
         params.update(HTTPHandler.extract_query_params(url))
+
+        if stream:
+            # Build and send an open SSE-style stream request. Caller is
+            # responsible for iterating ``response.aiter_lines()`` and
+            # eventually awaiting ``response.aclose()`` to release the
+            # underlying connection back to the pool.
+            req = self.client.build_request(
+                "GET",
+                url,
+                params=params,
+                headers=headers,
+                timeout=timeout if timeout is not None else self.timeout,
+            )
+            response = await self.client.send(
+                req, stream=True, follow_redirects=_follow_redirects
+            )
+            response.raise_for_status()
+            return response
 
         response = await self.client.get(
             url, params=params, headers=headers, follow_redirects=_follow_redirects  # type: ignore

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1027,6 +1027,8 @@ class HTTPHandler:
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         follow_redirects: Optional[bool] = None,
+        stream: bool = False,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ):
         # Set follow_redirects to UseClientDefault if None
         _follow_redirects = (
@@ -1035,14 +1037,51 @@ class HTTPHandler:
         params = params or {}
         params.update(self.extract_query_params(url))
 
-        response = self.client.get(
-            url,
-            params=params,
-            headers=headers,
-            follow_redirects=_follow_redirects,
-        )
+        try:
+            if stream or timeout is not None:
+                if timeout is not None:
+                    req = self.client.build_request(
+                        "GET",
+                        url,
+                        params=params,
+                        headers=headers,
+                        timeout=timeout,
+                    )
+                else:
+                    req = self.client.build_request(
+                        "GET",
+                        url,
+                        params=params,
+                        headers=headers,
+                    )
 
-        return response
+                response = self.client.send(
+                    req,
+                    stream=stream,
+                    follow_redirects=_follow_redirects,
+                )
+                if stream:
+                    response.raise_for_status()
+                return response
+
+            response = self.client.get(
+                url,
+                params=params,
+                headers=headers,
+                follow_redirects=_follow_redirects,
+            )
+
+            return response
+        except httpx.TimeoutException:
+            raise litellm.Timeout(
+                message=f"Connection timed out after {timeout} seconds.",
+                model="default-model-name",
+                llm_provider="litellm-httpx-handler",
+            )
+        except httpx.HTTPStatusError as e:
+            _raise_masked_sync_error(e, stream)
+        except Exception as e:
+            raise e
 
     @staticmethod
     def extract_query_params(url: str) -> Dict[str, str]:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2701,7 +2701,37 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            response = sync_httpx_client.get(url=url, headers=headers, params=data)
+            if stream:
+                response = sync_httpx_client.get(
+                    url=url,
+                    headers=headers,
+                    params=data,
+                    stream=True,
+                    timeout=timeout,
+                )
+                request_context: Dict[str, Any] = {
+                    "response_id": response_id,
+                    "stream": True,
+                    "starting_after": starting_after,
+                    "litellm_params": dict(litellm_params),
+                }
+                return SyncResponsesAPIStreamingIterator(
+                    response=response,
+                    model="",
+                    logging_obj=logging_obj,
+                    responses_api_provider_config=responses_api_provider_config,
+                    litellm_metadata=litellm_metadata,
+                    custom_llm_provider=custom_llm_provider,
+                    request_data=request_context,
+                    call_type=CallTypes.responses.value,
+                )
+
+            response = sync_httpx_client.get(
+                url=url,
+                headers=headers,
+                params=data,
+                timeout=timeout,
+            )
         except Exception as e:
             raise self._handle_error(
                 e=e,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2624,10 +2624,25 @@ class BaseLLMHTTPHandler:
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
         shared_session: Optional["ClientSession"] = None,
-    ) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
+        stream: bool = False,
+        starting_after: Optional[int] = None,
+        litellm_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Union[
+        ResponsesAPIResponse,
+        BaseResponsesAPIStreamingIterator,
+        Coroutine[
+            Any, Any, Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]
+        ],
+    ]:
         """
         Get a response by ID
-        Uses GET /v1/responses/{response_id} endpoint in the responses API
+        Uses GET /v1/responses/{response_id} endpoint in the responses API.
+
+        When ``stream=True``, performs cursor-based stream resume per the OpenAI
+        Responses API spec — equivalent to
+        ``client.responses.retrieve(response_id, stream=True, starting_after=N)``
+        on the OpenAI Python SDK. The provider must support resume; OpenAI and
+        Azure OpenAI (api-version 2025-04-01-preview) are known to support it.
         """
         if _is_async:
             return self.async_get_responses(
@@ -2641,6 +2656,9 @@ class BaseLLMHTTPHandler:
                 timeout=timeout,
                 client=client,
                 shared_session=shared_session,
+                stream=stream,
+                starting_after=starting_after,
+                litellm_metadata=litellm_metadata,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -2667,6 +2685,8 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             litellm_params=litellm_params,
             headers=headers,
+            stream=stream,
+            starting_after=starting_after,
         )
 
         ## LOGGING
@@ -2705,9 +2725,17 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         shared_session: Optional["ClientSession"] = None,
-    ) -> ResponsesAPIResponse:
+        stream: bool = False,
+        starting_after: Optional[int] = None,
+        litellm_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]:
         """
-        Async version of get_responses
+        Async version of get_responses.
+
+        When ``stream=True``, returns a :class:`ResponsesAPIStreamingIterator`
+        that yields :class:`ResponsesAPIStreamingResponse` events parsed from
+        the upstream SSE stream — enabling cursor-based stream resume per the
+        OpenAI Responses API spec.
         """
         if client is None or not isinstance(client, AsyncHTTPHandler):
             verbose_logger.debug(
@@ -2738,6 +2766,8 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             litellm_params=litellm_params,
             headers=headers,
+            stream=stream,
+            starting_after=starting_after,
         )
 
         ## LOGGING
@@ -2752,6 +2782,34 @@ class BaseLLMHTTPHandler:
         )
 
         try:
+            if stream:
+                # Open an SSE-style stream against the retrieve endpoint and
+                # wrap it in the same iterator used for streaming POSTs so
+                # parsing, hooks, and logging stay uniform across paths.
+                response = await async_httpx_client.get(
+                    url=url,
+                    headers=headers,
+                    params=data,
+                    stream=True,
+                    timeout=timeout,
+                )
+                request_context: Dict[str, Any] = {
+                    "response_id": response_id,
+                    "stream": True,
+                    "starting_after": starting_after,
+                    "litellm_params": dict(litellm_params),
+                }
+                return ResponsesAPIStreamingIterator(
+                    response=response,
+                    model="",
+                    logging_obj=logging_obj,
+                    responses_api_provider_config=responses_api_provider_config,
+                    litellm_metadata=litellm_metadata,
+                    custom_llm_provider=custom_llm_provider,
+                    request_data=request_context,
+                    call_type=CallTypes.aresponses.value,
+                )
+
             response = await async_httpx_client.get(
                 url=url, headers=headers, params=data
             )

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -156,6 +156,26 @@ else:
 
 
 class BaseLLMHTTPHandler:
+    @staticmethod
+    def _get_responses_streaming_model(
+        logging_obj: LiteLLMLoggingObj,
+        litellm_params: GenericLiteLLMParams,
+    ) -> str:
+        model_call_details = getattr(logging_obj, "model_call_details", {}) or {}
+        request_model = model_call_details.get("model")
+        if isinstance(request_model, str) and request_model:
+            return request_model
+
+        logging_model = getattr(logging_obj, "model", None)
+        if isinstance(logging_model, str) and logging_model:
+            return logging_model
+
+        litellm_model = getattr(litellm_params, "model", None)
+        if isinstance(litellm_model, str):
+            return litellm_model
+
+        return ""
+
     async def _make_common_async_call(
         self,
         async_httpx_client: AsyncHTTPHandler,
@@ -2699,6 +2719,9 @@ class BaseLLMHTTPHandler:
                 "headers": headers,
             },
         )
+        request_model = self._get_responses_streaming_model(
+            logging_obj=logging_obj, litellm_params=litellm_params
+        )
 
         try:
             if stream:
@@ -2717,7 +2740,7 @@ class BaseLLMHTTPHandler:
                 }
                 return SyncResponsesAPIStreamingIterator(
                     response=response,
-                    model="",
+                    model=request_model,
                     logging_obj=logging_obj,
                     responses_api_provider_config=responses_api_provider_config,
                     litellm_metadata=litellm_metadata,
@@ -2810,6 +2833,9 @@ class BaseLLMHTTPHandler:
                 "headers": headers,
             },
         )
+        request_model = self._get_responses_streaming_model(
+            logging_obj=logging_obj, litellm_params=litellm_params
+        )
 
         try:
             if stream:
@@ -2831,7 +2857,7 @@ class BaseLLMHTTPHandler:
                 }
                 return ResponsesAPIStreamingIterator(
                     response=response,
-                    model="",
+                    model=request_model,
                     logging_obj=logging_obj,
                     responses_api_provider_config=responses_api_provider_config,
                     litellm_metadata=litellm_metadata,

--- a/litellm/llms/manus/responses/transformation.py
+++ b/litellm/llms/manus/responses/transformation.py
@@ -261,6 +261,8 @@ class ManusResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
         """
         Transform the get response API request into a URL and data.
@@ -269,6 +271,10 @@ class ManusResponsesAPIConfig(OpenAIResponsesAPIConfig):
         - GET /v1/responses/{response_id}
 
         Reference: https://open.manus.im/docs/openai-compatibility
+
+        Cursor-based stream resume (``stream`` / ``starting_after``) is not
+        supported by Manus; the arguments are accepted for signature parity
+        with the base class and silently ignored.
         """
         url = f"{api_base}/{response_id}"
         data: Dict = {}

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -450,15 +450,25 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
         """
-        Transform the get response API request into a URL and data
+        Transform the get response API request into a URL and data.
 
         OpenAI API expects the following request
         - GET /v1/responses/{response_id}
+
+        For cursor-based stream resume, OpenAI accepts ``stream`` and
+        ``starting_after`` as query parameters; we surface them via the
+        returned ``data`` dict so the HTTP layer can attach them.
         """
         url = f"{api_base}/{response_id}"
         data: Dict = {}
+        if stream:
+            data["stream"] = "true"
+        if starting_after is not None:
+            data["starting_after"] = starting_after
         return url, data
 
     def transform_get_response_api_response(

--- a/litellm/llms/volcengine/responses/transformation.py
+++ b/litellm/llms/volcengine/responses/transformation.py
@@ -332,7 +332,12 @@ class VolcEngineResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        stream: bool = False,
+        starting_after: Optional[int] = None,
     ) -> Tuple[str, Dict]:
+        # Volcengine does not support cursor-based stream resume on retrieve;
+        # ``stream`` and ``starting_after`` are accepted for signature parity
+        # with the base class and silently ignored.
         url = f"{api_base}/{response_id}"
         data: Dict = {}
         return url, data

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -527,6 +527,28 @@ async def get_response(
     # Normal provider response flow
     data = await _read_request_body(request=request)
     data["response_id"] = response_id
+
+    # Read cursor-based stream resume params from the query string. The
+    # OpenAI Python SDK sends ``client.responses.retrieve(id, stream=True,
+    # starting_after=N)`` as ``GET .../responses/{id}?stream=true&starting_after=N``
+    # — these never appear in the request body for a GET. Without this we
+    # silently drop them and return the cached non-stream response.
+    query_stream = request.query_params.get("stream")
+    if query_stream is not None and query_stream.lower() in ("true", "1"):
+        data["stream"] = True
+    query_starting_after = request.query_params.get("starting_after")
+    if query_starting_after is not None:
+        try:
+            data["starting_after"] = int(query_starting_after)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Query parameter 'starting_after' must be an integer "
+                    f"sequence number, got {query_starting_after!r}."
+                ),
+            )
+
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
         return await processor.base_process_llm_request(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1524,7 +1524,7 @@ def get_responses(
         # Pre Call logging
         litellm_logging_obj.update_from_kwargs(
             kwargs=local_vars,
-            model=None,
+            model=kwargs.get("model"),
             optional_params={
                 "response_id": response_id,
             },

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1365,19 +1365,31 @@ async def aget_responses(
     timeout: Optional[Union[float, httpx.Timeout]] = None,
     # LiteLLM specific params,
     custom_llm_provider: Optional[str] = None,
+    stream: bool = False,
+    starting_after: Optional[int] = None,
     **kwargs,
-) -> ResponsesAPIResponse:
+) -> Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]:
     """
     Async: Fetch a response by its ID.
 
-    GET /v1/responses/{response_id} endpoint in the responses API
+    GET /v1/responses/{response_id} endpoint in the responses API.
 
     Args:
         response_id: The ID of the response to fetch.
         custom_llm_provider: Optional provider name. If not specified, will be decoded from response_id.
+        stream: When ``True``, opens an SSE stream to resume the response from
+            ``starting_after`` and returns a streaming iterator instead of a
+            single :class:`ResponsesAPIResponse`. Equivalent to the OpenAI
+            Python SDK call
+            ``client.responses.retrieve(id, stream=True, starting_after=N)``.
+        starting_after: The last ``sequence_number`` the caller has already
+            received from the original stream. Only meaningful when
+            ``stream=True``.
 
     Returns:
-        The response object with complete information about the stored response.
+        The response object with complete information about the stored
+        response, or a :class:`ResponsesAPIStreamingIterator` when
+        ``stream=True``.
     """
     local_vars = locals()
     try:
@@ -1403,6 +1415,8 @@ async def aget_responses(
             extra_query=extra_query,
             extra_body=extra_body,
             timeout=timeout,
+            stream=stream,
+            starting_after=starting_after,
             **kwargs,
         )
 
@@ -1444,19 +1458,30 @@ def get_responses(
     timeout: Optional[Union[float, httpx.Timeout]] = None,
     # LiteLLM specific params,
     custom_llm_provider: Optional[str] = None,
+    stream: bool = False,
+    starting_after: Optional[int] = None,
     **kwargs,
-) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
+) -> Union[
+    ResponsesAPIResponse,
+    BaseResponsesAPIStreamingIterator,
+    Coroutine[Any, Any, Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]],
+]:
     """
     Fetch a response by its ID.
 
-    GET /v1/responses/{response_id} endpoint in the responses API
+    GET /v1/responses/{response_id} endpoint in the responses API.
 
     Args:
         response_id: The ID of the response to fetch.
         custom_llm_provider: Optional provider name. If not specified, will be decoded from response_id.
+        stream: When ``True``, opens an SSE stream to resume the response from
+            ``starting_after``. Returns a streaming iterator instead of a
+            single :class:`ResponsesAPIResponse`.
+        starting_after: The last ``sequence_number`` already received by the
+            caller. Only meaningful when ``stream=True``.
 
     Returns:
-        The response object with complete information about the stored response.
+        The response object, or a streaming iterator when ``stream=True``.
     """
     local_vars = locals()
     try:
@@ -1522,6 +1547,9 @@ def get_responses(
             _is_async=_is_async,
             client=kwargs.get("client"),
             shared_session=kwargs.get("shared_session"),
+            stream=stream,
+            starting_after=starting_after,
+            litellm_metadata=kwargs.get("litellm_metadata"),
         )
 
         # Update the responses_api_response_id with the model_id

--- a/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
+++ b/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
@@ -20,6 +20,7 @@ from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
     MaskedHTTPStatusError,
+    _safe_aclose_response,
     _raise_masked_async_error,
     _raise_masked_sync_error,
     _safe_aread_response,
@@ -174,6 +175,13 @@ class TestSafeResponseHelpers:
         result = await _safe_aread_response(response)
         assert result == b""
 
+    @pytest.mark.asyncio
+    async def test_safe_aclose_response_error(self):
+        response = MagicMock(spec=httpx.Response)
+        response.aclose = AsyncMock(side_effect=Exception("async close failure"))
+        await _safe_aclose_response(response)
+        response.aclose.assert_awaited_once()
+
 
 class TestRaiseMaskedError:
     def test_sync_non_stream(self):
@@ -232,6 +240,21 @@ class TestRaiseMaskedError:
         assert err.message is not None
 
     @pytest.mark.asyncio
+    async def test_async_stream_closes_response(self):
+        orig = _make_httpx_status_error(
+            url="https://api.example.com?key=LEAKED_KEY", body="async stream"
+        )
+        with patch.object(
+            orig.response,
+            "aclose",
+            new=AsyncMock(return_value=None),
+        ) as close_mock:
+            with pytest.raises(MaskedHTTPStatusError):
+                await _raise_masked_async_error(orig, stream=True)
+
+        close_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_async_breaks_chain(self):
         orig = _make_httpx_status_error()
         with pytest.raises(MaskedHTTPStatusError) as exc_info:
@@ -286,3 +309,44 @@ class TestHTTPHandlerErrorPaths:
                 await getattr(async_handler, method)(**kwargs)
 
             assert "SECRET" not in str(exc_info.value.request.url)
+
+    @pytest.mark.asyncio
+    async def test_async_get_stream_routes_status_errors_through_masked_handler(
+        self, async_handler
+    ):
+        request = httpx.Request("GET", "https://api.test.com?key=SECRET")
+        response = httpx.Response(status_code=500, request=request, content=b"boom")
+
+        with (
+            patch.object(
+                async_handler.client,
+                "build_request",
+                return_value=request,
+            ),
+            patch.object(
+                async_handler.client,
+                "send",
+                new=AsyncMock(return_value=response),
+            ),
+            patch(
+                "litellm.llms.custom_httpx.http_handler._raise_masked_async_error",
+                new=AsyncMock(
+                    side_effect=MaskedHTTPStatusError(
+                        _make_httpx_status_error(
+                            status_code=500,
+                            url="https://api.test.com?key=SECRET",
+                            body="boom",
+                        ),
+                        message="boom",
+                        text="boom",
+                    )
+                ),
+            ) as masked_handler,
+        ):
+            with pytest.raises(MaskedHTTPStatusError):
+                await async_handler.get(
+                    url="https://api.test.com?key=SECRET", stream=True
+                )
+
+        masked_handler.assert_awaited_once()
+        assert masked_handler.await_args.kwargs == {"stream": True}

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -8,10 +8,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.proxy_server import app
 
 
 class TestResponsesAPIEndpoints(unittest.TestCase):
+    @staticmethod
+    def _mock_user_api_key_dict() -> MagicMock:
+        mock_user_api_key_dict = MagicMock()
+        mock_user_api_key_dict.token = "test_token"
+        mock_user_api_key_dict.user_id = "test_user"
+        mock_user_api_key_dict.team_id = None
+        mock_user_api_key_dict.spend = 0.001
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.allowed_model_region = None
+        mock_user_api_key_dict.api_key = "sk-test-key"
+        mock_user_api_key_dict.metadata = {}
+        return mock_user_api_key_dict
+
     @pytest.mark.asyncio
     @patch("litellm.proxy.proxy_server.llm_router")
     @patch("litellm.proxy.proxy_server.user_api_key_auth")
@@ -134,17 +150,8 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
         from litellm.types.utils import ResponseOutputMessage, ResponseOutputText
 
         # Create mock user API key with initial spend
-        mock_user_api_key_dict = MagicMock()
-        mock_user_api_key_dict.token = "test_token"
-        mock_user_api_key_dict.user_id = "test_user"
-        mock_user_api_key_dict.team_id = None
+        mock_user_api_key_dict = self._mock_user_api_key_dict()
         mock_user_api_key_dict.spend = 0.001  # Initial spend: $0.001
-        mock_user_api_key_dict.tpm_limit = None
-        mock_user_api_key_dict.rpm_limit = None
-        mock_user_api_key_dict.max_budget = None
-        mock_user_api_key_dict.allowed_model_region = None
-        mock_user_api_key_dict.api_key = "sk-test-key"
-        mock_user_api_key_dict.metadata = {}
 
         mock_auth.return_value = mock_user_api_key_dict
 
@@ -196,3 +203,67 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
         assert "x-litellm-response-cost" in response.headers
         response_cost_value = float(response.headers["x-litellm-response-cost"])
         assert response_cost_value == pytest.approx(0.0005, abs=1e-10)
+
+    def test_get_response_forwards_stream_resume_query_params(self):
+        captured: dict = {}
+
+        class FakeProcessor:
+            def __init__(self, data: dict):
+                captured["data"] = data
+
+            async def base_process_llm_request(self, **kwargs):
+                return {"id": "resp_test123", "object": "response", "output": []}
+
+        client = TestClient(app)
+        app.dependency_overrides[user_api_key_auth] = (
+            lambda: self._mock_user_api_key_dict()
+        )
+
+        try:
+            with (
+                patch(
+                    "litellm.proxy.proxy_server._read_request_body",
+                    new=AsyncMock(return_value={}),
+                ),
+                patch(
+                    "litellm.proxy.response_api_endpoints.endpoints.ProxyBaseLLMRequestProcessing",
+                    FakeProcessor,
+                ),
+            ):
+                response = client.get(
+                    "/v1/responses/resp_test123?stream=true&starting_after=6",
+                    headers={"Authorization": "Bearer sk-test-key"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        assert captured["data"] == {
+            "response_id": "resp_test123",
+            "stream": True,
+            "starting_after": 6,
+        }
+
+    def test_get_response_rejects_non_integer_starting_after(self):
+        client = TestClient(app)
+        app.dependency_overrides[user_api_key_auth] = (
+            lambda: self._mock_user_api_key_dict()
+        )
+
+        try:
+            with patch(
+                "litellm.proxy.proxy_server._read_request_body",
+                new=AsyncMock(return_value={}),
+            ):
+                response = client.get(
+                    "/v1/responses/resp_test123?starting_after=oops",
+                    headers={"Authorization": "Bearer sk-test-key"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "Query parameter 'starting_after' must be an integer "
+            "sequence number, got 'oops'."
+        )

--- a/tests/test_litellm/responses/test_get_responses_stream_resume.py
+++ b/tests/test_litellm/responses/test_get_responses_stream_resume.py
@@ -168,12 +168,14 @@ async def test_aget_responses_stream_returns_streaming_iterator(
         response_id=response_id,
         stream=True,
         starting_after=6,
+        model="gpt-4.1-mini",
         custom_llm_provider="openai",
         api_key="sk-test",
         api_base="https://api.openai.com/v1/responses",
     )
 
     assert isinstance(result, ResponsesAPIStreamingIterator)
+    assert result.model == "gpt-4.1-mini"
     assert captured["stream"] is True
     assert captured["params"] == {"stream": "true", "starting_after": 6}
     assert response_id in captured["url"]
@@ -218,12 +220,14 @@ def test_get_responses_stream_returns_sync_streaming_iterator(
         response_id=response_id,
         stream=True,
         starting_after=6,
+        model="gpt-4.1-mini",
         custom_llm_provider="openai",
         api_key="sk-test",
         api_base="https://api.openai.com/v1/responses",
     )
 
     assert isinstance(result, SyncResponsesAPIStreamingIterator)
+    assert result.model == "gpt-4.1-mini"
     assert captured["stream"] is True
     assert captured["params"] == {"stream": "true", "starting_after": 6}
     assert response_id in captured["url"]

--- a/tests/test_litellm/responses/test_get_responses_stream_resume.py
+++ b/tests/test_litellm/responses/test_get_responses_stream_resume.py
@@ -1,0 +1,175 @@
+"""
+Tests for cursor-based stream resume on the Responses API retrieve endpoint.
+
+Covers the GET /v1/responses/{response_id}?stream=true&starting_after=N flow:
+
+- Provider transforms (OpenAI, Azure) put ``stream`` and ``starting_after``
+  into the returned ``data`` dict so the HTTP layer attaches them as query
+  params.
+- Provider transforms that do not support resume (Volcengine, Manus) accept
+  the new arguments without breaking (signature parity with the base class).
+- The async core dispatcher ``litellm.aget_responses(stream=True, ...)``
+  returns a streaming iterator instead of a non-streaming
+  :class:`ResponsesAPIResponse`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from litellm.llms.azure.responses.transformation import AzureOpenAIResponsesAPIConfig
+from litellm.llms.manus.responses.transformation import ManusResponsesAPIConfig
+from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+from litellm.llms.volcengine.responses.transformation import VolcEngineResponsesAPIConfig
+from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+from litellm.types.router import GenericLiteLLMParams
+
+
+# ---------------------------------------------------------------------------
+# Provider transform tests
+# ---------------------------------------------------------------------------
+
+
+def _params() -> GenericLiteLLMParams:
+    return GenericLiteLLMParams(api_base="https://api.openai.com/v1/responses")
+
+
+def test_openai_transform_includes_stream_and_starting_after() -> None:
+    config = OpenAIResponsesAPIConfig()
+    url, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://api.openai.com/v1/responses",
+        litellm_params=_params(),
+        headers={},
+        stream=True,
+        starting_after=42,
+    )
+    assert url == "https://api.openai.com/v1/responses/resp_abc"
+    assert data == {"stream": "true", "starting_after": 42}
+
+
+def test_openai_transform_omits_resume_args_when_not_set() -> None:
+    config = OpenAIResponsesAPIConfig()
+    url, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://api.openai.com/v1/responses",
+        litellm_params=_params(),
+        headers={},
+    )
+    assert url == "https://api.openai.com/v1/responses/resp_abc"
+    assert data == {}
+
+
+def test_azure_transform_includes_stream_and_starting_after() -> None:
+    config = AzureOpenAIResponsesAPIConfig()
+    url, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://example.openai.azure.com/openai/responses?api-version=2025-04-01-preview",
+        litellm_params=GenericLiteLLMParams(
+            api_base="https://example.openai.azure.com/",
+            api_version="2025-04-01-preview",
+        ),
+        headers={},
+        stream=True,
+        starting_after=6,
+    )
+    # URL must contain the response_id; query params live in ``data``.
+    assert "resp_abc" in url
+    assert data == {"stream": "true", "starting_after": 6}
+
+
+def test_volcengine_transform_accepts_resume_args_without_using_them() -> None:
+    config = VolcEngineResponsesAPIConfig()
+    _, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://example.volces.com/v1/responses",
+        litellm_params=_params(),
+        headers={},
+        stream=True,
+        starting_after=10,
+    )
+    # Volcengine does not support resume; args are silently ignored.
+    assert data == {}
+
+
+def test_manus_transform_accepts_resume_args_without_using_them() -> None:
+    config = ManusResponsesAPIConfig()
+    _, data = config.transform_get_response_api_request(
+        response_id="resp_abc",
+        api_base="https://api.manus.im/v1/responses",
+        litellm_params=_params(),
+        headers={},
+        stream=True,
+        starting_after=10,
+    )
+    assert data == {}
+
+
+# ---------------------------------------------------------------------------
+# Core dispatcher streaming test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aget_responses_stream_returns_streaming_iterator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``litellm.aget_responses(stream=True, starting_after=N)`` must return a
+    :class:`ResponsesAPIStreamingIterator` rather than a single
+    :class:`ResponsesAPIResponse`. We stub out the underlying HTTP client to
+    keep the test offline and assert on the wiring (URL params + iterator
+    type).
+    """
+    import litellm
+    from litellm.llms.custom_httpx import llm_http_handler as handler_module
+
+    captured: dict[str, Any] = {}
+
+    async def fake_get(
+        url: str,
+        headers: dict | None = None,
+        params: dict | None = None,
+        stream: bool = False,
+        timeout: Any = None,
+        **_: Any,
+    ) -> httpx.Response:
+        captured["url"] = url
+        captured["params"] = params
+        captured["stream"] = stream
+        # An empty SSE-style body — the iterator can be constructed from any
+        # httpx.Response with ``aiter_lines``; we only care about wiring here.
+        return httpx.Response(
+            status_code=200,
+            content=b"",
+            request=httpx.Request("GET", url),
+        )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr(
+        handler_module,
+        "get_async_httpx_client",
+        lambda *a, **kw: fake_client,
+    )
+
+    response_id = (
+        "resp_test_stream_resume_with_a_long_enough_id_to_satisfy_validators"
+    )
+    result = await litellm.aget_responses(
+        response_id=response_id,
+        stream=True,
+        starting_after=6,
+        custom_llm_provider="openai",
+        api_key="sk-test",
+        api_base="https://api.openai.com/v1/responses",
+    )
+
+    assert isinstance(result, ResponsesAPIStreamingIterator)
+    assert captured["stream"] is True
+    assert captured["params"] == {"stream": "true", "starting_after": 6}
+    assert response_id in captured["url"]

--- a/tests/test_litellm/responses/test_get_responses_stream_resume.py
+++ b/tests/test_litellm/responses/test_get_responses_stream_resume.py
@@ -22,10 +22,16 @@ import httpx
 import pytest
 
 from litellm.llms.azure.responses.transformation import AzureOpenAIResponsesAPIConfig
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.manus.responses.transformation import ManusResponsesAPIConfig
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
-from litellm.llms.volcengine.responses.transformation import VolcEngineResponsesAPIConfig
-from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+from litellm.llms.volcengine.responses.transformation import (
+    VolcEngineResponsesAPIConfig,
+)
+from litellm.responses.streaming_iterator import (
+    ResponsesAPIStreamingIterator,
+    SyncResponsesAPIStreamingIterator,
+)
 from litellm.types.router import GenericLiteLLMParams
 
 
@@ -157,9 +163,7 @@ async def test_aget_responses_stream_returns_streaming_iterator(
         lambda *a, **kw: fake_client,
     )
 
-    response_id = (
-        "resp_test_stream_resume_with_a_long_enough_id_to_satisfy_validators"
-    )
+    response_id = "resp_test_stream_resume_with_a_long_enough_id_to_satisfy_validators"
     result = await litellm.aget_responses(
         response_id=response_id,
         stream=True,
@@ -173,3 +177,99 @@ async def test_aget_responses_stream_returns_streaming_iterator(
     assert captured["stream"] is True
     assert captured["params"] == {"stream": "true", "starting_after": 6}
     assert response_id in captured["url"]
+
+
+def test_get_responses_stream_returns_sync_streaming_iterator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm
+    from litellm.llms.custom_httpx import llm_http_handler as handler_module
+
+    captured: dict[str, Any] = {}
+
+    def fake_get(
+        url: str,
+        headers: dict | None = None,
+        params: dict | None = None,
+        stream: bool = False,
+        timeout: Any = None,
+        **_: Any,
+    ) -> httpx.Response:
+        captured["url"] = url
+        captured["params"] = params
+        captured["stream"] = stream
+        captured["timeout"] = timeout
+        return httpx.Response(
+            status_code=200,
+            content=b"",
+            request=httpx.Request("GET", url),
+        )
+
+    fake_client = MagicMock()
+    fake_client.get = MagicMock(side_effect=fake_get)
+    monkeypatch.setattr(
+        handler_module,
+        "_get_httpx_client",
+        lambda *a, **kw: fake_client,
+    )
+
+    response_id = "resp_test_stream_resume_with_a_long_enough_id_to_satisfy_validators"
+    result = litellm.get_responses(
+        response_id=response_id,
+        stream=True,
+        starting_after=6,
+        custom_llm_provider="openai",
+        api_key="sk-test",
+        api_base="https://api.openai.com/v1/responses",
+    )
+
+    assert isinstance(result, SyncResponsesAPIStreamingIterator)
+    assert captured["stream"] is True
+    assert captured["params"] == {"stream": "true", "starting_after": 6}
+    assert response_id in captured["url"]
+
+
+def test_http_handler_get_stream_uses_open_request() -> None:
+    captured: dict[str, Any] = {}
+
+    class DummyClient:
+        def build_request(
+            self,
+            method: str,
+            url: str,
+            params: dict | None = None,
+            headers: dict | None = None,
+            timeout: Any = None,
+        ) -> httpx.Request:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return httpx.Request(method, url, params=params, headers=headers)
+
+        def send(
+            self,
+            request: httpx.Request,
+            stream: bool = False,
+            follow_redirects: Any = None,
+        ) -> httpx.Response:
+            captured["stream"] = stream
+            captured["follow_redirects"] = follow_redirects
+            captured["request_url"] = str(request.url)
+            return httpx.Response(status_code=200, content=b"", request=request)
+
+    handler = HTTPHandler(client=DummyClient())
+    response = handler.get(
+        url="https://api.openai.com/v1/responses/resp_abc?existing=1",
+        params={"stream": "true"},
+        headers={"x-test": "1"},
+        stream=True,
+        timeout=12.0,
+    )
+
+    assert response.status_code == 200
+    assert captured["method"] == "GET"
+    assert captured["params"] == {"stream": "true", "existing": "1"}
+    assert captured["stream"] is True
+    assert captured["timeout"] == 12.0


### PR DESCRIPTION
## Relevant issues

Related bug report: #26762

Follow-up to #26671, retargeted to the public OSS staging branch and updated to fix the synchronous retrieve streaming gap identified during review.

This PR adds support for OpenAI-style `client.responses.retrieve(response_id, stream=True, starting_after=N)` across LiteLLM's retrieve path.

Before this change:

- the proxy retrieve endpoint forwarded `stream` / `starting_after` query params for provider-backed GET requests
- the async retrieve path could open an SSE stream and return a `ResponsesAPIStreamingIterator`
- the sync `get_responses(stream=True)` path still issued a normal GET and then treated the SSE body like a non-streaming JSON response

This PR closes that gap and adds regression coverage for the sync and proxy paths.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: after PR creation

- [ ] **CI run for the last commit**  
       Link: after final push

- [ ] **Merge / cherry-pick CI run**  
       Links: N/A (maintainer-owned)

## Screenshots / Proof of Fix

Added regression coverage for:

- async retrieve streaming returning a `ResponsesAPIStreamingIterator`
- sync retrieve streaming returning a `SyncResponsesAPIStreamingIterator`
- sync `HTTPHandler.get(..., stream=True)` opening an actual streaming GET request
- proxy forwarding of `stream` / `starting_after` query params on `GET /v1/responses/{response_id}`
- proxy validation for non-integer `starting_after`

Local targeted verification:

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -p pytest_asyncio.plugin \
  tests/test_litellm/responses/test_get_responses_stream_resume.py \
  tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py \
  -x -vv
```

Result: `13 passed`

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

- add sync streaming GET support to `HTTPHandler.get()`
- return `SyncResponsesAPIStreamingIterator` from `get_responses(..., stream=True)` instead of treating the SSE body as a non-streaming response
- preserve the existing async retrieve streaming behavior
- add sync-path regression tests for responses retrieve stream resume
- add proxy endpoint tests for query-param forwarding and invalid `starting_after` handling

