### PR TITLE
Fix Responses API developer/system message merging

### DIFF
--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -272,7 +272,33 @@ def _merge_system_message_contents(contents: List[Any]) -> Union[str, List[Any]]
             continue
 
         if merged_blocks:
-            merged_blocks.append({"type": "text", "text": "\n\n"})
+            last_block = merged_blocks[-1]
+            first_block = content_blocks[0]
+            if (
+                isinstance(last_block, dict)
+                and last_block.get("type") == "text"
+                and isinstance(last_block.get("text"), str)
+                and isinstance(first_block, dict)
+                and first_block.get("type") == "text"
+                and isinstance(first_block.get("text"), str)
+            ):
+                last_block["text"] += "\n\n" + first_block["text"]
+                merged_blocks.extend(content_blocks[1:])
+                continue
+            if (
+                isinstance(last_block, dict)
+                and last_block.get("type") == "text"
+                and isinstance(last_block.get("text"), str)
+            ):
+                last_block["text"] += "\n\n"
+            elif (
+                isinstance(first_block, dict)
+                and first_block.get("type") == "text"
+                and isinstance(first_block.get("text"), str)
+            ):
+                first_block = dict(first_block)
+                first_block["text"] = "\n\n" + first_block["text"]
+                content_blocks = [first_block, *content_blocks[1:]]
         merged_blocks.extend(content_blocks)
     return merged_blocks
 

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -218,28 +218,44 @@ def map_developer_role_to_system_role(
     if not any(m["role"] == "developer" for m in messages):
         return messages
 
-    system_message: Optional[Dict[str, Any]] = None
-    system_contents: List[Any] = []
-    non_system_messages: List[AllMessageValues] = []
-    for m in messages:
-        if m["role"] in {"developer", "system"}:
-            if system_message is None:
-                system_message = dict(m)
-                system_message["role"] = "system"
-            system_contents.append(m["content"])
-        else:
-            non_system_messages.append(m)
+    new_messages: List[AllMessageValues] = []
+    leading_system_message: Optional[Dict[str, Any]] = None
+    leading_system_contents: List[Any] = []
+    idx = 0
 
+    while idx < len(messages) and messages[idx]["role"] in {"developer", "system"}:
+        m = messages[idx]
+        if leading_system_message is None:
+            leading_system_message = dict(m)
+            leading_system_message["role"] = "system"
+        leading_system_contents.append(m["content"])
         if m["role"] == "developer":
-            verbose_logger.debug(
-                "Translating developer role to system role for non-OpenAI providers."
-            )  # ensure user knows what's happening with their input.
+            _log_developer_role_translation()
+        idx += 1
 
-    if system_message is None:
-        return non_system_messages
+    if leading_system_message is not None:
+        leading_system_message["content"] = _merge_system_message_contents(
+            leading_system_contents
+        )
+        new_messages.append(cast(AllMessageValues, leading_system_message))
 
-    system_message["content"] = _merge_system_message_contents(system_contents)
-    return [cast(AllMessageValues, system_message), *non_system_messages]
+    for m in messages[idx:]:
+        if m["role"] in {"developer", "system"}:
+            if m["role"] == "developer":
+                _log_developer_role_translation()
+                new_messages.append(cast(AllMessageValues, {**m, "role": "system"}))
+            else:
+                new_messages.append(m)
+            continue
+
+        new_messages.append(m)
+    return new_messages
+
+
+def _log_developer_role_translation() -> None:
+    verbose_logger.debug(
+        "Translating developer role to system role for non-OpenAI providers."
+    )  # ensure user knows what's happening with their input.
 
 
 def _merge_system_message_contents(contents: List[Any]) -> Union[str, List[Any]]:

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -5,7 +5,7 @@ Utility functions for base LLM classes.
 import copy
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union, cast
 
 from openai.lib import _parsing, _pydantic
 from pydantic import BaseModel
@@ -215,13 +215,55 @@ def map_developer_role_to_system_role(
     """
     Translate `developer` role to `system` role for non-OpenAI providers.
     """
-    new_messages: List[AllMessageValues] = []
+    if not any(m["role"] == "developer" for m in messages):
+        return messages
+
+    system_message: Optional[Dict[str, Any]] = None
+    system_contents: List[Any] = []
+    non_system_messages: List[AllMessageValues] = []
     for m in messages:
+        if m["role"] in {"developer", "system"}:
+            if system_message is None:
+                system_message = dict(m)
+                system_message["role"] = "system"
+            system_contents.append(m["content"])
+        else:
+            non_system_messages.append(m)
+
         if m["role"] == "developer":
             verbose_logger.debug(
                 "Translating developer role to system role for non-OpenAI providers."
             )  # ensure user knows what's happening with their input.
-            new_messages.append({"role": "system", "content": m["content"]})
-        else:
-            new_messages.append(m)
-    return new_messages
+
+    if system_message is None:
+        return non_system_messages
+
+    system_message["content"] = _merge_system_message_contents(system_contents)
+    return [cast(AllMessageValues, system_message), *non_system_messages]
+
+
+def _merge_system_message_contents(contents: List[Any]) -> Union[str, List[Any]]:
+    """
+    Merge system-equivalent content into one leading system message.
+    """
+    if all(isinstance(content, str) or content is None for content in contents):
+        return "\n\n".join(content for content in contents if content)
+
+    merged_blocks: List[Any] = []
+    for content in contents:
+        content_blocks = _system_message_content_to_blocks(content)
+        if not content_blocks:
+            continue
+
+        if merged_blocks:
+            merged_blocks.append({"type": "text", "text": "\n\n"})
+        merged_blocks.extend(content_blocks)
+    return merged_blocks
+
+
+def _system_message_content_to_blocks(content: Any) -> List[Any]:
+    if content is None or content == "":
+        return []
+    if isinstance(content, list):
+        return list(content)
+    return [{"type": "text", "text": str(content)}]

--- a/tests/llm_translation/test_base_llm_base_utils.py
+++ b/tests/llm_translation/test_base_llm_base_utils.py
@@ -1,0 +1,79 @@
+from litellm.llms.base_llm.base_utils import map_developer_role_to_system_role
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+
+
+def test_map_developer_role_leaves_messages_without_developer_role_unchanged():
+    messages = [
+        {"role": "system", "content": "Follow the product policy."},
+        {"role": "user", "content": "Hello!"},
+    ]
+
+    assert map_developer_role_to_system_role(messages=messages) is messages
+
+
+def test_map_developer_role_merges_system_equivalent_messages():
+    messages = [
+        {"role": "system", "content": "Follow the product policy."},
+        {"role": "developer", "content": "Prefer concise answers."},
+        {"role": "user", "content": "Hello!"},
+        {"role": "system", "content": "Use markdown only when helpful."},
+    ]
+
+    result = map_developer_role_to_system_role(messages=messages)
+
+    assert result == [
+        {
+            "role": "system",
+            "content": (
+                "Follow the product policy.\n\n"
+                "Prefer concise answers.\n\n"
+                "Use markdown only when helpful."
+            ),
+        },
+        {"role": "user", "content": "Hello!"},
+    ]
+
+
+def test_map_developer_role_preserves_structured_system_content():
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "System rules."}]},
+        {"role": "developer", "content": "Developer rules."},
+        {"role": "user", "content": "Hello!"},
+    ]
+
+    result = map_developer_role_to_system_role(messages=messages)
+
+    assert result == [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "System rules."},
+                {"type": "text", "text": "\n\n"},
+                {"type": "text", "text": "Developer rules."},
+            ],
+        },
+        {"role": "user", "content": "Hello!"},
+    ]
+
+
+def test_responses_instructions_and_developer_input_become_single_system_message():
+    request = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+        model="anthropic/claude-sonnet-4-5",
+        input=[
+            {"role": "developer", "content": "Prefer concise answers."},
+            {"role": "user", "content": "Hello!"},
+        ],
+        responses_api_request={"instructions": "Follow the product policy."},
+    )
+
+    result = map_developer_role_to_system_role(messages=request["messages"])
+
+    assert result == [
+        {
+            "role": "system",
+            "content": "Follow the product policy.\n\nPrefer concise answers.",
+        },
+        {"role": "user", "content": "Hello!"},
+    ]

