### PR TITLE
[Feature] image cost: token-based fallback when (quality, size) lookup misses

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1925,17 +1925,14 @@ def _image_cost_from_token_usage(
     image_in = _detail("prompt_tokens_details", "image_tokens")
     image_out = _detail("completion_tokens_details", "image_tokens")
 
-    if image_in > 0 and cost_info.get("cache_read_input_image_token_cost") is not None:
-        text_in_uncached = text_in
-        cache_rate_key = "cache_read_input_image_token_cost"
-    else:
-        text_in_uncached = max(text_in - cached_in, 0)
-        cache_rate_key = "cache_read_input_token_cost"
+    text_cached = min(text_in, cached_in)
+    image_cached = cached_in - text_cached
 
     rates: List[Tuple[str, int]] = [
-        ("input_cost_per_token", text_in_uncached),
-        (cache_rate_key, cached_in),
-        ("input_cost_per_image_token", image_in),
+        ("input_cost_per_token", text_in - text_cached),
+        ("cache_read_input_token_cost", text_cached),
+        ("input_cost_per_image_token", image_in - image_cached),
+        ("cache_read_input_image_token_cost", image_cached),
         ("output_cost_per_image_token", image_out),
     ]
     if not any(cost_info.get(key) is not None for key, _ in rates):

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1900,6 +1900,41 @@ def transcription_cost(
     )
 
 
+def _image_cost_from_token_usage(
+    cost_info: dict, image_response: ImageResponse
+) -> Optional[float]:
+    """Token-based image cost from ``cost_info`` + ``image_response.usage``.
+
+    Returns ``None`` when no token-cost keys match any non-zero token count.
+    """
+    usage = getattr(image_response, "usage", None)
+    if usage is None:
+        return None
+
+    def _detail(parent: str, key: str) -> int:
+        details = getattr(usage, parent, None)
+        if details is None:
+            return 0
+        if isinstance(details, dict):
+            return int(details.get(key) or 0)
+        return int(getattr(details, key, 0) or 0)
+
+    text_in = _detail("prompt_tokens_details", "text_tokens")
+    cached_in = _detail("prompt_tokens_details", "cached_tokens")
+    image_in = _detail("prompt_tokens_details", "image_tokens")
+    image_out = _detail("completion_tokens_details", "image_tokens")
+    text_in_uncached = max(text_in - cached_in, 0)
+
+    rates: List[Tuple[str, int]] = [
+        ("input_cost_per_token", text_in_uncached),
+        ("cache_read_input_token_cost", cached_in),
+        ("input_cost_per_image_token", image_in),
+        ("output_cost_per_image_token", image_out),
+    ]
+    cost = sum((cost_info.get(key) or 0) * tokens for key, tokens in rates)
+    return cost if cost > 0 else None
+
+
 def default_image_cost_calculator(
     model: str,
     custom_llm_provider: Optional[str] = None,
@@ -1907,13 +1942,15 @@ def default_image_cost_calculator(
     n: Optional[int] = 1,  # Default to 1 image
     size: Optional[str] = "1024-x-1024",  # OpenAI default
     optional_params: Optional[dict] = None,
+    image_response: Optional[ImageResponse] = None,
 ) -> float:
     """
     Default image cost calculator for image generation
 
     Args:
         model (str): Model name
-        image_response (ImageResponse): Response from image generation
+        image_response (Optional[ImageResponse]): When provided, used as a
+            token-based fallback if the (quality, size) lookup misses.
         quality (Optional[str]): Image quality setting
         n (Optional[int]): Number of images generated
         size (Optional[str]): Image size (e.g. "1024x1024" or "1024-x-1024")
@@ -1978,27 +2015,36 @@ def default_image_cost_calculator(
         if _model is not None and _model in litellm.model_cost:
             cost_info = litellm.model_cost[_model]
             break
+
+    # Priority 1: Use per-image pricing if available (for gpt-image-1 and similar models)
+    if cost_info is not None and cost_info.get("input_cost_per_image") is not None:
+        return cost_info["input_cost_per_image"] * n
+    # Priority 2: Fall back to per-pixel pricing for backward compatibility
+    if cost_info is not None and cost_info.get("input_cost_per_pixel") is not None:
+        return cost_info["input_cost_per_pixel"] * height * width * n
+
+    # Priority 3: token-based fallback (e.g. gpt-image-2 with non-standard
+    # sizes where the (quality, size) chain cannot match).
+    if image_response is not None:
+        fallback_entries = [cost_info] if cost_info is not None else []
+        for fallback_key in (model.split("/")[-1] if "/" in model else None, model):
+            if fallback_key is None:
+                continue
+            entry = litellm.model_cost.get(fallback_key)
+            if entry is not None and entry is not cost_info:
+                fallback_entries.append(entry)
+        for entry in fallback_entries:
+            cost = _image_cost_from_token_usage(entry, image_response)
+            if cost is not None:
+                return cost
+
     if cost_info is None:
         raise Exception(
             f"Model not found in cost map. Tried checking {models_to_check}"
         )
-
-    # Priority 1: Use per-image pricing if available (for gpt-image-1 and similar models)
-    if (
-        "input_cost_per_image" in cost_info
-        and cost_info["input_cost_per_image"] is not None
-    ):
-        return cost_info["input_cost_per_image"] * n
-    # Priority 2: Fall back to per-pixel pricing for backward compatibility
-    elif (
-        "input_cost_per_pixel" in cost_info
-        and cost_info["input_cost_per_pixel"] is not None
-    ):
-        return cost_info["input_cost_per_pixel"] * height * width * n
-    else:
-        raise Exception(
-            f"No pricing information found for model {model}. Tried checking {models_to_check}"
-        )
+    raise Exception(
+        f"No pricing information found for model {model}. Tried checking {models_to_check}"
+    )
 
 
 def default_video_cost_calculator(

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1905,7 +1905,8 @@ def _image_cost_from_token_usage(
 ) -> Optional[float]:
     """Token-based image cost from ``cost_info`` + ``image_response.usage``.
 
-    Returns ``None`` when no token-cost keys match any non-zero token count.
+    Returns ``None`` only when ``cost_info`` declares no recognised per-token
+    rate keys; zero-cost models that explicitly declare zero rates return ``0.0``.
     """
     usage = getattr(image_response, "usage", None)
     if usage is None:
@@ -1923,16 +1924,23 @@ def _image_cost_from_token_usage(
     cached_in = _detail("prompt_tokens_details", "cached_tokens")
     image_in = _detail("prompt_tokens_details", "image_tokens")
     image_out = _detail("completion_tokens_details", "image_tokens")
-    text_in_uncached = max(text_in - cached_in, 0)
+
+    if image_in > 0 and cost_info.get("cache_read_input_image_token_cost") is not None:
+        text_in_uncached = text_in
+        cache_rate_key = "cache_read_input_image_token_cost"
+    else:
+        text_in_uncached = max(text_in - cached_in, 0)
+        cache_rate_key = "cache_read_input_token_cost"
 
     rates: List[Tuple[str, int]] = [
         ("input_cost_per_token", text_in_uncached),
-        ("cache_read_input_token_cost", cached_in),
+        (cache_rate_key, cached_in),
         ("input_cost_per_image_token", image_in),
         ("output_cost_per_image_token", image_out),
     ]
-    cost = sum((cost_info.get(key) or 0) * tokens for key, tokens in rates)
-    return cost if cost > 0 else None
+    if not any(cost_info.get(key) is not None for key, _ in rates):
+        return None
+    return sum((cost_info.get(key) or 0) * tokens for key, tokens in rates)
 
 
 def default_image_cost_calculator(

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1002,6 +1002,7 @@ class CostCalculatorUtils:
                 n=n,
                 size=size,
                 optional_params=optional_params,
+                image_response=completion_response,
             )
         elif custom_llm_provider == litellm.LlmProviders.AZURE.value:
             # gpt-image models use token-based pricing.
@@ -1024,6 +1025,7 @@ class CostCalculatorUtils:
                 n=n,
                 size=size,
                 optional_params=optional_params,
+                image_response=completion_response,
             )
         else:
             return default_image_cost_calculator(
@@ -1033,5 +1035,6 @@ class CostCalculatorUtils:
                 n=n,
                 size=size,
                 optional_params=optional_params,
+                image_response=completion_response,
             )
         return 0.0

--- a/tests/test_litellm/test_default_image_cost_calculator.py
+++ b/tests/test_litellm/test_default_image_cost_calculator.py
@@ -206,11 +206,13 @@ class TestDefaultImageCostCalculator:
         expected = 40 * 5e-6 + 160 * 1.25e-6 + 600 * 3e-5
         assert abs(cost - expected) < 1e-9
 
-    def test_token_fallback_uses_image_cache_rate_when_declared(self, monkeypatch):
-        """Image-edit responses report a single ``cached_tokens`` count;
-        when the model declares ``cache_read_input_image_token_cost`` and
-        image input tokens are present, that rate is used (and text input
-        is billed in full).
+    def test_token_fallback_splits_cached_tokens_between_text_and_image(
+        self, monkeypatch
+    ):
+        """Image-edit responses report a single ``cached_tokens`` count.
+        Charge text input first against the standard cache rate; the
+        remainder is billed at the dedicated image cache rate. Avoids
+        double-billing the text portion at the image cache rate.
         """
         monkeypatch.setitem(
             litellm.model_cost,
@@ -226,6 +228,8 @@ class TestDefaultImageCostCalculator:
             },
         )
 
+        # cached_in (300) > text_in (10) so 10 are charged at the text cache
+        # rate and the remaining 290 at the image cache rate.
         cost = default_image_cost_calculator(
             model="openai/synthetic-image-cache-model",
             custom_llm_provider="openai",
@@ -233,11 +237,11 @@ class TestDefaultImageCostCalculator:
             n=1,
             size="1280x720",
             image_response=_image_response(
-                text_in=510, image_in=1452, cached_in=300, image_out=5488
+                text_in=10, image_in=1452, cached_in=300, image_out=5488
             ),
         )
-        # text fully uncached, cached_tokens charged at image cache rate
-        expected = 510 * 5e-6 + 300 * 2e-6 + 1452 * 8e-6 + 5488 * 3e-5
+        # text uncached: 0, text cache: 10, image uncached: 1162, image cache: 290
+        expected = 0 * 5e-6 + 10 * 1.25e-6 + 1162 * 8e-6 + 290 * 2e-6 + 5488 * 3e-5
         assert abs(cost - expected) < 1e-9
 
     def test_token_fallback_returns_zero_for_free_model(self, monkeypatch):

--- a/tests/test_litellm/test_default_image_cost_calculator.py
+++ b/tests/test_litellm/test_default_image_cost_calculator.py
@@ -206,6 +206,65 @@ class TestDefaultImageCostCalculator:
         expected = 40 * 5e-6 + 160 * 1.25e-6 + 600 * 3e-5
         assert abs(cost - expected) < 1e-9
 
+    def test_token_fallback_uses_image_cache_rate_when_declared(self, monkeypatch):
+        """Image-edit responses report a single ``cached_tokens`` count;
+        when the model declares ``cache_read_input_image_token_cost`` and
+        image input tokens are present, that rate is used (and text input
+        is billed in full).
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "synthetic-image-cache-model",
+            {
+                "input_cost_per_token": 5e-6,
+                "cache_read_input_token_cost": 1.25e-6,
+                "input_cost_per_image_token": 8e-6,
+                "cache_read_input_image_token_cost": 2e-6,
+                "output_cost_per_image_token": 3e-5,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        cost = default_image_cost_calculator(
+            model="openai/synthetic-image-cache-model",
+            custom_llm_provider="openai",
+            quality="high",
+            n=1,
+            size="1280x720",
+            image_response=_image_response(
+                text_in=510, image_in=1452, cached_in=300, image_out=5488
+            ),
+        )
+        # text fully uncached, cached_tokens charged at image cache rate
+        expected = 510 * 5e-6 + 300 * 2e-6 + 1452 * 8e-6 + 5488 * 3e-5
+        assert abs(cost - expected) < 1e-9
+
+    def test_token_fallback_returns_zero_for_free_model(self, monkeypatch):
+        """A model that declares zero per-token rates is genuinely free —
+        the fallback must return ``0.0`` rather than raising.
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "synthetic-free-image-model",
+            {
+                "input_cost_per_token": 0.0,
+                "output_cost_per_image_token": 0.0,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        cost = default_image_cost_calculator(
+            model="openai/synthetic-free-image-model",
+            custom_llm_provider="openai",
+            quality="low",
+            n=1,
+            size="2048x768",
+            image_response=_image_response(text_in=25, image_out=772),
+        )
+        assert cost == 0.0
+
     def test_unmapped_model_without_image_response_raises(self):
         """Negative: cost map miss + no ``image_response`` to fall back on
         — preserve the original behaviour of raising rather than silently

--- a/tests/test_litellm/test_default_image_cost_calculator.py
+++ b/tests/test_litellm/test_default_image_cost_calculator.py
@@ -1,0 +1,248 @@
+"""
+Tests for ``litellm.cost_calculator.default_image_cost_calculator``,
+focused on the token-based fallback path used when the (quality, size)
+lookup chain cannot resolve a per-image / per-pixel entry.
+
+Motivation: newer image-gen models (e.g. ``gpt-image-2``) accept
+"thousands of valid resolutions" but only publish per-token pricing,
+so the size-aliased lookup misses on non-standard sizes.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import pytest
+
+import litellm
+from litellm.cost_calculator import default_image_cost_calculator
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    ImageObject,
+    ImageResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+@pytest.fixture(autouse=True)
+def _use_local_model_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+
+
+def _image_response(
+    text_in: int = 0,
+    image_in: int = 0,
+    image_out: int = 0,
+    cached_in: int = 0,
+) -> ImageResponse:
+    usage = Usage(
+        prompt_tokens=text_in + image_in,
+        completion_tokens=image_out,
+        total_tokens=text_in + image_in + image_out,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=text_in,
+            image_tokens=image_in,
+            cached_tokens=cached_in,
+        ),
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            text_tokens=0,
+            image_tokens=image_out,
+            reasoning_tokens=0,
+        ),
+    )
+    response = ImageResponse(
+        created=1234567890,
+        data=[ImageObject(url="http://example.com/image.jpg")],
+    )
+    response.usage = usage
+    return response
+
+
+class TestDefaultImageCostCalculator:
+    def test_per_image_entry_hits_existing_path(self):
+        """Regression: ``high/1024-x-1024/gpt-image-1`` resolves via the
+        size-aliased lookup chain and returns its ``input_cost_per_image``
+        unchanged — the new fallback must not interfere.
+        """
+        cost = default_image_cost_calculator(
+            model="openai/gpt-image-1",
+            custom_llm_provider="openai",
+            quality="high",
+            n=1,
+            size="1024x1024",
+            image_response=_image_response(text_in=10, image_out=4000),
+        )
+        expected = litellm.model_cost["high/1024-x-1024/gpt-image-1"][
+            "input_cost_per_image"
+        ]
+        assert cost == expected
+
+    def test_per_image_entry_takes_precedence_over_token_fallback(self, monkeypatch):
+        """Regression: when both a (quality, size) per-image entry and a
+        plain token-cost entry exist for the same model, the per-image
+        entry wins.
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "high/1024-x-1024/synthetic-image-model",
+            {
+                "input_cost_per_image": 0.5,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "synthetic-image-model",
+            {
+                "input_cost_per_token": 5e-6,
+                "output_cost_per_image_token": 3e-5,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        cost = default_image_cost_calculator(
+            model="openai/synthetic-image-model",
+            custom_llm_provider="openai",
+            quality="high",
+            n=1,
+            size="1024x1024",
+            image_response=_image_response(text_in=100, image_out=4000),
+        )
+        assert cost == 0.5
+
+    def test_token_fallback_for_non_standard_size(self, monkeypatch):
+        """Token-based fallback triggers when only a plain ``model`` entry
+        with token-cost keys is registered and the (quality, size) chain
+        misses.
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "synthetic-token-only-model",
+            {
+                "input_cost_per_token": 5e-6,
+                "output_cost_per_image_token": 3e-5,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        cost = default_image_cost_calculator(
+            model="openai/synthetic-token-only-model",
+            custom_llm_provider="openai",
+            quality="low",
+            n=1,
+            size="2048x768",
+            image_response=_image_response(text_in=25, image_out=772),
+        )
+        expected = 25 * 5e-6 + 772 * 3e-5
+        assert abs(cost - expected) < 1e-9
+
+    def test_token_fallback_includes_image_input_tokens(self, monkeypatch):
+        """For image-edit responses both ``image_tokens`` (input) and
+        ``image_tokens`` (output) must contribute to cost when their
+        per-token rates are registered.
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "synthetic-edit-model",
+            {
+                "input_cost_per_token": 5e-6,
+                "input_cost_per_image_token": 8e-6,
+                "output_cost_per_image_token": 3e-5,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        cost = default_image_cost_calculator(
+            model="openai/synthetic-edit-model",
+            custom_llm_provider="openai",
+            quality="medium",
+            n=1,
+            size="1280x720",
+            image_response=_image_response(text_in=510, image_in=1452, image_out=5488),
+        )
+        expected = 510 * 5e-6 + 1452 * 8e-6 + 5488 * 3e-5
+        assert abs(cost - expected) < 1e-9
+
+    def test_token_fallback_subtracts_cached_input_tokens(self, monkeypatch):
+        """Cached input tokens are billed at ``cache_read_input_token_cost``;
+        the uncached remainder uses the standard ``input_cost_per_token``
+        rate so caching is reflected in the final cost.
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "synthetic-cached-model",
+            {
+                "input_cost_per_token": 5e-6,
+                "cache_read_input_token_cost": 1.25e-6,
+                "output_cost_per_image_token": 3e-5,
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        cost = default_image_cost_calculator(
+            model="openai/synthetic-cached-model",
+            custom_llm_provider="openai",
+            quality="low",
+            n=1,
+            size="2048x768",
+            image_response=_image_response(text_in=200, cached_in=160, image_out=600),
+        )
+        # 40 uncached text + 160 cached text + 600 image_out
+        expected = 40 * 5e-6 + 160 * 1.25e-6 + 600 * 3e-5
+        assert abs(cost - expected) < 1e-9
+
+    def test_unmapped_model_without_image_response_raises(self):
+        """Negative: cost map miss + no ``image_response`` to fall back on
+        — preserve the original behaviour of raising rather than silently
+        returning 0.
+        """
+        with pytest.raises(Exception, match="Model not found in cost map"):
+            default_image_cost_calculator(
+                model="openai/totally-unmapped-image-model",
+                custom_llm_provider="openai",
+                quality="high",
+                n=1,
+                size="1024x1024",
+            )
+
+    def test_entry_without_pricing_keys_raises(self, monkeypatch):
+        """Negative: cost map entry resolves but carries no per-image,
+        per-pixel, or token cost keys — ``raise`` the original
+        ``No pricing information found`` error.
+        """
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "high/1024-x-1024/synthetic-no-pricing-model",
+            {
+                "litellm_provider": "openai",
+                "mode": "image_generation",
+            },
+        )
+
+        with pytest.raises(Exception, match="No pricing information found"):
+            default_image_cost_calculator(
+                model="openai/synthetic-no-pricing-model",
+                custom_llm_provider="openai",
+                quality="high",
+                n=1,
+                size="1024x1024",
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Relevant issues

Fixes #26876

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

I've set the gpt-image-2 token-cost entry in my local environment like below.

```json
    "gpt-image-2": {
        "cache_read_input_image_token_cost": 2e-06,
        "cache_read_input_token_cost": 1.25e-06,
        "input_cost_per_image_token": 8e-06,
        "input_cost_per_token": 5e-06,
        "litellm_provider": "openai",
        "mode": "image_generation",
        "output_cost_per_image_token": 3e-05,
        "supported_endpoints": [
            "/v1/images/generations",
            "/v1/images/edits"
        ]
    },
```


### AS-IS

<img width="766" height="1189" alt="스크린샷 2026-04-30 오후 7 15 06" src="https://github.com/user-attachments/assets/7c7792a9-79dc-4a39-8661-1f5f31271f55" />


### TO-BE

<img width="766" height="1189" alt="스크린샷 2026-04-30 오후 7 12 18" src="https://github.com/user-attachments/assets/e2dbf22d-807e-4f8a-b7a7-8ccd6d102403" />

Verified end-to-end against an internal LiteLLM proxy with the patch applied,  calling `gpt-image-2` at a non-standard size (`2048x768`).


## Type


🆕 New Feature


## Changes

Add a token-based fallback to `default_image_cost_calculator` for image-gen models that publish only per-token pricing (e.g. `gpt-image-2` accepting "thousands of valid resolutions").

- New helper `_image_cost_from_token_usage` computes cost from `usage` block + per-token rates (`input_cost_per_token`, `input_cost_per_image_token`, `output_cost_per_image_token`, `cache_read_input_token_cost`).
- `default_image_cost_calculator` accepts an optional `image_response`. When the per-image / per-pixel paths do not resolve, it falls back to the helper using the response's `usage`.
- Three call sites in `route_image_generation_cost_calculator` forward `completion_response` so the fallback has access to `usage`.
- Backward compatible: per-image / per-pixel paths unchanged, fallback only fires when the original code would have raised.

