### PR TITLE
test(vertex-batches): set is_redirect=False on mocked retrieve response

### DIFF
--- a/tests/batches_tests/test_openai_batches_and_files.py
+++ b/tests/batches_tests/test_openai_batches_and_files.py
@@ -557,6 +557,7 @@ async def test_avertex_batch_prediction(monkeypatch):
             mock_get_response = MagicMock()
             mock_get_response.json.return_value = mock_vertex_batch_response
             mock_get_response.status_code = 200
+            mock_get_response.is_redirect = False
             mock_get_response.raise_for_status.return_value = None
             mock_get.return_value = mock_get_response
 


### PR DESCRIPTION
## Summary

`test_avertex_batch_prediction` started failing deterministically after [dedaf74a5e](https://github.com/BerriAI/litellm/commit/dedaf74a5e) wrapped `_async_retrieve_batch`'s GET in `async_safe_get`. `async_safe_get` reads `response.is_redirect` to decide whether to follow a redirect. The test's `MagicMock` response never set `is_redirect`, so it auto-generated a truthy mock — the loop fell into `_extract_redirect_url`, `response.headers.get("location")` returned another truthy `MagicMock`, and `httpx.URL(request_url).join(<MagicMock>)` raised:

```
TypeError: Invalid type for url. Expected str or httpx.URL, got <class 'unittest.mock.MagicMock'>: <MagicMock name='get().headers.get()' ...>
```

One-line fix: set `is_redirect = False` on the mocked retrieve response so it's treated as terminal.

The sibling test `test_vertex_list_batches` uses the same mock shape but passes because `_async_list_batches` is not wrapped in `async_safe_get`.

## Test plan

- [x] `uv run pytest tests/batches_tests/test_openai_batches_and_files.py::test_avertex_batch_prediction` passes locally