### PR TITLE
fix(proxy) add support setting budget_duration on individual member budgets

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3860,6 +3860,12 @@ class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
         default=None,
         description="List of models this team member can access. Pass an empty list to remove per-member model restrictions.",
     )
+    budget_duration: Optional[str] = Field(
+        default=None,
+        description="Budget reset period for this team member (e.g. '30d', '1mo'). "
+        "Pass null to explicitly set a lifetime cap. "
+        "If omitted, inherits the team's team_member_budget_duration.",
+    )
 
 
 class TeamMemberUpdateResponse(MemberUpdateResponse):
@@ -3868,6 +3874,7 @@ class TeamMemberUpdateResponse(MemberUpdateResponse):
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     allowed_models: Optional[List[str]] = None
+    budget_duration: Optional[str] = None
 
 
 class TeamModelAddRequest(BaseModel):

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -363,9 +363,7 @@ def _budget_disconnect_all_unset(
     )
 
 
-async def _disconnect_team_member_budget(
-    tx, *, team_id: str, user_id: str
-) -> None:
+async def _disconnect_team_member_budget(tx, *, team_id: str, user_id: str) -> None:
     await tx.litellm_teammembership.update(
         where={"user_id_team_id": {"user_id": user_id, "team_id": team_id}},
         data={"litellm_budget_table": {"disconnect": True}},

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -345,6 +345,198 @@ def _set_object_metadata_field(
     object_data.metadata[field_name] = value
 
 
+def _budget_disconnect_all_unset(
+    max_budget: Optional[float],
+    tpm_limit: Optional[int],
+    rpm_limit: Optional[int],
+    allowed_models: Optional[List[str]],
+    budget_duration: Optional[str],
+    budget_duration_explicit: bool,
+) -> bool:
+    return (
+        max_budget is None
+        and tpm_limit is None
+        and rpm_limit is None
+        and allowed_models is None
+        and budget_duration is None
+        and not budget_duration_explicit
+    )
+
+
+async def _disconnect_team_member_budget(
+    tx, *, team_id: str, user_id: str
+) -> None:
+    await tx.litellm_teammembership.update(
+        where={"user_id_team_id": {"user_id": user_id, "team_id": team_id}},
+        data={"litellm_budget_table": {"disconnect": True}},
+    )
+
+
+def _non_none_budget_limit_fields(
+    max_budget: Optional[float],
+    tpm_limit: Optional[int],
+    rpm_limit: Optional[int],
+    allowed_models: Optional[List[str]],
+) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    if max_budget is not None:
+        out["max_budget"] = max_budget
+    if tpm_limit is not None:
+        out["tpm_limit"] = tpm_limit
+    if rpm_limit is not None:
+        out["rpm_limit"] = rpm_limit
+    if allowed_models is not None:
+        out["allowed_models"] = allowed_models
+    return out
+
+
+def _apply_budget_duration_to_update_dict(
+    update_data: Dict[str, Any],
+    budget_duration: Optional[str],
+    budget_duration_explicit: bool,
+) -> None:
+    if budget_duration_explicit:
+        if budget_duration is not None:
+            update_data["budget_duration"] = budget_duration
+            update_data["budget_reset_at"] = get_budget_reset_time(
+                budget_duration=budget_duration
+            )
+        else:
+            update_data["budget_duration"] = None
+            update_data["budget_reset_at"] = None
+    elif budget_duration is not None:
+        update_data["budget_duration"] = budget_duration
+        update_data["budget_reset_at"] = get_budget_reset_time(
+            budget_duration=budget_duration
+        )
+
+
+async def _update_existing_member_budget_in_place(
+    tx,
+    *,
+    existing_budget_id: str,
+    user_api_key_dict: UserAPIKeyAuth,
+    max_budget: Optional[float],
+    tpm_limit: Optional[int],
+    rpm_limit: Optional[int],
+    allowed_models: Optional[List[str]],
+    budget_duration: Optional[str],
+    budget_duration_explicit: bool,
+) -> None:
+    update_data: Dict[str, Any] = {
+        "updated_by": user_api_key_dict.user_id or "",
+        **_non_none_budget_limit_fields(
+            max_budget, tpm_limit, rpm_limit, allowed_models
+        ),
+    }
+    _apply_budget_duration_to_update_dict(
+        update_data, budget_duration, budget_duration_explicit
+    )
+    await tx.litellm_budgettable.update(
+        where={"budget_id": existing_budget_id},
+        data=update_data,
+    )
+
+
+async def _clone_shared_default_into_create_data(
+    tx, create_data: Dict[str, Any], *, existing_budget_id: str
+) -> None:
+    default_budget_row = await tx.litellm_budgettable.find_unique(
+        where={"budget_id": existing_budget_id}
+    )
+    if default_budget_row is None:
+        return
+    default_budget_dict = default_budget_row.model_dump()
+    for field in (
+        "max_budget",
+        "soft_budget",
+        "max_parallel_requests",
+        "tpm_limit",
+        "rpm_limit",
+        "model_max_budget",
+        "budget_duration",
+        "allowed_models",
+    ):
+        value = default_budget_dict.get(field)
+        if value is None:
+            continue
+        if isinstance(value, list) and len(value) == 0:
+            continue
+        create_data[field] = value
+
+
+def _merge_limit_overrides_into_create_data(
+    create_data: Dict[str, Any],
+    *,
+    max_budget: Optional[float],
+    tpm_limit: Optional[int],
+    rpm_limit: Optional[int],
+    allowed_models: Optional[List[str]],
+) -> None:
+    if max_budget is not None:
+        create_data["max_budget"] = max_budget
+    if tpm_limit is not None:
+        create_data["tpm_limit"] = tpm_limit
+    if rpm_limit is not None:
+        create_data["rpm_limit"] = rpm_limit
+    if allowed_models is not None:
+        create_data["allowed_models"] = allowed_models
+
+
+def _merge_duration_into_create_data(
+    create_data: Dict[str, Any],
+    budget_duration: Optional[str],
+    budget_duration_explicit: bool,
+) -> None:
+    if budget_duration_explicit:
+        if budget_duration is not None:
+            create_data["budget_duration"] = budget_duration
+        else:
+            create_data.pop("budget_duration", None)
+            create_data.pop("budget_reset_at", None)
+    elif budget_duration is not None:
+        create_data["budget_duration"] = budget_duration
+
+
+def _set_create_data_budget_reset_from_duration(create_data: Dict[str, Any]) -> None:
+    bd = create_data.get("budget_duration")
+    if bd is not None:
+        create_data["budget_reset_at"] = get_budget_reset_time(budget_duration=bd)
+    else:
+        create_data.pop("budget_reset_at", None)
+
+
+async def _create_private_budget_and_link_membership(
+    tx, *, team_id: str, user_id: str, create_data: Dict[str, Any]
+) -> None:
+    new_budget = await tx.litellm_budgettable.create(
+        data=create_data,
+        include={"team_membership": True},
+    )
+    await tx.litellm_teammembership.upsert(
+        where={
+            "user_id_team_id": {
+                "user_id": user_id,
+                "team_id": team_id,
+            }
+        },
+        data={
+            "create": {
+                "user_id": user_id,
+                "team_id": team_id,
+                "litellm_budget_table": {
+                    "connect": {"budget_id": new_budget.budget_id},
+                },
+            },
+            "update": {
+                "litellm_budget_table": {
+                    "connect": {"budget_id": new_budget.budget_id},
+                },
+            },
+        },
+    )
+
+
 async def _upsert_budget_and_membership(
     tx,
     *,
@@ -389,19 +581,15 @@ async def _upsert_budget_and_membership(
 
     If any of these values exist, a budget is updated or created and linked to the team membership.
     """
-    if (
-        max_budget is None
-        and tpm_limit is None
-        and rpm_limit is None
-        and allowed_models is None
-        and budget_duration is None
-        and not budget_duration_explicit
+    if _budget_disconnect_all_unset(
+        max_budget,
+        tpm_limit,
+        rpm_limit,
+        allowed_models,
+        budget_duration,
+        budget_duration_explicit,
     ):
-        # disconnect the budget since all limits are None
-        await tx.litellm_teammembership.update(
-            where={"user_id_team_id": {"user_id": user_id, "team_id": team_id}},
-            data={"litellm_budget_table": {"disconnect": True}},
-        )
+        await _disconnect_team_member_budget(tx, team_id=team_id, user_id=user_id)
         return
 
     is_shared_default = (
@@ -411,121 +599,41 @@ async def _upsert_budget_and_membership(
     )
 
     if existing_budget_id is not None and not is_shared_default:
-        # Update the existing budget in-place to preserve fields not being changed.
-        # Only write fields that the caller explicitly provided (non-None).
-        update_data: Dict[str, Any] = {
-            "updated_by": user_api_key_dict.user_id or "",
-        }
-        if max_budget is not None:
-            update_data["max_budget"] = max_budget
-        if tpm_limit is not None:
-            update_data["tpm_limit"] = tpm_limit
-        if rpm_limit is not None:
-            update_data["rpm_limit"] = rpm_limit
-        if allowed_models is not None:
-            update_data["allowed_models"] = allowed_models
-        if budget_duration_explicit:
-            if budget_duration is not None:
-                update_data["budget_duration"] = budget_duration
-                update_data["budget_reset_at"] = get_budget_reset_time(
-                    budget_duration=budget_duration
-                )
-            else:
-                update_data["budget_duration"] = None
-                update_data["budget_reset_at"] = None
-        elif budget_duration is not None:
-            update_data["budget_duration"] = budget_duration
-            update_data["budget_reset_at"] = get_budget_reset_time(
-                budget_duration=budget_duration
-            )
-        await tx.litellm_budgettable.update(
-            where={"budget_id": existing_budget_id},
-            data=update_data,
+        await _update_existing_member_budget_in_place(
+            tx,
+            existing_budget_id=existing_budget_id,
+            user_api_key_dict=user_api_key_dict,
+            max_budget=max_budget,
+            tpm_limit=tpm_limit,
+            rpm_limit=rpm_limit,
+            allowed_models=allowed_models,
+            budget_duration=budget_duration,
+            budget_duration_explicit=budget_duration_explicit,
         )
         return
 
-    # Either there is no existing budget, OR the membership is still pointing
-    # at the team's shared default member budget. In both cases we create a
-    # NEW private budget for this user and (re)link the membership to it.
     create_data: Dict[str, Any] = {
         "created_by": user_api_key_dict.user_id or "",
         "updated_by": user_api_key_dict.user_id or "",
     }
-
-    # If we're forking off the shared default, seed the new row with the
-    # default's values so fields the caller did not change carry over.
     if is_shared_default:
-        default_budget_row = await tx.litellm_budgettable.find_unique(
-            where={"budget_id": existing_budget_id}
+        assert existing_budget_id is not None
+        await _clone_shared_default_into_create_data(
+            tx, create_data, existing_budget_id=existing_budget_id
         )
-        if default_budget_row is not None:
-            default_budget_dict = default_budget_row.model_dump()
-            for field in (
-                "max_budget",
-                "soft_budget",
-                "max_parallel_requests",
-                "tpm_limit",
-                "rpm_limit",
-                "model_max_budget",
-                "budget_duration",
-                "allowed_models",
-            ):
-                value = default_budget_dict.get(field)
-                if value is None:
-                    continue
-                if isinstance(value, list) and len(value) == 0:
-                    continue
-                create_data[field] = value
-
-    # Caller-provided values take precedence over the cloned defaults.
-    if max_budget is not None:
-        create_data["max_budget"] = max_budget
-    if tpm_limit is not None:
-        create_data["tpm_limit"] = tpm_limit
-    if rpm_limit is not None:
-        create_data["rpm_limit"] = rpm_limit
-    if allowed_models is not None:
-        create_data["allowed_models"] = allowed_models
-    if budget_duration_explicit:
-        if budget_duration is not None:
-            create_data["budget_duration"] = budget_duration
-        else:
-            create_data.pop("budget_duration", None)
-            create_data.pop("budget_reset_at", None)
-    elif budget_duration is not None:
-        create_data["budget_duration"] = budget_duration
-
-    bd = create_data.get("budget_duration")
-    if bd is not None:
-        create_data["budget_reset_at"] = get_budget_reset_time(budget_duration=bd)
-    else:
-        create_data.pop("budget_reset_at", None)
-
-    new_budget = await tx.litellm_budgettable.create(
-        data=create_data,
-        include={"team_membership": True},
+    _merge_limit_overrides_into_create_data(
+        create_data,
+        max_budget=max_budget,
+        tpm_limit=tpm_limit,
+        rpm_limit=rpm_limit,
+        allowed_models=allowed_models,
     )
-    await tx.litellm_teammembership.upsert(
-        where={
-            "user_id_team_id": {
-                "user_id": user_id,
-                "team_id": team_id,
-            }
-        },
-        data={
-            "create": {
-                "user_id": user_id,
-                "team_id": team_id,
-                "litellm_budget_table": {
-                    "connect": {"budget_id": new_budget.budget_id},
-                },
-            },
-            "update": {
-                "litellm_budget_table": {
-                    "connect": {"budget_id": new_budget.budget_id},
-                },
-            },
-        },
+    _merge_duration_into_create_data(
+        create_data, budget_duration, budget_duration_explicit
+    )
+    _set_create_data_budget_reset_from_duration(create_data)
+    await _create_private_budget_and_link_membership(
+        tx, team_id=team_id, user_id=user_id, create_data=create_data
     )
 
 

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -358,6 +358,7 @@ async def _upsert_budget_and_membership(
     allowed_models: Optional[List[str]] = None,
     team_default_budget_id: Optional[str] = None,
     budget_duration: Optional[str] = None,
+    budget_duration_explicit: bool = False,
 ):
     """
     Helper function to Create/Update or Delete the budget within the team membership
@@ -377,8 +378,15 @@ async def _upsert_budget_and_membership(
             member's budget does not mutate the shared default (and therefore
             every other member who still points at it).
         budget_duration: Budget reset period for the team member (e.g. '30d', '1mo')
+        budget_duration_explicit: True when the HTTP caller included ``budget_duration``
+            in the request body (so ``None`` means explicit lifetime). When False,
+            ``None`` means duration was not supplied for this write path.
 
-    If max_budget, tpm_limit, rpm_limit, allowed_models, and budget_duration are all None, the user's budget is removed from the team membership.
+    If max_budget, tpm_limit, rpm_limit, and allowed_models are all None, and there
+    is no explicit ``budget_duration`` in the request (``budget_duration_explicit``
+    is False) with a resolved ``budget_duration`` of None, the user's budget is
+    removed from the team membership.
+
     If any of these values exist, a budget is updated or created and linked to the team membership.
     """
     if (
@@ -387,6 +395,7 @@ async def _upsert_budget_and_membership(
         and rpm_limit is None
         and allowed_models is None
         and budget_duration is None
+        and not budget_duration_explicit
     ):
         # disconnect the budget since all limits are None
         await tx.litellm_teammembership.update(
@@ -415,7 +424,16 @@ async def _upsert_budget_and_membership(
             update_data["rpm_limit"] = rpm_limit
         if allowed_models is not None:
             update_data["allowed_models"] = allowed_models
-        if budget_duration is not None:
+        if budget_duration_explicit:
+            if budget_duration is not None:
+                update_data["budget_duration"] = budget_duration
+                update_data["budget_reset_at"] = get_budget_reset_time(
+                    budget_duration=budget_duration
+                )
+            else:
+                update_data["budget_duration"] = None
+                update_data["budget_reset_at"] = None
+        elif budget_duration is not None:
             update_data["budget_duration"] = budget_duration
             update_data["budget_reset_at"] = get_budget_reset_time(
                 budget_duration=budget_duration
@@ -468,12 +486,20 @@ async def _upsert_budget_and_membership(
         create_data["rpm_limit"] = rpm_limit
     if allowed_models is not None:
         create_data["allowed_models"] = allowed_models
-    if budget_duration is not None:
+    if budget_duration_explicit:
+        if budget_duration is not None:
+            create_data["budget_duration"] = budget_duration
+        else:
+            create_data.pop("budget_duration", None)
+            create_data.pop("budget_reset_at", None)
+    elif budget_duration is not None:
         create_data["budget_duration"] = budget_duration
 
     bd = create_data.get("budget_duration")
     if bd is not None:
         create_data["budget_reset_at"] = get_budget_reset_time(budget_duration=bd)
+    else:
+        create_data.pop("budget_reset_at", None)
 
     new_budget = await tx.litellm_budgettable.create(
         data=create_data,

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -388,25 +388,28 @@ def _non_none_budget_limit_fields(
     return out
 
 
-def _apply_budget_duration_to_update_dict(
+def _apply_explicit_budget_duration_to_update_dict(
     update_data: Dict[str, Any],
     budget_duration: Optional[str],
-    budget_duration_explicit: bool,
 ) -> None:
-    if budget_duration_explicit:
-        if budget_duration is not None:
-            update_data["budget_duration"] = budget_duration
-            update_data["budget_reset_at"] = get_budget_reset_time(
-                budget_duration=budget_duration
-            )
-        else:
-            update_data["budget_duration"] = None
-            update_data["budget_reset_at"] = None
-    elif budget_duration is not None:
+    """
+    Persist ``budget_duration`` / ``budget_reset_at`` only when the caller
+    explicitly included ``budget_duration`` in the request (see
+    ``budget_duration_explicit`` at the /team/member_update layer).
+
+    When duration is omitted, inherited team defaults are still passed into
+    ``_upsert_budget_and_membership`` for *create* / clone paths, but in-place
+    updates must not rewrite ``budget_reset_at`` or the member's cycle is reset
+    mid-period (Greptile / PR #26779).
+    """
+    if budget_duration is not None:
         update_data["budget_duration"] = budget_duration
         update_data["budget_reset_at"] = get_budget_reset_time(
             budget_duration=budget_duration
         )
+    else:
+        update_data["budget_duration"] = None
+        update_data["budget_reset_at"] = None
 
 
 async def _update_existing_member_budget_in_place(
@@ -427,9 +430,8 @@ async def _update_existing_member_budget_in_place(
             max_budget, tpm_limit, rpm_limit, allowed_models
         ),
     }
-    _apply_budget_duration_to_update_dict(
-        update_data, budget_duration, budget_duration_explicit
-    )
+    if budget_duration_explicit:
+        _apply_explicit_budget_duration_to_update_dict(update_data, budget_duration)
     await tx.litellm_budgettable.update(
         where={"budget_id": existing_budget_id},
         data=update_data,

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
+from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy._types import (
     KeyRequestBase,
     LiteLLM_ManagementEndpoint_MetadataFields,
@@ -356,6 +357,7 @@ async def _upsert_budget_and_membership(
     rpm_limit: Optional[int] = None,
     allowed_models: Optional[List[str]] = None,
     team_default_budget_id: Optional[str] = None,
+    budget_duration: Optional[str] = None,
 ):
     """
     Helper function to Create/Update or Delete the budget within the team membership
@@ -374,8 +376,9 @@ async def _upsert_budget_and_membership(
             existing_budget_id matches this, we clone-on-write so editing one
             member's budget does not mutate the shared default (and therefore
             every other member who still points at it).
+        budget_duration: Budget reset period for the team member (e.g. '30d', '1mo')
 
-    If max_budget, tpm_limit, rpm_limit, and allowed_models are all None, the user's budget is removed from the team membership.
+    If max_budget, tpm_limit, rpm_limit, allowed_models, and budget_duration are all None, the user's budget is removed from the team membership.
     If any of these values exist, a budget is updated or created and linked to the team membership.
     """
     if (
@@ -383,6 +386,7 @@ async def _upsert_budget_and_membership(
         and tpm_limit is None
         and rpm_limit is None
         and allowed_models is None
+        and budget_duration is None
     ):
         # disconnect the budget since all limits are None
         await tx.litellm_teammembership.update(
@@ -411,6 +415,11 @@ async def _upsert_budget_and_membership(
             update_data["rpm_limit"] = rpm_limit
         if allowed_models is not None:
             update_data["allowed_models"] = allowed_models
+        if budget_duration is not None:
+            update_data["budget_duration"] = budget_duration
+            update_data["budget_reset_at"] = get_budget_reset_time(
+                budget_duration=budget_duration
+            )
         await tx.litellm_budgettable.update(
             where={"budget_id": existing_budget_id},
             data=update_data,
@@ -459,6 +468,12 @@ async def _upsert_budget_and_membership(
         create_data["rpm_limit"] = rpm_limit
     if allowed_models is not None:
         create_data["allowed_models"] = allowed_models
+    if budget_duration is not None:
+        create_data["budget_duration"] = budget_duration
+
+    bd = create_data.get("budget_duration")
+    if bd is not None:
+        create_data["budget_reset_at"] = get_budget_reset_time(budget_duration=bd)
 
     new_budget = await tx.litellm_budgettable.create(
         data=create_data,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2723,7 +2723,8 @@ async def team_member_update(
     ### resolve effective budget_duration
     # - Explicit value (including null) takes precedence
     # - If omitted, inherit the team's configured team_member_budget_duration
-    if "budget_duration" in data.model_fields_set:
+    budget_duration_explicit = "budget_duration" in data.model_fields_set
+    if budget_duration_explicit:
         effective_budget_duration = data.budget_duration
     else:
         if team_default_budget_id:
@@ -2750,6 +2751,7 @@ async def team_member_update(
             allowed_models=data.allowed_models,
             team_default_budget_id=team_default_budget_id,
             budget_duration=effective_budget_duration,
+            budget_duration_explicit=budget_duration_explicit,
         )
 
     ### update team member role

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4353,7 +4353,9 @@ async def list_team(
         except Exception as e:
             team_exception = """Invalid team object for team_id: {}. team_object={}.
             Error: {}
-            """.format(team.team_id, team.model_dump(), str(e))
+            """.format(
+                team.team_id, team.model_dump(), str(e)
+            )
             verbose_proxy_logger.exception(team_exception)
             continue
     # Sort the responses by team_alias

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2714,14 +2714,27 @@ async def team_member_update(
             identified_budget_id = tm.budget_id
             break
 
-    # If this membership still points at the team's shared default member
-    # budget, _upsert_budget_and_membership will clone-on-write so that the
-    # update only touches this user (not every member sharing the default).
     team_default_budget_id: Optional[str] = None
     if team_table.metadata is not None:
         raw_default_budget_id = team_table.metadata.get("team_member_budget_id")
         if isinstance(raw_default_budget_id, str):
             team_default_budget_id = raw_default_budget_id
+
+    ### resolve effective budget_duration
+    # - Explicit value (including null) takes precedence
+    # - If omitted, inherit the team's configured team_member_budget_duration
+    if "budget_duration" in data.model_fields_set:
+        effective_budget_duration = data.budget_duration
+    else:
+        if team_default_budget_id:
+            _team_budget_row = await prisma_client.db.litellm_budgettable.find_unique(
+                where={"budget_id": team_default_budget_id}
+            )
+            effective_budget_duration = (
+                _team_budget_row.budget_duration if _team_budget_row else None
+            )
+        else:
+            effective_budget_duration = None
 
     ### upsert new budget
     async with prisma_client.db.tx() as tx:
@@ -2736,6 +2749,7 @@ async def team_member_update(
             rpm_limit=data.rpm_limit,
             allowed_models=data.allowed_models,
             team_default_budget_id=team_default_budget_id,
+            budget_duration=effective_budget_duration,
         )
 
     ### update team member role
@@ -2769,6 +2783,7 @@ async def team_member_update(
         tpm_limit=data.tpm_limit,
         rpm_limit=data.rpm_limit,
         allowed_models=data.allowed_models,
+        budget_duration=effective_budget_duration,
     )
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2673,7 +2673,11 @@ def _resolve_team_member_user_id_from_request(
 ) -> str:
     if data.user_id is not None:
         return data.user_id
-    assert data.user_email is not None
+    if data.user_email is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Either user_id or user_email needs to be passed in"},
+        )
     for member in returned_team_info["team_info"].members_with_roles:
         if member.user_email is not None and member.user_email == data.user_email:
             if member.user_id is None:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2614,6 +2614,147 @@ async def team_member_delete(
     return existing_team_row
 
 
+def _validate_team_member_update_request(
+    data: TeamMemberUpdateRequest, premium_user: bool
+) -> None:
+    if data.team_id is None:
+        raise HTTPException(status_code=400, detail={"error": "No team id passed in"})
+
+    if data.role == "admin" and not premium_user:
+        raise HTTPException(
+            status_code=400,
+            detail="Assigning team admins is a premium feature. You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/#trial. Pricing: https://www.litellm.ai/#pricing",
+        )
+    if data.user_id is None and data.user_email is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Either user_id or user_email needs to be passed in"},
+        )
+
+
+async def _team_member_update_fetch_team_or_raise(
+    prisma_client: PrismaClient, team_id: str
+) -> LiteLLM_TeamTable:
+    _existing_team_row = await prisma_client.db.litellm_teamtable.find_unique(
+        where={"team_id": team_id}
+    )
+    if _existing_team_row is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Team id={} does not exist in db".format(team_id)},
+        )
+    return LiteLLM_TeamTable(**_existing_team_row.model_dump())
+
+
+async def _team_member_update_require_authorized(
+    user_api_key_dict: UserAPIKeyAuth, existing_team_row: LiteLLM_TeamTable
+) -> None:
+    if (
+        user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
+        and not _is_user_team_admin(
+            user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
+        )
+        and not await _is_user_org_admin_for_team(
+            user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
+        )
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "Call not allowed. User not proxy admin OR team admin. route={}, team_id={}".format(
+                    "/team/member_delete", existing_team_row.team_id
+                )
+            },
+        )
+
+
+def _resolve_team_member_user_id_from_request(
+    data: TeamMemberUpdateRequest, returned_team_info: TeamInfoResponseObject
+) -> str:
+    if data.user_id is not None:
+        return data.user_id
+    assert data.user_email is not None
+    for member in returned_team_info["team_info"].members_with_roles:
+        if member.user_email is not None and member.user_email == data.user_email:
+            if member.user_id is None:
+                break
+            return member.user_id
+    raise HTTPException(
+        status_code=400,
+        detail={"error": "User id doesn't exist in team table. Data={}".format(data)},
+    )
+
+
+def _identified_member_budget_id(
+    team_memberships: List[LiteLLM_TeamMembership], received_user_id: str
+) -> Optional[str]:
+    for tm in team_memberships:
+        if tm.user_id == received_user_id:
+            return tm.budget_id
+    return None
+
+
+def _team_default_member_budget_id(
+    team_table: TeamInfoResponseObjectTeamTable,
+) -> Optional[str]:
+    if team_table.metadata is None:
+        return None
+    raw_default_budget_id = team_table.metadata.get("team_member_budget_id")
+    if isinstance(raw_default_budget_id, str):
+        return raw_default_budget_id
+    return None
+
+
+async def _effective_member_budget_duration(
+    data: TeamMemberUpdateRequest,
+    prisma_client: PrismaClient,
+    team_default_budget_id: Optional[str],
+) -> Tuple[bool, Optional[str]]:
+    budget_duration_explicit = "budget_duration" in data.model_fields_set
+    if budget_duration_explicit:
+        return budget_duration_explicit, data.budget_duration
+    if team_default_budget_id:
+        _team_budget_row = await prisma_client.db.litellm_budgettable.find_unique(
+            where={"budget_id": team_default_budget_id}
+        )
+        return (
+            budget_duration_explicit,
+            _team_budget_row.budget_duration if _team_budget_row else None,
+        )
+    return budget_duration_explicit, None
+
+
+async def _team_member_update_apply_role_if_requested(
+    prisma_client: PrismaClient,
+    *,
+    data: TeamMemberUpdateRequest,
+    team_table: TeamInfoResponseObjectTeamTable,
+    received_user_id: str,
+) -> None:
+    if data.role is None:
+        return
+    team_members: List[Member] = []
+    for member in team_table.members_with_roles:
+        if member.user_id == received_user_id:
+            team_members.append(
+                Member(
+                    user_id=member.user_id,
+                    role=data.role,
+                    user_email=data.user_email or member.user_email,
+                )
+            )
+        else:
+            team_members.append(member)
+
+    team_table.members_with_roles = team_members
+
+    _db_team_members: List[dict] = [m.model_dump() for m in team_members]
+    await prisma_client.db.litellm_teamtable.update(
+        where={"team_id": data.team_id},
+        data={"members_with_roles": json.dumps(_db_team_members)},  # type: ignore
+    )
+
+
 @router.post(
     "/team/member_update",
     tags=["team management"],
@@ -2636,51 +2777,13 @@ async def team_member_update(
     if prisma_client is None:
         raise HTTPException(status_code=500, detail={"error": "No db connected"})
 
-    if data.team_id is None:
-        raise HTTPException(status_code=400, detail={"error": "No team id passed in"})
-
-    if data.role == "admin" and not premium_user:
-        # exactly the same text your proxy throws for add:
-        raise HTTPException(
-            status_code=400,
-            detail="Assigning team admins is a premium feature. You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/#trial. Pricing: https://www.litellm.ai/#pricing",
-        )
-    if data.user_id is None and data.user_email is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Either user_id or user_email needs to be passed in"},
-        )
-
-    _existing_team_row = await prisma_client.db.litellm_teamtable.find_unique(
-        where={"team_id": data.team_id}
+    _validate_team_member_update_request(data, premium_user)
+    existing_team_row = await _team_member_update_fetch_team_or_raise(
+        prisma_client, data.team_id
     )
-
-    if _existing_team_row is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Team id={} does not exist in db".format(data.team_id)},
-        )
-    existing_team_row = LiteLLM_TeamTable(**_existing_team_row.model_dump())
-
-    ## CHECK IF USER IS PROXY ADMIN OR TEAM ADMIN OR ORG ADMIN
-
-    if (
-        user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
-        and not _is_user_team_admin(
-            user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
-        )
-        and not await _is_user_org_admin_for_team(
-            user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
-        )
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": "Call not allowed. User not proxy admin OR team admin. route={}, team_id={}".format(
-                    "/team/member_delete", existing_team_row.team_id
-                )
-            },
-        )
+    await _team_member_update_require_authorized(
+        user_api_key_dict, existing_team_row
+    )
 
     returned_team_info: TeamInfoResponseObject = await team_info(
         http_request=http_request,
@@ -2689,55 +2792,19 @@ async def team_member_update(
     )
 
     team_table = returned_team_info["team_info"]
-
-    ## get user id
-    received_user_id: Optional[str] = None
-    if data.user_id is not None:
-        received_user_id = data.user_id
-    elif data.user_email is not None:
-        for member in returned_team_info["team_info"].members_with_roles:
-            if member.user_email is not None and member.user_email == data.user_email:
-                received_user_id = member.user_id
-                break
-
-    if received_user_id is None:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "User id doesn't exist in team table. Data={}".format(data)
-            },
+    received_user_id = _resolve_team_member_user_id_from_request(
+        data, returned_team_info
+    )
+    identified_budget_id = _identified_member_budget_id(
+        returned_team_info["team_memberships"], received_user_id
+    )
+    team_default_budget_id = _team_default_member_budget_id(team_table)
+    budget_duration_explicit, effective_budget_duration = (
+        await _effective_member_budget_duration(
+            data, prisma_client, team_default_budget_id
         )
-    ## find the relevant team membership
-    identified_budget_id: Optional[str] = None
-    for tm in returned_team_info["team_memberships"]:
-        if tm.user_id == received_user_id:
-            identified_budget_id = tm.budget_id
-            break
+    )
 
-    team_default_budget_id: Optional[str] = None
-    if team_table.metadata is not None:
-        raw_default_budget_id = team_table.metadata.get("team_member_budget_id")
-        if isinstance(raw_default_budget_id, str):
-            team_default_budget_id = raw_default_budget_id
-
-    ### resolve effective budget_duration
-    # - Explicit value (including null) takes precedence
-    # - If omitted, inherit the team's configured team_member_budget_duration
-    budget_duration_explicit = "budget_duration" in data.model_fields_set
-    if budget_duration_explicit:
-        effective_budget_duration = data.budget_duration
-    else:
-        if team_default_budget_id:
-            _team_budget_row = await prisma_client.db.litellm_budgettable.find_unique(
-                where={"budget_id": team_default_budget_id}
-            )
-            effective_budget_duration = (
-                _team_budget_row.budget_duration if _team_budget_row else None
-            )
-        else:
-            effective_budget_duration = None
-
-    ### upsert new budget
     async with prisma_client.db.tx() as tx:
         await _upsert_budget_and_membership(
             tx=tx,
@@ -2754,28 +2821,12 @@ async def team_member_update(
             budget_duration_explicit=budget_duration_explicit,
         )
 
-    ### update team member role
-    if data.role is not None:
-        team_members: List[Member] = []
-        for member in team_table.members_with_roles:
-            if member.user_id == received_user_id:
-                team_members.append(
-                    Member(
-                        user_id=member.user_id,
-                        role=data.role,
-                        user_email=data.user_email or member.user_email,
-                    )
-                )
-            else:
-                team_members.append(member)
-
-        team_table.members_with_roles = team_members
-
-        _db_team_members: List[dict] = [m.model_dump() for m in team_members]
-        await prisma_client.db.litellm_teamtable.update(
-            where={"team_id": data.team_id},
-            data={"members_with_roles": json.dumps(_db_team_members)},  # type: ignore
-        )
+    await _team_member_update_apply_role_if_requested(
+        prisma_client,
+        data=data,
+        team_table=team_table,
+        received_user_id=received_user_id,
+    )
 
     return TeamMemberUpdateResponse(
         team_id=data.team_id,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2781,9 +2781,7 @@ async def team_member_update(
     existing_team_row = await _team_member_update_fetch_team_or_raise(
         prisma_client, data.team_id
     )
-    await _team_member_update_require_authorized(
-        user_api_key_dict, existing_team_row
-    )
+    await _team_member_update_require_authorized(user_api_key_dict, existing_team_row)
 
     returned_team_info: TeamInfoResponseObject = await team_info(
         http_request=http_request,
@@ -4355,9 +4353,7 @@ async def list_team(
         except Exception as e:
             team_exception = """Invalid team object for team_id: {}. team_object={}.
             Error: {}
-            """.format(
-                team.team_id, team.model_dump(), str(e)
-            )
+            """.format(team.team_id, team.model_dump(), str(e))
             verbose_proxy_logger.exception(team_exception)
             continue
     # Sort the responses by team_alias

--- a/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
+++ b/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
@@ -423,6 +423,96 @@ async def test_upsert_clones_when_pointing_at_shared_default(mock_tx, fake_user)
     )
 
 
+@pytest.mark.asyncio
+async def test_upsert_explicit_lifetime_clears_duration_on_private_budget(
+    mock_tx, fake_user
+):
+    """Explicit ``budget_duration: null`` clears periodic duration on private row."""
+    await _upsert_budget_and_membership(
+        mock_tx,
+        team_id="team-lifetime",
+        user_id="user-lifetime",
+        max_budget=None,
+        existing_budget_id="private-budget-periodic",
+        user_api_key_dict=fake_user,
+        team_default_budget_id="team-default-budget-1",
+        budget_duration=None,
+        budget_duration_explicit=True,
+    )
+
+    mock_tx.litellm_budgettable.update.assert_awaited_once_with(
+        where={"budget_id": "private-budget-periodic"},
+        data={
+            "updated_by": fake_user.user_id,
+            "budget_duration": None,
+            "budget_reset_at": None,
+        },
+    )
+    mock_tx.litellm_budgettable.create.assert_not_called()
+    mock_tx.litellm_teammembership.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upsert_clone_explicit_lifetime_strips_cloned_duration(
+    mock_tx, fake_user
+):
+    """Clone-from-default: explicit null must not keep default's budget_duration."""
+    shared_default_id = "team-default-budget-1"
+    default_row = MagicMock()
+    default_row.model_dump.return_value = {
+        "budget_id": shared_default_id,
+        "max_budget": 200.0,
+        "soft_budget": None,
+        "max_parallel_requests": None,
+        "tpm_limit": 500,
+        "rpm_limit": None,
+        "model_max_budget": None,
+        "budget_duration": "1d",
+        "allowed_models": [],
+    }
+    mock_tx.litellm_budgettable.find_unique = AsyncMock(return_value=default_row)
+
+    await _upsert_budget_and_membership(
+        mock_tx,
+        team_id="team-shared-lt",
+        user_id="user-shared-lt",
+        max_budget=50.0,
+        existing_budget_id=shared_default_id,
+        user_api_key_dict=fake_user,
+        team_default_budget_id=shared_default_id,
+        budget_duration=None,
+        budget_duration_explicit=True,
+    )
+
+    mock_tx.litellm_budgettable.create.assert_awaited_once_with(
+        data={
+            "created_by": fake_user.user_id,
+            "updated_by": fake_user.user_id,
+            "max_budget": 50.0,
+            "tpm_limit": 500,
+        },
+        include={"team_membership": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_explicit_null_only_does_not_disconnect(mock_tx, fake_user):
+    """Explicit lifetime with no other fields must not disconnect membership budget."""
+    await _upsert_budget_and_membership(
+        mock_tx,
+        team_id="team-explicit-null",
+        user_id="user-explicit-null",
+        max_budget=None,
+        existing_budget_id=None,
+        user_api_key_dict=fake_user,
+        budget_duration=None,
+        budget_duration_explicit=True,
+    )
+
+    mock_tx.litellm_teammembership.update.assert_not_called()
+    mock_tx.litellm_budgettable.create.assert_awaited_once()
+
+
 # TEST: when team default exists but member already has their own budget, in-place update
 @pytest.mark.asyncio
 async def test_upsert_updates_in_place_when_member_has_private_budget(

--- a/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
+++ b/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
@@ -95,6 +95,37 @@ async def test_upsert_with_existing_budget_id_creates_new(mock_tx, fake_user):
     mock_tx.litellm_teammembership.update.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_upsert_in_place_omitted_duration_does_not_touch_duration_fields(
+    mock_tx,
+    fake_user,
+):
+    """
+    When budget_duration was omitted from the API (explicit=False), an in-place
+    update must not write budget_duration / budget_reset_at even if the caller
+    passes a resolved team-default duration string (Greptile P1, PR #26779).
+    """
+    await _upsert_budget_and_membership(
+        mock_tx,
+        team_id="team-no-dur-touch",
+        user_id="user-no-dur-touch",
+        max_budget=10.0,
+        existing_budget_id="priv-budget-1",
+        user_api_key_dict=fake_user,
+        team_default_budget_id="team-default-xyz",
+        budget_duration="30d",
+        budget_duration_explicit=False,
+    )
+
+    mock_tx.litellm_budgettable.update.assert_awaited_once_with(
+        where={"budget_id": "priv-budget-1"},
+        data={
+            "max_budget": 10.0,
+            "updated_by": fake_user.user_id,
+        },
+    )
+
+
 # TEST: create new budget and link membership
 @pytest.mark.asyncio
 async def test_upsert_create_and_link(mock_tx, fake_user):

--- a/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
+++ b/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
@@ -225,6 +225,80 @@ async def test_upsert_rpm_limit_update_creates_new_budget(mock_tx, fake_user):
     mock_tx.litellm_teammembership.upsert.assert_not_called()
 
 
+# TEST: budget_duration is threaded through to the new budget row
+@pytest.mark.asyncio
+async def test_upsert_with_budget_duration(mock_tx, fake_user):
+    """
+    When budget_duration is passed, it (and a derived budget_reset_at) should
+    appear in the create_data sent to Prisma.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/25509
+    """
+    from unittest.mock import patch
+    from datetime import datetime as dt
+
+    fake_reset_at = dt(2026, 1, 31, 0, 0, 0)
+
+    with patch(
+        "litellm.proxy.management_endpoints.common_utils.get_budget_reset_time",
+        return_value=fake_reset_at,
+    ):
+        await _upsert_budget_and_membership(
+            mock_tx,
+            team_id="team-dur",
+            user_id="user-dur",
+            max_budget=10.0,
+            existing_budget_id=None,
+            user_api_key_dict=fake_user,
+            budget_duration="30d",
+        )
+
+    call_data = mock_tx.litellm_budgettable.create.call_args.kwargs["data"]
+    assert call_data["budget_duration"] == "30d"
+    assert call_data["budget_reset_at"] == fake_reset_at
+
+    # membership upsert should still happen
+    mock_tx.litellm_teammembership.upsert.assert_awaited_once()
+
+
+# TEST: budget_duration alone (no max_budget/limits) creates a budget rather than disconnecting
+@pytest.mark.asyncio
+async def test_upsert_budget_duration_only_creates_budget(mock_tx, fake_user):
+    """
+    When only budget_duration is provided (no max_budget, tpm_limit, rpm_limit),
+    a new budget should be created rather than disconnecting.
+    """
+    from unittest.mock import patch
+    from datetime import datetime as dt
+
+    fake_reset_at = dt(2026, 1, 8, 0, 0, 0)
+
+    with patch(
+        "litellm.proxy.management_endpoints.common_utils.get_budget_reset_time",
+        return_value=fake_reset_at,
+    ):
+        await _upsert_budget_and_membership(
+            mock_tx,
+            team_id="team-dur-only",
+            user_id="user-dur-only",
+            max_budget=None,
+            existing_budget_id=None,
+            user_api_key_dict=fake_user,
+            budget_duration="7d",
+        )
+
+    # Should NOT disconnect
+    mock_tx.litellm_teammembership.update.assert_not_called()
+
+    # Should create a budget with budget_duration set
+    call_data = mock_tx.litellm_budgettable.create.call_args.kwargs["data"]
+    assert call_data["budget_duration"] == "7d"
+    assert call_data["budget_reset_at"] == fake_reset_at
+
+    # Should upsert membership
+    mock_tx.litellm_teammembership.upsert.assert_awaited_once()
+
+
 # TEST: create new budget with only rpm_limit (no max_budget)
 @pytest.mark.asyncio
 async def test_upsert_rpm_only_creates_new_budget(mock_tx, fake_user):
@@ -279,6 +353,9 @@ async def test_upsert_clones_when_pointing_at_shared_default(mock_tx, fake_user)
     shared row. Instead we should create a new private budget for this member
     (seeded with the default's values) and re-link the membership to it.
     """
+    from unittest.mock import patch
+    from datetime import datetime as dt
+
     shared_default_id = "team-default-budget-1"
 
     # Default budget row in the DB: $200 cap, daily reset, 500 tpm.
@@ -296,16 +373,21 @@ async def test_upsert_clones_when_pointing_at_shared_default(mock_tx, fake_user)
     }
     mock_tx.litellm_budgettable.find_unique = AsyncMock(return_value=default_row)
 
-    # Caller is changing only this member's max_budget.
-    await _upsert_budget_and_membership(
-        mock_tx,
-        team_id="team-shared",
-        user_id="user-shared",
-        max_budget=50.0,
-        existing_budget_id=shared_default_id,
-        user_api_key_dict=fake_user,
-        team_default_budget_id=shared_default_id,
-    )
+    fake_reset_at = dt(2026, 2, 1, 12, 0, 0)
+    with patch(
+        "litellm.proxy.management_endpoints.common_utils.get_budget_reset_time",
+        return_value=fake_reset_at,
+    ):
+        # Caller is changing only this member's max_budget.
+        await _upsert_budget_and_membership(
+            mock_tx,
+            team_id="team-shared",
+            user_id="user-shared",
+            max_budget=50.0,
+            existing_budget_id=shared_default_id,
+            user_api_key_dict=fake_user,
+            team_default_budget_id=shared_default_id,
+        )
 
     # Must NOT touch the shared default row in place.
     mock_tx.litellm_budgettable.update.assert_not_called()
@@ -319,6 +401,7 @@ async def test_upsert_clones_when_pointing_at_shared_default(mock_tx, fake_user)
             "max_budget": 50.0,  # caller wins
             "tpm_limit": 500,  # cloned from default
             "budget_duration": "1d",  # cloned from default
+            "budget_reset_at": fake_reset_at,
         },
         include={"team_membership": True},
     )

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -21,6 +21,7 @@ from litellm.proxy.management_endpoints.team_endpoints import team_member_update
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_request():
     scope = {"type": "http", "method": "POST", "path": "/team/member_update"}
     return Request(scope)
@@ -75,6 +76,7 @@ def _mock_prisma(team_table, team_budget_duration=None):
 # Tests for budget_duration resolution logic
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_team_member_update_explicit_budget_duration():
     """
@@ -91,16 +93,18 @@ async def test_team_member_update_explicit_budget_duration():
         budget_duration="30d",
     )
 
-    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
-         patch("litellm.proxy.proxy_server.premium_user", True), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints.team_info",
-             new=AsyncMock(return_value=_team_info_response(team_table)),
-         ), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
-             new=AsyncMock(),
-         ) as mock_upsert:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.team_info",
+            new=AsyncMock(return_value=_team_info_response(team_table)),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+            new=AsyncMock(),
+        ) as mock_upsert,
+    ):
         await team_member_update(data, _make_request(), _admin_auth())
 
     mock_upsert.assert_awaited_once()
@@ -122,20 +126,27 @@ async def test_team_member_update_explicit_null_budget_duration():
     # Simulate the client sending {"budget_duration": null} by including the
     # field in the model_fields_set while keeping the value None.
     data = TeamMemberUpdateRequest.model_validate(
-        {"team_id": "team-1", "user_id": "user-A", "max_budget_in_team": 5.0, "budget_duration": None}
+        {
+            "team_id": "team-1",
+            "user_id": "user-A",
+            "max_budget_in_team": 5.0,
+            "budget_duration": None,
+        }
     )
     assert "budget_duration" in data.model_fields_set  # sanity check
 
-    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
-         patch("litellm.proxy.proxy_server.premium_user", True), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints.team_info",
-             new=AsyncMock(return_value=_team_info_response(team_table)),
-         ), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
-             new=AsyncMock(),
-         ) as mock_upsert:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.team_info",
+            new=AsyncMock(return_value=_team_info_response(team_table)),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+            new=AsyncMock(),
+        ) as mock_upsert,
+    ):
         await team_member_update(data, _make_request(), _admin_auth())
 
     mock_upsert.assert_awaited_once()
@@ -162,16 +173,18 @@ async def test_team_member_update_inherits_team_budget_duration():
     )
     assert "budget_duration" not in data.model_fields_set  # sanity check
 
-    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
-         patch("litellm.proxy.proxy_server.premium_user", True), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints.team_info",
-             new=AsyncMock(return_value=_team_info_response(team_table)),
-         ), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
-             new=AsyncMock(),
-         ) as mock_upsert:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.team_info",
+            new=AsyncMock(return_value=_team_info_response(team_table)),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+            new=AsyncMock(),
+        ) as mock_upsert,
+    ):
         await team_member_update(data, _make_request(), _admin_auth())
 
     mock_upsert.assert_awaited_once()
