### PR TITLE
fix: normalize Anthropic server tool usage

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1522,6 +1522,11 @@ class ServerToolUse(BaseModel):
     web_search_requests: Optional[int] = None
     tool_search_requests: Optional[int] = None
 
+    def __getitem__(self, key: str) -> Optional[int]:
+        if key not in self.__class__.model_fields:
+            raise KeyError(key)
+        return getattr(self, key)
+
 
 class Usage(SafeAttributeModel, CompletionUsage):
     _cache_creation_input_tokens: int = PrivateAttr(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1552,7 +1552,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
         completion_tokens_details: Optional[
             Union[CompletionTokensDetailsWrapper, dict]
         ] = None,
-        server_tool_use: Optional[ServerToolUse] = None,
+        server_tool_use: Optional[Union[ServerToolUse, dict]] = None,
         cost: Optional[float] = None,
         **params,
     ):
@@ -1652,6 +1652,9 @@ class Usage(SafeAttributeModel, CompletionUsage):
             completion_tokens_details=_completion_tokens_details or None,
             prompt_tokens_details=_prompt_tokens_details or None,
         )
+
+        if isinstance(server_tool_use, dict):
+            server_tool_use = ServerToolUse(**server_tool_use)
 
         if server_tool_use is not None:
             self.server_tool_use = server_tool_use

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -1,17 +1,14 @@
-import json
 import os
 import sys
-from unittest.mock import MagicMock
 
 import pytest
-from fastapi.testclient import TestClient
 
 import litellm
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
     StandardBuiltInToolCostTracking,
 )
 from litellm.types.llms.openai import FileSearchTool, WebSearchOptions
-from litellm.types.utils import ModelInfo, ModelResponse, StandardBuiltInToolsParams
+from litellm.types.utils import ModelResponse, StandardBuiltInToolsParams
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -137,6 +134,22 @@ def test_get_cost_for_anthropic_web_search():
         custom_llm_provider="anthropic",
     )
     assert cost > 0.0
+
+
+def test_get_cost_for_anthropic_web_search_with_server_tool_use_dict():
+    """
+    Anthropic-compatible passthrough responses can construct Usage from a raw
+    usage payload. Ensure dict server_tool_use values are normalized before
+    built-in tool cost tracking reads server_tool_use.web_search_requests.
+    """
+    from litellm.types.utils import ServerToolUse, Usage
+
+    usage = Usage(server_tool_use={"web_search_requests": 1})
+
+    assert isinstance(usage.server_tool_use, ServerToolUse)
+    assert StandardBuiltInToolCostTracking.response_object_includes_web_search_call(
+        response_object=None, usage=usage
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -83,11 +83,15 @@ def test_usage_converts_server_tool_use_dict():
 
     assert isinstance(usage.server_tool_use, ServerToolUse)
     assert usage.server_tool_use.web_search_requests == 4
+    assert usage.server_tool_use["web_search_requests"] == 4
     assert usage.server_tool_use.tool_search_requests == 1
+    with pytest.raises(KeyError):
+        usage.server_tool_use["unknown_metric"]
 
     round_trip = Usage(**usage.model_dump())
     assert isinstance(round_trip.server_tool_use, ServerToolUse)
     assert round_trip.server_tool_use.web_search_requests == 4
+    assert round_trip.server_tool_use["web_search_requests"] == 4
     assert round_trip.server_tool_use.tool_search_requests == 1
 
 

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -1,13 +1,9 @@
-import asyncio
 import os
 import sys
-from typing import Optional
-from unittest.mock import AsyncMock, patch
 
 import pytest
 
 sys.path.insert(0, os.path.abspath("../.."))
-import json
 
 from litellm.types.utils import HiddenParams
 
@@ -73,6 +69,26 @@ def test_usage_dump():
 
     new_usage = Usage(**current_usage.model_dump())
     assert new_usage.prompt_tokens_details.web_search_requests == 1
+
+
+def test_usage_converts_server_tool_use_dict():
+    from litellm.types.utils import ServerToolUse, Usage
+
+    usage = Usage(
+        completion_tokens=2,
+        prompt_tokens=1,
+        total_tokens=3,
+        server_tool_use={"web_search_requests": 4, "tool_search_requests": 1},
+    )
+
+    assert isinstance(usage.server_tool_use, ServerToolUse)
+    assert usage.server_tool_use.web_search_requests == 4
+    assert usage.server_tool_use.tool_search_requests == 1
+
+    round_trip = Usage(**usage.model_dump())
+    assert isinstance(round_trip.server_tool_use, ServerToolUse)
+    assert round_trip.server_tool_use.web_search_requests == 4
+    assert round_trip.server_tool_use.tool_search_requests == 1
 
 
 def test_usage_completion_tokens_details_text_tokens():


### PR DESCRIPTION
## Summary
- normalize dict `server_tool_use` values into `ServerToolUse` inside `Usage`
- preserve constructor/model_dump round-trips for raw Anthropic-compatible usage payloads
- cover the built-in tool cost tracking path that reads `usage.server_tool_use.web_search_requests`

Fixes #26749.

## Tests
- `/tmp/uv-0.10.9-env/bin/uv run --extra proxy pytest tests/test_litellm/types/test_types_utils.py tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py -q`
- `/tmp/uv-0.10.9-env/bin/uv run --extra proxy ruff check --ignore PLR0915 litellm/types/utils.py tests/test_litellm/types/test_types_utils.py tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py`
- `git diff --check`

Note: full touched-file ruff still reports the existing `PLR0915` limit on `Delta.__init__`; the targeted lint command above keeps the check focused on actionable findings for this patch.