### PR TITLE
fix(bedrock): add 1-hour cache write pricing for Claude 4.5/4.6/4.7 (Global, US)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -712,6 +712,7 @@
     },
     "anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
@@ -735,6 +736,7 @@
     },
     "anthropic.claude-haiku-4-5@20251001": {
         "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
@@ -955,6 +957,7 @@
     },
     "anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -982,6 +985,7 @@
     },
     "anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1011,6 +1015,7 @@
     },
     "global.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1040,6 +1045,7 @@
     },
     "us.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1127,6 +1133,7 @@
     },
     "anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1157,6 +1164,7 @@
     },
     "global.anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1187,6 +1195,7 @@
     },
     "us.anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1277,6 +1286,7 @@
     },
     "anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
@@ -1305,6 +1315,7 @@
     },
     "global.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
@@ -1333,6 +1344,7 @@
     },
     "us.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock_converse",
@@ -1447,11 +1459,13 @@
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -17921,11 +17935,13 @@
     },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -17982,6 +17998,7 @@
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
@@ -30116,6 +30133,7 @@
     },
     "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.375e-06,
+        "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
@@ -30267,11 +30285,13 @@
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "input_cost_per_token_above_200k_tokens": 6.6e-06,
         "output_cost_per_token_above_200k_tokens": 2.475e-05,
         "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.32e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -30372,6 +30392,7 @@
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
@@ -30399,6 +30420,7 @@
     },
     "global.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -712,6 +712,7 @@
     },
     "anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
@@ -735,6 +736,7 @@
     },
     "anthropic.claude-haiku-4-5@20251001": {
         "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
@@ -955,6 +957,7 @@
     },
     "anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -982,6 +985,7 @@
     },
     "anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1011,6 +1015,7 @@
     },
     "global.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1040,6 +1045,7 @@
     },
     "us.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1127,6 +1133,7 @@
     },
     "anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1171,6 +1178,7 @@
     },
     "global.anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1201,6 +1209,7 @@
     },
     "us.anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
@@ -1291,6 +1300,7 @@
     },
     "anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
@@ -1319,6 +1329,7 @@
     },
     "global.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
@@ -1347,6 +1358,7 @@
     },
     "us.anthropic.claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock_converse",
@@ -1461,11 +1473,13 @@
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -17935,11 +17949,13 @@
     },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -17996,6 +18012,7 @@
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
@@ -30170,6 +30187,7 @@
     },
     "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.375e-06,
+        "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
@@ -30321,11 +30339,13 @@
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "input_cost_per_token_above_200k_tokens": 6.6e-06,
         "output_cost_per_token_above_200k_tokens": 2.475e-05,
         "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.32e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -30426,6 +30446,7 @@
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
@@ -30453,6 +30474,7 @@
     },
     "global.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",

