### PR TITLE
fix: forward /v1/messages request timeout

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -188,13 +188,22 @@ class BaseLLMHTTPHandler:
             return None
         if isinstance(timeout, httpx.Timeout):
             return timeout
-        if isinstance(timeout, str):
-            if timeout.startswith("os.environ/"):
-                timeout = litellm.get_secret(timeout)  # type: ignore[assignment]
-                if timeout is None:
-                    return None
-            return float(timeout)
-        return float(timeout)
+
+        timeout_value: Any = timeout
+        if isinstance(timeout, str) and timeout.startswith("os.environ/"):
+            timeout_value = litellm.get_secret(timeout)
+            if timeout_value is None:
+                return None
+            if isinstance(timeout_value, httpx.Timeout):
+                return timeout_value
+
+        try:
+            return float(cast(Union[float, int, str], timeout_value))
+        except (TypeError, ValueError):
+            verbose_logger.warning(
+                "Invalid Anthropic /v1/messages timeout value: %s", timeout_value
+            )
+            return None
 
     @staticmethod
     def _get_anthropic_messages_timeout(

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -180,6 +180,37 @@ def _google_genai_streaming_hidden_params(
 
 
 class BaseLLMHTTPHandler:
+    @staticmethod
+    def _coerce_http_timeout(
+        timeout: Optional[Union[float, int, str, httpx.Timeout]],
+    ) -> Optional[Union[float, httpx.Timeout]]:
+        if timeout is None:
+            return None
+        if isinstance(timeout, httpx.Timeout):
+            return timeout
+        if isinstance(timeout, str):
+            if timeout.startswith("os.environ/"):
+                timeout = litellm.get_secret(timeout)  # type: ignore[assignment]
+                if timeout is None:
+                    return None
+            return float(timeout)
+        return float(timeout)
+
+    @staticmethod
+    def _get_anthropic_messages_timeout(
+        *,
+        litellm_params: GenericLiteLLMParams,
+        stream: bool,
+    ) -> Optional[Union[float, httpx.Timeout]]:
+        request_timeout = dict(litellm_params).get("request_timeout")
+        if stream and litellm_params.stream_timeout is not None:
+            return BaseLLMHTTPHandler._coerce_http_timeout(
+                litellm_params.stream_timeout
+            )
+        if litellm_params.timeout is not None:
+            return BaseLLMHTTPHandler._coerce_http_timeout(litellm_params.timeout)
+        return BaseLLMHTTPHandler._coerce_http_timeout(request_timeout)
+
     async def _make_common_async_call(
         self,
         async_httpx_client: AsyncHTTPHandler,
@@ -1865,6 +1896,10 @@ class BaseLLMHTTPHandler:
         )
         litellm_params_dict = dict(litellm_params)
         optional_params_dict = dict(litellm_params)
+        timeout = self._get_anthropic_messages_timeout(
+            litellm_params=litellm_params,
+            stream=stream,
+        )
         for attempt_idx in range(max_attempts):
             try:
                 response = await async_httpx_client.post(
@@ -1873,6 +1908,7 @@ class BaseLLMHTTPHandler:
                     data=signed_json_body or json.dumps(request_body),
                     stream=stream or False,
                     logging_obj=logging_obj,
+                    timeout=timeout,
                 )
                 response.raise_for_status()
                 return response

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -116,6 +116,7 @@ def test_fingerprint_agentic_tools_is_deterministic():
     "litellm_params,stream,expected_timeout",
     [
         (GenericLiteLLMParams(timeout=1.25), False, 1.25),
+        (GenericLiteLLMParams(timeout=1.25), True, 1.25),
         (GenericLiteLLMParams(timeout=30, stream_timeout=0.75), True, 0.75),
         (GenericLiteLLMParams(request_timeout=2.5), False, 2.5),
     ],
@@ -151,6 +152,25 @@ async def test_anthropic_messages_post_forwards_request_timeout(
     assert response == mock_response
     mock_client.post.assert_awaited_once()
     assert mock_client.post.call_args.kwargs["timeout"] == expected_timeout
+
+
+def test_coerce_http_timeout_reads_env_secret():
+    with patch("litellm.get_secret", return_value="3.5") as mock_get_secret:
+        result = BaseLLMHTTPHandler._coerce_http_timeout(
+            "os.environ/ANTHROPIC_MESSAGES_TIMEOUT"
+        )
+
+    assert result == 3.5
+    mock_get_secret.assert_called_once_with("os.environ/ANTHROPIC_MESSAGES_TIMEOUT")
+
+
+def test_coerce_http_timeout_returns_none_for_invalid_env_secret():
+    with patch("litellm.get_secret", return_value="not-a-number"):
+        result = BaseLLMHTTPHandler._coerce_http_timeout(
+            "os.environ/ANTHROPIC_MESSAGES_TIMEOUT"
+        )
+
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -112,6 +112,48 @@ def test_fingerprint_agentic_tools_is_deterministic():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "litellm_params,stream,expected_timeout",
+    [
+        (GenericLiteLLMParams(timeout=1.25), False, 1.25),
+        (GenericLiteLLMParams(timeout=30, stream_timeout=0.75), True, 0.75),
+        (GenericLiteLLMParams(request_timeout=2.5), False, 2.5),
+    ],
+)
+async def test_anthropic_messages_post_forwards_request_timeout(
+    litellm_params, stream, expected_timeout
+):
+    """Anthropic /v1/messages must honor per-request timeout settings."""
+
+    handler = BaseLLMHTTPHandler()
+    mock_client = AsyncMock()
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    mock_config = Mock()
+    mock_config.max_retry_on_anthropic_messages_http_error = 1
+
+    response = await handler._async_post_anthropic_messages_with_http_error_retry(
+        async_httpx_client=mock_client,
+        request_url="https://api.anthropic.com/v1/messages",
+        headers={"x-api-key": "test-key"},
+        signed_json_body=None,
+        request_body={"model": "claude-3-5-sonnet", "messages": []},
+        stream=stream,
+        logging_obj=Mock(),
+        provider_config=mock_config,
+        litellm_params=litellm_params,
+        api_key="test-key",
+        model="claude-3-5-sonnet",
+    )
+
+    assert response == mock_response
+    mock_client.post.assert_awaited_once()
+    assert mock_client.post.call_args.kwargs["timeout"] == expected_timeout
+
+
+@pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_extra_headers():
     """
     Test that async_anthropic_messages_handler correctly extracts and merges


### PR DESCRIPTION
## What changed
- Forward the effective Anthropic Messages request timeout into the underlying `AsyncHTTPHandler.post()` call.
- Preserve the expected precedence: `stream_timeout` for streaming requests, then `timeout`, then the `request_timeout` alias.
- Add focused tests proving `/v1/messages` no longer drops those timeout settings before the HTTP layer.

## Why
`/v1/messages` accepted client-supplied `timeout` / `stream_timeout`, but the Anthropic messages HTTP path never passed the resolved value into httpx. This meant the request silently fell back to the shared client default while `/chat/completions` timed out as expected.

Fixes #26752.

## Validation
- `/tmp/litellm-uv-venv/bin/uv run --extra proxy pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q`
- `/tmp/litellm-uv-venv/bin/uv run --extra proxy black --check litellm/llms/custom_httpx/llm_http_handler.py tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py`
- `/tmp/litellm-uv-venv/bin/uv run --extra proxy ruff check litellm/llms/custom_httpx/llm_http_handler.py tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py`
- `git diff --check -- litellm/llms/custom_httpx/llm_http_handler.py tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py`
