### PR TITLE
Refactor content traversal in moderation/guardrail hooks

### DIFF
--- a/enterprise/enterprise_hooks/banned_keywords.py
+++ b/enterprise/enterprise_hooks/banned_keywords.py
@@ -10,6 +10,7 @@
 from typing import Literal
 import litellm
 from litellm.caching.caching import DualCache
+from litellm.litellm_core_utils.safe_messages import iter_message_texts
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.integrations.custom_logger import CustomLogger
 from litellm._logging import verbose_proxy_logger
@@ -74,9 +75,8 @@ class _ENTERPRISE_BannedKeywords(CustomLogger):
             """
             self.print_verbose("Inside Banned Keyword List Pre-Call Hook")
             if call_type == "completion" and "messages" in data:
-                for m in data["messages"]:
-                    if "content" in m and isinstance(m["content"], str):
-                        self.test_violation(test_str=m["content"])
+                for _, _, text in iter_message_texts(data["messages"]):
+                    self.test_violation(test_str=text)
 
         except HTTPException as e:
             raise e

--- a/enterprise/enterprise_hooks/google_text_moderation.py
+++ b/enterprise/enterprise_hooks/google_text_moderation.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.safe_messages import collect_message_text
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import CallTypesLiteral
 
@@ -95,10 +96,7 @@ class _ENTERPRISE_GoogleTextModeration(CustomLogger):
         - Rejects request if it fails safety check
         """
         if "messages" in data and isinstance(data["messages"], list):
-            text = ""
-            for m in data["messages"]:  # assume messages is a list
-                if "content" in m and isinstance(m["content"], str):
-                    text += m["content"]
+            text = collect_message_text(data["messages"])
             document = self.language_document(content=text, type_=self.document_type)
 
             request = self.moderate_text_request(

--- a/enterprise/enterprise_hooks/openai_moderation.py
+++ b/enterprise/enterprise_hooks/openai_moderation.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.safe_messages import collect_message_text
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import CallTypesLiteral
 
@@ -39,9 +40,7 @@ class _ENTERPRISE_OpenAI_Moderation(CustomLogger):
     ):
         text = ""
         if "messages" in data and isinstance(data["messages"], list):
