### PR TITLE
Omit Anthropic thinking blocks from Responses input

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -165,12 +165,10 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                     "arguments": json.dumps(block.get("input", {})),
                                 }
                             )
-                        elif btype == "thinking":
-                            thinking_text = block.get("thinking", "")
-                            if thinking_text:
-                                asst_parts.append(
-                                    {"type": "output_text", "text": thinking_text}
-                                )
+                        elif btype in ("thinking", "redacted_thinking"):
+                            # Anthropic thinking blocks are hidden reasoning state,
+                            # not assistant-visible output for OpenAI Responses.
+                            continue
                     if asst_parts:
                         input_items.append(
                             {

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -414,6 +414,36 @@ class TestTranslateMessagesToResponsesInput:
             {"type": "output_text", "text": "Here is the answer."}
         ]
 
+    def test_assistant_thinking_with_tool_use_keeps_function_call(self):
+        """Thinking is dropped while adjacent tool_use blocks are still replayed."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I should call the weather tool.",
+                        "signature": "sig_abc",
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_03",
+                        "name": "get_weather",
+                        "input": {"location": "Paris"},
+                    },
+                ],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result == [
+            {
+                "type": "function_call",
+                "call_id": "toolu_03",
+                "name": "get_weather",
+                "arguments": json.dumps({"location": "Paris"}),
+            }
+        ]
+
     def test_assistant_only_thinking_block_skipped(self):
         """Assistant messages with only thinking blocks are omitted on replay."""
         messages = [

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -394,20 +394,42 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
 
-    def test_assistant_thinking_block_becomes_output_text(self):
-        """Assistant thinking block text is included as output_text."""
+    def test_assistant_thinking_block_is_not_sent_as_output_text(self):
+        """Assistant thinking blocks are hidden reasoning state, not visible output."""
         messages = [
             {
                 "role": "assistant",
                 "content": [
-                    {"type": "thinking", "thinking": "Let me reason step by step."}
+                    {
+                        "type": "thinking",
+                        "thinking": "Let me reason step by step.",
+                        "signature": "sig_abc",
+                    },
+                    {"type": "text", "text": "Here is the answer."},
                 ],
             }
         ]
         result = _translate_messages(messages)
         assert result[0]["content"] == [
-            {"type": "output_text", "text": "Let me reason step by step."}
+            {"type": "output_text", "text": "Here is the answer."}
         ]
+
+    def test_assistant_only_thinking_block_skipped(self):
+        """Assistant messages with only thinking blocks are omitted on replay."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Hidden reasoning",
+                        "signature": "sig_abc",
+                    }
+                ],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result == []
 
     def test_assistant_empty_thinking_block_skipped(self):
         """Assistant thinking block with empty thinking text is skipped."""
@@ -419,6 +441,22 @@ class TestTranslateMessagesToResponsesInput:
         ]
         result = _translate_messages(messages)
         assert result == []
+
+    def test_assistant_redacted_thinking_block_skipped(self):
+        """Redacted thinking blocks should not be replayed as visible text."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "redacted_thinking", "data": "encrypted-state"},
+                    {"type": "text", "text": "Visible answer."},
+                ],
+            }
+        ]
+        result = _translate_messages(messages)
+        assert result[0]["content"] == [
+            {"type": "output_text", "text": "Visible answer."}
+        ]
 
     def test_mixed_messages_ordering(self):
         """Full multi-turn conversation is converted in order."""


### PR DESCRIPTION
## Summary
- stop replaying Anthropic assistant `thinking` blocks as OpenAI Responses `output_text`
- also omit `redacted_thinking` blocks from the Responses input history
- preserve adjacent visible assistant text and existing tool-use translation
- update adapter regression coverage for thinking-only, thinking+text, and redacted-thinking histories

## Why
Anthropic thinking blocks are hidden reasoning state. The Responses adapter was serializing prior assistant `thinking` content as normal assistant-visible `output_text`, which can leak reasoning text back into a later OpenAI request and alter model behavior.

Fixes #26916.

## Validation
- `PYTHONPATH=. /tmp/litellm-26913-venv/bin/python -m pytest tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py -q`
  - `83 passed, 2 warnings`
- `UV_NO_PROJECT=1 uvx black litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py --check --diff`
  - `2 files would be left unchanged`

Note: project `uv run` is blocked locally because installed uv is `0.10.4` and this branch requires `>=0.10.9`; targeted tests ran with Python 3.13 via an existing local venv.
