### PR TITLE
feat: add FuturMix as named OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -101,5 +101,18 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "aihubmix": {
+    "base_url": "https://aihubmix.com/v1",
+    "api_key_env": "AIHUBMIX_API_KEY",
+    "api_base_env": "AIHUBMIX_API_BASE"
+  },
+  "futurmix": {
+    "base_url": "https://futurmix.ai/v1",
+    "api_key_env": "FUTURMIX_API_KEY",
+    "api_base_env": "FUTURMIX_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -193,6 +193,23 @@
         "a2a": false
       }
     },
+    "aihubmix": {
+      "display_name": "AIHubMix (`aihubmix`)",
+      "url": "https://docs.litellm.ai/docs/providers/aihubmix",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": true,
+        "image_generations": true,
+        "audio_transcriptions": true,
+        "audio_speech": true,
+        "moderations": true,
+        "batches": false,
+        "rerank": true,
+        "a2a": false
+      }
+    },
     "assemblyai": {
       "display_name": "AssemblyAI (`assemblyai`)",
       "url": "https://docs.litellm.ai/docs/pass_through/assembly_ai",
@@ -2568,6 +2585,24 @@
         "moderations": false,
         "batches": false,
         "rerank": false
+      }
+    },
+    "futurmix": {
+      "display_name": "FuturMix (`futurmix`)",
+      "url": "https://docs.litellm.ai/docs/providers/futurmix",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": true,
+        "image_generations": true,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": true
       }
     }
   },


### PR DESCRIPTION
## Summary

Adds [FuturMix](https://futurmix.ai) as a named OpenAI-compatible provider in LiteLLM.

### Changes
- **`litellm/llms/openai_like/providers.json`**: Added `futurmix` entry with base URL, API key env vars, and `max_completion_tokens` → `max_tokens` param mapping
- **`provider_endpoints_support.json`**: Added `futurmix` provider with supported endpoints (chat, messages, responses, embeddings, image generations, interactions)

### Usage
```python
from litellm import completion

response = completion(
    model="futurmix/claude-sonnet-4-20250514",
    messages=[{"role": "user", "content": "Hello!"}]
)
```

### About FuturMix
- enterprise AI agent platform — 
- OpenAI-compatible API at (see [futurmix.ai](https://futurmix.ai))
- 99.99% SLA, competitive pricing

Signed-off-by: Gzhao-redpoint <87687895+Gzhao-redpoint@users.noreply.github.com>