### PR TITLE
fix(proxy): run model-level post_call guardrails on streaming requests

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2274,6 +2274,13 @@ class ProxyLogging:
         Covers:
         1. /chat/completions
         """
+        from litellm.proxy.proxy_server import llm_router
+
+        # Merge model-level guardrails before checking which guardrails to run
+        request_data = _check_and_merge_model_level_guardrails(
+            data=request_data, llm_router=llm_router
+        )
+
         current_response = response
 
         for callback in litellm.callbacks:

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -294,3 +294,134 @@ async def test_post_call_success_hook_skips_guardrail_not_on_model():
         )
 
         assert guardrail.was_called is False
+
+
+# ---------------------------------------------------------------------------
+# Integration test: async_post_call_streaming_iterator_hook with model-level guardrails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_iterator_hook_runs_model_level_guardrail():
+    """
+    Model-level guardrails configured on a deployment should execute in
+    async_post_call_streaming_iterator_hook (streaming path) — even when
+    `default_on: false` and the guardrail is not in the request body.
+    """
+    from litellm.caching.caching import DualCache
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.utils import ProxyLogging
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class TestStreamingGuardrail(CustomGuardrail):
+        def __init__(self):
+            super().__init__(
+                guardrail_name="test-model-guardrail",
+                event_hook=GuardrailEventHooks.post_call,
+            )
+            self.was_called = False
+
+        async def async_post_call_streaming_iterator_hook(
+            self, user_api_key_dict, response, request_data
+        ):
+            self.was_called = True
+            async for chunk in response:
+                yield chunk
+
+    guardrail = TestStreamingGuardrail()
+
+    mock_router = MagicMock()
+    mock_deployment = MagicMock()
+    mock_deployment.litellm_params.get.return_value = ["test-model-guardrail"]
+    mock_router.get_deployment.return_value = mock_deployment
+
+    async def fake_response():
+        yield "chunk-1"
+        yield "chunk-2"
+
+    with (
+        patch("litellm.callbacks", [guardrail]),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        request_data = {
+            "model": "gpt-4",
+            "metadata": {"model_info": {"id": "model-uuid-123"}},
+        }
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        chunks = []
+        async for chunk in proxy_logging.async_post_call_streaming_iterator_hook(
+            response=fake_response(),
+            user_api_key_dict=user_api_key_dict,
+            request_data=request_data,
+        ):
+            chunks.append(chunk)
+
+        assert guardrail.was_called is True
+        assert chunks == ["chunk-1", "chunk-2"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_iterator_hook_skips_guardrail_not_on_model():
+    """
+    Streaming guardrails NOT configured on the model (and not in the request
+    body / key / team) should not execute, even after the dispatcher merge
+    runs. Confirms the gate stays closed for unrelated guardrails.
+    """
+    from litellm.caching.caching import DualCache
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.utils import ProxyLogging
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class TestStreamingGuardrail(CustomGuardrail):
+        def __init__(self):
+            super().__init__(
+                guardrail_name="unrelated-guardrail",
+                event_hook=GuardrailEventHooks.post_call,
+            )
+            self.was_called = False
+
+        async def async_post_call_streaming_iterator_hook(
+            self, user_api_key_dict, response, request_data
+        ):
+            self.was_called = True
+            async for chunk in response:
+                yield chunk
+
+    guardrail = TestStreamingGuardrail()
+
+    # Deployment has a DIFFERENT guardrail configured
+    mock_router = MagicMock()
+    mock_deployment = MagicMock()
+    mock_deployment.litellm_params.get.return_value = ["some-other-guardrail"]
+    mock_router.get_deployment.return_value = mock_deployment
+
+    async def fake_response():
+        yield "chunk-1"
+
+    with (
+        patch("litellm.callbacks", [guardrail]),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        request_data = {
+            "model": "gpt-4",
+            "metadata": {"model_info": {"id": "model-uuid-123"}},
+        }
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        chunks = []
+        async for chunk in proxy_logging.async_post_call_streaming_iterator_hook(
+            response=fake_response(),
+            user_api_key_dict=user_api_key_dict,
+            request_data=request_data,
+        ):
+            chunks.append(chunk)
+
+        assert guardrail.was_called is False
+        assert chunks == ["chunk-1"]


### PR DESCRIPTION
## Relevant issues

Follow-up to #23774 — same bug class, missed call site on the streaming path.

## Linear ticket

<!-- not applicable -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

The new unit test `test_streaming_iterator_hook_runs_model_level_guardrail` is bisect-confirmed: it fails with `assert False is True` against `litellm_internal_staging` without this change and passes with it. The companion `test_streaming_iterator_hook_skips_guardrail_not_on_model` guards against false positives by asserting the dispatcher gate stays closed for guardrails not attached at the model level.

## Type

🐛 Bug Fix

## Changes

### Bug

For a request with `stream: true` against a model that has a post_call guardrail attached at the model level (`litellm_params.guardrails`) and configured with `default_on: false`, the guardrail is silently skipped — no log entry, no error, `metadata.guardrail_information` ends up `null`. The same configuration on the same model fires correctly for non-streaming after #23774.

### Root cause

`ProxyLogging.async_post_call_streaming_iterator_hook` in `litellm/proxy/utils.py` is the streaming-side dispatcher that wraps each callback's iterator hook into the response stream. It gates each callback by calling `should_run_guardrail(data=request_data, ...)` against the raw `request_data` — without first merging `deployment.litellm_params.guardrails` into `metadata.guardrails`. With `default_on: false`, `should_run_guardrail` consults `metadata.guardrails` / `data.guardrails` (both empty for a no-body-attached request) and returns `False`. None of the dispatcher's three downstream branches fire — so for `apply_guardrail` guardrails (OpenAI Moderation, Bedrock Guardrails, Lakera, etc.) the `unified_guardrail` end-of-stream block that writes `guardrail_information` never runs.

#23774 patched the three non-streaming sites where `should_run_guardrail` is called against request data. The streaming iterator dispatcher is the missed fourth site.

### Fix

Mirror #23774's pattern: at the top of `async_post_call_streaming_iterator_hook`, call `_check_and_merge_model_level_guardrails(...)` and assign the result back to `request_data` before the per-callback loop. The merge helper's existing shallow-copy semantics propagate the merged `metadata.guardrails` to all downstream wrappers (including `unified_guardrail.async_post_call_streaming_iterator_hook`'s own internal `should_run_guardrail` check) through the shared `metadata` reference.

The local `from litellm.proxy.proxy_server import llm_router` import matches the established pattern at the two existing call sites in `utils.py` (`post_call_success_hook` and the per-chunk `async_post_call_streaming_hook`), where the local import breaks a circular dependency with `proxy_server`.

### Tests

Two new async tests in `tests/test_litellm/proxy/test_model_level_guardrails.py`, mirroring the file's existing non-streaming tests verbatim:

- `test_streaming_iterator_hook_runs_model_level_guardrail` — asserts the model-level guardrail fires for streaming with `default_on: false` and no body-level `guardrails` field.
- `test_streaming_iterator_hook_skips_guardrail_not_on_model` — regression guard: deployment configured with a different guardrail name, the dispatcher gate stays closed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the streaming response dispatch path to run model-level `post_call` guardrails, which can affect safety/compliance behavior for streamed completions. Low code churn, but touches guardrail gating logic that can change which callbacks execute in production.
> 
> **Overview**
> Fixes a gap where **model-level `post_call` guardrails were skipped for streaming responses** by merging deployment guardrails into `request_data` at the start of `ProxyLogging.async_post_call_streaming_iterator_hook` before `should_run_guardrail` checks.
> 
> Adds two async integration tests to verify that a model-attached streaming guardrail runs even when not specified in the request body, and that unrelated guardrails remain gated off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1558ae21917fc36a3d2d3bd54450974ca2515a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->