### PR TITLE
Fix: drop client_metadata from provider requests

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -431,6 +431,7 @@ def filter_internal_params(
         "skip_mcp_handler",
         "mcp_handler_context",
         "_skip_mcp_handler",
+        "client_metadata",
     }
 
     # Add any additional internal params if provided

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -4,6 +4,7 @@ import pytest
 
 from litellm.litellm_core_utils.core_helpers import (
     _FINISH_REASON_MAP,
+    filter_internal_params,
     map_finish_reason,
     reconstruct_model_name,
     redact_nested_match_and_regex_keys,
@@ -201,3 +202,11 @@ class TestRedactNestedMatchAndRegexKeys:
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
         assert redact_nested_match_and_regex_keys("plain") == "plain"
+
+
+class TestFilterInternalParams:
+    def test_should_strip_client_metadata(self):
+        data = {"temperature": 0.7, "client_metadata": {"app": "codex-cli"}}
+        result = filter_internal_params(data)
+        assert "client_metadata" not in result
+        assert result["temperature"] == 0.7


### PR DESCRIPTION
**Summary**

Responses API clients (e.g. OpenAI Codex CLI) send a client_metadata field in the request body. This field leaks through kwargs into Bedrock's additionalModelRequestFields, causing a 400 error: client_metadata: Extra inputs are not permitted.

**Relevant issues**
Addresses the same issue as #26172 with a centralized approach (per Greptile review feedback).

**Unit Test **
```
❯  uv run pytest tests/test_litellm/litellm_core_utils/test_core_helpers.py -v 2>&1 | tail -5
tests/test_litellm/litellm_core_utils/test_core_helpers.py::TestMapFinishReasonZhipu::test_sensitive PASSED [ 95%]
tests/test_litellm/litellm_core_utils/test_core_helpers.py::TestFilterInternalParams::test_should_strip_client_metadata PASSED [ 97%]
tests/test_litellm/litellm_core_utils/test_core_helpers.py::TestMapFinishReasonUnknown::test_unknown_value_defaults_to_stop PASSED [100%]

============================== 44 passed in 0.11s ==============================
```