### PR TITLE
[Fix] Responses API: Omit Empty Body On DELETE

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2535,10 +2535,16 @@ class BaseLLMHTTPHandler:
             },
         )
 
+        delete_kwargs: Dict[str, Any] = {
+            "url": url,
+            "headers": headers,
+            "timeout": timeout,
+        }
+        if data:
+            delete_kwargs["json"] = data
+
         try:
-            response = await async_httpx_client.delete(
-                url=url, headers=headers, json=data, timeout=timeout
-            )
+            response = await async_httpx_client.delete(**delete_kwargs)
 
         except Exception as e:
             raise self._handle_error(
@@ -2619,10 +2625,16 @@ class BaseLLMHTTPHandler:
             },
         )
 
+        delete_kwargs: Dict[str, Any] = {
+            "url": url,
+            "headers": headers,
+            "timeout": timeout,
+        }
+        if data:
+            delete_kwargs["json"] = data
+
         try:
-            response = sync_httpx_client.delete(
-                url=url, headers=headers, json=data, timeout=timeout
-            )
+            response = sync_httpx_client.delete(**delete_kwargs)
 
         except Exception as e:
             raise self._handle_error(

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from unittest.mock import AsyncMock, Mock, patch
@@ -8,6 +9,8 @@ import pytest
 sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
+import litellm
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _google_genai_streaming_hidden_params,
@@ -103,7 +106,9 @@ def test_fingerprint_agentic_tools_is_deterministic():
     tools_a = {"tool_calls": [{"id": "1", "input": {"q": "abc"}, "name": "web_search"}]}
     tools_b = {"tool_calls": [{"name": "web_search", "input": {"q": "abc"}, "id": "1"}]}
 
-    assert handler._fingerprint_agentic_tools(tools_a) == handler._fingerprint_agentic_tools(tools_b)
+    assert handler._fingerprint_agentic_tools(
+        tools_a
+    ) == handler._fingerprint_agentic_tools(tools_b)
 
 
 @pytest.mark.asyncio
@@ -350,3 +355,70 @@ def test_google_genai_streaming_hidden_params_model_info_and_router_fallback():
         response_headers=httpx.Headers({}),
     )
     assert from_router["model_id"] == "router-model-id"
+
+
+def _build_delete_response_mock(captured: dict):
+    """Returns a fake httpx delete that records its kwargs."""
+
+    def _response() -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            content=b'{"id": "resp_x", "object": "response", "deleted": true}',
+            request=httpx.Request(method="DELETE", url="https://test.openai.azure.com"),
+        )
+
+    async def fake_async_delete(*args, **kwargs):
+        captured.update(kwargs)
+        return _response()
+
+    def fake_sync_delete(*args, **kwargs):
+        captured.update(kwargs)
+        return _response()
+
+    return fake_async_delete, fake_sync_delete
+
+
+def test_async_delete_responses_omits_body_for_azure():
+    """Azure responses DELETE rejects requests with any body. Verify the handler
+    does not pass `json=` to httpx when the transformer returns an empty dict."""
+    captured: dict = {}
+    fake_async_delete, _ = _build_delete_response_mock(captured)
+
+    async def run():
+        with patch.object(AsyncHTTPHandler, "delete", new=fake_async_delete):
+            await litellm.adelete_responses(
+                response_id="resp_xyz",
+                custom_llm_provider="azure",
+                api_base="https://test.openai.azure.com",
+                api_key="test-key",
+                api_version="2025-03-01-preview",
+            )
+
+    asyncio.run(run())
+
+    assert "json" not in captured
+    assert "data" not in captured
+    assert captured["url"].endswith(
+        "/openai/responses/resp_xyz?api-version=2025-03-01-preview"
+    )
+
+
+def test_sync_delete_responses_omits_body_for_azure():
+    captured: dict = {}
+    _, fake_sync_delete = _build_delete_response_mock(captured)
+
+    with patch.object(HTTPHandler, "delete", new=fake_sync_delete):
+        litellm.delete_responses(
+            response_id="resp_xyz",
+            custom_llm_provider="azure",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-03-01-preview",
+        )
+
+    assert "json" not in captured
+    assert "data" not in captured
+    assert captured["url"].endswith(
+        "/openai/responses/resp_xyz?api-version=2025-03-01-preview"
+    )


### PR DESCRIPTION
## Summary

The Azure Responses `DELETE /openai/responses/{id}` endpoint now rejects any request body with:

```
{
  "error": {
    "message": "Unexpected body with size 2. This API method does not accept a request body.",
    "type": "invalid_request_error",
    "code": "unexpected_body"
  }
}
```

`delete_response_api_handler` (sync) and `async_delete_response_api_handler` always pass `json=data` into `httpx.delete`, where `data` is the empty dict returned by `transform_delete_response_api_request`. httpx serializes `json={}` to a 2-byte `{}` body — the size in the error message above. OpenAI's endpoint and the prior Azure deployment tolerated it; the current Azure deployment doesn't.

This breaks `test_basic_openai_responses_delete_endpoint[True]` on the `llm_responses_api_testing` CircleCI job — green at `50ef2d51a2` (03:39 UTC, 2026-04-30), red at `609454d0f1` (17:56 UTC) with byte-identical trees, so the change came from outside the repo.

## Changes

- `litellm/llms/custom_httpx/llm_http_handler.py`: build the `httpx.delete` kwargs dict and only set `json=` when `data` is truthy (sync + async).
- `tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py`: two regression tests that patch `httpx.delete` and assert `json` / `data` aren't in the captured kwargs for the Azure DELETE path.

## Scope deliberately not changed

- **Cancel** uses POST. Empty POST bodies are spec-allowed and not part of the failing test.
- **Get** uses `params=data`, not `json=`, so an empty dict is already a no-op.

## Test plan

- [x] `uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -v` — 9 passed locally.
- [ ] CircleCI `llm_responses_api_testing` job goes green (the actual signal — local mocks can't prove Azure stops rejecting).