--- a/tests/test_litellm/test_bedrock_anthropic_1hr_cache_pricing.py
+++ b/tests/test_litellm/test_bedrock_anthropic_1hr_cache_pricing.py
@@ -1,0 +1,123 @@
+"""
+Validate that Bedrock-hosted Anthropic Claude 4.5/4.6/4.7 entries carry the
+1-hour prompt-cache write tier (`cache_creation_input_token_cost_above_1hr`)
+in `model_prices_and_context_window.json`.
+
+AWS Bedrock pricing (https://aws.amazon.com/bedrock/pricing/) publishes a
+separate 1-hour cache write column for the Claude 4.5 / 4.6 / 4.7 family.
+Without these fields, cost tracking on Bedrock 1-hour-TTL prompt caching
+falls back to the 5-minute write rate and undercounts spend by ~60%.
+
+Source values (per million tokens) for the 1-hour cache write column,
+as published on the AWS Bedrock pricing page:
+
+  Global pricing:
+    Opus 4.7  / Opus 4.6 / Opus 4.5             -> $10.00
+    Sonnet 4.6 / Sonnet 4.5 (regular tier)      -> $6.00
+    Sonnet 4.5 long-context (>200K tier)        -> $12.00
+    Haiku 4.5                                   -> $2.00
+
+  US pricing (10% premium over Global):
+    Opus 4.7 / Opus 4.6 / Opus 4.5              -> $11.00
+    Sonnet 4.6 / Sonnet 4.5 (regular tier)      -> $6.60
+    Sonnet 4.5 long-context (>200K tier)        -> $13.20
+    Haiku 4.5                                   -> $2.20
+"""
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def model_data():
+    json_path = os.path.join(
+        os.path.dirname(__file__), "../../model_prices_and_context_window.json"
+    )
+    with open(json_path) as f:
+        return json.load(f)
+
+
+# (model_key, expected 1hr cache write per token, expected 1hr LC tier or None)
+GLOBAL_EXPECTED = [
+    # Opus 4.7 - $10.00 / MTok
+    ("anthropic.claude-opus-4-7", 1e-05, None),
+    ("global.anthropic.claude-opus-4-7", 1e-05, None),
+    # Opus 4.6 - $10.00 / MTok
+    ("anthropic.claude-opus-4-6-v1", 1e-05, None),
+    ("global.anthropic.claude-opus-4-6-v1", 1e-05, None),
+    # Opus 4.5 - $10.00 / MTok
+    ("anthropic.claude-opus-4-5-20251101-v1:0", 1e-05, None),
+    ("global.anthropic.claude-opus-4-5-20251101-v1:0", 1e-05, None),
+    # Sonnet 4.6 - $6.00 / MTok (no separate LC tier per AWS)
+    ("anthropic.claude-sonnet-4-6", 6e-06, None),
+    ("global.anthropic.claude-sonnet-4-6", 6e-06, None),
+    # Sonnet 4.5 - $6.00 / MTok regular, $12.00 / MTok long-context (>200K)
+    ("anthropic.claude-sonnet-4-5-20250929-v1:0", 6e-06, 1.2e-05),
+    ("global.anthropic.claude-sonnet-4-5-20250929-v1:0", 6e-06, 1.2e-05),
+    # Haiku 4.5 - $2.00 / MTok
+    ("anthropic.claude-haiku-4-5-20251001-v1:0", 2e-06, None),
+    ("anthropic.claude-haiku-4-5@20251001", 2e-06, None),
+    ("global.anthropic.claude-haiku-4-5-20251001-v1:0", 2e-06, None),
+]
+
+US_EXPECTED = [
+    # US is +10% over Global.
+    ("us.anthropic.claude-opus-4-7", 1.1e-05, None),
+    ("us.anthropic.claude-opus-4-6-v1", 1.1e-05, None),
+    ("us.anthropic.claude-opus-4-5-20251101-v1:0", 1.1e-05, None),
+    ("us.anthropic.claude-sonnet-4-6", 6.6e-06, None),
+    ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", 6.6e-06, 1.32e-05),
+    ("us.anthropic.claude-haiku-4-5-20251001-v1:0", 2.2e-06, None),
+]
+
+
+@pytest.mark.parametrize(
+    "model_key, expected_1hr, expected_1hr_lc", GLOBAL_EXPECTED + US_EXPECTED
+)
+def test_bedrock_anthropic_1hr_cache_write_pricing(
+    model_data, model_key, expected_1hr, expected_1hr_lc
+):
+    assert model_key in model_data, f"Missing model entry: {model_key}"
+    info = model_data[model_key]
+
+    # 1hr cache write rate must be present and exact.
+    assert "cache_creation_input_token_cost_above_1hr" in info, (
+        f"{model_key}: missing cache_creation_input_token_cost_above_1hr - "
+        "AWS Bedrock charges a separate 1-hour cache write rate for this model"
+    )
+    assert info["cache_creation_input_token_cost_above_1hr"] == expected_1hr, (
+        f"{model_key}: 1hr cache write rate "
+        f"{info['cache_creation_input_token_cost_above_1hr']} does not match "
+        f"expected {expected_1hr} from AWS Bedrock pricing"
+    )
+
+    # 1hr cache write rate must be 1.6x the 5-minute rate (AWS standard ratio).
+    five_min = info["cache_creation_input_token_cost"]
+    ratio = info["cache_creation_input_token_cost_above_1hr"] / five_min
+    assert (
+        abs(ratio - 1.6) < 1e-9
+    ), f"{model_key}: 1hr/5min ratio is {ratio}, expected 1.6"
+
+    # Long-context (>200K) tier, where AWS publishes one.
+    if expected_1hr_lc is not None:
+        assert (
+            "cache_creation_input_token_cost_above_1hr_above_200k_tokens" in info
+        ), f"{model_key}: missing 1hr cache write tier for >200K context"
+        assert (
+            info["cache_creation_input_token_cost_above_1hr_above_200k_tokens"]
+            == expected_1hr_lc
+        ), (
+            f"{model_key}: long-context 1hr cache write rate "
+            f"{info['cache_creation_input_token_cost_above_1hr_above_200k_tokens']} "
+            f"does not match expected {expected_1hr_lc}"
+        )
+        five_min_lc = info["cache_creation_input_token_cost_above_200k_tokens"]
+        ratio_lc = (
+            info["cache_creation_input_token_cost_above_1hr_above_200k_tokens"]
+            / five_min_lc
+        )
+        assert (
+            abs(ratio_lc - 1.6) < 1e-9
+        ), f"{model_key}: long-context 1hr/5min ratio is {ratio_lc}, expected 1.6"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Spot-check of LiteLLM model pricing against [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) (Global and US regions) for the Anthropic Claude family.

