### PR TITLE
fix(mcp): add timeout to _descovery_metadata to prevent startup hang

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1506,7 +1506,10 @@ class MCPServerManager:
         """Discover OAuth metadata by following RFC 9728 (protected resource metadata discovery)."""
 
         try:
-            client = get_async_httpx_client(llm_provider=httpxSpecialProvider.MCP)
+            client = get_async_httpx_client(
+                llm_provider=httpxSpecialProvider.MCP,
+                params={"timeout": MCP_METADATA_TIMEOUT},
+            )
             response = await client.get(server_url)
             response.raise_for_status()
             (

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -3,7 +3,6 @@ import os
 import sys
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from contextlib import asynccontextmanager
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -15,7 +14,8 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPTransport,
 )
 from litellm.proxy._types import LiteLLM_ObjectPermissionTable
-from mcp.types import Tool as MCPTool, CallToolResult, ListToolsResult
+from litellm.types.mcp_server.mcp_server_manager import MCPOAuthMetadata
+from mcp.types import Tool as MCPTool, CallToolResult
 from mcp.types import TextContent
 
 
@@ -395,7 +395,6 @@ async def test_mcp_http_transport_tool_not_found():
 @pytest.mark.asyncio
 async def test_streamable_http_mcp_handler_mock():
     """Test the streamable HTTP MCP handler functionality"""
-    from litellm.proxy._types import UserAPIKeyAuth
 
     # Mock the session manager and its methods
     mock_session_manager = AsyncMock()
@@ -661,9 +660,7 @@ async def test_list_tools_rest_api_server_not_found():
     """Test the list_tools REST API when server is not found"""
     from litellm.proxy._experimental.mcp_server.rest_endpoints import (
         list_tool_rest_api,
-        global_mcp_server_manager,
     )
-    from fastapi import Query
     from litellm.proxy._types import UserAPIKeyAuth
 
     # Mock UserAPIKeyAuth with explicit permission to access the requested server id
@@ -719,7 +716,6 @@ async def test_list_tools_rest_api_success():
     from litellm.proxy._experimental.mcp_server.server import (
         ListMCPToolsRestAPIResponseObject,
     )
-    from fastapi import Query
     from litellm.proxy._types import UserAPIKeyAuth
 
     # Mock successful tools
@@ -1067,7 +1063,6 @@ async def test_mcp_server_manager_access_groups_from_config():
     mcp_server_manager_mod.global_mcp_server_manager = test_manager
     try:
         # Should find config_server for group-a, both for group-b, other_server for group-c
-        import asyncio
 
         server_ids_a = await MCPRequestHandler._get_mcp_servers_from_access_groups(
             ["group-a"]
@@ -2837,3 +2832,140 @@ async def test_call_mcp_tool_resolves_unprefixed_tool_name_and_checks_permission
     assert mock_get_server.call_args_list[0][0][0] == "gmail_send_email"
     # Permissions check should be invoked with the resolved server name
     mock_is_allowed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_discovery_metadata_timeout():
+    """Test that _descovery_metadata passes timeout to httpx client."""
+    from unittest.mock import AsyncMock, patch
+    from litellm.constants import MCP_METADATA_TIMEOUT
+
+    manager = MCPServerManager()
+
+    # Mock httpx client
+    mock_client = AsyncMock()
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+        return_value=mock_client,
+    ) as mock_get_client:
+        with patch.object(
+            manager, "_attempt_well_known_discovery", return_value=([], None)
+        ):
+            with patch.object(
+                manager, "_fetch_authorization_server_metadata", return_value=None
+            ):
+                await manager._descovery_metadata("https://example.com")
+
+                # Verify timeout was passed
+                mock_get_client.assert_called_once_with(
+                    llm_provider="mcp", params={"timeout": MCP_METADATA_TIMEOUT}
+                )
+                mock_client.get.assert_called_once_with("https://example.com")
+
+
+@pytest.mark.asyncio
+async def test_discovery_metadata_success():
+    """Test successful OAuth metadata discovery."""
+    from unittest.mock import AsyncMock, patch
+
+    manager = MCPServerManager()
+
+    # Mock httpx client
+    mock_client = AsyncMock()
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    expected_metadata = MCPOAuthMetadata(scopes=["read", "write"])
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        with patch.object(
+            manager,
+            "_attempt_well_known_discovery",
+            return_value=(["https://auth.example.com"], ["read"]),
+        ):
+            with patch.object(
+                manager,
+                "_fetch_authorization_server_metadata",
+                return_value=expected_metadata,
+            ):
+                result = await manager._descovery_metadata("https://example.com")
+
+                assert result == expected_metadata
+
+
+@pytest.mark.asyncio
+async def test_discovery_metadata_http_error():
+    """Test handling of HTTP status errors during discovery."""
+    from unittest.mock import AsyncMock, patch
+    from httpx import HTTPStatusError
+
+    manager = MCPServerManager()
+
+    # Mock HTTPStatusError
+    mock_response = AsyncMock()
+    mock_response.status_code = 401
+    mock_response.headers = {
+        "WWW-Authenticate": 'Bearer realm="example" scope="read write"'
+    }
+    http_error = HTTPStatusError(
+        "Unauthorized", request=AsyncMock(), response=mock_response
+    )
+
+    # Mock httpx client to raise HTTPStatusError
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=http_error)
+
+    expected_metadata = MCPOAuthMetadata(scopes=["read", "write"])
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        with patch.object(
+            manager,
+            "_parse_www_authenticate_header",
+            return_value=(None, ["read", "write"]),
+        ):
+            with patch.object(
+                manager,
+                "_attempt_well_known_discovery",
+                return_value=(["https://auth.example.com"], None),
+            ):
+                with patch.object(
+                    manager,
+                    "_fetch_authorization_server_metadata",
+                    return_value=expected_metadata,
+                ):
+                    result = await manager._descovery_metadata("https://example.com")
+
+                    assert result == expected_metadata
+
+
+@pytest.mark.asyncio
+async def test_discovery_metadata_general_exception():
+    """Test handling of general exceptions during discovery."""
+    from unittest.mock import AsyncMock, patch
+
+    manager = MCPServerManager()
+
+    # Mock httpx client to raise general exception
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=Exception("Network error"))
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        result = await manager._descovery_metadata("https://example.com")
+
+        assert result is None


### PR DESCRIPTION
The _descovery_metadata method in mcp_server_manager.py creates an async httpx client without passing the MCP_METADATA_TIMEOUT, causing the OAuth metadata discovery request to use the much longer COMPLETION_HTTP_FALLBACK default (600s) instead. In some environments (Python 3.13 + uvloop + macOS) this manifests as an indefinite hang of the proxy startup ('Loading MCP Servers from config-----' never returns).

This is inconsistent with the two other places in the same file that already pass the correct timeout:
  - _fetch_oauth_metadata_from_resource          (line ~1607)
  - _fetch_single_authorization_server_metadata  (line ~1703)

The fix is to apply the same timeout convention here.

Related issues:
  - #20715 (asyncio.wait_for + anyio TaskGroup conflict, partially fixed)
  - #22928 (TaskGroup race in MCP discovery, still open)
  - #23221 (OAuth 3LO discovery falls back to 2LO incorrectly, still open)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
