### PR TITLE
test(vertex_ai/rerank): add e2e tests for userLabels propagation

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_userlabels_e2e.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_userlabels_e2e.py
@@ -1,0 +1,215 @@
+"""
+End-to-end tests for Vertex AI rerank `userLabels` propagation.
+
+These tests go through the full `litellm.rerank()` call path with the HTTP
+layer mocked, so they catch plumbing bugs (e.g. `litellm_params` being
+mutated upstream of the transform) that unit tests on
+`VertexAIRerankConfig.transform_rerank_request` miss.
+
+See PR #25499 for the feature this guards.
+"""
+
+import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import litellm
+import litellm.llms.vertex_ai.rerank.transformation  # noqa: F401  (ensure submodule loaded)
+
+
+def _extract_body(call_kwargs):
+    """The rerank handler sends `data=json.dumps(...)`, not `json=...`."""
+    if "json" in call_kwargs and call_kwargs["json"] is not None:
+        return call_kwargs["json"]
+    raw = call_kwargs.get("data")
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    return json.loads(raw) if raw else None
+
+
+VERTEX_DISCOVERY_RANK_URL = (
+    "https://discoveryengine.googleapis.com/v1/projects/"
+    "test-project-2049/locations/global/rankingConfigs/"
+    "default_ranking_config:rank"
+)
+
+
+def _make_mock_rank_response():
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {
+        "records": [
+            {"id": "0", "score": 0.9, "title": "doc 0", "content": "hello"},
+            {"id": "1", "score": 0.1, "title": "doc 1", "content": "world"},
+        ]
+    }
+    mock_response.text = '{"records": []}'
+    return mock_response
+
+
+def _make_async_mock_rank_response():
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json = MagicMock(
+        return_value={
+            "records": [
+                {"id": "0", "score": 0.9, "title": "doc 0", "content": "hello"},
+            ]
+        }
+    )
+    mock_response.text = '{"records": []}'
+    return mock_response
+
+
+@pytest.fixture
+def clean_vertex_env():
+    saved = {}
+    for var in (
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "VERTEXAI_PROJECT",
+        "VERTEXAI_CREDENTIALS",
+        "VERTEX_AI_CREDENTIALS",
+        "VERTEX_PROJECT",
+        "VERTEX_LOCATION",
+        "VERTEX_AI_PROJECT",
+    ):
+        if var in os.environ:
+            saved[var] = os.environ.pop(var)
+    yield
+    for var, value in saved.items():
+        os.environ[var] = value
+
+
+def _patch_vertex_auth():
+    """
+    Patch Vertex auth on the rerank config so we don't need real GCP creds.
+    Returns the patch context manager — caller uses `with`.
+    """
+    return patch.object(
+        litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig,
+        "_ensure_access_token",
+        return_value=("test-access-token", "test-project-2049"),
+    )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Currently fails on two paths: (1) `litellm_internal_staging` doesn't "
+        "have the feature yet; (2) PR #25499 has the feature but loses "
+        "`metadata` because `litellm/rerank_api/main.py` passes the same "
+        "`rerank_litellm_params` dict to `Logging.update_from_kwargs` "
+        "(which pops `metadata`) AND to the provider handler. Remove this "
+        "marker once both the feature is merged and the dict-mutation bug is "
+        "fixed (e.g. by passing a copy to `update_from_kwargs`)."
+    ),
+)
+def test_rerank_userlabels_propagates_from_metadata_sync(clean_vertex_env):
+    """
+    `litellm.rerank(metadata={"requester_metadata": {...}})` must end up as
+    `userLabels` on the Discovery Engine `:rank` request body.
+
+    This catches the bug where `rerank_litellm_params` is mutated by
+    `Logging.update_from_kwargs` (which pops `metadata`), so by the time the
+    Vertex transform reads it, no labels remain.
+    """
+    captured = {}
+
+    def fake_post(*args, **kwargs):
+        captured["body"] = _extract_body(kwargs)
+        return _make_mock_rank_response()
+
+    with (
+        _patch_vertex_auth(),
+        patch(
+            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+            side_effect=fake_post,
+        ),
+    ):
+        litellm.rerank(
+            model="vertex_ai/semantic-ranker-default@latest",
+            query="what is gemini?",
+            documents=["hello", "world"],
+            vertex_project="test-project-2049",
+            vertex_credentials='{"type": "service_account"}',
+            metadata={"requester_metadata": {"team": "platform", "env": "prod"}},
+        )
+
+    body = captured["body"]
+    assert body is not None, "expected POST body to be captured"
+    assert "userLabels" in body, (
+        "Vertex rerank request body is missing `userLabels` — metadata was "
+        "lost between litellm.rerank() and transform_rerank_request. "
+        f"body keys: {sorted(body.keys())}"
+    )
+    assert body["userLabels"] == {"team": "platform", "env": "prod"}
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Same as the sync variant — see the sync test's xfail reason.",
+)
+def test_rerank_userlabels_propagates_from_metadata_async(clean_vertex_env):
+    """Same as the sync test, but through `litellm.arerank`."""
+    captured = {}
+
+    async def fake_post(*args, **kwargs):
+        captured["body"] = _extract_body(kwargs)
+        return _make_async_mock_rank_response()
+
+    with (
+        _patch_vertex_auth(),
+        patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            side_effect=fake_post,
+        ),
+    ):
+        asyncio.run(
+            litellm.arerank(
+                model="vertex_ai/semantic-ranker-default@latest",
+                query="what is gemini?",
+                documents=["hello", "world"],
+                vertex_project="test-project-2049",
+                vertex_credentials='{"type": "service_account"}',
+                metadata={"requester_metadata": {"team": "platform"}},
+            )
+        )
+
+    body = captured["body"]
+    assert body is not None
+    assert body.get("userLabels") == {"team": "platform"}
+
+
+def test_rerank_userlabels_absent_when_no_metadata(clean_vertex_env):
+    """No metadata → no `userLabels` key (don't send empty maps)."""
+    captured = {}
+
+    def fake_post(*args, **kwargs):
+        captured["body"] = _extract_body(kwargs)
+        return _make_mock_rank_response()
+
+    with (
+        _patch_vertex_auth(),
+        patch(
+            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+            side_effect=fake_post,
+        ),
+    ):
+        litellm.rerank(
+            model="vertex_ai/semantic-ranker-default@latest",
+            query="what is gemini?",
+            documents=["hello", "world"],
+            vertex_project="test-project-2049",
+            vertex_credentials='{"type": "service_account"}',
+        )
+
+    body = captured["body"]
+    assert body is not None
+    assert "userLabels" not in body