-            for m in data["messages"]:  # assume messages is a list
-                if "content" in m and isinstance(m["content"], str):
-                    text += m["content"]
+            text = collect_message_text(data["messages"])
 
         from litellm.proxy.proxy_server import llm_router
 

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -17,6 +17,10 @@ from typing import Optional
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.safe_messages import (
+    iter_request_texts,
+    set_request_text,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 
 GUARDRAIL_NAME = "hide_secrets"
@@ -473,75 +477,20 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
         if await self.should_run_check(user_api_key_dict) is False:
             return
 
-        if "messages" in data and isinstance(data["messages"], list):
-            for message in data["messages"]:
-                if "content" in message and isinstance(message["content"], str):
-                    detected_secrets = self.scan_message_for_secrets(message["content"])
-
-                    for secret in detected_secrets:
-                        message["content"] = message["content"].replace(
-                            secret["value"], "[REDACTED]"
-                        )
-
-                    if len(detected_secrets) > 0:
-                        secret_types = [secret["type"] for secret in detected_secrets]
-                        verbose_proxy_logger.warning(
-                            f"Detected and redacted secrets in message: {secret_types}"
-                        )
-                    else:
-                        verbose_proxy_logger.debug("No secrets detected on input.")
-
-        if "prompt" in data:
-            if isinstance(data["prompt"], str):
-                detected_secrets = self.scan_message_for_secrets(data["prompt"])
-                for secret in detected_secrets:
-                    data["prompt"] = data["prompt"].replace(
-                        secret["value"], "[REDACTED]"
-                    )
-                if len(detected_secrets) > 0:
-                    secret_types = [secret["type"] for secret in detected_secrets]
-                    verbose_proxy_logger.warning(
-                        f"Detected and redacted secrets in prompt: {secret_types}"
-                    )
-            elif isinstance(data["prompt"], list):
-                for item in data["prompt"]:
-                    if isinstance(item, str):
-                        detected_secrets = self.scan_message_for_secrets(item)
-                        for secret in detected_secrets:
-                            item = item.replace(secret["value"], "[REDACTED]")
-                        if len(detected_secrets) > 0:
-                            secret_types = [
-                                secret["type"] for secret in detected_secrets
-                            ]
-                            verbose_proxy_logger.warning(
-                                f"Detected and redacted secrets in prompt: {secret_types}"
-                            )
-
-        if "input" in data:
-            if isinstance(data["input"], str):
-                detected_secrets = self.scan_message_for_secrets(data["input"])
-                for secret in detected_secrets:
-                    data["input"] = data["input"].replace(secret["value"], "[REDACTED]")
-                if len(detected_secrets) > 0:
-                    secret_types = [secret["type"] for secret in detected_secrets]
-                    verbose_proxy_logger.warning(
-                        f"Detected and redacted secrets in input: {secret_types}"
-                    )
-            elif isinstance(data["input"], list):
-                _input_in_request = data["input"]
-                for idx, item in enumerate(_input_in_request):
-                    if isinstance(item, str):
-                        detected_secrets = self.scan_message_for_secrets(item)
-                        for secret in detected_secrets:
-                            _input_in_request[idx] = item.replace(
-                                secret["value"], "[REDACTED]"
-                            )
-                        if len(detected_secrets) > 0:
-                            secret_types = [
-                                secret["type"] for secret in detected_secrets
-                            ]
-                            verbose_proxy_logger.warning(
-                                f"Detected and redacted secrets in input: {secret_types}"
-                            )
-                verbose_proxy_logger.debug("Data after redacting input %s", data)
+        any_detected = False
+        for source, slot, text in iter_request_texts(data):
+            detected_secrets = self.scan_message_for_secrets(text)
+            if not detected_secrets:
+                continue
+            any_detected = True
+            redacted = text
+            for secret in detected_secrets:
+                redacted = redacted.replace(secret["value"], "[REDACTED]")
+            set_request_text(data, source, slot, redacted)
+            secret_types = [secret["type"] for secret in detected_secrets]
+            verbose_proxy_logger.warning(
+                f"Detected and redacted secrets in {source}: {secret_types}"
+            )
+        if not any_detected:
+            verbose_proxy_logger.debug("No secrets detected on input.")
         return

--- a/litellm/litellm_core_utils/safe_messages.py
+++ b/litellm/litellm_core_utils/safe_messages.py
@@ -1,0 +1,132 @@
+"""
+Safe traversal of message and request content for guardrails.
+
+Chat-completion `message["content"]` may be either a plain string OR a list of
+content parts (multimodal: `[{"type": "text", "text": "..."}, {"type": "image_url", ...}]`).
+Guardrails that only check `isinstance(content, str)` silently skip the list
+shape, allowing users to bypass moderation, secret detection, and banned-keyword
+checks. All guardrail and moderation hooks must traverse content through these
+helpers so the list shape is handled consistently in one place.
+"""
+
+from typing import Iterator, List, Optional, Tuple
+
+# (msg_idx, part_idx_or_None, text)
+TextSlot = Tuple[int, Optional[int], str]
+# (source, slot, text) where source ∈ {"messages", "prompt", "input"}
+RequestTextSlot = Tuple[str, TextSlot, str]
+
+
+def iter_message_texts(messages: List[dict]) -> Iterator[TextSlot]:
+    """Yield (msg_idx, part_idx, text) for every text fragment in `messages`.
+
+    - `part_idx` is None when the message's `content` is a plain string.
+    - `part_idx` is an int when `content` is a list; only items whose
+      `type == "text"` (or bare-string items, which bedrock allows) are yielded.
+    - Messages with content that is None, missing, or an unexpected shape are
+      skipped silently.
+    - Non-string `text` values inside a part dict are skipped silently.
+    Does not mutate `messages`.
+    """
+    for msg_idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            yield msg_idx, None, content
+        elif isinstance(content, list):
+            for part_idx, part in enumerate(content):
+                if isinstance(part, str):
+                    yield msg_idx, part_idx, part
+                elif isinstance(part, dict) and part.get("type") == "text":
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        yield msg_idx, part_idx, text
+
+
+def set_message_text(
+    messages: List[dict],
+    msg_idx: int,
+    part_idx: Optional[int],
+    new_text: str,
+) -> None:
+    """Write `new_text` into the slot previously yielded by `iter_message_texts`.
+
+    - If `part_idx is None`, replaces the message's string `content`.
+    - If `part_idx is not None`, replaces `content[part_idx]["text"]`, or replaces
+      a bare-string list entry directly.
+    - No-ops if the slot no longer exists (defensive against concurrent mutation).
+    """
+    if msg_idx < 0 or msg_idx >= len(messages):
+        return
+    msg = messages[msg_idx]
+    if not isinstance(msg, dict):
+        return
+    if part_idx is None:
+        msg["content"] = new_text
+        return
+    content = msg.get("content")
+    if not isinstance(content, list) or part_idx < 0 or part_idx >= len(content):
+        return
+    part = content[part_idx]
+    if isinstance(part, str):
+        content[part_idx] = new_text
+    elif isinstance(part, dict) and part.get("type") == "text":
+        part["text"] = new_text
+
+
+def collect_message_text(messages: List[dict], separator: str = "") -> str:
+    """Concatenate every text fragment from `messages` in iteration order.
+
+    Convenience for moderation hooks that batch one string per request.
+    Default separator is "" to preserve existing concatenation semantics.
+    """
+    return separator.join(text for _, _, text in iter_message_texts(messages))
+
+
+def iter_request_texts(data: dict) -> Iterator[RequestTextSlot]:
+    """Yield (source, slot, text) for every scannable text in a proxy request.
+
+    Walks `data["messages"]`, `data["prompt"]`, and `data["input"]`. Each yielded
+    `slot` is a `TextSlot` that can be passed to `set_request_text` to write a
+    redacted value back into the same location.
+
+    For `prompt` and `input` (which are str or list[str]), the slot's
+    `part_idx` is None for the string shape and an int for the list shape.
+    """
+    messages = data.get("messages")
+    if isinstance(messages, list):
+        for msg_idx, part_idx, text in iter_message_texts(messages):
+            yield "messages", (msg_idx, part_idx, text), text
+
+    for source in ("prompt", "input"):
+        value = data.get(source)
+        if isinstance(value, str):
+            yield source, (0, None, value), value
+        elif isinstance(value, list):
+            for idx, item in enumerate(value):
+                if isinstance(item, str):
+                    yield source, (0, idx, item), item
+
+
+def set_request_text(data: dict, source: str, slot: TextSlot, new_text: str) -> None:
+    """Mutating counterpart to `iter_request_texts`.
+
+    Writes `new_text` back into the slot that was yielded by `iter_request_texts`.
+    """
+    msg_idx, part_idx, _ = slot
+    if source == "messages":
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            set_message_text(messages, msg_idx, part_idx, new_text)
+        return
+    if source not in ("prompt", "input"):
+        return
+    value = data.get(source)
+    if part_idx is None:
+        if isinstance(value, str):
+            data[source] = new_text
+        return
+    if isinstance(value, list) and 0 <= part_idx < len(value):
+        if isinstance(value[part_idx], str):
+            value[part_idx] = new_text

--- a/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/ibm_detector.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/ibm_detector.py
@@ -15,6 +15,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.safe_messages import iter_message_texts
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -465,11 +466,9 @@ class IBMGuardrailDetector(CustomGuardrail):
 
         _messages = data.get("messages")
         if _messages:
-            contents_to_check: List[str] = []
-            for message in _messages:
-                _content = message.get("content")
-                if isinstance(_content, str):
-                    contents_to_check.append(_content)
+            contents_to_check: List[str] = [
+                text for _, _, text in iter_message_texts(_messages)
+            ]
 
             if contents_to_check:
                 if self.is_detector_server:
@@ -552,11 +551,9 @@ class IBMGuardrailDetector(CustomGuardrail):
 
         _messages = data.get("messages")
         if _messages:
-            contents_to_check: List[str] = []
-            for message in _messages:
-                _content = message.get("content")
-                if isinstance(_content, str):
-                    contents_to_check.append(_content)
+            contents_to_check: List[str] = [
+                text for _, _, text in iter_message_texts(_messages)
+            ]
 
             if contents_to_check:
                 if self.is_detector_server:

--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
@@ -1,7 +1,7 @@
 import copy
 import os
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 from fastapi import HTTPException
 
@@ -89,8 +89,11 @@ class LakeraAIGuardrail(CustomGuardrail):
         flattened: List[AllMessageValues] = []
         for msg in messages:
             if isinstance(msg, dict) and isinstance(msg.get("content"), list):
-                new_msg = {**msg, "content": collect_message_text([msg])}
-                flattened.append(new_msg)  # type: ignore[arg-type]
+                new_msg = {
+                    **msg,
+                    "content": collect_message_text([cast(dict, msg)]),
+                }
+                flattened.append(cast(AllMessageValues, new_msg))
             else:
                 flattened.append(msg)
         return flattened
@@ -191,7 +194,7 @@ class LakeraAIGuardrail(CustomGuardrail):
             is_list_content = isinstance(content, list)
             if is_list_content:
                 # Flatten to the same string Lakera saw, so offsets line up.
-                content_str = collect_message_text([msg])
+                content_str = collect_message_text([cast(dict, msg)])
                 if not content_str:
                     continue
             elif isinstance(content, str):
@@ -230,7 +233,7 @@ class LakeraAIGuardrail(CustomGuardrail):
                     )
                     masked_entity_count[typ] = masked_entity_count.get(typ, 0) + 1
 
