### PR TITLE
[Fix] Propagate cache_control through Responses API → Chat Completion transform

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -988,14 +988,16 @@ class LiteLLMCompletionResponsesConfig:
             # Since guardrails skip None content anyway, we return empty list to exclude it from structured messages
             if content is None:
                 return []
-            return [
-                GenericChatCompletionMessage(
-                    role=input_item.get("role") or "user",
-                    content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
-                        content
-                    ),
-                )
-            ]
+            message = GenericChatCompletionMessage(
+                role=input_item.get("role") or "user",
+                content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+                    content
+                ),
+            )
+            cache_control = input_item.get("cache_control")
+            if cache_control is not None:
+                message["cache_control"] = cache_control  # type: ignore[typeddict-unknown-key]
+            return [message]
 
     @staticmethod
     def _is_input_item_tool_call_output(input_item: Any) -> bool:
@@ -1294,14 +1296,16 @@ class LiteLLMCompletionResponsesConfig:
                         text_value = item.get("text")
                         if text_value is None:
                             continue
-                        content_list.append(
-                            {
-                                "type": LiteLLMCompletionResponsesConfig._get_chat_completion_request_content_type(
-                                    item.get("type") or "text"
-                                ),
-                                "text": text_value,
-                            }
-                        )
+                        block = {
+                            "type": LiteLLMCompletionResponsesConfig._get_chat_completion_request_content_type(
+                                item.get("type") or "text"
+                            ),
+                            "text": text_value,
+                        }
+                        cache_control = item.get("cache_control")
+                        if cache_control is not None:
+                            block["cache_control"] = cache_control
+                        content_list.append(block)
             return content_list
         else:
             raise ValueError(f"Invalid content type: {type(content)}")

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1278,19 +1278,23 @@ class LiteLLMCompletionResponsesConfig:
                     content_list.append(item)
                 elif isinstance(item, dict):
                     if item.get("type") == "input_file":
-                        content_list.append(
-                            LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
+                        block = LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
+                            item
+                        )
+                        cache_control = item.get("cache_control")
+                        if cache_control is not None:
+                            block["cache_control"] = cache_control  # type: ignore[typeddict-unknown-key]
+                        content_list.append(block)
+                    elif item.get("type") == "input_image":
+                        block = dict(
+                            LiteLLMCompletionResponsesConfig._transform_input_image_item_to_image_item(
                                 item
                             )
                         )
-                    elif item.get("type") == "input_image":
-                        content_list.append(
-                            dict(
-                                LiteLLMCompletionResponsesConfig._transform_input_image_item_to_image_item(
-                                    item
-                                )
-                            )
-                        )
+                        cache_control = item.get("cache_control")
+                        if cache_control is not None:
+                            block["cache_control"] = cache_control
+                        content_list.append(block)
                     else:
                         # Skip text blocks with None text to avoid downstream errors
                         text_value = item.get("text")

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2101,7 +2101,7 @@ class LiteLLMCompletionResponsesConfig:
             and usage.prompt_tokens_details is not None
         ):
             prompt_details = usage.prompt_tokens_details
-            input_details_dict: Dict[str, int] = {}
+            input_details_dict: Dict[str, Any] = {}
 
             if (
                 hasattr(prompt_details, "cached_tokens")
@@ -2122,6 +2122,16 @@ class LiteLLMCompletionResponsesConfig:
                 and prompt_details.audio_tokens is not None
             ):
                 input_details_dict["audio_tokens"] = prompt_details.audio_tokens
+
+            # Forward Anthropic prompt-caching fields so callers see cache
+            # creation token counts on the Responses API usage payload.
+            for cache_field in (
+                "cache_creation_tokens",
+                "cache_creation_token_details",
+            ):
+                value = getattr(prompt_details, cache_field, None)
+                if value is not None:
+                    input_details_dict[cache_field] = value
 
             if input_details_dict:
                 response_usage.input_tokens_details = InputTokensDetails(

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -992,6 +992,58 @@ class TestContentTypeTransformation:
         assert result[0]["text"] == "valid text"
         assert result[1]["text"] == "another valid"
 
+    def test_cache_control_propagated_to_content_block(self):
+        """
+        Test that a cache_control field on a Responses API content item is
+        propagated onto the Chat Completion content block.
+        """
+        cache_control = {"type": "ephemeral"}
+        content = [
+            {"type": "text", "text": "cached text", "cache_control": cache_control},
+            {"type": "text", "text": "uncached text"},
+        ]
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+            content
+        )
+        assert len(result) == 2
+        assert result[0]["text"] == "cached text"
+        assert result[0]["cache_control"] == cache_control
+        assert result[1]["text"] == "uncached text"
+        assert "cache_control" not in result[1]
+
+    def test_cache_control_propagated_to_message(self):
+        """
+        Test that a cache_control field on a Responses API input item is
+        propagated onto the resulting GenericChatCompletionMessage.
+        """
+        cache_control = {"type": "ephemeral"}
+        input_item = {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+            "cache_control": cache_control,
+        }
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item
+        )
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert result[0]["cache_control"] == cache_control
+
+    def test_cache_control_absent_when_not_provided(self):
+        """
+        Test that no cache_control key is added when the input item does not
+        carry one.
+        """
+        input_item = {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+        }
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item
+        )
+        assert len(result) == 1
+        assert "cache_control" not in result[0]
+
 
 class TestToolTransformation:
     """Test cases for tool transformation from Responses API to Chat Completion format"""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1011,6 +1011,48 @@ class TestContentTypeTransformation:
         assert result[1]["text"] == "uncached text"
         assert "cache_control" not in result[1]
 
