### PR TITLE
Fix Vertex web search with function tool conflict

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -560,9 +560,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         }
         return any(key in tool for key in search_tool_keys)
 
-    def _drop_search_tools_if_mixed_with_functions(
-        self, optional_params: dict
-    ) -> None:
+    def _drop_search_tools_if_mixed_with_functions(self, optional_params: dict) -> None:
         tools = optional_params.get("tools")
         if not isinstance(tools, list) or not self._has_function_declarations_tool(
             tools
@@ -575,9 +573,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if server_side_tool_invocations:
             return
 
-        filtered_tools = [
-            tool for tool in tools if not self._is_search_tool(tool=tool)
-        ]
+        filtered_tools = [tool for tool in tools if not self._is_search_tool(tool=tool)]
         if len(filtered_tools) == len(tools):
             return
 
@@ -593,9 +589,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         optional_params = super()._add_tools_to_optional_params(
             optional_params=optional_params, tools=tools
         )
-        self._drop_search_tools_if_mixed_with_functions(
-            optional_params=optional_params
-        )
+        self._drop_search_tools_if_mixed_with_functions(optional_params=optional_params)
         return optional_params
 
     def _map_function(  # noqa: PLR0915

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -536,6 +536,68 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         return googleSearch, googleSearchRetrieval, enterpriseWebSearch, urlContext
 
+    @staticmethod
+    def _has_function_declarations_tool(tools: Optional[List[dict]]) -> bool:
+        if not tools:
+            return False
+
+        return any(
+            bool(tool.get("function_declarations") or tool.get("functionDeclarations"))
+            for tool in tools
+        )
+
+    @staticmethod
+    def _is_search_tool(tool: dict) -> bool:
+        search_tool_keys = {
+            VertexToolName.GOOGLE_SEARCH.value,
+            VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value,
+            VertexToolName.ENTERPRISE_WEB_SEARCH.value,
+            VertexToolName.URL_CONTEXT.value,
+            "google_search",
+            "google_search_retrieval",
+            "enterprise_web_search",
+            "urlContext",
+        }
+        return any(key in tool for key in search_tool_keys)
+
+    def _drop_search_tools_if_mixed_with_functions(
+        self, optional_params: dict
+    ) -> None:
+        tools = optional_params.get("tools")
+        if not isinstance(tools, list) or not self._has_function_declarations_tool(
+            tools
+        ):
+            return
+
+        server_side_tool_invocations = optional_params.get(
+            "include_server_side_tool_invocations", False
+        )
+        if server_side_tool_invocations:
+            return
+
+        filtered_tools = [
+            tool for tool in tools if not self._is_search_tool(tool=tool)
+        ]
+        if len(filtered_tools) == len(tools):
+            return
+
+        verbose_logger.warning(
+            "Vertex AI does not support mixing function declarations with "
+            "search tools in the same request. Dropping search tools and "
+            "keeping function declarations. To use search tools, send a "
+            "request without function calling tools."
+        )
+        optional_params["tools"] = filtered_tools
+
+    def _add_tools_to_optional_params(self, optional_params: dict, tools: List) -> dict:
+        optional_params = super()._add_tools_to_optional_params(
+            optional_params=optional_params, tools=tools
+        )
+        self._drop_search_tools_if_mixed_with_functions(
+            optional_params=optional_params
+        )
+        return optional_params
+
     def _map_function(  # noqa: PLR0915
         self, value: List[dict], optional_params: dict
     ) -> List[Tools]:

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -3905,6 +3905,124 @@ def test_vertex_ai_web_search_options_in_map_openai_params():
     ), "web_search_options should be removed after transformation"
 
 
+def test_vertex_ai_web_search_options_after_function_tools_drops_search():
+    """
+    web_search_options is mapped outside _map_function, so the conflict resolver
+    must also run when tools are appended to optional_params.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    v = VertexGeminiConfig()
+    optional_params = {}
+
+    function_tools = v._map_function(
+        value=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "description": "Lookup weather",
+                },
+            }
+        ],
+        optional_params=optional_params,
+    )
+    optional_params = v._add_tools_to_optional_params(
+        optional_params=optional_params, tools=function_tools
+    )
+
+    search_tool = v._map_web_search_options({})
+    optional_params = v._add_tools_to_optional_params(
+        optional_params=optional_params, tools=[search_tool]
+    )
+
+    assert len(optional_params["tools"]) == 1
+    assert "function_declarations" in optional_params["tools"][0]
+    assert optional_params["tools"][0]["function_declarations"][0]["name"] == (
+        "lookup_weather"
+    )
+
+
+def test_vertex_ai_web_search_options_before_function_tools_drops_search():
+    """
+    The same conflict can occur when web_search_options is processed before
+    function tools, depending on request parameter order.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    v = VertexGeminiConfig()
+    optional_params = {}
+
+    search_tool = v._map_web_search_options({})
+    optional_params = v._add_tools_to_optional_params(
+        optional_params=optional_params, tools=[search_tool]
+    )
+
+    function_tools = v._map_function(
+        value=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "description": "Lookup weather",
+                },
+            }
+        ],
+        optional_params=optional_params,
+    )
+    optional_params = v._add_tools_to_optional_params(
+        optional_params=optional_params, tools=function_tools
+    )
+
+    assert len(optional_params["tools"]) == 1
+    assert "function_declarations" in optional_params["tools"][0]
+    assert optional_params["tools"][0]["function_declarations"][0]["name"] == (
+        "lookup_weather"
+    )
+
+
+def test_vertex_ai_web_search_options_with_function_tools_preserved_for_server_side_invocations():
+    """
+    Gemini 3+ server-side tool invocation mode intentionally allows combining
+    function declarations with search tools.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    v = VertexGeminiConfig()
+    optional_params = {"include_server_side_tool_invocations": True}
+
+    function_tools = v._map_function(
+        value=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "description": "Lookup weather",
+                },
+            }
+        ],
+        optional_params=optional_params,
+    )
+    optional_params = v._add_tools_to_optional_params(
+        optional_params=optional_params, tools=function_tools
+    )
+
+    search_tool = v._map_web_search_options({})
+    optional_params = v._add_tools_to_optional_params(
+        optional_params=optional_params, tools=[search_tool]
+    )
+
+    tool_keys = {key for tool in optional_params["tools"] for key in tool.keys()}
+    assert "function_declarations" in tool_keys
+    assert "googleSearch" in tool_keys
+
+
 def test_vertex_ai_service_tier_in_map_openai_params():
     """Test that service_tier is correctly mapped to optional_params."""
     from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -3499,7 +3499,12 @@ def test_video_metadata_supported_for_all_gemini_models():
         }
     ]
 
-    for model in ["gemini-1.5-pro", "gemini-2.5-flash", "gemini-2.5-pro", "gemini-3-pro-preview"]:
+    for model in [
+        "gemini-1.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+        "gemini-3-pro-preview",
+    ]:
         contents = _gemini_convert_messages_with_history(messages=messages, model=model)
 
         file_part = None
@@ -3509,19 +3514,25 @@ def test_video_metadata_supported_for_all_gemini_models():
                 break
 
         assert file_part is not None, f"{model}: file part should exist"
-        assert "video_metadata" in file_part, f"{model}: video_metadata should be present"
+        assert (
+            "video_metadata" in file_part
+        ), f"{model}: video_metadata should be present"
         assert file_part["video_metadata"]["fps"] == 5, f"{model}: fps should be 5"
 
     # Per-part media_resolution is Gemini 3+ only; 2.x uses generation_config global
     for model in ["gemini-3-pro-preview"]:
         contents = _gemini_convert_messages_with_history(messages=messages, model=model)
         file_part = next(p for p in contents[0]["parts"] if "file_data" in p)
-        assert "media_resolution" in file_part, f"{model}: media_resolution should be present"
+        assert (
+            "media_resolution" in file_part
+        ), f"{model}: media_resolution should be present"
 
     for model in ["gemini-1.5-pro", "gemini-2.5-flash", "gemini-2.5-pro"]:
         contents = _gemini_convert_messages_with_history(messages=messages, model=model)
         file_part = next(p for p in contents[0]["parts"] if "file_data" in p)
-        assert "media_resolution" not in file_part, f"{model}: per-part media_resolution should not be set"
+        assert (
+            "media_resolution" not in file_part
+        ), f"{model}: per-part media_resolution should not be set"
 
 
 def test_chunk_parser_handles_prompt_feedback_block():
@@ -4272,8 +4283,9 @@ def test_vertex_ai_usage_metadata_with_document_tokens_in_prompt():
 
     # DOCUMENT tokens should be included in text_tokens: 8 (TEXT) + 774 (DOCUMENT) = 782
     assert result.prompt_tokens_details is not None
-    assert result.prompt_tokens_details.text_tokens == 782, \
-        "DOCUMENT modality tokens should be added to text_tokens (8 TEXT + 774 DOCUMENT = 782)"
+    assert (
+        result.prompt_tokens_details.text_tokens == 782
+    ), "DOCUMENT modality tokens should be added to text_tokens (8 TEXT + 774 DOCUMENT = 782)"
 
     # Verify completion token details
     assert result.completion_tokens_details is not None
@@ -4308,8 +4320,9 @@ def test_vertex_ai_usage_metadata_with_document_tokens_cached():
 
     # DOCUMENT cached tokens map to cached_text_tokens, so:
     # text_tokens = (8 TEXT + 774 DOCUMENT) - 400 cached = 382
-    assert result.prompt_tokens_details.text_tokens == 382, \
-        "text_tokens should be (8 + 774) - 400 cached = 382"
+    assert (
+        result.prompt_tokens_details.text_tokens == 382
+    ), "text_tokens should be (8 + 774) - 400 cached = 382"
     assert result.prompt_tokens_details.cached_tokens == 400
 
 


### PR DESCRIPTION
## What changed

Fixes #26882.

Vertex Gemini already drops search tools when `_map_function()` sees them alongside function declarations, but `web_search_options` is mapped separately and appended to `optional_params["tools"]` later. That allowed requests with both function tools and `web_search_options` to reach Vertex as multiple Tool objects, triggering `Multiple tools are supported only when they are all search tools`.

This adds a Vertex-specific append guard so search tools are dropped whenever function declarations are present, regardless of whether `tools` or `web_search_options` is processed first. The existing `include_server_side_tool_invocations` escape hatch is preserved for Gemini 3+ tool combination mode.

## Tests

- `uv run --extra proxy pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py -q`