### PR TITLE
chore(mcp): SSRF guard on OAuth metadata discovery follow-up fetches

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1550,6 +1550,9 @@ class MCPServerManager:
         except socket.gaierror:
             return False
 
+        if not infos:
+            return False
+
         # Reuse the proxy-wide outbound block list (private / loopback /
         # link-local / multicast / reserved / cloud-fabric IPs).  Defence
         # in depth only — the resolution here and the one httpx performs at
@@ -1557,7 +1560,10 @@ class MCPServerManager:
         # also controls the resource server is already in scope, so the
         # primary mitigation is the same-authority pin above.
         for info in infos:
-            if _is_blocked_ip(info[4][0]):
+            sockaddr_host = info[4][0]
+            if not isinstance(sockaddr_host, str):
+                return False
+            if _is_blocked_ip(sockaddr_host):
                 return False
         return True
 
@@ -1697,7 +1703,10 @@ class MCPServerManager:
                 llm_provider=httpxSpecialProvider.MCP,
                 params={"timeout": MCP_METADATA_TIMEOUT},
             )
-            response = await client.get(resource_metadata_url)
+            # Redirects bypass the SSRF guard (the new ``Location`` is not
+            # re-checked against ``server_url``), so refuse to follow them.
+            # Spec-compliant OAuth metadata endpoints serve the JSON directly.
+            response = await client.get(resource_metadata_url, follow_redirects=False)
             response.raise_for_status()
             data = response.json()
         except Exception as exc:  # pragma: no cover - network issues
@@ -1806,7 +1815,11 @@ class MCPServerManager:
                     llm_provider=httpxSpecialProvider.MCP,
                     params={"timeout": MCP_METADATA_TIMEOUT},
                 )
-                response = await client.get(url)
+                # Disable redirects: a redirect to a private IP would bypass
+                # the SSRF guard (the ``Location`` target is not re-checked
+                # against ``server_url``).  Spec-compliant OAuth/OIDC
+                # metadata endpoints serve the JSON directly.
+                response = await client.get(url, follow_redirects=False)
                 response.raise_for_status()
                 data = response.json()
             except Exception as exc:  # pragma: no cover - network issues

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import re
+import socket
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 from urllib.parse import urlparse
 
@@ -41,6 +42,7 @@ from litellm.constants import (
     MCP_TOOL_LISTING_TIMEOUT,
 )
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
+from litellm.litellm_core_utils.url_utils import _is_blocked_ip
 from litellm.experimental_mcp_client.client import MCPClient, MCPSigV4Auth
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
@@ -1499,6 +1501,66 @@ class MCPServerManager:
         )
         return await client.get_prompt(get_prompt_request_params)
 
