### PR TITLE
Fix MCP semantic filter native tool passthrough

### DIFF
--- a/litellm/proxy/_lazy_openapi_snapshot.py
+++ b/litellm/proxy/_lazy_openapi_snapshot.py
@@ -86,7 +86,6 @@ def generate_snapshot() -> Dict[str, Dict]:
     import importlib
 
     from fastapi.openapi.utils import get_openapi
-
     from litellm.proxy._lazy_features import LAZY_FEATURES
     from litellm.proxy.proxy_server import app, ensure_unique_openapi_operation_ids
 
@@ -132,7 +131,6 @@ def generate_snapshot() -> Dict[str, Dict]:
             "components": {"schemas": full.get("components", {}).get("schemas", {})},
         }
     return fragments
-
 
 if __name__ == "__main__":
     fragments = generate_snapshot()

--- a/litellm/proxy/_lazy_openapi_snapshot.py
+++ b/litellm/proxy/_lazy_openapi_snapshot.py
@@ -86,6 +86,7 @@ def generate_snapshot() -> Dict[str, Dict]:
     import importlib
 
     from fastapi.openapi.utils import get_openapi
+
     from litellm.proxy._lazy_features import LAZY_FEATURES
     from litellm.proxy.proxy_server import app, ensure_unique_openapi_operation_ids
 
@@ -131,6 +132,7 @@ def generate_snapshot() -> Dict[str, Dict]:
             "components": {"schemas": full.get("components", {}).get("schemas", {})},
         }
     return fragments
+
 
 if __name__ == "__main__":
     fragments = generate_snapshot()

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -146,23 +146,50 @@ class SemanticToolFilterHook(CustomLogger):
         name = getattr(tool, "name", "")
         return name if isinstance(name, str) else ""
 
-    def _is_mcp_router_tool(self, tool: Any) -> bool:
+    @staticmethod
+    def _is_native_function_tool(tool: Any) -> bool:
+        if not isinstance(tool, dict):
+            return False
+
+        if isinstance(tool.get("function"), dict):
+            return True
+
+        return tool.get("type") == "function" and isinstance(tool.get("name"), str)
+
+    @staticmethod
+    def _candidate_canonical_names(tool_name: str) -> List[str]:
+        return [
+            tool_name[index + 1 :]
+            for index, char in enumerate(tool_name)
+            if char in {"_", "-"} and index + 1 < len(tool_name)
+        ]
+
+    def _get_matching_mcp_canonical_name(self, tool: Any) -> Optional[str]:
+        if self._is_native_function_tool(tool):
+            return None
+
         tool_name = self._get_tool_name(tool)
         if not tool_name:
-            return False
+            return None
 
         tool_map = getattr(self.filter, "_tool_map", {})
         if tool_name in tool_map:
-            return True
+            return tool_name
 
         name_matches_canonical = getattr(self.filter, "_name_matches_canonical", None)
         if name_matches_canonical is None:
-            return False
+            return None
 
