### PR TITLE
fix: allow S3 callback health test

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -126,6 +126,7 @@ services = Union[
         "datadog_llm_observability",
         "generic_api",
         "arize",
+        "s3",
         "sqs",
     ],
     str,
@@ -200,6 +201,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             "datadog_llm_observability",
             "generic_api",
             "arize",
+            "s3",
             "sqs",
         ]:
             raise HTTPException(

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -240,6 +240,13 @@ async def health_services_endpoint(  # noqa: PLR0915
                 "status": "success",
                 "message": "Mock LLM request made - check {}.".format(service),
             }
+        elif service == "s3":
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error": '"s3" not in proxy config: litellm_settings.success_callback. Unable to test this.'
+                },
+            )
         elif service == "datadog":
             from litellm.integrations.datadog.datadog import DataDogLogger
 

--- a/tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
@@ -1,0 +1,17 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.proxy.health_endpoints._health_endpoints import health_services_endpoint
+
+
+@pytest.mark.asyncio
+async def test_health_services_endpoint_accepts_s3_callback():
+    with (
+        patch("litellm.success_callback", ["s3"]),
+        patch("litellm.acompletion", new=AsyncMock(return_value={})),
+    ):
+        result = await health_services_endpoint(service="s3")
+
+    assert result["status"] == "success"
+    assert "s3" in result["message"]

--- a/tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from litellm.proxy.health_endpoints._health_endpoints import health_services_endpoint
+from litellm.proxy._types import ProxyException
 
 
 @pytest.mark.asyncio
@@ -15,3 +16,13 @@ async def test_health_services_endpoint_accepts_s3_callback():
 
     assert result["status"] == "success"
     assert "s3" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_health_services_endpoint_rejects_unconfigured_s3_callback():
+    with patch("litellm.success_callback", []):
+        with pytest.raises(ProxyException) as exc_info:
+            await health_services_endpoint(service="s3")
+
+    assert exc_info.value.code == "422"
+    assert "litellm_settings.success_callback" in str(exc_info.value.message)


### PR DESCRIPTION
## What

Fixes #26770 by allowing the S3 callback to use the existing /health/services generic success-callback probe instead of being rejected by the endpoint service allowlist.

The runtime already supports s3 as a callback and the UI exposes it. The missing piece was that /health/services validated service names before checking litellm.success_callback, so service=s3 returned a 400 even when S3 was configured.

## Tests

- uv run --extra proxy --extra extra-proxy pytest tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_services_endpoint_sqs tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_services_endpoint_datadog_llm_observability tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_services_endpoint_rejects_unknown_service -q
- uv run --extra proxy --extra extra-proxy black --check litellm/proxy/health_endpoints/_health_endpoints.py tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
- uv run --extra proxy --extra extra-proxy ruff check litellm/proxy/health_endpoints/_health_endpoints.py tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
- uv run --extra proxy --extra extra-proxy mypy litellm/proxy/health_endpoints/_health_endpoints.py
- git diff --check -- litellm/proxy/health_endpoints/_health_endpoints.py tests/test_litellm/proxy/health_endpoints/test_health_services_callbacks.py
