### PR TITLE
fix(langfuse_otel): serialize pydantic Message objects in set_messages

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel_attributes.py
+++ b/litellm/integrations/langfuse/langfuse_otel_attributes.py
@@ -86,7 +86,18 @@ class LangfuseLLMObsOTELAttributes(BaseLLMObsOTELAttributes):
     @staticmethod
     @override
     def set_messages(span: "Span", kwargs: Dict[str, Any]):
-        prompt = {"messages": kwargs.get("messages")}
+        # Normalize litellm.Message (pydantic) -> dict so json.dumps works.
+        # Callers can pass list[litellm.Message] via the documented public
+        # export; without this, json.dumps raises TypeError and the whole
+        # OpenInference attribute setter bails — surfacing as the spammy
+        # "Failed to set OpenInference span attributes: Object of type
+        # Message is not JSON serializable" error and dropping the input
+        # payload from the span.
+        raw_messages = kwargs.get("messages") or []
+        messages = [
+            m.model_dump() if isinstance(m, BaseModel) else m for m in raw_messages
+        ]
+        prompt: Dict[str, Any] = {"messages": messages}
         optional_params = kwargs.get("optional_params", {})
         functions = optional_params.get("functions")
         tools = optional_params.get("tools")

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -115,6 +115,66 @@ class TestLangfuseOtelIntegration:
                 mock_span, mock_kwargs, mock_response, LangfuseLLMObsOTELAttributes
             )
 
+    def test_set_messages_handles_pydantic_message_objects(self):
+        """Pydantic ``litellm.Message`` objects in ``messages`` must not raise.
+
+        Regression test for the spammy "Object of type Message is not JSON
+        serializable" error that previously fired on every LLM call when the
+        caller passed ``list[litellm.Message]`` (a documented public API)
+        rather than ``list[dict]``.
+        """
+        from litellm.integrations.langfuse.langfuse_otel_attributes import (
+            LangfuseLLMObsOTELAttributes,
+        )
+        from litellm.types.utils import Message
+
+        captured: dict = {}
+
+        def _capture(span, key, value):
+            captured[key] = value
+
+        kwargs = {
+            "messages": [
+                Message(role="user", content="hello"),
+                Message(role="assistant", content="hi back"),
+            ]
+        }
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse_otel_attributes.safe_set_attribute",
+            side_effect=_capture,
+        ):
+            # Must not raise — previously raised TypeError inside json.dumps.
+            LangfuseLLMObsOTELAttributes.set_messages(MagicMock(), kwargs)
+
+        payload = json.loads(captured["langfuse.observation.input"])
+        assert payload["messages"][0]["role"] == "user"
+        assert payload["messages"][0]["content"] == "hello"
+        assert payload["messages"][1]["role"] == "assistant"
+        assert payload["messages"][1]["content"] == "hi back"
+
+    def test_set_messages_passes_through_plain_dicts(self):
+        """Plain-dict messages (the existing path) must keep working unchanged."""
+        from litellm.integrations.langfuse.langfuse_otel_attributes import (
+            LangfuseLLMObsOTELAttributes,
+        )
+
+        captured: dict = {}
+
+        def _capture(span, key, value):
+            captured[key] = value
+
+        kwargs = {"messages": [{"role": "user", "content": "hello"}]}
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse_otel_attributes.safe_set_attribute",
+            side_effect=_capture,
+        ):
+            LangfuseLLMObsOTELAttributes.set_messages(MagicMock(), kwargs)
+
+        payload = json.loads(captured["langfuse.observation.input"])
+        assert payload["messages"] == [{"role": "user", "content": "hello"}]
+
     def test_set_langfuse_environment_attribute(self):
         """Test that Langfuse environment is set correctly when environment variable is present."""
         mock_span = MagicMock()


### PR DESCRIPTION
Fixes #26977. Refs #13672.

## Problem

`LangfuseLLMObsOTELAttributes.set_messages` does `json.dumps({\"messages\": kwargs.get(\"messages\"), ...})` directly. When the caller passes `list[litellm.Message]` — a documented public API surface (`litellm.Message`) — `json.dumps` raises `TypeError: Object of type Message is not JSON serializable`, the OpenInference attribute setter bails, and every LLM call spams:

```
LiteLLM:ERROR: _utils.py:415 - [Arize/Phoenix] Failed to set OpenInference span attributes: Object of type Message is not JSON serializable
```

Beyond the noise, the failure has real telemetry impact: the trace is still exported but with the input payload missing, and the span's kind is degraded from `GENERATION` to a generic span (the `OPENINFERENCE_SPAN_KIND` attribute is set later in the same `try/except` in `arize/_utils.set_attributes`, so it gets skipped along with `set_messages` when the latter raises).

## Fix

`set_messages` now normalises pydantic objects to dicts via `.model_dump()` before `json.dumps`. Plain-dict messages keep working unchanged — only the previously-broken pydantic path is touched.

```python
raw_messages = kwargs.get(\"messages\") or []
messages = [
    m.model_dump() if hasattr(m, \"model_dump\") else m
    for m in raw_messages
]
prompt: Dict[str, Any] = {\"messages\": messages}
```

## Tests

Two new tests in `tests/test_litellm/integrations/test_langfuse_otel.py`:

- `test_set_messages_handles_pydantic_message_objects` — passing `list[litellm.Message]` no longer raises and the dumped JSON contains the expected role/content fields.
- `test_set_messages_passes_through_plain_dicts` — the existing dict path still works.

```
$ pytest tests/test_litellm/integrations/test_langfuse_otel.py
22 passed
```

## End-to-end verification

Reproduced and verified against a self-hosted Langfuse instance with `bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0`:

| | before | after |
| --- | --- | --- |
| `[Arize/Phoenix] Failed ...` log | every LLM call | gone |
| Langfuse observation `input` | empty | full message list |
| Langfuse observation kind | `TOOL` (fallback) | `GENERATION` |
| Trace export | succeeds | succeeds |

Verified by querying `/api/public/traces/{id}` after each call.

## Out of scope

The same `json.dumps(messages)` pattern exists in `weave/weave_otel.py`, and a related-but-distinct issue (`.get()` against pydantic objects) exists in `arize/_utils.py`. Both have different fix shapes and are kept separate. Happy to file follow-ups if useful.