### PR TITLE
fix: make policy pipeline test response JSON-safe

### DIFF
--- a/litellm/proxy/policy_engine/policy_endpoints.py
+++ b/litellm/proxy/policy_engine/policy_endpoints.py
@@ -4,7 +4,7 @@ CRUD ENDPOINTS FOR POLICIES
 Provides REST API endpoints for managing policies and policy attachments.
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -16,6 +16,7 @@ from litellm.proxy.policy_engine.pipeline_executor import PipelineExecutor
 from litellm.proxy.policy_engine.policy_registry import get_policy_registry
 from litellm.types.proxy.policy_engine import (
     GuardrailPipeline,
+    PipelineExecutionResult,
     PipelineTestRequest,
     PolicyAttachmentCreateRequest,
     PolicyAttachmentDBResponse,
@@ -31,6 +32,43 @@ from litellm.types.proxy.policy_engine import (
 )
 
 router = APIRouter()
+
+_PIPELINE_RESPONSE_INTERNAL_KEYS = {
+    "litellm_parent_otel_span",
+    "parent_otel_span",
+    "user_api_key_auth",
+}
+
+
+def _sanitize_pipeline_response_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _sanitize_pipeline_response_value(item)
+            for key, item in value.items()
+            if str(key) not in _PIPELINE_RESPONSE_INTERNAL_KEYS
+        }
+
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize_pipeline_response_value(item) for item in value]
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if hasattr(value, "model_dump"):
+        try:
+            return _sanitize_pipeline_response_value(
+                value.model_dump(mode="json", fallback=str)
+            )
+        except Exception:
+            pass
+
+    return str(value)
+
+
+def _dump_pipeline_result_for_response(
+    result: PipelineExecutionResult,
+) -> Dict[str, Any]:
+    return _sanitize_pipeline_response_value(result.model_dump())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -601,7 +639,7 @@ async def test_pipeline(
             call_type="completion",
             policy_name="test-pipeline",
         )