--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_userlabels_e2e.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_userlabels_e2e.py
@@ -31,13 +31,6 @@ def _extract_body(call_kwargs):
     return json.loads(raw) if raw else None
 
 
-VERTEX_DISCOVERY_RANK_URL = (
-    "https://discoveryengine.googleapis.com/v1/projects/"
-    "test-project-2049/locations/global/rankingConfigs/"
-    "default_ranking_config:rank"
-)
-
-
 def _make_mock_rank_response():
     mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 200


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Companion to #25499 (`feat(vertex_ai): propagate metadata labels to embedding, Imagen, rerank`).

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/` (this PR is *only* tests)
- [x] My PR passes all unit tests on `make test-unit` (1 passed, 2 xfailed locally)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

✅ Test

## Changes

Adds `tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_userlabels_e2e.py` — three end-to-end tests that exercise the full `litellm.rerank()` / `litellm.arerank()` flow with the HTTP layer mocked, asserting that `metadata.requester_metadata` ends up as `userLabels` on the Vertex Discovery Engine `:rank` request body:

1. `test_rerank_userlabels_propagates_from_metadata_sync` (`xfail`)
2. `test_rerank_userlabels_propagates_from_metadata_async` (`xfail`)
3. `test_rerank_userlabels_absent_when_no_metadata` (passes; locks in that we don't send empty maps)

## Why xfail?

The two propagation tests fail today on **both** branches:

1. On `litellm_internal_staging` the feature isn't merged yet (PR #25499).
2. On PR #25499's branch the metadata is silently lost. `litellm/rerank_api/main.py` builds a `rerank_litellm_params` dict and hands the **same reference** to `Logging.update_from_kwargs(...)` (which calls `litellm_params.pop("metadata", None)`) AND to every downstream `base_llm_http_handler.rerank(litellm_params=rerank_litellm_params, ...)` call. By the time `VertexAIRerankConfig.transform_rerank_request` runs `vertex_request_labels_from_litellm_params(litellm_params)`, `metadata` has already been popped → no `userLabels` ever reaches Vertex.

I verified this by checking out PR #25499's `litellm/` tree on top of these tests and running pytest:

```
test_rerank_userlabels_absent_when_no_metadata PASSED
test_rerank_userlabels_propagates_from_metadata_async FAILED
test_rerank_userlabels_propagates_from_metadata_sync  FAILED
  AssertionError: Vertex rerank request body is missing `userLabels`
  body keys: ['ignoreRecordDetailsInResponse', 'model', 'query', 'records']
```

## Why this PR is useful even though it xfails

- It documents the contract: `userLabels` *must* end up on the wire when `metadata.requester_metadata` is set.
- The transform-only unit test added in PR #25499 doesn't catch the upstream-mutation bug because it constructs `litellm_params` itself and calls the transform directly.
- Once PR #25499 lands AND the dict-mutation bug is fixed (e.g. by passing `dict(rerank_litellm_params)` to `update_from_kwargs`), removing the `xfail` markers will turn the tests green and prevent regressions.

## Screenshots / Proof of Fix

n/a — output above shows the tests failing-as-expected against PR #25499's code, and 1 passed + 2 xfailed against staging.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777437999785579?thread_ts=1777437999.785579&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-06ffad08-d4a2-5e70-834b-ec386fa62049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06ffad08-d4a2-5e70-834b-ec386fa62049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

