### PR TITLE
feat(ui): Workflow Runs page — durable agent state tracking

### DIFF
--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -40,6 +40,7 @@ import { ProjectsPage } from "@/components/Projects/ProjectsPage";
 import VectorStoreManagement from "@/components/vector_store_management";
 import ToolPoliciesView from "@/components/ToolPoliciesView";
 import { MemoryView } from "@/components/MemoryView";
+import WorkflowRuns from "@/components/workflow_runs";
 import SpendLogsTable from "@/components/view_logs";
 import ViewUserDashboard from "@/components/view_users";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -631,6 +632,8 @@ function CreateKeyPageContent() {
                     <VectorStoreManagement accessToken={accessToken} userRole={userRole} userID={userID} />
                   ) : page == "tool-policies" ? (
                     <ToolPoliciesView accessToken={accessToken} userRole={userRole} />
+                  ) : page == "workflows" ? (
+                    <WorkflowRuns accessToken={accessToken} />
                   ) : page == "memory" ? (
                     <MemoryView
                       accessToken={accessToken}

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -3,6 +3,7 @@ import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import {
   ApiOutlined,
+  ApartmentOutlined,
   AppstoreOutlined,
   AuditOutlined,
   BankOutlined,
@@ -120,11 +121,31 @@ const menuGroups: MenuGroup[] = [
         roles: rolesWithWriteAccess,
       },
       {
-        key: "agents",
-        page: "agents",
-        label: "Agents",
+        key: "agentic",
+        page: "agentic",
+        label: "Agentic",
         icon: <RobotOutlined />,
-        roles: rolesWithWriteAccess,
+        children: [
+          {
+            key: "agents",
+            page: "agents",
+            label: "Agents",
+            icon: <RobotOutlined />,
+            roles: rolesWithWriteAccess,
+          },
+          {
+            key: "workflows",
+            page: "workflows",
+            label: "Workflow Runs",
+            icon: <ApartmentOutlined />,
+          },
+          {
+            key: "memory",
+            page: "memory",
+            label: "Memory",
+            icon: <BookOutlined />,
+          },
+        ],
       },
       {
         key: "mcp-servers",
@@ -138,12 +159,6 @@ const menuGroups: MenuGroup[] = [
         label: "Skills",
         icon: <ApiOutlined />,
         roles: all_admin_roles,
-      },
-      {
-        key: "memory",
-        page: "memory",
-        label: "Memory",
-        icon: <BookOutlined />,
       },
       {
         key: "guardrails",

--- a/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
+++ b/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
@@ -1,0 +1,444 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  Button,
+  List,
+  Spin,
+  Empty,
+  Table,
+  Tag,
+  Typography,
+  Divider,
+} from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
+import { proxyBaseUrl } from "@/components/networking";
+import type { ColumnsType } from "antd/es/table";
+const { Text, Title } = Typography;
+
+interface WorkflowRunsProps {
+  accessToken: string | null;
+}
+
+type WorkflowStatus = "pending" | "running" | "paused" | "completed" | "failed";
+
+interface WorkflowRun {
+  run_id: string;
+  status: WorkflowStatus;
+  workflow_type: string;
+  created_at: string;
+  first_message?: string;
+}
+
+interface WorkflowRunEvent {
+  event_type: string;
+  step_name: string;
+  sequence_number: number;
+  created_at: string;
+}
+
+interface WorkflowRunMessage {
+  role: string;
+  content: string;
+  sequence_number: number;
+}
+
+interface WorkflowRunsListResponse {
+  runs: WorkflowRun[];
+  count: number;
+}
+
+interface WorkflowRunEventsResponse {
+  events: WorkflowRunEvent[];
+}
+
+interface WorkflowRunMessagesResponse {
+  messages: WorkflowRunMessage[];
+}
+
+function statusTagColor(
+  status: WorkflowStatus
+): "default" | "processing" | "warning" | "success" | "error" {
+  switch (status) {
+    case "pending":
+      return "default";
+    case "running":
+      return "processing";
+    case "paused":
+      return "warning";
+    case "completed":
+      return "success";
+    case "failed":
+      return "error";
+    default:
+      return "default";
+  }
+}
+
+function timeAgo(isoDate: string): string {
+  try {
+    const diff = Date.now() - new Date(isoDate).getTime();
+    if (isNaN(diff)) return isoDate;
+    const secs = Math.floor(diff / 1000);
+    if (secs < 60) return `${secs}s ago`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d ago`;
+  } catch {
+    return isoDate;
+  }
+}
+
+function truncateText(text: string, maxLen: number): string {
+  if (!text) return "";
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen) + "…";
+}
+
+const eventColumns: ColumnsType<WorkflowRunEvent> = [
+  {
+    title: "TYPE",
+    dataIndex: "event_type",
+    key: "event_type",
+    render: (val: string) => <Text code>{val}</Text>,
+  },
+  {
+    title: "STEP",
+    dataIndex: "step_name",
+    key: "step_name",
+    render: (val: string) => val ?? "-",
+  },
+  {
+    title: "SEQ",
+    dataIndex: "sequence_number",
+    key: "sequence_number",
+    width: 70,
+  },
+  {
+    title: "TIME",
+    dataIndex: "created_at",
+    key: "created_at",
+    render: (val: string) => timeAgo(val),
+  },
+];
+
+const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
+  const [runs, setRuns] = useState<WorkflowRun[]>([]);
+  const [loadingRuns, setLoadingRuns] = useState(false);
+  const [selectedRun, setSelectedRun] = useState<WorkflowRun | null>(null);
+  const [events, setEvents] = useState<WorkflowRunEvent[]>([]);
+  const [messages, setMessages] = useState<WorkflowRunMessage[]>([]);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+
+  const fetchRuns = useCallback(async () => {
+    if (!accessToken) return;
+    setLoadingRuns(true);
+    try {
+      const base = proxyBaseUrl ?? "";
+      const res = await fetch(`${base}/v1/workflows/runs`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: WorkflowRunsListResponse = await res.json();
+      setRuns(data.runs ?? []);
+    } catch (err) {
+      console.error("Failed to fetch workflow runs:", err);
+    } finally {
+      setLoadingRuns(false);
+    }
+  }, [accessToken]);
+
+  const fetchRunDetail = useCallback(
+    async (run: WorkflowRun) => {
+      if (!accessToken) return;
+      setSelectedRun(run);
+      setLoadingDetail(true);
+      setEvents([]);
+      setMessages([]);
+      try {
+        const base = proxyBaseUrl ?? "";
+        const [eventsRes, messagesRes] = await Promise.all([
+          fetch(`${base}/v1/workflows/runs/${run.run_id}/events`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          }),
+          fetch(`${base}/v1/workflows/runs/${run.run_id}/messages`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          }),
+        ]);
+        const eventsData: WorkflowRunEventsResponse = eventsRes.ok
+          ? await eventsRes.json()
+          : { events: [] };
+        const messagesData: WorkflowRunMessagesResponse = messagesRes.ok
+          ? await messagesRes.json()
+          : { messages: [] };
+        const sortedEvents = [...(eventsData.events ?? [])].sort(
+          (a, b) => a.sequence_number - b.sequence_number
+        );
+        const sortedMessages = [...(messagesData.messages ?? [])].sort(
+          (a, b) => a.sequence_number - b.sequence_number
+        );
+        setEvents(sortedEvents);
+        setMessages(sortedMessages);
+      } catch (err) {
+        console.error("Failed to fetch run detail:", err);
+      } finally {
+        setLoadingDetail(false);
+      }
+    },
+    [accessToken]
+  );
+
+  const refreshDetail = useCallback(() => {
+    if (selectedRun) fetchRunDetail(selectedRun);
+  }, [selectedRun, fetchRunDetail]);
+
+  useEffect(() => {
+    fetchRuns();
+  }, [fetchRuns]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "calc(100vh - 64px)",
+        background: "#fff",
+        overflow: "hidden",
+      }}
+    >
+      {/* Left panel — run list */}
+      <div
+        style={{
+          width: 300,
+          borderRight: "1px solid #f0f0f0",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "16px 16px 8px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderBottom: "1px solid #f0f0f0",
+          }}
+        >
+          <Title level={5} style={{ margin: 0 }}>
+            Workflow Runs
+          </Title>
+          <Button
+            size="small"
+            icon={<ReloadOutlined />}
+            onClick={fetchRuns}
+            loading={loadingRuns}
+          />
+        </div>
+
+        <div style={{ flex: 1, overflowY: "auto" }}>
+          {loadingRuns && runs.length === 0 ? (
+            <div
+              style={{ display: "flex", justifyContent: "center", padding: 32 }}
+            >
+              <Spin />
+            </div>
+          ) : runs.length === 0 ? (
+            <Empty
+              description="No workflow runs"
+              style={{ marginTop: 48 }}
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          ) : (
+            <List
+              dataSource={runs}
+              renderItem={(run) => {
+                const isSelected = selectedRun?.run_id === run.run_id;
+                return (
+                  <List.Item
+                    key={run.run_id}
+                    onClick={() => fetchRunDetail(run)}
+                    style={{
+                      padding: "10px 16px",
+                      cursor: "pointer",
+                      background: isSelected ? "#e6f4ff" : "transparent",
+                      borderLeft: isSelected
+                        ? "3px solid #1677ff"
+                        : "3px solid transparent",
+                      transition: "background 0.15s",
+                    }}
+                  >
+                    <div style={{ width: "100%" }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                          marginBottom: 4,
+                        }}
+                      >
+                        <Text
+                          style={{
+                            fontFamily: "monospace",
+                            fontSize: 12,
+                            color: "#595959",
+                          }}
+                        >
+                          {truncateText(run.run_id, 18)}
+                        </Text>
+                        <Tag color={statusTagColor(run.status)}>
+                          {run.status}
+                        </Tag>
+                      </div>
+                      <div
+                        style={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Text
+                          type="secondary"
+                          style={{ fontSize: 12 }}
+                          ellipsis
+                        >
+                          {truncateText(
+                            run.first_message ?? run.workflow_type ?? "",
+                            28
+                          )}
+                        </Text>
+                        <Text
+                          type="secondary"
+                          style={{ fontSize: 11, whiteSpace: "nowrap" }}
+                        >
+                          {timeAgo(run.created_at)}
+                        </Text>
+                      </div>
+                    </div>
+                  </List.Item>
+                );
+              }}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Right panel — run detail */}
+      <div style={{ flex: 1, overflowY: "auto", padding: "24px 32px" }}>
+        {!selectedRun ? (
+          <Empty
+            description="Select a run to view details"
+            style={{ marginTop: 80 }}
+          />
+        ) : loadingDetail ? (
+          <div style={{ display: "flex", justifyContent: "center", marginTop: 80 }}>
+            <Spin size="large" />
+          </div>
+        ) : (
+          <>
+            {/* Header */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                marginBottom: 24,
+              }}
+            >
+              <div>
+                <Text
+                  style={{
+                    fontFamily: "monospace",
+                    fontSize: 15,
+                    fontWeight: 600,
+                    display: "block",
+                    marginBottom: 8,
+                  }}
+                >
+                  {selectedRun.run_id}
+                </Text>
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: 8 }}
+                >
+                  <Tag color={statusTagColor(selectedRun.status)}>
+                    {selectedRun.status}
+                  </Tag>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    {selectedRun.workflow_type}
+                  </Text>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    ·
+                  </Text>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    {timeAgo(selectedRun.created_at)}
+                  </Text>
+                </div>
+              </div>
+              <Button
+                icon={<ReloadOutlined />}
+                onClick={refreshDetail}
+                loading={loadingDetail}
+              >
+                Refresh
+              </Button>
+            </div>
+
+            <Divider orientation="left">Events</Divider>
+
+            {/* Events table */}
+            {events.length === 0 ? (
+              <Empty
+                description="No events"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                style={{ marginBottom: 24 }}
+              />
+            ) : (
+              <Table
+                dataSource={events}
+                columns={eventColumns}
+                rowKey={(r) => `${r.event_type}-${r.sequence_number}`}
+                size="small"
+                pagination={false}
+                style={{ marginBottom: 24 }}
+              />
+            )}
+
+            <Divider orientation="left">Messages</Divider>
+
+            {/* Messages list */}
+            {messages.length === 0 ? (
+              <Empty
+                description="No messages"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
+            ) : (
+              <List
+                dataSource={messages}
+                renderItem={(msg) => (
+                  <List.Item
+                    key={msg.sequence_number}
+                    style={{ padding: "8px 0", alignItems: "flex-start" }}
+                  >
+                    <div>
+                      <Tag
+                        color={msg.role === "assistant" ? "blue" : "default"}
+                        style={{ marginBottom: 4 }}
+                      >
+                        {msg.role}
+                      </Tag>
+                      <Text style={{ display: "block", whiteSpace: "pre-wrap" }}>
+                        {msg.content}
+                      </Text>
+                    </div>
+                  </List.Item>
+                )}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowRuns;

--- a/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
+++ b/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
@@ -1,127 +1,369 @@
 import React, { useState, useEffect, useCallback } from "react";
-import {
-  Button,
-  List,
-  Spin,
-  Empty,
-  Table,
-  Tag,
-  Typography,
-  Divider,
-} from "antd";
+import { Button, Empty, Spin, Tooltip, Typography } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
 import { proxyBaseUrl } from "@/components/networking";
-import type { ColumnsType } from "antd/es/table";
-const { Text, Title } = Typography;
+
+const { Text } = Typography;
 
 interface WorkflowRunsProps {
   accessToken: string | null;
 }
 
-type WorkflowStatus = "pending" | "running" | "paused" | "completed" | "failed";
+type RunStatus = "pending" | "running" | "paused" | "completed" | "failed";
+
+interface RunMetadata {
+  title?: string;
+  state?: string;
+  [key: string]: unknown;
+}
 
 interface WorkflowRun {
   run_id: string;
-  status: WorkflowStatus;
+  status: RunStatus;
   workflow_type: string;
   created_at: string;
-  first_message?: string;
+  metadata?: RunMetadata | null;
 }
 
 interface WorkflowRunEvent {
+  event_id: string;
   event_type: string;
   step_name: string;
   sequence_number: number;
   created_at: string;
+  data?: Record<string, unknown> | null;
 }
 
 interface WorkflowRunMessage {
+  message_id: string;
   role: string;
   content: string;
   sequence_number: number;
+  created_at: string;
 }
 
-interface WorkflowRunsListResponse {
-  runs: WorkflowRun[];
-  count: number;
+// ── design tokens ─────────────────────────────────────────────────────────────
+
+const STATUS_DOT: Record<RunStatus, string> = {
+  pending: "#a1a1aa",
+  running: "#3b82f6",
+  paused: "#f59e0b",
+  completed: "#22c55e",
+  failed: "#ef4444",
+};
+
+const EVENT_COLOR: Record<string, { bar: string; border: string; text: string }> = {
+  "step.started":  { bar: "#f0fdf4", border: "#86efac", text: "#16a34a" },
+  "step.failed":   { bar: "#fef2f2", border: "#fca5a5", text: "#dc2626" },
+  "hook.waiting":  { bar: "#fffbeb", border: "#fcd34d", text: "#d97706" },
+  "hook.received": { bar: "#eff6ff", border: "#93c5fd", text: "#2563eb" },
+};
+
+function eventStyle(type: string) {
+  return EVENT_COLOR[type] ?? { bar: "#f4f4f5", border: "#d4d4d8", text: "#52525b" };
 }
 
-interface WorkflowRunEventsResponse {
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (isNaN(diff)) return iso;
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function durationMs(from: string, to: string): number {
+  return new Date(to).getTime() - new Date(from).getTime();
+}
+
+function fmtDuration(ms: number): string {
+  if (ms < 0) return "";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function runTitle(run: WorkflowRun): string {
+  const t = run.metadata?.title;
+  if (t) return String(t);
+  return run.workflow_type ?? run.run_id.slice(0, 8);
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+// ── status dot ────────────────────────────────────────────────────────────────
+
+const StatusDot: React.FC<{ status: RunStatus; size?: number }> = ({ status, size = 8 }) => (
+  <span
+    style={{
+      display: "inline-block",
+      width: size,
+      height: size,
+      borderRadius: "50%",
+      background: STATUS_DOT[status] ?? "#a1a1aa",
+      flexShrink: 0,
+    }}
+  />
+);
+
+// ── gantt timeline ────────────────────────────────────────────────────────────
+
+const GanttTimeline: React.FC<{
+  run: WorkflowRun;
   events: WorkflowRunEvent[];
-}
-
-interface WorkflowRunMessagesResponse {
-  messages: WorkflowRunMessage[];
-}
-
-function statusTagColor(
-  status: WorkflowStatus
-): "default" | "processing" | "warning" | "success" | "error" {
-  switch (status) {
-    case "pending":
-      return "default";
-    case "running":
-      return "processing";
-    case "paused":
-      return "warning";
-    case "completed":
-      return "success";
-    case "failed":
-      return "error";
-    default:
-      return "default";
+}> = ({ run, events }) => {
+  if (events.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "20px 0",
+          color: "#a1a1aa",
+          fontSize: 12,
+          fontFamily: "monospace",
+        }}
+      >
+        No events recorded
+      </div>
+    );
   }
-}
 
-function timeAgo(isoDate: string): string {
-  try {
-    const diff = Date.now() - new Date(isoDate).getTime();
-    if (isNaN(diff)) return isoDate;
-    const secs = Math.floor(diff / 1000);
-    if (secs < 60) return `${secs}s ago`;
-    const mins = Math.floor(secs / 60);
-    if (mins < 60) return `${mins}m ago`;
-    const hrs = Math.floor(mins / 60);
-    if (hrs < 24) return `${hrs}h ago`;
-    const days = Math.floor(hrs / 24);
-    return `${days}d ago`;
-  } catch {
-    return isoDate;
-  }
-}
+  const runStart = new Date(run.created_at).getTime();
+  const eventTimes = events.map((e) => new Date(e.created_at).getTime());
+  const lastTime = Math.max(...eventTimes);
+  const totalSpan = Math.max(lastTime - runStart, 1);
 
-function truncateText(text: string, maxLen: number): string {
-  if (!text) return "";
-  if (text.length <= maxLen) return text;
-  return text.slice(0, maxLen) + "…";
-}
+  // outer bar duration label
+  const totalDur = fmtDuration(lastTime - runStart);
 
-const eventColumns: ColumnsType<WorkflowRunEvent> = [
-  {
-    title: "TYPE",
-    dataIndex: "event_type",
-    key: "event_type",
-    render: (val: string) => <Text code>{val}</Text>,
-  },
-  {
-    title: "STEP",
-    dataIndex: "step_name",
-    key: "step_name",
-    render: (val: string) => val ?? "-",
-  },
-  {
-    title: "SEQ",
-    dataIndex: "sequence_number",
-    key: "sequence_number",
-    width: 70,
-  },
-  {
-    title: "TIME",
-    dataIndex: "created_at",
-    key: "created_at",
-    render: (val: string) => timeAgo(val),
-  },
-];
+  return (
+    <div style={{ fontFamily: "monospace", fontSize: 12 }}>
+      {/* ruler */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "180px 1fr",
+          gap: "0 12px",
+          marginBottom: 2,
+        }}
+      >
+        <div />
+        <div style={{ position: "relative", height: 16 }}>
+          {[0, 25, 50, 75, 100].map((pct) => (
+            <span
+              key={pct}
+              style={{
+                position: "absolute",
+                left: `${pct}%`,
+                transform: "translateX(-50%)",
+                fontSize: 10,
+                color: "#a1a1aa",
+              }}
+            >
+              {pct === 0 ? "0" : pct === 100 ? totalDur : ""}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* outer run bar */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "180px 1fr",
+          gap: "0 12px",
+          marginBottom: 4,
+        }}
+      >
+        <div
+          style={{
+            color: "#3f3f46",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            paddingTop: 2,
+          }}
+        >
+          {runTitle(run)}
+        </div>
+        <div
+          style={{
+            position: "relative",
+            height: 24,
+            background: "#f4f4f5",
+            border: "1px solid #d4d4d8",
+            borderRadius: 4,
+            display: "flex",
+            alignItems: "center",
+            paddingLeft: 8,
+          }}
+        >
+          <span style={{ color: "#71717a", fontSize: 11 }}>{totalDur}</span>
+        </div>
+      </div>
+
+      {/* vertical guide line */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "180px 1fr",
+          gap: "0 12px",
+          rowGap: 3,
+        }}
+      >
+        {events.map((ev) => {
+          const evTime = new Date(ev.created_at).getTime();
+          const leftPct = ((evTime - runStart) / totalSpan) * 100;
+
+          // width: time until next event or 8% minimum
+          const nextIdx = events.findIndex((e) => e.sequence_number > ev.sequence_number);
+          const nextTime =
+            nextIdx >= 0
+              ? new Date(events[nextIdx].created_at).getTime()
+              : lastTime + Math.max(totalSpan * 0.12, 500);
+          const widthPct = Math.max(
+            8,
+            ((nextTime - evTime) / totalSpan) * 100
+          );
+
+          const style = eventStyle(ev.event_type);
+          const dur = fmtDuration(nextTime - evTime);
+
+          return (
+            <React.Fragment key={ev.event_id}>
+              {/* label col */}
+              <div
+                style={{
+                  color: "#52525b",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  paddingTop: 2,
+                  paddingLeft: 12,
+                }}
+              >
+                <span style={{ color: style.text }}>{ev.step_name || ev.event_type}</span>
+              </div>
+
+              {/* bar col */}
+              <div style={{ position: "relative", height: 24 }}>
+                <Tooltip
+                  title={
+                    <div style={{ fontFamily: "monospace", fontSize: 11, lineHeight: 1.6 }}>
+                      <div>
+                        <span style={{ color: "#a1a1aa" }}>type: </span>
+                        <span style={{ color: style.text }}>{ev.event_type}</span>
+                      </div>
+                      <div>
+                        <span style={{ color: "#a1a1aa" }}>step: </span>
+                        {ev.step_name}
+                      </div>
+                      <div>
+                        <span style={{ color: "#a1a1aa" }}>seq:  </span>
+                        {ev.sequence_number}
+                      </div>
+                      <div>
+                        <span style={{ color: "#a1a1aa" }}>time: </span>
+                        {timeAgo(ev.created_at)}
+                      </div>
+                      {ev.data && Object.keys(ev.data).length > 0 && (
+                        <div>
+                          <span style={{ color: "#a1a1aa" }}>data: </span>
+                          {JSON.stringify(ev.data)}
+                        </div>
+                      )}
+                    </div>
+                  }
+                >
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: `${Math.min(leftPct, 92)}%`,
+                      width: `${Math.min(widthPct, 100 - Math.min(leftPct, 92))}%`,
+                      height: "100%",
+                      background: style.bar,
+                      border: `1px solid ${style.border}`,
+                      borderRadius: 4,
+                      display: "flex",
+                      alignItems: "center",
+                      paddingLeft: 8,
+                      cursor: "default",
+                      overflow: "hidden",
+                      gap: 6,
+                    }}
+                  >
+                    <span style={{ color: style.text, whiteSpace: "nowrap", fontSize: 11 }}>
+                      {ev.event_type}
+                    </span>
+                    {dur && (
+                      <span style={{ color: "#a1a1aa", whiteSpace: "nowrap", fontSize: 11 }}>
+                        {dur}
+                      </span>
+                    )}
+                  </div>
+                </Tooltip>
+              </div>
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ── messages list ─────────────────────────────────────────────────────────────
+
+const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
+  const roleColor: Record<string, string> = {
+    user: "#2563eb",
+    assistant: "#16a34a",
+    system: "#7c3aed",
+    tool_result: "#d97706",
+  };
+  const color = roleColor[msg.role] ?? "#52525b";
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "80px 1fr",
+        gap: "0 16px",
+        paddingTop: 10,
+        paddingBottom: 10,
+        borderBottom: "1px solid #f4f4f5",
+        fontFamily: "monospace",
+        fontSize: 12,
+        alignItems: "start",
+      }}
+    >
+      <span style={{ color, paddingTop: 1 }}>[{msg.role}]</span>
+      <div>
+        <span
+          style={{
+            color: "#27272a",
+            lineHeight: 1.6,
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            display: "block",
+            fontFamily: "inherit",
+          }}
+        >
+          {msg.content}
+        </span>
+        <span style={{ color: "#a1a1aa", fontSize: 11, marginTop: 2, display: "block" }}>
+          {timeAgo(msg.created_at)}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+// ── main component ────────────────────────────────────────────────────────────
 
 const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
   const [runs, setRuns] = useState<WorkflowRun[]>([]);
@@ -135,15 +377,14 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
     if (!accessToken) return;
     setLoadingRuns(true);
     try {
-      const base = proxyBaseUrl ?? "";
-      const res = await fetch(`${base}/v1/workflows/runs`, {
+      const res = await fetch(`${proxyBaseUrl ?? ""}/v1/workflows/runs?limit=100`, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: WorkflowRunsListResponse = await res.json();
+      const data = await res.json();
       setRuns(data.runs ?? []);
     } catch (err) {
-      console.error("Failed to fetch workflow runs:", err);
+      console.error("workflow runs fetch failed:", err);
     } finally {
       setLoadingRuns(false);
     }
@@ -158,7 +399,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
       setMessages([]);
       try {
         const base = proxyBaseUrl ?? "";
-        const [eventsRes, messagesRes] = await Promise.all([
+        const [evRes, msgRes] = await Promise.all([
           fetch(`${base}/v1/workflows/runs/${run.run_id}/events`, {
             headers: { Authorization: `Bearer ${accessToken}` },
           }),
@@ -166,32 +407,28 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }),
         ]);
-        const eventsData: WorkflowRunEventsResponse = eventsRes.ok
-          ? await eventsRes.json()
-          : { events: [] };
-        const messagesData: WorkflowRunMessagesResponse = messagesRes.ok
-          ? await messagesRes.json()
-          : { messages: [] };
-        const sortedEvents = [...(eventsData.events ?? [])].sort(
-          (a, b) => a.sequence_number - b.sequence_number
+        const evData = evRes.ok ? await evRes.json() : { events: [] };
+        const msgData = msgRes.ok ? await msgRes.json() : { messages: [] };
+        setEvents(
+          [...(evData.events ?? [])].sort(
+            (a: WorkflowRunEvent, b: WorkflowRunEvent) =>
+              a.sequence_number - b.sequence_number
+          )
         );
-        const sortedMessages = [...(messagesData.messages ?? [])].sort(
-          (a, b) => a.sequence_number - b.sequence_number
+        setMessages(
+          [...(msgData.messages ?? [])].sort(
+            (a: WorkflowRunMessage, b: WorkflowRunMessage) =>
+              a.sequence_number - b.sequence_number
+          )
         );
-        setEvents(sortedEvents);
-        setMessages(sortedMessages);
       } catch (err) {
-        console.error("Failed to fetch run detail:", err);
+        console.error("workflow run detail fetch failed:", err);
       } finally {
         setLoadingDetail(false);
       }
     },
     [accessToken]
   );
-
-  const refreshDetail = useCallback(() => {
-    if (selectedRun) fetchRunDetail(selectedRun);
-  }, [selectedRun, fetchRunDetail]);
 
   useEffect(() => {
     fetchRuns();
@@ -204,237 +441,370 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         height: "calc(100vh - 64px)",
         background: "#fff",
         overflow: "hidden",
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
       }}
     >
-      {/* Left panel — run list */}
+      {/* ── left panel ── */}
       <div
         style={{
-          width: 300,
-          borderRight: "1px solid #f0f0f0",
+          width: 280,
+          borderRight: "1px solid #e4e4e7",
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",
+          flexShrink: 0,
         }}
       >
+        {/* panel header */}
         <div
           style={{
-            padding: "16px 16px 8px",
+            padding: "12px 16px",
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
-            borderBottom: "1px solid #f0f0f0",
+            borderBottom: "1px solid #e4e4e7",
           }}
         >
-          <Title level={5} style={{ margin: 0 }}>
+          <span style={{ fontSize: 13, fontWeight: 500, color: "#18181b" }}>
             Workflow Runs
-          </Title>
-          <Button
-            size="small"
-            icon={<ReloadOutlined />}
+            {runs.length > 0 && (
+              <span
+                style={{
+                  marginLeft: 6,
+                  fontSize: 11,
+                  color: "#a1a1aa",
+                  fontWeight: 400,
+                }}
+              >
+                {runs.length}
+              </span>
+            )}
+          </span>
+          <button
             onClick={fetchRuns}
-            loading={loadingRuns}
-          />
+            disabled={loadingRuns}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 4,
+              color: "#a1a1aa",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <ReloadOutlined style={{ fontSize: 13 }} spin={loadingRuns} />
+          </button>
         </div>
 
+        {/* run list */}
         <div style={{ flex: 1, overflowY: "auto" }}>
           {loadingRuns && runs.length === 0 ? (
             <div
-              style={{ display: "flex", justifyContent: "center", padding: 32 }}
+              style={{ display: "flex", justifyContent: "center", padding: 40 }}
             >
-              <Spin />
+              <Spin size="small" />
             </div>
           ) : runs.length === 0 ? (
             <Empty
-              description="No workflow runs"
+              description={
+                <span style={{ color: "#a1a1aa", fontSize: 12 }}>
+                  No workflow runs
+                </span>
+              }
               style={{ marginTop: 48 }}
               image={Empty.PRESENTED_IMAGE_SIMPLE}
             />
           ) : (
-            <List
-              dataSource={runs}
-              renderItem={(run) => {
+            <div>
+              {runs.map((run) => {
                 const isSelected = selectedRun?.run_id === run.run_id;
+                const label = runTitle(run);
+                const state = run.metadata?.state;
                 return (
-                  <List.Item
+                  <div
                     key={run.run_id}
                     onClick={() => fetchRunDetail(run)}
                     style={{
                       padding: "10px 16px",
                       cursor: "pointer",
-                      background: isSelected ? "#e6f4ff" : "transparent",
+                      background: isSelected ? "#fafafa" : "transparent",
                       borderLeft: isSelected
-                        ? "3px solid #1677ff"
-                        : "3px solid transparent",
-                      transition: "background 0.15s",
+                        ? "2px solid #18181b"
+                        : "2px solid transparent",
+                      transition: "background 0.1s",
                     }}
                   >
-                    <div style={{ width: "100%" }}>
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          alignItems: "center",
-                          marginBottom: 4,
-                        }}
-                      >
-                        <Text
-                          style={{
-                            fontFamily: "monospace",
-                            fontSize: 12,
-                            color: "#595959",
-                          }}
-                        >
-                          {truncateText(run.run_id, 18)}
-                        </Text>
-                        <Tag color={statusTagColor(run.status)}>
-                          {run.status}
-                        </Tag>
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          alignItems: "center",
-                        }}
-                      >
-                        <Text
-                          type="secondary"
-                          style={{ fontSize: 12 }}
-                          ellipsis
-                        >
-                          {truncateText(
-                            run.first_message ?? run.workflow_type ?? "",
-                            28
-                          )}
-                        </Text>
-                        <Text
-                          type="secondary"
-                          style={{ fontSize: 11, whiteSpace: "nowrap" }}
-                        >
-                          {timeAgo(run.created_at)}
-                        </Text>
-                      </div>
+                    {/* title */}
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: "#18181b",
+                        lineHeight: 1.45,
+                        marginBottom: 4,
+                        overflow: "hidden",
+                        display: "-webkit-box",
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: "vertical",
+                      }}
+                    >
+                      {label}
                     </div>
-                  </List.Item>
+                    {/* meta row */}
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 6,
+                      }}
+                    >
+                      <StatusDot status={run.status} size={7} />
+                      <span
+                        style={{
+                          fontSize: 11,
+                          color: "#71717a",
+                          textTransform: "capitalize",
+                        }}
+                      >
+                        {state ?? run.status}
+                      </span>
+                      <span style={{ color: "#d4d4d8", fontSize: 10 }}>·</span>
+                      <span style={{ fontSize: 11, color: "#a1a1aa" }}>
+                        {timeAgo(run.created_at)}
+                      </span>
+                    </div>
+                  </div>
                 );
-              }}
-            />
+              })}
+            </div>
           )}
         </div>
       </div>
 
-      {/* Right panel — run detail */}
-      <div style={{ flex: 1, overflowY: "auto", padding: "24px 32px" }}>
+      {/* ── right panel ── */}
+      <div style={{ flex: 1, overflowY: "auto" }}>
         {!selectedRun ? (
-          <Empty
-            description="Select a run to view details"
-            style={{ marginTop: 80 }}
-          />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              height: "100%",
+              color: "#a1a1aa",
+              fontSize: 13,
+            }}
+          >
+            Select a run to view details
+          </div>
         ) : loadingDetail ? (
-          <div style={{ display: "flex", justifyContent: "center", marginTop: 80 }}>
-            <Spin size="large" />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              marginTop: 80,
+            }}
+          >
+            <Spin />
           </div>
         ) : (
-          <>
-            {/* Header */}
+          <div style={{ padding: "24px 32px", maxWidth: 900 }}>
+            {/* ── run header ── */}
             <div
               style={{
                 display: "flex",
-                alignItems: "flex-start",
+                alignItems: "center",
                 justifyContent: "space-between",
-                marginBottom: 24,
+                marginBottom: 20,
               }}
             >
-              <div>
-                <Text
+              {/* status + run id + meta */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 16,
+                  flexWrap: "wrap",
+                }}
+              >
+                {/* status pill */}
+                <div
                   style={{
-                    fontFamily: "monospace",
-                    fontSize: 15,
-                    fontWeight: 600,
-                    display: "block",
-                    marginBottom: 8,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    background: "#f4f4f5",
+                    border: "1px solid #e4e4e7",
+                    borderRadius: 6,
+                    padding: "3px 10px",
                   }}
                 >
-                  {selectedRun.run_id}
-                </Text>
-                <div
-                  style={{ display: "flex", alignItems: "center", gap: 8 }}
-                >
-                  <Tag color={statusTagColor(selectedRun.status)}>
+                  <StatusDot status={selectedRun.status} size={8} />
+                  <span
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 500,
+                      color: "#3f3f46",
+                      textTransform: "capitalize",
+                    }}
+                  >
                     {selectedRun.status}
-                  </Tag>
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    {selectedRun.workflow_type}
-                  </Text>
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    ·
-                  </Text>
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    {timeAgo(selectedRun.created_at)}
-                  </Text>
+                  </span>
                 </div>
+
+                {/* run id */}
+                <span
+                  style={{
+                    fontFamily: "monospace",
+                    fontSize: 12,
+                    color: "#71717a",
+                  }}
+                >
+                  {shortId(selectedRun.run_id)}
+                </span>
+
+                {/* workflow type */}
+                <span style={{ fontSize: 12, color: "#a1a1aa" }}>
+                  {selectedRun.workflow_type}
+                </span>
+
+                {/* duration */}
+                {events.length > 0 && (
+                  <span
+                    style={{
+                      fontFamily: "monospace",
+                      fontSize: 12,
+                      color: "#a1a1aa",
+                    }}
+                  >
+                    {fmtDuration(
+                      durationMs(
+                        selectedRun.created_at,
+                        events[events.length - 1].created_at
+                      )
+                    )}
+                  </span>
+                )}
               </div>
+
               <Button
+                size="small"
                 icon={<ReloadOutlined />}
-                onClick={refreshDetail}
+                onClick={() => fetchRunDetail(selectedRun)}
                 loading={loadingDetail}
+                style={{ color: "#71717a", borderColor: "#e4e4e7" }}
               >
                 Refresh
               </Button>
             </div>
 
-            <Divider orientation="left">Events</Divider>
+            {/* ── timeline ── */}
+            <div
+              style={{
+                borderRadius: 8,
+                border: "1px solid #e4e4e7",
+                padding: "16px 20px",
+                marginBottom: 24,
+                background: "#fff",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: "#a1a1aa",
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  marginBottom: 12,
+                }}
+              >
+                Timeline · {events.length} events
+              </div>
+              <GanttTimeline run={selectedRun} events={events} />
+            </div>
 
-            {/* Events table */}
-            {events.length === 0 ? (
-              <Empty
-                description="No events"
-                image={Empty.PRESENTED_IMAGE_SIMPLE}
-                style={{ marginBottom: 24 }}
-              />
-            ) : (
-              <Table
-                dataSource={events}
-                columns={eventColumns}
-                rowKey={(r) => `${r.event_type}-${r.sequence_number}`}
-                size="small"
-                pagination={false}
-                style={{ marginBottom: 24 }}
-              />
+            {/* ── messages ── */}
+            {messages.length > 0 && (
+              <div
+                style={{
+                  borderRadius: 8,
+                  border: "1px solid #e4e4e7",
+                  padding: "16px 20px",
+                  background: "#fff",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 500,
+                    color: "#a1a1aa",
+                    letterSpacing: "0.05em",
+                    textTransform: "uppercase",
+                    marginBottom: 4,
+                  }}
+                >
+                  Messages · {messages.length}
+                </div>
+                <div>
+                  {messages.map((msg) => (
+                    <MessageRow key={msg.message_id} msg={msg} />
+                  ))}
+                </div>
+              </div>
             )}
 
-            <Divider orientation="left">Messages</Divider>
-
-            {/* Messages list */}
-            {messages.length === 0 ? (
-              <Empty
-                description="No messages"
-                image={Empty.PRESENTED_IMAGE_SIMPLE}
-              />
-            ) : (
-              <List
-                dataSource={messages}
-                renderItem={(msg) => (
-                  <List.Item
-                    key={msg.sequence_number}
-                    style={{ padding: "8px 0", alignItems: "flex-start" }}
-                  >
-                    <div>
-                      <Tag
-                        color={msg.role === "assistant" ? "blue" : "default"}
-                        style={{ marginBottom: 4 }}
+            {/* ── run metadata (collapsed details) ── */}
+            {selectedRun.metadata && Object.keys(selectedRun.metadata).length > 0 && (
+              <div
+                style={{
+                  marginTop: 16,
+                  borderRadius: 8,
+                  border: "1px solid #e4e4e7",
+                  padding: "16px 20px",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 500,
+                    color: "#a1a1aa",
+                    letterSpacing: "0.05em",
+                    textTransform: "uppercase",
+                    marginBottom: 10,
+                  }}
+                >
+                  Metadata
+                </div>
+                <div style={{ fontFamily: "monospace", fontSize: 11 }}>
+                  {Object.entries(selectedRun.metadata)
+                    .filter(([, v]) => v !== null && v !== undefined && v !== "")
+                    .map(([k, v]) => (
+                      <div
+                        key={k}
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: "140px 1fr",
+                          gap: "0 12px",
+                          paddingTop: 4,
+                          paddingBottom: 4,
+                          borderBottom: "1px solid #f4f4f5",
+                        }}
                       >
-                        {msg.role}
-                      </Tag>
-                      <Text style={{ display: "block", whiteSpace: "pre-wrap" }}>
-                        {msg.content}
-                      </Text>
-                    </div>
-                  </List.Item>
-                )}
-              />
+                        <span style={{ color: "#a1a1aa" }}>{k}</span>
+                        <span
+                          style={{
+                            color: "#27272a",
+                            wordBreak: "break-all",
+                          }}
+                        >
+                          {typeof v === "object" ? JSON.stringify(v) : String(v)}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
             )}
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
+++ b/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Button, Empty, Spin, Tooltip, Typography } from "antd";
+import { Button, Collapse, Drawer, Empty, Spin, Table, Tooltip, Typography } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
 import { proxyBaseUrl } from "@/components/networking";
 
@@ -14,6 +14,11 @@ type RunStatus = "pending" | "running" | "paused" | "completed" | "failed";
 interface RunMetadata {
   title?: string;
   state?: string;
+  pr_url?: string;
+  worktree_path?: string;
+  plan_text?: string;
+  grill_session_id?: string;
+  session_id?: string;
   [key: string]: unknown;
 }
 
@@ -45,11 +50,11 @@ interface WorkflowRunMessage {
 // ── design tokens ─────────────────────────────────────────────────────────────
 
 const STATUS_DOT: Record<RunStatus, string> = {
-  pending: "#a1a1aa",
-  running: "#3b82f6",
-  paused: "#f59e0b",
+  pending:   "#a1a1aa",
+  running:   "#3b82f6",
+  paused:    "#f59e0b",
   completed: "#22c55e",
-  failed: "#ef4444",
+  failed:    "#ef4444",
 };
 
 const EVENT_COLOR: Record<string, { bar: string; border: string; text: string }> = {
@@ -75,10 +80,6 @@ function timeAgo(iso: string): string {
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h ago`;
   return `${Math.floor(h / 24)}d ago`;
-}
-
-function durationMs(from: string, to: string): number {
-  return new Date(to).getTime() - new Date(from).getTime();
 }
 
 function fmtDuration(ms: number): string {
@@ -112,6 +113,144 @@ const StatusDot: React.FC<{ status: RunStatus; size?: number }> = ({ status, siz
   />
 );
 
+// ── metadata card ─────────────────────────────────────────────────────────────
+
+const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
+  const meta = run.metadata ?? {};
+
+  // Primary fields shown prominently at the top
+  const primaryFields: { key: string; label: string }[] = [
+    { key: "state",            label: "state" },
+    { key: "worktree_path",    label: "worktree" },
+    { key: "grill_session_id", label: "grill session" },
+    { key: "session_id",       label: "session" },
+  ];
+
+  // Remaining fields (not title, not primary, not nullish)
+  const primaryKeys = new Set(["title", ...primaryFields.map((f) => f.key)]);
+  const extraEntries = Object.entries(meta).filter(
+    ([k, v]) => !primaryKeys.has(k) && v !== null && v !== undefined && v !== ""
+  );
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: "1px solid #e4e4e7",
+        marginBottom: 16,
+        overflow: "hidden",
+      }}
+    >
+      {/* title bar */}
+      <div
+        style={{
+          padding: "14px 20px",
+          borderBottom: "1px solid #f4f4f5",
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+        }}
+      >
+        <StatusDot status={run.status} size={10} />
+        <span style={{ fontSize: 14, fontWeight: 600, color: "#18181b", flex: 1 }}>
+          {runTitle(run)}
+        </span>
+        <span
+          style={{
+            fontFamily: "monospace",
+            fontSize: 11,
+            color: "#a1a1aa",
+            background: "#f4f4f5",
+            padding: "2px 8px",
+            borderRadius: 4,
+          }}
+        >
+          {shortId(run.run_id)}
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            color: "#a1a1aa",
+            background: "#f4f4f5",
+            padding: "2px 8px",
+            borderRadius: 4,
+          }}
+        >
+          {run.workflow_type}
+        </span>
+      </div>
+
+      {/* key fields grid */}
+      <div
+        style={{
+          padding: "12px 20px",
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: "8px 24px",
+          fontFamily: "monospace",
+          fontSize: 12,
+        }}
+      >
+        {/* always-visible: run status + created */}
+        <FieldPair label="status">
+          <span style={{ textTransform: "capitalize", color: "#27272a" }}>{run.status}</span>
+        </FieldPair>
+        <FieldPair label="created">
+          <span style={{ color: "#27272a" }}>{timeAgo(run.created_at)}</span>
+        </FieldPair>
+
+        {/* pr_url as clickable link */}
+        {meta.pr_url && (
+          <FieldPair label="pr">
+            <a
+              href={String(meta.pr_url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "#2563eb", textDecoration: "none", wordBreak: "break-all" }}
+            >
+              {String(meta.pr_url)}
+            </a>
+          </FieldPair>
+        )}
+
+        {/* primary metadata fields */}
+        {primaryFields.map(({ key, label }) => {
+          const v = meta[key];
+          if (v === null || v === undefined || v === "") return null;
+          return (
+            <FieldPair key={key} label={label}>
+              <span style={{ color: "#27272a", wordBreak: "break-all" }}>
+                {typeof v === "object" ? JSON.stringify(v) : String(v)}
+              </span>
+            </FieldPair>
+          );
+        })}
+
+        {/* extra fields */}
+        {extraEntries.map(([k, v]) => (
+          <FieldPair key={k} label={k}>
+            <span style={{ color: "#27272a", wordBreak: "break-all" }}>
+              {typeof v === "object" ? JSON.stringify(v) : String(v)}
+            </span>
+          </FieldPair>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const FieldPair: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+    <span style={{ fontSize: 10, color: "#a1a1aa", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+      {label}
+    </span>
+    <span style={{ fontSize: 12 }}>{children}</span>
+  </div>
+);
+
 // ── gantt timeline ────────────────────────────────────────────────────────────
 
 const GanttTimeline: React.FC<{
@@ -120,14 +259,7 @@ const GanttTimeline: React.FC<{
 }> = ({ run, events }) => {
   if (events.length === 0) {
     return (
-      <div
-        style={{
-          padding: "20px 0",
-          color: "#a1a1aa",
-          fontSize: 12,
-          fontFamily: "monospace",
-        }}
-      >
+      <div style={{ padding: "16px 0", color: "#a1a1aa", fontSize: 12, fontFamily: "monospace" }}>
         No events recorded
       </div>
     );
@@ -137,63 +269,38 @@ const GanttTimeline: React.FC<{
   const eventTimes = events.map((e) => new Date(e.created_at).getTime());
   const lastTime = Math.max(...eventTimes);
   const totalSpan = Math.max(lastTime - runStart, 1);
-
-  // outer bar duration label
   const totalDur = fmtDuration(lastTime - runStart);
 
   return (
     <div style={{ fontFamily: "monospace", fontSize: 12 }}>
       {/* ruler */}
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "180px 1fr",
-          gap: "0 12px",
-          marginBottom: 2,
-        }}
-      >
+      <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: "0 12px", marginBottom: 2 }}>
         <div />
         <div style={{ position: "relative", height: 16 }}>
-          {[0, 25, 50, 75, 100].map((pct) => (
+          {[0, 100].map((pct) => (
             <span
               key={pct}
               style={{
                 position: "absolute",
                 left: `${pct}%`,
-                transform: "translateX(-50%)",
+                transform: pct === 100 ? "translateX(-100%)" : undefined,
                 fontSize: 10,
                 color: "#a1a1aa",
               }}
             >
-              {pct === 0 ? "0" : pct === 100 ? totalDur : ""}
+              {pct === 0 ? "0" : totalDur}
             </span>
           ))}
         </div>
       </div>
 
       {/* outer run bar */}
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "180px 1fr",
-          gap: "0 12px",
-          marginBottom: 4,
-        }}
-      >
-        <div
-          style={{
-            color: "#3f3f46",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            paddingTop: 2,
-          }}
-        >
+      <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: "0 12px", marginBottom: 4 }}>
+        <div style={{ color: "#3f3f46", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", paddingTop: 2 }}>
           {runTitle(run)}
         </div>
         <div
           style={{
-            position: "relative",
             height: 24,
             background: "#f4f4f5",
             border: "1px solid #d4d4d8",
@@ -207,39 +314,26 @@ const GanttTimeline: React.FC<{
         </div>
       </div>
 
-      {/* vertical guide line */}
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "180px 1fr",
-          gap: "0 12px",
-          rowGap: 3,
-        }}
-      >
+      {/* event rows */}
+      <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: "0 12px", rowGap: 3 }}>
         {events.map((ev) => {
           const evTime = new Date(ev.created_at).getTime();
           const leftPct = ((evTime - runStart) / totalSpan) * 100;
 
-          // width: time until next event or 8% minimum
           const nextIdx = events.findIndex((e) => e.sequence_number > ev.sequence_number);
           const nextTime =
             nextIdx >= 0
               ? new Date(events[nextIdx].created_at).getTime()
               : lastTime + Math.max(totalSpan * 0.12, 500);
-          const widthPct = Math.max(
-            8,
-            ((nextTime - evTime) / totalSpan) * 100
-          );
-
+          const widthPct = Math.max(8, ((nextTime - evTime) / totalSpan) * 100);
           const style = eventStyle(ev.event_type);
           const dur = fmtDuration(nextTime - evTime);
 
           return (
             <React.Fragment key={ev.event_id}>
-              {/* label col */}
               <div
                 style={{
-                  color: "#52525b",
+                  color: style.text,
                   overflow: "hidden",
                   textOverflow: "ellipsis",
                   whiteSpace: "nowrap",
@@ -247,35 +341,18 @@ const GanttTimeline: React.FC<{
                   paddingLeft: 12,
                 }}
               >
-                <span style={{ color: style.text }}>{ev.step_name || ev.event_type}</span>
+                {ev.step_name || ev.event_type}
               </div>
-
-              {/* bar col */}
               <div style={{ position: "relative", height: 24 }}>
                 <Tooltip
                   title={
                     <div style={{ fontFamily: "monospace", fontSize: 11, lineHeight: 1.6 }}>
-                      <div>
-                        <span style={{ color: "#a1a1aa" }}>type: </span>
-                        <span style={{ color: style.text }}>{ev.event_type}</span>
-                      </div>
-                      <div>
-                        <span style={{ color: "#a1a1aa" }}>step: </span>
-                        {ev.step_name}
-                      </div>
-                      <div>
-                        <span style={{ color: "#a1a1aa" }}>seq:  </span>
-                        {ev.sequence_number}
-                      </div>
-                      <div>
-                        <span style={{ color: "#a1a1aa" }}>time: </span>
-                        {timeAgo(ev.created_at)}
-                      </div>
+                      <div><span style={{ color: "#a1a1aa" }}>type: </span><span style={{ color: style.text }}>{ev.event_type}</span></div>
+                      <div><span style={{ color: "#a1a1aa" }}>step: </span>{ev.step_name}</div>
+                      <div><span style={{ color: "#a1a1aa" }}>seq:  </span>{ev.sequence_number}</div>
+                      <div><span style={{ color: "#a1a1aa" }}>time: </span>{timeAgo(ev.created_at)}</div>
                       {ev.data && Object.keys(ev.data).length > 0 && (
-                        <div>
-                          <span style={{ color: "#a1a1aa" }}>data: </span>
-                          {JSON.stringify(ev.data)}
-                        </div>
+                        <div><span style={{ color: "#a1a1aa" }}>data: </span>{JSON.stringify(ev.data)}</div>
                       )}
                     </div>
                   }
@@ -297,14 +374,8 @@ const GanttTimeline: React.FC<{
                       gap: 6,
                     }}
                   >
-                    <span style={{ color: style.text, whiteSpace: "nowrap", fontSize: 11 }}>
-                      {ev.event_type}
-                    </span>
-                    {dur && (
-                      <span style={{ color: "#a1a1aa", whiteSpace: "nowrap", fontSize: 11 }}>
-                        {dur}
-                      </span>
-                    )}
+                    <span style={{ color: style.text, whiteSpace: "nowrap", fontSize: 11 }}>{ev.event_type}</span>
+                    {dur && <span style={{ color: "#a1a1aa", whiteSpace: "nowrap", fontSize: 11 }}>{dur}</span>}
                   </div>
                 </Tooltip>
               </div>
@@ -316,13 +387,13 @@ const GanttTimeline: React.FC<{
   );
 };
 
-// ── messages list ─────────────────────────────────────────────────────────────
+// ── message row ───────────────────────────────────────────────────────────────
 
 const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
   const roleColor: Record<string, string> = {
-    user: "#2563eb",
-    assistant: "#16a34a",
-    system: "#7c3aed",
+    user:        "#2563eb",
+    assistant:   "#16a34a",
+    system:      "#7c3aed",
     tool_result: "#d97706",
   };
   const color = roleColor[msg.role] ?? "#52525b";
@@ -333,8 +404,7 @@ const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
         display: "grid",
         gridTemplateColumns: "80px 1fr",
         gap: "0 16px",
-        paddingTop: 10,
-        paddingBottom: 10,
+        padding: "10px 0",
         borderBottom: "1px solid #f4f4f5",
         fontFamily: "monospace",
         fontSize: 12,
@@ -350,7 +420,6 @@ const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
             display: "block",
-            fontFamily: "inherit",
           }}
         >
           {msg.content}
@@ -372,6 +441,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
   const [events, setEvents] = useState<WorkflowRunEvent[]>([]);
   const [messages, setMessages] = useState<WorkflowRunMessage[]>([]);
   const [loadingDetail, setLoadingDetail] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const fetchRuns = useCallback(async () => {
     if (!accessToken) return;
@@ -394,6 +464,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
     async (run: WorkflowRun) => {
       if (!accessToken) return;
       setSelectedRun(run);
+      setDrawerOpen(true);
       setLoadingDetail(true);
       setEvents([]);
       setMessages([]);
@@ -411,14 +482,12 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         const msgData = msgRes.ok ? await msgRes.json() : { messages: [] };
         setEvents(
           [...(evData.events ?? [])].sort(
-            (a: WorkflowRunEvent, b: WorkflowRunEvent) =>
-              a.sequence_number - b.sequence_number
+            (a: WorkflowRunEvent, b: WorkflowRunEvent) => a.sequence_number - b.sequence_number
           )
         );
         setMessages(
           [...(msgData.messages ?? [])].sort(
-            (a: WorkflowRunMessage, b: WorkflowRunMessage) =>
-              a.sequence_number - b.sequence_number
+            (a: WorkflowRunMessage, b: WorkflowRunMessage) => a.sequence_number - b.sequence_number
           )
         );
       } catch (err) {
@@ -434,259 +503,157 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
     fetchRuns();
   }, [fetchRuns]);
 
+  const columns = [
+    {
+      title: "Run",
+      dataIndex: "run_id",
+      key: "run",
+      render: (_: string, run: WorkflowRun) => (
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <StatusDot status={run.status} size={7} />
+          <div>
+            <div style={{ fontSize: 13, color: "#18181b", fontWeight: 500, lineHeight: 1.4 }}>
+              {runTitle(run)}
+            </div>
+            <div style={{ fontFamily: "monospace", fontSize: 11, color: "#a1a1aa" }}>
+              {shortId(run.run_id)}
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: "Type",
+      dataIndex: "workflow_type",
+      key: "workflow_type",
+      render: (v: string) => (
+        <span style={{ fontFamily: "monospace", fontSize: 12, color: "#71717a" }}>{v}</span>
+      ),
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      render: (status: RunStatus, run: WorkflowRun) => {
+        const state = run.metadata?.state;
+        return (
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <StatusDot status={status} size={7} />
+            <span style={{ fontSize: 12, color: "#52525b", textTransform: "capitalize" }}>
+              {state ?? status}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      title: "Created",
+      dataIndex: "created_at",
+      key: "created_at",
+      render: (v: string) => (
+        <span style={{ fontSize: 12, color: "#a1a1aa" }}>{timeAgo(v)}</span>
+      ),
+    },
+  ];
+
   return (
     <div
       style={{
-        display: "flex",
-        height: "calc(100vh - 64px)",
+        padding: "24px 32px",
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        minHeight: "calc(100vh - 64px)",
         background: "#fff",
-        overflow: "hidden",
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
       }}
     >
-      {/* ── left panel ── */}
+      {/* page header */}
       <div
         style={{
-          width: 280,
-          borderRight: "1px solid #e4e4e7",
           display: "flex",
-          flexDirection: "column",
-          overflow: "hidden",
-          flexShrink: 0,
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 20,
         }}
       >
-        {/* panel header */}
-        <div
-          style={{
-            padding: "12px 16px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            borderBottom: "1px solid #e4e4e7",
-          }}
+        <div>
+          <div style={{ fontSize: 18, fontWeight: 600, color: "#18181b" }}>Workflow Runs</div>
+          <div style={{ fontSize: 13, color: "#71717a", marginTop: 2 }}>
+            Durable state tracking for agents and automated workflows
+          </div>
+        </div>
+        <Button
+          icon={<ReloadOutlined />}
+          onClick={fetchRuns}
+          loading={loadingRuns}
+          style={{ color: "#71717a", borderColor: "#e4e4e7" }}
         >
-          <span style={{ fontSize: 13, fontWeight: 500, color: "#18181b" }}>
-            Workflow Runs
-            {runs.length > 0 && (
-              <span
-                style={{
-                  marginLeft: 6,
-                  fontSize: 11,
-                  color: "#a1a1aa",
-                  fontWeight: 400,
-                }}
-              >
-                {runs.length}
-              </span>
-            )}
-          </span>
-          <button
-            onClick={fetchRuns}
-            disabled={loadingRuns}
-            style={{
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              padding: 4,
-              color: "#a1a1aa",
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
-            <ReloadOutlined style={{ fontSize: 13 }} spin={loadingRuns} />
-          </button>
-        </div>
-
-        {/* run list */}
-        <div style={{ flex: 1, overflowY: "auto" }}>
-          {loadingRuns && runs.length === 0 ? (
-            <div
-              style={{ display: "flex", justifyContent: "center", padding: 40 }}
-            >
-              <Spin size="small" />
-            </div>
-          ) : runs.length === 0 ? (
-            <Empty
-              description={
-                <span style={{ color: "#a1a1aa", fontSize: 12 }}>
-                  No workflow runs
-                </span>
-              }
-              style={{ marginTop: 48 }}
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-            />
-          ) : (
-            <div>
-              {runs.map((run) => {
-                const isSelected = selectedRun?.run_id === run.run_id;
-                const label = runTitle(run);
-                const state = run.metadata?.state;
-                return (
-                  <div
-                    key={run.run_id}
-                    onClick={() => fetchRunDetail(run)}
-                    style={{
-                      padding: "10px 16px",
-                      cursor: "pointer",
-                      background: isSelected ? "#fafafa" : "transparent",
-                      borderLeft: isSelected
-                        ? "2px solid #18181b"
-                        : "2px solid transparent",
-                      transition: "background 0.1s",
-                    }}
-                  >
-                    {/* title */}
-                    <div
-                      style={{
-                        fontSize: 12,
-                        color: "#18181b",
-                        lineHeight: 1.45,
-                        marginBottom: 4,
-                        overflow: "hidden",
-                        display: "-webkit-box",
-                        WebkitLineClamp: 2,
-                        WebkitBoxOrient: "vertical",
-                      }}
-                    >
-                      {label}
-                    </div>
-                    {/* meta row */}
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 6,
-                      }}
-                    >
-                      <StatusDot status={run.status} size={7} />
-                      <span
-                        style={{
-                          fontSize: 11,
-                          color: "#71717a",
-                          textTransform: "capitalize",
-                        }}
-                      >
-                        {state ?? run.status}
-                      </span>
-                      <span style={{ color: "#d4d4d8", fontSize: 10 }}>·</span>
-                      <span style={{ fontSize: 11, color: "#a1a1aa" }}>
-                        {timeAgo(run.created_at)}
-                      </span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
+          Refresh
+        </Button>
       </div>
 
-      {/* ── right panel ── */}
-      <div style={{ flex: 1, overflowY: "auto" }}>
-        {!selectedRun ? (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              height: "100%",
-              color: "#a1a1aa",
-              fontSize: 13,
-            }}
-          >
-            Select a run to view details
-          </div>
-        ) : loadingDetail ? (
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              marginTop: 80,
-            }}
-          >
+      {/* runs table */}
+      <Table
+        dataSource={runs}
+        columns={columns}
+        rowKey="run_id"
+        loading={loadingRuns}
+        size="small"
+        pagination={{ pageSize: 50, hideOnSinglePage: true }}
+        onRow={(run) => ({
+          onClick: () => fetchRunDetail(run),
+          style: { cursor: "pointer" },
+        })}
+        locale={{
+          emptyText: (
+            <Empty
+              description={<span style={{ color: "#a1a1aa", fontSize: 13 }}>No workflow runs yet</span>}
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          ),
+        }}
+        style={{ borderRadius: 8, border: "1px solid #e4e4e7", overflow: "hidden" }}
+      />
+
+      {/* detail drawer */}
+      <Drawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        width={680}
+        title={null}
+        closable={false}
+        bodyStyle={{ padding: 0 }}
+        styles={{ body: { padding: 0 } }}
+      >
+        {!selectedRun ? null : loadingDetail ? (
+          <div style={{ display: "flex", justifyContent: "center", padding: 80 }}>
             <Spin />
           </div>
         ) : (
-          <div style={{ padding: "24px 32px", maxWidth: 900 }}>
-            {/* ── run header ── */}
+          <div style={{ padding: "24px 28px", fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' }}>
+            {/* drawer close + refresh */}
             <div
               style={{
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "space-between",
-                marginBottom: 20,
+                marginBottom: 16,
               }}
             >
-              {/* status + run id + meta */}
-              <div
+              <button
+                onClick={() => setDrawerOpen(false)}
                 style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: "4px 0",
+                  fontSize: 12,
+                  color: "#a1a1aa",
                   display: "flex",
                   alignItems: "center",
-                  gap: 16,
-                  flexWrap: "wrap",
+                  gap: 4,
                 }}
               >
-                {/* status pill */}
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 6,
-                    background: "#f4f4f5",
-                    border: "1px solid #e4e4e7",
-                    borderRadius: 6,
-                    padding: "3px 10px",
-                  }}
-                >
-                  <StatusDot status={selectedRun.status} size={8} />
-                  <span
-                    style={{
-                      fontSize: 12,
-                      fontWeight: 500,
-                      color: "#3f3f46",
-                      textTransform: "capitalize",
-                    }}
-                  >
-                    {selectedRun.status}
-                  </span>
-                </div>
-
-                {/* run id */}
-                <span
-                  style={{
-                    fontFamily: "monospace",
-                    fontSize: 12,
-                    color: "#71717a",
-                  }}
-                >
-                  {shortId(selectedRun.run_id)}
-                </span>
-
-                {/* workflow type */}
-                <span style={{ fontSize: 12, color: "#a1a1aa" }}>
-                  {selectedRun.workflow_type}
-                </span>
-
-                {/* duration */}
-                {events.length > 0 && (
-                  <span
-                    style={{
-                      fontFamily: "monospace",
-                      fontSize: 12,
-                      color: "#a1a1aa",
-                    }}
-                  >
-                    {fmtDuration(
-                      durationMs(
-                        selectedRun.created_at,
-                        events[events.length - 1].created_at
-                      )
-                    )}
-                  </span>
-                )}
-              </div>
-
+                ← close
+              </button>
               <Button
                 size="small"
                 icon={<ReloadOutlined />}
@@ -698,115 +665,58 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
               </Button>
             </div>
 
-            {/* ── timeline ── */}
-            <div
-              style={{
-                borderRadius: 8,
-                border: "1px solid #e4e4e7",
-                padding: "16px 20px",
-                marginBottom: 24,
-                background: "#fff",
-              }}
-            >
-              <div
-                style={{
-                  fontSize: 11,
-                  fontWeight: 500,
-                  color: "#a1a1aa",
-                  letterSpacing: "0.05em",
-                  textTransform: "uppercase",
-                  marginBottom: 12,
-                }}
-              >
-                Timeline · {events.length} events
-              </div>
-              <GanttTimeline run={selectedRun} events={events} />
-            </div>
+            {/* metadata card — top */}
+            <MetadataCard run={selectedRun} />
 
-            {/* ── messages ── */}
-            {messages.length > 0 && (
-              <div
-                style={{
-                  borderRadius: 8,
-                  border: "1px solid #e4e4e7",
-                  padding: "16px 20px",
-                  background: "#fff",
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 11,
-                    fontWeight: 500,
-                    color: "#a1a1aa",
-                    letterSpacing: "0.05em",
-                    textTransform: "uppercase",
-                    marginBottom: 4,
-                  }}
-                >
-                  Messages · {messages.length}
-                </div>
-                <div>
-                  {messages.map((msg) => (
-                    <MessageRow key={msg.message_id} msg={msg} />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* ── run metadata (collapsed details) ── */}
-            {selectedRun.metadata && Object.keys(selectedRun.metadata).length > 0 && (
-              <div
-                style={{
-                  marginTop: 16,
-                  borderRadius: 8,
-                  border: "1px solid #e4e4e7",
-                  padding: "16px 20px",
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 11,
-                    fontWeight: 500,
-                    color: "#a1a1aa",
-                    letterSpacing: "0.05em",
-                    textTransform: "uppercase",
-                    marginBottom: 10,
-                  }}
-                >
-                  Metadata
-                </div>
-                <div style={{ fontFamily: "monospace", fontSize: 11 }}>
-                  {Object.entries(selectedRun.metadata)
-                    .filter(([, v]) => v !== null && v !== undefined && v !== "")
-                    .map(([k, v]) => (
-                      <div
-                        key={k}
-                        style={{
-                          display: "grid",
-                          gridTemplateColumns: "140px 1fr",
-                          gap: "0 12px",
-                          paddingTop: 4,
-                          paddingBottom: 4,
-                          borderBottom: "1px solid #f4f4f5",
-                        }}
-                      >
-                        <span style={{ color: "#a1a1aa" }}>{k}</span>
-                        <span
-                          style={{
-                            color: "#27272a",
-                            wordBreak: "break-all",
-                          }}
-                        >
-                          {typeof v === "object" ? JSON.stringify(v) : String(v)}
-                        </span>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
+            {/* collapsible sections */}
+            <Collapse
+              defaultActiveKey={[]}
+              ghost={false}
+              style={{ border: "1px solid #e4e4e7", borderRadius: 8, overflow: "hidden" }}
+              items={[
+                {
+                  key: "timeline",
+                  label: (
+                    <span style={{ fontSize: 12, fontWeight: 500, color: "#3f3f46" }}>
+                      Timeline
+                      <span style={{ marginLeft: 6, fontSize: 11, color: "#a1a1aa", fontWeight: 400 }}>
+                        {events.length} {events.length === 1 ? "event" : "events"}
+                      </span>
+                    </span>
+                  ),
+                  children: (
+                    <div style={{ padding: "4px 4px 12px" }}>
+                      <GanttTimeline run={selectedRun} events={events} />
+                    </div>
+                  ),
+                },
+                {
+                  key: "messages",
+                  label: (
+                    <span style={{ fontSize: 12, fontWeight: 500, color: "#3f3f46" }}>
+                      Messages
+                      <span style={{ marginLeft: 6, fontSize: 11, color: "#a1a1aa", fontWeight: 400 }}>
+                        {messages.length}
+                      </span>
+                    </span>
+                  ),
+                  children: messages.length === 0 ? (
+                    <div style={{ padding: "12px 4px", color: "#a1a1aa", fontSize: 12, fontFamily: "monospace" }}>
+                      No messages
+                    </div>
+                  ) : (
+                    <div style={{ paddingBottom: 4 }}>
+                      {messages.map((msg) => (
+                        <MessageRow key={msg.message_id} msg={msg} />
+                      ))}
+                    </div>
+                  ),
+                },
+              ]}
+            />
           </div>
         )}
-      </div>
+      </Drawer>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
+++ b/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
@@ -113,12 +113,41 @@ const StatusDot: React.FC<{ status: RunStatus; size?: number }> = ({ status, siz
   />
 );
 
+// ── truncated text value ──────────────────────────────────────────────────────
+
+const TRUNCATE_AT = 120;
+
+const TruncatedValue: React.FC<{ value: string }> = ({ value }) => {
+  const [expanded, setExpanded] = useState(false);
+  if (value.length <= TRUNCATE_AT) {
+    return <span style={{ color: "#27272a", wordBreak: "break-all" }}>{value}</span>;
+  }
+  return (
+    <span style={{ color: "#27272a", wordBreak: "break-all" }}>
+      {expanded ? value : value.slice(0, TRUNCATE_AT) + "…"}
+      <button
+        onClick={() => setExpanded((e) => !e)}
+        style={{
+          background: "none",
+          border: "none",
+          padding: "0 4px",
+          cursor: "pointer",
+          color: "#2563eb",
+          fontSize: 11,
+          flexShrink: 0,
+        }}
+      >
+        {expanded ? "less" : "more"}
+      </button>
+    </span>
+  );
+};
+
 // ── metadata card ─────────────────────────────────────────────────────────────
 
 const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
   const meta = run.metadata ?? {};
 
-  // Primary fields shown prominently at the top
   const primaryFields: { key: string; label: string }[] = [
     { key: "state",            label: "state" },
     { key: "worktree_path",    label: "worktree" },
@@ -126,7 +155,6 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
     { key: "session_id",       label: "session" },
   ];
 
-  // Remaining fields (not title, not primary, not nullish)
   const primaryKeys = new Set(["title", ...primaryFields.map((f) => f.key)]);
   const extraEntries = Object.entries(meta).filter(
     ([k, v]) => !primaryKeys.has(k) && v !== null && v !== undefined && v !== ""
@@ -191,7 +219,6 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
           fontSize: 12,
         }}
       >
-        {/* always-visible: run status + created */}
         <FieldPair label="status">
           <span style={{ textTransform: "capitalize", color: "#27272a" }}>{run.status}</span>
         </FieldPair>
@@ -199,7 +226,6 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
           <span style={{ color: "#27272a" }}>{timeAgo(run.created_at)}</span>
         </FieldPair>
 
-        {/* pr_url as clickable link */}
         {meta.pr_url && (
           <FieldPair label="pr">
             <a
@@ -213,27 +239,25 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
           </FieldPair>
         )}
 
-        {/* primary metadata fields */}
         {primaryFields.map(({ key, label }) => {
           const v = meta[key];
           if (v === null || v === undefined || v === "") return null;
+          const str = typeof v === "object" ? JSON.stringify(v) : String(v);
           return (
             <FieldPair key={key} label={label}>
-              <span style={{ color: "#27272a", wordBreak: "break-all" }}>
-                {typeof v === "object" ? JSON.stringify(v) : String(v)}
-              </span>
+              <TruncatedValue value={str} />
             </FieldPair>
           );
         })}
 
-        {/* extra fields */}
-        {extraEntries.map(([k, v]) => (
-          <FieldPair key={k} label={k}>
-            <span style={{ color: "#27272a", wordBreak: "break-all" }}>
-              {typeof v === "object" ? JSON.stringify(v) : String(v)}
-            </span>
-          </FieldPair>
-        ))}
+        {extraEntries.map(([k, v]) => {
+          const str = typeof v === "object" ? JSON.stringify(v) : String(v);
+          return (
+            <FieldPair key={k} label={k}>
+              <TruncatedValue value={str} />
+            </FieldPair>
+          );
+        })}
       </div>
     </div>
   );
@@ -590,28 +614,31 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         </Button>
       </div>
 
-      {/* runs table */}
-      <Table
-        dataSource={runs}
-        columns={columns}
-        rowKey="run_id"
-        loading={loadingRuns}
-        size="small"
-        pagination={{ pageSize: 50, hideOnSinglePage: true }}
-        onRow={(run) => ({
-          onClick: () => fetchRunDetail(run),
-          style: { cursor: "pointer" },
-        })}
-        locale={{
-          emptyText: (
-            <Empty
-              description={<span style={{ color: "#a1a1aa", fontSize: 13 }}>No workflow runs yet</span>}
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-            />
-          ),
-        }}
-        style={{ borderRadius: 8, border: "1px solid #e4e4e7", overflow: "hidden" }}
-      />
+      {/* runs table — matches logs page density */}
+      <div className="rounded-lg custom-border overflow-x-auto w-full">
+        <Table
+          dataSource={runs}
+          columns={columns}
+          rowKey="run_id"
+          loading={loadingRuns}
+          size="small"
+          pagination={{ pageSize: 50, hideOnSinglePage: true, size: "small" }}
+          onRow={(run) => ({
+            onClick: () => fetchRunDetail(run),
+            style: { cursor: "pointer" },
+          })}
+          locale={{
+            emptyText: (
+              <Empty
+                description={<span style={{ color: "#a1a1aa", fontSize: 13 }}>No workflow runs yet</span>}
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
+            ),
+          }}
+          className="[&_.ant-table-cell]:py-0.5 [&_.ant-table-thead_.ant-table-cell]:py-1"
+          style={{ border: "none" }}
+        />
+      </div>
 
       {/* detail drawer */}
       <Drawer
@@ -670,7 +697,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
 
             {/* collapsible sections */}
             <Collapse
-              defaultActiveKey={[]}
+              defaultActiveKey={["timeline"]}
               ghost={false}
               style={{ border: "1px solid #e4e4e7", borderRadius: 8, overflow: "hidden" }}
               items={[


### PR DESCRIPTION
## Relevant issues
<img width="884" height="941" alt="Screenshot 2026-04-29 at 3 16 36 PM" src="https://github.com/user-attachments/assets/b76a84bf-5d9f-4eaa-9de7-03f21107e7a5" />

Part of the durable agent workflow runs feature.

## Pre-Submission checklist

- [ ] I have added testing in the \`tests/test_litellm/\` directory, **Adding at least 1 test is a hard requirement**
- [ ] My PR passes all unit tests on \`make test-unit\`
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

**Backend (proxy):**
- \`litellm/proxy/schema.prisma\` — three new tables: \`LiteLLM_WorkflowRun\`, \`LiteLLM_WorkflowEvent\`, \`LiteLLM_WorkflowMessage\`
- \`litellm/proxy/management_endpoints/workflow_management_endpoints.py\` — REST API: POST/GET/PATCH runs, POST/GET events, POST/GET messages; tenant isolation, atomic event+status updates, sequence-number retry on collision
- \`litellm/proxy/proxy_server.py\` — registers workflow router

**UI (shared components):**
- \`src/components/shared/DrawerShell.tsx\` (new) — shared antd Drawer layout with collapsible 224px sidebar + flex-1 main area, reused by both LogDetailsDrawer and WorkflowRunDrawer
- \`src/components/shared/useItemNavigation.ts\` (new) — generic J/K/Escape keyboard nav hook for detail drawers, works with any item type via \`getId: (item: T) => string\`
- \`src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx\` — updated to use shared \`DrawerShell\`

**UI (Workflow Runs page):**
- \`src/components/workflow_runs/index.tsx\` — full-width page using the same \`DataTable\` (TanStack + Tremor) as the logs page. Clicking a row opens a 60% drawer with: metadata card, Gantt timeline, Messages section. Sidebar shows the conversation messages for the selected run. J/K keyboard navigation between runs.
- \`src/components/leftnav.tsx\` — collapsible Agentic nav group (Agents, Workflow Runs, Memory)
- \`src/app/page.tsx\` — \`page == "workflows"\` branch wired to WorkflowRuns component