### PR TITLE
fix(bedrock): handle document content blocks with citations and context in Converse API

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3558,6 +3558,7 @@ from litellm.types.llms.bedrock import (
     BedrockConverseReasoningContentBlock,
     BedrockConverseReasoningTextBlock,
 )
+from litellm.types.llms.bedrock import CitationsConfig as BedrockCitationsConfig
 from litellm.types.llms.bedrock import ContentBlock as BedrockContentBlock
 from litellm.types.llms.bedrock import DocumentBlock as BedrockDocumentBlock
 from litellm.types.llms.bedrock import ImageBlock as BedrockImageBlock
@@ -4091,6 +4092,12 @@ def _convert_to_bedrock_tool_call_result(
                         list(_file_block.keys()),
                         content,
                     )
+            elif content["type"] == "document":
+                _doc_block = BedrockConverseMessagesProcessor._process_document_message(content)
+                if "document" in _doc_block:
+                    tool_result_content_blocks.append(
+                        BedrockToolResultContentBlock(document=_doc_block["document"])
+                    )
 
     message.get("name", "")
     id = str(message.get("tool_call_id", str(uuid.uuid4())))
@@ -4582,6 +4589,9 @@ class BedrockConverseMessagesProcessor:
                                     message=cast(ChatCompletionFileObject, element)
                                 )
                                 _parts.append(_part)
+                            elif element["type"] == "document":
+                                _part = BedrockConverseMessagesProcessor._process_document_message(element)
+                                _parts.append(_part)
                             _cache_point_block = (
                                 litellm.AmazonConverseConfig()._get_cache_point_block(
                                     message_block=cast(
@@ -4845,6 +4855,63 @@ class BedrockConverseMessagesProcessor:
         )
 
     @staticmethod
+    def _process_document_message(element: dict) -> BedrockContentBlock:
+        """Convert an Anthropic-style document content block to a Bedrock DocumentBlock.
+
+        Handles: {"type": "document", "source": {"type": "base64", "media_type": "...", "data": "..."}}
+        Also forwards optional `citations` and `context` fields supported by the Bedrock Converse API.
+        """
+        source = element.get("source", {})
+        source_type = source.get("type")
+        if source_type != "base64":
+            raise litellm.BadRequestError(
+                message=f"Bedrock Converse only supports base64-encoded document sources, got '{source_type}'. "
+                "Please convert the document to base64 before sending to Bedrock.",
+                model="",
+                llm_provider="bedrock",
+            )
+
+        media_type: str = source["media_type"]
+        data: str = source["data"]
+
+        _mime_to_format: dict = {
+            "application/pdf": "pdf",
+            "text/csv": "csv",
+            "application/msword": "doc",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+            "application/vnd.ms-excel": "xls",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+            "text/html": "html",
+            "text/plain": "txt",
+            "text/markdown": "md",
+        }
+        doc_format = _mime_to_format.get(media_type, media_type.split("/")[-1])
+
+        HASH_SAMPLE_BYTES = 64 * 1024
+        normalized = "".join(data.split()).encode("utf-8")
+        sample = normalized[:HASH_SAMPLE_BYTES]
+        hasher = hashlib.sha256()
+        hasher.update(sample)
+        hasher.update(str(len(normalized)).encode("utf-8"))
+        content_hash = hasher.hexdigest()[:16]
+        document_name = f"Document_{content_hash}_{doc_format}"
+
+        doc_block = BedrockDocumentBlock(
+            source=BedrockSourceBlock(bytes=data),
+            format=doc_format,
+            name=document_name,
+        )
+
+        anthropic_citations = element.get("citations")
+        if isinstance(anthropic_citations, dict) and anthropic_citations.get("enabled"):
+            doc_block["citations"] = BedrockCitationsConfig(enabled=True)
+
+        if element.get("context"):
+            doc_block["context"] = element["context"]
+
+        return BedrockContentBlock(document=doc_block)
+
+    @staticmethod
     async def _async_process_file_message(
         message: ChatCompletionFileObject,
     ) -> BedrockContentBlock:
@@ -4960,6 +5027,9 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                                     message=cast(ChatCompletionFileObject, element)
                                 )
                             )