+    @staticmethod
+    def _is_safe_metadata_url(url: str, server_url: str) -> bool:
+        """
+        Whether ``url`` is safe to fetch during OAuth discovery for ``server_url``.
+
+        OAuth metadata discovery follows attacker-influenceable URLs from a
+        WWW-Authenticate header and from the protected-resource-metadata JSON.
+        Without a guard those become an SSRF primitive: a malicious MCP server
+        can point the proxy at cloud metadata services, internal admin panels,
+        or loopback debug endpoints.
+
+        A URL is allowed when:
+          - it shares (scheme, host, port) with ``server_url`` — well-known
+            endpoints constructed from the admin's URL, and PRM published at
+            the resource server itself per RFC 9728 §3.3, OR
+          - it resolves to one or more public IPs only — covers federated
+            authorization servers (Azure Entra, Google, Okta, GitHub) hosted
+            cross-origin from the resource.
+
+        URLs that resolve to private / loopback / link-local / cloud-metadata
+        addresses, or that don't resolve at all, are rejected. ``http`` and
+        ``https`` are the only schemes accepted.
+        """
+        try:
+            target = urlparse(url)
+            base = urlparse(server_url)
+        except Exception:
+            return False
+
+        if target.scheme not in ("http", "https") or not target.hostname:
+            return False
+
+        target_port = target.port or (443 if target.scheme == "https" else 80)
+        base_port = base.port or (443 if base.scheme == "https" else 80)
+        same_authority = (
+            base.scheme == target.scheme
+            and (base.hostname or "").lower() == target.hostname.lower()
+            and base_port == target_port
+        )
+        if same_authority:
+            return True
+
+        try:
+            infos = socket.getaddrinfo(
+                target.hostname, target_port, type=socket.SOCK_STREAM
+            )
+        except socket.gaierror:
+            return False
+
+        # Reuse the proxy-wide outbound block list (private / loopback /
+        # link-local / multicast / reserved / cloud-fabric IPs).  Defence
+        # in depth only — the resolution here and the one httpx performs at
+        # request time leave a small DNS-rebinding window; an attacker who
+        # also controls the resource server is already in scope, so the
+        # primary mitigation is the same-authority pin above.
+        for info in infos:
+            if _is_blocked_ip(info[4][0]):
+                return False
+        return True
+
     async def _descovery_metadata(
         self,
         server_url: str,
@@ -1514,7 +1576,7 @@ class MCPServerManager:
                 resource_scopes,
             ) = await self._attempt_well_known_discovery(server_url)
             metadata = await self._fetch_authorization_server_metadata(
-                authorization_servers
+                authorization_servers, server_url
             )
             if (
                 metadata is None
@@ -1555,7 +1617,7 @@ class MCPServerManager:
                     authorization_servers,
                     resource_scopes,
                 ) = await self._fetch_oauth_metadata_from_resource(
-                    resource_metadata_url
+                    resource_metadata_url, server_url
                 )
             else:
                 (
@@ -1576,7 +1638,7 @@ class MCPServerManager:
 
             if authorization_servers:
                 metadata = await self._fetch_authorization_server_metadata(
-                    authorization_servers
+                    authorization_servers, server_url
                 )
 
             preferred_scopes = scopes or resource_scopes
@@ -1616,9 +1678,18 @@ class MCPServerManager:
         return resource_metadata_url, scopes
 
     async def _fetch_oauth_metadata_from_resource(
-        self, resource_metadata_url: str
+        self, resource_metadata_url: str, server_url: str
     ) -> Tuple[List[str], Optional[List[str]]]:
         if not resource_metadata_url:
+            return [], None
+
+        if not self._is_safe_metadata_url(resource_metadata_url, server_url):
+            verbose_logger.warning(
+                "MCP OAuth discovery: refusing to fetch resource metadata from %s "
+                "(rejected by SSRF guard for server %s)",
+                resource_metadata_url,
+                server_url,
+            )
             return [], None
 
         try:
@@ -1677,23 +1748,25 @@ class MCPServerManager:
             (
                 authorization_servers,
                 scopes,
-            ) = await self._fetch_oauth_metadata_from_resource(url)
+            ) = await self._fetch_oauth_metadata_from_resource(url, server_url)
             if authorization_servers:
                 return authorization_servers, scopes
 
         return [], None
 
     async def _fetch_authorization_server_metadata(
-        self, authorization_servers: List[str]
+        self, authorization_servers: List[str], server_url: str
     ) -> Optional[MCPOAuthMetadata]:
         for issuer in authorization_servers:
-            metadata = await self._fetch_single_authorization_server_metadata(issuer)
+            metadata = await self._fetch_single_authorization_server_metadata(
+                issuer, server_url
+            )
             if metadata is not None:
                 return metadata
         return None
 
     async def _fetch_single_authorization_server_metadata(
-        self, issuer_url: str
+        self, issuer_url: str, server_url: str
     ) -> Optional[MCPOAuthMetadata]:
         try:
             parsed = urlparse(issuer_url)
@@ -1720,6 +1793,14 @@ class MCPServerManager:
         candidate_urls.append(issuer_url.rstrip("/"))
 
         for url in candidate_urls:
