### PR TITLE
Fix org-level MCP permission enforcement

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -8,7 +8,6 @@ from starlette.types import Scope
 from litellm._logging import verbose_logger
 from litellm.proxy._types import (
     LiteLLM_ObjectPermissionTable,
-    LiteLLM_OrganizationTable,
     LiteLLM_TeamTable,
     ProxyException,
     SpecialHeaders,
@@ -628,7 +627,12 @@ class MCPRequestHandler:
         """
         Get the organization object_permission for the authenticated key/team.
         """
-        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.auth.auth_checks import get_object_permission, get_org_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
 
         org_id = await MCPRequestHandler._get_org_id_for_user_auth(user_api_key_auth)
         verbose_logger.debug(f"MCP org permission lookup: org_id={org_id}")
@@ -636,16 +640,40 @@ class MCPRequestHandler:
         if not org_id or prisma_client is None:
             return None
 
-        org_obj: Optional[LiteLLM_OrganizationTable] = (
-            await prisma_client.db.litellm_organizationtable.find_unique(
-                where={"organization_id": org_id},
-                include={"object_permission": True},
-            )
+        org_obj = await get_org_object(
+            org_id=org_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=(
+                user_api_key_auth.parent_otel_span if user_api_key_auth else None
+            ),
+            proxy_logging_obj=proxy_logging_obj,
+            include_object_permission=True,
         )
         if not org_obj:
             return None
 
-        return org_obj.object_permission
+        if org_obj.object_permission:
+            return org_obj.object_permission
+
+        if org_obj.object_permission_id:
+            object_permission = await get_object_permission(
+                object_permission_id=org_obj.object_permission_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=(
+                    user_api_key_auth.parent_otel_span if user_api_key_auth else None
+                ),
+                proxy_logging_obj=proxy_logging_obj,
+            )
+            if object_permission is None:
+                raise Exception(
+                    "Organization object_permission could not be loaded. "
+                    f"org_id={org_id}, object_permission_id={org_obj.object_permission_id}"
+                )
+            return object_permission
+
+        return None
 
     @staticmethod
     async def get_allowed_tools_for_server(
@@ -750,7 +778,7 @@ class MCPRequestHandler:
 
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed tools for server: {str(e)}")
-            return None
+            return []
 
     @staticmethod
     async def is_tool_allowed_for_server(
@@ -872,44 +900,38 @@ class MCPRequestHandler:
 
         Returns the MCP servers from the organization's object_permission.
         """
-        try:
-            object_permissions = await MCPRequestHandler._get_org_object_permission(
-                user_api_key_auth
-            )
+        object_permissions = await MCPRequestHandler._get_org_object_permission(
+            user_api_key_auth
+        )
 
-            if object_permissions is None:
-                return []
-
-            # Permission entries may be server_ids OR names/aliases — expand to ids.
-            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-                global_mcp_server_manager,
-            )
-
-            direct_mcp_servers = global_mcp_server_manager.expand_permission_list(
-                object_permissions.mcp_servers or []
-            )
-
-            # Get MCP servers from access groups
-            access_group_servers = (
-                await MCPRequestHandler._get_mcp_servers_from_access_groups(
-                    object_permissions.mcp_access_groups or []
-                )
-            )
-
-            # Servers referenced in tool permissions should also be accessible
-            tool_perm_servers = list(
-                global_mcp_server_manager.expand_tool_permissions(
-                    object_permissions.mcp_tool_permissions
-                ).keys()
-            )
-
-            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
-            return list(set(all_servers))
-        except Exception as e:
-            verbose_logger.warning(
-                f"Failed to get allowed MCP servers for org: {str(e)}"
-            )
+        if object_permissions is None:
             return []
+
+        # Permission entries may be server_ids OR names/aliases — expand to ids.
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        direct_mcp_servers = global_mcp_server_manager.expand_permission_list(
+            object_permissions.mcp_servers or []
+        )
+
+        # Get MCP servers from access groups
+        access_group_servers = (
+            await MCPRequestHandler._get_mcp_servers_from_access_groups(
+                object_permissions.mcp_access_groups or []
+            )
+        )
+
+        # Servers referenced in tool permissions should also be accessible
+        tool_perm_servers = list(
+            global_mcp_server_manager.expand_tool_permissions(
+                object_permissions.mcp_tool_permissions
+            ).keys()
+        )
+
+        all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+        return list(set(all_servers))
 
     @staticmethod
     async def _get_allowed_mcp_servers_for_team(

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -7,6 +7,8 @@ from starlette.types import Scope
 
 from litellm._logging import verbose_logger
 from litellm.proxy._types import (
+    LiteLLM_ObjectPermissionTable,
+    LiteLLM_OrganizationTable,
     LiteLLM_TeamTable,
     ProxyException,
     SpecialHeaders,
@@ -408,10 +410,11 @@ class MCPRequestHandler:
         Get list of allowed MCP servers for the given user/key based on permissions.
 
         Permission hierarchy (all rules are intersections):
-        1. Get allowed servers from key permissions
-        2. Get allowed servers from team permissions
-        3. Get allowed servers from end_user permissions
-        4. Final result = intersection of key/team AND end_user (if end_user has permissions set)
+        1. Get allowed servers from organization permissions
+        2. Get allowed servers from key permissions
+        3. Get allowed servers from team permissions
+        4. Get allowed servers from end_user permissions
+        5. Final result = intersection of org/key/team AND end_user (if end_user has permissions set)
 
         Returns:
             List[str]: List of allowed MCP servers by server id
@@ -427,6 +430,11 @@ class MCPRequestHandler:
             )
             allowed_mcp_servers_for_team = (
                 await MCPRequestHandler._get_allowed_mcp_servers_for_team(
+                    user_api_key_auth
+                )
+            )
+            allowed_mcp_servers_for_org = (
+                await MCPRequestHandler._get_allowed_mcp_servers_for_org(
                     user_api_key_auth
                 )
             )
@@ -446,6 +454,21 @@ class MCPRequestHandler:
                     allowed_mcp_servers = allowed_mcp_servers_for_team
             else:
                 allowed_mcp_servers = allowed_mcp_servers_for_key
+
+            #########################################################
+            # Apply organization permissions if set
+            #########################################################
+            if len(allowed_mcp_servers_for_org) > 0:
+                if len(allowed_mcp_servers) > 0:
+                    # Key/team have their own MCP permissions - intersect with org
+                    allowed_mcp_servers = [
+                        _mcp_server
+                        for _mcp_server in allowed_mcp_servers
+                        if _mcp_server in allowed_mcp_servers_for_org
+                    ]
+                else:
+                    # Key/team have no MCP permissions - inherit from org
+                    allowed_mcp_servers = allowed_mcp_servers_for_org
 
             #########################################################
             # Check end_user permissions if end_user_id is set
@@ -558,6 +581,73 @@ class MCPRequestHandler:
         return team_obj.object_permission
 
     @staticmethod
+    async def _get_org_id_for_user_auth(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> Optional[str]:
+        """
+        Resolve the organization id for the current request.
+
+        Prefer the key/JWT org_id already carried on UserAPIKeyAuth. If the key
+        has no direct org_id, fall back to the authenticated team membership so
+        teams nested under an organization inherit org-level MCP permissions.
+        """
+        if not user_api_key_auth:
+            return None
+
+        if user_api_key_auth.org_id:
+            return user_api_key_auth.org_id
+
+        if not user_api_key_auth.team_id:
+            return None
+
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if prisma_client is None:
+            return None
+
+        team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
+            team_id=user_api_key_auth.team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=user_api_key_auth.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        if not team_obj:
+            return None
+        return team_obj.organization_id
+
+    @staticmethod
+    async def _get_org_object_permission(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> Optional[LiteLLM_ObjectPermissionTable]:
+        """
+        Get the organization object_permission for the authenticated key/team.
+        """
+        from litellm.proxy.proxy_server import prisma_client
+
+        org_id = await MCPRequestHandler._get_org_id_for_user_auth(user_api_key_auth)
+        verbose_logger.debug(f"MCP org permission lookup: org_id={org_id}")
+
+        if not org_id or prisma_client is None:
+            return None
+
+        org_obj: Optional[LiteLLM_OrganizationTable] = (
+            await prisma_client.db.litellm_organizationtable.find_unique(
+                where={"organization_id": org_id},
+                include={"object_permission": True},
+            )
+        )
+        if not org_obj:
+            return None
+
+        return org_obj.object_permission
+
+    @staticmethod
     async def get_allowed_tools_for_server(
         server_id: str,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
@@ -584,6 +674,9 @@ class MCPRequestHandler:
             team_obj_perm = await MCPRequestHandler._get_team_object_permission(
                 user_api_key_auth
             )
+            org_obj_perm = await MCPRequestHandler._get_org_object_permission(
+                user_api_key_auth
+            )
 
             # Extract tool permissions for this server. Dict keys may be
             # server_ids OR names/aliases; normalize to server_id-keyed form
@@ -607,6 +700,13 @@ class MCPRequestHandler:
                 if team_obj_perm
                 else None
             )
+            org_tools = (
+                global_mcp_server_manager.expand_tool_permissions(
+                    org_obj_perm.mcp_tool_permissions
+                ).get(server_id)
+                if org_obj_perm
+                else None
+            )
 
             # Apply same inheritance logic as get_allowed_mcp_servers
             if team_tools:
@@ -619,6 +719,14 @@ class MCPRequestHandler:
             else:
                 # No team restrictions → use key restrictions
                 allowed_tools = cast(List[str], key_tools)
+
+            if org_tools:
+                if allowed_tools is not None:
+                    # Key/team restrictions must stay inside org-level tool permissions
+                    allowed_tools = list(set(allowed_tools) & set(org_tools))
+                else:
+                    # No key/team tool restrictions → inherit org restrictions
+                    allowed_tools = org_tools
 
             # Intersect with agent's tool permissions if agent_id is set
             if user_api_key_auth.agent_id:
@@ -752,6 +860,54 @@ class MCPRequestHandler:
         except Exception as e:
             verbose_logger.warning(
                 f"Failed to get allowed MCP servers for key: {str(e)}"
+            )
+            return []
+
+    @staticmethod
+    async def _get_allowed_mcp_servers_for_org(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[str]:
+        """
+        Get allowed MCP servers for an organization.
+
+        Returns the MCP servers from the organization's object_permission.
+        """
+        try:
+            object_permissions = await MCPRequestHandler._get_org_object_permission(
+                user_api_key_auth
+            )
+
+            if object_permissions is None:
+                return []
+
+            # Permission entries may be server_ids OR names/aliases — expand to ids.
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                global_mcp_server_manager,
+            )
+
+            direct_mcp_servers = global_mcp_server_manager.expand_permission_list(
+                object_permissions.mcp_servers or []
+            )
+
+            # Get MCP servers from access groups
+            access_group_servers = (
+                await MCPRequestHandler._get_mcp_servers_from_access_groups(
+                    object_permissions.mcp_access_groups or []
+                )
+            )
+
+            # Servers referenced in tool permissions should also be accessible
+            tool_perm_servers = list(
+                global_mcp_server_manager.expand_tool_permissions(
+                    object_permissions.mcp_tool_permissions
+                ).keys()
+            )
+
+            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+            return list(set(all_servers))
+        except Exception as e:
+            verbose_logger.warning(
+                f"Failed to get allowed MCP servers for org: {str(e)}"
             )
             return []
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2522,6 +2522,7 @@ async def get_org_object(
     parent_otel_span: Optional[Span] = None,
     proxy_logging_obj: Optional[ProxyLogging] = None,
     include_budget_table: bool = False,
+    include_object_permission: bool = False,
 ) -> Optional[LiteLLM_OrganizationTable]:
     """
     - Check if org id in proxy Org Table
@@ -2535,6 +2536,7 @@ async def get_org_object(
         parent_otel_span: Optional OpenTelemetry span
         proxy_logging_obj: Optional proxy logging object
         include_budget_table: If True, includes litellm_budget_table in the query
+        include_object_permission: If True, includes object_permission in the query
     """
     if prisma_client is None:
         raise Exception(
@@ -2543,10 +2545,13 @@ async def get_org_object(
     if not isinstance(org_id, str):
         return None
 
-    # Use different cache key if budget table is included
+    # Use different cache keys when loading relations so a plain org cache entry
+    # does not mask permission or budget data on auth-critical paths.
     cache_key = "org_id:{}".format(org_id)
     if include_budget_table:
         cache_key = "org_id:{}:with_budget".format(org_id)
+    if include_object_permission:
+        cache_key = "{}:with_object_permission".format(cache_key)
 
     # check if in cache
     deserialized_org = await user_api_key_cache.async_get_cache(
@@ -2558,8 +2563,13 @@ async def get_org_object(
     # else, check db
     try:
         query_kwargs: Dict[str, Any] = {"where": {"organization_id": org_id}}
+        include: Dict[str, bool] = {}
         if include_budget_table:
-            query_kwargs["include"] = {"litellm_budget_table": True}
+            include["litellm_budget_table"] = True
+        if include_object_permission:
+            include["object_permission"] = True
+        if include:
+            query_kwargs["include"] = include
 
         response = await prisma_client.db.litellm_organizationtable.find_unique(
             **query_kwargs

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -1,12 +1,9 @@
 import json
 import os
 import sys
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import orjson
 import pytest
-from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 sys.path.insert(
@@ -19,7 +16,6 @@ from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
 )
 from litellm.proxy._types import SpecialHeaders, UserAPIKeyAuth
-from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 
 @pytest.mark.asyncio
@@ -414,7 +410,7 @@ class TestMCPRequestHandler:
         with patch(
             "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
             side_effect=mock_user_api_key_auth,
-        ) as mock_auth:
+        ):
             # Call the method
             (
                 auth_result,
@@ -1923,10 +1919,9 @@ async def test_get_allowed_mcp_servers_for_org_uses_object_permission():
         )
         org_row = MagicMock()
         org_row.object_permission = org_object_permission
+        org_row.object_permission_id = "org-perm-123"
         mock_prisma = MagicMock()
-        mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(
-            return_value=org_row
-        )
+        mock_cache = MagicMock()
 
         user_api_key_auth = UserAPIKeyAuth(
             api_key="test-key",
@@ -1936,6 +1931,13 @@ async def test_get_allowed_mcp_servers_for_org_uses_object_permission():
 
         with (
             patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", None),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_org_object",
+                new_callable=AsyncMock,
+                return_value=org_row,
+            ) as mock_get_org_object,
             patch.object(
                 MCPRequestHandler,
                 "_get_mcp_servers_from_access_groups",
@@ -1952,9 +1954,13 @@ async def test_get_allowed_mcp_servers_for_org_uses_object_permission():
             "org-group-server",
             "org-tool-server",
         }
-        mock_prisma.db.litellm_organizationtable.find_unique.assert_awaited_once_with(
-            where={"organization_id": "org-123"},
-            include={"object_permission": True},
+        mock_get_org_object.assert_awaited_once_with(
+            org_id="org-123",
+            prisma_client=mock_prisma,
+            user_api_key_cache=mock_cache,
+            parent_otel_span=user_api_key_auth.parent_otel_span,
+            proxy_logging_obj=None,
+            include_object_permission=True,
         )
         mock_access_groups.assert_called_once_with(["org-dev-group"])
     finally:
@@ -2091,7 +2097,7 @@ async def test_get_org_object_permission_returns_none_when_org_is_missing():
     """Missing organization rows should not create implicit MCP permissions."""
 
     mock_prisma = MagicMock()
-    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(return_value=None)
+    mock_cache = MagicMock()
 
     with (
         patch.object(
@@ -2101,16 +2107,157 @@ async def test_get_org_object_permission_returns_none_when_org_is_missing():
             return_value="org-missing",
         ),
         patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", None),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_org_object",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_get_org_object,
     ):
         result = await MCPRequestHandler._get_org_object_permission(
             UserAPIKeyAuth(api_key="test-key", user_id="test-user")
         )
 
     assert result is None
+
+    mock_get_org_object.assert_awaited_once_with(
+        org_id="org-missing",
+        prisma_client=mock_prisma,
+        user_api_key_cache=mock_cache,
+        parent_otel_span=None,
+        proxy_logging_obj=None,
+        include_object_permission=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_org_object_permission_loads_configured_permission_by_id():
+    """Configured org permission ids must resolve before org MCP access is granted."""
+
+    org_object_permission = MagicMock()
+    org_row = MagicMock()
+    org_row.object_permission = None
+    org_row.object_permission_id = "org-perm-123"
+    mock_prisma = MagicMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_org_id_for_user_auth",
+            new_callable=AsyncMock,
+            return_value="org-123",
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", None),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_org_object",
+            new_callable=AsyncMock,
+            return_value=org_row,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_object_permission",
+            new_callable=AsyncMock,
+            return_value=org_object_permission,
+        ) as mock_get_object_permission,
+    ):
+        result = await MCPRequestHandler._get_org_object_permission(
+            UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        )
+
+    assert result == org_object_permission
+    mock_get_object_permission.assert_awaited_once_with(
+        object_permission_id="org-perm-123",
+        prisma_client=mock_prisma,
+        user_api_key_cache=mock_cache,
+        parent_otel_span=None,
+        proxy_logging_obj=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_org_object_permission_raises_when_configured_permission_is_missing():
+    """A configured org permission that cannot be loaded should not fail open."""
+
+    org_row = MagicMock()
+    org_row.object_permission = None
+    org_row.object_permission_id = "org-perm-123"
+    mock_prisma = MagicMock()
+    mock_cache = MagicMock()
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_org_id_for_user_auth",
+            new_callable=AsyncMock,
+            return_value="org-123",
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", None),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_org_object",
+            new_callable=AsyncMock,
+            return_value=org_row,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_object_permission",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        with pytest.raises(Exception, match="Organization object_permission"):
+            await MCPRequestHandler._get_org_object_permission(
+                UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_org_object_includes_object_permission_with_separate_cache_key():
+    """Org lookups that load permissions should not reuse plain org cache entries."""
+
+    from litellm.proxy.auth.auth_checks import get_org_object
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.async_set_cache = AsyncMock()
+
+    org_row = MagicMock()
+    org_row.model_dump.return_value = {
+        "organization_id": "org-123",
+        "organization_alias": "Org 123",
+        "budget_id": "budget-123",
+        "spend": 0.0,
+        "metadata": {},
+        "models": [],
+        "created_by": "admin",
+        "updated_by": "admin",
+        "object_permission_id": "org-perm-123",
+        "object_permission": None,
+    }
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(
+        return_value=org_row
+    )
+
+    result = await get_org_object(
+        org_id="org-123",
+        prisma_client=mock_prisma,
+        user_api_key_cache=mock_cache,
+        include_object_permission=True,
+    )
+
+    assert result == org_row
+    mock_cache.async_get_cache.assert_awaited_once_with(
+        key="org_id:org-123:with_object_permission"
+    )
     mock_prisma.db.litellm_organizationtable.find_unique.assert_awaited_once_with(
-        where={"organization_id": "org-missing"},
+        where={"organization_id": "org-123"},
         include={"object_permission": True},
     )
+    mock_cache.async_set_cache.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2182,8 +2329,8 @@ async def test_get_allowed_mcp_servers_for_key_returns_empty_when_db_returns_non
 
 
 @pytest.mark.asyncio
-async def test_get_allowed_mcp_servers_for_org_returns_empty_on_lookup_failure():
-    """Org permission lookup failures should fail closed to no org MCP servers."""
+async def test_get_allowed_mcp_servers_for_org_propagates_lookup_failure():
+    """Org permission lookup failures must reach the top-level fail-closed guard."""
 
     with patch.object(
         MCPRequestHandler,
@@ -2191,9 +2338,45 @@ async def test_get_allowed_mcp_servers_for_org_returns_empty_on_lookup_failure()
         new_callable=AsyncMock,
         side_effect=Exception("lookup failed"),
     ):
-        result = await MCPRequestHandler._get_allowed_mcp_servers_for_org(
-            UserAPIKeyAuth(api_key="test-key", user_id="test-user", org_id="org-123")
-        )
+        with pytest.raises(Exception, match="lookup failed"):
+            await MCPRequestHandler._get_allowed_mcp_servers_for_org(
+                UserAPIKeyAuth(
+                    api_key="test-key", user_id="test-user", org_id="org-123"
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_fails_closed_on_org_lookup_failure():
+    """An org lookup error should deny MCP server access instead of dropping the org ceiling."""
+
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        org_id="org-123",
+    )
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_allowed_mcp_servers_for_key",
+            new_callable=AsyncMock,
+            return_value=["server-from-key"],
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_allowed_mcp_servers_for_team",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_allowed_mcp_servers_for_org",
+            new_callable=AsyncMock,
+            side_effect=Exception("lookup failed"),
+        ),
+    ):
+        result = await MCPRequestHandler.get_allowed_mcp_servers(user_api_key_auth)
 
     assert result == []
 
@@ -2460,6 +2643,39 @@ class TestAgentMCPPermissions:
                     )
 
         assert result == ["tool_b"]
+
+    async def test_get_allowed_tools_for_server_fails_closed_on_permission_error(self):
+        """Permission lookup errors should deny tools, not become unrestricted access."""
+
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            org_id="org-tools",
+        )
+        key_perm = MagicMock()
+        key_perm.mcp_tool_permissions = {"server_1": ["tool_a", "tool_b"]}
+
+        with patch.object(
+            MCPRequestHandler, "_get_key_object_permission", return_value=key_perm
+        ):
+            with patch.object(
+                MCPRequestHandler,
+                "_get_team_object_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                with patch.object(
+                    MCPRequestHandler,
+                    "_get_org_object_permission",
+                    new_callable=AsyncMock,
+                    side_effect=Exception("lookup failed"),
+                ):
+                    result = await MCPRequestHandler.get_allowed_tools_for_server(
+                        server_id="server_1",
+                        user_api_key_auth=user_api_key_auth,
+                    )
+
+        assert result == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -170,6 +170,78 @@ class TestMCPRequestHandler:
                 mock_key_servers.assert_called_once_with(user_api_key_auth)
                 mock_team_servers.assert_called_once_with(user_api_key_auth)
 
+    @pytest.mark.parametrize(
+        "org_servers,team_servers,key_servers,expected_servers,scenario",
+        [
+            (
+                ["org_server1", "org_server2"],
+                [],
+                [],
+                ["org_server1", "org_server2"],
+                "inherit_from_org",
+            ),
+            (
+                ["server1", "server2"],
+                ["server1", "server3"],
+                [],
+                ["server1"],
+                "team_intersects_org",
+            ),
+            (
+                ["server1", "server2"],
+                [],
+                ["server2", "server3"],
+                ["server2"],
+                "key_intersects_org",
+            ),
+            (
+                ["server1", "server2"],
+                ["server1", "server2", "server3"],
+                ["server2", "server3"],
+                ["server2"],
+                "key_team_intersection_then_org",
+            ),
+            (
+                [],
+                ["team_server"],
+                [],
+                ["team_server"],
+                "no_org_permissions_keeps_key_team_result",
+            ),
+        ],
+    )
+    async def test_get_allowed_mcp_servers_org_inheritance_logic(
+        self, org_servers, team_servers, key_servers, expected_servers, scenario
+    ):
+        """Test organization MCP permissions inherit/intersect with key/team permissions."""
+
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            team_id="test-team" if team_servers else None,
+            org_id="test-org" if org_servers else None,
+        )
+
+        with patch.object(
+            MCPRequestHandler, "_get_allowed_mcp_servers_for_key"
+        ) as mock_key_servers:
+            with patch.object(
+                MCPRequestHandler, "_get_allowed_mcp_servers_for_team"
+            ) as mock_team_servers:
+                with patch.object(
+                    MCPRequestHandler, "_get_allowed_mcp_servers_for_org"
+                ) as mock_org_servers:
+                    mock_key_servers.return_value = key_servers
+                    mock_team_servers.return_value = team_servers
+                    mock_org_servers.return_value = org_servers
+
+                    result = await MCPRequestHandler.get_allowed_mcp_servers(
+                        user_api_key_auth
+                    )
+
+                    assert sorted(result) == sorted(expected_servers)
+                    mock_org_servers.assert_called_once_with(user_api_key_auth)
+
     async def test_permission_inheritance_edge_cases(self):
         """Test edge cases in permission inheritance"""
 
@@ -1823,6 +1895,101 @@ async def test_get_allowed_mcp_servers_for_team_without_team_id_returns_empty():
 
 
 @pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_for_org_uses_object_permission():
+    """Organization object permissions should grant direct, group, and tool-scoped servers."""
+
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+    from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+    from litellm.types.mcp import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    for sid in ("org-direct-server", "org-tool-server"):
+        global_mcp_server_manager.registry[sid] = MCPServer(
+            server_id=sid,
+            name=sid,
+            server_name=sid,
+            url=f"https://{sid}.example.com",
+            transport=MCPTransport.http,
+        )
+
+    try:
+        org_object_permission = LiteLLM_ObjectPermissionTable(
+            object_permission_id="org-perm-123",
+            mcp_servers=["org-direct-server"],
+            mcp_access_groups=["org-dev-group"],
+            mcp_tool_permissions={"org-tool-server": ["tool_a"]},
+        )
+        org_row = MagicMock()
+        org_row.object_permission = org_object_permission
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(
+            return_value=org_row
+        )
+
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            org_id="org-123",
+        )
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch.object(
+                MCPRequestHandler,
+                "_get_mcp_servers_from_access_groups",
+                new_callable=AsyncMock,
+                return_value=["org-group-server"],
+            ) as mock_access_groups,
+        ):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_org(
+                user_api_key_auth
+            )
+
+        assert set(result) == {
+            "org-direct-server",
+            "org-group-server",
+            "org-tool-server",
+        }
+        mock_prisma.db.litellm_organizationtable.find_unique.assert_awaited_once_with(
+            where={"organization_id": "org-123"},
+            include={"object_permission": True},
+        )
+        mock_access_groups.assert_called_once_with(["org-dev-group"])
+    finally:
+        for sid in ("org-direct-server", "org-tool-server"):
+            global_mcp_server_manager.registry.pop(sid, None)
+
+
+@pytest.mark.asyncio
+async def test_get_org_id_for_user_auth_falls_back_to_team_organization():
+    """Keys without org_id should inherit org permissions through their team."""
+
+    mock_team_obj = MagicMock()
+    mock_team_obj.organization_id = "org-from-team"
+    mock_prisma = MagicMock()
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="team-123",
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team_obj,
+        ) as mock_get_team_object,
+    ):
+        result = await MCPRequestHandler._get_org_id_for_user_auth(user_api_key_auth)
+
+    assert result == "org-from-team"
+    mock_get_team_object.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "user_api_key_auth, prisma_client_value, scenario",
     [
@@ -2086,6 +2253,72 @@ class TestAgentMCPPermissions:
                         user_api_key_auth=user_api_key_auth,
                     )
                     assert sorted(result) == ["tool_a", "tool_b"]
+
+    async def test_get_allowed_tools_for_server_org_inheritance(self):
+        """Org-level tool permissions apply when key/team do not restrict tools."""
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            org_id="org-tools",
+        )
+        org_perm = MagicMock()
+        org_perm.mcp_tool_permissions = {"server_1": ["tool_a", "tool_c"]}
+
+        with patch.object(
+            MCPRequestHandler, "_get_key_object_permission", return_value=None
+        ):
+            with patch.object(
+                MCPRequestHandler,
+                "_get_team_object_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                with patch.object(
+                    MCPRequestHandler,
+                    "_get_org_object_permission",
+                    new_callable=AsyncMock,
+                    return_value=org_perm,
+                ):
+                    result = await MCPRequestHandler.get_allowed_tools_for_server(
+                        server_id="server_1",
+                        user_api_key_auth=user_api_key_auth,
+                    )
+
+        assert sorted(result) == ["tool_a", "tool_c"]
+
+    async def test_get_allowed_tools_for_server_org_intersection(self):
+        """Key/team tool restrictions stay inside org-level tool permissions."""
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            org_id="org-tools",
+        )
+        key_perm = MagicMock()
+        key_perm.mcp_tool_permissions = {"server_1": ["tool_a", "tool_b"]}
+        org_perm = MagicMock()
+        org_perm.mcp_tool_permissions = {"server_1": ["tool_b", "tool_c"]}
+
+        with patch.object(
+            MCPRequestHandler, "_get_key_object_permission", return_value=key_perm
+        ):
+            with patch.object(
+                MCPRequestHandler,
+                "_get_team_object_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                with patch.object(
+                    MCPRequestHandler,
+                    "_get_org_object_permission",
+                    new_callable=AsyncMock,
+                    return_value=org_perm,
+                ):
+                    result = await MCPRequestHandler.get_allowed_tools_for_server(
+                        server_id="server_1",
+                        user_api_key_auth=user_api_key_auth,
+                    )
+
+        assert result == ["tool_b"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -1991,6 +1991,130 @@ async def test_get_org_id_for_user_auth_falls_back_to_team_organization():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "user_api_key_auth,prisma_client_value,expected_org_id",
+    [
+        (None, object(), None),
+        (
+            UserAPIKeyAuth(
+                api_key="test-key", user_id="test-user", org_id="direct-org"
+            ),
+            object(),
+            "direct-org",
+        ),
+        (
+            UserAPIKeyAuth(api_key="test-key", user_id="test-user"),
+            object(),
+            None,
+        ),
+        (
+            UserAPIKeyAuth(api_key="test-key", user_id="test-user", team_id="team-123"),
+            None,
+            None,
+        ),
+    ],
+)
+async def test_get_org_id_for_user_auth_guard_conditions(
+    user_api_key_auth, prisma_client_value, expected_org_id
+):
+    """Org id resolution should exit early when no lookup is possible."""
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client_value),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new_callable=AsyncMock,
+        ) as mock_get_team_object,
+    ):
+        result = await MCPRequestHandler._get_org_id_for_user_auth(user_api_key_auth)
+
+    assert result == expected_org_id
+    mock_get_team_object.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_org_id_for_user_auth_returns_none_when_team_is_missing():
+    """Team fallback should not grant org permissions when the team cannot be loaded."""
+
+    mock_prisma = object()
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="team-missing",
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_get_team_object,
+    ):
+        result = await MCPRequestHandler._get_org_id_for_user_auth(user_api_key_auth)
+
+    assert result is None
+    mock_get_team_object.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resolved_org_id,prisma_client_value",
+    [
+        (None, object()),
+        ("org-123", None),
+    ],
+)
+async def test_get_org_object_permission_guard_conditions(
+    resolved_org_id, prisma_client_value
+):
+    """Org permission lookup should return None when org or prisma state is missing."""
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_org_id_for_user_auth",
+            new_callable=AsyncMock,
+            return_value=resolved_org_id,
+        ) as mock_get_org_id,
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client_value),
+    ):
+        result = await MCPRequestHandler._get_org_object_permission(
+            UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        )
+
+    assert result is None
+    mock_get_org_id.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_org_object_permission_returns_none_when_org_is_missing():
+    """Missing organization rows should not create implicit MCP permissions."""
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(return_value=None)
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_org_id_for_user_auth",
+            new_callable=AsyncMock,
+            return_value="org-missing",
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+    ):
+        result = await MCPRequestHandler._get_org_object_permission(
+            UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        )
+
+    assert result is None
+    mock_prisma.db.litellm_organizationtable.find_unique.assert_awaited_once_with(
+        where={"organization_id": "org-missing"},
+        include={"object_permission": True},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "user_api_key_auth, prisma_client_value, scenario",
     [
         (None, object(), "no_user"),
@@ -2055,6 +2179,23 @@ async def test_get_allowed_mcp_servers_for_key_returns_empty_when_db_returns_non
 
     assert result == []
     mock_get_perm.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_for_org_returns_empty_on_lookup_failure():
+    """Org permission lookup failures should fail closed to no org MCP servers."""
+
+    with patch.object(
+        MCPRequestHandler,
+        "_get_org_object_permission",
+        new_callable=AsyncMock,
+        side_effect=Exception("lookup failed"),
+    ):
+        result = await MCPRequestHandler._get_allowed_mcp_servers_for_org(
+            UserAPIKeyAuth(api_key="test-key", user_id="test-user", org_id="org-123")
+        )
+
+    assert result == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -2249,9 +2249,12 @@ async def test_get_org_object_includes_object_permission_with_separate_cache_key
         include_object_permission=True,
     )
 
-    assert result == org_row
+    assert result is not None
+    assert result.organization_id == "org-123"
+    assert result.object_permission_id == "org-perm-123"
     mock_cache.async_get_cache.assert_awaited_once_with(
-        key="org_id:org-123:with_object_permission"
+        key="org_id:org-123:with_object_permission",
+        model_type=type(result),
     )
     mock_prisma.db.litellm_organizationtable.find_unique.assert_awaited_once_with(
         where={"organization_id": "org-123"},

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_jwt_mcp_enforcement.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_jwt_mcp_enforcement.py
@@ -511,12 +511,19 @@ async def test_e2e_jwt_team_mcp_key_intersection(monkeypatch):
                 ) as mock_access_groups:
                     mock_access_groups.return_value = []
 
-                    allowed_servers = await MCPRequestHandler.get_allowed_mcp_servers(
-                        user_api_key_auth
-                    )
+                    with patch.object(
+                        MCPRequestHandler, "_get_allowed_mcp_servers_for_org"
+                    ) as mock_org_servers:
+                        mock_org_servers.return_value = []
 
-                    # Should be intersection: only server-2 is in both
-                    expected = ["server-2"]
-                    assert sorted(allowed_servers) == sorted(
-                        expected
-                    ), f"Expected intersection {expected}, got {allowed_servers}"
+                        allowed_servers = (
+                            await MCPRequestHandler.get_allowed_mcp_servers(
+                                user_api_key_auth
+                            )
+                        )
+
+                        # Should be intersection: only server-2 is in both
+                        expected = ["server-2"]
+                        assert sorted(allowed_servers) == sorted(
+                            expected
+                        ), f"Expected intersection {expected}, got {allowed_servers}"

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -5477,6 +5477,7 @@ async def test_update_team_guardrails_with_org_id():
         mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
             return_value=mock_existing_team
         )
+        mock_cache.async_get_cache = AsyncMock(return_value=None)
         mock_cache.async_set_cache = AsyncMock()
 
         # Mock organization fetch - this is where the bug occurred


### PR DESCRIPTION
## Summary
- enforce organization-level MCP server permissions in the runtime allowlist path
- resolve org permissions from direct key/JWT org_id or the authenticated team organization
- apply org MCP server and tool permissions as inheritance when lower levels are unset, and as intersections when key/team restrictions exist

## Why
The UI and API can configure organization-level MCP servers/tool permissions, but MCP request authorization only evaluated key, team, end-user, and agent permissions. This meant teams and keys under an organization did not inherit or get bounded by the organization MCP object permissions.

Fixes #26791.

## Validation
- `/tmp/litellm-uv-venv/bin/uv run --extra proxy pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py -q`
- `/tmp/litellm-uv-venv/bin/uv run --extra proxy black --check litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py`
- `/tmp/litellm-uv-venv/bin/uv run --extra proxy ruff check litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py`
- `git diff --cached --check`