### PR TITLE
tests(vcr): instrument Redis target + per-cassette persist log lines

### DIFF
--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Optional
 
@@ -8,6 +9,15 @@ from vcr.serialize import deserialize, serialize
 
 CASSETTE_TTL_SECONDS = 24 * 60 * 60
 REDIS_KEY_PREFIX = "litellm:vcr:cassette:"
+
+# Tagged so it's grep-able in CircleCI logs, e.g. ``grep '\[VCR\]' build.log``.
+_log = logging.getLogger("litellm.vcr.persister")
+if not _log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("[VCR] %(message)s"))
+    _log.addHandler(_h)
+    _log.setLevel(logging.INFO)
+    _log.propagate = False
 
 
 def redis_key_for(cassette_path: str) -> str:
@@ -60,20 +70,82 @@ def make_redis_persister(
     class _RedisPersister:
         @staticmethod
         def load_cassette(cassette_path, serializer):
-            data = redis_client.get(redis_key_for(cassette_path))
+            key = redis_key_for(cassette_path)
+            data = redis_client.get(key)
             if data is None:
+                _log.info(f"miss key={key}")
                 raise CassetteNotFoundError()
             if isinstance(data, bytes):
                 data = data.decode("utf-8")
+            _log.info(f"hit  key={key} bytes={len(data)}")
             return deserialize(data, serializer)
 
         @staticmethod
         def save_cassette(cassette_path, cassette_dict, serializer):
+            key = redis_key_for(cassette_path)
             data = serialize(cassette_dict, serializer)
             payload = data.encode("utf-8") if isinstance(data, str) else data
-            redis_client.set(redis_key_for(cassette_path), payload, ex=ttl_seconds)
+            req_count = len(cassette_dict.get("requests", []) or [])
+            try:
+                redis_client.set(key, payload, ex=ttl_seconds)
+                _log.info(
+                    f"persist key={key} bytes={len(payload)} episodes={req_count}"
+                )
+            except Exception as exc:
+                _log.info(
+                    f"persist-failed key={key} bytes={len(payload)} "
+                    f"episodes={req_count} err={type(exc).__name__}: {exc}"
+                )
+                raise
 
     return _RedisPersister
+
+
+def log_redis_target_banner() -> None:
+    """Print the resolved Redis target + a few server attributes once per worker.
+
+    Goal: make it possible to confirm from CircleCI logs (a) that the worker is
+    pointed at the expected Redis instance, and (b) what its eviction policy and
+    current memory pressure look like before the test session starts."""
+    url = _redis_url_from_env()
+    if not url:
+        _log.info("VCR disabled (no REDIS_URL/REDIS_SSL_URL/REDIS_HOST in env)")
+        return
+
+    safe_url = url
+    if "@" in safe_url:
+        # rediss://user:pass@host:port -> rediss://user:***@host:port
+        head, tail = safe_url.split("@", 1)
+        if ":" in head:
+            scheme_user, _ = head.rsplit(":", 1)
+            safe_url = f"{scheme_user}:***@{tail}"
+
+    _log.info(f"target={safe_url}")
+    try:
+        import redis
+
+        client = redis.Redis.from_url(
+            url, socket_timeout=5, socket_connect_timeout=5, decode_responses=True
+        )
+        info = client.info("memory")
+        for attr in (
+            "maxmemory_human",
+            "maxmemory_policy",
+            "used_memory_human",
+            "used_memory_peak_human",
+        ):
+            if attr in info:
+                _log.info(f"server {attr}={info[attr]}")
+        try:
+            evicted = client.info("stats").get("evicted_keys")
+            if evicted is not None:
+                _log.info(f"server evicted_keys={evicted}")
+        except Exception:
+            pass
+        prefix_count = sum(1 for _ in client.scan_iter(match=f"{REDIS_KEY_PREFIX}*", count=500))
+        _log.info(f"existing vcr keys under {REDIS_KEY_PREFIX!r}: {prefix_count}")
+    except Exception as exc:
+        _log.info(f"banner failed: {type(exc).__name__}: {exc}")
 
 
 def filter_non_2xx_response(response):

--- a/tests/llm_translation/conftest.py
+++ b/tests/llm_translation/conftest.py
@@ -20,6 +20,7 @@ import litellm  # noqa: E402
 
 from tests._vcr_redis_persister import (  # noqa: E402
     filter_non_2xx_response,
+    log_redis_target_banner,
     make_redis_persister,
     patch_vcrpy_aiohttp_record_path,
 )
@@ -120,7 +121,9 @@ def _vcr_disabled() -> bool:
 
 def pytest_recording_configure(config, vcr):
     if _vcr_disabled():
+        log_redis_target_banner()
         return
+    log_redis_target_banner()
     vcr.register_persister(make_redis_persister())
     patch_vcrpy_aiohttp_record_path()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Stacked on top of #26838. We want to be able to answer three questions from a single CircleCI log:

1. Which Redis instance is each xdist worker actually talking to?
2. Are `SET` calls succeeding (or silently failing — `noeviction` will start refusing writes once memory fills)?
3. Which tests result in cache hits vs misses vs no recording at all?

Right now the persister logs nothing, so all three of those are guesses.

## What

Two diagnostic surfaces, both namespaced under the `litellm.vcr.persister` logger and prefixed with `[VCR]` so they're trivially grep-able (`grep '\[VCR\]' build.log`):

1. `log_redis_target_banner()` — fires once per worker at `pytest_recording_configure`. Logs the resolved Redis URL (password masked), `maxmemory_policy`, `used_memory_human`, `used_memory_peak_human`, `evicted_keys`, and the current count of keys under the `litellm:vcr:cassette:` prefix.

2. `_RedisPersister.{load,save}_cassette` — one `[VCR]` line per call: `hit` / `miss` / `persist` / `persist-failed`, with key, payload size, and episode count.

## Sample output

Smoke-tested against the actual CI Redis (`redis-19853.crce262.us-east-1-1.ec2.cloud.redislabs.com:19853`):

```
[VCR] target=redis://default:***@redis-19853.crce262.us-east-1-1.ec2.cloud.redislabs.com:19853
[VCR] server maxmemory_policy=noeviction
[VCR] server used_memory_human=7.31M
[VCR] server used_memory_peak_human=1.7G
[VCR] server evicted_keys=0
[VCR] existing vcr keys under 'litellm:vcr:cassette:': 0
[VCR] persist key=litellm:vcr:cassette:tests/llm_translation/diagnostic_smoke/test_one bytes=334 episodes=1
[VCR] hit  key=litellm:vcr:cassette:tests/llm_translation/diagnostic_smoke/test_one bytes=334
[VCR] miss key=litellm:vcr:cassette:tests/llm_translation/diagnostic_smoke/missing
```

That output already confirms two things worth knowing about the target instance independent of this change:

- `maxmemory_policy=noeviction` — once we hit `maxmemory`, every `SET` (VCR or otherwise) will start failing with OOM. There is nothing automatic that prunes our keys; the only pruning is the per-key 24h TTL set by `save_cassette`, and a successful `SET` resets that TTL.
- `used_memory_peak_human=1.7G` — the instance has filled in the past, almost certainly during a previous llm_translation run.

## Tests

`tests/llm_translation/test_vcr_redis_persister.py` (the existing 16 unit tests) still pass.

## Type

🚄 Infrastructure
✅ Test

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777616301749029?thread_ts=1777616301.749029&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-9f9022aa-abe9-5029-a136-5d6d9185760e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f9022aa-abe9-5029-a136-5d6d9185760e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