@@ -197,16 +210,18 @@ async def test_team_member_update_no_team_budget_duration_defaults_to_none():
         max_budget_in_team=5.0,
     )
 
-    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
-         patch("litellm.proxy.proxy_server.premium_user", True), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints.team_info",
-             new=AsyncMock(return_value=_team_info_response(team_table)),
-         ), \
-         patch(
-             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
-             new=AsyncMock(),
-         ) as mock_upsert:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.team_info",
+            new=AsyncMock(return_value=_team_info_response(team_table)),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+            new=AsyncMock(),
+        ) as mock_upsert,
+    ):
         await team_member_update(data, _make_request(), _admin_auth())
 
     mock_upsert.assert_awaited_once()
@@ -215,9 +230,32 @@ async def test_team_member_update_no_team_budget_duration_defaults_to_none():
     prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
 
 
+def test_resolve_team_member_user_id_without_identifier_raises():
+    """
+    _resolve_team_member_user_id_from_request must not rely on ``assert`` for
+    invariants (stripped under ``python -O``); missing identifiers raise 400.
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _resolve_team_member_user_id_from_request,
+    )
+
+    team_table = _make_team_table()
+    info = _team_info_response(team_table)
+    data = TeamMemberUpdateRequest.model_construct(
+        team_id="team-1", user_id=None, user_email=None
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_team_member_user_id_from_request(data, info)
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == {
+        "error": "Either user_id or user_email needs to be passed in"
+    }
+
+
 # ---------------------------------------------------------------------------
 # Role / premium-user guard tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_ateam_member_update_admin_requires_premium(monkeypatch):

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -105,6 +105,7 @@ async def test_team_member_update_explicit_budget_duration():
 
     mock_upsert.assert_awaited_once()
     assert mock_upsert.call_args.kwargs["budget_duration"] == "30d"
+    assert mock_upsert.call_args.kwargs["budget_duration_explicit"] is True
     # Should NOT have fetched the team-level budget row
     prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
 
@@ -139,6 +140,7 @@ async def test_team_member_update_explicit_null_budget_duration():
 
     mock_upsert.assert_awaited_once()
     assert mock_upsert.call_args.kwargs["budget_duration"] is None
+    assert mock_upsert.call_args.kwargs["budget_duration_explicit"] is True
     # Should NOT have fetched the team-level budget row
     prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
 
@@ -174,6 +176,7 @@ async def test_team_member_update_inherits_team_budget_duration():
 
     mock_upsert.assert_awaited_once()
     assert mock_upsert.call_args.kwargs["budget_duration"] == "30d"
+    assert mock_upsert.call_args.kwargs["budget_duration_explicit"] is False
     prisma.db.litellm_budgettable.find_unique.assert_awaited_once_with(
         where={"budget_id": "team-bud-1"}
     )
@@ -208,6 +211,7 @@ async def test_team_member_update_no_team_budget_duration_defaults_to_none():
 
     mock_upsert.assert_awaited_once()
     assert mock_upsert.call_args.kwargs["budget_duration"] is None
+    assert mock_upsert.call_args.kwargs["budget_duration_explicit"] is False
     prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
 
 

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -1,11 +1,219 @@
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
 
 import litellm.proxy.proxy_server as proxy_server
-from litellm.proxy._types import TeamMemberUpdateRequest
+from litellm.proxy._types import (
+    LiteLLM_TeamMembership,
+    LiteLLM_TeamTable,
+    LitellmUserRoles,
+    Member,
+    TeamMemberUpdateRequest,
+    UserAPIKeyAuth,
+)
 from litellm.proxy.management_endpoints.team_endpoints import team_member_update
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request():
+    scope = {"type": "http", "method": "POST", "path": "/team/member_update"}
+    return Request(scope)
+
+
+def _admin_auth():
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-user",
+    )
+
+
+def _make_team_table(metadata=None):
+    return LiteLLM_TeamTable(
+        team_id="team-1",
+        members_with_roles=[Member(user_id="user-A", role="user")],
+        metadata=metadata or {},
+    )
+
+
+def _team_info_response(team_table, budget_id=None):
+    membership = LiteLLM_TeamMembership(
+        user_id="user-A",
+        team_id="team-1",
+        budget_id=budget_id,
+        litellm_budget_table=None,
+    )
+    return {"team_info": team_table, "team_memberships": [membership]}
+
+
+def _mock_prisma(team_table, team_budget_duration=None):
+    """Build a minimal mock prisma client for team_member_update tests."""
+    mock_existing_team = MagicMock()
+    mock_existing_team.model_dump.return_value = team_table.model_dump()
+
+    mock_budget_row = MagicMock()
+    mock_budget_row.budget_duration = team_budget_duration
+
+    # tx context manager
+    mock_tx = MagicMock()
+    mock_tx.__aenter__ = AsyncMock(return_value=mock_tx)
+    mock_tx.__aexit__ = AsyncMock(return_value=False)
+
+    prisma = MagicMock()
+    prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+    prisma.db.litellm_budgettable.find_unique = AsyncMock(return_value=mock_budget_row)
+    prisma.db.tx = MagicMock(return_value=mock_tx)
+    return prisma
+
+
+# ---------------------------------------------------------------------------
+# Tests for budget_duration resolution logic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_team_member_update_explicit_budget_duration():
+    """
+    When budget_duration is explicitly provided in the request, it should be
+    passed straight to _upsert_budget_and_membership, ignoring any team setting.
+    """
+    team_table = _make_team_table(metadata={"team_member_budget_id": "team-bud-1"})
+    prisma = _mock_prisma(team_table, team_budget_duration="90d")
+
+    data = TeamMemberUpdateRequest(
+        team_id="team-1",
+        user_id="user-A",
+        max_budget_in_team=5.0,
+        budget_duration="30d",
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
+         patch("litellm.proxy.proxy_server.premium_user", True), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints.team_info",
+             new=AsyncMock(return_value=_team_info_response(team_table)),
+         ), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+             new=AsyncMock(),
+         ) as mock_upsert:
+        await team_member_update(data, _make_request(), _admin_auth())
+
+    mock_upsert.assert_awaited_once()
+    assert mock_upsert.call_args.kwargs["budget_duration"] == "30d"
+    # Should NOT have fetched the team-level budget row
+    prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_team_member_update_explicit_null_budget_duration():
+    """
+    When budget_duration is explicitly set to null in the request, None should
+    be used (lifetime cap), NOT the team's configured duration.
+    """
+    team_table = _make_team_table(metadata={"team_member_budget_id": "team-bud-1"})
+    prisma = _mock_prisma(team_table, team_budget_duration="30d")
+
+    # Simulate the client sending {"budget_duration": null} by including the
+    # field in the model_fields_set while keeping the value None.
+    data = TeamMemberUpdateRequest.model_validate(
+        {"team_id": "team-1", "user_id": "user-A", "max_budget_in_team": 5.0, "budget_duration": None}
+    )
+    assert "budget_duration" in data.model_fields_set  # sanity check
+
+    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
+         patch("litellm.proxy.proxy_server.premium_user", True), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints.team_info",
+             new=AsyncMock(return_value=_team_info_response(team_table)),
+         ), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+             new=AsyncMock(),
+         ) as mock_upsert:
+        await team_member_update(data, _make_request(), _admin_auth())
+
+    mock_upsert.assert_awaited_once()
+    assert mock_upsert.call_args.kwargs["budget_duration"] is None
+    # Should NOT have fetched the team-level budget row
+    prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_team_member_update_inherits_team_budget_duration():
+    """
+    When budget_duration is omitted from the request and the team has a
+    team_member_budget_id, the team budget's duration should be inherited.
+    """
+    team_table = _make_team_table(metadata={"team_member_budget_id": "team-bud-1"})
+    prisma = _mock_prisma(team_table, team_budget_duration="30d")
+
+    # budget_duration NOT included in request at all
+    data = TeamMemberUpdateRequest(
+        team_id="team-1",
+        user_id="user-A",
+        max_budget_in_team=5.0,
+    )
+    assert "budget_duration" not in data.model_fields_set  # sanity check
+
+    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
+         patch("litellm.proxy.proxy_server.premium_user", True), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints.team_info",
+             new=AsyncMock(return_value=_team_info_response(team_table)),
+         ), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+             new=AsyncMock(),
+         ) as mock_upsert:
+        await team_member_update(data, _make_request(), _admin_auth())
+
+    mock_upsert.assert_awaited_once()
+    assert mock_upsert.call_args.kwargs["budget_duration"] == "30d"
+    prisma.db.litellm_budgettable.find_unique.assert_awaited_once_with(
+        where={"budget_id": "team-bud-1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_member_update_no_team_budget_duration_defaults_to_none():
+    """
+    When budget_duration is omitted and the team has no team_member_budget_id,
+    budget_duration should default to None.
+    """
+    team_table = _make_team_table(metadata={})  # no team_member_budget_id
+    prisma = _mock_prisma(team_table)
+
+    data = TeamMemberUpdateRequest(
+        team_id="team-1",
+        user_id="user-A",
+        max_budget_in_team=5.0,
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", prisma), \
+         patch("litellm.proxy.proxy_server.premium_user", True), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints.team_info",
+             new=AsyncMock(return_value=_team_info_response(team_table)),
+         ), \
+         patch(
+             "litellm.proxy.management_endpoints.team_endpoints._upsert_budget_and_membership",
+             new=AsyncMock(),
+         ) as mock_upsert:
+        await team_member_update(data, _make_request(), _admin_auth())
+
+    mock_upsert.assert_awaited_once()
+    assert mock_upsert.call_args.kwargs["budget_duration"] is None
+    prisma.db.litellm_budgettable.find_unique.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Role / premium-user guard tests
+# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_ateam_member_update_admin_requires_premium(monkeypatch):


### PR DESCRIPTION
Rebased onto current litellm_internal_staging, cherry-picked community commit 81518b7 (daanhendrio / #25560) onto litellm_fix_team_member_budget_duration_25509, and verified with python3 -m pytest

## Relevant issues

Fixes #25509
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

Currently setting a team member budget is not working following the expected behavior. Unlike a team member budget its not possible to set a budget duration and as such these budgets are lifeteam budgets and not periodic. This PR makes it possible to pass a team member budget duration. If the field is not passed we should use the value from the parent team. If it is passed we should use the value and if null is passed we keep the current behavior of a lifetime budget.