### PR TITLE
fix models access group leak into /models - issue #25550

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -64,6 +64,44 @@ def _get_models_from_access_groups(
     return all_models
 
 
+def _is_access_group_only_string(
+    model: str,
+    proxy_model_list: List[str],
+    model_access_groups: Dict[str, List[str]],
+) -> bool:
+    """
+    Identify entries in a key/team `models` list that are access-group strings
+    rather than real model identifiers.
+
+    Issue #25550: when a virtual key was created with `models=["foo"]` against
+    an access group "foo" that has since been removed (or that was never
+    defined on any model), "foo" remains in the key but is no longer in
+    `model_access_groups`. The current expansion logic only strips entries
+    that ARE in the access-groups dict, so the stale string passes through
+    /v1/models as if it were a model name.
+
+    A string is treated as access-group-only when none of the markers of a
+    real model identifier are present:
+      - it is in proxy_model_list (a configured proxy model group)
+      - it is in model_access_groups (an active access group; expanded above)
+      - it is in litellm.model_list_set (a known base model id)
+      - it contains "/" (provider-qualified route, e.g. `openai/gpt-4o`)
+      - it contains "*" (wildcard route, expanded by `_get_wildcard_models`)
+      - it starts with "ft:" (OpenAI fine-tune id)
+    """
+    if model in proxy_model_list:
+        return False
+    if model in model_access_groups:
+        return False
+    if model in litellm.model_list_set:
+        return False
+    if "/" in model or "*" in model:
+        return False
+    if model.startswith("ft:"):
+        return False
+    return True
+
+
 async def get_mcp_server_ids(
     user_api_key_dict: UserAPIKeyAuth,
 ) -> List[str]:
@@ -210,6 +248,20 @@ def get_complete_model_list(
         if infer_model_from_keys:
             valid_models = get_valid_models()
             append_unique(valid_models)
+
+    # Drop stale access-group strings carried in key/team `models` (issue #25550).
+    # Only filter the key/team paths — the proxy-admin path above is sourced
+    # from authoritative state (proxy_model_list, model_access_groups keys).
+    if key_models or team_models:
+        unique_models = [
+            m
+            for m in unique_models
+            if not _is_access_group_only_string(
+                model=m,
+                proxy_model_list=proxy_model_list,
+                model_access_groups=model_access_groups,
+            )
+        ]
 
     if only_model_access_groups:
         model_access_groups_to_return: List[str] = []

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -64,30 +64,26 @@ def _get_models_from_access_groups(
     return all_models
 
 
-def _is_access_group_only_string(
+def _is_unresolvable_model_identifier(
     model: str,
     proxy_model_list: List[str],
     model_access_groups: Dict[str, List[str]],
 ) -> bool:
     """
-    Identify entries in a key/team `models` list that are access-group strings
-    rather than real model identifiers.
-
-    Issue #25550: when a virtual key was created with `models=["foo"]` against
-    an access group "foo" that has since been removed (or that was never
-    defined on any model), "foo" remains in the key but is no longer in
-    `model_access_groups`. The current expansion logic only strips entries
-    that ARE in the access-groups dict, so the stale string passes through
-    /v1/models as if it were a model name.
-
-    A string is treated as access-group-only when none of the markers of a
-    real model identifier are present:
-      - it is in proxy_model_list (a configured proxy model group)
+    A string from a key/team `models` list resolves to a real model id when
+    any of these are true:
+      - it is in proxy_model_list (a configured proxy model name, including
+        custom enterprise aliases not present in litellm.model_list_set)
       - it is in model_access_groups (an active access group; expanded above)
       - it is in litellm.model_list_set (a known base model id)
       - it contains "/" (provider-qualified route, e.g. `openai/gpt-4o`)
       - it contains "*" (wildcard route, expanded by `_get_wildcard_models`)
       - it starts with "ft:" (OpenAI fine-tune id)
+
+    Anything else is unresolvable and would otherwise leak into /v1/models as
+    if it were a real model. The most common case (issue #25550) is a stale
+    access-group label whose group was removed; identifiers for proxy models
+    that have since been removed from config are filtered for the same reason.
     """
     if model in proxy_model_list:
         return False
@@ -249,14 +245,16 @@ def get_complete_model_list(
             valid_models = get_valid_models()
             append_unique(valid_models)
 
-    # Drop stale access-group strings carried in key/team `models` (issue #25550).
-    # Only filter the key/team paths — the proxy-admin path above is sourced
-    # from authoritative state (proxy_model_list, model_access_groups keys).
+    # Drop unresolvable identifiers carried in key/team `models` — most
+    # commonly stale access-group labels (issue #25550), but also names of
+    # proxy models that have since been removed from config. Only filter the
+    # key/team paths; the proxy-admin path above is sourced from authoritative
+    # state (proxy_model_list, model_access_groups keys).
     if key_models or team_models:
         unique_models = [
             m
             for m in unique_models
-            if not _is_access_group_only_string(
+            if not _is_unresolvable_model_identifier(
                 model=m,
                 proxy_model_list=proxy_model_list,
                 model_access_groups=model_access_groups,

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -84,6 +84,17 @@ def _is_unresolvable_model_identifier(
     if it were a real model. The most common case (issue #25550) is a stale
     access-group label whose group was removed; identifiers for proxy models
     that have since been removed from config are filtered for the same reason.
+
+    Known narrow gap: a bare, unprefixed model id (no "/") that is genuinely
+    valid but absent from litellm.model_list_set — for example a brand-new
+    provider model id, or a custom Azure deployment name — will be treated
+    as unresolvable. In practice such names are surfaced to a key/team via
+    either (a) the proxy admin registering them in `model_list` (puts them
+    in proxy_model_list), (b) a provider-qualified form (e.g.
+    `azure/<deployment>`), or (c) wildcard routing — all of which short-
+    circuit the filter above. A bare unknown name that bypasses all three
+    would not be routable by the proxy anyway, so dropping it from
+    /v1/models matches what the call would do at request time.
     """
     if model in proxy_model_list:
         return False

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -227,6 +227,155 @@ def test_get_complete_model_list_order(
     )
 
 
+def test_get_complete_model_list_drops_stale_access_group_string():
+    """
+    Regression for issue #25550.
+
+    A virtual key with `models=["team-sales-api"]` where "team-sales-api"
+    is neither a configured proxy model nor an active access group should
+    NOT leak the bare access-group string into /v1/models.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["team-sales-api"],
+        team_models=[],
+        proxy_model_list=["gpt-4o-mini"],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == []
+
+
+def test_get_complete_model_list_drops_stale_access_group_string_team():
+    """Same regression as above but exercised through the team_models path."""
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=["team-sales-api"],
+        proxy_model_list=["gpt-4o-mini"],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == []
+
+
+def test_get_complete_model_list_keeps_active_access_group_expansion():
+    """
+    Active access groups still expand to their member models. The filter
+    must not interfere with the existing expansion path (i.e., key_models
+    must arrive already-expanded from get_key_models).
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_complete_model_list, get_key_models
+
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["group-engineering"],
+        api_key="test-key",
+    )
+    proxy_model_list = ["gpt-4o-mini"]
+    model_access_groups = {"group-engineering": ["gpt-4o-mini"]}
+
+    key_models = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+    )
+
+    result = get_complete_model_list(
+        key_models=key_models,
+        team_models=[],
+        proxy_model_list=proxy_model_list,
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups=model_access_groups,
+    )
+
+    assert result == ["gpt-4o-mini"]
+
+
+def test_get_complete_model_list_keeps_provider_qualified_string():
+    """
+    Provider-qualified identifiers carry a syntactic marker (`/`) and must
+    survive the access-group filter — even if the exact model id is not
+    present in the static litellm.model_list_set.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["bedrock/very-new-model"],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["bedrock/very-new-model"]
+
+
+def test_get_complete_model_list_keeps_known_base_model():
+    """
+    A known LiteLLM base model id (in litellm.model_list_set) must survive
+    the filter even when not configured on the proxy.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["gpt-4o-mini"],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["gpt-4o-mini"]
+
+
+def test_get_complete_model_list_keeps_finetune_id():
+    """OpenAI fine-tune ids (`ft:...`) must survive the filter."""
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    ft_id = "ft:gpt-4o:my-org:custom-suffix:abc123"
+    result = get_complete_model_list(
+        key_models=[ft_id],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == [ft_id]
+
+
+def test_get_complete_model_list_does_not_filter_proxy_admin_path():
+    """
+    The filter must only apply when key_models or team_models is set. When
+    both are empty (proxy-admin / scope=expand path), unique_models is
+    sourced from the authoritative proxy_model_list and should pass through
+    untouched.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["arbitrary-named-model"],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["arbitrary-named-model"]
+
+
 def test_get_complete_model_list_byok_wildcard_expansion():
     """
     Test that wildcard models (e.g., openai/*) are expanded when the router has

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -338,6 +338,28 @@ def test_get_complete_model_list_keeps_known_base_model():
     assert result == ["gpt-4o-mini"]
 
 
+def test_get_complete_model_list_keeps_custom_proxy_alias():
+    """
+    A custom enterprise proxy model name (e.g. 'internal-assistant') that is
+    listed in proxy_model_list but is NOT a known LiteLLM base model id must
+    survive the filter. This locks in the proxy_model_list-membership branch
+    of _is_unresolvable_model_identifier — the most common preservation path
+    in real deployments.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["internal-assistant"],
+        team_models=[],
+        proxy_model_list=["internal-assistant"],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["internal-assistant"]
+
+
 def test_get_complete_model_list_keeps_finetune_id():
     """OpenAI fine-tune ids (`ft:...`) must survive the filter."""
     from litellm.proxy.auth.model_checks import get_complete_model_list


### PR DESCRIPTION
A virtual key created with `models=["foo"]` against an access group "foo" that has since been removed (or that was never defined on any model) keeps "foo" in `key.models`. The current expansion in `_get_models_from_access_groups` only strips entries that ARE in the active `model_access_groups` dict, so the stale string falls through and is returned by `/v1/models` as if it were a model name.

This change adds a narrow filter applied only on the key/team paths in `get_complete_model_list`. An entry is treated as an access-group-only string (and dropped) when none of the markers of a real model identifier are present:

  - configured proxy model (in `proxy_model_list`)
  - active access group (key in `model_access_groups`)
  - known LiteLLM base model id (in `litellm.model_list_set`)
  - provider-qualified or wildcard route (contains `/` or `*`)
  - OpenAI fine-tune id (`ft:` prefix)

The proxy-admin path (no key/team models) is sourced from authoritative state and is not filtered.

## Relevant issues

Fixes Issue BerriAI/litellm#25550

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [X] **I am requesting** a Greptile review by commenting `@greptileai` **will receive** a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix


## Screenshots / Proof of Fix



```bash
# Start LiteLLM (no config file required)
export LITELLM_MASTER_KEY=sk-repro-master-key-25550
export DATABASE_URL=postgresql://...
export OPENAI_API_KEY=sk-fake
# note: nothing in the proxy configuration mentions `team-sales-api` not as a model, not as an access group, not anywhere.

litellm --model gpt-4o-mini --port 4000
```

```bash
# Create a virtual key referencing a name the proxy does not know 
# This can be interpreted as a non-existent "access group"
curl -s -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"models": ["team-sales-api"]}'
```

### BEFORE — released `ghcr.io/berriai/litellm:v1.82.3`

```bash
curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $KEY"
```

```json
{
  "data": [
    {
      "id": "team-sales-api",
      "object": "model",
      "created": 1677610602,
      "owned_by": "openai"
    }
  ],
  "object": "list"
}
```

### AFTER — from-source build off this branch

```bash
curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $KEY"
```

```json
{ "data": [], "object": "list" }
```