### PR TITLE
feat(pricing): add gpt-image-2 and azure_ai/gpt-image-2 model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -2061,6 +2061,20 @@
         "litellm_provider": "azure",
         "mode": "chat"
     },
+    "azure_ai/gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "azure_ai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
     "azure_ai/gpt-oss-120b": {
         "input_cost_per_token": 1.5e-07,
         "output_cost_per_token": 6e-07,
@@ -20925,6 +20939,20 @@
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_image_token": 8e-06,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
+    "gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "source": "https://platform.openai.com/docs/models/gpt-image-2",
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2075,6 +2075,20 @@
         "litellm_provider": "azure",
         "mode": "chat"
     },
+    "azure_ai/gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "azure_ai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
     "azure_ai/gpt-oss-120b": {
         "input_cost_per_token": 1.5e-07,
         "output_cost_per_token": 6e-07,
@@ -20939,6 +20953,20 @@
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_image_token": 8e-06,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
+    "gpt-image-2": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3e-05,
+        "source": "https://platform.openai.com/docs/models/gpt-image-2",
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"


### PR DESCRIPTION
## Summary

Adds pricing entries for OpenAI's `gpt-image-2` model and its Azure AI Foundry (`azure_ai/gpt-image-2`) variant to both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`.

Pricing values sourced from https://platform.openai.com/docs/models/gpt-image-2 and https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/:

| Field | Value |
|---|---|
| `input_cost_per_token` (text) | `5e-06` ($5.00 / 1M tokens) |
| `cache_read_input_token_cost` | `1.25e-06` ($1.25 / 1M tokens) |
| `input_cost_per_image_token` | `8e-06` ($8.00 / 1M image tokens) |
| `cache_read_input_image_token_cost` | `2e-06` ($2.00 / 1M image tokens) |
| `output_cost_per_image_token` | `3e-05` ($30.00 / 1M image tokens) |

Both `openai` and `azure_ai` providers support `/v1/images/generations` and `/v1/images/edits` endpoints.

Closes #26765
Relates to #26863 (gpt-image-2 cost always 0 — this adds the missing cost entry)

## Test plan

- [x] Both JSON files parse as valid JSON (`python3 -c "import json; json.load(open(...))"`)
- [x] Pricing values match the official OpenAI API pricing page for gpt-image-2
- [x] Entry format mirrors existing `gpt-image-1` / `azure/gpt-image-1` structure