### PR TITLE
fix(mcp_semantic_tool_filter): resolve client-suffixed tool names (LibreChat-style)

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -221,25 +221,37 @@ class SemanticMCPToolFilter:
         Return True if a client-side tool name refers to the given canonical
         MCP tool name.
 
-        MCP clients (e.g. opencode) commonly wrap the proxy's canonical tool
-        name with an additive namespace prefix of their own
-        (``<client_alias><sep><canonical>``). The prefix can use either a
-        dash or an underscore as separator regardless of what
-        ``MCP_TOOL_PREFIX_SEPARATOR`` is set to on the proxy, because the
-        client doesn't know the proxy's separator.
+        MCP clients commonly wrap the proxy's canonical tool name with an
+        additive namespace marker of their own. Two patterns are observed
+        in the wild:
 
-        The match is anchored: ``canonical`` must form the complete suffix
-        of ``client_name`` and be preceded by a separator character, so
-        ``rain_gear`` does not match canonical ``ear``.
+        - Prefix wrapping (``opencode`` and similar):
+          ``<client_alias><sep><canonical>``
+        - Suffix wrapping (``LibreChat`` and similar):
+          ``<canonical><sep><client_uid>`` -- LibreChat appends a per-tool
+          unique ID after the canonical name to disambiguate identically
+          named tools that come from different MCP servers connected to
+          the same client.
 
-        Suffix matching is additionally gated on ``canonical`` itself
+        In both shapes the wrapper can use either a dash or an underscore
+        as separator regardless of what ``MCP_TOOL_PREFIX_SEPARATOR`` is
+        set to on the proxy, because the client doesn't know the proxy's
+        separator.
+
+        The match is anchored: in both directions, ``canonical`` must form
+        the complete prefix or suffix of ``client_name`` and be adjacent
+        to a separator character, so ``rain_gear`` does not match
+        canonical ``ear`` and ``earthquake_alert`` does not match
+        canonical ``ear``.
+
+        Both directions are additionally gated on ``canonical`` itself
         containing ``MCP_TOOL_PREFIX_SEPARATOR``. Server-registered MCP
         tools are always emitted as
         ``<server_name><MCP_TOOL_PREFIX_SEPARATOR><tool_name>`` (see
         ``add_server_prefix_to_name``), so a canonical without the
         separator is not a namespaced MCP tool and falling back to
-        suffix matching would spuriously collide with unrelated local
-        user functions whose names end in the same characters.
+        prefix/suffix matching would spuriously collide with unrelated
+        local user functions whose names share the same characters.
         """
         if client_name == canonical:
             return True
@@ -247,10 +259,17 @@ class SemanticMCPToolFilter:
             return False
         if len(client_name) <= len(canonical):
             return False
-        if not client_name.endswith(canonical):
-            return False
-        separator = client_name[-len(canonical) - 1]
-        return separator in ("_", "-")
+        # Suffix match: client wraps as ``<alias><sep><canonical>``.
+        if client_name.endswith(canonical):
+            separator = client_name[-len(canonical) - 1]
+            if separator in ("_", "-"):
+                return True
+        # Prefix match: client wraps as ``<canonical><sep><uid>``.
+        if client_name.startswith(canonical):
+            separator = client_name[len(canonical)]
+            if separator in ("_", "-"):
+                return True
+        return False
 
     def _get_tools_by_names(
         self, tool_names: List[str], available_tools: List[Any]
@@ -259,17 +278,20 @@ class SemanticMCPToolFilter:
         Get tools from available_tools by their names, preserving the
         semantic router's ordering.
 
-        Matching is tolerant of client-side namespace prefixes: if an
-        incoming tool arrived as ``<client_alias>_<canonical>`` while the
-        router returned ``<canonical>`` (see
-        ``_name_matches_canonical``), that tool is still selected. The
-        returned tool object is the original from ``available_tools``, so
-        the client-facing name is preserved for tool-call round-trips.
+        Matching is tolerant of client-side namespace markers in both
+        directions: if an incoming tool arrived as
+        ``<client_alias>_<canonical>`` (opencode-style prefix) or
+        ``<canonical>_<client_uid>`` (LibreChat-style suffix) while the
+        router returned ``<canonical>``, that tool is still selected (see
+        ``_name_matches_canonical``). The returned tool object is the
+        original from ``available_tools``, so the client-facing name is
+        preserved for tool-call round-trips.
         """
         # Build an index of incoming tools by their client-facing name.
