### PR TITLE
fix(cost): apply cache pricing for custom token costs

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -172,6 +172,7 @@ _MCP_CALL_TYPE = CallTypes.call_mcp_tool.value
 def _cost_per_token_custom_pricing_helper(
     prompt_tokens: float = 0,
     completion_tokens: float = 0,
+    usage_object: Optional[Usage] = None,
     response_time_ms: Optional[float] = 0.0,
     ### CUSTOM PRICING ###
     custom_cost_per_token: Optional[CostPerToken] = None,
@@ -182,7 +183,36 @@ def _cost_per_token_custom_pricing_helper(
         return None
 
     if custom_cost_per_token is not None:
-        input_cost = custom_cost_per_token["input_cost_per_token"] * prompt_tokens
+        input_cost_per_token = custom_cost_per_token["input_cost_per_token"]
+        custom_cost_map = cast(dict[str, float], custom_cost_per_token)
+        cache_read_input_token_cost = custom_cost_map.get(
+            "cache_read_input_token_cost", input_cost_per_token
+        )
+        cache_creation_input_token_cost = custom_cost_map.get(
+            "cache_creation_input_token_cost", input_cost_per_token
+        )
+        cache_read_tokens = 0
+        cache_creation_tokens = 0
+        if usage_object is not None:
+            if usage_object.prompt_tokens_details is not None:
+                prompt_tokens_details = _parse_prompt_tokens_details(usage_object)
+                cache_read_tokens = prompt_tokens_details["cache_hit_tokens"]
+                cache_creation_tokens = prompt_tokens_details["cache_creation_tokens"]
+            cache_read_tokens = cache_read_tokens or (
+                getattr(usage_object, "cache_read_input_tokens", None) or 0
+            )
+            cache_creation_tokens = cache_creation_tokens or (
+                getattr(usage_object, "cache_creation_input_tokens", None) or 0
+            )
+
+        uncached_prompt_tokens = max(
+            0, prompt_tokens - cache_read_tokens - cache_creation_tokens
+        )
+        input_cost = (
+            uncached_prompt_tokens * input_cost_per_token
+            + cache_read_tokens * cache_read_input_token_cost
+            + cache_creation_tokens * cache_creation_input_token_cost
+        )
         output_cost = custom_cost_per_token["output_cost_per_token"] * completion_tokens
         return input_cost, output_cost
     elif custom_cost_per_second is not None:
@@ -326,6 +356,7 @@ def cost_per_token(  # noqa: PLR0915
     response_cost = _cost_per_token_custom_pricing_helper(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
+        usage_object=usage_block,
         response_time_ms=response_time_ms,
         custom_cost_per_second=custom_cost_per_second,
         custom_cost_per_token=custom_cost_per_token,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -40,7 +40,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Required, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 from litellm._uuid import uuid
 from litellm.types.llms.base import (
@@ -110,6 +110,8 @@ SupportedCacheControls = ["ttl", "s-maxage", "no-cache", "no-store"]
 class CostPerToken(TypedDict):
     input_cost_per_token: float
     output_cost_per_token: float
+    cache_creation_input_token_cost: NotRequired[float]
+    cache_read_input_token_cost: NotRequired[float]
 
 
 class ProviderField(TypedDict):
@@ -1264,7 +1266,7 @@ class Delta(SafeAttributeModel, OpenAIObject):
     reasoning_items: Optional[List[ChatCompletionReasoningItem]] = None
     provider_specific_fields: Optional[Dict[str, Any]] = Field(default=None)
 
-    def __init__(
+    def __init__(  # noqa: PLR0915
         self,
         content=None,
         role=None,

--- a/tests/test_litellm/test_custom_pricing_cache_cost.py
+++ b/tests/test_litellm/test_custom_pricing_cache_cost.py
@@ -31,7 +31,67 @@ def test_custom_cost_per_token_uses_cache_read_pricing():
             "input_cost_per_token": 0.0000025,
             "output_cost_per_token": 0.000015,
             "cache_read_input_token_cost": 0.00000025,
-        },  # type: ignore[typeddict-unknown-key]
+        },
     )
 
     assert cost == pytest.approx(0.011684)
+
+
+def test_custom_cost_per_token_uses_cache_read_usage_field():
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        cache_read_input_tokens=40,
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/custom",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="openai/custom",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.01,
+            "output_cost_per_token": 0.02,
+            "cache_read_input_token_cost": 0.001,
+        },
+    )
+
+    assert cost == pytest.approx((60 * 0.01) + (40 * 0.001) + (10 * 0.02))
+
+
+def test_custom_cost_per_token_uses_cache_creation_pricing():
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        cache_creation_input_tokens=30,
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/custom",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="openai/custom",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.01,
+            "output_cost_per_token": 0.02,
+            "cache_creation_input_token_cost": 0.015,
+        },
+    )
+
+    assert cost == pytest.approx((70 * 0.01) + (30 * 0.015) + (10 * 0.02))

--- a/tests/test_litellm/test_custom_pricing_cache_cost.py
+++ b/tests/test_litellm/test_custom_pricing_cache_cost.py
@@ -1,0 +1,37 @@
+import pytest
+
+from litellm import completion_cost
+from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
+
+
+def test_custom_cost_per_token_uses_cache_read_pricing():
+    usage = Usage(
+        prompt_tokens=6074,
+        completion_tokens=285,
+        total_tokens=6359,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=3456,
+            audio_tokens=0,
+        ),
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+            "cache_read_input_token_cost": 0.00000025,
+        },  # type: ignore[typeddict-unknown-key]
+    )
+
+    assert cost == pytest.approx(0.011684)


### PR DESCRIPTION
## What changed

Fixes #26807.

When `completion_cost()` receives `custom_cost_per_token`, the custom pricing shortcut previously billed all prompt tokens at `input_cost_per_token` and returned before cache-aware cost calculation could run. This meant cached prompt tokens were overcharged when `cache_read_input_token_cost` was provided.

This PR updates the custom token pricing path to:
- bill uncached prompt tokens at `input_cost_per_token`
- bill cached prompt tokens at `cache_read_input_token_cost` when provided
- preserve the previous behavior by falling back to `input_cost_per_token` when no cache read price is provided

## Test plan

- `python3 -m pytest tests/test_litellm/test_custom_pricing_cache_cost.py tests/test_litellm/test_cost_calculator.py -k "custom_pricing or custom_cost_per_token"`
- `ruff check litellm/cost_calculator.py tests/test_litellm/test_custom_pricing_cache_cost.py`
- `git diff --check origin/litellm_internal_staging...HEAD`