+    def test_cache_control_propagated_to_input_file_block(self):
+        """
+        Test that cache_control on an input_file item is propagated onto the
+        resulting file content block.
+        """
+        cache_control = {"type": "ephemeral"}
+        content = [
+            {
+                "type": "input_file",
+                "file_id": "file-abc123",
+                "cache_control": cache_control,
+            },
+            {"type": "input_file", "file_id": "file-xyz789"},
+        ]
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+            content
+        )
+        assert len(result) == 2
+        assert result[0]["cache_control"] == cache_control
+        assert "cache_control" not in result[1]
+
+    def test_cache_control_propagated_to_input_image_block(self):
+        """
+        Test that cache_control on an input_image item is propagated onto the
+        resulting image content block.
+        """
+        cache_control = {"type": "ephemeral"}
+        content = [
+            {
+                "type": "input_image",
+                "image_url": "https://example.com/img.png",
+                "cache_control": cache_control,
+            },
+            {"type": "input_image", "image_url": "https://example.com/other.png"},
+        ]
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+            content
+        )
+        assert len(result) == 2
+        assert result[0]["cache_control"] == cache_control
+        assert "cache_control" not in result[1]
+
     def test_cache_control_propagated_to_message(self):
         """
         Test that a cache_control field on a Responses API input item is

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1565,6 +1565,86 @@ class TestUsageTransformation:
         assert response_usage.input_tokens_details.cached_tokens == 3
         assert response_usage.input_tokens_details.text_tokens == 6
 
+    def test_transform_usage_with_cache_creation_tokens_anthropic(self):
+        """Test that Anthropic cache creation token fields are propagated onto input_tokens_details"""
+        usage = Usage(
+            prompt_tokens=20,
+            completion_tokens=10,
+            total_tokens=30,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=4,  # cache_read_input_tokens
+                cache_creation_tokens=12,  # cache_creation_input_tokens
+                text_tokens=4,
+            ),
+        )
+
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="claude-sonnet-4",
+            object="chat.completion",
+            usage=usage,
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hi!", role="assistant"),
+                )
+            ],
+        )
+
+        response_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
+            chat_completion_response=chat_completion_response
+        )
+
+        assert response_usage.input_tokens_details is not None
+        assert response_usage.input_tokens_details.cached_tokens == 4
+        assert (
+            getattr(
+                response_usage.input_tokens_details, "cache_creation_tokens", None
+            )
+            == 12
+        )
+
+    def test_transform_usage_without_cache_creation_tokens(self):
+        """Test that cache_creation_tokens is absent when not present on prompt_tokens_details"""
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=0,
+                text_tokens=10,
+            ),
+        )
+
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+            usage=usage,
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hi!", role="assistant"),
+                )
+            ],
+        )
+
+        response_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
+            chat_completion_response=chat_completion_response
+        )
+
+        assert response_usage.input_tokens_details is not None
+        assert (
+            getattr(
+                response_usage.input_tokens_details, "cache_creation_tokens", None
+            )
+            is None
+        )
+
     def test_transform_usage_with_reasoning_tokens_gemini(self):
         """Test that reasoning_tokens from Gemini are properly transformed to output_tokens_details"""
         # Setup: Simulate Gemini usage with thoughtsTokenCount


### PR DESCRIPTION
## Relevant issues
Fixes #25335

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

```python
import asyncio

import bore.litellm.responses_input_cache_control_patch  # noqa: F401  applies patch
import litellm

SYSTEM_PROMPT = "You are a helpful assistant. " + ("Filler. " * 2000)

INPUT = [
    {"role": "system", "content": SYSTEM_PROMPT},
    {"role": "user", "content": "Hi"},
]

INJECTION = [
    {"location": "message", "role": "system"},
    {"location": "message", "index": -1},
]


async def main() -> None:
    print("===== aresponses run 1 =====")
    r1 = await litellm.aresponses(
        model="anthropic/claude-sonnet-4-6",
        input=INPUT,
        max_output_tokens=32,
        cache_control_injection_points=INJECTION,
    )
    print(r1.usage)

    print("\n===== aresponses run 2 =====")
    r2 = await litellm.aresponses(
        model="anthropic/claude-sonnet-4-6",
        input=INPUT,
        max_output_tokens=32,
        cache_control_injection_points=INJECTION,
    )
    print(r2.usage)


if __name__ == "__main__":
    asyncio.run(main())
```

Without fix
```
===== aresponses run 1 =====
input_tokens=8016 input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=0, text_tokens=None) output_tokens=21 output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=21) total_tokens=8037 cost=None

===== aresponses run 2 =====
input_tokens=8016 input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=0, text_tokens=None) output_tokens=21 output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=21) total_tokens=8037 cost=None
```

With Fix
```
===== aresponses run 1 =====
input_tokens=8016 input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=8013, text_tokens=None) output_tokens=21 output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=21) total_tokens=8037 cost=None

===== aresponses run 2 =====
input_tokens=8016 input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=8013, text_tokens=None) output_tokens=24 output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=24) total_tokens=8040 cost=None
```

## Type

🐛 Bug Fix
✅ Test

## Changes
Adding support for cache_control fields in Responses API messages -> Completions API messages