## Linear ticket

Resolves LIT-2693

## Type

🐛 Bug Fix

## Changes

AWS Bedrock publishes a separate **1-hour prompt-cache write** rate (1.6× the 5-minute rate) for the Claude 4.5 / 4.6 / 4.7 family. Every spot-checked Bedrock-hosted Anthropic entry in `model_prices_and_context_window.json` was missing `cache_creation_input_token_cost_above_1hr`, so cost tracking for 1-hour-TTL prompt caching on Bedrock falls back to the 5-minute rate and undercounts spend by ~60%.

This PR adds the field to the spot-checked **Global** (`anthropic.*`, `global.anthropic.*`) and **US** (`us.anthropic.*`) entries, including the long-context (>200K) variant for Sonnet 4.5. The mirrored `litellm/model_prices_and_context_window_backup.json` is updated in lockstep.

### Values added (per AWS Bedrock pricing page)

**Global region** (`anthropic.*` / `global.anthropic.*`):

| Model | 5-min (existing) | **1-hr (added)** | LC 5-min (existing) | **LC 1-hr (added)** |
|---|---|---|---|---|
| Opus 4.7 | $6.25 | **$10.00** | – | – |
| Opus 4.6 (`-v1`) | $6.25 | **$10.00** | – | – |
| Opus 4.5 (`-20251101-v1:0`) | $6.25 | **$10.00** | – | – |
| Sonnet 4.6 | $3.75 | **$6.00** | – | – |
| Sonnet 4.5 (`-20250929-v1:0`) | $3.75 | **$6.00** | $7.50 | **$12.00** |
| Haiku 4.5 (`-20251001-v1:0`, `@20251001`) | $1.25 | **$2.00** | – | – |

**US region** (`us.anthropic.*`, +10% premium):

| Model | 5-min (existing) | **1-hr (added)** | LC 5-min (existing) | **LC 1-hr (added)** |
|---|---|---|---|---|
| Opus 4.7 | $6.875 | **$11.00** | – | – |
| Opus 4.6 (`-v1`) | $6.875 | **$11.00** | – | – |
| Opus 4.5 (`-20251101-v1:0`) | $6.875 | **$11.00** | – | – |
| Sonnet 4.6 | $4.125 | **$6.60** | – | – |
| Sonnet 4.5 (`-20250929-v1:0`) | $4.125 | **$6.60** | $8.25 | **$13.20** |
| Haiku 4.5 (`-20251001-v1:0`) | $1.375 | **$2.20** | – | – |

All values are verified to be exactly 1.6× the existing 5-minute rate, matching the AWS published 1-hour rate.

### Out of scope

EU / AU / APAC / JP / `us-gov` regional variants (`eu.anthropic.*`, `au.anthropic.*`, `apac.anthropic.*`, `jp.anthropic.*`, `bedrock/us-gov-*`, `us-gov.anthropic.*`) follow the same 1.6× multiplier in principle, but their AWS pricing was not spot-checked against the AWS pricing page in this change. Worth a follow-up PR if those regions also publish a 1-hour tier on the AWS pricing page.

The Claude 3.x Bedrock entries (`claude-3-5-sonnet-20240620`, `claude-3-haiku-20240307`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`) currently carry 5-minute cache pricing in LiteLLM that AWS lists as N/A; that's a separate question (does Bedrock actually return cached_tokens for these?) and not addressed here.

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — `tests/test_litellm/test_bedrock_anthropic_1hr_cache_pricing.py` covers all 19 entries with parameterized assertions for the exact 1-hr value, presence of the field, and the 1.6× ratio invariant.
- [x] My PR passes the new unit tests locally (`19 passed in 0.18s`).
- [x] My PR's scope is as isolated as possible — it only fills in the missing 1-hour cache write tier for the spot-checked Global/US entries.
- [ ] I have requested a Greptile review.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777488678667429?thread_ts=1777488678.667429&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-b275892b-16d0-56bb-b496-80ac320e2db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b275892b-16d0-56bb-b496-80ac320e2db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

