### PR TITLE
fix(cost): add gpt-image-2 pricing and routing

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -984,7 +984,7 @@ class CostCalculatorUtils:
         elif custom_llm_provider == litellm.LlmProviders.OPENAI.value:
             # Check if this is a gpt-image model (token-based pricing)
             model_lower = model.lower()
-            if "gpt-image-1" in model_lower:
+            if model_lower.startswith("gpt-image-") or "/gpt-image-" in model_lower:
                 from litellm.llms.openai.image_generation.cost_calculator import (
                     cost_calculator as openai_gpt_image_cost_calculator,
                 )
@@ -1006,7 +1006,7 @@ class CostCalculatorUtils:
         elif custom_llm_provider == litellm.LlmProviders.AZURE.value:
             # Check if this is a gpt-image model (token-based pricing)
             model_lower = model.lower()
-            if "gpt-image-1" in model_lower:
+            if model_lower.startswith("gpt-image-") or "/gpt-image-" in model_lower:
                 from litellm.llms.openai.image_generation.cost_calculator import (
                     cost_calculator as openai_gpt_image_cost_calculator,
                 )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5114,7 +5114,9 @@
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"
-        ]
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "azure/gpt-image-2-2026-04-21": {
         "cache_read_input_image_token_cost": 2e-06,
@@ -5127,7 +5129,9 @@
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"
-        ]
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
         "input_cost_per_pixel": 2.0751953125e-09,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5103,6 +5103,32 @@
             "/v1/images/edits"
         ]
     },
+    "azure/gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_image_token": 8e-06,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
+    "azure/gpt-image-2-2026-04-21": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_image_token": 8e-06,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
         "input_cost_per_pixel": 2.0751953125e-09,
         "litellm_provider": "azure",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -19068,6 +19068,34 @@
         "supports_vision": true,
         "supports_pdf_input": true
     },
+    "gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
+    "gpt-image-2-2026-04-21": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
     "gpt-image-1.5-2025-12-16": {
         "cache_read_input_image_token_cost": 2e-06,
         "cache_read_input_token_cost": 1.25e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -19082,6 +19082,34 @@
         "supports_vision": true,
         "supports_pdf_input": true
     },
+    "gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
+    "gpt-image-2-2026-04-21": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
     "gpt-image-1.5-2025-12-16": {
         "cache_read_input_image_token_cost": 2e-06,
         "cache_read_input_token_cost": 1.25e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5117,6 +5117,32 @@
             "/v1/images/edits"
         ]
     },
+    "azure/gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_image_token": 8e-06,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
+    "azure/gpt-image-2-2026-04-21": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_image_token": 8e-06,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
         "input_cost_per_pixel": 2.0751953125e-09,
         "litellm_provider": "azure",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5128,7 +5128,9 @@
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"
-        ]
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "azure/gpt-image-2-2026-04-21": {
         "cache_read_input_image_token_cost": 2e-06,
@@ -5141,7 +5143,9 @@
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"
-        ]
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
         "input_cost_per_pixel": 2.0751953125e-09,

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -303,5 +303,62 @@ class TestCompletionCostIntegration:
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
 
