### PR TITLE
[Test] Proxy E2E: Opt In To Client Mock Response For Model Access Tests

### DIFF
--- a/tests/otel_tests/test_e2e_model_access.py
+++ b/tests/otel_tests/test_e2e_model_access.py
@@ -6,13 +6,19 @@ from httpx import AsyncClient
 from typing import Any, Optional, List, Literal
 
 
+# The proxy strips client-supplied `mock_response` unless the calling key or
+# team has this admin-metadata flag set. See `_UNTRUSTED_ROOT_CONTROL_FIELDS`
+# in litellm/proxy/litellm_pre_call_utils.py.
+_ALLOW_CLIENT_MOCK_METADATA = {"allow_client_mock_response": True}
+
+
 async def generate_key(
     session, models: Optional[List[str]] = None, team_id: Optional[str] = None
 ):
     """Helper function to generate a key with specific model access controls"""
     url = "http://0.0.0.0:4000/key/generate"
     headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
-    data = {}
+    data: dict = {"metadata": dict(_ALLOW_CLIENT_MOCK_METADATA)}
     if models is not None:
         data["models"] = models
     if team_id is not None:
@@ -25,7 +31,7 @@ async def generate_team(session, models: Optional[List[str]] = None):
     """Helper function to generate a team with specific model access"""
     url = "http://0.0.0.0:4000/team/new"
     headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
-    data = {}
+    data: dict = {"metadata": dict(_ALLOW_CLIENT_MOCK_METADATA)}
     if models is not None:
         data["models"] = models
     async with session.post(url, headers=headers, json=data) as response:
@@ -111,7 +117,12 @@ async def test_model_access_update():
 
     # Create initial key with restricted access
     response = await client.post(
-        "/key/generate", json={"models": ["openai/gpt-4"]}, headers=headers
+        "/key/generate",
+        json={
+            "models": ["openai/gpt-4"],
+            "metadata": dict(_ALLOW_CLIENT_MOCK_METADATA),
+        },
+        headers=headers,
     )
     assert response.status_code == 200
     key_data = response.json()
@@ -214,7 +225,11 @@ async def test_team_model_access_update():
     # Create initial team with restricted access
     response = await client.post(
         "/team/new",
-        json={"models": ["openai/gpt-4"], "name": "test-team"},
+        json={
+            "models": ["openai/gpt-4"],
+            "name": "test-team",
+            "metadata": dict(_ALLOW_CLIENT_MOCK_METADATA),
+        },
         headers=headers,
     )
     assert response.status_code == 200
@@ -223,7 +238,12 @@ async def test_team_model_access_update():
 
     # Generate a key for this team
     response = await client.post(
-        "/key/generate", json={"team_id": team_id}, headers=headers
+        "/key/generate",
+        json={
+            "team_id": team_id,
+            "metadata": dict(_ALLOW_CLIENT_MOCK_METADATA),
+        },
+        headers=headers,
     )
     assert response.status_code == 200
     key = response.json()["key"]


### PR DESCRIPTION
## Summary

- The proxy's ingress hardening ([842eea0131](https://github.com/BerriAI/litellm/commit/842eea0131)) added `mock_response` / `mock_tool_calls` to `_UNTRUSTED_ROOT_CONTROL_FIELDS` in `litellm/proxy/litellm_pre_call_utils.py` — they are now stripped from client requests unless the calling key or team has admin-metadata `allow_client_mock_response: true`.
- `tests/otel_tests/test_e2e_model_access.py` relies on `mock_response` (passed in `extra_body`) to short-circuit completions. Without the flag the request actually runs; the `bedrock/*` route in `otel_test_config.yaml` points at a shared fake endpoint that 404s on unsupported bedrock paths, so `test_model_access_patterns[key_models2-bedrock/anthropic.claude-3-True]` started failing in CI.
- Fix: set `allow_client_mock_response: true` on every key and team this test creates. No production code changes.

Failing job: https://app.circleci.com/pipelines/github/BerriAI/litellm/75860/workflows/b6853c9c-8b58-4036-a6b3-43e1d3616c9c/jobs/1589284/tests#failed-test-0

## Test plan

- [ ] CI `proxy_logging_guardrails_model_info_tests` passes (it runs `tests/otel_tests` against the proxy with `otel_test_config.yaml`)
- [ ] No regression in the gpt-4 / openai-only parametrize rows (those previously passed via real OpenAI)