+                            _parts.append(_part)
+                        elif element["type"] == "document":
+                            _part = BedrockConverseMessagesProcessor._process_document_message(element)
                             _parts.append(_part)
                         _cache_point_block = (
                             litellm.AmazonConverseConfig()._get_cache_point_block(

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -48,9 +48,9 @@ class CitationsConfig(TypedDict, total=False):
 
 
 class DocumentBlock(TypedDict, total=False):
-    format: Union[BedrockDocumentTypes, str]
-    source: SourceBlock
-    name: str
+    format: Required[Union[BedrockDocumentTypes, str]]
+    source: Required[SourceBlock]
+    name: Required[str]
     citations: CitationsConfig
     context: str
 

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -43,10 +43,16 @@ BedrockDocumentTypes = Literal[
 ]
 
 
-class DocumentBlock(TypedDict):
+class CitationsConfig(TypedDict, total=False):
+    enabled: bool
+
+
+class DocumentBlock(TypedDict, total=False):
     format: Union[BedrockDocumentTypes, str]
     source: SourceBlock
     name: str
+    citations: CitationsConfig
+    context: str
 
 
 class ToolResultContentBlock(TypedDict, total=False):

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_document_blocks.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_document_blocks.py
@@ -5,11 +5,14 @@ Covers: basic document conversion, citations, context, tool results, and format 
 
 import pytest
 
+import litellm
 from litellm.litellm_core_utils.prompt_templates.factory import (
+    BedrockConverseMessagesProcessor,
     _bedrock_converse_messages_pt,
     _convert_to_bedrock_tool_call_result,
-    _process_bedrock_document_block,
 )
+
+_process_document_message = BedrockConverseMessagesProcessor._process_document_message
 
 
 def _make_doc_message(extra_fields: dict = {}) -> list:
@@ -95,19 +98,13 @@ def test_document_block_context_forwarded():
 
 def test_document_block_deterministic_name():
     """Same document data always produces the same deterministic name."""
-    block = _process_bedrock_document_block(
-        {
-            "type": "document",
-            "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="},
-        }
-    )
-    block2 = _process_bedrock_document_block(
-        {
-            "type": "document",
-            "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="},
-        }
-    )
-    assert block["document"]["name"] == block2["document"]["name"]
+    element = {
+        "type": "document",
+        "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="},
+    }
+    block1 = _process_document_message(element)
+    block2 = _process_document_message(element)
+    assert block1["document"]["name"] == block2["document"]["name"]
 
 
 @pytest.mark.parametrize(
@@ -124,7 +121,7 @@ def test_document_block_deterministic_name():
 )
 def test_document_format_mapping(media_type, expected_format):
     """Various MIME types map to the correct Bedrock document format."""
