### PR TITLE
fix(embedding): respect drop_params for unsupported dimensions parameter

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3309,12 +3309,19 @@ def get_optional_params_embeddings(  # noqa: PLR0915
             and "dimensions" in non_default_params.keys()
             and "dimensions" not in (allowed_openai_params or [])
         ):
-            raise UnsupportedParamsError(
-                status_code=500,
-                message="Setting dimensions is not supported for OpenAI `text-embedding-3` and later models. To drop it from the call, set `litellm.drop_params = True`.",
-            )
-        else:
-            optional_params = non_default_params
+            # Honor drop_params (per-call) and litellm.drop_params (global) the same
+            # way `_check_valid_arg` does above. The raised error message itself
+            # tells users to set `drop_params=True`, so respect it here.
+            if litellm.drop_params is True or (
+                drop_params is not None and drop_params is True
+            ):
+                non_default_params.pop("dimensions", None)
+            else:
+                raise UnsupportedParamsError(
+                    status_code=500,
+                    message="Setting dimensions is not supported for OpenAI `text-embedding-3` and later models. To drop it from the call, set `litellm.drop_params = True`.",
+                )
+        optional_params = non_default_params
     elif custom_llm_provider == "triton":
         supported_params = get_supported_openai_params(
             model=model,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3312,9 +3312,7 @@ def get_optional_params_embeddings(  # noqa: PLR0915
             # Honor drop_params (per-call) and litellm.drop_params (global) the same
             # way `_check_valid_arg` does above. The raised error message itself
             # tells users to set `drop_params=True`, so respect it here.
-            if litellm.drop_params is True or (
-                drop_params is not None and drop_params is True
-            ):
+            if litellm.drop_params is True or drop_params is True:
                 non_default_params.pop("dimensions", None)
             else:
                 raise UnsupportedParamsError(

--- a/tests/local_testing/test_get_optional_params_embeddings.py
+++ b/tests/local_testing/test_get_optional_params_embeddings.py
@@ -97,12 +97,69 @@ def test_openai_non_text_embedding_3_without_allowed_openai_params_raises():
     """
     from litellm.exceptions import UnsupportedParamsError
 
-    model, custom_llm_provider, _, _ = get_llm_provider(
-        model="openai/nvidia/llama-3.2-nv-embedqa-1b-v2"
-    )
-    with pytest.raises(UnsupportedParamsError):
-        get_optional_params_embeddings(
+    # ensure global drop_params is off (other tests in this file flip it on)
+    prev_drop_params = litellm.drop_params
+    litellm.drop_params = False
+    try:
+        model, custom_llm_provider, _, _ = get_llm_provider(
+            model="openai/nvidia/llama-3.2-nv-embedqa-1b-v2"
+        )
+        with pytest.raises(UnsupportedParamsError):
+            get_optional_params_embeddings(
+                model=model,
+                dimensions=1024,
+                custom_llm_provider=custom_llm_provider,
+            )
+    finally:
+        litellm.drop_params = prev_drop_params
+
+
+def test_openai_non_text_embedding_3_drop_params_per_call():
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/26787
+
+    When drop_params=True is passed per-call, `dimensions` should be silently
+    stripped for a non-`text-embedding-3` OpenAI-provider model instead of
+    raising UnsupportedParamsError.
+    """
+    prev_drop_params = litellm.drop_params
+    litellm.drop_params = False  # ensure only per-call flag is in effect
+    try:
+        model, custom_llm_provider, _, _ = get_llm_provider(
+            model="openai/Qwen/Qwen3-Embedding-0.6B"
+        )
+        optional_params = get_optional_params_embeddings(
+            model=model,
+            dimensions=1024,
+            custom_llm_provider=custom_llm_provider,
+            drop_params=True,
+        )
+        print(f"received optional_params: {optional_params}")
+        assert "dimensions" not in optional_params
+    finally:
+        litellm.drop_params = prev_drop_params
+
+
+def test_openai_non_text_embedding_3_drop_params_global():
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/26787
+
+    When `litellm.drop_params = True` is set globally, `dimensions` should be
+    silently stripped for a non-`text-embedding-3` OpenAI-provider model
+    instead of raising UnsupportedParamsError.
+    """
+    prev_drop_params = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        model, custom_llm_provider, _, _ = get_llm_provider(
+            model="openai/Qwen/Qwen3-Embedding-0.6B"
+        )
+        optional_params = get_optional_params_embeddings(
             model=model,
             dimensions=1024,
             custom_llm_provider=custom_llm_provider,
         )
+        print(f"received optional_params: {optional_params}")
+        assert "dimensions" not in optional_params
+    finally:
+        litellm.drop_params = prev_drop_params


### PR DESCRIPTION
## Summary
Closes #26787. The OpenAI-provider branch in `get_optional_params_embeddings` hard-raised `UnsupportedParamsError` whenever `dimensions` was passed to a non-`text-embedding-3` model — even though **the error message itself instructed users to set `litellm.drop_params=True`**. The flag (per-call and global) had no effect, so the documented escape hatch was a dead end.

## Root cause
`litellm/utils.py:3304-3317` short-circuited with a raise *before* honoring `drop_params`. The same function's `_check_valid_arg` (lines 3252-3268) already respects `litellm.drop_params is True or drop_params is True`, but this OpenAI-specific check bypassed that path entirely.

## Fix
Before raising, check `litellm.drop_params is True or drop_params is True`. If true, pop `dimensions` from `non_default_params` and continue; otherwise preserve the original raise (default behavior unchanged). Then assign `optional_params = non_default_params` unconditionally — when dropped, `dimensions` is no longer in the dict, so it doesn't leak to the OpenAI request; when supported (text-embedding-3 or in `allowed_openai_params`), it passes through normally.

## Changes
- `litellm/utils.py` (lines 3304-3324): structural rewrite of the dimensions check
- `tests/local_testing/test_get_optional_params_embeddings.py`:
  - `test_openai_non_text_embedding_3_with_per_call_drop_params` — per-call `drop_params=True` succeeds and emits no `dimensions`
  - `test_openai_non_text_embedding_3_with_global_drop_params` — `litellm.drop_params=True` succeeds likewise
  - Added try/finally state isolation to the existing raise test (another test in the file mutates `litellm.drop_params` without restoring, which would otherwise contaminate this test under randomized order)

## Test plan
- [x] `pytest tests/local_testing/test_get_optional_params_embeddings.py -v` → 7/7 pass
- [x] Verified the new tests fail without the fix (they catch the real bug)
- [x] Default behavior preserved: `drop_params=False` (default) still raises
- [x] `text-embedding-3` and `allowed_openai_params` paths unchanged

## Notes
- `drop_params` precedence (per-call vs global) follows the existing `_check_valid_arg` pattern: either being True wins. No new policy introduced.
- PR #23120 (referenced in the issue thread) addresses a different branch in the same function (`provider_config.map_openai_params` path); orthogonal to this fix.
- Other providers (Cohere, Voyage, Bedrock) flow through `BaseEmbeddingConfig.map_openai_params` and already honor `drop_params` per provider config.