### PR TITLE
fix(ui): tag filter dropdown on Usage page respects selected date range

### DIFF
--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -12,9 +12,10 @@ All /tag management endpoints
 
 import asyncio
 import json
-from typing import TYPE_CHECKING, Dict, List, Optional
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import UserAPIKeyAuth
@@ -395,6 +396,32 @@ async def info_tag(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _validate_tag_list_date_range(
+    start_date: Optional[str], end_date: Optional[str]
+) -> None:
+    """Require both dates together, and enforce YYYY-MM-DD format with start <= end."""
+    if (start_date is None) != (end_date is None):
+        raise HTTPException(
+            status_code=400,
+            detail="start_date and end_date must be provided together",
+        )
+    if start_date is None:
+        return
+    try:
+        start = datetime.strptime(start_date, "%Y-%m-%d")
+        end = datetime.strptime(end_date, "%Y-%m-%d")  # type: ignore[arg-type]
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid date format, expected YYYY-MM-DD: {e}",
+        )
+    if start > end:
+        raise HTTPException(
+            status_code=400,
+            detail="start_date must be on or before end_date",
+        )
+
+
 @router.get(
     "/tag/list",
     tags=["tag management"],
@@ -402,6 +429,18 @@ async def info_tag(
 )
 async def list_tags(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    start_date: Optional[str] = Query(
+        None,
+        description=(
+            "Optional start date (YYYY-MM-DD). When provided together with "
+            "end_date, dynamic tags are limited to those active in the window. "
+            "Stored tags are always returned."
+        ),
+    ),
+    end_date: Optional[str] = Query(
+        None,
+        description="Optional end date (YYYY-MM-DD). Must be given with start_date.",
+    ),
 ):
     """
     List all available tags with their budget information.
@@ -410,6 +449,8 @@ async def list_tags(
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail="Database not connected")
+
+    _validate_tag_list_date_range(start_date, end_date)
 
     try:
         ## QUERY STORED TAGS ##
@@ -453,9 +494,13 @@ async def list_tags(
         # Prisma's distinct fetches all columns for all rows and deduplicates
         # in application code, which is extremely slow on large tables.
         # See: https://www.prisma.io/docs/orm/prisma-client/queries/aggregation-grouping-summarizing#distinct-under-the-hood
+        dynamic_tag_where: Dict[str, Any] = {"tag": {"not": None}}
+        if start_date is not None and end_date is not None:
+            dynamic_tag_where["date"] = {"gte": start_date, "lte": end_date}
+
         dynamic_tag_rows = await prisma_client.db.litellm_dailytagspend.group_by(
             by=["tag"],
-            where={"tag": {"not": None}},
+            where=dynamic_tag_where,
             min={"created_at": True},
             max={"updated_at": True},
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -381,6 +381,116 @@ async def test_list_tags_no_dynamic_tags():
 
 
 @pytest.mark.asyncio
+async def test_list_tags_with_date_range_filters_dynamic_tags():
+    """
+    /tag/list?start_date=...&end_date=... should push the date window into
+    the dailytagspend group_by WHERE clause so large tables don't get scanned.
+    """
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+            mock_db.litellm_tagtable.find_many = AsyncMock(return_value=[])
+            group_by_mock = AsyncMock(return_value=[])
+            mock_db.litellm_dailytagspend.group_by = group_by_mock
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get(
+                "/tag/list?start_date=2026-04-01&end_date=2026-04-29",
+                headers=headers,
+            )
+
+            assert response.status_code == 200
+            group_by_mock.assert_awaited_once()
+            where = group_by_mock.await_args.kwargs["where"]
+            assert where["tag"] == {"not": None}
+            assert where["date"] == {"gte": "2026-04-01", "lte": "2026-04-29"}
+
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_list_tags_without_date_range_omits_date_filter():
+    """When no date range is passed, the WHERE clause must not carry a date key."""
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+            mock_db.litellm_tagtable.find_many = AsyncMock(return_value=[])
+            group_by_mock = AsyncMock(return_value=[])
+            mock_db.litellm_dailytagspend.group_by = group_by_mock
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get("/tag/list", headers=headers)
+
+            assert response.status_code == 200
+            where = group_by_mock.await_args.kwargs["where"]
+            assert "date" not in where
+
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.parametrize(
+    "query, expected_detail_fragment",
+    [
+        ("?start_date=2026-04-01", "must be provided together"),
+        ("?end_date=2026-04-29", "must be provided together"),
+        ("?start_date=2026-04-29&end_date=2026-04-01", "on or before end_date"),
+        ("?start_date=not-a-date&end_date=2026-04-29", "YYYY-MM-DD"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_list_tags_rejects_invalid_date_range(query, expected_detail_fragment):
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+            mock_db.litellm_tagtable.find_many = AsyncMock(return_value=[])
+            mock_db.litellm_dailytagspend.group_by = AsyncMock(return_value=[])
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get(f"/tag/list{query}", headers=headers)
+
+            assert response.status_code == 400
+            assert expected_detail_fragment in response.json()["detail"]
+
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
 async def test_get_deployments_by_model_id():
     """
     Test get_deployments_by_model when model is found by model_id

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -445,6 +445,7 @@ async def test_list_tags_without_date_range_omits_date_filter():
             response = client.get("/tag/list", headers=headers)
 
             assert response.status_code == 200
+            group_by_mock.assert_awaited_once()
             where = group_by_mock.await_args.kwargs["where"]
             assert "date" not in where
 

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -145,23 +145,6 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const [topKeysLimit, setTopKeysLimit] = useState<number>(5);
   const [topModelsLimit, setTopModelsLimit] = useState<number>(5);
   const [showTokenBreakdown, setShowTokenBreakdown] = useState(false);
-  const getAllTags = async () => {
-    if (!accessToken) {
-      return;
-    }
-    const tags = await tagListCall(accessToken);
-    setAllTags(
-      Object.values(tags).map((tag: Tag) => ({
-        label: tag.name,
-        value: tag.name,
-      })),
-    );
-  };
-
-  useEffect(() => {
-    getAllTags();
-  }, [accessToken]);
-
   // Sync selectedUserId when auth state settles (isAdmin/userID may be null on initial render)
   useEffect(() => {
     if (!isAdmin && userID) {
@@ -174,6 +157,24 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
 
   const startTime = useMemo(() => (dateValue.from ? new Date(dateValue.from) : null), [dateValue.from]);
   const endTime = useMemo(() => (dateValue.to ? new Date(dateValue.to) : null), [dateValue.to]);
+
+  useEffect(() => {
+    if (!accessToken) return;
+    let cancelled = false;
+    (async () => {
+      const tags = await tagListCall(accessToken, startTime, endTime);
+      if (cancelled) return;
+      setAllTags(
+        Object.values(tags).map((tag: Tag) => ({
+          label: tag.name,
+          value: tag.name,
+        })),
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, startTime, endTime]);
 
   // Try aggregated endpoint first, fall back to paginated on failure
   const aggregatedFetchIdRef = useRef(0);

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -162,14 +162,20 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
     if (!accessToken) return;
     let cancelled = false;
     (async () => {
-      const tags = await tagListCall(accessToken, startTime, endTime);
-      if (cancelled) return;
-      setAllTags(
-        Object.values(tags).map((tag: Tag) => ({
-          label: tag.name,
-          value: tag.name,
-        })),
-      );
+      try {
+        const tags = await tagListCall(accessToken, startTime, endTime);
+        if (cancelled) return;
+        setAllTags(
+          Object.values(tags).map((tag: Tag) => ({
+            label: tag.name,
+            value: tag.name,
+          })),
+        );
+      } catch (e) {
+        if (!cancelled) {
+          console.error("Failed to fetch tag list", e);
+        }
+      }
     })();
     return () => {
       cancelled = true;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -7288,9 +7288,28 @@ export const tagInfoCall = async (accessToken: string, tagNames: string[]): Prom
   }
 };
 
-export const tagListCall = async (accessToken: string): Promise<TagListResponse> => {
+const formatYmd = (value: Date): string => {
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const tagListCall = async (
+  accessToken: string,
+  startTime?: Date | null,
+  endTime?: Date | null,
+): Promise<TagListResponse> => {
   try {
     let url = proxyBaseUrl ? `${proxyBaseUrl}/tag/list` : `/tag/list`;
+
+    if (startTime && endTime) {
+      const params = new URLSearchParams({
+        start_date: formatYmd(startTime),
+        end_date: formatYmd(endTime),
+      });
+      url = `${url}?${params.toString()}`;
+    }
 
     const response = await fetch(url, {
       method: "GET",


### PR DESCRIPTION
# PR: fix(ui): tag filter dropdown on Usage page respects selected date range

> **Branch**: `Bytechoreographer:fix/tag-list-time-window`
> **Target**: `BerriAI:litellm_internal_staging`

---

## Relevant issues

<!-- No open issue; bug reproduced locally on the Usage page with tags that have no spend in the selected period. -->

## Pre-Submission checklist

- [x] Unit tests added in `tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py`
- [x] `uv run pytest tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py -v` passes
- [x] Scope is isolated: 2 backend files + 2 frontend files, no new dependencies
- [x] Comment `@greptileai` and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix / ⚡ Performance

## Changes

### Reproduction

1. Open the Usage page (`?page=new_usage`) with a date range narrow enough to exclude some tags (e.g. last 7 days).
2. Open the **Tag** filter dropdown.

**Before**: Every tag ever created in the system appears — including ones with no spend in the selected window. Users must guess which tags are relevant.

**After**: Only tags with spend within the selected date window appear. Stored (budget-configured) tags are always included regardless of the window.

---

### Root cause — tag list fetch ignores the active date filter and scans all rows

`UsagePageView.tsx` fetched all tags on mount and never re-fetched when the date range changed:

```ts
// Before — fires once on mount, never again
const getAllTags = async () => {
  const tags = await tagListCall(accessToken);
  setAllTags(...);
};
useEffect(() => {
  getAllTags();
}, [accessToken]);
```

`tagListCall` hit `/tag/list` with no query params. The backend then ran a `group_by` on `litellm_dailytagspend` with only `WHERE tag IS NOT NULL` — a **full table scan** of the entire spend history. On a busy proxy this table can contain millions of rows, making every Usage-page load unnecessarily expensive. The existing `@@index([tag, date])` composite index in `schema.prisma` is never engaged when there is no `date` predicate.

---

### Fix

Three coordinated changes:

#### 1. Backend — `GET /tag/list` accepts optional date-range params

```python
async def list_tags(
    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
    start_date: Optional[str] = Query(None, description="YYYY-MM-DD"),
    end_date:   Optional[str] = Query(None, description="YYYY-MM-DD"),
):
```

- Validated by a pure helper `_validate_tag_list_date_range`: both must be supplied together, must parse as `%Y-%m-%d`, and `start <= end`.
- When both are present, the `group_by` WHERE clause on `litellm_dailytagspend` gains a `date` filter:

  ```python
  dynamic_tag_where: Dict[str, Any] = {"tag": {"not": None}}
  if start_date and end_date:
      dynamic_tag_where["date"] = {"gte": start_date, "lte": end_date}
  ```

  This engages the existing `@@index([tag, date])` composite index in `schema.prisma`, limiting the scan to rows within the requested window instead of the full table.

- Stored tags (`litellm_tagtable`) are always returned; date filter applies only to dynamic tags.

#### 2. Frontend — `tagListCall` forwards the date window

```ts
// networking.tsx — before
export const tagListCall = async (accessToken: string): Promise<TagListResponse>

// After
export const tagListCall = async (
  accessToken: string,
  startTime?: Date | null,
  endTime?: Date | null,
): Promise<TagListResponse>
```

When both dates are non-null, `YYYY-MM-DD` strings are appended as `?start_date=...&end_date=...`. A local `formatYmd` helper avoids locale-sensitive `toISOString()`.

#### 3. Frontend — `UsagePageView` re-fetches tags on date change

```ts
// UsagePageView.tsx — after
useEffect(() => {
  if (!accessToken) return;
  let cancelled = false;
  (async () => {
    const tags = await tagListCall(accessToken, startTime, endTime);
    if (cancelled) return;
    setAllTags(...);
  })();
  return () => { cancelled = true; };
}, [accessToken, startTime, endTime]);   // ← re-fires when date range changes
```

`startTime` and `endTime` are memoised from the existing `dateValue` state, so this effect fires only when the user actually changes the picker.

---

### Files changed

| File | Change |
|------|--------|
| `litellm/proxy/management_endpoints/tag_management_endpoints.py` | Add `start_date`/`end_date` query params + `_validate_tag_list_date_range` helper + conditional WHERE clause on `litellm_dailytagspend` |
| `tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py` | Add `test_list_tags_with_date_range_filters_dynamic_tags` and `test_list_tags_without_date_range_omits_date_filter` |
| `ui/litellm-dashboard/src/components/networking.tsx` | `tagListCall` gains optional `startTime`/`endTime` params; adds `formatYmd` helper |
| `ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx` | Replace static mount-only tag fetch with date-aware effect that re-fetches on `[accessToken, startTime, endTime]` change |

---

### Test results

```
$ uv run pytest tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py -v
...
PASSED test_list_tags_with_date_range_filters_dynamic_tags
PASSED test_list_tags_without_date_range_omits_date_filter
...
```

---

### Before / After behaviour

| Scenario | Before | After |
|---|---|---|
| Tag dropdown on Usage page | Shows all tags ever seen | Shows only tags with spend in selected date window |
| No date range selected | All tags (full table scan) | All tags (full table scan, unchanged) |
| Date range selected | Full table scan regardless | `@@index([tag, date])` used — only scans the date window |
| Stored (budget-configured) tags | Always shown | Always shown (unchanged) |
| Date range changes | Dropdown unchanged | Dropdown re-fetches automatically |
| Missing only one of start/end | N/A | 400 — `"start_date and end_date must be provided together"` |
| Invalid date format | N/A | 400 — `"Invalid date format, expected YYYY-MM-DD"` |
| `start_date > end_date` | N/A | 400 — `"start_date must be on or before end_date"` |