--- a/tests/test_litellm/litellm_core_utils/test_base_llm_base_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_base_llm_base_utils.py
@@ -13,12 +13,12 @@ def test_map_developer_role_leaves_messages_without_developer_role_unchanged():
     assert map_developer_role_to_system_role(messages=messages) is messages
 
 
-def test_map_developer_role_merges_system_equivalent_messages():
+def test_map_developer_role_merges_leading_system_equivalent_messages():
     messages = [
         {"role": "system", "content": "Follow the product policy."},
         {"role": "developer", "content": "Prefer concise answers."},
-        {"role": "user", "content": "Hello!"},
         {"role": "system", "content": "Use markdown only when helpful."},
+        {"role": "user", "content": "Hello!"},
     ]
 
     result = map_developer_role_to_system_role(messages=messages)
@@ -36,9 +36,11 @@ def test_map_developer_role_merges_system_equivalent_messages():
     ]
 
 
-def test_map_developer_role_preserves_structured_system_content():
+def test_map_developer_role_preserves_structured_leading_system_content():
     messages = [
+        {"role": "developer", "content": ""},
         {"role": "system", "content": [{"type": "text", "text": "System rules."}]},
+        {"role": "developer", "content": None},
         {"role": "developer", "content": "Developer rules."},
         {"role": "user", "content": "Hello!"},
     ]