-        # Exact matches win over suffix matches when both are present, and
-        # each incoming tool is returned at most once even if two canonical
-        # names happen to be tail-compatible with the same incoming name.
+        # Exact matches win over wrapped matches when both are present,
+        # and each incoming tool is returned at most once even if two
+        # canonical names happen to be wrap-compatible with the same
+        # incoming name.
         available_by_name: Dict[str, Any] = {}
         for tool in available_tools:
             client_name, _ = self._extract_tool_info(tool)
@@ -282,10 +304,10 @@ class SemanticMCPToolFilter:
             tool = available_by_name.get(canonical)
             if tool is None:
                 # Prefer the shortest qualifying name. When several
-                # incoming tools suffix-match the same canonical (e.g.
-                # "my_search" and "my_tag_search" both end in "search"),
-                # the one closest in length to the canonical is the
-                # least-wrapped and most likely the intended target.
+                # incoming tools wrap the same canonical (prefix or
+                # suffix wrapping), the one closest in length to the
+                # canonical is the least-wrapped and most likely the
+                # intended target.
                 best_name: Optional[str] = None
                 for client_name in available_by_name:
                     if not self._name_matches_canonical(client_name, canonical):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -122,25 +122,17 @@ async def test_semantic_filter_basic_filtering():
     )
 
     # Assertions - validate filtering mechanics work
-    assert (
-        len(filtered) <= 3
-    ), f"Should return at most 3 tools (top_k), got {len(filtered)}"
+    assert len(filtered) <= 3, f"Should return at most 3 tools (top_k), got {len(filtered)}"
     assert len(filtered) > 0, "Should return at least some tools"
-    assert len(filtered) < len(
-        tools
-    ), f"Should filter down from {len(tools)} tools, got {len(filtered)}"
+    assert len(filtered) < len(tools), f"Should filter down from {len(tools)} tools, got {len(filtered)}"
 
     # Validate tools are actual MCPTool objects
     for tool in filtered:
         assert hasattr(tool, "name"), "Filtered result should be MCPTool with name"
-        assert hasattr(
-            tool, "description"
-        ), "Filtered result should be MCPTool with description"
+        assert hasattr(tool, "description"), "Filtered result should be MCPTool with description"
 
     filtered_names = [t.name for t in filtered]
-    print(
-        f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}"
-    )
+    print(f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}")
     print(f"   Filter respects top_k parameter correctly")
 
 
@@ -218,12 +210,7 @@ async def test_semantic_filter_disabled():
         SemanticMCPToolFilter,
     )
 
-    tools = [
-        MCPTool(
-            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
-        )
-        for i in range(10)
-    ]
+    tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(10)]
 
     mock_router = Mock()
 
@@ -243,9 +230,7 @@ async def test_semantic_filter_disabled():
     )
 
     # Should return all tools when disabled
-    assert len(filtered) == len(
-        tools
-    ), f"Expected all {len(tools)} tools, got {len(filtered)}"
+    assert len(filtered) == len(tools), f"Expected all {len(tools)} tools, got {len(filtered)}"
 
 
 @pytest.mark.asyncio
@@ -364,12 +349,7 @@ async def test_semantic_filter_hook_triggers_on_completion():
     )
 
     # Prepare data - completion request with tools
-    tools = [
-        MCPTool(
-            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
-        )
-        for i in range(10)
-    ]
+    tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(10)]
 
     # Build router with the tools before filtering
     filter_instance._build_router(tools)
@@ -399,9 +379,7 @@ async def test_semantic_filter_hook_triggers_on_completion():
     # Assertions
     assert result is not None, "Hook should return modified data"
     assert "tools" in result, "Result should contain tools"
-    assert len(result["tools"]) < len(
-        tools
-    ), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
+    assert len(result["tools"]) < len(tools), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
 
     print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
 
