### PR TITLE
Fix OpenAPI MCP extra_headers passthrough

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -51,6 +51,7 @@ from litellm.proxy._experimental.mcp_server.oauth2_token_cache import resolve_mc
 from litellm.proxy._experimental.mcp_server.utils import (
     MCP_TOOL_PREFIX_SEPARATOR,
     add_server_prefix_to_name,
+    build_mcp_runtime_extra_headers,
     compute_short_server_prefix,
     get_server_prefix,
     is_short_mcp_tool_prefix_enabled,
@@ -2522,34 +2523,16 @@ class MCPServerManager:
         server_auth_header: Optional[Union[Dict[str, str], str]],
     ) -> Optional[Dict[str, str]]:
         """Build outbound headers shared by MCP transports and OpenAPI handlers."""
-        extra_headers: Dict[str, str] = {}
-
-        if oauth2_headers:
-            extra_headers.update(oauth2_headers)
-
-        if mcp_server.extra_headers and raw_headers:
-            normalized_raw_headers = {
-                str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
-            }
-            for header in mcp_server.extra_headers:
-                if not isinstance(header, str):
-                    continue
-                if (
-                    mcp_server.has_client_credentials
-                    and header.lower() == "authorization"
-                ):
-                    continue
-                header_value = normalized_raw_headers.get(header.lower())
-                if header_value is None:
-                    continue
-                extra_headers[header] = header_value
-
-        if include_static_headers and mcp_server.static_headers:
-            extra_headers.update(mcp_server.static_headers)
+        extra_headers = build_mcp_runtime_extra_headers(
+            server=mcp_server,
+            oauth2_headers=oauth2_headers,
+            raw_headers=raw_headers,
+            include_static_headers=include_static_headers,
+        )
 
         if hook_extra_headers:
             if "Authorization" in hook_extra_headers:
-                if "Authorization" in extra_headers:
+                if extra_headers and "Authorization" in extra_headers:
                     verbose_logger.warning(
                         "MCPServerManager: hook_extra_headers 'Authorization' will overwrite "
                         "the existing Authorization header from static_headers or oauth2_headers. "
@@ -2568,9 +2551,11 @@ class MCPServerManager:
                         "the hook JWT to be the sole credential.",
                         mcp_server.server_name or mcp_server.name,
                     )
+            if extra_headers is None:
+                extra_headers = {}
             extra_headers.update(hook_extra_headers)
 
-        return extra_headers or None
+        return extra_headers
 
     async def _call_regular_mcp_tool(  # noqa: PLR0915
         self,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2503,12 +2503,31 @@ class MCPServerManager:
         hook_extra_headers: Optional[Dict[str, str]],
     ) -> Optional[Dict[str, str]]:
         """Build per-request headers for OpenAPI-generated MCP tool handlers."""
-        extra_headers = oauth2_headers.copy() if oauth2_headers else None
+        return self._build_runtime_extra_headers(
+            mcp_server=mcp_server,
+            oauth2_headers=oauth2_headers,
+            raw_headers=raw_headers,
+            hook_extra_headers=hook_extra_headers,
+            include_static_headers=False,
+            server_auth_header=None,
+        )
+
+    def _build_runtime_extra_headers(
+        self,
+        mcp_server: MCPServer,
+        oauth2_headers: Optional[Dict[str, str]],
+        raw_headers: Optional[Dict[str, str]],
+        hook_extra_headers: Optional[Dict[str, str]],
+        include_static_headers: bool,
+        server_auth_header: Optional[Union[Dict[str, str], str]],
+    ) -> Optional[Dict[str, str]]:
+        """Build outbound headers shared by MCP transports and OpenAPI handlers."""
+        extra_headers: Dict[str, str] = {}
+
+        if oauth2_headers:
+            extra_headers.update(oauth2_headers)
 
         if mcp_server.extra_headers and raw_headers:
-            if extra_headers is None:
-                extra_headers = {}
-
             normalized_raw_headers = {
                 str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
             }
@@ -2525,19 +2544,33 @@ class MCPServerManager:
                     continue
                 extra_headers[header] = header_value
 
-        if mcp_server.static_headers:
-            if extra_headers is None:
-                extra_headers = {}
+        if include_static_headers and mcp_server.static_headers:
             extra_headers.update(mcp_server.static_headers)
 
         if hook_extra_headers:
-            if extra_headers is None:
-                extra_headers = {}
+            if "Authorization" in hook_extra_headers:
+                if "Authorization" in extra_headers:
+                    verbose_logger.warning(
+                        "MCPServerManager: hook_extra_headers 'Authorization' will overwrite "
+                        "the existing Authorization header from static_headers or oauth2_headers. "
+                        "The hook JWT will take precedence."
+                    )
+                elif server_auth_header is not None:
+                    # server_auth_header is passed separately to _create_mcp_client as
+                    # auth_value.  Both will reach the upstream server — warn so admins
+                    # know two Authorization credentials are being sent.
+                    verbose_logger.warning(
+                        "MCPServerManager: hook_extra_headers injects 'Authorization' while "
+                        "server '%s' already has a configured authentication_token. "
+                        "Both credentials will be sent; the hook header is in extra_headers "
+                        "and the server token is in auth_value — the upstream server decides "
+                        "which one wins.  Consider unsetting authentication_token if you want "
+                        "the hook JWT to be the sole credential.",
+                        mcp_server.server_name or mcp_server.name,
+                    )
             extra_headers.update(hook_extra_headers)
 
-        if extra_headers is not None and len(extra_headers) == 0:
-            return None
-        return extra_headers
+        return extra_headers or None
 
     async def _call_regular_mcp_tool(  # noqa: PLR0915
         self,
@@ -2599,68 +2632,19 @@ class MCPServerManager:
         if server_auth_header is None:
             server_auth_header = mcp_auth_header
 
-        # oauth2 headers
-        extra_headers: Optional[Dict[str, str]] = None
-        if mcp_server.auth_type == MCPAuth.oauth2:
-            if mcp_server.has_client_credentials:
-                # For M2M OAuth servers, Authorization must come from token fetch.
-                extra_headers = None
-            else:
-                extra_headers = oauth2_headers
-
-        if mcp_server.extra_headers and raw_headers:
-            if extra_headers is None:
-                extra_headers = {}
-
-            normalized_raw_headers = {
-                str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
-            }
-            for header in mcp_server.extra_headers:
-                if not isinstance(header, str):
-                    continue
-                if (
-                    mcp_server.has_client_credentials
-                    and header.lower() == "authorization"
-                ):
-                    continue
-                header_value = normalized_raw_headers.get(header.lower())
-                if header_value is None:
-                    continue
-                extra_headers[header] = header_value
-
-        if mcp_server.static_headers:
-            if extra_headers is None:
-                extra_headers = {}
-            extra_headers.update(mcp_server.static_headers)
-
-        if hook_extra_headers:
-            if extra_headers is None:
-                extra_headers = {}
-            if "Authorization" in hook_extra_headers:
-                if "Authorization" in extra_headers:
-                    verbose_logger.warning(
-                        "MCPServerManager: hook_extra_headers 'Authorization' will overwrite "
-                        "the existing Authorization header from static_headers. "
-                        "The hook JWT will take precedence."
-                    )
-                elif server_auth_header is not None:
-                    # server_auth_header is passed separately to _create_mcp_client as
-                    # auth_value.  Both will reach the upstream server — warn so admins
-                    # know two Authorization credentials are being sent.
-                    verbose_logger.warning(
-                        "MCPServerManager: hook_extra_headers injects 'Authorization' while "
-                        "server '%s' already has a configured authentication_token. "
-                        "Both credentials will be sent; the hook header is in extra_headers "
-                        "and the server token is in auth_value — the upstream server decides "
-                        "which one wins.  Consider unsetting authentication_token if you want "
-                        "the hook JWT to be the sole credential.",
-                        mcp_server.server_name or mcp_server.name,
-                    )
-            extra_headers.update(hook_extra_headers)
-
-        # Reset to None if no headers were actually added
-        if extra_headers is not None and len(extra_headers) == 0:
-            extra_headers = None
+        extra_headers = self._build_runtime_extra_headers(
+            mcp_server=mcp_server,
+            oauth2_headers=(
+                oauth2_headers
+                if mcp_server.auth_type == MCPAuth.oauth2
+                and not mcp_server.has_client_credentials
+                else None
+            ),
+            raw_headers=raw_headers,
+            hook_extra_headers=hook_extra_headers,
+            include_static_headers=True,
+            server_auth_header=server_auth_header,
+        )
 
         stdio_env = self._build_stdio_env(mcp_server, raw_headers)
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2264,6 +2264,8 @@ class MCPServerManager:
         server: MCPServer,
         tool_name: str,
         arguments: Dict[str, Any],
+        mcp_auth_header: Optional[str] = None,
+        request_extra_headers: Optional[Dict[str, str]] = None,
     ) -> CallToolResult:
         """
         Call an OpenAPI tool handler directly.
@@ -2281,6 +2283,10 @@ class MCPServerManager:
         """
         from mcp.types import TextContent
 