-        return result.model_dump()
+        return _dump_pipeline_result_for_response(result)
     except Exception as e:
         verbose_proxy_logger.exception(f"Error testing pipeline: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/litellm/proxy/policy_engine/policy_endpoints.py
+++ b/litellm/proxy/policy_engine/policy_endpoints.py
@@ -38,31 +38,77 @@ _PIPELINE_RESPONSE_INTERNAL_KEYS = {
     "parent_otel_span",
     "user_api_key_auth",
 }
+_JSON_SCALAR_TYPES = (str, int, float, bool)
 
 
-def _sanitize_pipeline_response_value(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {
-            str(key): _sanitize_pipeline_response_value(item)
-            for key, item in value.items()
-            if str(key) not in _PIPELINE_RESPONSE_INTERNAL_KEYS
-        }
-
-    if isinstance(value, (list, tuple, set)):
-        return [_sanitize_pipeline_response_value(item) for item in value]
-
-    if value is None or isinstance(value, (str, int, float, bool)):
+def _prepare_pipeline_response_item(value: Any) -> Any:
+    if value is None or isinstance(value, _JSON_SCALAR_TYPES):
         return value
 
     if hasattr(value, "model_dump"):
         try:
-            return _sanitize_pipeline_response_value(
-                value.model_dump(mode="json", fallback=str)
-            )
+            return value.model_dump(mode="json", fallback=str)
         except Exception:
-            pass
+            return str(value)
 
-    return str(value)
+    return value
+
+
+def _store_pipeline_response_item(
+    target: Any,
+    key: Optional[str],
+    item: Any,
+    stack: list[tuple[Any, Any]],
+) -> None:
+    item = _prepare_pipeline_response_item(item)
+
+    if isinstance(item, dict):
+        child: Any = {}
+        stack.append((item, child))
+    elif isinstance(item, (list, tuple, set)):
+        child = []
+        stack.append((item, child))
+    elif item is None or isinstance(item, _JSON_SCALAR_TYPES):
+        child = item
+    else:
+        child = str(item)
+
+    if key is None:
+        target.append(child)
+    else:
+        target[key] = child
+
+
+def _sanitize_pipeline_response_value(value: Any) -> Any:
+    value = _prepare_pipeline_response_item(value)
+
+    if value is None or isinstance(value, _JSON_SCALAR_TYPES):
+        return value
+
+    if isinstance(value, dict):
+        root: Any = {}
+    elif isinstance(value, (list, tuple, set)):
+        root = []
+    else:
+        return str(value)
+
+    stack: list[tuple[Any, Any]] = [(value, root)]
+
+    while stack:
+        source, target = stack.pop()
+
+        if isinstance(source, dict):
+            for key, raw_item in source.items():
+                key_str = str(key)
+                if key_str in _PIPELINE_RESPONSE_INTERNAL_KEYS:
+                    continue
+
+                _store_pipeline_response_item(target, key_str, raw_item, stack)
+        else:
+            for raw_item in source:
+                _store_pipeline_response_item(target, None, raw_item, stack)
+
+    return root
 
 
 def _dump_pipeline_result_for_response(

--- a/tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from litellm.proxy.policy_engine.policy_endpoints import (
+    _dump_pipeline_result_for_response,
+)
+from litellm.types.proxy.policy_engine import (
+    PipelineExecutionResult,
+    PipelineStepResult,
+)
+
+
+class OpaqueSpan:
+    __slots__ = ()
+
+    def __str__(self) -> str:
+        return "opaque-span"
+
+
+def test_pipeline_test_response_removes_internal_non_json_values():
+    opaque_span = OpaqueSpan()
+    result = PipelineExecutionResult(
+        terminal_action="allow",
+        step_results=[
+            PipelineStepResult(
+                guardrail_name="pii",
+                outcome="pass",
+                action_taken="allow",
+                modified_data={
+                    "metadata": {
+                        "parent_otel_span": opaque_span,
+                        "litellm_parent_otel_span": opaque_span,
+                        "safe": "kept",
+                    },
+                    "non_internal_object": opaque_span,
+                },
+            )
+        ],
+        modified_data={
+            "metadata": {
+                "parent_otel_span": opaque_span,
+                "safe": "kept",
+            },
+        },
+    )
+
+    with pytest.raises(ValueError):
+        jsonable_encoder(result.model_dump())
+
+    dumped = _dump_pipeline_result_for_response(result)
+
+    json.dumps(dumped)
+    assert dumped["modified_data"]["metadata"] == {"safe": "kept"}
+    assert dumped["step_results"][0]["modified_data"]["metadata"] == {"safe": "kept"}
+    assert (
+        dumped["step_results"][0]["modified_data"]["non_internal_object"]
+        == "opaque-span"
+    )

--- a/tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel
 
 from litellm.proxy.policy_engine.policy_endpoints import (
     _dump_pipeline_result_for_response,
@@ -17,6 +18,10 @@ class OpaqueSpan:
 
     def __str__(self) -> str:
         return "opaque-span"
+
+
+class NestedPolicyPayload(BaseModel):
+    value: str
 
 
 def test_pipeline_test_response_removes_internal_non_json_values():
@@ -58,3 +63,16 @@ def test_pipeline_test_response_removes_internal_non_json_values():
         dumped["step_results"][0]["modified_data"]["non_internal_object"]
         == "opaque-span"
     )
+
+
+def test_pipeline_test_response_preserves_nested_pydantic_models():
+    result = PipelineExecutionResult(
+        terminal_action="allow",
+        step_results=[],
+        modified_data={"nested": NestedPolicyPayload(value="kept")},
+    )
+
+    dumped = _dump_pipeline_result_for_response(result)
+
+    json.dumps(dumped)
+    assert dumped["modified_data"]["nested"] == {"value": "kept"}


### PR DESCRIPTION
## What

Fixes #26877 by making the /policies/test-pipeline response JSON-safe after the pipeline executor completes. The endpoint now recursively removes internal tracing/auth objects such as parent_otel_span, litellm_parent_otel_span, and user_api_key_auth from returned pipeline data, while preserving normal JSON values and stringifying any remaining opaque objects instead of letting FastAPI fail during response serialization.

## Why

The pipeline can pass successfully but still return HTTP 500 if a guardrail-modified payload contains OpenTelemetry internals. The previous result.model_dump() used Python-mode values, which lets those objects leak into FastAPI jsonable_encoder.

## Tests

- uv run --extra proxy pytest tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py -q
- uv run --extra proxy black --check litellm/proxy/policy_engine/policy_endpoints.py tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
- uv run --extra proxy ruff check litellm/proxy/policy_engine/policy_endpoints.py tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
- uv run --extra proxy mypy litellm/proxy/policy_engine/policy_endpoints.py
- git diff --check -- litellm/proxy/policy_engine/policy_endpoints.py tests/test_litellm/proxy/policy_engine/test_policy_endpoints.py