-            if is_list_content:
+            if isinstance(content, list):
                 # Write masked text into the first text part; clear the rest.
                 # Non-text parts (image_url, etc.) are preserved in place.
                 first_text_idx: Optional[int] = None

--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.safe_messages import collect_message_text
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -69,6 +70,31 @@ class LakeraAIGuardrail(CustomGuardrail):
         self.on_flagged = on_flagged or "block"
         super().__init__(**kwargs)
 
+    @staticmethod
+    def _flatten_messages_for_lakera(
+        messages: List[AllMessageValues],
+    ) -> List[AllMessageValues]:
+        """
+        Return a copy of `messages` with multimodal list-shaped content
+        flattened to a single string per message.
+
+        Lakera's v2 API expects string content; if we forward multimodal
+        list content unchanged, Lakera does not scan the text fragments
+        and the request bypasses detection. By concatenating text parts
+        into a string before sending, we ensure detection runs over all
+        text the user provided. Non-text parts (image_url, etc.) are
+        dropped from the copy sent to Lakera but preserved in the
+        original `messages` list passed elsewhere.
+        """
+        flattened: List[AllMessageValues] = []
+        for msg in messages:
+            if isinstance(msg, dict) and isinstance(msg.get("content"), list):
+                new_msg = {**msg, "content": collect_message_text([msg])}
+                flattened.append(new_msg)  # type: ignore[arg-type]
+            else:
+                flattened.append(msg)
+        return flattened
+
     async def call_v2_guard(
         self,
         messages: List[AllMessageValues],
@@ -87,7 +113,7 @@ class LakeraAIGuardrail(CustomGuardrail):
         try:
             request = dict(
                 LakeraAIRequest(
-                    messages=messages,
+                    messages=self._flatten_messages_for_lakera(messages),
                     project_id=self.project_id,
                     payload=self.payload,
                     breakdown=self.breakdown,
@@ -144,6 +170,12 @@ class LakeraAIGuardrail(CustomGuardrail):
         """
         Return a copy of messages with any detected PII replaced by
         “[MASKED <TYPE>]” tokens.
+
+        For multimodal list-shaped content, masking is applied against the
+        same flattened text we sent to Lakera (see `_flatten_messages_for_lakera`),
+        so Lakera's reported offsets line up. The masked result is written
+        back into the first text part of the list; any remaining text parts
+        are cleared. Non-text parts (image_url, etc.) are preserved.
         """
         payload = lakera_response.get("payload") if lakera_response else None
         if not payload:
@@ -156,8 +188,15 @@ class LakeraAIGuardrail(CustomGuardrail):
             if not content:
                 continue
 
-            # For v1, we only support masking content strings
-            if not isinstance(content, str):
+            is_list_content = isinstance(content, list)
+            if is_list_content:
+                # Flatten to the same string Lakera saw, so offsets line up.
+                content_str = collect_message_text([msg])
+                if not content_str:
+                    continue
+            elif isinstance(content, str):
+                content_str = content
+            else:
                 continue
 
             # Filter only detections for this message
@@ -183,15 +222,33 @@ class LakeraAIGuardrail(CustomGuardrail):
                 typ = detector_type.split("/")[-1].upper() or "PII"
                 mask = f"[MASKED {typ}]"
                 if start is not None and end is not None:
-                    content = self.mask_content_in_string(
-                        content_string=content,
+                    content_str = self.mask_content_in_string(
+                        content_string=content_str,
                         mask_string=mask,
                         start_index=start,
                         end_index=end,
                     )
                     masked_entity_count[typ] = masked_entity_count.get(typ, 0) + 1
 
-            msg["content"] = content
+            if is_list_content:
+                # Write masked text into the first text part; clear the rest.
+                # Non-text parts (image_url, etc.) are preserved in place.
+                first_text_idx: Optional[int] = None
+                for part_idx, part in enumerate(content):
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        if first_text_idx is None:
+                            first_text_idx = part_idx
+                            part["text"] = content_str
+                        else:
+                            part["text"] = ""
+                    elif isinstance(part, str):
+                        if first_text_idx is None:
+                            first_text_idx = part_idx
+                            content[part_idx] = content_str
+                        else:
+                            content[part_idx] = ""
+            else:
+                msg["content"] = content_str
         return messages
 
     async def async_pre_call_hook(

--- a/litellm/proxy/hooks/azure_content_safety.py
+++ b/litellm/proxy/hooks/azure_content_safety.py
@@ -7,6 +7,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.safe_messages import iter_message_texts
 from litellm.proxy._types import UserAPIKeyAuth
 
 
@@ -119,9 +120,8 @@ class _PROXY_AzureContentSafety(
         verbose_proxy_logger.debug("Inside Azure Content-Safety Pre-Call Hook")
         try:
             if call_type == "completion" and "messages" in data:
-                for m in data["messages"]:
-                    if "content" in m and isinstance(m["content"], str):
-                        await self.test_violation(content=m["content"], source="input")
+                for _, _, text in iter_message_texts(data["messages"]):
+                    await self.test_violation(content=text, source="input")
 
         except HTTPException as e:
             raise e

--- a/tests/test_litellm/litellm_core_utils/test_safe_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_messages.py
@@ -1,0 +1,166 @@
+"""Unit tests for the safe_messages traversal helpers."""
+
+import copy
+
+from litellm.litellm_core_utils.safe_messages import (
+    collect_message_text,
+    iter_message_texts,
+    iter_request_texts,
+    set_message_text,
+    set_request_text,
+)
+
+
+def test_iter_string_content():
+    messages = [{"role": "user", "content": "hello"}]
+    assert list(iter_message_texts(messages)) == [(0, None, "hello")]
+
+
+def test_iter_multimodal_text_part():
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    assert list(iter_message_texts(messages)) == [(0, 0, "hello")]
+
+
+def test_iter_mixed_parts_skips_non_text():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "image_url", "image_url": {"url": "https://x"}},
+                {"type": "text", "text": "second"},
+            ],
+        }
+    ]
+    assert list(iter_message_texts(messages)) == [
+        (0, 0, "first"),
+        (0, 2, "second"),
+    ]
+
+
+def test_iter_bare_string_in_list():
+    messages = [{"role": "user", "content": ["a", "b"]}]
+    assert list(iter_message_texts(messages)) == [(0, 0, "a"), (0, 1, "b")]
+
+
+def test_iter_skips_none_missing_and_garbage():
+    messages = [
+        {"role": "assistant", "content": None},
+        {"role": "user"},
+        {"role": "user", "content": 42},
+        {"role": "user", "content": [{"type": "image_url"}]},
+        {"role": "user", "content": [{"type": "text", "text": None}]},
+        "not-a-dict",
+    ]
+    assert list(iter_message_texts(messages)) == []
+
+
+def test_set_string_content():
+    messages = [{"role": "user", "content": "old"}]
+    set_message_text(messages, 0, None, "new")
+    assert messages[0]["content"] == "new"
+
+
+def test_set_text_part_preserves_other_parts():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "old"},
+                {"type": "image_url", "image_url": {"url": "https://x"}},
+            ],
+        }
+    ]
+    set_message_text(messages, 0, 0, "new")
+    assert messages[0]["content"][0] == {"type": "text", "text": "new"}
+    assert messages[0]["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "https://x"},
+    }
+
+
+def test_set_bare_string_in_list():
+    messages = [{"role": "user", "content": ["a", "b"]}]
+    set_message_text(messages, 0, 1, "B")
+    assert messages[0]["content"] == ["a", "B"]
+
+
+def test_set_out_of_bounds_no_op():
+    messages = [{"role": "user", "content": "x"}]
+    before = copy.deepcopy(messages)
+    set_message_text(messages, 5, None, "y")
+    set_message_text(messages, 0, 99, "y")
+    assert messages == before
+
+
+def test_collect_concatenates_in_order():
+    messages = [
+        {"role": "user", "content": "one "},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "two "},
+                {"type": "image_url", "image_url": {"url": "x"}},
+                {"type": "text", "text": "three"},
+            ],
+        },
+    ]
+    assert collect_message_text(messages) == "one two three"
+    assert collect_message_text(messages, separator="|") == "one |two |three"
+
+
+def test_round_trip_iter_then_set_is_idempotent():
+    messages = [
+        {"role": "user", "content": "raw"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "mm"},
+                {"type": "image_url", "image_url": {"url": "x"}},
+            ],
+        },
+    ]
+    before = copy.deepcopy(messages)
+    for msg_idx, part_idx, text in list(iter_message_texts(messages)):
+        set_message_text(messages, msg_idx, part_idx, text)
+    assert messages == before
+
+
+def test_iter_request_texts_walks_messages_prompt_and_input():
+    data = {
+        "messages": [
+            {"role": "user", "content": "msg"},
+            {"role": "user", "content": [{"type": "text", "text": "mm"}]},
+        ],
+        "prompt": ["p0", "p1"],
+        "input": "in",
+    }
+    yielded = list(iter_request_texts(data))
+    assert yielded == [
+        ("messages", (0, None, "msg"), "msg"),
+        ("messages", (1, 0, "mm"), "mm"),
+        ("prompt", (0, 0, "p0"), "p0"),
+        ("prompt", (0, 1, "p1"), "p1"),
+        ("input", (0, None, "in"), "in"),
+    ]
+
+
+def test_set_request_text_writes_back_for_each_source():
+    data = {
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "m"}]}],
+        "prompt": ["p"],
+        "input": "i",
+    }
+    set_request_text(data, "messages", (0, 0, "m"), "M")
+    set_request_text(data, "prompt", (0, 0, "p"), "P")
+    set_request_text(data, "input", (0, None, "i"), "I")
+    assert data["messages"][0]["content"][0]["text"] == "M"
+    assert data["prompt"] == ["P"]
+    assert data["input"] == "I"
+
+
+def test_set_request_text_unknown_source_is_no_op():
+    data = {"messages": [{"role": "user", "content": "x"}]}
+    before = copy.deepcopy(data)
+    set_request_text(data, "bogus", (0, None, "x"), "y")
+    assert data == before

