### PR TITLE
fix(ui): virtual keys filter silently resets after navigating away an…

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -203,8 +203,7 @@ beforeEach(() => {
       "User ID": "user-1",
       "User Email": "user@example.com",
       "User Role": "user",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -322,8 +321,7 @@ it("should show 'No keys found' message when filteredKeys is empty", () => {
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -370,8 +368,7 @@ it("should handle models with more than 3 entries to trigger expansion UI", () =
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -518,8 +515,7 @@ it("should display 'Default Proxy Admin' for user_id when value is 'default_user
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -568,8 +564,7 @@ it("should display 'Default Proxy Admin' for created_by when value is 'default_u
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -626,8 +621,7 @@ it("should display created_by_user email in 'Created By' column when available",
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -681,8 +675,7 @@ it("should display created_by_user alias over email when both available", async 
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -731,8 +724,7 @@ it("should render table without crashing when models is null", async () => {
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -782,8 +774,7 @@ it("should render table without crashing when models is undefined", async () => 
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -868,8 +859,7 @@ it("should display 'Unknown' for last_active when value is null", async () => {
       "Organization ID": "",
       "Key Alias": "",
       "User ID": "",
-      "Sort By": "created_at",
-      "Sort Order": "desc",
+      "Key Hash": "",
     },
     allTeams: [mockTeam],
     allOrganizations: [mockOrganization],
@@ -916,7 +906,7 @@ describe("pagination display – total count and page count", () => {
     } as any);
 
     mockUseFilterLogic.mockReturnValue({
-      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "", "User ID": "", "Sort By": "created_at", "Sort Order": "desc" },
+      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "", "User ID": "", "Key Hash": "" },
       allTeams: [mockTeam],
       allOrganizations: [mockOrganization],
       handleFilterChange: vi.fn(),
@@ -947,7 +937,7 @@ describe("pagination display – total count and page count", () => {
     } as any);
 
     mockUseFilterLogic.mockReturnValue({
-      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "aaaaa", "User ID": "", "Sort By": "created_at", "Sort Order": "desc" },
+      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "aaaaa", "User ID": "", "Key Hash": "" },
       allTeams: [mockTeam],
       allOrganizations: [mockOrganization],
       handleFilterChange: vi.fn(),
@@ -964,7 +954,7 @@ describe("pagination display – total count and page count", () => {
 
   it("should pass current filter values into useKeys so remount/refetch keeps the filter applied", async () => {
     mockUseFilterLogic.mockReturnValue({
-      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "aaaaa", "User ID": "", "Sort By": "created_at", "Sort Order": "desc" },
+      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "aaaaa", "User ID": "", "Key Hash": "" },
       allTeams: [mockTeam],
       allOrganizations: [mockOrganization],
       handleFilterChange: vi.fn(),
@@ -980,6 +970,26 @@ describe("pagination display – total count and page count", () => {
         expect.any(Number),
         expect.any(Number),
         expect.objectContaining({ selectedKeyAlias: "aaaaa" }),
+      );
+    });
+  });
+
+  it("should forward the Key Hash filter into useKeys", async () => {
+    mockUseFilterLogic.mockReturnValue({
+      filters: { "Team ID": "", "Organization ID": "", "Key Alias": "", "User ID": "", "Key Hash": "hash-xyz" },
+      allTeams: [mockTeam],
+      allOrganizations: [mockOrganization],
+      handleFilterChange: vi.fn(),
+      handleFilterReset: vi.fn(),
+    });
+
+    renderWithProviders(<VirtualKeysTable {...defaultMockProps} />);
+
+    await waitFor(() => {
+      expect(mockUseKeys).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.any(Number),
+        expect.objectContaining({ keyHash: "hash-xyz" }),
       );
     });
   });

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -105,6 +105,7 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
     debouncedFilters["Organization ID"],
     debouncedFilters["Key Alias"],
     debouncedFilters["User ID"],
+    debouncedFilters["Key Hash"],
   ]);
 
   const {
@@ -121,6 +122,7 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
     organizationID: debouncedFilters["Organization ID"] || undefined,
     selectedKeyAlias: debouncedFilters["Key Alias"] || undefined,
     userID: debouncedFilters["User ID"] || undefined,
+    keyHash: debouncedFilters["Key Hash"] || undefined,
   });
   const [expandedAccordions, setExpandedAccordions] = useState<Record<string, boolean>>({});
 
@@ -700,7 +702,11 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
               options={filterOptions}
               onApplyFilters={handleFilterChange}
               initialValues={filters}
-              onResetFilters={handleFilterReset}
+              onResetFilters={() => {
+                handleFilterReset();
+                setSorting([{ id: "created_at", desc: true }]);
+                onSortChange?.("created_at", "desc");
+              }}
             />
           </div>
 

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx
@@ -17,8 +17,7 @@ const DEFAULT_FILTERS = {
   "Organization ID": "",
   "Key Alias": "",
   "User ID": "",
-  "Sort By": "created_at",
-  "Sort Order": "desc",
+  "Key Hash": "",
 };
 
 describe("useFilterLogic – filter state management", () => {
@@ -40,6 +39,16 @@ describe("useFilterLogic – filter state management", () => {
     });
 
     expect(result.current.filters["Key Alias"]).toBe("my-alias");
+  });
+
+  it("records the Key Hash filter when handleFilterChange is called", () => {
+    const { result } = renderHook(() => useFilterLogic(defaultProps));
+
+    act(() => {
+      result.current.handleFilterChange({ "Key Hash": "abc123" });
+    });
+
+    expect(result.current.filters["Key Hash"]).toBe("abc123");
   });
 
   it("preserves filter state across re-renders (regression: bug where results reset on remount)", () => {

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
@@ -10,8 +10,7 @@ export interface FilterState {
   "Key Alias": string;
   [key: string]: string;
   "User ID": string;
-  "Sort By": string;
-  "Sort Order": string;
+  "Key Hash": string;
 }
 
 const DEFAULT_FILTERS: FilterState = {
@@ -19,8 +18,7 @@ const DEFAULT_FILTERS: FilterState = {
   "Organization ID": "",
   "Key Alias": "",
   "User ID": "",
-  "Sort By": "created_at",
-  "Sort Order": "desc",
+  "Key Hash": "",
 };
 
 export function useFilterLogic({
@@ -71,8 +69,7 @@ export function useFilterLogic({
       "Organization ID": newFilters["Organization ID"] || "",
       "Key Alias": newFilters["Key Alias"] || "",
       "User ID": newFilters["User ID"] || "",
-      "Sort By": newFilters["Sort By"] || "created_at",
-      "Sort Order": newFilters["Sort Order"] || "desc",
+      "Key Hash": newFilters["Key Hash"] || "",
     });
   };
 


### PR DESCRIPTION
# PR: fix(ui): virtual keys filter silently resets after navigating away and back

> **Branch**: `Bytechoreographer:fix/virtual-keys-filter-persistence`
> **Target**: `BerriAI:litellm_internal_staging`
> **PR link**: https://github.com/Bytechoreographer/litellm/pull/new/fix/virtual-keys-filter-persistence

---

## Relevant issues

<!-- No open issue found; reproduced locally. -->

## Pre-Submission checklist

- [x] `npm run test` passes for affected files (30/30)
- [x] Scope is isolated: 4 files changed, no new dependencies
- [x] Comment `@greptileai` and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Root cause

On the **Virtual Keys** page, applying a filter (e.g. Key Alias) worked on
first click — but after navigating to another page and coming back, the
filter chips still showed the selected values while the table reverted to
all keys, as if the filter had never been applied.

The page ran **two parallel data paths** for the same list:

```
VirtualKeysTable
  ├─ useKeys(page, size, { sortBy, sortOrder, expand })        ← NO filters
  │    └─ result: paginated full key list  → passed as `keys` prop to useFilterLogic
  │
  └─ useFilterLogic({ keys, teams, organizations })
       ├─ filters:        useState<FilterState>   (filter UI state)
       ├─ debouncedSearch: one-off keyListCall with filters, writes filteredKeys
       └─ useEffect([keys, filters]):
             result = [...keys]
             if (filters["Team ID"])        result = result.filter(...)
             if (filters["Organization ID"]) result = result.filter(...)
             setFilteredKeys(result)        ← ONLY Team/Org branches, nothing else
```

Timeline of the bug:

1. User types `"foo"` into **Key Alias** → `debouncedSearch` fires a filtered
   `keyListCall` → `filteredKeys = server result` ✓ the table shows the filtered rows.
2. User navigates away. Component stays mounted or unmounts; either way
   `useKeys` eventually re-runs (`staleTime: 30s` expiry, `storage` event,
   window re-focus, remount).
3. New `keys` prop arrives → the `[keys, filters]` effect re-runs →
   `result = [...keys]` (unfiltered) → **Key Alias and User ID have no
   client-side filter branch**, so `setFilteredKeys(result)` overwrites the
   server-filtered list with the full page.
4. `filters` state is untouched, so the FilterComponent still shows `"foo"`
   — but the table displays everything.

**Reproduce:**
1. On the **Virtual Keys** page, filter by Key Alias (e.g. `"foo"`) → rows filter correctly ✓
2. Click another page in the sidebar, wait ~30 s, click back to **Virtual Keys**
3. Filter chip still shows `"foo"` but the table now lists all keys ✗
4. Toggle the chip off and re-apply → rows filter again ✓ (one-shot)

### Fix

Route filter values through the main `useKeys` query so React Query's cache
key tracks them. Same (page, filter, sort) tuple → same cache entry, which
means any remount or refetch naturally pulls the filtered page — the UI and
the data can no longer drift apart.

```diff
  const { data: keys, ... } = useKeys(page, size, {
    sortBy, sortOrder, expand: "user",
+   teamID:           debouncedFilters["Team ID"]         || undefined,
+   organizationID:   debouncedFilters["Organization ID"] || undefined,
+   selectedKeyAlias: debouncedFilters["Key Alias"]       || undefined,
+   userID:           debouncedFilters["User ID"]         || undefined,
  });

- const { filters, filteredKeys, filteredTotalCount, ... } = useFilterLogic({
-   keys: keys?.keys || [], teams, organizations,
- });
+ const { filters, ... } = useFilterLogic({ teams, organizations });

- data: filteredKeys,
+ data: keys?.keys ?? [],

- const totalCount = filteredTotalCount ?? keys?.total_count ?? 0;
+ const totalCount = keys?.total_count ?? 0;
```

A 300 ms debounce sits between `filters` and the values fed to `useKeys` —
`FilterComponent` fires `onApplyFilters` on every keystroke of the text
inputs (Key Alias, User ID), so without debouncing each character would
trigger its own request. Pagination resets to page 1 when the debounced
filter values change, so a narrowed result set doesn't leave the user
stranded on an out-of-range page.

`useFilterLogic` is reduced to a pure state holder: `filters`,
`handleFilterChange`, `handleFilterReset`, plus the existing
`allTeams` / `allOrganizations` bootstrap. The `debouncedSearch` branch,
the `[keys, filters]` effect, `filteredKeys`, and `filteredTotalCount`
are all removed.

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx` | Drop `debouncedSearch`, the `[keys, filters]` effect, `filteredKeys`, and `filteredTotalCount`; remove the `keys` prop; `handleFilterChange` now just updates state |
| `ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx` | Feed debounced filters (300 ms) into `useKeys` options; drive the table from `keys?.keys`; reset pagination to page 1 on filter change; remove the redundant `skipDebounce` hop on the sort handler |
| `ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx` | Rewrite against the new contract; includes a regression test that filter state survives re-renders |
| `ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx` | Update per-test mocks so table rows come from `useKeys` instead of `filteredKeys`; replace the two `filteredTotalCount` pagination cases with one server-filtered-total case and one assertion that filter values are forwarded into `useKeys` |