### PR TITLE
fix(streaming): propagate provider cost through streaming chunk builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -544,6 +544,7 @@ class ChunkProcessor:
         web_search_requests: Optional[int] = None
         completion_tokens_details: Optional[CompletionTokensDetails] = None
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+        cost: Optional[float] = None
         for chunk in chunks:
             usage_chunk: Optional[Usage] = None
             if "usage" in chunk:
@@ -589,6 +590,11 @@ class ChunkProcessor:
                     and usage_chunk.server_tool_use is not None
                 ):
                     server_tool_use = usage_chunk.server_tool_use
+                _cost = getattr(usage_chunk, "cost", None)
+                if _cost is None and isinstance(usage_chunk, dict):
+                    _cost = usage_chunk.get("cost")
+                if _cost is not None:
+                    cost = _cost
                 if (
                     usage_chunk_dict["prompt_tokens_details"] is not None
                     and getattr(
@@ -614,6 +620,7 @@ class ChunkProcessor:
             web_search_requests=web_search_requests,
             completion_tokens_details=completion_tokens_details,
             prompt_tokens_details=prompt_tokens_details,
+            cost=cost,
         )
 
     def calculate_usage(
@@ -711,6 +718,8 @@ class ChunkProcessor:
 
         if server_tool_use is not None:
             returned_usage.server_tool_use = server_tool_use
+        if calculated_usage_per_chunk["cost"] is not None:
+            returned_usage.cost = calculated_usage_per_chunk["cost"]
         if web_search_requests is not None:
             if returned_usage.prompt_tokens_details is None:
                 returned_usage.prompt_tokens_details = PromptTokensDetailsWrapper(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7462,6 +7462,12 @@ def stream_chunk_builder(  # noqa: PLR0915
             )
             setattr(response, "usage", usage)
 
+            _provider_response_cost = getattr(usage, "cost", None)
+            if _provider_response_cost is not None:
+                response._hidden_params.setdefault("additional_headers", {})[
+                    "llm_provider-x-litellm-response-cost"
+                ] = _provider_response_cost
+
             # Propagate provider_specific_fields from chunk hidden params when present.
             for chunk in reversed(chunks):
                 if isinstance(chunk, dict):
@@ -7639,6 +7645,12 @@ def stream_chunk_builder(  # noqa: PLR0915
         )
 
         setattr(response, "usage", usage)
+
+        _provider_response_cost = getattr(usage, "cost", None)
+        if _provider_response_cost is not None:
+            response._hidden_params.setdefault("additional_headers", {})[
+                "llm_provider-x-litellm-response-cost"
+            ] = _provider_response_cost
 
         # Propagate provider_specific_fields from the last chunk (contains provider
         # metadata like traffic_type set during streaming)

--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -14,3 +14,4 @@ class UsagePerChunk(TypedDict):
     web_search_requests: Optional[int]
     completion_tokens_details: Optional[CompletionTokensDetails]
     prompt_tokens_details: Optional[PromptTokensDetailsWrapper]
+    cost: Optional[float]

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -528,6 +528,61 @@ def test_openrouter_cost_tracking_streaming():
     assert result2.usage.cost == 0.0001
 
 
+def test_openrouter_streaming_cost_propagated_to_final_response():
+    """
+    OpenRouter streams `usage.cost` in the final chunk. After
+    stream_chunk_builder rebuilds the response, the cost must land on
+    `_hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"]`
+    so response_cost_calculator picks it up (mirrors the non-streaming path).
+    """
+    from litellm.main import stream_chunk_builder
+
+    handler = OpenRouterChatCompletionStreamingHandler(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk1 = {
+        "id": "gen-stream-789",
+        "created": 1234567890,
+        "model": "openrouter/anthropic/claude-sonnet-4.5",
+        "choices": [{"delta": {"content": "Hi", "reasoning": None}, "index": 0}],
+    }
+    chunk2 = {
+        "id": "gen-stream-789",
+        "created": 1234567890,
+        "model": "openrouter/anthropic/claude-sonnet-4.5",
+        "usage": {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10,
+            "cost": 0.00042,
+        },
+        "choices": [
+            {
+                "delta": {"content": "", "reasoning": None},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+    }
+
+    parsed_chunks = [handler.chunk_parser(chunk1), handler.chunk_parser(chunk2)]
+
+    final_response = stream_chunk_builder(
+        chunks=parsed_chunks,
+        messages=[{"role": "user", "content": "Hi"}],
+    )
+
+    assert final_response is not None
+    assert final_response.usage.cost == 0.00042
+    assert (
+        final_response._hidden_params["additional_headers"][
+            "llm_provider-x-litellm-response-cost"
+        ]
+        == 0.00042
+    )
+
+
 def test_openrouter_reasoning_models_allow_reasoning_effort_param():
     """
     OpenRouter reasoning-capable models should accept the reasoning_effort param.


### PR DESCRIPTION
## Relevant issues
Closes #16021 

## Pre-Submission checklist
- [x] I have added testing in the tests/litellm/ directory
- [x] My PR passes all unit tests on make test-unit  
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type
🐛 Bug Fix
✅ Test

## Root Cause
OpenRouter (and similar providers) emit usage.cost in the final streaming
chunk. chunk_parser correctly preserved it on each ModelResponseStream, but
_calculate_usage_per_chunk never extracted or accumulated it, so the cost
was silently dropped during stream reassembly.

## Changes
1. `UsagePerChunk` — add `cost: Optional[float]` field
2. `_calculate_usage_per_chunk` — extract cost from usage chunks
   (handles both Usage objects via getattr and plain dicts via
   isinstance fallback, preserving cost=0.0)
3. `calculate_usage` — set returned_usage.cost when cost is present
4. `stream_chunk_builder` — bridge usage.cost into
   _hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"]
   so response_cost_calculator picks it up (mirrors the non-streaming path)

## Testing
Added test_openrouter_streaming_cost_propagated_to_final_response to
the existing test file. Verifies end-to-end: chunk1 (content) + chunk2
(usage with cost=0.00042) → stream_chunk_builder → final response has
both usage.cost and _hidden_params cost set correctly.

## Notes
This PR was developed with AI assistance (Cursor).