+class TestGPTImage2Cost:
+    """
+    Regression test for GitHub issue #26863:
+    https://github.com/BerriAI/litellm/issues/26863
+
+    gpt-image-2 cost was always reported as 0 because the model was
+    missing from the cost map. Pricing (per OpenAI docs,
+    https://developers.openai.com/api/docs/pricing):
+    - Text Input: $5.00 / 1M tokens   (5e-06)
+    - Image Input: $8.00 / 1M tokens  (8e-06)
+    - Image Output: $30.00 / 1M tokens (3e-05)
+    """
+
+    def test_gpt_image_2_cost(self):
+        """Test that gpt-image-2 cost is calculated correctly (non-zero)."""
+        usage = Usage(
+            prompt_tokens=169,
+            completion_tokens=4160,
+            total_tokens=4329,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                text_tokens=169,
+                image_tokens=0,
+            ),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                text_tokens=0,
+                image_tokens=4160,
+            ),
+        )
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(b64_json="test")],
+        )
+        image_response.usage = usage
+        image_response._hidden_params = {"custom_llm_provider": "openai"}
+
+        cost = litellm.completion_cost(
+            completion_response=image_response,
+            model="gpt-image-2",
+            call_type="image_generation",
+            custom_llm_provider="openai",
+        )
+
+        # gpt-image-2 pricing (per OpenAI docs):
+        # - input_cost_per_token: 5e-06 ($5/1M for text input)
+        # - output_cost_per_image_token: 3e-05 ($30/1M for image output)
+        #
+        # Expected cost:
+        # Input text: 169 * $5/1M = $0.000845
+        # Output image: 4160 * $30/1M = $0.1248
+        expected_cost = 169 * 5e-06 + 4160 * 3e-05
+        assert cost > 0, "gpt-image-2 cost should not be zero (issue #26863)"
+        assert abs(cost - expected_cost) < 1e-6, (
+            f"Expected {expected_cost}, got {cost}."
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -316,8 +316,7 @@ class TestGPTImage2Cost:
     - Image Output: $30.00 / 1M tokens (3e-05)
     """
 
-    def test_gpt_image_2_cost(self):
-        """Test that gpt-image-2 cost is calculated correctly (non-zero)."""
+    def _build_image_response(self):
         usage = Usage(
             prompt_tokens=169,
             completion_tokens=4160,
@@ -337,6 +336,18 @@ class TestGPTImage2Cost:
             data=[ImageObject(b64_json="test")],
         )
         image_response.usage = usage
+        return image_response
+
+    def test_gpt_image_2_cost(self, monkeypatch):
+        """Test that gpt-image-2 cost is calculated correctly (non-zero).
+
+        Uses the local cost map because gpt-image-2 may not yet be in the
+        remote cost map fetched at runtime.
+        """
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        image_response = self._build_image_response()
         image_response._hidden_params = {"custom_llm_provider": "openai"}
 
         cost = litellm.completion_cost(
@@ -358,6 +369,26 @@ class TestGPTImage2Cost:
         assert abs(cost - expected_cost) < 1e-6, (
             f"Expected {expected_cost}, got {cost}."
         )
+
+    def test_azure_gpt_image_2_routes_to_token_calculator(self, monkeypatch):
+        """Azure-prefixed gpt-image-2 must route to the token-based calculator
+        (the `/gpt-image-` substring branch in route_image_generation_cost_calculator).
+        """
+        from litellm.litellm_core_utils.llm_cost_calc.utils import CostCalculatorUtils
+
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        image_response = self._build_image_response()
+
+        cost = CostCalculatorUtils.route_image_generation_cost_calculator(
+            model="azure/gpt-image-2",
+            completion_response=image_response,
+            custom_llm_provider="azure",
+        )
+
+        # Same token math as openai path; assert routing reached token calc.
+        assert cost > 0, "azure/gpt-image-2 should route to token-based calculator"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Closes #26863. `gpt-image-2` cost was always 0 because it was both **missing from the cost map** and **misrouted** to the per-image (DALL-E) calculator instead of the token-based calculator.

## Changes
- **Cost map** (`model_prices_and_context_window.json` + `litellm/model_prices_and_context_window_backup.json`): add `gpt-image-2`, `gpt-image-2-2026-04-21`, `azure/gpt-image-2`, `azure/gpt-image-2-2026-04-21` with token pricing per [OpenAI docs](https://developers.openai.com/api/docs/pricing#image-generation):
  - text input: $5/1M, cached $1.25/1M
  - image input: $8/1M, cached $2/1M
  - image output: $30/1M
- **Routing** (`litellm/litellm_core_utils/llm_cost_calc/utils.py`): replace the `"gpt-image-1" in model_lower` substring check with `model_lower.startswith("gpt-image-") or "/gpt-image-" in model_lower`. The old substring incidentally matched `gpt-image-1.5`, but never `gpt-image-2`. New matcher covers all current and future `gpt-image-*` variants and Azure-prefixed forms.
- **Tests** (`tests/test_litellm/test_gpt_image_cost_calculator.py`): add `TestGPTImage2Cost` with two cases — direct `completion_cost` for `gpt-image-2`, and `azure/gpt-image-2` routing through `CostCalculatorUtils`. Both use `LITELLM_LOCAL_MODEL_COST_MAP=True` so they don't depend on the remote cost map.

## Test plan
- [x] `pytest tests/test_litellm/test_gpt_image_cost_calculator.py -v` → 10/10 pass
- [x] Verified `gpt-image-1` and `gpt-image-1.5` still route correctly (existing tests unchanged)
- [x] Verified DALL-E still routes to per-image calculator (existing test unchanged)

## Notes
- `output_cost_per_token` (text output) is intentionally omitted — OpenAI's gpt-image-2 pricing section lists token costs but does not include a separate text output rate (unlike gpt-image-1.5 which lists $10/1M).
- Per-image quality/size variants (`high/1024-x-1024/gpt-image-2` etc.) are not added because OpenAI's gpt-image-2 pricing page only lists token-based pricing.