### PR TITLE
Forward extra headers for OpenAPI MCP tools

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -30,6 +30,23 @@ HEADERS: Dict[str, str] = {}
 _request_auth_header: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "_request_auth_header", default=None
 )
+_request_extra_headers: contextvars.ContextVar[Optional[Dict[str, str]]] = (
+    contextvars.ContextVar("_request_extra_headers", default=None)
+)
+
+
+def _build_effective_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Merge static OpenAPI headers with request-scoped MCP header overrides."""
+    effective_headers = dict(headers)
+    request_extra_headers = _request_extra_headers.get()
+    if request_extra_headers:
+        effective_headers.update(request_extra_headers)
+
+    override_auth = _request_auth_header.get()
+    if override_auth:
+        effective_headers["Authorization"] = override_auth
+
+    return effective_headers
 
 
 def _sanitize_path_parameter_value(param_value: Any, param_name: str) -> str:
@@ -314,10 +331,7 @@ def create_tool_function(
         # The ContextVar holds the full Authorization header value, including the
         # correct prefix (Bearer / ApiKey / Basic) formatted by the caller in
         # server.py based on the server's configured auth_type.
-        effective_headers = dict(headers)
-        override_auth = _request_auth_header.get()
-        if override_auth:
-            effective_headers["Authorization"] = override_auth
+        effective_headers = _build_effective_headers(headers)
 
         # Build URL from base_url and path
         url = base_url + path

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -157,6 +157,7 @@ if MCP_AVAILABLE:
     )
     from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
         _request_auth_header,
+        _request_extra_headers,
     )
     from litellm.proxy._experimental.mcp_server.sse_transport import SseServerTransport
     from litellm.proxy._experimental.mcp_server.tool_registry import (
@@ -1123,6 +1124,29 @@ if MCP_AVAILABLE:
             server_auth_header = mcp_auth_header
 
         return server_auth_header, extra_headers
+
+    def _prepare_local_mcp_request_extra_headers(
+        server: Optional[MCPServer],
+        raw_headers: Optional[Dict[str, str]],
+    ) -> Optional[Dict[str, str]]:
+        """Build request-time extra headers for local OpenAPI-generated tools."""
+        if not server or not server.extra_headers or not raw_headers:
+            return None
+
+        normalized_raw_headers = {
+            str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
+        }
+        extra_headers: Dict[str, str] = {}
+
+        for header in server.extra_headers:
+            if not isinstance(header, str):
+                continue
+
+            header_value = normalized_raw_headers.get(header.lower())
+            if header_value is not None:
+                extra_headers[header] = header_value
+
+        return extra_headers or None
 
     def _merge_gateway_initialize_instructions(
         allowed_mcp_servers: List[MCPServer],
@@ -2120,11 +2144,17 @@ if MCP_AVAILABLE:
                     auth_header_value = f"Basic {mcp_auth_header}"
                 else:
                     auth_header_value = f"Bearer {mcp_auth_header}"
+            request_extra_headers = _prepare_local_mcp_request_extra_headers(
+                server=mcp_server,
+                raw_headers=raw_headers,
+            )
             _auth_token = _request_auth_header.set(auth_header_value)
+            _extra_headers_token = _request_extra_headers.set(request_extra_headers)
             try:
                 local_content = await _handle_local_mcp_tool(name, arguments)
             finally:
                 _request_auth_header.reset(_auth_token)
+                _request_extra_headers.reset(_extra_headers_token)
             response = CallToolResult(content=cast(Any, local_content), isError=False)
 
         # Try managed MCP server tool (pass the full prefixed name)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -165,6 +165,97 @@ def test_prepare_local_mcp_request_extra_headers_case_insensitive():
     }
 
 
+def test_prepare_local_mcp_request_extra_headers_ignores_empty_and_invalid_entries():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _prepare_local_mcp_request_extra_headers,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    server = MCPServer(
+        server_id="server-case",
+        name="server",
+        transport=MCPTransport.http,
+        extra_headers=["X-TOKEN"],
+    )
+    server.extra_headers = [None, "X-TOKEN"]  # type: ignore[list-item]
+
+    assert (
+        _prepare_local_mcp_request_extra_headers(
+            server=server,
+            raw_headers=None,
+        )
+        is None
+    )
+    assert _prepare_local_mcp_request_extra_headers(
+        server=server,
+        raw_headers={"x-token": "request-token"},
+    ) == {"X-TOKEN": "request-token"}
+
+
+@pytest.mark.asyncio
+async def test_execute_local_mcp_tool_sets_request_extra_headers_context():
+    try:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+            _request_auth_header,
+            _request_extra_headers,
+        )
+        from litellm.proxy._experimental.mcp_server.server import execute_mcp_tool
+        from litellm.proxy._experimental.mcp_server.tool_registry import (
+            global_mcp_tool_registry,
+        )
+        from litellm.types.mcp import MCPAuth
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    server = MCPServer(
+        server_id="server-local",
+        name="server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.api_key,
+        extra_headers=["X-TOKEN"],
+    )
+    tool_name = "server-tool"
+    captured_context = {}
+
+    async def local_handler(**kwargs):
+        captured_context["auth"] = _request_auth_header.get()
+        captured_context["extra_headers"] = _request_extra_headers.get()
+        return "ok"
+
+    global_mcp_server_manager.registry[server.server_id] = server
+    global_mcp_server_manager.tool_name_to_mcp_server_name_mapping[tool_name] = (
+        server.name
+    )
+    global_mcp_tool_registry.register_tool(
+        name=tool_name,
+        description="test tool",
+        input_schema={},
+        handler=local_handler,
+    )
+
+    response = await execute_mcp_tool(
+        name=tool_name,
+        arguments={},
+        allowed_mcp_servers=[server],
+        start_time=datetime.now(),
+        mcp_auth_header="request-auth",
+        raw_headers={"x-token": "request-token"},
+    )
+
+    assert response.isError is False
+    assert captured_context == {
+        "auth": "ApiKey request-auth",
+        "extra_headers": {"X-TOKEN": "request-token"},
+    }
+    assert _request_auth_header.get() is None
+    assert _request_extra_headers.get() is None
+
+
 @pytest.mark.asyncio
 async def test_get_prompts_from_mcp_servers_success():
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -135,6 +135,36 @@ def test_prepare_mcp_server_headers_case_insensitive_extra_headers():
     assert extra_headers == {"Authorization": "Bearer token"}
 
 
+def test_prepare_local_mcp_request_extra_headers_case_insensitive():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _prepare_local_mcp_request_extra_headers,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    server = MCPServer(
+        server_id="server-case",
+        name="server",
+        transport=MCPTransport.http,
+        extra_headers=["X-TOKEN", "X-API-Key"],
+    )
+
+    extra_headers = _prepare_local_mcp_request_extra_headers(
+        server=server,
+        raw_headers={
+            "x-token": "request-token",
+            "X-API-KEY": "request-api-key",
+            "x-litellm-api-key": "litellm-key",
+        },
+    )
+
+    assert extra_headers == {
+        "X-TOKEN": "request-token",
+        "X-API-Key": "request-api-key",
+    }
+
+
 @pytest.mark.asyncio
 async def test_get_prompts_from_mcp_servers_success():
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -17,6 +17,8 @@ import pytest
 from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
     _resolve_param_list,
     _resolve_ref,
+    _request_auth_header,
+    _request_extra_headers,
     build_input_schema,
     create_tool_function,
     extract_parameters,
@@ -368,6 +370,69 @@ class TestCreateToolFunction:
 
         # Should have no exec() calls
         assert len(exec_calls) == 0, "create_tool_function should not use exec()"
+
+    @pytest.mark.asyncio
+    async def test_request_extra_headers_are_forwarded(self):
+        """Test request-time extra headers are forwarded to OpenAPI requests."""
+        func = create_tool_function(
+            path="/protected",
+            method="get",
+            operation={},
+            base_url="https://api.example.com",
+            headers={"X-Static": "static-value"},
+        )
+
+        with patch(GET_ASYNC_CLIENT_TARGET) as mock_client:
+            async_client = _create_mock_client("get", "ok")
+            mock_client.return_value = async_client
+
+            token = _request_extra_headers.set({"X-TOKEN": "request-token"})
+            try:
+                result = await func()
+            finally:
+                _request_extra_headers.reset(token)
+
+            assert result == "ok"
+            call_args = async_client.get.call_args
+            assert call_args.kwargs["headers"] == {
+                "X-Static": "static-value",
+                "X-TOKEN": "request-token",
+            }
+
+    @pytest.mark.asyncio
+    async def test_auth_override_wins_over_request_extra_headers(self):
+        """Test x-mcp-auth Authorization override preserves existing precedence."""
+        func = create_tool_function(
+            path="/protected",
+            method="get",
+            operation={},
+            base_url="https://api.example.com",
+            headers={"Authorization": "Bearer static-token"},
+        )
+
+        with patch(GET_ASYNC_CLIENT_TARGET) as mock_client:
+            async_client = _create_mock_client("get", "ok")
+            mock_client.return_value = async_client
+
+            extra_token = _request_extra_headers.set(
+                {
+                    "Authorization": "Bearer request-token",
+                    "X-TOKEN": "request-token",
+                }
+            )
+            auth_token = _request_auth_header.set("Bearer mcp-auth-token")
+            try:
+                result = await func()
+            finally:
+                _request_auth_header.reset(auth_token)
+                _request_extra_headers.reset(extra_token)
+
+            assert result == "ok"
+            call_args = async_client.get.call_args
+            assert call_args.kwargs["headers"] == {
+                "Authorization": "Bearer mcp-auth-token",
+                "X-TOKEN": "request-token",
+            }
 
 
 class TestBuildInputSchema:


### PR DESCRIPTION
## Relevant issues

Fixes #26794

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Validated locally with:

```bash
git diff --check
python3 -m ruff check litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
python3 -m py_compile litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
uv run --extra proxy pytest -q tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q
```

## Type

🐛 Bug Fix
✅ Test

## Changes

OpenAPI-generated MCP tools now forward request headers listed in the MCP server `extra_headers` config to the upstream OpenAPI request.

This matches the existing managed MCP server behavior and preserves existing `x-mcp-auth` Authorization override precedence.