--- a/tests/test_litellm/proxy/guardrails/test_multimodal_content_bypass.py
+++ b/tests/test_litellm/proxy/guardrails/test_multimodal_content_bypass.py
@@ -1,0 +1,320 @@
+"""
+Regression tests for the multimodal-content guardrail bypass.
+
+Each guardrail covered here previously short-circuited on
+`isinstance(content, str)` and silently skipped multimodal list-shaped
+message content (e.g. `[{"type": "text", "text": "..."}]`), allowing users
+to evade scanning. These tests assert that the same logical payload triggers
+the same guardrail behavior whether it arrives as a plain string or as a
+multimodal list.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _string_messages(payload: str):
+    return [{"role": "user", "content": payload}]
+
+
+def _multimodal_messages(payload: str):
+    return [{"role": "user", "content": [{"type": "text", "text": payload}]}]
+
+
+@pytest.fixture(params=["string", "multimodal"], ids=["string", "multimodal"])
+def messages_factory(request):
+    return _string_messages if request.param == "string" else _multimodal_messages
+
+
+# ---------------------------------------------------------------------------
+# secret_detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secret_detection_redacts_in_both_shapes(messages_factory):
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm_enterprise.enterprise_callbacks.secret_detection import (
+        _ENTERPRISE_SecretDetection,
+    )
+
+    secret_instance = _ENTERPRISE_SecretDetection()
+    payload = "API_KEY = 'sk_1234567890abcdef'"
+    data = {"messages": messages_factory(payload), "model": "gpt-3.5-turbo"}
+
+    await secret_instance.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+        call_type="completion",
+    )
+
+    content = data["messages"][0]["content"]
+    if isinstance(content, str):
+        assert "[REDACTED]" in content
+        assert "sk_1234567890abcdef" not in content
+    else:
+        assert "[REDACTED]" in content[0]["text"]
+        assert "sk_1234567890abcdef" not in content[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_secret_detection_redacts_prompt_list_writes_back():
+    """Regression for the latent bug where `for item in data['prompt']: item = ...`
+    rebound the loop variable but never wrote back."""
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm_enterprise.enterprise_callbacks.secret_detection import (
+        _ENTERPRISE_SecretDetection,
+    )
+
+    secret_instance = _ENTERPRISE_SecretDetection()
+    data = {
+        "prompt": [
+            "first prompt with API_KEY = 'sk_1234567890abcdef'",
+            "second clean prompt",
+        ]
+    }
+
+    await secret_instance.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+        call_type="completion",
+    )
+
+    assert "[REDACTED]" in data["prompt"][0]
+    assert "sk_1234567890abcdef" not in data["prompt"][0]
+    assert data["prompt"][1] == "second clean prompt"
+
+
+# ---------------------------------------------------------------------------
+# banned_keywords
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_banned_keywords_blocks_in_both_shapes(messages_factory):
+    import litellm
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    litellm.banned_keywords_list = ["forbidden"]
+    from enterprise.enterprise_hooks.banned_keywords import _ENTERPRISE_BannedKeywords
+
+    instance = _ENTERPRISE_BannedKeywords()
+    data = {"messages": messages_factory("please say forbidden out loud")}
+
+    with pytest.raises(HTTPException) as exc:
+        await instance.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+            cache=DualCache(),
+            call_type="completion",
+            data=data,
+        )
+    assert "forbidden" in str(exc.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# openai_moderation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_moderation_sends_text_in_both_shapes(messages_factory):
+    from enterprise.enterprise_hooks.openai_moderation import (
+        _ENTERPRISE_OpenAI_Moderation,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    instance = _ENTERPRISE_OpenAI_Moderation()
+    payload = "scan-this-text"
+    data = {"messages": messages_factory(payload)}
+
+    fake_router = MagicMock()
+    fake_response = MagicMock()
+    fake_response.results = [MagicMock(flagged=False)]
+    fake_router.amoderation = AsyncMock(return_value=fake_response)
+
+    with patch("litellm.proxy.proxy_server.llm_router", fake_router):
+        await instance.async_moderation_hook(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+            call_type="completion",
+        )
+
+    fake_router.amoderation.assert_awaited_once()
+    sent_input = fake_router.amoderation.await_args.kwargs["input"]
+    assert payload in sent_input
+
+
+# ---------------------------------------------------------------------------
+# google_text_moderation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_google_text_moderation_sends_text_in_both_shapes(messages_factory):
+    pytest.importorskip("google.cloud.language_v1")
+    from enterprise.enterprise_hooks.google_text_moderation import (
+        _ENTERPRISE_GoogleTextModeration,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    # Skip __init__ to avoid spinning up a real Google client.
+    instance = _ENTERPRISE_GoogleTextModeration.__new__(
+        _ENTERPRISE_GoogleTextModeration
+    )
+    captured = {}
+
+    def fake_document(content, type_):
+        captured["content"] = content
+        return {"content": content}
+
+    def fake_request(document):
+        return {"document": document}
+
+    fake_client = MagicMock()
+    fake_client.moderate_text = MagicMock(
+        return_value=MagicMock(moderation_categories=[])
+    )
+    instance.client = fake_client
+    instance.language_document = fake_document
+    instance.moderate_text_request = fake_request
+    instance.document_type = "plain"
+
+    payload = "scan-this-text"
+    await instance.async_moderation_hook(
+        data={"messages": messages_factory(payload)},
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+        call_type="completion",
+    )
+
+    assert payload in captured["content"]
+
+
+# ---------------------------------------------------------------------------
+# azure_content_safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_azure_content_safety_scans_in_both_shapes(messages_factory):
+    pytest.importorskip("azure.ai.contentsafety")
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.hooks.azure_content_safety import _PROXY_AzureContentSafety
+
+    # Skip __init__ to avoid the real Azure client.
+    instance = _PROXY_AzureContentSafety.__new__(_PROXY_AzureContentSafety)
+    instance.test_violation = AsyncMock()
+
+    payload = "anything"
+    await instance.async_pre_call_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+        cache=DualCache(),
+        data={"messages": messages_factory(payload)},
+        call_type="completion",
+    )
+
+    instance.test_violation.assert_awaited_once_with(content=payload, source="input")
+
+
+# ---------------------------------------------------------------------------
+# ibm_detector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ibm_detector_scans_in_both_shapes(messages_factory):
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.guardrails.guardrail_hooks.ibm_guardrails.ibm_detector import (
+        IBMGuardrailDetector,
+    )
+
+    instance = IBMGuardrailDetector(
+        guardrail_name="ibm_test",
+        auth_token="t",
+        base_url="https://x",
+        detector_id="d",
+        is_detector_server=True,
+    )
+    instance.should_run_guardrail = MagicMock(return_value=True)
+    instance._call_detector_server = AsyncMock(return_value=[[]])
+    instance._filter_detections_by_threshold = MagicMock(return_value=[])
+
+    payload = "scan-me"
+    await instance.async_pre_call_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-12345"),
+        cache=MagicMock(),
+        data={"messages": messages_factory(payload)},
+        call_type="completion",
+    )
+
+    instance._call_detector_server.assert_awaited_once()
+    sent_contents = instance._call_detector_server.await_args.kwargs["contents"]
+    assert sent_contents == [payload]
+
+
+# ---------------------------------------------------------------------------
+# lakera_ai_v2
+# ---------------------------------------------------------------------------
+
+
+def test_lakera_flatten_messages_for_lakera_collapses_multimodal():
+    from litellm.proxy.guardrails.guardrail_hooks.lakera_ai_v2 import LakeraAIGuardrail
+
+    messages = [
+        {"role": "user", "content": "plain"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first "},
+                {"type": "image_url", "image_url": {"url": "x"}},
+                {"type": "text", "text": "second"},
+            ],
+        },
+    ]
+    flattened = LakeraAIGuardrail._flatten_messages_for_lakera(messages)
+    assert flattened[0]["content"] == "plain"
+    assert flattened[1]["content"] == "first second"
+    # original is not mutated
+    assert isinstance(messages[1]["content"], list)
+
+
+def test_lakera_mask_pii_writes_back_into_multimodal_first_text_part():
+    from litellm.proxy.guardrails.guardrail_hooks.lakera_ai_v2 import LakeraAIGuardrail
+
+    instance = LakeraAIGuardrail.__new__(LakeraAIGuardrail)
+    # The flattened text Lakera saw: "my secret is hunter2"
+    # Lakera reports an offset for "hunter2" (positions 13..20 in the flattened string).
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "my secret is "},
+                {"type": "image_url", "image_url": {"url": "x"}},
+                {"type": "text", "text": "hunter2"},
+            ],
+        }
+    ]
+    lakera_response = {
+        "payload": [
+            {
+                "message_id": 0,
+                "start": 13,
+                "end": 20,
+                "detector_type": "pii/password",
+            }
+        ]
+    }
+    masked = instance._mask_pii_in_messages(messages, lakera_response, {})
+    parts = masked[0]["content"]
+    # First text part holds the masked result; remaining text parts cleared;
+    # image part preserved.
+    assert parts[0]["text"] == "my secret is [MASKED PASSWORD]"
+    assert parts[1] == {"type": "image_url", "image_url": {"url": "x"}}
+    assert parts[2]["text"] == ""


### PR DESCRIPTION
## Summary

Internal refactor: centralize message-content traversal across guardrail and moderation hooks behind a shared helper. No user-facing API change.

## Linear ticket

Resolves LIT-2747

## Pre-Submission checklist

- [x] I have added tests under `tests/test_litellm/`
- [x] My PR's scope is isolated to this single problem
- [x] `make test-unit` passes locally