### PR TITLE
chore(proxy): block env callback refs in key metadata

### DIFF
--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -23,6 +23,13 @@ def _raise_env_reference_error(param: str, *, source: str) -> None:
     )
 
 
+def validate_no_callback_env_reference(
+    param: str, value: object, *, source: str
+) -> None:
+    if _is_env_reference(value):
+        _raise_env_reference_error(param, source=source)
+
+
 # Hardcoded list of supported callback params to avoid runtime inspection issues with TypedDict
 _supported_callback_params = [
     "langfuse_public_key",
@@ -66,8 +73,9 @@ def initialize_standard_callback_dynamic_params(
         for param in _supported_callback_params:
             if param in kwargs:
                 _param_value = kwargs.get(param)
-                if _is_env_reference(_param_value):
-                    _raise_env_reference_error(param, source="request body")
+                validate_no_callback_env_reference(
+                    param, _param_value, source="request body"
+                )
                 standard_callback_dynamic_params[param] = _param_value  # type: ignore
 
         # 2. Fallback: check "metadata" or "litellm_params" -> "metadata"
@@ -80,8 +88,9 @@ def initialize_standard_callback_dynamic_params(
             for param in _supported_callback_params:
                 if param not in standard_callback_dynamic_params and param in metadata:
                     _param_value = metadata.get(param)
-                    if _is_env_reference(_param_value):
-                        _raise_env_reference_error(param, source="metadata")
+                    validate_no_callback_env_reference(
+                        param, _param_value, source="metadata"
+                    )
                     standard_callback_dynamic_params[param] = _param_value  # type: ignore
 
     return standard_callback_dynamic_params

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1871,11 +1871,9 @@ class AddTeamCallback(LiteLLMPydanticObjectBase):
                 raise ValueError(
                     f"Invalid callback variable: {key}. Must be one of {valid_keys}"
                 )
-            if not isinstance(value, str):
-                callback_vars[key] = str(value)
-                value = callback_vars[key]
+            callback_vars[key] = str(value)
             validate_no_callback_env_reference(
-                key, value, source="key/team callback metadata"
+                key, callback_vars[key], source="key/team callback metadata"
             )
         return values
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -17,6 +17,9 @@ from typing_extensions import Required, TypedDict
 
 from litellm._uuid import uuid
 from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
+from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+    validate_no_callback_env_reference,
+)
 from litellm.types.integrations.slack_alerting import AlertType
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -1870,6 +1873,10 @@ class AddTeamCallback(LiteLLMPydanticObjectBase):
                 )
             if not isinstance(value, str):
                 callback_vars[key] = str(value)
+                value = callback_vars[key]
+            validate_no_callback_env_reference(
+                key, value, source="key/team callback metadata"
+            )
         return values
 
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -228,9 +228,7 @@ def convert_key_logging_metadata_to_callback(
     for var, value in data.callback_vars.items():
         if team_callback_settings_obj.callback_vars is None:
             team_callback_settings_obj.callback_vars = {}
-        team_callback_settings_obj.callback_vars[var] = str(
-            litellm.utils.get_secret(value, default_value=value) or value
-        )
+        team_callback_settings_obj.callback_vars[var] = str(value)
 
     return team_callback_settings_obj
 
@@ -904,6 +902,14 @@ class LiteLLMProxyRequestSetup:
         callback_vars_dict.pop("team_id", None)
         callback_vars_dict.pop("success_callback", None)
         callback_vars_dict.pop("failure_callback", None)
+        callback_vars_dict = {
+            key: (
+                litellm.utils.get_secret(value, default_value=value) or value
+                if isinstance(value, str)
+                else value
+            )
+            for key, value in callback_vars_dict.items()
+        }
 
         return TeamCallbackMetadata(
             success_callback=team_config.get("success_callback", None),

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from fastapi import Request
+from pydantic import ValidationError as PydanticValidationError
 from starlette.datastructures import Headers
 
 import litellm
@@ -238,7 +239,7 @@ def _get_validated_callback_metadata(
 ) -> Optional[AddTeamCallback]:
     try:
         return AddTeamCallback(**item)
-    except ValueError as e:
+    except (PydanticValidationError, ValueError) as e:
         verbose_proxy_logger.warning(
             "Ignoring invalid %s callback metadata: %s",
             source,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -233,6 +233,20 @@ def convert_key_logging_metadata_to_callback(
     return team_callback_settings_obj
 
 
+def _get_validated_callback_metadata(
+    item: dict, *, source: str
+) -> Optional[AddTeamCallback]:
+    try:
+        return AddTeamCallback(**item)
+    except ValueError as e:
+        verbose_proxy_logger.warning(
+            "Ignoring invalid %s callback metadata: %s",
+            source,
+            _sanitize_for_log(str(e)),
+        )
+        return None
+
+
 class KeyAndTeamLoggingSettings:
     """
     Helper class to get the dynamic logging settings for the key and team
@@ -272,8 +286,11 @@ def _get_dynamic_logging_metadata(
     #########################################################################################
     if key_dynamic_logging_settings is not None:
         for item in key_dynamic_logging_settings:
+            callback = _get_validated_callback_metadata(item=item, source="key-level")
+            if callback is None:
+                continue
             callback_settings_obj = convert_key_logging_metadata_to_callback(
-                data=AddTeamCallback(**item),
+                data=callback,
                 team_callback_settings_obj=callback_settings_obj,
             )
     #########################################################################################
@@ -281,8 +298,11 @@ def _get_dynamic_logging_metadata(
     #########################################################################################
     elif team_dynamic_logging_settings is not None:
         for item in team_dynamic_logging_settings:
+            callback = _get_validated_callback_metadata(item=item, source="team-level")
+            if callback is None:
+                continue
             callback_settings_obj = convert_key_logging_metadata_to_callback(
-                data=AddTeamCallback(**item),
+                data=callback,
                 team_callback_settings_obj=callback_settings_obj,
             )
     #########################################################################################

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -235,18 +235,10 @@ async def test_add_key_or_team_level_spend_logs_metadata_to_request(
             "langfuse_host": "https://us.cloud.langfuse.com",
             "langfuse_public_key": "pk-lf-9636b7a6-c066",
             "langfuse_secret_key": "sk-lf-7cc8b620",
-        },
-        {
-            "langfuse_host": "os.environ/LANGFUSE_HOST_TEMP",
-            "langfuse_public_key": "os.environ/LANGFUSE_PUBLIC_KEY_TEMP",
-            "langfuse_secret_key": "os.environ/LANGFUSE_SECRET_KEY_TEMP",
-        },
+        }
     ],
 )
 def test_dynamic_logging_metadata_key_and_team_metadata(callback_vars):
-    os.environ["LANGFUSE_PUBLIC_KEY_TEMP"] = "pk-lf-9636b7a6-c066"
-    os.environ["LANGFUSE_SECRET_KEY_TEMP"] = "sk-lf-7cc8b620"
-    os.environ["LANGFUSE_HOST_TEMP"] = "https://us.cloud.langfuse.com"
     from litellm.proxy.proxy_server import ProxyConfig
 
     proxy_config = ProxyConfig()
@@ -315,6 +307,38 @@ def test_dynamic_logging_metadata_key_and_team_metadata(callback_vars):
 
     for var in callbacks.callback_vars.values():
         assert "os.environ" not in var
+
+
+def test_dynamic_logging_metadata_rejects_env_references_from_key_metadata(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY_TEMP", "server-side-secret")
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        metadata={
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_type": "success",
+                    "callback_vars": {
+                        "langfuse_secret_key": "os.environ/LANGFUSE_SECRET_KEY_TEMP",
+                    },
+                }
+            ]
+        },
+        team_metadata={},
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _get_dynamic_logging_metadata(
+            user_api_key_dict=user_api_key_dict, proxy_config=proxy_config
+        )
+
+    assert "os.environ/" in str(exc_info.value)
+    assert "server-side-secret" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -1263,10 +1287,15 @@ def test_proxy_config_state_post_init_callback_call(monkeypatch):
         }
     )
 
-    LiteLLMProxyRequestSetup.add_team_based_callbacks_from_config(
+    callback_metadata = LiteLLMProxyRequestSetup.add_team_based_callbacks_from_config(
         team_id="test",
         proxy_config=pc,
     )
+
+    assert callback_metadata is not None
+    assert callback_metadata.callback_vars is not None
+    assert callback_metadata.callback_vars["langfuse_public_key"] == "test_public_key"
+    assert callback_metadata.callback_vars["langfuse_secret"] == "test_secret_key"
 
     config = pc.get_config_state()
     assert config["litellm_settings"]["default_team_settings"][0]["team_id"] == "test"

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -309,10 +309,15 @@ def test_dynamic_logging_metadata_key_and_team_metadata(callback_vars):
         assert "os.environ" not in var
 
 
-def test_dynamic_logging_metadata_rejects_env_references_from_key_metadata(
+def test_dynamic_logging_metadata_ignores_env_references_from_key_metadata(
     monkeypatch,
 ):
     monkeypatch.setenv("LANGFUSE_SECRET_KEY_TEMP", "server-side-secret")
+    monkeypatch.setattr(
+        litellm.utils,
+        "get_secret",
+        lambda *args, **kwargs: pytest.fail("get_secret should not be called"),
+    )
     from litellm.proxy.proxy_server import ProxyConfig
 
     proxy_config = ProxyConfig()
@@ -332,13 +337,11 @@ def test_dynamic_logging_metadata_rejects_env_references_from_key_metadata(
         team_metadata={},
     )
 
-    with pytest.raises(ValueError) as exc_info:
-        _get_dynamic_logging_metadata(
-            user_api_key_dict=user_api_key_dict, proxy_config=proxy_config
-        )
+    callbacks = _get_dynamic_logging_metadata(
+        user_api_key_dict=user_api_key_dict, proxy_config=proxy_config
+    )
 
-    assert "os.environ/" in str(exc_info.value)
-    assert "server-side-secret" not in str(exc_info.value)
+    assert callbacks is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -10,7 +10,7 @@ from fastapi import Request
 from starlette.datastructures import Headers
 
 import litellm
-from litellm.proxy._types import TeamCallbackMetadata, UserAPIKeyAuth
+from litellm.proxy._types import AddTeamCallback, TeamCallbackMetadata, UserAPIKeyAuth
 from litellm.proxy.litellm_pre_call_utils import (
     KeyAndTeamLoggingSettings,
     LiteLLMProxyRequestSetup,
@@ -1274,10 +1274,28 @@ def test_get_dynamic_logging_metadata_with_arize_team_logging():
     assert result.callback_vars["arize_space_id"] == "test_arize_space_id"
 
 
-def test_get_dynamic_logging_metadata_rejects_env_reference_from_key_metadata(
+def test_add_team_callback_rejects_env_reference():
+    with pytest.raises(ValueError) as exc_info:
+        AddTeamCallback(
+            callback_name="langfuse",
+            callback_type="success",
+            callback_vars={
+                "langfuse_secret_key": "os.environ/LANGFUSE_SECRET_KEY_TEMP"
+            },
+        )
+
+    assert "os.environ/" in str(exc_info.value)
+
+
+def test_get_dynamic_logging_metadata_ignores_env_reference_from_key_metadata(
     monkeypatch,
 ):
     monkeypatch.setenv("LANGFUSE_SECRET_KEY_TEMP", "server-side-secret")
+    monkeypatch.setattr(
+        litellm.utils,
+        "get_secret",
+        lambda *args, **kwargs: pytest.fail("get_secret should not be called"),
+    )
     user_api_key_dict = UserAPIKeyAuth(
         api_key="test-key",
         metadata={
@@ -1294,13 +1312,11 @@ def test_get_dynamic_logging_metadata_rejects_env_reference_from_key_metadata(
         team_metadata={},
     )
 
-    with pytest.raises(ValueError) as exc_info:
-        _get_dynamic_logging_metadata(
-            user_api_key_dict=user_api_key_dict, proxy_config=MagicMock()
-        )
+    result = _get_dynamic_logging_metadata(
+        user_api_key_dict=user_api_key_dict, proxy_config=MagicMock()
+    )
 
-    assert "os.environ/" in str(exc_info.value)
-    assert "server-side-secret" not in str(exc_info.value)
+    assert result is None
 
 
 def test_get_num_retries_from_request():

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1274,6 +1274,35 @@ def test_get_dynamic_logging_metadata_with_arize_team_logging():
     assert result.callback_vars["arize_space_id"] == "test_arize_space_id"
 
 
+def test_get_dynamic_logging_metadata_rejects_env_reference_from_key_metadata(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY_TEMP", "server-side-secret")
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        metadata={
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_type": "success",
+                    "callback_vars": {
+                        "langfuse_secret_key": "os.environ/LANGFUSE_SECRET_KEY_TEMP",
+                    },
+                }
+            ]
+        },
+        team_metadata={},
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _get_dynamic_logging_metadata(
+            user_api_key_dict=user_api_key_dict, proxy_config=MagicMock()
+        )
+
+    assert "os.environ/" in str(exc_info.value)
+    assert "server-side-secret" not in str(exc_info.value)
+
+
 def test_get_num_retries_from_request():
     """
     Test LiteLLMProxyRequestSetup._get_num_retries_from_request method
@@ -3326,7 +3355,9 @@ async def test_team_guardrail_merges_with_global_policy():
     policy_registry = get_policy_registry()
     policy_registry._policies = {
         "global-policy": Policy(
-            guardrails=PolicyGuardrails(add=["policy-guardrail-1", "policy-guardrail-2"]),
+            guardrails=PolicyGuardrails(
+                add=["policy-guardrail-1", "policy-guardrail-2"]
+            ),
         ),
     }
     policy_registry._initialized = True
@@ -3347,14 +3378,18 @@ async def test_team_guardrail_merges_with_global_policy():
 
         guardrails = data["metadata"].get("guardrails", [])
 
-        assert "team-direct-guardrail" in guardrails, \
-            f"Team guardrail missing from merged list: {guardrails}"
-        assert "policy-guardrail-1" in guardrails, \
-            f"policy-guardrail-1 missing: {guardrails}"
-        assert "policy-guardrail-2" in guardrails, \
-            f"policy-guardrail-2 missing: {guardrails}"
-        assert len(guardrails) == len(set(guardrails)), \
-            f"Duplicates in guardrails list: {guardrails}"
+        assert (
+            "team-direct-guardrail" in guardrails
+        ), f"Team guardrail missing from merged list: {guardrails}"
+        assert (
+            "policy-guardrail-1" in guardrails
+        ), f"policy-guardrail-1 missing: {guardrails}"
+        assert (
+            "policy-guardrail-2" in guardrails
+        ), f"policy-guardrail-2 missing: {guardrails}"
+        assert len(guardrails) == len(
+            set(guardrails)
+        ), f"Duplicates in guardrails list: {guardrails}"
 
         # Verify get_guardrail_from_metadata returns the merged list even
         # when litellm_metadata is present (the bug: it returned [] before fix)
@@ -3365,9 +3400,9 @@ async def test_team_guardrail_merges_with_global_policy():
 
         dummy = _DummyGuardrail(guardrail_name="team-direct-guardrail")
         returned = dummy.get_guardrail_from_metadata(data)
-        assert "team-direct-guardrail" in returned, (
-            f"get_guardrail_from_metadata shadowed by litellm_metadata; got: {returned}"
-        )
+        assert (
+            "team-direct-guardrail" in returned
+        ), f"get_guardrail_from_metadata shadowed by litellm_metadata; got: {returned}"
 
     finally:
         policy_registry._policies = {}
@@ -3396,9 +3431,10 @@ async def test_get_guardrail_from_metadata_prefers_metadata_over_litellm_metadat
     }
 
     result = dummy.get_guardrail_from_metadata(data)
-    assert result == ["my-guardrail", "other-guardrail"], (
-        f"Expected guardrails from metadata, got: {result}"
-    )
+    assert result == [
+        "my-guardrail",
+        "other-guardrail",
+    ], f"Expected guardrails from metadata, got: {result}"
 
 
 def test_get_guardrail_from_metadata_reads_litellm_metadata_when_no_metadata():
@@ -3419,6 +3455,6 @@ def test_get_guardrail_from_metadata_reads_litellm_metadata_when_no_metadata():
     }
 
     result = dummy.get_guardrail_from_metadata(data)
-    assert result == ["my-guardrail"], (
-        f"Expected guardrails from litellm_metadata fallback, got: {result}"
-    )
+    assert result == [
+        "my-guardrail"
+    ], f"Expected guardrails from litellm_metadata fallback, got: {result}"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import Request
+from pydantic import ValidationError as PydanticValidationError
 from starlette.datastructures import Headers
 
 import litellm
@@ -1275,7 +1276,7 @@ def test_get_dynamic_logging_metadata_with_arize_team_logging():
 
 
 def test_add_team_callback_rejects_env_reference():
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(PydanticValidationError) as exc_info:
         AddTeamCallback(
             callback_name="langfuse",
             callback_type="success",


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test

## Changes

Key/team callback logging metadata could include values like `os.environ/DATABASE_URL`. During request setup, `convert_key_logging_metadata_to_callback()` resolved those values with `get_secret()` before the request-time callback param guard saw them, so a DB-backed callback setting could turn an arbitrary server environment variable into a dynamic callback credential.

This PR keeps the existing request-body guard and closes the DB-backed bypass.

Four changes:

- Shared the callback env-reference rejection helper so model validation and request initialization use the same error path.
- Reject `os.environ/*` callback vars when constructing `AddTeamCallback` from new key/team logging metadata.
- Stop resolving secrets from key/team metadata in `convert_key_logging_metadata_to_callback()`, while preserving trusted `config.yaml` team callback env resolution in `add_team_based_callbacks_from_config()`.
- Gracefully ignore already-stored invalid key/team callback metadata rows at request setup instead of failing the live request.

**Files**

- Modified: `litellm/litellm_core_utils/initialize_dynamic_callback_params.py`, `litellm/proxy/_types.py`, `litellm/proxy/litellm_pre_call_utils.py`
- Tests: extends `tests/proxy_unit_tests/test_proxy_utils.py` and `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`

**Behaviour notes for operators**

- Server-owned callback secrets can still be configured through trusted proxy config.
- Key/team metadata can still carry literal callback credentials, but it can no longer ask the proxy to dereference arbitrary environment variables.
- Existing DB rows with `os.environ/*` callback vars are ignored for callback setup instead of being resolved or crashing the LLM request.

**Validation**

- `uv run black .`
- `uv run black litellm/proxy/_types.py litellm/proxy/litellm_pre_call_utils.py tests/proxy_unit_tests/test_proxy_utils.py tests/test_litellm/proxy/test_litellm_pre_call_utils.py`
- `uv run pytest tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py -q`
- `uv run pytest tests/proxy_unit_tests/test_proxy_utils.py -k "dynamic_logging_metadata or add_team_based_callbacks_from_config" -q`
- `uv run pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py -k "dynamic_logging_metadata or add_team_callback_rejects_env_reference" -q`

