### PR TITLE
fix: implement sync service failure hook

### DIFF
--- a/litellm/_service_logger.py
+++ b/litellm/_service_logger.py
@@ -99,10 +99,45 @@ class ServiceLogging(CustomLogger):
         self, service: ServiceTypes, duration: float, error: Exception, call_type: str
     ):
         """
-        [TODO] Not implemented for sync calls yet. V0 is focused on async monitoring (used by proxy).
+        Handles both sync and async monitoring by checking for existing event loop.
         """
         if self.mock_testing:
             self.mock_testing_sync_failure_hook += 1
+
+        try:
+            # Try to get the current event loop
+            loop = asyncio.get_event_loop()
+            # Check if the loop is running
+            if loop.is_running():
+                # If we're in a running loop, create a task
+                loop.create_task(
+                    self.async_service_failure_hook(
+                        service=service,
+                        duration=duration,
+                        error=error,
+                        call_type=call_type,
+                    )
+                )
+            else:
+                # Loop exists but not running, we can use run_until_complete
+                loop.run_until_complete(
+                    self.async_service_failure_hook(
+                        service=service,
+                        duration=duration,
+                        error=error,
+                        call_type=call_type,
+                    )
+                )
+        except RuntimeError:
+            # No event loop exists, create a new one and run
+            asyncio.run(
+                self.async_service_failure_hook(
+                    service=service,
+                    duration=duration,
+                    error=error,
+                    call_type=call_type,
+                )
+            )
 
     async def async_service_success_hook(
         self,

--- a/tests/test_litellm/test_service_logger.py
+++ b/tests/test_litellm/test_service_logger.py
@@ -5,11 +5,14 @@ Regression test for KeyError: 'call_type' when async_log_success_event
 is called without call_type in kwargs (e.g. from batch polling callbacks).
 """
 
-import pytest
-from datetime import datetime, timedelta
+import asyncio
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from litellm._service_logger import ServiceLogging
+from litellm.types.services import ServiceTypes
 
 
 @pytest.mark.asyncio
@@ -95,3 +98,29 @@ async def test_async_log_success_event_should_handle_float_duration():
         mock_hook.assert_called_once()
         call_kwargs = mock_hook.call_args
         assert call_kwargs.kwargs["duration"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_service_failure_hook_should_schedule_async_failure_hook():
+    service_logger = ServiceLogging(mock_testing=True)
+
+    with patch.object(
+        service_logger, "async_service_failure_hook", new_callable=AsyncMock
+    ) as mock_hook:
+        service_logger.service_failure_hook(
+            service=ServiceTypes.REDIS,
+            duration=0.123,
+            error=Exception("boom"),
+            call_type="health_check",
+        )
+
+        # Let the event loop run scheduled tasks
+        await asyncio.sleep(0)
+
+        mock_hook.assert_awaited_once()
+        call_kwargs = mock_hook.call_args
+        assert call_kwargs.kwargs["service"] == ServiceTypes.REDIS
+        assert call_kwargs.kwargs["duration"] == 0.123
+        assert isinstance(call_kwargs.kwargs["error"], Exception)
+        assert str(call_kwargs.kwargs["error"]) == "boom"
+        assert call_kwargs.kwargs["call_type"] == "health_check"


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Focused test passed locally:

```bash
python3 -m pytest tests/test_litellm/test_service_logger.py -v
```

Result:

```text
4 passed
```

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Implemented the sync `service_failure_hook()` path by delegating to `async_service_failure_hook()`.
- Updated the stale docstring that said sync failure logging was not implemented.
- Added mocked unit test coverage for the sync failure hook behavior in `tests/test_litellm/test_service_logger.py`.