+            if not self._is_safe_metadata_url(url, server_url):
+                verbose_logger.warning(
+                    "MCP OAuth discovery: refusing to fetch authorization-server "
+                    "metadata from %s (rejected by SSRF guard for server %s)",
+                    url,
+                    server_url,
+                )
+                continue
             try:
                 client = get_async_httpx_client(
                     llm_provider=httpxSpecialProvider.MCP,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -12,7 +12,6 @@ import hashlib
 import json
 import os
 import re
-import socket
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 from urllib.parse import urlparse
 
@@ -42,7 +41,7 @@ from litellm.constants import (
     MCP_TOOL_LISTING_TIMEOUT,
 )
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
-from litellm.litellm_core_utils.url_utils import _is_blocked_ip
+from litellm.litellm_core_utils.url_utils import SSRFError, async_safe_get
 from litellm.experimental_mcp_client.client import MCPClient, MCPSigV4Auth
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
@@ -1502,27 +1501,15 @@ class MCPServerManager:
         return await client.get_prompt(get_prompt_request_params)
 
     @staticmethod
-    def _is_safe_metadata_url(url: str, server_url: str) -> bool:
+    def _is_same_authority_metadata_url(url: str, server_url: str) -> bool:
         """
-        Whether ``url`` is safe to fetch during OAuth discovery for ``server_url``.
+        Whether ``url`` shares scheme, host, and port with ``server_url``.
 
-        OAuth metadata discovery follows attacker-influenceable URLs from a
-        WWW-Authenticate header and from the protected-resource-metadata JSON.
-        Without a guard those become an SSRF primitive: a malicious MCP server
-        can point the proxy at cloud metadata services, internal admin panels,
-        or loopback debug endpoints.
-
-        A URL is allowed when:
-          - it shares (scheme, host, port) with ``server_url`` — well-known
-            endpoints constructed from the admin's URL, and PRM published at
-            the resource server itself per RFC 9728 §3.3, OR
-          - it resolves to one or more public IPs only — covers federated
-            authorization servers (Azure Entra, Google, Okta, GitHub) hosted
-            cross-origin from the resource.
-
-        URLs that resolve to private / loopback / link-local / cloud-metadata
-        addresses, or that don't resolve at all, are rejected. ``http`` and
-        ``https`` are the only schemes accepted.
+        Same-authority metadata URLs are produced by our well-known discovery
+        construction and by resource servers that publish protected-resource
+        metadata on the resource origin. These must keep working for
+        administrator-configured internal MCP servers, so they are fetched
+        directly. Cross-origin URLs are fetched through ``async_safe_get``.
         """
         try:
             target = urlparse(url)
@@ -1535,37 +1522,24 @@ class MCPServerManager:
 
         target_port = target.port or (443 if target.scheme == "https" else 80)
         base_port = base.port or (443 if base.scheme == "https" else 80)
-        same_authority = (
+        return (
             base.scheme == target.scheme
             and (base.hostname or "").lower() == target.hostname.lower()
             and base_port == target_port
         )
-        if same_authority:
-            return True
 
-        try:
-            infos = socket.getaddrinfo(
-                target.hostname, target_port, type=socket.SOCK_STREAM
-            )
-        except socket.gaierror:
-            return False
-
-        if not infos:
-            return False
-
-        # Reuse the proxy-wide outbound block list (private / loopback /
-        # link-local / multicast / reserved / cloud-fabric IPs).  Defence
-        # in depth only — the resolution here and the one httpx performs at
-        # request time leave a small DNS-rebinding window; an attacker who
-        # also controls the resource server is already in scope, so the
-        # primary mitigation is the same-authority pin above.
-        for info in infos:
-            sockaddr_host = info[4][0]
-            if not isinstance(sockaddr_host, str):
-                return False
-            if _is_blocked_ip(sockaddr_host):
-                return False
-        return True
+    async def _fetch_oauth_discovery_url(self, url: str, server_url: str) -> Any:
+        client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.MCP,
+            params={"timeout": MCP_METADATA_TIMEOUT},
+        )
+        if self._is_same_authority_metadata_url(url, server_url):
+            # Same-authority URLs may point at administrator-configured
+            # internal MCP servers. Do not run them through user URL
+            # validation, but also do not follow redirects because the
+            # redirect target would not inherit the same-authority guarantee.
+            return await client.get(url, follow_redirects=False)
+        return await async_safe_get(client, url)
 
     async def _descovery_metadata(
         self,
@@ -1689,26 +1663,21 @@ class MCPServerManager:
         if not resource_metadata_url:
             return [], None
 
-        if not self._is_safe_metadata_url(resource_metadata_url, server_url):
-            verbose_logger.warning(
-                "MCP OAuth discovery: refusing to fetch resource metadata from %s "
-                "(rejected by SSRF guard for server %s)",
-                resource_metadata_url,
-                server_url,
-            )
-            return [], None
-
         try:
-            client = get_async_httpx_client(
-                llm_provider=httpxSpecialProvider.MCP,
-                params={"timeout": MCP_METADATA_TIMEOUT},
+            response = await self._fetch_oauth_discovery_url(
+                resource_metadata_url, server_url
             )
-            # Redirects bypass the SSRF guard (the new ``Location`` is not
-            # re-checked against ``server_url``), so refuse to follow them.
-            # Spec-compliant OAuth metadata endpoints serve the JSON directly.
-            response = await client.get(resource_metadata_url, follow_redirects=False)
             response.raise_for_status()
             data = response.json()
+        except SSRFError as exc:
+            verbose_logger.warning(
+                "MCP OAuth discovery: refusing to fetch resource metadata from %s "
+                "(rejected by SSRF guard for server %s): %s",
+                resource_metadata_url,
+                server_url,
+                exc,
+            )
+            return [], None
         except Exception as exc:  # pragma: no cover - network issues
             verbose_logger.debug(
                 "Failed to fetch MCP OAuth metadata from %s: %s",
@@ -1802,26 +1771,19 @@ class MCPServerManager:
         candidate_urls.append(issuer_url.rstrip("/"))
 
         for url in candidate_urls:
-            if not self._is_safe_metadata_url(url, server_url):
-                verbose_logger.warning(
-                    "MCP OAuth discovery: refusing to fetch authorization-server "
-                    "metadata from %s (rejected by SSRF guard for server %s)",
-                    url,
-                    server_url,
-                )
-                continue
             try:
-                client = get_async_httpx_client(
-                    llm_provider=httpxSpecialProvider.MCP,
-                    params={"timeout": MCP_METADATA_TIMEOUT},
-                )
-                # Disable redirects: a redirect to a private IP would bypass
-                # the SSRF guard (the ``Location`` target is not re-checked
-                # against ``server_url``).  Spec-compliant OAuth/OIDC
-                # metadata endpoints serve the JSON directly.
-                response = await client.get(url, follow_redirects=False)
+                response = await self._fetch_oauth_discovery_url(url, server_url)
                 response.raise_for_status()
                 data = response.json()
+            except SSRFError as exc:
+                verbose_logger.warning(
+                    "MCP OAuth discovery: refusing to fetch authorization-server "
+                    "metadata from %s (rejected by SSRF guard for server %s): %s",
+                    url,
+                    server_url,
+                    exc,
+                )
+                continue
             except Exception as exc:  # pragma: no cover - network issues
                 verbose_logger.debug(
                     "Failed to fetch authorization metadata from %s: %s",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 from datetime import datetime
+from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2971,7 +2972,7 @@ class TestOAuthDiscoverySSRFGuard:
         """Patch ``socket.getaddrinfo`` for a deterministic SSRF-guard test.
 
         ``mapping`` is ``{hostname: [ip-string, ...]}``; unknown hosts raise
-        ``gaierror`` (treated as "unresolvable" -> blocked).
+        ``gaierror`` (treated as "unresolvable" -> blocked by async_safe_get).
         """
         import socket as _socket
 
@@ -2984,26 +2985,21 @@ class TestOAuthDiscoverySSRFGuard:
             ]
 
         monkeypatch.setattr(
-            "litellm.proxy._experimental.mcp_server.mcp_server_manager.socket.getaddrinfo",
+            "litellm.litellm_core_utils.url_utils.socket.getaddrinfo",
             fake_getaddrinfo,
         )
 
-    def test_same_authority_url_is_safe(self):
+    def test_same_authority_url_is_direct_fetch_eligible(self):
         # Same scheme + host + port skips DNS entirely — the well-known
         # endpoint construction in _attempt_well_known_discovery always
         # produces same-authority URLs against the admin's server_url.
-        assert MCPServerManager._is_safe_metadata_url(
+        assert MCPServerManager._is_same_authority_metadata_url(
             "https://example.com/.well-known/oauth-protected-resource",
             "https://example.com/mcp",
         )
 
-    def test_same_host_different_port_blocked_when_resolves_to_private_ip(
-        self, monkeypatch
-    ):
-        # Cross-authority (different port). Falls through to DNS check.
-        # If the resolved IP is private, the guard rejects.
-        self._patch_resolves(monkeypatch, {"example.com": ["10.1.2.3"]})
-        assert not MCPServerManager._is_safe_metadata_url(
+    def test_same_host_different_port_uses_safe_fetch_path(self):
+        assert not MCPServerManager._is_same_authority_metadata_url(
             "https://example.com:9999/.well-known/oauth-protected-resource",
             "https://example.com/mcp",
         )
@@ -3023,48 +3019,133 @@ class TestOAuthDiscoverySSRFGuard:
             "fc00::1",  # IPv6 ULA
         ],
     )
-    def test_cross_origin_blocked_when_resolves_to_unsafe_ip(self, monkeypatch, ip):
+    @pytest.mark.asyncio
+    async def test_cross_origin_blocked_when_resolves_to_unsafe_ip(
+        self, monkeypatch, ip
+    ):
         self._patch_resolves(monkeypatch, {"attacker.example.com": [ip]})
-        assert not MCPServerManager._is_safe_metadata_url(
-            f"https://attacker.example.com/.well-known/oauth-authorization-server",
-            "https://legit-mcp.example.com/mcp",
-        )
+        manager = MCPServerManager()
 
-    def test_cross_origin_allowed_when_resolves_to_public_ip(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            result = await manager._fetch_single_authorization_server_metadata(
+                "https://attacker.example.com",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert result is None
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_allowed_when_resolves_to_public_ip(self, monkeypatch):
         self._patch_resolves(
             monkeypatch, {"login.microsoftonline.com": ["20.190.151.7"]}
         )
-        assert MCPServerManager._is_safe_metadata_url(
-            "https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration",
-            "https://atlassian-mcp.example.com/mcp",
+        manager = MCPServerManager()
+
+        mock_response = MagicMock()
+        mock_response.is_redirect = False
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "authorization_servers": ["https://login.microsoftonline.com/tenant/v2.0"],
+            "scopes_supported": ["mcp.read"],
+        }
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            servers, scopes = await manager._fetch_oauth_metadata_from_resource(
+                "https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration",
+                "https://atlassian-mcp.example.com/mcp",
+            )
+
+        assert servers == ["https://login.microsoftonline.com/tenant/v2.0"]
+        assert scopes == ["mcp.read"]
+        mock_client.get.assert_awaited_once()
+        assert mock_client.get.await_args.kwargs["follow_redirects"] is False
+        assert (
+            mock_client.get.await_args.kwargs["headers"]["Host"]
+            == "login.microsoftonline.com"
         )
 
-    def test_cross_origin_blocked_when_unresolvable(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_cross_origin_blocked_when_unresolvable(self, monkeypatch):
         self._patch_resolves(monkeypatch, {})
-        assert not MCPServerManager._is_safe_metadata_url(
-            "https://nope.example.invalid/.well-known/oauth-authorization-server",
-            "https://legit-mcp.example.com/mcp",
-        )
+        manager = MCPServerManager()
 
-    def test_non_http_scheme_is_not_safe(self):
-        assert not MCPServerManager._is_safe_metadata_url(
-            "file:///etc/passwd", "https://example.com/mcp"
-        )
-        assert not MCPServerManager._is_safe_metadata_url(
-            "gopher://example.com/", "https://example.com/mcp"
-        )
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
 
-    def test_dual_resolution_blocked_if_any_ip_unsafe(self, monkeypatch):
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            servers, scopes = await manager._fetch_oauth_metadata_from_resource(
+                "https://nope.example.invalid/.well-known/oauth-authorization-server",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert servers == []
+        assert scopes is None
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_http_scheme_is_not_safe(self):
+        manager = MCPServerManager()
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            servers, scopes = await manager._fetch_oauth_metadata_from_resource(
+                "file:///etc/passwd",
+                "https://example.com/mcp",
+            )
+            result = await manager._fetch_single_authorization_server_metadata(
+                "gopher://example.com/",
+                "https://example.com/mcp",
+            )
+
+        assert servers == []
+        assert scopes is None
+        assert result is None
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dual_resolution_blocked_if_any_ip_unsafe(self, monkeypatch):
         # If the attacker controls a DNS record returning multiple A records,
-        # one of which is private, the guard must reject — pinning to the
-        # safe IP would be a TOCTOU window.
+        # one of which is private, async_safe_get rejects before any network call.
         self._patch_resolves(
             monkeypatch, {"dual-stack.example.com": ["8.8.8.8", "127.0.0.1"]}
         )
-        assert not MCPServerManager._is_safe_metadata_url(
-            "https://dual-stack.example.com/.well-known/oauth-authorization-server",
-            "https://legit-mcp.example.com/mcp",
-        )
+        manager = MCPServerManager()
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            servers, scopes = await manager._fetch_oauth_metadata_from_resource(
+                "https://dual-stack.example.com/.well-known/oauth-authorization-server",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert servers == []
+        assert scopes is None
+        mock_client.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fetch_oauth_metadata_refuses_unsafe_url(self, monkeypatch):
@@ -3089,23 +3170,67 @@ class TestOAuthDiscoverySSRFGuard:
         assert scopes is None
         mock_client.get.assert_not_called()
 
-    def test_empty_getaddrinfo_result_blocks_url(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_empty_getaddrinfo_result_blocks_url(self, monkeypatch):
         # POSIX doesn't strictly forbid an empty success-list from getaddrinfo.
-        # The guard must fail closed rather than fall through to ``return True``.
+        # async_safe_get must fail closed rather than making a network call.
         monkeypatch.setattr(
-            "litellm.proxy._experimental.mcp_server.mcp_server_manager.socket.getaddrinfo",
+            "litellm.litellm_core_utils.url_utils.socket.getaddrinfo",
             lambda *a, **k: [],
         )
-        assert not MCPServerManager._is_safe_metadata_url(
-            "https://no-records.example.com/.well-known/oauth-authorization-server",
-            "https://legit-mcp.example.com/mcp",
-        )
+        manager = MCPServerManager()
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            servers, scopes = await manager._fetch_oauth_metadata_from_resource(
+                "https://no-records.example.com/.well-known/oauth-authorization-server",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert servers == []
+        assert scopes is None
+        mock_client.get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_fetch_oauth_metadata_does_not_follow_redirects(self):
-        # If the validated origin redirects to a loopback or other unsafe
-        # address, httpx must NOT follow — the new ``Location`` would not
-        # be re-checked against ``server_url``.
+    async def test_cross_origin_redirect_is_revalidated(self, monkeypatch):
+        self._patch_resolves(
+            monkeypatch,
+            {
+                "provider.example.com": ["8.8.8.8"],
+                "127.0.0.1": ["127.0.0.1"],
+            },
+        )
+        manager = MCPServerManager()
+
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"location": "http://127.0.0.1/admin"}
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=redirect_response)
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            result = await manager._fetch_single_authorization_server_metadata(
+                "https://provider.example.com",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert result is None
+        assert mock_client.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_same_authority_fetch_does_not_follow_redirects(self):
+        # Same-authority URLs may be internal admin-configured MCP servers, so
+        # they are fetched directly. Redirects are still disabled because a
+        # Location target would not inherit the same-authority guarantee.
         manager = MCPServerManager()
 
         mock_response = MagicMock()
@@ -3134,7 +3259,7 @@ class TestOAuthDiscoverySSRFGuard:
         assert captured_kwargs.get("follow_redirects") is False
 
     @pytest.mark.asyncio
-    async def test_fetch_single_auth_server_does_not_follow_redirects(self):
+    async def test_same_authority_auth_server_fetch_does_not_follow_redirects(self):
         # Same redirect-bypass concern for the authorization-server fetch path.
         manager = MCPServerManager()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -719,7 +719,8 @@ class TestMCPServerManager:
             return_value=mock_client,
         ):
             servers, scopes = await manager._fetch_oauth_metadata_from_resource(
-                "https://protected.example.com/.well-known/oauth"
+                "https://protected.example.com/.well-known/oauth",
+                "https://protected.example.com/mcp",
             )
 
         assert servers == [
@@ -772,7 +773,8 @@ class TestMCPServerManager:
 
         mock_well_known.assert_awaited_once_with("http://localhost:8001/mcp")
         mock_fetch_auth.assert_awaited_once_with(
-            ["https://login.microsoftonline.com/test-tenant-id/v2.0"]
+            ["https://login.microsoftonline.com/test-tenant-id/v2.0"],
+            "http://localhost:8001/mcp",
         )
         assert result is mock_metadata
         assert result.scopes == ["api://some-scope/.default"]
@@ -810,7 +812,12 @@ class TestMCPServerManager:
             "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
             return_value=mock_client,
         ):
-            result = await manager._fetch_single_authorization_server_metadata(issuer)
+            # The Azure issuer is cross-origin against the server_url — use
+            # the issuer itself as server_url so the test exercises the
+            # well-known fetch logic without needing real DNS.
+            result = await manager._fetch_single_authorization_server_metadata(
+                issuer, issuer
+            )
 
         assert result is not None
         assert (
@@ -846,7 +853,9 @@ class TestMCPServerManager:
             "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
             return_value=mock_client,
         ):
-            result = await manager._fetch_single_authorization_server_metadata(issuer)
+            result = await manager._fetch_single_authorization_server_metadata(
+                issuer, issuer
+            )
 
         assert result is not None
         assert (
@@ -910,7 +919,7 @@ class TestMCPServerManager:
         ):
             result = await manager._descovery_metadata(server_url)
 
-        mock_fetch_auth.assert_awaited_once_with(["https://example.com"])
+        mock_fetch_auth.assert_awaited_once_with(["https://example.com"], server_url)
         assert result is mock_metadata
         assert result.scopes == ["read"]
 
@@ -2945,6 +2954,161 @@ class TestMCPServerManagerExpandToolPermissions:
             {"uuid-a": ["read_file"], "alias-a": ["write_file"]}
         )
         assert sorted(result["uuid-a"]) == ["read_file", "write_file"]
+
+
+class TestOAuthDiscoverySSRFGuard:
+    """SSRF guard for the OAuth metadata discovery follow-up fetches.
+
+    The vulnerability: a malicious MCP server returns a ``WWW-Authenticate``
+    header pointing at an attacker-chosen ``resource_metadata`` URL, then a
+    PRM JSON whose ``authorization_servers[0]`` points at internal/loopback
+    addresses, coercing the proxy into making blind GETs to cloud-metadata
+    services, internal admin panels, or loopback debug endpoints.
+    """
+
+    @staticmethod
+    def _patch_resolves(monkeypatch, mapping):
+        """Patch ``socket.getaddrinfo`` for a deterministic SSRF-guard test.
+
+        ``mapping`` is ``{hostname: [ip-string, ...]}``; unknown hosts raise
+        ``gaierror`` (treated as "unresolvable" -> blocked).
+        """
+        import socket as _socket
+
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            if host not in mapping:
+                raise _socket.gaierror(f"unknown host {host}")
+            family = _socket.AF_INET
+            return [
+                (family, _socket.SOCK_STREAM, 0, "", (ip, port)) for ip in mapping[host]
+            ]
+
+        monkeypatch.setattr(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.socket.getaddrinfo",
+            fake_getaddrinfo,
+        )
+
+    def test_same_authority_url_is_safe(self):
+        # Same scheme + host + port skips DNS entirely — the well-known
+        # endpoint construction in _attempt_well_known_discovery always
+        # produces same-authority URLs against the admin's server_url.
+        assert MCPServerManager._is_safe_metadata_url(
+            "https://example.com/.well-known/oauth-protected-resource",
+            "https://example.com/mcp",
+        )
+
+    def test_same_host_different_port_blocked_when_resolves_to_private_ip(
+        self, monkeypatch
+    ):
+        # Cross-authority (different port). Falls through to DNS check.
+        # If the resolved IP is private, the guard rejects.
+        self._patch_resolves(monkeypatch, {"example.com": ["10.1.2.3"]})
+        assert not MCPServerManager._is_safe_metadata_url(
+            "https://example.com:9999/.well-known/oauth-protected-resource",
+            "https://example.com/mcp",
+        )
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.5",  # RFC1918
+            "172.16.0.1",  # RFC1918
+            "192.168.1.1",  # RFC1918
+            "169.254.169.254",  # AWS / Azure / GCP IMDS
+            "100.100.100.200",  # Alibaba Cloud metadata
+            "0.0.0.0",  # unspecified
+            "::1",  # IPv6 loopback
+            "fe80::1",  # IPv6 link-local
+            "fc00::1",  # IPv6 ULA
+        ],
+    )
+    def test_cross_origin_blocked_when_resolves_to_unsafe_ip(self, monkeypatch, ip):
+        self._patch_resolves(monkeypatch, {"attacker.example.com": [ip]})
+        assert not MCPServerManager._is_safe_metadata_url(
+            f"https://attacker.example.com/.well-known/oauth-authorization-server",
+            "https://legit-mcp.example.com/mcp",
+        )
+
+    def test_cross_origin_allowed_when_resolves_to_public_ip(self, monkeypatch):
+        self._patch_resolves(
+            monkeypatch, {"login.microsoftonline.com": ["20.190.151.7"]}
+        )
+        assert MCPServerManager._is_safe_metadata_url(
+            "https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration",
+            "https://atlassian-mcp.example.com/mcp",
+        )
+
+    def test_cross_origin_blocked_when_unresolvable(self, monkeypatch):
+        self._patch_resolves(monkeypatch, {})
+        assert not MCPServerManager._is_safe_metadata_url(
+            "https://nope.example.invalid/.well-known/oauth-authorization-server",
+            "https://legit-mcp.example.com/mcp",
+        )
+
+    def test_non_http_scheme_is_not_safe(self):
+        assert not MCPServerManager._is_safe_metadata_url(
+            "file:///etc/passwd", "https://example.com/mcp"
+        )
+        assert not MCPServerManager._is_safe_metadata_url(
+            "gopher://example.com/", "https://example.com/mcp"
+        )
+
+    def test_dual_resolution_blocked_if_any_ip_unsafe(self, monkeypatch):
+        # If the attacker controls a DNS record returning multiple A records,
+        # one of which is private, the guard must reject — pinning to the
+        # safe IP would be a TOCTOU window.
+        self._patch_resolves(
+            monkeypatch, {"dual-stack.example.com": ["8.8.8.8", "127.0.0.1"]}
+        )
+        assert not MCPServerManager._is_safe_metadata_url(
+            "https://dual-stack.example.com/.well-known/oauth-authorization-server",
+            "https://legit-mcp.example.com/mcp",
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetch_oauth_metadata_refuses_unsafe_url(self, monkeypatch):
+        # End-to-end: a malicious WWW-Authenticate redirecting to a loopback
+        # resource_metadata URL must not produce a network call.
+        self._patch_resolves(monkeypatch, {"attacker.example.com": ["127.0.0.1"]})
+        manager = MCPServerManager()
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            servers, scopes = await manager._fetch_oauth_metadata_from_resource(
+                "https://attacker.example.com/meta",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert servers == []
+        assert scopes is None
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_authorization_server_refuses_unsafe_issuer(self, monkeypatch):
+        # Mirrors the GHSA-mrfv repro: PRM lists a loopback issuer URL.
+        self._patch_resolves(monkeypatch, {"attacker.example.com": ["127.0.0.1"]})
+        manager = MCPServerManager()
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            result = await manager._fetch_single_authorization_server_metadata(
+                "http://attacker.example.com:19999",
+                "https://legit-mcp.example.com/mcp",
+            )
+
+        assert result is None
+        mock_client.get.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -786,7 +786,7 @@ class TestMCPServerManager:
         manager = MCPServerManager()
         issuer = "https://login.microsoftonline.com/test-tenant-id/v2.0"
 
-        def build_response(url: str):
+        def build_response(url: str, **kwargs):
             mock_response = MagicMock()
             if url == f"{issuer}/.well-known/openid-configuration":
                 mock_response.json.return_value = {
@@ -3088,6 +3088,81 @@ class TestOAuthDiscoverySSRFGuard:
         assert servers == []
         assert scopes is None
         mock_client.get.assert_not_called()
+
+    def test_empty_getaddrinfo_result_blocks_url(self, monkeypatch):
+        # POSIX doesn't strictly forbid an empty success-list from getaddrinfo.
+        # The guard must fail closed rather than fall through to ``return True``.
+        monkeypatch.setattr(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.socket.getaddrinfo",
+            lambda *a, **k: [],
+        )
+        assert not MCPServerManager._is_safe_metadata_url(
+            "https://no-records.example.com/.well-known/oauth-authorization-server",
+            "https://legit-mcp.example.com/mcp",
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetch_oauth_metadata_does_not_follow_redirects(self):
+        # If the validated origin redirects to a loopback or other unsafe
+        # address, httpx must NOT follow — the new ``Location`` would not
+        # be re-checked against ``server_url``.
+        manager = MCPServerManager()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "authorization_servers": ["https://auth.example.com"],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def fake_get(url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_response
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=fake_get)
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            await manager._fetch_oauth_metadata_from_resource(
+                "https://protected.example.com/.well-known/oauth",
+                "https://protected.example.com/mcp",
+            )
+        assert captured_kwargs.get("follow_redirects") is False
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_auth_server_does_not_follow_redirects(self):
+        # Same redirect-bypass concern for the authorization-server fetch path.
+        manager = MCPServerManager()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "authorization_endpoint": "https://provider.example.com/authorize",
+            "token_endpoint": "https://provider.example.com/token",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def fake_get(url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_response
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=fake_get)
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+            return_value=mock_client,
+        ):
+            await manager._fetch_single_authorization_server_metadata(
+                "https://provider.example.com",
+                "https://provider.example.com",
+            )
+        assert captured_kwargs.get("follow_redirects") is False
 
     @pytest.mark.asyncio
     async def test_fetch_authorization_server_refuses_unsafe_issuer(self, monkeypatch):


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The OAuth discovery code in `MCPServerManager` followed two attacker-influenceable URLs:

1. The `resource_metadata` URL parsed out of a `WWW-Authenticate` challenge returned by the MCP server.
2. The `authorization_servers[0]` field of the protected-resource-metadata JSON returned by the resource server.

A malicious MCP server could point either URL at a cloud-instance-metadata service, an internal admin panel, or a loopback debug endpoint, and the proxy would issue blind GETs during config-load / add-server OAuth discovery.

This PR keeps same-authority metadata fetches direct with `follow_redirects=False`. That preserves well-known discovery and administrator-configured internal MCP servers where the metadata URL shares scheme, host, and port with the configured MCP `server_url`. Redirects stay disabled on that path because a `Location` target would not inherit the same-authority guarantee.

Cross-origin OAuth metadata fetches now go through the existing `async_safe_get()` helper from `litellm_core_utils.url_utils`. That reuses the proxy-wide user URL validation policy instead of adding a second URL safety implementation: `http` / `https` only, DNS validation, blocked private / loopback / link-local / cloud-metadata targets, safe Host handling, and redirect revalidation on every hop.

`SSRFError` is caught at both OAuth metadata fetch sites so denied discovery URLs fail closed and no network call is made for blocked targets.

### Compatibility

No config or workflow changes are expected for normal public OAuth providers. Federated public auth servers such as Azure Entra, Google, Okta, and GitHub remain supported through `async_safe_get()`.

Same-authority internal MCP servers remain supported. Cross-origin internal / loopback / metadata OAuth discovery URLs are blocked by the existing safe URL policy unless an administrator has explicitly opted into the existing URL validation controls.

### Tests

`TestOAuthDiscoverySSRFGuard` covers:

- Same-authority metadata URLs are direct-fetch eligible.
- Same-authority fetches do not follow redirects.
- Cross-origin private, loopback, link-local, cloud-metadata, and IPv6 local targets are rejected before any network call.
- Cross-origin public federated auth metadata is allowed through `async_safe_get()`.
- Unresolvable hosts, empty DNS results, non-`http` / `https` schemes, and mixed safe/unsafe DNS results fail closed.
- Cross-origin redirects are revalidated, including a redirect from a public host to loopback.

Validation run locally:

- `uv run black litellm/proxy/_experimental/mcp_server/mcp_server_manager.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py`
- `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py -q` (`119 passed`)
- `uv run ruff check litellm/proxy/_experimental/mcp_server/mcp_server_manager.py`
- `uv run ruff check tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py --ignore T201` (`T201` is from a pre-existing `print()` elsewhere in the test file)

