### PR TITLE
fix: apply cache_read_input_token_cost in custom pricing path

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -175,13 +175,25 @@ def _cost_per_token_custom_pricing_helper(
     ### CUSTOM PRICING ###
     custom_cost_per_token: Optional[CostPerToken] = None,
     custom_cost_per_second: Optional[float] = None,
+    ### USAGE OBJECT ###
+    usage_object: Optional[Usage] = None,
 ) -> Optional[Tuple[float, float]]:
     """Internal helper function for calculating cost, if custom pricing given"""
     if custom_cost_per_token is None and custom_cost_per_second is None:
         return None
 
     if custom_cost_per_token is not None:
-        input_cost = custom_cost_per_token["input_cost_per_token"] * prompt_tokens
+        cache_read_cost = custom_cost_per_token.get("cache_read_input_token_cost")  # type: ignore
+        if cache_read_cost is not None and usage_object is not None:
+            details = _parse_prompt_tokens_details(usage_object)
+            cached_tokens = details["cache_hit_tokens"]
+            non_cached_tokens = prompt_tokens - cached_tokens
+            input_cost = (
+                custom_cost_per_token["input_cost_per_token"] * non_cached_tokens
+                + cache_read_cost * cached_tokens
+            )
+        else:
+            input_cost = custom_cost_per_token["input_cost_per_token"] * prompt_tokens
         output_cost = custom_cost_per_token["output_cost_per_token"] * completion_tokens
         return input_cost, output_cost
     elif custom_cost_per_second is not None:
@@ -328,6 +340,7 @@ def cost_per_token(  # noqa: PLR0915
         response_time_ms=response_time_ms,
         custom_cost_per_second=custom_cost_per_second,
         custom_cost_per_token=custom_cost_per_token,
+        usage_object=usage_block,
     )
 
     if response_cost is not None:

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1997,3 +1997,60 @@ def test_additional_costs_only_for_azure_ai():
         completion_tokens=50,
     )
     assert result is None, "Vertex AI should have no additional costs"
+
+
+def test_custom_pricing_applies_cache_read_token_cost():
+    """
+    Cached prompt tokens must be billed at cache_read_input_token_cost,
+    not at the regular input_cost_per_token, when custom pricing is provided.
+    Regression test for https://github.com/BerriAI/litellm/issues/26807
+    """
+    prompt_tokens = 6074
+    completion_tokens = 285
+    cached_tokens = 3456
+
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=cached_tokens,
+            audio_tokens=0,
+        ),
+    )
+
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    input_cost_per_token = 0.0000025
+    output_cost_per_token = 0.000015
+    cache_read_input_token_cost = 0.00000025
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": input_cost_per_token,
+            "output_cost_per_token": output_cost_per_token,
+            "cache_read_input_token_cost": cache_read_input_token_cost,
+        },
+    )
+
+    non_cached_tokens = prompt_tokens - cached_tokens
+    expected_cost = (
+        non_cached_tokens * input_cost_per_token
+        + cached_tokens * cache_read_input_token_cost
+        + completion_tokens * output_cost_per_token
+    )
+
+    assert pytest.approx(cost, rel=1e-6) == expected_cost, (
+        f"Expected {expected_cost} but got {cost}. "
+        "Cached tokens should be billed at cache_read_input_token_cost."
+    )


### PR DESCRIPTION
## Summary

- In `_cost_per_token_custom_pricing_helper`, cached prompt tokens were billed at `input_cost_per_token` even when `cache_read_input_token_cost` was supplied in `custom_cost_per_token`
- The custom-pricing early-return path bypassed the cache-aware cost logic that the model-cost-map path uses
- Fix: pass the `usage_block` into the helper and, when `cache_read_input_token_cost` is present, apply it to cached tokens while charging only non-cached tokens at `input_cost_per_token`

## Test plan

- [ ] New test `test_custom_pricing_applies_cache_read_token_cost` in `tests/test_litellm/test_cost_calculator.py` verifies the exact numbers from the issue report
- [ ] All 37 existing `test_cost_calculator.py` tests still pass

Fixes #26807