-        return any(
-            name_matches_canonical(tool_name, canonical_name)
-            for canonical_name in tool_map
-        )
+        for canonical_name in self._candidate_canonical_names(tool_name):
+            if canonical_name in tool_map and name_matches_canonical(
+                tool_name, canonical_name
+            ):
+                return canonical_name
+
+        return None
+
+    def _is_mcp_router_tool(self, tool: Any) -> bool:
+        return self._get_matching_mcp_canonical_name(tool) is not None
 
     def _partition_mcp_router_tools(
         self, tools: List[Any]

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -5,6 +5,7 @@ Pre-call hook that filters MCP tools semantically before LLM inference.
 Reduces context window size and improves tool selection accuracy.
 """
 
+from collections import Counter
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
@@ -177,6 +178,30 @@ class SemanticToolFilterHook(CustomLogger):
 
         return native_tools, mcp_tools
 
+    def _merge_filtered_tools_preserving_request_order(
+        self,
+        tools: List[Any],
+        filtered_mcp_tools: List[Any],
+    ) -> List[Any]:
+        filtered_mcp_tool_counts = Counter(
+            tool_name
+            for tool in filtered_mcp_tools
+            if (tool_name := self._get_tool_name(tool))
+        )
+        filtered_tools: List[Any] = []
+
+        for tool in tools:
+            if not self._is_mcp_router_tool(tool):
+                filtered_tools.append(tool)
+                continue
+
+            tool_name = self._get_tool_name(tool)
+            if filtered_mcp_tool_counts[tool_name] > 0:
+                filtered_tools.append(tool)
+                filtered_mcp_tool_counts[tool_name] -= 1
+
+        return filtered_tools
+
     async def async_pre_call_hook(
         self,
         user_api_key_dict: "UserAPIKeyAuth",
@@ -272,7 +297,7 @@ class SemanticToolFilterHook(CustomLogger):
                 f"with query: '{user_query[:50]}...'"
             )
 
-            native_tools, mcp_tools = self._partition_mcp_router_tools(tools)
+            _, mcp_tools = self._partition_mcp_router_tools(tools)
             if not mcp_tools:
                 verbose_proxy_logger.debug(
                     "No MCP router tools in request, skipping semantic filter"
@@ -284,7 +309,9 @@ class SemanticToolFilterHook(CustomLogger):
                 query=user_query,
                 available_tools=mcp_tools,  # type: ignore
             )
-            filtered_tools = native_tools + filtered_mcp_tools
+            filtered_tools = self._merge_filtered_tools_preserving_request_order(
+                tools, filtered_mcp_tools
+            )
 
             # Always update tools and emit header (even if count unchanged)
             data["tools"] = filtered_tools

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -77,10 +77,10 @@ class SemanticToolFilterHook(CustomLogger):
         )
 
         # Parse to separate MCP tools from other tools
-        mcp_tools, _ = LiteLLM_Proxy_MCP_Handler._parse_mcp_tools(tools)
+        mcp_tools, other_tools = LiteLLM_Proxy_MCP_Handler._parse_mcp_tools(tools)
 
         if not mcp_tools:
-            return []
+            return other_tools
 
         # Use single combined method instead of 3 separate calls
         # This already handles: fetch -> filter by allowed_tools -> deduplicate -> transform
@@ -118,15 +118,64 @@ class SemanticToolFilterHook(CustomLogger):
                 openai_tools_as_dicts.append(tool)
 
         verbose_proxy_logger.debug(
-            f"Expanded {len(mcp_tools)} MCP reference(s) to {len(openai_tools_as_dicts)} tools (all as dicts)"
+            f"Expanded {len(mcp_tools)} MCP reference(s) to {len(openai_tools_as_dicts)} "
+            f"tools and preserved {len(other_tools)} non-MCP tool(s)"
         )
 
-        return openai_tools_as_dicts
+        return other_tools + openai_tools_as_dicts
 
     def _get_metadata_variable_name(self, data: dict) -> str:
         if "litellm_metadata" in data:
             return "litellm_metadata"
         return "metadata"
+
+    @staticmethod
+    def _get_tool_name(tool: Any) -> str:
+        if isinstance(tool, dict):
+            function = tool.get("function")
+            if isinstance(function, dict) and isinstance(function.get("name"), str):
+                return function["name"]
+
+            name = tool.get("name")
+            if isinstance(name, str):
+                return name
+
+            return ""
+
+        name = getattr(tool, "name", "")
+        return name if isinstance(name, str) else ""
+
+    def _is_mcp_router_tool(self, tool: Any) -> bool:
+        tool_name = self._get_tool_name(tool)
+        if not tool_name:
+            return False
+
+        tool_map = getattr(self.filter, "_tool_map", {})
+        if tool_name in tool_map:
+            return True
+
+        name_matches_canonical = getattr(self.filter, "_name_matches_canonical", None)
+        if name_matches_canonical is None:
+            return False
+
+        return any(
+            name_matches_canonical(tool_name, canonical_name)
+            for canonical_name in tool_map
+        )
+
+    def _partition_mcp_router_tools(
+        self, tools: List[Any]
+    ) -> tuple[List[Any], List[Any]]:
+        native_tools: List[Any] = []
+        mcp_tools: List[Any] = []
+
+        for tool in tools:
+            if self._is_mcp_router_tool(tool):
+                mcp_tools.append(tool)
+            else:
+                native_tools.append(tool)
+
+        return native_tools, mcp_tools
 
     async def async_pre_call_hook(
         self,
@@ -223,11 +272,19 @@ class SemanticToolFilterHook(CustomLogger):
                 f"with query: '{user_query[:50]}...'"
             )
 
+            native_tools, mcp_tools = self._partition_mcp_router_tools(tools)
+            if not mcp_tools:
+                verbose_proxy_logger.debug(
+                    "No MCP router tools in request, skipping semantic filter"
+                )
+                return None
+
             # Filter tools semantically
-            filtered_tools = await self.filter.filter_tools(
+            filtered_mcp_tools = await self.filter.filter_tools(
                 query=user_query,
-                available_tools=tools,  # type: ignore
+                available_tools=mcp_tools,  # type: ignore
             )
+            filtered_tools = native_tools + filtered_mcp_tools
 
             # Always update tools and emit header (even if count unchanged)
             data["tools"] = filtered_tools
@@ -294,11 +351,7 @@ class SemanticToolFilterHook(CustomLogger):
 
         tool_names = []
         for tool in tools:
-            name = (
-                tool.get("name", "")
-                if isinstance(tool, dict)
-                else getattr(tool, "name", "")
-            )
+            name = self._get_tool_name(tool)
             if name:
                 tool_names.append(name)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -200,6 +200,7 @@ async def test_semantic_filter_top_k_limiting():
     # Should return at most 5 tools
     assert len(filtered) <= 5, f"Expected at most 5 tools, got {len(filtered)}"
 
+
 @pytest.mark.asyncio
 async def test_semantic_filter_disabled():
     """
@@ -559,6 +560,87 @@ async def test_semantic_filter_hook_preserves_native_openai_tools():
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_hook_keeps_native_tool_name_collisions_native():
+    """
+    Responses API native tools can carry a top-level name. If that name happens
+    to equal an MCP canonical name, the native tool must not be filtered as MCP.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    mcp_tool = {"name": "github-search", "description": "Search GitHub"}
+    filter_instance._tool_map = {mcp_tool["name"]: mcp_tool}
+    filter_instance.filter_tools = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    native_tool = {
+        "type": "function",
+        "name": "github-search",
+        "description": "Caller-owned search tool",
+        "parameters": {"type": "object"},
+    }
+    hook = SemanticToolFilterHook(filter_instance)
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Search GitHub"}],
+        "tools": [native_tool],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is None
+    filter_instance.filter_tools.assert_not_awaited()
+    assert data["tools"] == [native_tool]
+
+
+def test_semantic_filter_hook_prefixed_match_does_not_scan_whole_tool_map():
+    """
+    Matching a client-prefixed MCP tool should check candidate suffixes from the
+    incoming name instead of scanning every registered canonical tool.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    filter_instance._tool_map = {
+        **{f"server-{index}": {"name": f"server-{index}"} for index in range(1000)},
+        "github-search": {"name": "github-search"},
+    }
+    filter_instance._name_matches_canonical = Mock(  # type: ignore[method-assign]
+        wraps=filter_instance._name_matches_canonical
+    )
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    assert hook._is_mcp_router_tool({"name": "client_github-search"})
+    filter_instance._name_matches_canonical.assert_called_once_with(
+        "client_github-search", "github-search"
+    )
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_hook_preserves_remaining_tool_order():
     """
     Filtering MCP router tools should not reorder caller-owned native tools
@@ -704,9 +786,7 @@ class TestGetToolsByNames:
             {"name": "send_email", "description": "send mail"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            ["send_email"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["send_email"], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "send_email"
@@ -718,9 +798,7 @@ class TestGetToolsByNames:
         client_name = "litellm_" + canonical
         available_tools = [{"name": client_name, "description": "scrape"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         # Must return the incoming tool unchanged so the client-facing
@@ -731,13 +809,9 @@ class TestGetToolsByNames:
         """Some clients use dash as alias separator; accept that too."""
         filter_instance = self._make_filter()
         canonical = "weather_svc-get_weather"
-        available_tools = [
-            {"name": "mcp-" + canonical, "description": "weather"}
-        ]
+        available_tools = [{"name": "mcp-" + canonical, "description": "weather"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "mcp-" + canonical
@@ -767,9 +841,7 @@ class TestGetToolsByNames:
             {"name": "litellm_" + canonical, "description": "wrapped"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == canonical
@@ -782,9 +854,7 @@ class TestGetToolsByNames:
         separator-anchored suffixes of ``litellm_api-fs-read_file``.
         """
         filter_instance = self._make_filter()
-        available_tools = [
-            {"name": "litellm_api-fs-read_file", "description": "read"}
-        ]
+        available_tools = [{"name": "litellm_api-fs-read_file", "description": "read"}]
 
         matched = filter_instance._get_tools_by_names(
             ["fs-read_file", "api-fs-read_file"], available_tools
@@ -805,9 +875,7 @@ class TestGetToolsByNames:
             {"name": "my_" + canonical, "description": "plain search"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "my_" + canonical

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -5,10 +5,9 @@ Tests the core filtering logic that takes a long list of tools and returns
 an ordered set of top K tools based on semantic similarity.
 """
 
-import asyncio
 import os
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -137,12 +136,6 @@ async def test_semantic_filter_basic_filtering():
             tool, "description"
         ), "Filtered result should be MCPTool with description"
 
-    filtered_names = [t.name for t in filtered]
-    print(
-        f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}"
-    )
-    print(f"   Filter respects top_k parameter correctly")
-
 
 @pytest.mark.asyncio
 async def test_semantic_filter_top_k_limiting():
@@ -206,8 +199,6 @@ async def test_semantic_filter_top_k_limiting():
 
     # Should return at most 5 tools
     assert len(filtered) <= 5, f"Expected at most 5 tools, got {len(filtered)}"
-    print(f"Returned {len(filtered)} tools out of {len(tools)} (top_k=5)")
-
 
 @pytest.mark.asyncio
 async def test_semantic_filter_disabled():
@@ -403,8 +394,6 @@ async def test_semantic_filter_hook_triggers_on_completion():
         tools
     ), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
 
-    print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
-
 
 @pytest.mark.asyncio
 async def test_semantic_filter_hook_skips_no_tools():
@@ -449,7 +438,174 @@ async def test_semantic_filter_hook_skips_no_tools():
 
     # Should return None (no modification)
     assert result is None, "Hook should skip requests without tools"
-    print("✅ Hook correctly skips requests without tools")
+
+
+@pytest.mark.asyncio
+async def test_expand_mcp_tools_preserves_native_tools(monkeypatch):
+    """
+    MCP-reference expansion should not discard native tools that arrived in
+    the same request.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.responses.mcp.litellm_proxy_mcp_handler import (
+        LiteLLM_Proxy_MCP_Handler,
+    )
+
+    async def fake_process_mcp_tools_to_openai_format(*args, **kwargs):
+        return ([{"name": "github-search", "description": "Search GitHub"}], None)
+
+    monkeypatch.setattr(
+        LiteLLM_Proxy_MCP_Handler,
+        "_process_mcp_tools_to_openai_format",
+        fake_process_mcp_tools_to_openai_format,
+    )
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    hook = SemanticToolFilterHook(filter_instance)
+    native_tool = {
+        "type": "function",
+        "function": {
+            "name": "weather_lookup",
+            "description": "Look up weather for a city",
+            "parameters": {"type": "object"},
+        },
+    }
+    mcp_reference = {"type": "mcp", "server_url": "litellm_proxy/mcp/github"}
+
+    expanded = await hook._expand_mcp_tools(
+        [mcp_reference, native_tool],
+        user_api_key_dict=Mock(),
+    )
+
+    assert expanded == [
+        native_tool,
+        {"name": "github-search", "description": "Search GitHub"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_preserves_native_openai_tools():
+    """
+    The MCP semantic filter must not drop native tools owned by the caller.
+
+    Native tools are not present in the MCP router map, so they should bypass
+    MCP semantic filtering and be merged back into the request unchanged.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    mcp_tool = {"name": "github-search", "description": "Search GitHub"}
+    filter_instance._tool_map = {mcp_tool["name"]: mcp_tool}
+    filter_instance.filter_tools = AsyncMock(return_value=[mcp_tool])  # type: ignore[method-assign]
+
+    native_tool = {
+        "type": "function",
+        "function": {
+            "name": "weather_lookup",
+            "description": "Look up weather for a city",
+            "parameters": {"type": "object"},
+        },
+    }
+    responses_native_tool = {
+        "type": "function",
+        "name": "calculator",
+        "description": "Evaluate an expression",
+        "parameters": {"type": "object"},
+    }
+    hook = SemanticToolFilterHook(filter_instance)
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Check weather and search GitHub"}],
+        "tools": [native_tool, responses_native_tool, mcp_tool],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is data
+    filter_instance.filter_tools.assert_awaited_once_with(
+        query="Check weather and search GitHub",
+        available_tools=[mcp_tool],
+    )
+    assert result["tools"] == [native_tool, responses_native_tool, mcp_tool]
+    assert result["metadata"]["litellm_semantic_filter_stats"] == "3->3"
+    assert (
+        result["metadata"]["litellm_semantic_filter_tools"]
+        == "weather_lookup,calculator,github-search"
+    )
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_skips_all_native_openai_tools():
+    """
+    If a request contains only caller-owned native tools, the MCP semantic
+    filter should leave the request untouched and avoid emitting filter stats.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    filter_instance._tool_map = {"github-search": {"name": "github-search"}}
+    filter_instance.filter_tools = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    native_tool = {
+        "type": "function",
+        "function": {
+            "name": "weather_lookup",
+            "description": "Look up weather for a city",
+            "parameters": {"type": "object"},
+        },
+    }
+    hook = SemanticToolFilterHook(filter_instance)
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Check weather"}],
+        "tools": [native_tool],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is None
+    filter_instance.filter_tools.assert_not_awaited()
+    assert data["tools"] == [native_tool]
+    assert "litellm_semantic_filter_stats" not in data["metadata"]
 
 
 class TestGetToolsByNames:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -559,6 +559,65 @@ async def test_semantic_filter_hook_preserves_native_openai_tools():
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_hook_preserves_remaining_tool_order():
+    """
+    Filtering MCP router tools should not reorder caller-owned native tools
+    around the MCP tools that survive semantic filtering.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    mcp_search_tool = {"name": "github-search", "description": "Search GitHub"}
+    mcp_issue_tool = {"name": "github-issue", "description": "Create GitHub issue"}
+    filter_instance._tool_map = {
+        mcp_search_tool["name"]: mcp_search_tool,
+        mcp_issue_tool["name"]: mcp_issue_tool,
+    }
+    filter_instance.filter_tools = AsyncMock(  # type: ignore[method-assign]
+        return_value=[mcp_issue_tool, mcp_search_tool]
+    )
+
+    native_tool = {
+        "type": "function",
+        "function": {
+            "name": "weather_lookup",
+            "description": "Look up weather for a city",
+            "parameters": {"type": "object"},
+        },
+    }
+    hook = SemanticToolFilterHook(filter_instance)
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Search GitHub"}],
+        "tools": [mcp_search_tool, native_tool, mcp_issue_tool],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is data
+    assert result["tools"] == [mcp_search_tool, native_tool, mcp_issue_tool]
+    assert (
+        result["metadata"]["litellm_semantic_filter_tools"]
+        == "github-search,weather_lookup,github-issue"
+    )
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_hook_skips_all_native_openai_tools():
     """
     If a request contains only caller-owned native tools, the MCP semantic


### PR DESCRIPTION
## Relevant issues

Fixes #26212

## Summary

The MCP semantic filter now applies only to tools that are known to the MCP router. Caller-owned native tools pass through unchanged, so enabling `litellm_settings.mcp_semantic_tool_filter` no longer strips normal OpenAI-format tools from `/chat/completions` or `/responses` requests.

This covers three cases:
- all-native tool requests are left untouched and do not emit semantic-filter stats
- mixed native + MCP-router tools filter only the MCP tools and merge native tools back unchanged
- LiteLLM-proxy MCP reference expansion preserves non-MCP tools that arrived in the same `tools` array

The hook also extracts tool names from both Chat Completions-style nested function tools (`function.name`) and Responses-style top-level function tools (`name`), so headers remain accurate after native tools are preserved.

## Validation

- `uv run --extra proxy --extra semantic-router pytest tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py -q`
- `uv run ruff check litellm/proxy/hooks/mcp_semantic_filter/hook.py tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py`
- `git diff --check`

The semantic filter test module passes: 19 passed, with existing `semantic_router` Pydantic deprecation warnings from the dependency.
