### PR TITLE
fix(redis_cache): apply namespace prefix in delete_cache and async_delete_cache

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1259,10 +1259,11 @@ class RedisCache(BaseCache):
     async def async_delete_cache(self, key: str):
         # typed as Any, redis python lib has incomplete type stubs for RedisCluster and does not include `delete`
         _redis_client: Any = self.init_async_client()
-        # keys is str
+        key = self.check_and_fix_namespace(key=key)
         return await _redis_client.delete(key)
 
-    def delete_cache(self, key):
+    def delete_cache(self, key: str):
+        key = self.check_and_fix_namespace(key=key)
         self.redis_client.delete(key)
 
     async def _pipeline_increment_helper(

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -3,7 +3,6 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -473,3 +472,29 @@ async def test_async_lpop_with_float_redis_version(
 
             # Verify the method completed without error
             assert result is not None
+
+
+@pytest.mark.parametrize("namespace", [None, "myns"])
+@pytest.mark.asyncio
+async def test_delete_cache_applies_namespace(namespace, monkeypatch, redis_no_ping):
+    """async_delete_cache and delete_cache must apply the namespace prefix so that
+    DEL targets the same key that SET/GET use."""
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace=namespace)
+
+    raw_key = "cronjob_lock:db_spend_update_job"
+    expected_key = f"{namespace}:{raw_key}" if namespace else raw_key
+
+    # --- async path ---
+    mock_async_client = AsyncMock()
+    with patch.object(
+        redis_cache, "init_async_client", return_value=mock_async_client
+    ):
+        await redis_cache.async_delete_cache(key=raw_key)
+        mock_async_client.delete.assert_called_once_with(expected_key)
+
+    # --- sync path ---
+    mock_sync_client = MagicMock()
+    redis_cache.redis_client = mock_sync_client
+    redis_cache.delete_cache(key=raw_key)
+    mock_sync_client.delete.assert_called_once_with(expected_key)


### PR DESCRIPTION
## Summary

- `async_delete_cache` and `delete_cache` in `litellm/caching/redis_cache.py` were not calling `check_and_fix_namespace()` before issuing the Redis `DEL` command
- When a `namespace` is configured, `SET` and `GET` correctly prefix the key (e.g. `litellm.caching.caching:cronjob_lock:db_spend_update_job`), but `DEL` targeted the raw key — which does not exist — so it always returned 0
- This caused `PodLockManager` to never explicitly release locks; every lock expired by TTL instead, producing a `failed to release Redis lock` warning on every batch-write cycle for every pod

## Changes

- `litellm/caching/redis_cache.py`: add `key = self.check_and_fix_namespace(key=key)` to both `async_delete_cache` and `delete_cache`, matching the pattern used in every other cache method
- `tests/test_litellm/caching/test_redis_cache.py`: add `test_delete_cache_applies_namespace` — parametrized over `namespace=None` and `namespace="myns"` — asserting the correct key is passed to `redis_client.delete` in both the async and sync paths

## Test plan

- [x] `uv run pytest tests/test_litellm/caching/test_redis_cache.py -v` — all 26 tests pass
- [ ] `uv run ruff check litellm/caching/redis_cache.py tests/test_litellm/caching/test_redis_cache.py` — clean
- [ ] `uv run mypy litellm/caching/redis_cache.py --ignore-missing-imports` — no issues