@@ -55,6 +57,38 @@ def test_map_developer_role_preserves_structured_system_content():
             ],
         },
         {"role": "user", "content": "Hello!"},
+    ]
+
+
+def test_map_developer_role_converts_later_developer_messages_in_place():
+    messages = [
+        {"role": "system", "content": "Follow the product policy."},
+        {"role": "user", "content": "Hello!"},
+        {"role": "developer", "content": "Prefer concise answers."},
+        {"role": "assistant", "content": "Hi."},
+    ]
+
+    result = map_developer_role_to_system_role(messages=messages)
+
+    assert result == [
+        {"role": "system", "content": "Follow the product policy."},
+        {"role": "user", "content": "Hello!"},
+        {"role": "system", "content": "Prefer concise answers."},
+        {"role": "assistant", "content": "Hi."},
+    ]
+
+
+def test_map_developer_role_converts_later_developer_without_leading_system():
+    messages = [
+        {"role": "user", "content": "Hello!"},
+        {"role": "developer", "content": "Prefer concise answers."},
+    ]
+
+    result = map_developer_role_to_system_role(messages=messages)
+
+    assert result == [
+        {"role": "user", "content": "Hello!"},
+        {"role": "system", "content": "Prefer concise answers."},
     ]
 
 

--- a/tests/test_litellm/litellm_core_utils/test_base_llm_base_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_base_llm_base_utils.py
@@ -81,6 +81,7 @@ def test_map_developer_role_converts_later_developer_messages_in_place():
 def test_map_developer_role_converts_later_developer_without_leading_system():
     messages = [
         {"role": "user", "content": "Hello!"},
+        {"role": "system", "content": "Keep later system messages in place."},
         {"role": "developer", "content": "Prefer concise answers."},
     ]
 
@@ -88,6 +89,7 @@ def test_map_developer_role_converts_later_developer_without_leading_system():
 
     assert result == [
         {"role": "user", "content": "Hello!"},
+        {"role": "system", "content": "Keep later system messages in place."},
         {"role": "system", "content": "Prefer concise answers."},
     ]
 

--- a/tests/test_litellm/litellm_core_utils/test_base_llm_base_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_base_llm_base_utils.py
@@ -51,9 +51,28 @@ def test_map_developer_role_preserves_structured_leading_system_content():
         {
             "role": "system",
             "content": [
-                {"type": "text", "text": "System rules."},
-                {"type": "text", "text": "\n\n"},
-                {"type": "text", "text": "Developer rules."},
+                {"type": "text", "text": "System rules.\n\nDeveloper rules."},
+            ],
+        },
+        {"role": "user", "content": "Hello!"},
+    ]
+
+
+def test_map_developer_role_avoids_standalone_separator_blocks():
+    messages = [
+        {"role": "system", "content": [{"type": "image", "url": "policy.png"}]},
+        {"role": "developer", "content": "Developer rules."},
+        {"role": "user", "content": "Hello!"},
+    ]
+
+    result = map_developer_role_to_system_role(messages=messages)
+
+    assert result == [
+        {
+            "role": "system",
+            "content": [
+                {"type": "image", "url": "policy.png"},
+                {"type": "text", "text": "\n\nDeveloper rules."},
             ],
         },
         {"role": "user", "content": "Hello!"},


### PR DESCRIPTION
## Summary
- merge developer-role messages into the leading system message for non-OpenAI providers
- preserve existing behavior when no developer role is present
- cover the Responses API bridge path where instructions and developer input previously produced multiple system messages

Fixes #26879

## Tests
- uv run --extra proxy pytest tests/llm_translation/test_base_llm_base_utils.py -q
- uv run --extra proxy black --check litellm/llms/base_llm/base_utils.py tests/llm_translation/test_base_llm_base_utils.py
- uv run --extra proxy ruff check litellm/llms/base_llm/base_utils.py tests/llm_translation/test_base_llm_base_utils.py