### PR TITLE
adds deepseek-v4 pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12468,6 +12468,21 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "deepseek/deepseek-v4-pro": {
+        "max_tokens": 384000,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "input_cost_per_token": 4.35e-07,
+        "output_cost_per_token": 8.7e-07,
+        "cache_read_input_token_cost": 3.625e-09,
+        "litellm_provider": "deepseek",
+        "mode": "chat",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "deepseek.v3-v1:0": {
         "input_cost_per_token": 5.8e-07,
         "litellm_provider": "bedrock_converse",


### PR DESCRIPTION
## Relevant issues

  N/A

  Pre-Submission checklist

  - My PR's scope is as isolated as possible, it only solves 1 specific problem

  Screenshots / Proof of Fix

  Verified locally via litellm.cost_calculator.completion_cost — call with 11 input / 207 output tokens returns $0.000184875, matching 11 × 4.35e-7 + 207 × 8.7e-7.

  Without this entry, litellm logs Cost calculation failed for deepseek/deepseek-v4-pro: This model isn't mapped yet. and reports cost=0.0.

  Type

  🆕 New Feature

  Changes

  Add pricing and context-window entry for deepseek/deepseek-v4-pro.

  - Context: 1M input, 384K max output
  - Pricing (current promo, valid through 2026-05-31): $0.435 / $0.87 per 1M input/output, $0.003625 per 1M cache-hit input
  - Source: https://api-docs.deepseek.com/quick_start/pricing