### PR TITLE
fix(proxy): reject user_id=None on non-admin analytics endpoints (cross-tenant disclosure)

### DIFF
--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from fastapi import HTTPException, status
+
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
 from litellm.proxy._types import (
@@ -27,6 +29,34 @@ def _user_has_admin_view(user_api_key_dict: UserAPIKeyAuth) -> bool:
         user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
         or user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
     )
+
+
+def require_caller_user_id_for_non_admin(
+    user_api_key_dict: UserAPIKeyAuth,
+) -> str:
+    """Return the caller's user_id, or raise 403 if missing.
+
+    Non-admin analytics endpoints scope queries by the caller's own user_id.
+    Service-account keys are deliberately created with user_id=None
+    (key_management_endpoints.py forces ``data.user_id = None`` at key
+    creation). Without this guard, that None value flows through to the
+    daily-activity builder, which treats ``entity_id is None`` as "no filter"
+    and returns every tenant's data.
+
+    Callers must check is_admin first; this helper is only valid on the
+    non-admin scoping branch.
+    """
+    if user_api_key_dict.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": (
+                    "Service-account keys cannot query user analytics. "
+                    "Use a user-bound key, or call as a proxy admin."
+                )
+            },
+        )
+    return user_api_key_dict.user_id
 
 
 def _is_user_team_admin(

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -35,6 +35,7 @@ from litellm.proxy.management_endpoints.common_daily_activity import (
 from litellm.proxy.management_endpoints.common_utils import (
     _is_user_team_admin,
     _user_has_admin_view,
+    require_caller_user_id_for_non_admin,
 )
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     generate_key_helper_fn,
@@ -2587,9 +2588,10 @@ async def get_user_daily_activity(
         if is_admin:
             entity_id = user_id  # None means global view, otherwise filter by user
         else:
+            caller_user_id = require_caller_user_id_for_non_admin(user_api_key_dict)
             if user_id is None:
-                user_id = user_api_key_dict.user_id
-            if user_id != user_api_key_dict.user_id:
+                user_id = caller_user_id
+            if user_id != caller_user_id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail={
@@ -2684,9 +2686,10 @@ async def get_user_daily_activity_aggregated(
         if is_admin:
             entity_id = user_id  # None means global view, otherwise filter by user
         else:
+            caller_user_id = require_caller_user_id_for_non_admin(user_api_key_dict)
             if user_id is None:
-                user_id = user_api_key_dict.user_id
-            if user_id != user_api_key_dict.user_id:
+                user_id = caller_user_id
+            if user_id != caller_user_id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail={

--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -440,6 +440,15 @@ def _resolve_fetch_kwargs(
     kwargs: Dict[str, Any] = {"start_date": start_date, "end_date": end_date}
     if fn_name == "get_usage_data":
         if not is_admin:
+            if user_id is None:
+                # Defense-in-depth: the endpoint guard in usage_endpoints/endpoints.py
+                # should have already rejected this. If we ever reach here it means
+                # a future caller invoked the helper without scoping — fail loudly
+                # rather than issuing an unfiltered global query.
+                raise ValueError(
+                    "Non-admin caller has user_id=None; refusing to issue an "
+                    "unscoped query. Endpoint-level guard missing."
+                )
             kwargs["user_id"] = user_id
         elif fn_args.get("user_id"):
             kwargs["user_id"] = fn_args["user_id"]

--- a/litellm/proxy/management_endpoints/usage_endpoints/endpoints.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/endpoints.py
@@ -44,13 +44,17 @@ async def usage_ai_chat(
     """
     from litellm.proxy.management_endpoints.common_utils import (
         _user_has_admin_view,
+        require_caller_user_id_for_non_admin,
     )
     from litellm.proxy.management_endpoints.usage_endpoints.ai_usage_chat import (
         stream_usage_ai_chat,
     )
 
     is_admin = _user_has_admin_view(user_api_key_dict)
-    user_id = user_api_key_dict.user_id
+    if is_admin:
+        user_id = user_api_key_dict.user_id
+    else:
+        user_id = require_caller_user_id_for_non_admin(user_api_key_dict)
     messages = [{"role": m.role, "content": m.content} for m in data.messages]
 
     return StreamingResponse(

--- a/tests/test_litellm/proxy/management_endpoints/test_common_utils.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_utils.py
@@ -481,3 +481,39 @@ class TestSetObjectMetadataField:
         ):
             _set_object_metadata_field(team, "model_rpm_limit", {"x": 1})
         assert team.metadata == {"model_rpm_limit": {"x": 1}}
+
+
+class TestRequireCallerUserIdForNonAdmin:
+    """
+    Security regression: service-account keys (user_id=None) must not bypass
+    the non-admin scoping branch on analytics endpoints.
+    """
+
+    def test_returns_user_id_when_present(self):
+        from litellm.proxy.management_endpoints.common_utils import (
+            require_caller_user_id_for_non_admin,
+        )
+
+        key_dict = UserAPIKeyAuth(
+            user_id="user-abc",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        assert require_caller_user_id_for_non_admin(key_dict) == "user-abc"
+
+    def test_raises_403_when_user_id_is_none(self):
+        from fastapi import HTTPException
+
+        from litellm.proxy.management_endpoints.common_utils import (
+            require_caller_user_id_for_non_admin,
+        )
+
+        # Simulates a service-account key (user_id forced to None at key creation)
+        service_account_key = UserAPIKeyAuth(
+            user_id=None,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            require_caller_user_id_for_non_admin(service_account_key)
+
+        assert exc_info.value.status_code == 403
+        assert "Service-account keys" in str(exc_info.value.detail)

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1733,6 +1733,107 @@ async def test_get_user_daily_activity_non_admin_cannot_view_other_users(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_get_user_daily_activity_rejects_service_account_caller(monkeypatch):
+    """
+    Security regression: a non-admin caller with user_id=None (a service-account
+    key, where user_id is forced to None at key creation) must not be able to
+    bypass the entity filter and read every tenant's daily spend.
+
+    Before the fix, the endpoint silently defaulted user_id to
+    user_api_key_dict.user_id, which is itself None for service-account keys.
+    None != None is False, the same-user check passed, and entity_id=None
+    flowed into get_daily_activity, where the SQL builder treats None as
+    "no filter".
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import HTTPException
+
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        get_user_daily_activity,
+    )
+
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Tripwire: ensure get_daily_activity is never reached
+    mock_get_daily = AsyncMock()
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.get_daily_activity",
+        mock_get_daily,
+    )
+
+    service_account_key = UserAPIKeyAuth(
+        user_id=None,  # service-account keys have user_id forced to None
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_user_daily_activity(
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            user_id=None,
+            page=1,
+            page_size=50,
+            timezone=None,
+            user_api_key_dict=service_account_key,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "Service-account keys" in str(exc_info.value.detail)
+    mock_get_daily.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_user_daily_activity_aggregated_rejects_service_account_caller(
+    monkeypatch,
+):
+    """
+    Same security regression as
+    test_get_user_daily_activity_rejects_service_account_caller, on the
+    aggregated route. Same shape, raw-SQL builder, same fix.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import HTTPException
+
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        get_user_daily_activity_aggregated,
+    )
+
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    mock_get_daily_agg = AsyncMock()
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.get_daily_activity_aggregated",
+        mock_get_daily_agg,
+    )
+
+    service_account_key = UserAPIKeyAuth(
+        user_id=None,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_user_daily_activity_aggregated(
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            user_id=None,
+            timezone=None,
+            user_api_key_dict=service_account_key,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "Service-account keys" in str(exc_info.value.detail)
+    mock_get_daily_agg.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_user_daily_activity_aggregated_admin_global_view(monkeypatch):
     """
     Test that admin users can call the aggregated endpoint without a user_id

--- a/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
+++ b/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
@@ -409,3 +409,60 @@ class TestStreamUsageAiChat:
                 end_date="2025-01-31",
                 user_id="my-user-id",
             )
+
+
+class TestUsageAiChatServiceAccountGuard:
+    """
+    Security regression: a non-admin caller with user_id=None (service-account
+    key) must be rejected at the endpoint boundary, before any tool dispatch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_admin_with_user_id_none_is_rejected(self):
+        from fastapi import HTTPException
+
+        from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+        from litellm.proxy.management_endpoints.usage_endpoints.endpoints import (
+            ChatMessage,
+            UsageAIChatRequest,
+            usage_ai_chat,
+        )
+
+        service_account_key = UserAPIKeyAuth(
+            user_id=None,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        request = MagicMock()
+        body = UsageAIChatRequest(
+            messages=[ChatMessage(role="user", content="hi")],
+            model="gpt-4o-mini",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await usage_ai_chat(
+                data=body,
+                request=request,
+                user_api_key_dict=service_account_key,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "Service-account keys" in str(exc_info.value.detail)
+
+    def test_resolve_fetch_kwargs_tripwire_fires_on_none_user_id(self):
+        """
+        Defense-in-depth: if a future endpoint forgets the entry guard and
+        a non-admin caller with user_id=None reaches _resolve_fetch_kwargs,
+        the tripwire must fire rather than issuing an unscoped query.
+        """
+        from litellm.proxy.management_endpoints.usage_endpoints.ai_usage_chat import (
+            _resolve_fetch_kwargs,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _resolve_fetch_kwargs(
+                fn_name="get_usage_data",
+                fn_args={"start_date": "2025-01-01", "end_date": "2025-01-31"},
+                user_id=None,
+                is_admin=False,
+            )
+        assert "Endpoint-level guard missing" in str(exc_info.value)


### PR DESCRIPTION
## Title

fix(proxy): reject user_id=None on non-admin analytics endpoints (cross-tenant disclosure)

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Changes

### Bug

A non-admin caller authenticated with a service-account key (where `user_id` is intentionally forced to `None` at key creation in `key_management_endpoints.py`) could call three analytics endpoints and receive aggregated daily-spend data for every tenant on the platform:

- `POST /usage/ai/chat`
- `GET /user/daily/activity`
- `GET /user/daily/activity/aggregated`

Each handler scoped non-admin queries by `user_api_key_dict.user_id`, then forwarded that value into the shared daily-activity SQL/Prisma builder in `common_daily_activity.py`. The builder treats `entity_id is None` as "skip the entity filter entirely" — appropriate for admin global views, unsafe on a non-admin path. With a service-account key, `user_id` is `None`, so the resulting query had no `WHERE "user_id" = $N` clause and returned every row in `LiteLLM_DailyUserSpend` (spend, tokens, request volumes, model breakdowns, provider distributions, API key identifiers).

`/user/daily/activity` and its aggregated variant are reachable from any vanilla service-account key — they sit in `LiteLLMRoutes.self_managed_routes` and `route_checks.non_proxy_admin_allowed_routes_check` lets non-admins through without any `allowed_routes` configuration. `/usage/ai/chat` additionally requires the key to carry an `allowed_routes` value covering it.

For `/user/daily/activity` specifically, the silent fallback `if user_id is None: user_id = user_api_key_dict.user_id` made the same-user check `user_id != user_api_key_dict.user_id` a no-op (`None != None` is `False`), so the existing 403 guard never fired for service-account callers.

### Fix

Add a single shared helper `require_caller_user_id_for_non_admin` in `litellm/proxy/management_endpoints/common_utils.py` that returns the caller's `user_id` or raises `HTTPException(403)` if it is `None`. Call it from each of the three handlers, on the non-admin scoping branch only — admin global views are unchanged.

Plus a defense-in-depth `ValueError` tripwire in `_resolve_fetch_kwargs` (the layer between `/usage/ai/chat` and the daily-activity builder) so that if a future endpoint forgets the entry guard, the unscoped global query fails loudly rather than silently leaking.

### Files changed

| File | Change |
|---|---|
| `litellm/proxy/management_endpoints/common_utils.py` | New `require_caller_user_id_for_non_admin` helper next to `_user_has_admin_view` |
| `litellm/proxy/management_endpoints/usage_endpoints/endpoints.py` | `/usage/ai/chat`: split admin/non-admin scoping branches and call the helper on the non-admin path |
| `litellm/proxy/management_endpoints/internal_user_endpoints.py` | `/user/daily/activity` and `/user/daily/activity/aggregated`: resolve `caller_user_id` via the helper instead of the silent default-to-`user_api_key_dict.user_id` |
| `litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py` | Tripwire in `_resolve_fetch_kwargs` non-admin branch |

### Tests added

- `tests/test_litellm/proxy/management_endpoints/test_common_utils.py::TestRequireCallerUserIdForNonAdmin` — helper returns `user_id` when present, raises 403 when `None`.
- `tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py::TestUsageAiChatServiceAccountGuard` — `/usage/ai/chat` rejects non-admin with `user_id=None`; the `_resolve_fetch_kwargs` tripwire fires when reached with `user_id=None` on the non-admin branch.
- `tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py::test_get_user_daily_activity_rejects_service_account_caller` and `test_get_user_daily_activity_aggregated_rejects_service_account_caller` — both routes return 403 and never reach the daily-activity builder when called by a non-admin with `user_id=None`.

The existing `test_get_user_daily_activity_non_admin_cannot_view_other_users` continues to pass — its caller has a non-`None` `user_id`, so the new guard does not fire on it.

### Backwards compatibility

Service-account keys calling the three affected endpoints will now receive 403s where they previously received 200s with cross-tenant data. The 403 message indicates that a user-bound key or a proxy admin should be used instead. User-bound keys (non-`None` `user_id`) and proxy-admin keys are entirely unaffected.

### Out of scope

Hardening the daily-activity builders (`_build_where_conditions`, `_build_aggregated_sql_query`) to refuse `entity_id=None` on non-admin paths is the right defense-in-depth follow-up, but touches all eight callers of `get_daily_activity` / `get_daily_activity_aggregated` and is intentionally deferred to a separate PR to keep this one surgical.
