### PR TITLE
fix(dashboard): use numeric npm min-release-age

### DIFF
--- a/ui/litellm-dashboard/.npmrc
+++ b/ui/litellm-dashboard/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3


### PR DESCRIPTION
Fixes #26668

## What changed
- change ui/litellm-dashboard/.npmrc from min-release-age=3d to min-release-age=3

## Why
Npm 11 treats 3d as an invalid min-release-age value, while 3 is parsed as a valid three-day release age window.

## Verification
- npm --version
- npm config get before in ui/litellm-dashboard
- npm config list --location=project in ui/litellm-dashboard
- git diff --check