### PR TITLE
feat: add Cortecs AI as named OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -106,5 +106,9 @@
     "base_url": "https://aihubmix.com/v1",
     "api_key_env": "AIHUBMIX_API_KEY",
     "api_base_env": "AIHUBMIX_API_BASE"
+  },
+  "cortecs": {
+    "base_url": "https://api.cortecs.ai/v1",
+    "api_key_env": "CORTECS_API_KEY"
   }
 }

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -474,6 +474,23 @@
         "a2a": false
       }
     },
+    "cortecs": {
+      "display_name": "Cortecs AI (`cortecs`)",
+      "url": "https://docs.litellm.ai/docs/providers/cortecs",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "clarifai": {
       "display_name": "Clarifai (`clarifai`)",
       "url": "https://docs.litellm.ai/docs/providers/clarifai",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -509,6 +509,23 @@
         "a2a": false
       }
     },
+    "cortecs": {
+      "display_name": "Cortecs AI (`cortecs`)",
+      "url": "https://docs.litellm.ai/docs/providers/cortecs",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "clarifai": {
       "display_name": "Clarifai (`clarifai`)",
       "url": "https://docs.litellm.ai/docs/providers/clarifai",


### PR DESCRIPTION
## Description
Adds [Cortecs](https://cortecs.ai/) as a named OpenAI-compatible provider in LiteLLM.

## Changes
* `litellm/llms/openai_like/providers.json`: Added cortecs entry with base URL (`https://api.cortecs.ai/v1`) and API key env var
* `provider_endpoints_support.json`: Added cortecs provider with supported endpoints (chat_completions)
* `litellm/provider_endpoints_support_backup.json`: Same as above

## Usage
```python
from litellm import completion

response = completion(
    model="cortecs/<model-name>",
    messages=[{"role": "user", "content": "Hello!"}]
)
```

## About Cortecs
* 150+ models
* Popular in Europe (GDPR-native)
* Often combined with LiteLLM's BYOK

