### PR TITLE
fix: parse multipart user_config JSON

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -41,7 +41,7 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
         content_type = _request_headers.get("content-type", "")
 
         if "form" in content_type:
-            parsed_body = dict(await request.form())
+            parsed_body: Dict[str, Any] = dict(await request.form())
             for field in _JSON_OBJECT_FORM_FIELDS:
                 if field in parsed_body and isinstance(parsed_body[field], str):
                     parsed_body[field] = json.loads(parsed_body[field])

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -13,6 +13,9 @@ from litellm.proxy.common_utils.callback_utils import (
 from litellm.types.router import Deployment
 
 
+_JSON_OBJECT_FORM_FIELDS = ("metadata", "litellm_metadata", "user_config")
+
+
 async def _read_request_body(request: Optional[Request]) -> Dict:
     """
     Safely read the request body and parse it as JSON.
@@ -39,8 +42,18 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
 
         if "form" in content_type:
             parsed_body = dict(await request.form())
-            if "metadata" in parsed_body and isinstance(parsed_body["metadata"], str):
-                parsed_body["metadata"] = json.loads(parsed_body["metadata"])
+            for field in _JSON_OBJECT_FORM_FIELDS:
+                if field in parsed_body and isinstance(parsed_body[field], str):
+                    parsed_body[field] = json.loads(parsed_body[field])
+            if "tags" in parsed_body and isinstance(parsed_body["tags"], str):
+                stripped_tags = parsed_body["tags"].strip()
+                if stripped_tags.startswith("["):
+                    try:
+                        parsed_tags = json.loads(stripped_tags)
+                    except json.JSONDecodeError:
+                        parsed_tags = None
+                    if isinstance(parsed_tags, list):
+                        parsed_body["tags"] = parsed_tags
         else:
             # Read the request body
             body = await request.body()

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -148,6 +148,110 @@ async def test_form_data_with_json_metadata():
 
 
 @pytest.mark.asyncio
+async def test_form_data_with_json_user_config_and_tags():
+    """
+    Multipart endpoints receive structured fields as strings. user_config must
+    be decoded before route_request splats it into Router(**user_config), and a
+    JSON-list tags field should behave like the same field in JSON requests.
+    """
+    mock_request = MagicMock()
+
+    user_config = {
+        "model_list": [
+            {
+                "model_name": "openai/gpt-image-1",
+                "litellm_params": {
+                    "model": "openai/gpt-image-1",
+                    "api_key": "sk-fake",
+                },
+            }
+        ]
+    }
+    litellm_metadata = {"request_id": "req-123"}
+
+    test_data = {
+        "model": "openai/gpt-image-1",
+        "prompt": "edit this image",
+        "image": "tiny.png",
+        "user_config": json.dumps(user_config),
+        "litellm_metadata": json.dumps(litellm_metadata),
+        "tags": json.dumps(["image-edit", "multipart"]),
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    result = await _read_request_body(mock_request)
+
+    assert result["user_config"] == user_config
+    assert result["litellm_metadata"] == litellm_metadata
+    assert result["tags"] == ["image-edit", "multipart"]
+    assert result["model"] == "openai/gpt-image-1"
+    assert result["prompt"] == "edit this image"
+    assert result["image"] == "tiny.png"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_invalid_json_user_config():
+    """Invalid JSON in structured multipart fields should fail during parsing."""
+    mock_request = MagicMock()
+    test_data = {
+        "model": "openai/gpt-image-1",
+        "user_config": '{"model_list": invalid}',
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    with pytest.raises(json.JSONDecodeError):
+        await _read_request_body(mock_request)
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_plain_string_tags():
+    """Plain string tags are preserved unless the caller sends a JSON list."""
+    mock_request = MagicMock()
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "tags": "production",
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    result = await _read_request_body(mock_request)
+
+    assert result["tags"] == "production"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_malformed_json_like_tags():
+    """Malformed JSON-like tag strings should stay unchanged."""
+    mock_request = MagicMock()
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "tags": "[production",
+    }
+
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    result = await _read_request_body(mock_request)
+
+    assert result["tags"] == "[production"
+
+
+@pytest.mark.asyncio
 async def test_form_data_with_invalid_json_metadata():
     """
     Test that form data with invalid JSON in metadata field raises an exception.


### PR DESCRIPTION
## Summary
- parse structured multipart form fields (`metadata`, `litellm_metadata`, and `user_config`) before proxy routing
- decode JSON-list `tags` while preserving plain string tags
- add regression coverage for multipart `user_config`, invalid `user_config`, and string tags

Fixes #26707.

## Tests
- `uv run --python 3.12 --extra proxy pytest tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py -q`
- `uv run --python 3.12 ruff check litellm/proxy/common_utils/http_parsing_utils.py`
- `uv run --python 3.12 ruff check --ignore F401,F601 tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py`
- `git diff --check`

Note: the existing test module has pre-existing full-file ruff findings (`F401`, `F601`) on `main`; the scoped ruff command above ignores only those existing findings for that file.