### PR TITLE
fix: apply cache-read pricing in custom cost path

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -172,6 +172,8 @@ _MCP_CALL_TYPE = CallTypes.call_mcp_tool.value
 def _cost_per_token_custom_pricing_helper(
     prompt_tokens: float = 0,
     completion_tokens: float = 0,
+    cache_read_input_tokens: Optional[int] = 0,
+    usage_object: Optional[Usage] = None,
     response_time_ms: Optional[float] = 0.0,
     ### CUSTOM PRICING ###
     custom_cost_per_token: Optional[CostPerToken] = None,
@@ -182,7 +184,23 @@ def _cost_per_token_custom_pricing_helper(
         return None
 
     if custom_cost_per_token is not None:
-        input_cost = custom_cost_per_token["input_cost_per_token"] * prompt_tokens
+        cache_read_input_token_cost = cast(
+            Optional[float],
+            custom_cost_per_token.get("cache_read_input_token_cost"),
+        )
+        if cache_read_input_token_cost is not None:
+            if not cache_read_input_tokens and usage_object is not None:
+                cache_read_input_tokens = _parse_prompt_tokens_details(usage_object)[
+                    "cache_hit_tokens"
+                ]
+            cache_read_tokens = max(0, cache_read_input_tokens or 0)
+            uncached_prompt_tokens = max(0, prompt_tokens - cache_read_tokens)
+            input_cost = (
+                custom_cost_per_token["input_cost_per_token"] * uncached_prompt_tokens
+                + cache_read_input_token_cost * cache_read_tokens
+            )
+        else:
+            input_cost = custom_cost_per_token["input_cost_per_token"] * prompt_tokens
         output_cost = custom_cost_per_token["output_cost_per_token"] * completion_tokens
         return input_cost, output_cost
     elif custom_cost_per_second is not None:
@@ -326,6 +344,8 @@ def cost_per_token(  # noqa: PLR0915
     response_cost = _cost_per_token_custom_pricing_helper(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+        usage_object=usage_block,
         response_time_ms=response_time_ms,
         custom_cost_per_second=custom_cost_per_second,
         custom_cost_per_token=custom_cost_per_token,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -190,9 +190,10 @@ def _cost_per_token_custom_pricing_helper(
         )
         if cache_read_input_token_cost is not None:
             if not cache_read_input_tokens and usage_object is not None:
-                cache_read_input_tokens = _parse_prompt_tokens_details(usage_object)[
-                    "cache_hit_tokens"
-                ]
+                cache_read_input_tokens = (
+                    getattr(usage_object, "cache_read_input_tokens", None)
+                    or _parse_prompt_tokens_details(usage_object)["cache_hit_tokens"]
+                )
             cache_read_tokens = max(0, cache_read_input_tokens or 0)
             uncached_prompt_tokens = max(0, prompt_tokens - cache_read_tokens)
             input_cost = (

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -81,6 +81,36 @@ def test_completion_cost_custom_pricing_uses_cache_read_rate():
     assert cost == pytest.approx(0.011684)
 
 
+def test_completion_cost_custom_pricing_uses_top_level_cache_read_tokens():
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        cache_read_input_tokens=80,
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="anthropic/claude-sonnet-4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="anthropic/claude-sonnet-4",
+        custom_llm_provider="anthropic",
+        custom_cost_per_token={
+            "input_cost_per_token": 1.0,
+            "output_cost_per_token": 2.0,
+            "cache_read_input_token_cost": 0.25,
+        },
+    )
+
+    assert cost == pytest.approx(60.0)
+
+
 def test_completion_cost_custom_pricing_without_cache_read_rate_preserves_input_rate():
     usage = Usage(
         prompt_tokens=6074,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -48,6 +48,71 @@ def test_completion_cost_uses_response_model_for_dynamic_routing():
     assert cost > 0, "Cost should be calculated using response model"
 
 
+def test_completion_cost_custom_pricing_uses_cache_read_rate():
+    usage = Usage(
+        prompt_tokens=6074,
+        completion_tokens=285,
+        total_tokens=6359,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=3456,
+            audio_tokens=0,
+        ),
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+            "cache_read_input_token_cost": 0.00000025,
+        },
+    )
+
+    assert cost == pytest.approx(0.011684)
+
+
+def test_completion_cost_custom_pricing_without_cache_read_rate_preserves_input_rate():
+    usage = Usage(
+        prompt_tokens=6074,
+        completion_tokens=285,
+        total_tokens=6359,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=3456,
+            audio_tokens=0,
+        ),
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+        },
+    )
+
+    assert cost == pytest.approx(0.01946)
+
+
 def test_cost_calculator_with_response_cost_in_additional_headers():
     class MockResponse(BaseModel):
         _hidden_params = {


### PR DESCRIPTION
## Summary
- apply `cache_read_input_token_cost` when `completion_cost` uses `custom_cost_per_token`
- preserve existing custom-pricing behavior when no cache-read rate is configured
- add regression coverage for the reproduced custom-pricing cached-token case from #26807

Fixes #26807.

## Validation
- `uv run --extra proxy pytest tests/test_litellm/test_cost_calculator.py -q` -> 40 passed
- `uv run --extra proxy black --check litellm/cost_calculator.py tests/test_litellm/test_cost_calculator.py`
- `uv run --extra proxy ruff check litellm/cost_calculator.py`
- `uv run --extra proxy mypy litellm/cost_calculator.py`
- `git diff --check -- litellm/cost_calculator.py tests/test_litellm/test_cost_calculator.py`

Note: a direct local `ruff check` on `tests/test_litellm/test_cost_calculator.py` reports pre-existing `print` statements throughout that test file; CI lint for this repo runs on the package directory, and the touched implementation file is clean.