+        from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+            _request_auth_header,
+            _request_extra_headers,
+        )
         from litellm.proxy._experimental.mcp_server.tool_registry import (
             global_mcp_tool_registry,
         )
@@ -2297,9 +2303,24 @@ class MCPServerManager:
             )
 
         try:
+            auth_header_value: Optional[str] = None
+            if mcp_auth_header:
+                if server.auth_type == MCPAuth.api_key:
+                    auth_header_value = f"ApiKey {mcp_auth_header}"
+                elif server.auth_type == MCPAuth.basic:
+                    auth_header_value = f"Basic {mcp_auth_header}"
+                else:
+                    auth_header_value = f"Bearer {mcp_auth_header}"
+
+            auth_token = _request_auth_header.set(auth_header_value)
+            extra_headers_token = _request_extra_headers.set(request_extra_headers)
             # Call the tool handler with the arguments
             # The handler is an async function that makes the HTTP request
-            handler_result = await tool.handler(**arguments)
+            try:
+                handler_result = await tool.handler(**arguments)
+            finally:
+                _request_extra_headers.reset(extra_headers_token)
+                _request_auth_header.reset(auth_token)
 
             # Convert the handler result (string response) to CallToolResult format
             result = CallToolResult(
@@ -2473,6 +2494,50 @@ class MCPServerManager:
                 call_type=CallTypes.call_mcp_tool.value,
             )
         )
+
+    def _build_openapi_request_extra_headers(
+        self,
+        mcp_server: MCPServer,
+        oauth2_headers: Optional[Dict[str, str]],
+        raw_headers: Optional[Dict[str, str]],
+        hook_extra_headers: Optional[Dict[str, str]],
+    ) -> Optional[Dict[str, str]]:
+        """Build per-request headers for OpenAPI-generated MCP tool handlers."""
+        extra_headers = oauth2_headers.copy() if oauth2_headers else None
+
+        if mcp_server.extra_headers and raw_headers:
+            if extra_headers is None:
+                extra_headers = {}
+
+            normalized_raw_headers = {
+                str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
+            }
+            for header in mcp_server.extra_headers:
+                if not isinstance(header, str):
+                    continue
+                if (
+                    mcp_server.has_client_credentials
+                    and header.lower() == "authorization"
+                ):
+                    continue
+                header_value = normalized_raw_headers.get(header.lower())
+                if header_value is None:
+                    continue
+                extra_headers[header] = header_value
+
+        if mcp_server.static_headers:
+            if extra_headers is None:
+                extra_headers = {}
+            extra_headers.update(mcp_server.static_headers)
+
+        if hook_extra_headers:
+            if extra_headers is None:
+                extra_headers = {}
+            extra_headers.update(hook_extra_headers)
+
+        if extra_headers is not None and len(extra_headers) == 0:
+            return None
+        return extra_headers
 
     async def _call_regular_mcp_tool(  # noqa: PLR0915
         self,
@@ -2746,17 +2811,21 @@ class MCPServerManager:
             verbose_logger.debug(
                 "Calling OpenAPI tool %s directly via HTTP handler", name
             )
-            if hook_result.get("extra_headers"):
-                verbose_logger.warning(
-                    "pre_mcp_call hook returned extra_headers for OpenAPI-backed "
-                    "MCP server '%s' — header injection is not supported for "
-                    "OpenAPI servers; headers will be ignored. Use SSE/HTTP "
-                    "transport to enable hook header injection.",
-                    server_name,
-                )
+            request_extra_headers = self._build_openapi_request_extra_headers(
+                mcp_server=mcp_server,
+                oauth2_headers=oauth2_headers,
+                raw_headers=raw_headers,
+                hook_extra_headers=hook_result.get("extra_headers"),
+            )
             tasks.append(
                 asyncio.create_task(
-                    self._call_openapi_tool_handler(mcp_server, name, arguments)
+                    self._call_openapi_tool_handler(
+                        mcp_server,
+                        name,
+                        arguments,
+                        mcp_auth_header=mcp_auth_header,
+                        request_extra_headers=request_extra_headers,
+                    )
                 )
             )
         else:

--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -30,6 +30,9 @@ HEADERS: Dict[str, str] = {}
 _request_auth_header: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "_request_auth_header", default=None
 )
