### PR TITLE
[Fix] CI/Tooling: Correct min-release-age value in .npmrc files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/litellm-js/proxy/.npmrc
+++ b/litellm-js/proxy/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/litellm-js/spend-logs/.npmrc
+++ b/litellm-js/spend-logs/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/tests/proxy_admin_ui_tests/.npmrc
+++ b/tests/proxy_admin_ui_tests/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc
+++ b/tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/ui/litellm-dashboard/.npmrc
+++ b/ui/litellm-dashboard/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3


### PR DESCRIPTION
## Summary

The `min-release-age` value `3d` in our six `.npmrc` files crashes every local `npm install` on current npm (11.x).

## Crash signature

```
npm warn invalid config before=null set in /…/.npmrc
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at RegistryFetcher.<computed> (…/pacote/lib/fetcher.js:110:…)
```

## Root cause

npm's config type for `min-release-age` is `[null, Number]`. The string `"3d"` parses to `NaN`, so npm sets `before = new Date(NaN)` (an Invalid Date). Pacote later calls `.toISOString()` on `before` and throws.

## Fix

Drop the `d` suffix — npm wants a plain Number; the `<days>` in npm's type hint is just a label. Verified locally on npm 11.12.1: with `min-release-age=3`, `npm config get before` returns a valid Date ~3 days back, and `npm install --dry-run` no longer errors.

Six files updated, all on line 5:

- `.npmrc`
- `litellm-js/proxy/.npmrc`
- `litellm-js/spend-logs/.npmrc`
- `tests/proxy_admin_ui_tests/.npmrc`
- `tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc`
- `ui/litellm-dashboard/.npmrc`

## Impact

No-op for CI — `npm ci` ignores this setting (per the comment already in each file). The fix only affects local `npm install`, which is currently broken.