-    block = _process_bedrock_document_block(
+    block = _process_document_message(
         {
             "type": "document",
             "source": {"type": "base64", "media_type": media_type, "data": "dGVzdA=="},
@@ -157,9 +154,9 @@ def test_document_in_tool_result():
 
 
 def test_non_base64_source_raises():
-    """Non-base64 source type raises a clear ValueError."""
-    with pytest.raises(ValueError, match="base64"):
-        _process_bedrock_document_block(
+    """Non-base64 source type raises BadRequestError."""
+    with pytest.raises(litellm.BadRequestError, match="base64"):
+        _process_document_message(
             {
                 "type": "document",
                 "source": {"type": "url", "url": "https://example.com/doc.pdf"},

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_document_blocks.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_document_blocks.py
@@ -1,0 +1,167 @@
+"""
+Tests for Bedrock Converse API document block handling in factory.py.
+Covers: basic document conversion, citations, context, tool results, and format mapping.
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    _bedrock_converse_messages_pt,
+    _convert_to_bedrock_tool_call_result,
+    _process_bedrock_document_block,
+)
+
+
+def _make_doc_message(extra_fields: dict = {}) -> list:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "dGVzdA==",
+                    },
+                    **extra_fields,
+                },
+                {"type": "text", "text": "What is the title?"},
+            ],
+        }
+    ]
+
+
+def test_document_block_basic():
+    """Document block produces correct format, source.bytes, and name."""
+    result = _bedrock_converse_messages_pt(
+        _make_doc_message(), "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    content = result[0]["content"]
+    doc_parts = [b for b in content if "document" in b]
+    assert len(doc_parts) == 1
+    doc = doc_parts[0]["document"]
+    assert doc["format"] == "pdf"
+    assert doc["source"]["bytes"] == "dGVzdA=="
+    assert doc["name"].startswith("Document_")
+
+
+def test_document_block_not_dropped_with_text():
+    """Mixed document + text preserves both blocks (reproduces the silent-drop bug)."""
+    result = _bedrock_converse_messages_pt(
+        _make_doc_message(), "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    content = result[0]["content"]
+    types = [list(b.keys())[0] for b in content]
+    assert "document" in types
+    assert "text" in types
+
+
+def test_document_block_citations_forwarded():
+    """citations.enabled=True is forwarded to BedrockCitationsConfig on the DocumentBlock."""
+    result = _bedrock_converse_messages_pt(
+        _make_doc_message({"citations": {"enabled": True}}),
+        "anthropic.claude-sonnet-4-6",
+        "bedrock",
+    )
+    content = result[0]["content"]
+    doc = next(b["document"] for b in content if "document" in b)
+    assert doc.get("citations") == {"enabled": True}
+
+
+def test_document_block_citations_not_set_when_disabled():
+    """citations field is absent when citations.enabled is False or not set."""
+    result = _bedrock_converse_messages_pt(
+        _make_doc_message({"citations": {"enabled": False}}),
+        "anthropic.claude-sonnet-4-6",
+        "bedrock",
+    )
+    content = result[0]["content"]
+    doc = next(b["document"] for b in content if "document" in b)
+    assert "citations" not in doc
+
+
+def test_document_block_context_forwarded():
+    """context field is forwarded to the Bedrock DocumentBlock."""
+    result = _bedrock_converse_messages_pt(
+        _make_doc_message({"context": "Q4 financial report"}),
+        "anthropic.claude-sonnet-4-6",
+        "bedrock",
+    )
+    content = result[0]["content"]
+    doc = next(b["document"] for b in content if "document" in b)
+    assert doc.get("context") == "Q4 financial report"
+
+
+def test_document_block_deterministic_name():
+    """Same document data always produces the same deterministic name."""
+    block = _process_bedrock_document_block(
+        {
+            "type": "document",
+            "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="},
+        }
+    )
+    block2 = _process_bedrock_document_block(
+        {
+            "type": "document",
+            "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="},
+        }
+    )
+    assert block["document"]["name"] == block2["document"]["name"]
+
+
+@pytest.mark.parametrize(
+    "media_type,expected_format",
+    [
+        ("application/pdf", "pdf"),
+        ("text/csv", "csv"),
+        ("text/html", "html"),
+        ("text/plain", "txt"),
+        ("text/markdown", "md"),
+        ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx"),
+    ],
+)
+def test_document_format_mapping(media_type, expected_format):
+    """Various MIME types map to the correct Bedrock document format."""
+    block = _process_bedrock_document_block(
+        {
+            "type": "document",
+            "source": {"type": "base64", "media_type": media_type, "data": "dGVzdA=="},
+        }
+    )
+    assert block["document"]["format"] == expected_format
+
+
+def test_document_in_tool_result():
+    """Document block in tool result content produces correct BedrockToolResultContentBlock."""
+    message = {
+        "role": "tool",
+        "tool_call_id": "tool_123",
+        "content": [
+            {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "dGVzdA==",
+                },
+            }
+        ],
+    }
+    result = _convert_to_bedrock_tool_call_result(message)
+    tool_result_content = result["toolResult"]["content"]
+    doc_blocks = [b for b in tool_result_content if "document" in b]
+    assert len(doc_blocks) == 1
+    assert doc_blocks[0]["document"]["format"] == "pdf"
+
+
+def test_non_base64_source_raises():
+    """Non-base64 source type raises a clear ValueError."""
+    with pytest.raises(ValueError, match="base64"):
+        _process_bedrock_document_block(
+            {
+                "type": "document",
+                "source": {"type": "url", "url": "https://example.com/doc.pdf"},
+            }
+        )


### PR DESCRIPTION
## Relevant issues

Fixes #26937

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix / ✨ Enhancement

## Changes

`document` content blocks (PDF, CSV, etc. via Anthropic's API format) were **silently dropped** during Bedrock Converse API message conversion. Additionally, the Bedrock Converse API supports `citations` and `context` fields on `DocumentBlock` which were never forwarded.

### Root cause

1. The `for element in message_block["content"]` loop in both the sync and async Bedrock Converse message paths had no `elif element["type"] == "document"` branch — blocks were skipped silently.
2. `_convert_to_bedrock_tool_call_result()` only handled `text` and `image_url`, dropping `document` blocks in tool results.
3. `DocumentBlock` in `litellm/types/llms/bedrock.py` was missing `citations` and `context` fields.

### Fix

- Added `_process_document_message()` static method on `BedrockConverseMessagesProcessor`:
  - Validates `source.type == "base64"`
  - Maps `media_type` → Bedrock format string (pdf, csv, docx, xlsx, html, txt, md, etc.)
  - Generates a deterministic document name using SHA-256 content hashing
  - Forwards `citations: {enabled: true}` → `CitationsConfig(enabled=True)` ([Bedrock Converse API docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html))
  - Forwards `context` field
- Added `elif element["type"] == "document"` branch in the **async** user-message path
- Added `elif element["type"] == "document"` branch in the **sync** user-message path (`_bedrock_converse_messages_pt`)
- Added `elif content["type"] == "document"` branch in `_convert_to_bedrock_tool_call_result()` (tool results)
- Added `CitationsConfig` TypedDict and extended `DocumentBlock` with optional `citations` and `context` fields

### Before / After

```python
messages = [{"role": "user", "content": [
    {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="},
     "citations": {"enabled": True}, "context": "Q4 report"},
    {"type": "text", "text": "What is the title?"},
]}]

result = _bedrock_converse_messages_pt(messages, "anthropic.claude-sonnet-4-6", "bedrock")

# Before: [{'text': 'What is the title?'}]   — document dropped, citations/context lost
# After:  [{'document': {'source': {'bytes': 'dGVzdA=='}, 'format': 'pdf', 'name': '...',
#            'citations': {'enabled': True}, 'context': 'Q4 report'}},
#           {'text': 'What is the title?'}]
```

### Tests added (`tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_document_blocks.py`)

| Test | What it verifies |
|------|-----------------|
| `test_document_block_basic` | Document block produces correct format, source.bytes, and name |
| `test_document_block_not_dropped_with_text` | Mixed document + text preserves both blocks |
| `test_document_block_citations_forwarded` | `citations.enabled=True` forwarded to `CitationsConfig` |
| `test_document_block_citations_not_set_when_disabled` | `citations` absent when disabled |
| `test_document_block_context_forwarded` | `context` field forwarded to DocumentBlock |
| `test_document_block_deterministic_name` | Same data always produces the same name |
| `test_document_format_mapping` | 7 MIME types map to correct Bedrock format strings |
| `test_document_in_tool_result` | Document in tool result produces correct content block |
| `test_non_base64_source_raises` | Non-base64 source raises a clear error |

🤖 Generated with [Claude Code](https://claude.com/claude-code)