### PR TITLE
fix(proxy): support SMTP_SSL (port 465) in send_email()

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4717,13 +4717,18 @@ async def send_email(
     # Attach the body to the email
     email_message.attach(MIMEText(html, "html"))
 
+    smtp_use_ssl = os.getenv("SMTP_USE_SSL", "False") == "True"
+    use_ssl = smtp_use_ssl or smtp_port == 465
+
     try:
-        # Establish a secure connection with the SMTP server
-        with smtplib.SMTP(
-            host=smtp_host,
-            port=smtp_port,
-        ) as server:
-            if os.getenv("SMTP_TLS", "True") != "False":
+        # Port 465 requires implicit SSL (SMTP_SSL); port 587 uses STARTTLS.
+        if use_ssl:
+            server_ctx = smtplib.SMTP_SSL(host=smtp_host, port=smtp_port)
+        else:
+            server_ctx = smtplib.SMTP(host=smtp_host, port=smtp_port)
+
+        with server_ctx as server:
+            if not use_ssl and os.getenv("SMTP_TLS", "True") != "False":
                 server.starttls()
 
             # Login to your email account only if smtp_username and smtp_password are provided

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4717,7 +4717,7 @@ async def send_email(
     # Attach the body to the email
     email_message.attach(MIMEText(html, "html"))
 
-    smtp_use_ssl = os.getenv("SMTP_USE_SSL", "False") == "True"
+    smtp_use_ssl = os.getenv("SMTP_USE_SSL", "False").lower() == "true"
     use_ssl = smtp_use_ssl or smtp_port == 465
 
     try:

--- a/tests/test_litellm/proxy/test_utils.py
+++ b/tests/test_litellm/proxy/test_utils.py
@@ -1,6 +1,9 @@
+import smtplib
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from litellm.proxy.utils import _get_openapi_url
+from litellm.proxy.utils import _get_openapi_url, send_email
 
 
 @pytest.mark.parametrize(
@@ -20,3 +23,85 @@ def test_get_openapi_url(monkeypatch, env_vars, expected_url):
 
     result = _get_openapi_url()
     assert result == expected_url
+
+
+# ── SMTP connection selection tests ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_email_port_465_uses_smtp_ssl(monkeypatch):
+    """Port 465 must use SMTP_SSL (implicit SSL), not SMTP + starttls."""
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "465")
+    monkeypatch.setenv("SMTP_SENDER_EMAIL", "noreply@example.com")
+    monkeypatch.delenv("SMTP_USE_SSL", raising=False)
+
+    mock_server = MagicMock()
+    mock_server.__enter__ = lambda s: s
+    mock_server.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("smtplib.SMTP_SSL", return_value=mock_server) as mock_ssl,
+        patch("smtplib.SMTP") as mock_plain,
+    ):
+        await send_email(
+            receiver_email="user@example.com",
+            subject="Test",
+            html="<p>Hi</p>",
+        )
+        mock_ssl.assert_called_once_with(host="smtp.example.com", port=465)
+        mock_plain.assert_not_called()
+        mock_server.starttls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_email_smtp_use_ssl_env_forces_ssl(monkeypatch):
+    """SMTP_USE_SSL=True must use SMTP_SSL regardless of port."""
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+    monkeypatch.setenv("SMTP_USE_SSL", "True")
+    monkeypatch.setenv("SMTP_SENDER_EMAIL", "noreply@example.com")
+
+    mock_server = MagicMock()
+    mock_server.__enter__ = lambda s: s
+    mock_server.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("smtplib.SMTP_SSL", return_value=mock_server) as mock_ssl,
+        patch("smtplib.SMTP") as mock_plain,
+    ):
+        await send_email(
+            receiver_email="user@example.com",
+            subject="Test",
+            html="<p>Hi</p>",
+        )
+        mock_ssl.assert_called_once_with(host="smtp.example.com", port=2525)
+        mock_plain.assert_not_called()
+        mock_server.starttls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_email_port_587_uses_starttls(monkeypatch):
+    """Port 587 (default) must use SMTP + starttls — backwards compat regression guard."""
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_SENDER_EMAIL", "noreply@example.com")
+    monkeypatch.delenv("SMTP_USE_SSL", raising=False)
+    monkeypatch.delenv("SMTP_TLS", raising=False)
+
+    mock_server = MagicMock()
+    mock_server.__enter__ = lambda s: s
+    mock_server.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("smtplib.SMTP", return_value=mock_server) as mock_plain,
+        patch("smtplib.SMTP_SSL") as mock_ssl,
+    ):
+        await send_email(
+            receiver_email="user@example.com",
+            subject="Test",
+            html="<p>Hi</p>",
+        )
+        mock_plain.assert_called_once_with(host="smtp.example.com", port=587)
+        mock_ssl.assert_not_called()
+        mock_server.starttls.assert_called_once()

--- a/tests/test_litellm/proxy/test_utils.py
+++ b/tests/test_litellm/proxy/test_utils.py
@@ -81,6 +81,31 @@ async def test_send_email_smtp_use_ssl_env_forces_ssl(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_email_smtp_use_ssl_env_lowercase(monkeypatch):
+    """SMTP_USE_SSL=true (lowercase) must also trigger SMTP_SSL."""
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+    monkeypatch.setenv("SMTP_USE_SSL", "true")
+    monkeypatch.setenv("SMTP_SENDER_EMAIL", "noreply@example.com")
+
+    mock_server = MagicMock()
+    mock_server.__enter__ = lambda s: s
+    mock_server.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("smtplib.SMTP_SSL", return_value=mock_server) as mock_ssl,
+        patch("smtplib.SMTP") as mock_plain,
+    ):
+        await send_email(
+            receiver_email="user@example.com",
+            subject="Test",
+            html="<p>Hi</p>",
+        )
+        mock_ssl.assert_called_once_with(host="smtp.example.com", port=2525)
+        mock_plain.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_email_port_587_uses_starttls(monkeypatch):
     """Port 587 (default) must use SMTP + starttls — backwards compat regression guard."""
     monkeypatch.setenv("SMTP_HOST", "smtp.example.com")


### PR DESCRIPTION
## What

Add implicit-SSL support to `send_email()` in `litellm/proxy/utils.py`. Auto-detects port 465 → uses `smtplib.SMTP_SSL`. Adds `SMTP_USE_SSL` env var for explicit override on any port.

## Why

`send_email()` hardcoded `smtplib.SMTP + starttls()` which only works on port 587. Port 465 requires `smtplib.SMTP_SSL` (implicit SSL from byte 1). Setting `SMTP_PORT=465` caused a hang and `SMTPServerDisconnected: Connection unexpectedly closed: timed out`. Many corporate networks block 587 but allow 465.

## Plan

https://gist.github.com/ishaan-berri/7090f240409cf6770a57384c5da5b6bb

## Testing

### Before (broken state)
![Before: smtplib.SMTP hangs on port 465](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-7e893f44-2a71-4bcf-9bd4-2d781cf26103/task-7e893f44-2a71-4bcf-9bd4-2d781cf26103_before_ann.png)

### After (fixed state)
![After: SMTP_SSL connects on port 465, port 587 STARTTLS unaffected](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-7e893f44-2a71-4bcf-9bd4-2d781cf26103/task-7e893f44-2a71-4bcf-9bd4-2d781cf26103_after_ann.png)

![Unit tests: 3 SMTP cases pass](https://raw.githubusercontent.com/ishaan-berri/litellm/main/qa-screenshots/task-7e893f44-2a71-4bcf-9bd4-2d781cf26103/task-7e893f44-2a71-4bcf-9bd4-2d781cf26103_tests_ann.png)