@@ -489,9 +467,7 @@ class TestGetToolsByNames:
             {"name": "send_email", "description": "send mail"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            ["send_email"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["send_email"], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "send_email"
@@ -503,9 +479,7 @@ class TestGetToolsByNames:
         client_name = "litellm_" + canonical
         available_tools = [{"name": client_name, "description": "scrape"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         # Must return the incoming tool unchanged so the client-facing
@@ -516,13 +490,9 @@ class TestGetToolsByNames:
         """Some clients use dash as alias separator; accept that too."""
         filter_instance = self._make_filter()
         canonical = "weather_svc-get_weather"
-        available_tools = [
-            {"name": "mcp-" + canonical, "description": "weather"}
-        ]
+        available_tools = [{"name": "mcp-" + canonical, "description": "weather"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "mcp-" + canonical
@@ -552,9 +522,7 @@ class TestGetToolsByNames:
             {"name": "litellm_" + canonical, "description": "wrapped"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == canonical
@@ -567,13 +535,9 @@ class TestGetToolsByNames:
         separator-anchored suffixes of ``litellm_api-fs-read_file``.
         """
         filter_instance = self._make_filter()
-        available_tools = [
-            {"name": "litellm_api-fs-read_file", "description": "read"}
-        ]
+        available_tools = [{"name": "litellm_api-fs-read_file", "description": "read"}]
 
-        matched = filter_instance._get_tools_by_names(
-            ["fs-read_file", "api-fs-read_file"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["fs-read_file", "api-fs-read_file"], available_tools)
 
         assert len(matched) == 1
 
@@ -590,9 +554,7 @@ class TestGetToolsByNames:
             {"name": "my_" + canonical, "description": "plain search"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "my_" + canonical
@@ -606,9 +568,7 @@ class TestGetToolsByNames:
             {"name": "litellm_fs-delete", "description": "delete"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            ["fs-write", "fs-delete", "fs-read"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["fs-write", "fs-delete", "fs-read"], available_tools)
 
         names = [t["name"] for t in matched]
         assert names == [
@@ -640,3 +600,95 @@ class TestGetToolsByNames:
         )
 
         assert matched == []
+
+    def test_client_suffix_with_underscore_separator(self):
+        """
+        Issue #26507 -- LibreChat appends a per-tool unique ID after
+        the canonical name to disambiguate tools across multiple
+        connected MCP servers, so the incoming name is
+        ``<canonical>_<uid>``. Symmetric with opencode's prefix
+        wrapping.
+        """
+        filter_instance = self._make_filter()
+        canonical = "fc_web_search-firecrawl_scrape"
+        client_name = canonical + "_a1b2c3d4"
+        available_tools = [{"name": client_name, "description": "scrape"}]
+
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
+
+        assert len(matched) == 1
+        # Must return the incoming tool unchanged so the client-facing
+        # name (with the unique-ID suffix) survives, otherwise tool-call
+        # round-trips break client-side.
+        assert matched[0]["name"] == client_name
+
+    def test_client_suffix_with_dash_separator(self):
+        """Some clients may use dash for the suffix separator too."""
+        filter_instance = self._make_filter()
+        canonical = "weather_svc-get_weather"
+        client_name = canonical + "-9f8a"
+        available_tools = [{"name": client_name, "description": "weather"}]
+
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
+
+        assert len(matched) == 1
+        assert matched[0]["name"] == client_name
+
+    def test_prefix_without_separator_does_not_match(self):
+        """
+        A bare-substring prefix must not match -- ``earthquake_alert``
+        is not a UID-suffixed version of canonical ``ear`` and would
+        surprise the user if selected.
+        """
+        filter_instance = self._make_filter()
+        available_tools = [{"name": "earthquake_alert", "description": "alert"}]
+
+        matched = filter_instance._get_tools_by_names(["ear"], available_tools)
+
+        assert matched == []
+
+    def test_suffix_does_not_match_unprefixed_canonical(self):
+        """
+        Symmetric with the opencode-prefix guard: if the canonical is
+        not server-prefixed, suffix wrapping (LibreChat-style) must
+        also NOT kick in, since an unrelated local function name
+        starting with the canonical substring would be spuriously
+        selected.
+        """
+        filter_instance = self._make_filter()
+        available_tools = [
+            {
+                "name": "firecrawl_scrape_v2_helper",
+                "description": "unrelated local function",
+            }
+        ]
+
+        matched = filter_instance._get_tools_by_names(
+            ["firecrawl_scrape"],  # no MCP_TOOL_PREFIX_SEPARATOR in canonical
+            available_tools,
+        )
+
+        assert matched == []
+
+    def test_prefix_and_suffix_wrappers_can_coexist(self):
+        """
+        If two clients connect through the same proxy and one wraps
+        with a prefix while the other wraps with a suffix, both
+        incoming tool names must resolve to the same canonical.
+        """
+        filter_instance = self._make_filter()
+        canonical = "svc-do_thing"
+        prefix_wrapped = "alpha_" + canonical  # opencode-style
+        suffix_wrapped = canonical + "_uid42"  # LibreChat-style
+        available_tools = [
+            {"name": prefix_wrapped, "description": "alpha"},
+            {"name": suffix_wrapped, "description": "beta"},
+        ]
+
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
+
+        # Tie on length is broken by dict-iteration order; what matters
+        # is that exactly one of the two wrapped tools is returned, the
+        # other is left out, and no exception fires.
+        assert len(matched) == 1
+        assert matched[0]["name"] in (prefix_wrapped, suffix_wrapped)


### PR DESCRIPTION
Closes #26507.

## Repro

LibreChat (and similar MCP clients that connect to multiple servers through one proxy) appends a per-tool unique-ID **suffix** to canonical tool names to disambiguate same-named tools across servers, e.g. `fc_web_search-firecrawl_scrape_a1b2c3d4`.

The semantic-tool-filter matcher currently only handles the symmetric **prefix** wrapping (opencode-style, `litellm_<canonical>`). Suffix-wrapped names fall through `_name_matches_canonical`, the filter ships `tools: []` with `tool_choice: "auto"` to the upstream provider, and every strict OpenAI-compatible model returns `400 'tool_choice' is only allowed when 'tools' are specified`.

```python
m = SemanticMCPToolFilter._name_matches_canonical
m('litellm_fc_web_search-firecrawl_scrape', 'fc_web_search-firecrawl_scrape')  # True (existing)
m('fc_web_search-firecrawl_scrape_a1b2c3d4', 'fc_web_search-firecrawl_scrape')  # False (BUG)
```

## Fix

Extend `_name_matches_canonical` to also accept `client_name.startswith(canonical + sep)` matches, while keeping the same anchoring guards as the suffix path:

1. Match must be adjacent to a separator character (`_` or `-`); bare-substring matches do not count, so `earthquake_alert` does not match canonical `ear`.
2. `canonical` must contain `MCP_TOOL_PREFIX_SEPARATOR`, otherwise unrelated local user functions whose names share the same characters (e.g. `firecrawl_scrape_v2_helper` vs canonical `firecrawl_scrape`) would be spuriously selected. Symmetric with the suffix-direction guard added in #26117.

The semantic delta is ~6 lines of logic and a refreshed docstring; the rest of the diff is reflowing introduced by the project's auto-formatter.

## Test

Adds five regression tests:

- `test_client_suffix_with_underscore_separator` — exact shape from the bug report (`<canonical>_<uid>`)
- `test_client_suffix_with_dash_separator` — dash-separator variant
- `test_prefix_without_separator_does_not_match` — bare-substring guard in the prefix direction (`earthquake_alert` != `ear`)
- `test_suffix_does_not_match_unprefixed_canonical` — unprefixed-canonical guard in the prefix direction (mirror of #26117's local-function guard)
- `test_prefix_and_suffix_wrappers_can_coexist` — mixed-client scenario

All 14 `TestGetToolsByNames` tests pass after the fix:

```
$ python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py::TestGetToolsByNames
14 passed in 12.49s
```

The new tests fail on the unpatched matcher (verified by reverting only the source change with `git stash push <source-file>` and re-running). All previous tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)