### PR TITLE
[Fix] Release Workflow: Detect SemVer-Style Pre-Release Dev Tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, 1.84.0.post1; legacy v1.83.10-stable still accepted)"
+        description: "Release tag (e.g. 1.84.0, 1.84.0rc1, 1.84.0.dev42, 1.84.0-dev.2, 1.84.0.post1; legacy v1.83.10-stable still accepted)"
         required: true
         type: string
       commit_hash:
@@ -46,9 +46,11 @@ jobs:
             const commitHash = process.env.COMMIT_HASH;
 
             // Mark RC / dev / nightly / alpha / beta tags as GitHub pre-releases.
+            // Accept both PEP 440 (`.dev`) and SemVer (`-dev`) separators so tags
+            // like `1.84.0.dev2` and `1.84.0-dev.2` are both detected.
             // PEP 440 post-releases (e.g. `1.84.0.post1`) and legacy `-stable[.patch.N]`
             // are stable maintenance releases, not pre-releases.
-            const isPrerelease = /(?:rc|nightly|alpha|beta|\.dev)/i.test(tag);
+            const isPrerelease = /(?:rc|nightly|alpha|beta|[-.]dev)/i.test(tag);
 
             const cosignSection = [
               `## Verify Docker Image Signature`,


### PR DESCRIPTION
## Summary

`create-release.yml` decides whether to mark a GitHub release as a pre-release with this regex:

```js
const isPrerelease = /(?:rc|nightly|alpha|beta|\.dev)/i.test(tag);
```

`\.dev` requires a literal dot before `dev`, so it correctly catches PEP 440 canonical tags like `1.84.0.dev2` but misses the SemVer/Docker form `1.84.0-dev.2` (hyphen-dev). That tag was just published as a stable release on GitHub when it should have been a pre-release.

Per the release design doc's PyPI ↔ Docker mapping rule, both shapes are valid production-track release tags for the same channel, and both are pre-releases:

| PyPI canonical | Docker SemVer | Channel | Pre-release? |
|---|---|---|---|
| `1.86.0` | `1.86.0` | stable | no |
| `1.86.1` | `1.86.1` | hotfix | no |
| `1.86.0rc1` | `1.86.0-rc.1` | RC | yes (opt-in via `--pre`) |
| `1.86.0.dev2` | `1.86.0-dev.2` | dev (formerly nightly) | yes (opt-in via `--pre`) |

The fix is one character — change `\.dev` to `[-.]dev` so the regex accepts either separator. Also expanded the input description to include the new hyphen-dev form as an example.

## Verification

Runtime verification via `workflow_dispatch` was deliberately skipped: dispatching this workflow creates a real GitHub release object plus a real release branch (it chains `create-release-branch.yml`), which is disruptive even with a throwaway tag. The change is a self-contained regex modification inside an `actions/github-script` step, so I validated it offline by evaluating the patched regex against every relevant tag shape — both new (PyPI canonical, Docker SemVer, chained pre-releases like `1.86.0rc2.dev3`) and legacy (`v1.83.X-nightly`, `vX.Y.Z-stable`, `-stable.patch.N`):

```
PASS  1.84.0                       want STABLE      got STABLE
PASS  1.84.0-dev.2                 want prerelease  got prerelease
PASS  1.84.0-dev.1                 want prerelease  got prerelease
PASS  1.84.0.dev2                  want prerelease  got prerelease
PASS  1.84.0.dev42                 want prerelease  got prerelease
PASS  1.84.0rc1                    want prerelease  got prerelease
PASS  1.84.0.post1                 want STABLE      got STABLE
PASS  v1.83.14.rc.1                want prerelease  got prerelease
PASS  v1.83.13-nightly             want prerelease  got prerelease
PASS  v1.83.10-stable              want STABLE      got STABLE
PASS  v1.83.7-stable.patch.1       want STABLE      got STABLE
PASS  v1.82.3.dev.9                want prerelease  got prerelease
PASS  v1.82.3-stable.patch.4       want STABLE      got STABLE
PASS  1.84.0-alpha.1               want prerelease  got prerelease
PASS  1.84.0-beta.3                want prerelease  got prerelease
PASS  1.84.0-rc.1                  want prerelease  got prerelease
```

Reproducible offline:

```bash
node -e "
const re = /(?:rc|nightly|alpha|beta|[-.]dev)/i;
for (const t of ['1.84.0','1.84.0-dev.2','1.84.0.dev2','1.84.0rc1','1.84.0-rc.1','1.84.0.post1','v1.83.10-stable','v1.83.7-stable.patch.1','v1.83.13-nightly'])
  console.log(t.padEnd(28), re.test(t) ? 'prerelease' : 'STABLE');
"
```

The first time the patched regex actually runs end-to-end will be the next dev/RC release after this lands.

## Test plan

- [x] Patched regex correctly classifies every tag shape currently or historically used by this repo (16/16 cases above)
- [x] Workflow YAML still parses (only the JS string body changed; structure untouched)
- [ ] Next dev or RC release on `1.84.0-dev.N` / `1.86.0-rc.N` / `1.86.0.devN` is created with `prerelease: true` on GitHub