+_request_extra_headers: contextvars.ContextVar[Optional[Dict[str, str]]] = (
+    contextvars.ContextVar("_request_extra_headers", default=None)
+)
 
 
 def _sanitize_path_parameter_value(param_value: Any, param_name: str) -> str:
@@ -273,6 +276,20 @@ def build_input_schema(operation: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _get_effective_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    effective_headers = dict(headers)
+
+    request_extra_headers = _request_extra_headers.get()
+    if request_extra_headers:
+        effective_headers.update(request_extra_headers)
+
+    override_auth = _request_auth_header.get()
+    if override_auth:
+        effective_headers["Authorization"] = override_auth
+
+    return effective_headers
+
+
 def create_tool_function(
     path: str,
     method: str,
@@ -314,10 +331,7 @@ def create_tool_function(
         # The ContextVar holds the full Authorization header value, including the
         # correct prefix (Bearer / ApiKey / Basic) formatted by the caller in
         # server.py based on the server's configured auth_type.
-        effective_headers = dict(headers)
-        override_auth = _request_auth_header.get()
-        if override_auth:
-            effective_headers["Authorization"] = override_auth
+        effective_headers = _get_effective_headers(headers)
 
         # Build URL from base_url and path
         url = base_url + path

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -48,6 +48,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     LITELLM_MCP_SERVER_NAME,
     LITELLM_MCP_SERVER_VERSION,
     add_server_prefix_to_name,
+    build_mcp_runtime_extra_headers,
     get_server_prefix,
     iter_known_server_prefixes,
 )
@@ -1157,25 +1158,15 @@ if MCP_AVAILABLE:
         raw_headers: Optional[Dict[str, str]],
     ) -> Optional[Dict[str, str]]:
         """Build per-request headers for a local OpenAPI-generated MCP tool."""
-        extra_headers = oauth2_headers.copy() if oauth2_headers else None
+        if server is None:
+            return oauth2_headers.copy() if oauth2_headers else None
 
-        if server and server.extra_headers and raw_headers:
-            if extra_headers is None:
-                extra_headers = {}
-
-            normalized_raw_headers = {
-                str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
-            }
-
-            for header in server.extra_headers:
-                if not isinstance(header, str):
-                    continue
-                header_value = normalized_raw_headers.get(header.lower())
-                if header_value is None:
-                    continue
-                extra_headers[header] = header_value
-
-        return extra_headers
+        return build_mcp_runtime_extra_headers(
+            server=server,
+            oauth2_headers=oauth2_headers,
+            raw_headers=raw_headers,
+            include_static_headers=False,
+        )
 
     def _merge_gateway_initialize_instructions(
         allowed_mcp_servers: List[MCPServer],

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -158,6 +158,7 @@ if MCP_AVAILABLE:
     )
     from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
         _request_auth_header,
+        _request_extra_headers,
     )
     from litellm.proxy._experimental.mcp_server.sse_transport import SseServerTransport
     from litellm.proxy._experimental.mcp_server.tool_registry import (
@@ -1149,6 +1150,32 @@ if MCP_AVAILABLE:
             server_auth_header = mcp_auth_header
 
         return server_auth_header, extra_headers
+
+    def _get_request_extra_headers_for_openapi_tool(
+        server: Optional[MCPServer],
+        oauth2_headers: Optional[Dict[str, str]],
+        raw_headers: Optional[Dict[str, str]],
+    ) -> Optional[Dict[str, str]]:
+        """Build per-request headers for a local OpenAPI-generated MCP tool."""
+        extra_headers = oauth2_headers.copy() if oauth2_headers else None
+
+        if server and server.extra_headers and raw_headers:
+            if extra_headers is None:
+                extra_headers = {}
+
+            normalized_raw_headers = {
+                str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
+            }
+
+            for header in server.extra_headers:
+                if not isinstance(header, str):
+                    continue
+                header_value = normalized_raw_headers.get(header.lower())
+                if header_value is None:
+                    continue
+                extra_headers[header] = header_value
+
+        return extra_headers
 
     def _merge_gateway_initialize_instructions(
         allowed_mcp_servers: List[MCPServer],
@@ -2154,10 +2181,17 @@ if MCP_AVAILABLE:
                     auth_header_value = f"Basic {mcp_auth_header}"
                 else:
                     auth_header_value = f"Bearer {mcp_auth_header}"
+            request_extra_headers = _get_request_extra_headers_for_openapi_tool(
+                server=mcp_server,
+                oauth2_headers=oauth2_headers,
+                raw_headers=raw_headers,
+            )
             _auth_token = _request_auth_header.set(auth_header_value)
+            _extra_headers_token = _request_extra_headers.set(request_extra_headers)
             try:
                 local_content = await _handle_local_mcp_tool(name, arguments)
             finally:
+                _request_extra_headers.reset(_extra_headers_token)
                 _request_auth_header.reset(_auth_token)
             response = CallToolResult(content=cast(Any, local_content), isError=False)
 

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -320,3 +320,46 @@ def merge_mcp_headers(
         merged.update({str(k): str(v) for k, v in static_headers.items()})
 
     return merged or None
+
+
+def build_mcp_runtime_extra_headers(
+    *,
+    server: Any,
+    oauth2_headers: Optional[Mapping[str, str]] = None,
+    raw_headers: Optional[Mapping[Any, str]] = None,
+    hook_extra_headers: Optional[Mapping[str, str]] = None,
+    include_static_headers: bool = False,
+) -> Optional[Dict[str, str]]:
+    """Build per-request outbound headers for MCP and OpenAPI MCP calls."""
+    extra_headers: Dict[str, str] = {}
+
+    if oauth2_headers:
+        extra_headers.update({str(k): str(v) for k, v in oauth2_headers.items()})
+
+    configured_headers = getattr(server, "extra_headers", None)
+    if configured_headers and raw_headers:
+        normalized_raw_headers = {
+            str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)
+        }
+        for header in configured_headers:
+            if not isinstance(header, str):
+                continue
+            if (
+                getattr(server, "has_client_credentials", False)
+                and header.lower() == "authorization"
+            ):
+                continue
+            header_value = normalized_raw_headers.get(header.lower())
+            if header_value is None:
+                continue
+            extra_headers[header] = str(header_value)
+
+    if include_static_headers:
+        static_headers = getattr(server, "static_headers", None)
+        if static_headers:
+            extra_headers.update({str(k): str(v) for k, v in static_headers.items()})
+
+    if hook_extra_headers:
+        extra_headers.update({str(k): str(v) for k, v in hook_extra_headers.items()})
+
+    return extra_headers or None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -814,6 +814,28 @@ class TestHookHeaderMergePriority:
 
         assert headers == {"X-TOKEN": "request-token"}
 
+    def test_gateway_openapi_request_headers_match_manager_builder(self):
+        """Gateway OpenAPI execution uses the shared runtime header builder."""
+        manager = MCPServerManager()
+        server = self._make_server(extra_headers_config=["X-TOKEN", "X-Trace"])
+
+        manager_headers = manager._build_openapi_request_extra_headers(
+            mcp_server=server,
+            oauth2_headers={"Authorization": "Bearer oauth-token"},
+            raw_headers={"x-token": "request-token", "x-trace": "trace-from-request"},
+            hook_extra_headers=None,
+        )
+        gateway_headers = mcp_server_module._get_request_extra_headers_for_openapi_tool(
+            server=server,
+            oauth2_headers={"Authorization": "Bearer oauth-token"},
+            raw_headers={
+                "x-token": "request-token",
+                "x-trace": "trace-from-request",
+            },
+        )
+
+        assert gateway_headers == manager_headers
+
 
 class TestOpenAPIRequestContext:
     """Tests for request-scoped headers on OpenAPI-generated MCP tools."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -12,12 +12,21 @@ Validates that:
 """
 
 import asyncio
+from datetime import datetime
 from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from litellm.proxy._experimental.mcp_server import server as mcp_server_module
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+    _request_auth_header,
+    _request_extra_headers,
+)
+from litellm.proxy._experimental.mcp_server.tool_registry import (
+    global_mcp_tool_registry,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.mcp import MCPAuth, MCPTransport
@@ -789,6 +798,144 @@ class TestHookHeaderMergePriority:
             "X-TOKEN": "request-token",
             "X-Trace": "trace-from-request",
         }
+
+    def test_openapi_request_headers_forwards_raw_headers_without_oauth(self):
+        """Configured OpenAPI extra_headers are copied from raw request headers."""
+        manager = MCPServerManager()
+        server = self._make_server(extra_headers_config=["X-TOKEN", "X-Missing"])
+        server.__dict__["extra_headers"] = ["X-TOKEN", 123, "X-Missing"]
+
+        headers = manager._build_openapi_request_extra_headers(
+            mcp_server=server,
+            oauth2_headers=None,
+            raw_headers={"x-token": "request-token", 42: "ignored"},
+            hook_extra_headers=None,
+        )
+
+        assert headers == {"X-TOKEN": "request-token"}
+
+
+class TestOpenAPIRequestContext:
+    """Tests for request-scoped headers on OpenAPI-generated MCP tools."""
+
+    def _make_openapi_server(self, auth_type: MCPAuth = MCPAuth.bearer_token):
+        return MCPServer(
+            server_id="test-id",
+            name="openapi_server",
+            server_name="openapi_server",
+            url="https://example.com",
+            transport=MCPTransport.http,
+            auth_type=auth_type,
+            spec_path="/path/to/spec.yaml",
+        )
+
+    @pytest.mark.parametrize(
+        ("auth_type", "expected_auth_header"),
+        [
+            (MCPAuth.api_key, "ApiKey secret"),
+            (MCPAuth.basic, "Basic secret"),
+            (MCPAuth.bearer_token, "Bearer secret"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_direct_openapi_handler_sets_and_resets_request_context(
+        self, auth_type: MCPAuth, expected_auth_header: str
+    ):
+        manager = MCPServerManager()
+        server = self._make_openapi_server(auth_type=auth_type)
+        tool_name = f"{server.name}-test_tool"
+        observed_context: Dict[str, Any] = {}
+
+        async def handler(**kwargs):
+            observed_context["arguments"] = kwargs
+            observed_context["auth"] = _request_auth_header.get()
+            observed_context["extra"] = _request_extra_headers.get()
+            return "ok"
+
+        previous_tool = global_mcp_tool_registry.tools.get(tool_name)
+        global_mcp_tool_registry.register_tool(
+            name=tool_name,
+            description="test tool",
+            input_schema={},
+            handler=handler,
+        )
+        try:
+            result = await manager._call_openapi_tool_handler(
+                server=server,
+                tool_name="test_tool",
+                arguments={"item": "1"},
+                mcp_auth_header="secret",
+                request_extra_headers={"X-TOKEN": "request-token"},
+            )
+        finally:
+            if previous_tool is None:
+                global_mcp_tool_registry.tools.pop(tool_name, None)
+            else:
+                global_mcp_tool_registry.tools[tool_name] = previous_tool
+
+        assert result.isError is False
+        assert result.content[0].text == "ok"
+        assert observed_context == {
+            "arguments": {"item": "1"},
+            "auth": expected_auth_header,
+            "extra": {"X-TOKEN": "request-token"},
+        }
+        assert _request_auth_header.get() is None
+        assert _request_extra_headers.get() is None
+
+    @pytest.mark.asyncio
+    async def test_local_openapi_tool_execution_sets_request_headers(self):
+        server = self._make_openapi_server(auth_type=MCPAuth.basic)
+        server.__dict__["extra_headers"] = ["X-TOKEN", "X-Missing", 123]
+        tool_name = f"{server.name}-test_tool"
+        observed_context: Dict[str, Any] = {}
+
+        async def handler(**kwargs):
+            observed_context["arguments"] = kwargs
+            observed_context["auth"] = _request_auth_header.get()
+            observed_context["extra"] = _request_extra_headers.get()
+            return "ok"
+
+        previous_tool = global_mcp_tool_registry.tools.get(tool_name)
+        global_mcp_tool_registry.register_tool(
+            name=tool_name,
+            description="test tool",
+            input_schema={},
+            handler=handler,
+        )
+        try:
+            with patch.object(
+                mcp_server_module.global_mcp_server_manager,
+                "_get_mcp_server_from_tool_name",
+                return_value=server,
+            ):
+                result = await mcp_server_module.execute_mcp_tool(
+                    name=tool_name,
+                    arguments={"item": "1"},
+                    allowed_mcp_servers=[server],
+                    start_time=datetime.now(),
+                    mcp_auth_header="secret",
+                    oauth2_headers={"Authorization": "Bearer oauth-token"},
+                    raw_headers={"x-token": "request-token"},
+                )
+        finally:
+            if previous_tool is None:
+                global_mcp_tool_registry.tools.pop(tool_name, None)
+            else:
+                global_mcp_tool_registry.tools[tool_name] = previous_tool
+
+        assert result.isError is False
+        assert result.content[0].text == "ok"
+        assert observed_context == {
+            "arguments": {"item": "1"},
+            "auth": "Basic secret",
+            "extra": {
+                "Authorization": "Bearer oauth-token",
+                "X-TOKEN": "request-token",
+            },
+        }
+        assert _request_auth_header.get() is None
+        assert _request_extra_headers.get() is None
 
 
 class TestUserAPIKeyAuthJwtClaims:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -6,7 +6,7 @@ Validates that:
 2. pre_call_tool_check returns hook-provided extra_headers AND modified arguments
 3. call_tool flows hook headers and modified arguments downstream
 4. Hook-provided headers take highest priority (merge after static_headers)
-5. OpenAPI-backed servers log a warning and continue (skip injection) when hook headers are present
+5. OpenAPI-backed servers merge hook headers into request-scoped generated-tool headers
 6. JWT claims are propagated in both standard and virtual-key fast paths
 7. Backward compatibility: hooks without extra_headers continue to work
 """
@@ -16,7 +16,6 @@ from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
 
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
 from litellm.proxy._types import UserAPIKeyAuth
@@ -422,8 +421,8 @@ class TestCallToolFlowsHookHeaders:
                         assert call_kwargs.kwargs.get("arguments") == modified_args
 
     @pytest.mark.asyncio
-    async def test_openapi_server_warns_and_continues_on_hook_headers(self):
-        """OpenAPI-backed servers log a warning and continue when hook injects headers."""
+    async def test_openapi_server_forwards_hook_headers(self):
+        """OpenAPI-backed servers forward hook headers through request context."""
         manager = MCPServerManager()
         server = MCPServer(
             server_id="test-id",
@@ -454,24 +453,20 @@ class TestCallToolFlowsHookHeaders:
                         "_call_openapi_tool_handler",
                         new_callable=AsyncMock,
                         return_value=MagicMock(),
-                    ):
-                        import litellm.proxy._experimental.mcp_server.mcp_server_manager as mgr_mod
-
+                    ) as mock_call:
                         proxy_logging = MagicMock(spec=ProxyLogging)
 
-                        with patch.object(mgr_mod, "verbose_logger") as mock_logger:
-                            # Should NOT raise — just warn and proceed
-                            await manager.call_tool(
-                                server_name="openapi_server",
-                                name="test_tool",
-                                arguments={},
-                                proxy_logging_obj=proxy_logging,
-                            )
-                            mock_logger.warning.assert_called_once()
-                            assert (
-                                "header injection is not supported"
-                                in mock_logger.warning.call_args[0][0]
-                            )
+                        await manager.call_tool(
+                            server_name="openapi_server",
+                            name="test_tool",
+                            arguments={},
+                            proxy_logging_obj=proxy_logging,
+                        )
+
+                        mock_call.assert_called_once()
+                        assert mock_call.call_args.kwargs["request_extra_headers"] == {
+                            "Authorization": "Bearer jwt"
+                        }
 
     @pytest.mark.asyncio
     async def test_openapi_server_no_error_without_hook_headers(self):
@@ -772,6 +767,28 @@ class TestHookHeaderMergePriority:
         headers = captured_extra_headers.get("value") or {}
         assert "Authorization" not in headers
         assert headers.get("X-Custom") == "from-client"
+
+    def test_openapi_request_headers_merge_oauth_raw_and_hook_headers(self):
+        """OpenAPI tools receive the same runtime header sources as MCP transports."""
+        manager = MCPServerManager()
+        server = self._make_server(extra_headers_config=["X-TOKEN", "X-Trace"])
+
+        headers = manager._build_openapi_request_extra_headers(
+            mcp_server=server,
+            oauth2_headers={"Authorization": "Bearer oauth-token"},
+            raw_headers={
+                "x-token": "request-token",
+                "x-trace": "trace-from-request",
+                "x-ignored": "not-forwarded",
+            },
+            hook_extra_headers={"Authorization": "Bearer hook-token"},
+        )
+
+        assert headers == {
+            "Authorization": "Bearer hook-token",
+            "X-TOKEN": "request-token",
+            "X-Trace": "trace-from-request",
+        }
 
 
 class TestUserAPIKeyAuthJwtClaims:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -17,6 +17,8 @@ import pytest
 from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
     _resolve_param_list,
     _resolve_ref,
+    _request_auth_header,
+    _request_extra_headers,
     build_input_schema,
     create_tool_function,
     extract_parameters,
@@ -76,6 +78,67 @@ class TestCreateToolFunction:
             assert "repository-id" in str(call_args[0][0]) or "test-repo" in str(
                 call_args[0][0]
             )
+
+    @pytest.mark.asyncio
+    async def test_request_extra_headers_are_forwarded(self):
+        """OpenAPI tools should merge per-request header passthrough."""
+        operation = {}
+        func = create_tool_function(
+            path="/protected",
+            method="get",
+            operation=operation,
+            base_url="https://api.example.com",
+            headers={"X-Static": "static"},
+        )
+
+        with patch(GET_ASYNC_CLIENT_TARGET) as mock_client:
+            async_client = _create_mock_client("get", "ok")
+            mock_client.return_value = async_client
+
+            token = _request_extra_headers.set({"X-TOKEN": "request-token"})
+            try:
+                result = await func()
+            finally:
+                _request_extra_headers.reset(token)
+
+            assert result == "ok"
+            call_args = async_client.get.call_args
+            assert call_args.kwargs["headers"] == {
+                "X-Static": "static",
+                "X-TOKEN": "request-token",
+            }
+
+    @pytest.mark.asyncio
+    async def test_auth_context_overrides_request_extra_authorization_header(self):
+        """BYOK auth must keep highest precedence over generic request headers."""
+        operation = {}
+        func = create_tool_function(
+            path="/protected",
+            method="get",
+            operation=operation,
+            base_url="https://api.example.com",
+        )
+
+        with patch(GET_ASYNC_CLIENT_TARGET) as mock_client:
+            async_client = _create_mock_client("get", "ok")
+            mock_client.return_value = async_client
+
+            extra_token = _request_extra_headers.set(
+                {"Authorization": "Bearer request-token", "X-TOKEN": "request-token"}
+            )
+            auth_token = _request_auth_header.set("Bearer byok-token")
+            try:
+                result = await func()
+            finally:
+                _request_auth_header.reset(auth_token)
+                _request_extra_headers.reset(extra_token)
+
+            assert result == "ok"
+            call_args = async_client.get.call_args
+            assert call_args.kwargs["headers"] == {
+                "Authorization": "Bearer byok-token",
+                "X-TOKEN": "request-token",
+            }
 
     @pytest.mark.asyncio
     async def test_leading_digit_parameter(self):


### PR DESCRIPTION
Fixes OpenAPI-backed MCP servers so configured `extra_headers` are forwarded from each incoming request to the upstream OpenAPI request.

Root cause:
- OpenAPI MCP tools are generated as local handlers with registration-time headers closed over in the handler.
- Managed MCP transport calls already merge configured `extra_headers` from the incoming raw request, but the OpenAPI/local handler path only supported the `_request_auth_header` ContextVar for BYOK-style Authorization overrides.
- As a result, caller-provided headers such as `X-TOKEN` were never visible to generated OpenAPI tool handlers.

What changed:
- added a request-scoped `_request_extra_headers` ContextVar used by generated OpenAPI tool functions
- populated that context in the local OpenAPI dispatch path from OAuth headers and configured raw-request `extra_headers`
- did the same in `MCPServerManager.call_tool`, including hook-provided `extra_headers`
- preserved BYOK Authorization override precedence over generic request header passthrough
- updated hook tests now that OpenAPI-backed servers can receive hook headers instead of warning/ignoring them

Validation:
- `/private/tmp/litellm-26794-venv/bin/python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py -q` (69 passed)
- `/private/tmp/litellm-26794-venv/bin/python -m ruff check litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py litellm/proxy/_experimental/mcp_server/server.py litellm/proxy/_experimental/mcp_server/mcp_server_manager.py tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py`
- `/private/tmp/litellm-26794-venv/bin/python -m compileall -q litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py litellm/proxy/_experimental/mcp_server/server.py litellm/proxy/_experimental/mcp_server/mcp_server_manager.py`

Closes #26794.
