### PR TITLE
fix: apply LITELLM_LOG to verbose_logger

### DIFF
--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -815,7 +815,8 @@ def init_verbose_loggers():
 
                     # this must ALWAYS remain logging.INFO, DO NOT MODIFY THIS
 
-                    verbose_logger.setLevel(level=logging.INFO)  # sets package logs to info
+                    # sets package logs to info
+                    verbose_logger.setLevel(level=logging.INFO)
                     verbose_router_logger.setLevel(
                         level=logging.INFO
                     )  # set router logs to info
@@ -831,7 +832,8 @@ def init_verbose_loggers():
                         verbose_router_logger,
                     )
 
-                    verbose_logger.setLevel(level=logging.DEBUG)  # set package log to debug
+                    # set package log to debug
+                    verbose_logger.setLevel(level=logging.DEBUG)
                     verbose_router_logger.setLevel(
                         level=logging.DEBUG
                     )  # set router logs to debug

--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -808,12 +808,14 @@ def init_verbose_loggers():
                     import logging
 
                     from litellm._logging import (
+                        verbose_logger,
                         verbose_proxy_logger,
                         verbose_router_logger,
                     )
 
                     # this must ALWAYS remain logging.INFO, DO NOT MODIFY THIS
 
+                    verbose_logger.setLevel(level=logging.INFO)  # sets package logs to info
                     verbose_router_logger.setLevel(
                         level=logging.INFO
                     )  # set router logs to info
@@ -824,13 +826,15 @@ def init_verbose_loggers():
                     import logging
 
                     from litellm._logging import (
+                        verbose_logger,
                         verbose_proxy_logger,
                         verbose_router_logger,
                     )
 
+                    verbose_logger.setLevel(level=logging.DEBUG)  # set package log to debug
                     verbose_router_logger.setLevel(
                         level=logging.DEBUG
-                    )  # set router logs to info
+                    )  # set router logs to debug
                     verbose_proxy_logger.setLevel(
                         level=logging.DEBUG
                     )  # set proxy logs to debug

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5826,10 +5826,15 @@ async def initialize(  # noqa: PLR0915
             if litellm_log_setting.upper() == "INFO":
                 import logging
 
-                from litellm._logging import verbose_proxy_logger, verbose_router_logger
+                from litellm._logging import (
+                    verbose_logger,
+                    verbose_proxy_logger,
+                    verbose_router_logger,
+                )
 
                 # this must ALWAYS remain logging.INFO, DO NOT MODIFY THIS
 
+                verbose_logger.setLevel(level=logging.INFO)  # sets package logs to info
                 verbose_router_logger.setLevel(
                     level=logging.INFO
                 )  # set router logs to info

--- a/tests/test_litellm/proxy/common_utils/test_debug_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_debug_utils.py
@@ -1,0 +1,46 @@
+import json
+import logging
+
+import pytest
+
+from litellm._logging import (
+    verbose_logger,
+    verbose_proxy_logger,
+    verbose_router_logger,
+)
+from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
+
+
+VERBOSE_LOGGERS = (
+    verbose_logger,
+    verbose_router_logger,
+    verbose_proxy_logger,
+)
+
+
+@pytest.mark.parametrize(
+    ("litellm_log", "expected_level"),
+    (("INFO", logging.INFO), ("DEBUG", logging.DEBUG)),
+)
+def test_litellm_log_env_sets_all_verbose_loggers(
+    monkeypatch: pytest.MonkeyPatch, litellm_log: str, expected_level: int
+):
+    original_levels = {logger: logger.level for logger in VERBOSE_LOGGERS}
+    try:
+        for logger in VERBOSE_LOGGERS:
+            logger.setLevel(logging.WARNING)
+
+        monkeypatch.setenv(
+            "WORKER_CONFIG",
+            json.dumps({"debug": False, "detailed_debug": False}),
+        )
+        monkeypatch.setenv("LITELLM_LOG", litellm_log)
+
+        init_verbose_loggers()
+
+        assert [logger.level for logger in VERBOSE_LOGGERS] == [
+            expected_level
+        ] * len(VERBOSE_LOGGERS)
+    finally:
+        for logger, level in original_levels.items():
+            logger.setLevel(level)

--- a/tests/test_litellm/proxy/common_utils/test_debug_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_debug_utils.py
@@ -38,9 +38,35 @@ def test_litellm_log_env_sets_all_verbose_loggers(
 
         init_verbose_loggers()
 
-        assert [logger.level for logger in VERBOSE_LOGGERS] == [
-            expected_level
-        ] * len(VERBOSE_LOGGERS)
+        assert [logger.level for logger in VERBOSE_LOGGERS] == [expected_level] * len(
+            VERBOSE_LOGGERS
+        )
+    finally:
+        for logger, level in original_levels.items():
+            logger.setLevel(level)
+
+
+@pytest.mark.asyncio
+async def test_initialize_litellm_log_info_sets_all_verbose_loggers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.proxy import proxy_server
+    from litellm.proxy.common_utils import banner
+
+    original_levels = {logger: logger.level for logger in VERBOSE_LOGGERS}
+    try:
+        for logger in VERBOSE_LOGGERS:
+            logger.setLevel(logging.WARNING)
+
+        monkeypatch.setenv("LITELLM_LOG", "INFO")
+        monkeypatch.setenv("LITELLM_DONT_SHOW_FEEDBACK_BOX", "true")
+        monkeypatch.setattr(banner, "show_banner", lambda: None)
+
+        await proxy_server.initialize(debug=False, detailed_debug=False)
+
+        assert [logger.level for logger in VERBOSE_LOGGERS] == [logging.INFO] * len(
+            VERBOSE_LOGGERS
+        )
     finally:
         for logger, level in original_levels.items():
             logger.setLevel(level)


### PR DESCRIPTION
## What
- Set the package `verbose_logger` level when `LITELLM_LOG=INFO` is used in proxy startup.
- Keep `verbose_logger`, router logger, and proxy logger aligned for `LITELLM_LOG=DEBUG` in `init_verbose_loggers()`.
- Add a regression test that verifies env-driven INFO and DEBUG settings update all three verbose loggers.

## Why
`LITELLM_LOG=INFO` previously updated only proxy/router loggers in the env-var fallback, so package-level INFO logs stayed suppressed unless `debug=True` was passed directly.

Fixes #26396

## Tests
- `uv run --python 3.12 --extra proxy pytest tests/test_litellm/proxy/common_utils/test_debug_utils.py -q`
- `uv run --python 3.12 ruff check litellm/proxy/common_utils/debug_utils.py litellm/proxy/proxy_server.py tests/test_litellm/proxy/common_utils/test_debug_utils.py`
- `git diff --check`