### PR TITLE
tests/ci: cassette proxy + opt every cost-bearing CI job in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,46 +113,66 @@ commands:
           timeout: "60"
   start_cassette_proxy:
     description: |
-      Start the e2e cassette proxy sidecar (mitmproxy + Redis-backed cache).
-      Egress HTTPS traffic from any container that points HTTPS_PROXY at
-      this sidecar is captured / replayed. After this command runs you'll
-      have:
-        - a container named ``cassette-proxy`` listening on host port 8080
-        - the proxy CA at /tmp/cassette-proxy-ca.crt on the host
-        - $CASSETTE_PROXY_URL exported in $BASH_ENV
-        - $CASSETTE_PROXY_CA  exported in $BASH_ENV
-      Consumers should ``-e HTTPS_PROXY=$CASSETTE_PROXY_URL`` and mount
-      $CASSETTE_PROXY_CA into the container's trust store. The
-      ``trust_ca.sh`` helper inside the image takes care of all known
-      Python / curl / boto3 trust stores in one shot.
+      Start the e2e cassette proxy sidecar (mitmproxy + Redis-backed
+      cache) as a background subprocess on the CI runner. Works on both
+      ``docker:`` and ``machine:`` executors (no Docker daemon access
+      required — we just install mitmproxy via uv and run mitmdump).
+
+      After this command runs you'll have:
+        - mitmdump listening on 0.0.0.0:8080 of the runner
+        - the proxy CA at /tmp/cassette-proxy-ca.crt
+        - $CASSETTE_PROXY_URL      exported in $BASH_ENV
+          (host.docker.internal:8080 — the URL containers should use)
+        - $CASSETTE_PROXY_HOST_URL exported in $BASH_ENV
+          (localhost:8080 — the URL the runner shell should use)
+        - $CASSETTE_PROXY_CA       exported in $BASH_ENV
+
+      For containers under test, also pass ``HTTPS_PROXY``,
+      ``SSL_CERT_FILE``, etc. via ``docker run -e`` (see
+      tests/e2e_cassette_proxy/README.md). For in-process pytest jobs,
+      follow this command with ``enable_cassette_proxy_for_pytest``.
+    parameters:
+      listen_port:
+        type: string
+        default: "8080"
     steps:
       - run:
-          name: Build cassette-proxy image
+          name: Install mitmproxy + addon dependencies
           command: |
-            docker build -t litellm-cassette-proxy:ci \
-              -f tests/e2e_cassette_proxy/Dockerfile \
-              .
+            # uv was installed by install_uv earlier in the job.
+            export PATH="$HOME/.local/bin:$PATH"
+            uv tool install --with redis==5.2.0 --with msgpack==1.1.0 \
+              "mitmproxy==11.0.2"
       - run:
-          name: Run cassette-proxy
+          name: Resolve Redis target for the cassette store
           command: |
-            # Prefer the project-level REDIS_SSL_URL (already set in
-            # CircleCI's env), fall back to constructing one from
-            # REDIS_HOST/PORT/PASSWORD if it isn't.
             if [ -n "${REDIS_SSL_URL:-}" ]; then
               REDIS_TARGET="$REDIS_SSL_URL"
+            elif [ -n "${REDIS_URL:-}" ]; then
+              REDIS_TARGET="$REDIS_URL"
             else
-              : "${REDIS_HOST:?REDIS_HOST or REDIS_SSL_URL must be set}"
+              : "${REDIS_HOST:?REDIS_HOST or REDIS_(SSL_)URL must be set}"
               : "${REDIS_PORT:?REDIS_PORT must be set}"
               : "${REDIS_PASSWORD:?REDIS_PASSWORD must be set}"
               REDIS_TARGET="rediss://default:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}"
             fi
-            docker run -d \
-              --name cassette-proxy \
-              -p 8080:8080 \
-              -e LITELLM_E2E_CASS_REDIS_URL="$REDIS_TARGET" \
-              litellm-cassette-proxy:ci
+            echo "export LITELLM_E2E_CASS_REDIS_URL=$REDIS_TARGET" >> "$BASH_ENV"
+      - run:
+          name: Launch cassette-proxy (mitmdump) in the background
+          background: true
+          command: |
+            export PATH="$HOME/.local/bin:$PATH"
+            export PYTHONPATH="$(pwd)"
+            mitmdump \
+              --listen-host 0.0.0.0 \
+              --listen-port << parameters.listen_port >> \
+              --set block_global=false \
+              --set ssl_insecure=true \
+              --set termlog_verbosity=info \
+              -s tests/e2e_cassette_proxy/addon.py \
+              2>&1 | tee /tmp/cassette-proxy.log
       - wait_for_service:
-          url: tcp://localhost:8080
+          url: tcp://localhost:<< parameters.listen_port >>
           timeout: "60"
       - run:
           name: Fetch CA from cassette-proxy
@@ -160,15 +180,123 @@ commands:
             mkdir -p /tmp
             for i in 1 2 3 4 5; do
               if curl --silent --show-error --max-time 30 \
-                   --proxy http://localhost:8080 \
+                   --proxy http://localhost:<< parameters.listen_port >> \
                    -o /tmp/cassette-proxy-ca.crt http://mitm.it/cert/pem; then
                 break
               fi
               sleep 2
             done
             test -s /tmp/cassette-proxy-ca.crt
-            echo "export CASSETTE_PROXY_URL=http://host.docker.internal:8080" >> "$BASH_ENV"
-            echo "export CASSETTE_PROXY_CA=/tmp/cassette-proxy-ca.crt"        >> "$BASH_ENV"
+            # Two URLs: containers reach the runner via host.docker.internal,
+            # the CircleCI step's own shell reaches it via localhost.
+            echo "export CASSETTE_PROXY_URL=http://host.docker.internal:<< parameters.listen_port >>" >> "$BASH_ENV"
+            echo "export CASSETTE_PROXY_HOST_URL=http://localhost:<< parameters.listen_port >>"       >> "$BASH_ENV"
+            echo "export CASSETTE_PROXY_CA=/tmp/cassette-proxy-ca.crt"                                >> "$BASH_ENV"
+  export_cassette_proxy_docker_args:
+    description: |
+      Export $CASSETTE_PROXY_DOCKER_ARGS — a string of ``-e ...`` and
+      ``-v ...`` flags ready to splice into a ``docker run`` command —
+      so opt-in for an in-Docker SUT job is exactly two lines:
+
+          - start_cassette_proxy
+          - export_cassette_proxy_docker_args
+
+      …followed by ``$CASSETTE_PROXY_DOCKER_ARGS \\`` somewhere inside
+      the SUT's ``docker run``.
+
+      Must be called *after* ``start_cassette_proxy``.
+    steps:
+      - run:
+          name: Compose docker-run flags for cassette-proxy
+          command: |
+            : "${CASSETTE_PROXY_URL:?run start_cassette_proxy first}"
+            : "${CASSETTE_PROXY_CA:?run start_cassette_proxy first}"
+            EXTRA_NO_PROXY=""
+            if [ -n "${REDIS_HOST:-}" ]; then
+              EXTRA_NO_PROXY=",${REDIS_HOST}"
+            fi
+            BASE_NO_PROXY="localhost,127.0.0.1,0.0.0.0,host.docker.internal,postgres-db,redis-cache,cassette-proxy${EXTRA_NO_PROXY}"
+            ARGS=$(printf '%s ' \
+              "-e HTTP_PROXY=$CASSETTE_PROXY_URL" \
+              "-e HTTPS_PROXY=$CASSETTE_PROXY_URL" \
+              "-e http_proxy=$CASSETTE_PROXY_URL" \
+              "-e https_proxy=$CASSETTE_PROXY_URL" \
+              "-e NO_PROXY=$BASE_NO_PROXY" \
+              "-e no_proxy=$BASE_NO_PROXY" \
+              "-e SSL_CERT_FILE=/etc/litellm-cassette-proxy-ca.crt" \
+              "-e REQUESTS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt" \
+              "-e CURL_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt" \
+              "-e AWS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt" \
+              "-e NODE_EXTRA_CA_CERTS=/etc/litellm-cassette-proxy-ca.crt" \
+              "-e AIOHTTP_TRUST_ENV=true" \
+              "-v $CASSETTE_PROXY_CA:/etc/litellm-cassette-proxy-ca.crt:ro")
+            echo "export CASSETTE_PROXY_DOCKER_ARGS='$ARGS'" >> "$BASH_ENV"
+  enable_cassette_proxy_for_pytest:
+    description: |
+      Route the *current shell's* HTTP egress through the cassette-proxy
+      sidecar. Use this in jobs where pytest runs in-process (the
+      ``llm_translation_testing``, ``agent_testing``, ``logging_testing``,
+      ``audio_testing``, etc. family) so live ``litellm.completion(...)``
+      calls flow through the recording proxy.
+
+      Must be called *after* ``start_cassette_proxy`` (which populates
+      $CASSETTE_PROXY_HOST_URL and $CASSETTE_PROXY_CA in $BASH_ENV).
+
+      Sets HTTP_PROXY / HTTPS_PROXY for every subsequent ``- run`` step in
+      the job. Also flips ``AIOHTTP_TRUST_ENV=true`` so litellm's aiohttp
+      transport actually honors the proxy variables (it ignores them by
+      default — see ``litellm/llms/custom_httpx/http_handler.py``).
+
+      Patches certifi's bundled cacert in every venv on the runner so
+      libraries that read certifi directly (openai-python, httpx,
+      google-auth, langfuse, etc.) trust the proxy CA without any code
+      changes.
+    steps:
+      - run:
+          name: Trust cassette-proxy CA + route egress for in-process pytest
+          command: |
+            : "${CASSETTE_PROXY_CA:?run start_cassette_proxy first}"
+            : "${CASSETTE_PROXY_HOST_URL:?run start_cassette_proxy first}"
+            # Append CA to certifi cacert.pem in every venv we can find so
+            # certifi-backed clients (openai-python, httpx) trust it.
+            for cacert in $(find / -name cacert.pem 2>/dev/null); do
+              if ! grep -q -F "$(head -n 2 "$CASSETTE_PROXY_CA")" "$cacert" 2>/dev/null; then
+                cat "$CASSETTE_PROXY_CA" >> "$cacert" || true
+              fi
+            done
+            # Append CA to the system trust store too (for curl/requests).
+            sudo cp "$CASSETTE_PROXY_CA" /usr/local/share/ca-certificates/litellm-cassette-proxy.crt 2>/dev/null \
+              || cp "$CASSETTE_PROXY_CA" /usr/local/share/ca-certificates/litellm-cassette-proxy.crt 2>/dev/null \
+              || true
+            sudo update-ca-certificates 2>/dev/null \
+              || update-ca-certificates 2>/dev/null \
+              || true
+            # Export env for every subsequent step. NO_PROXY keeps loopback
+            # and the postgres sidecar reachable directly.
+            # Redis hosts must be in NO_PROXY: redis is not HTTP, mitmproxy
+            # cannot proxy it. Same for any non-HTTP TCP services we depend
+            # on (Postgres, Datadog APM, Langfuse OTLP, etc.).
+            EXTRA_NO_PROXY=""
+            if [ -n "${REDIS_HOST:-}" ]; then
+              EXTRA_NO_PROXY=",${REDIS_HOST}"
+            fi
+            BASE_NO_PROXY="localhost,127.0.0.1,0.0.0.0,host.docker.internal,postgres-db,redis-cache,cassette-proxy${EXTRA_NO_PROXY}"
+            {
+              echo "export HTTP_PROXY=$CASSETTE_PROXY_HOST_URL"
+              echo "export HTTPS_PROXY=$CASSETTE_PROXY_HOST_URL"
+              echo "export http_proxy=$CASSETTE_PROXY_HOST_URL"
+              echo "export https_proxy=$CASSETTE_PROXY_HOST_URL"
+              echo "export NO_PROXY=$BASE_NO_PROXY"
+              echo "export no_proxy=$BASE_NO_PROXY"
+              echo "export SSL_CERT_FILE=$CASSETTE_PROXY_CA"
+              echo "export REQUESTS_CA_BUNDLE=$CASSETTE_PROXY_CA"
+              echo "export CURL_CA_BUNDLE=$CASSETTE_PROXY_CA"
+              echo "export AWS_CA_BUNDLE=$CASSETTE_PROXY_CA"
+              echo "export NODE_EXTRA_CA_CERTS=$CASSETTE_PROXY_CA"
+              # litellm's aiohttp transport ignores HTTPS_PROXY unless this
+              # is explicitly set (see http_handler.py:951-952).
+              echo "export AIOHTTP_TRUST_ENV=true"
+            } >> "$BASH_ENV"
   setup_litellm_enterprise_pip:
     steps:
       - run:
@@ -265,6 +393,8 @@ jobs:
           paths:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -330,6 +460,8 @@ jobs:
           paths:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -396,6 +528,8 @@ jobs:
           paths:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -579,6 +713,8 @@ jobs:
           paths:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -613,6 +749,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run realtime tests
           command: |
@@ -648,6 +786,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -681,6 +821,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -715,6 +857,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -757,6 +901,8 @@ jobs:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -780,6 +926,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -813,6 +961,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -847,6 +997,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run enterprise tests
           command: |
@@ -870,6 +1022,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -903,6 +1057,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -937,6 +1093,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -971,6 +1129,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -994,6 +1154,8 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -1027,6 +1189,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - start_cassette_proxy
+      - enable_cassette_proxy_for_pytest
       - run:
           name: Run tests
           command: |
@@ -1337,6 +1501,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - run:
           name: Load Docker Database Image
           command: |
@@ -1372,6 +1538,7 @@ jobs:
               -e LANGFUSE_PROJECT2_PUBLIC=$LANGFUSE_PROJECT2_PUBLIC \
               -e LANGFUSE_PROJECT1_SECRET=$LANGFUSE_PROJECT1_SECRET \
               -e LANGFUSE_PROJECT2_SECRET=$LANGFUSE_PROJECT2_SECRET \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/proxy_server_config.yaml:/app/config.yaml \
@@ -1410,6 +1577,7 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - attach_workspace:
           at: ~/project
       - run:
@@ -1448,18 +1616,10 @@ jobs:
               -e LANGFUSE_PROJECT2_PUBLIC=$LANGFUSE_PROJECT2_PUBLIC \
               -e LANGFUSE_PROJECT1_SECRET=$LANGFUSE_PROJECT1_SECRET \
               -e LANGFUSE_PROJECT2_SECRET=$LANGFUSE_PROJECT2_SECRET \
-              -e HTTP_PROXY="$CASSETTE_PROXY_URL" \
-              -e HTTPS_PROXY="$CASSETTE_PROXY_URL" \
-              -e NO_PROXY="localhost,127.0.0.1,host.docker.internal,postgres-db" \
-              -e SSL_CERT_FILE=/etc/litellm-cassette-proxy-ca.crt \
-              -e REQUESTS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
-              -e CURL_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
-              -e AWS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
-              -e NODE_EXTRA_CA_CERTS=/etc/litellm-cassette-proxy-ca.crt \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/oai_misc_config.yaml:/app/config.yaml \
-              -v "$CASSETTE_PROXY_CA":/etc/litellm-cassette-proxy-ca.crt:ro \
               litellm-docker-database:ci \
               --config /app/config.yaml \
               --port 4000 \
@@ -1479,7 +1639,7 @@ jobs:
 
       - run:
           name: Cassette-proxy stats
-          command: docker logs cassette-proxy 2>&1 | grep -E '\[E2ECASS\]' | tail -200 || true
+          command: grep -E '\[E2ECASS\]' /tmp/cassette-proxy.log 2>/dev/null | tail -200 || true
           when: always
 
       # Store test results
@@ -1499,6 +1659,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - attach_workspace:
           at: ~/project
       - run:
@@ -1530,6 +1692,7 @@ jobs:
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e COHERE_API_KEY=$COHERE_API_KEY \
               -e GCS_FLUSH_INTERVAL="1" \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/otel_test_config.yaml:/app/config.yaml \
@@ -1612,6 +1775,8 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - start_redis
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - attach_workspace:
           at: ~/project
       - run:
@@ -1643,6 +1808,7 @@ jobs:
               -e DD_SITE=$DD_SITE \
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e PROXY_BATCH_WRITE_AT=2 \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/spend_tracking_config.yaml:/app/config.yaml \
@@ -1770,6 +1936,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - attach_workspace:
           at: ~/project
       - run:
@@ -1788,6 +1956,7 @@ jobs:
               -e STORE_MODEL_IN_DB="True" \
               -e LITELLM_MASTER_KEY="sk-1234" \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/store_model_db_config.yaml:/app/config.yaml \
@@ -1838,6 +2007,8 @@ jobs:
           command: |
             docker build -t my-app:latest -f docker/build_from_pip/Dockerfile.build_from_pip .
       - start_postgres
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - run:
           name: Run Docker container
           # intentionally give bad redis credentials here
@@ -1861,6 +2032,7 @@ jobs:
               -e DD_API_KEY=$DD_API_KEY \
               -e DD_SITE=$DD_SITE \
               -e GCS_FLUSH_INTERVAL="1" \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/docker/build_from_pip/litellm_config.yaml:/app/config.yaml \
@@ -1903,6 +2075,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - attach_workspace:
           at: ~/project
       - run:
@@ -1928,6 +2102,7 @@ jobs:
               -e DD_SITE=$DD_SITE \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/pass_through_config.yaml:/app/config.yaml \
@@ -2034,6 +2209,8 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_cassette_proxy
+      - export_cassette_proxy_docker_args
       - attach_workspace:
           at: ~/project
       - run:
@@ -2053,6 +2230,7 @@ jobs:
               -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
               -e AWS_REGION_NAME="us-east-1" \
               -e LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS="True" \
+              $CASSETTE_PROXY_DOCKER_ARGS \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml:/app/config.yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,64 @@ commands:
       - wait_for_service:
           url: tcp://localhost:6379
           timeout: "60"
+  start_cassette_proxy:
+    description: |
+      Start the e2e cassette proxy sidecar (mitmproxy + Redis-backed cache).
+      Egress HTTPS traffic from any container that points HTTPS_PROXY at
+      this sidecar is captured / replayed. After this command runs you'll
+      have:
+        - a container named ``cassette-proxy`` listening on host port 8080
+        - the proxy CA at /tmp/cassette-proxy-ca.crt on the host
+        - $CASSETTE_PROXY_URL exported in $BASH_ENV
+        - $CASSETTE_PROXY_CA  exported in $BASH_ENV
+      Consumers should ``-e HTTPS_PROXY=$CASSETTE_PROXY_URL`` and mount
+      $CASSETTE_PROXY_CA into the container's trust store. The
+      ``trust_ca.sh`` helper inside the image takes care of all known
+      Python / curl / boto3 trust stores in one shot.
+    steps:
+      - run:
+          name: Build cassette-proxy image
+          command: |
+            docker build -t litellm-cassette-proxy:ci \
+              -f tests/e2e_cassette_proxy/Dockerfile \
+              .
+      - run:
+          name: Run cassette-proxy
+          command: |
+            # Prefer the project-level REDIS_SSL_URL (already set in
+            # CircleCI's env), fall back to constructing one from
+            # REDIS_HOST/PORT/PASSWORD if it isn't.
+            if [ -n "${REDIS_SSL_URL:-}" ]; then
+              REDIS_TARGET="$REDIS_SSL_URL"
+            else
+              : "${REDIS_HOST:?REDIS_HOST or REDIS_SSL_URL must be set}"
+              : "${REDIS_PORT:?REDIS_PORT must be set}"
+              : "${REDIS_PASSWORD:?REDIS_PASSWORD must be set}"
+              REDIS_TARGET="rediss://default:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}"
+            fi
+            docker run -d \
+              --name cassette-proxy \
+              -p 8080:8080 \
+              -e LITELLM_E2E_CASS_REDIS_URL="$REDIS_TARGET" \
+              litellm-cassette-proxy:ci
+      - wait_for_service:
+          url: tcp://localhost:8080
+          timeout: "60"
+      - run:
+          name: Fetch CA from cassette-proxy
+          command: |
+            mkdir -p /tmp
+            for i in 1 2 3 4 5; do
+              if curl --silent --show-error --max-time 30 \
+                   --proxy http://localhost:8080 \
+                   -o /tmp/cassette-proxy-ca.crt http://mitm.it/cert/pem; then
+                break
+              fi
+              sleep 2
+            done
+            test -s /tmp/cassette-proxy-ca.crt
+            echo "export CASSETTE_PROXY_URL=http://host.docker.internal:8080" >> "$BASH_ENV"
+            echo "export CASSETTE_PROXY_CA=/tmp/cassette-proxy-ca.crt"        >> "$BASH_ENV"
   setup_litellm_enterprise_pip:
     steps:
       - run:
@@ -1351,6 +1409,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
+      - start_cassette_proxy
       - attach_workspace:
           at: ~/project
       - run:
@@ -1389,9 +1448,18 @@ jobs:
               -e LANGFUSE_PROJECT2_PUBLIC=$LANGFUSE_PROJECT2_PUBLIC \
               -e LANGFUSE_PROJECT1_SECRET=$LANGFUSE_PROJECT1_SECRET \
               -e LANGFUSE_PROJECT2_SECRET=$LANGFUSE_PROJECT2_SECRET \
+              -e HTTP_PROXY="$CASSETTE_PROXY_URL" \
+              -e HTTPS_PROXY="$CASSETTE_PROXY_URL" \
+              -e NO_PROXY="localhost,127.0.0.1,host.docker.internal,postgres-db" \
+              -e SSL_CERT_FILE=/etc/litellm-cassette-proxy-ca.crt \
+              -e REQUESTS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
+              -e CURL_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
+              -e AWS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
+              -e NODE_EXTRA_CA_CERTS=/etc/litellm-cassette-proxy-ca.crt \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/oai_misc_config.yaml:/app/config.yaml \
+              -v "$CASSETTE_PROXY_CA":/etc/litellm-cassette-proxy-ca.crt:ro \
               litellm-docker-database:ci \
               --config /app/config.yaml \
               --port 4000 \
@@ -1408,6 +1476,11 @@ jobs:
           command: |
             uv run --no-sync python -m pytest -s -vv tests/openai_endpoints_tests --junitxml=test-results/junit.xml --durations=5
           no_output_timeout: 15m
+
+      - run:
+          name: Cassette-proxy stats
+          command: docker logs cassette-proxy 2>&1 | grep -E '\[E2ECASS\]' | tail -200 || true
+          when: always
 
       # Store test results
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,8 +233,7 @@ commands:
             echo "export CASSETTE_PROXY_DOCKER_ARGS='$ARGS'" >> "$BASH_ENV"
   enable_cassette_proxy_for_pytest:
     description: |
-      Route the *current shell's* HTTP egress through the cassette-proxy
-      sidecar. Use this in jobs where pytest runs in-process (the
+      Prepare the cassette-proxy environment for in-process pytest jobs (the
       ``llm_translation_testing``, ``agent_testing``, ``logging_testing``,
       ``audio_testing``, etc. family) so live ``litellm.completion(...)``
       calls flow through the recording proxy.
@@ -242,23 +241,37 @@ commands:
       Must be called *after* ``start_cassette_proxy`` (which populates
       $CASSETTE_PROXY_HOST_URL and $CASSETTE_PROXY_CA in $BASH_ENV).
 
-      Sets HTTP_PROXY / HTTPS_PROXY for every subsequent ``- run`` step in
-      the job. Also flips ``AIOHTTP_TRUST_ENV=true`` so litellm's aiohttp
-      transport actually honors the proxy variables (it ignores them by
-      default — see ``litellm/llms/custom_httpx/http_handler.py``).
+      Does three things:
 
-      Patches certifi's bundled cacert in every venv on the runner so
-      libraries that read certifi directly (openai-python, httpx,
-      google-auth, langfuse, etc.) trust the proxy CA without any code
-      changes.
+      1. Patches certifi's bundled cacert in every venv on the runner so
+         libraries that read certifi directly (openai-python, httpx,
+         google-auth, langfuse, etc.) trust the proxy CA without any code
+         changes.
+      2. Appends the proxy CA to the system trust store (curl/git/wget).
+      3. Writes the proxy/CA env vars to ``/tmp/cassette-proxy-pytest.env``
+         and installs a ``cassette-pytest`` wrapper at
+         ``/usr/local/bin/cassette-pytest`` that sources that env and execs
+         its arguments. Pytest invocations should use this wrapper.
+
+      We deliberately do NOT export HTTP_PROXY / HTTPS_PROXY / SSL_CERT_FILE
+      etc. globally via $BASH_ENV. Doing so would route the CircleCI agent's
+      own outbound calls (``circleci tests run`` plugin auto-installer,
+      ``store_test_results`` upload, etc.) through mitmproxy, and the
+      CircleCI Go binary uses Go's built-in cert pool which ignores
+      SSL_CERT_FILE, producing
+      ``tls: failed to verify certificate: x509: certificate signed by
+      unknown authority``. Scoping the env to just the ``cassette-pytest``
+      wrapper keeps mitmproxy traffic confined to test processes.
     steps:
       - run:
-          name: Trust cassette-proxy CA + route egress for in-process pytest
+          name: Trust cassette-proxy CA + install cassette-pytest wrapper
           command: |
             : "${CASSETTE_PROXY_CA:?run start_cassette_proxy first}"
             : "${CASSETTE_PROXY_HOST_URL:?run start_cassette_proxy first}"
             # Append CA to certifi cacert.pem in every venv we can find so
             # certifi-backed clients (openai-python, httpx) trust it.
+            # Note: certifi *appends* to its trust list; it does not
+            # *replace* it, so public CAs continue to work too.
             for cacert in $(find / -name cacert.pem 2>/dev/null); do
               if ! grep -q -F "$(head -n 2 "$CASSETTE_PROXY_CA")" "$cacert" 2>/dev/null; then
                 cat "$CASSETTE_PROXY_CA" >> "$cacert" || true
@@ -271,32 +284,55 @@ commands:
             sudo update-ca-certificates 2>/dev/null \
               || update-ca-certificates 2>/dev/null \
               || true
-            # Export env for every subsequent step. NO_PROXY keeps loopback
-            # and the postgres sidecar reachable directly.
-            # Redis hosts must be in NO_PROXY: redis is not HTTP, mitmproxy
-            # cannot proxy it. Same for any non-HTTP TCP services we depend
-            # on (Postgres, Datadog APM, Langfuse OTLP, etc.).
+            # Build NO_PROXY: loopback, container sidecars, and any non-HTTP
+            # TCP service we depend on (Postgres, Redis, Datadog APM, etc.)
+            # since mitmproxy only speaks HTTP/HTTPS.
             EXTRA_NO_PROXY=""
             if [ -n "${REDIS_HOST:-}" ]; then
               EXTRA_NO_PROXY=",${REDIS_HOST}"
             fi
             BASE_NO_PROXY="localhost,127.0.0.1,0.0.0.0,host.docker.internal,postgres-db,redis-cache,cassette-proxy${EXTRA_NO_PROXY}"
+
+            # Write the proxy env to a sourceable file. Pytest jobs source
+            # this via the cassette-pytest wrapper installed below; nothing
+            # else on the runner is affected. (Using printf instead of a
+            # heredoc to dodge YAML literal-block indentation surprises.)
             {
-              echo "export HTTP_PROXY=$CASSETTE_PROXY_HOST_URL"
-              echo "export HTTPS_PROXY=$CASSETTE_PROXY_HOST_URL"
-              echo "export http_proxy=$CASSETTE_PROXY_HOST_URL"
-              echo "export https_proxy=$CASSETTE_PROXY_HOST_URL"
-              echo "export NO_PROXY=$BASE_NO_PROXY"
-              echo "export no_proxy=$BASE_NO_PROXY"
-              echo "export SSL_CERT_FILE=$CASSETTE_PROXY_CA"
-              echo "export REQUESTS_CA_BUNDLE=$CASSETTE_PROXY_CA"
-              echo "export CURL_CA_BUNDLE=$CASSETTE_PROXY_CA"
-              echo "export AWS_CA_BUNDLE=$CASSETTE_PROXY_CA"
-              echo "export NODE_EXTRA_CA_CERTS=$CASSETTE_PROXY_CA"
+              printf 'export HTTP_PROXY=%s\n'           "$CASSETTE_PROXY_HOST_URL"
+              printf 'export HTTPS_PROXY=%s\n'          "$CASSETTE_PROXY_HOST_URL"
+              printf 'export http_proxy=%s\n'           "$CASSETTE_PROXY_HOST_URL"
+              printf 'export https_proxy=%s\n'          "$CASSETTE_PROXY_HOST_URL"
+              printf 'export NO_PROXY=%s\n'             "$BASE_NO_PROXY"
+              printf 'export no_proxy=%s\n'             "$BASE_NO_PROXY"
+              printf 'export SSL_CERT_FILE=%s\n'        "$CASSETTE_PROXY_CA"
+              printf 'export REQUESTS_CA_BUNDLE=%s\n'   "$CASSETTE_PROXY_CA"
+              printf 'export CURL_CA_BUNDLE=%s\n'       "$CASSETTE_PROXY_CA"
+              printf 'export AWS_CA_BUNDLE=%s\n'        "$CASSETTE_PROXY_CA"
+              printf 'export NODE_EXTRA_CA_CERTS=%s\n'  "$CASSETTE_PROXY_CA"
               # litellm's aiohttp transport ignores HTTPS_PROXY unless this
               # is explicitly set (see http_handler.py:951-952).
-              echo "export AIOHTTP_TRUST_ENV=true"
-            } >> "$BASH_ENV"
+              printf 'export AIOHTTP_TRUST_ENV=true\n'
+            } > /tmp/cassette-proxy-pytest.env
+
+            # Install the cassette-pytest wrapper. Build with printf so we
+            # don't have to fight YAML literal-block indentation (a #! line
+            # must start at column 0). The wrapper sources the env file and
+            # execs its arguments, scoping the proxy env to test
+            # subprocesses only.
+            {
+              printf '%s\n' '#!/usr/bin/env bash'
+              printf '%s\n' 'set -e'
+              printf '%s\n' 'if [ -f /tmp/cassette-proxy-pytest.env ]; then'
+              printf '%s\n' '  # shellcheck disable=SC1091'
+              printf '%s\n' '  . /tmp/cassette-proxy-pytest.env'
+              printf '%s\n' 'fi'
+              printf '%s\n' 'exec "$@"'
+            } > /tmp/cassette-pytest
+            chmod +x /tmp/cassette-pytest
+            sudo mv /tmp/cassette-pytest /usr/local/bin/cassette-pytest 2>/dev/null \
+              || mv /tmp/cassette-pytest /usr/local/bin/cassette-pytest
+            # Sanity-check the wrapper resolved on PATH.
+            command -v cassette-pytest
   setup_litellm_enterprise_pip:
     steps:
       - run:
@@ -414,7 +450,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
               --verbose \
-              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs cassette-pytest uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm \
                 --cov-report=xml \
@@ -481,7 +517,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
               --verbose \
-              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs cassette-pytest uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm \
                 --cov-report=xml \
@@ -542,7 +578,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/local_testing -x --junitxml=test-results/junit.xml --durations=5 -k "langfuse"
+            cassette-pytest uv run --no-sync python -m pytest -v tests/local_testing -x --junitxml=test-results/junit.xml --durations=5 -k "langfuse"
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -729,7 +765,7 @@ jobs:
             for dir in "${IGNORE_DIRS[@]}"; do
               IGNORE_ARGS="$IGNORE_ARGS --ignore=$dir"
             done
-            uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5
+            cassette-pytest uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5
           no_output_timeout: 15m
 
       # Store test results
@@ -756,7 +792,7 @@ jobs:
           command: |
             # Add --timeout to kill hanging tests after 120s (2 min)
             # Add --durations=20 to show 20 slowest tests for debugging
-            uv run --no-sync python -m pytest -vv tests/llm_translation/realtime --cov=litellm --cov-report=xml -v --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/llm_translation/realtime --cov=litellm --cov-report=xml -v --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -791,7 +827,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/agent_tests --ignore=tests/agent_tests/local_only_agent_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/agent_tests --ignore=tests/agent_tests/local_only_agent_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -826,7 +862,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            LITELLM_LOG=WARNING uv run --no-sync python -m pytest tests/guardrails_tests -vv --cov=litellm --cov-report=xml --junitxml=test-results/junit.xml --durations=5 -n 2 --timeout=120 --timeout_method=thread
+            LITELLM_LOG=WARNING cassette-pytest uv run --no-sync python -m pytest tests/guardrails_tests -vv --cov=litellm --cov-report=xml --junitxml=test-results/junit.xml --durations=5 -n 2 --timeout=120 --timeout_method=thread
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -862,7 +898,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/unified_google_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 --retries 3 --retry-delay 5
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/unified_google_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 --retries 3 --retry-delay 5
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -906,7 +942,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/llm_responses_api_testing -x --junitxml=test-results/junit.xml --durations=5 -n 8
+            cassette-pytest uv run --no-sync python -m pytest -v tests/llm_responses_api_testing -x --junitxml=test-results/junit.xml --durations=5 -n 8
           no_output_timeout: 15m
 
       # Store test results
@@ -931,7 +967,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/ocr_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/ocr_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -966,7 +1002,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/search_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/search_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -1003,7 +1039,7 @@ jobs:
           name: Run enterprise tests
           command: |
             uv run --no-sync python -m prisma generate
-            uv run --no-sync python -m pytest -v tests/enterprise -x --junitxml=test-results/junit-enterprise.xml --durations=10 -n 4
+            cassette-pytest uv run --no-sync python -m pytest -v tests/enterprise -x --junitxml=test-results/junit-enterprise.xml --durations=10 -n 4
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -1027,7 +1063,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/batches_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 -n 2
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/batches_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 -n 2
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -1062,7 +1098,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/litellm_utils_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 -n 2
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/litellm_utils_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 -n 2
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -1098,7 +1134,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/pass_through_unit_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/pass_through_unit_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -1134,7 +1170,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/image_gen_tests -n 4 -x --junitxml=test-results/junit.xml --durations=5
+            cassette-pytest uv run --no-sync python -m pytest -v tests/image_gen_tests -n 4 -x --junitxml=test-results/junit.xml --durations=5
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -1159,7 +1195,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            LITELLM_LOG=WARNING uv run --no-sync python -m pytest tests/logging_callback_tests -vv --cov=litellm --cov-report=xml -n 4 --junitxml=test-results/junit.xml --durations=5 --timeout=120 --timeout_method=thread
+            LITELLM_LOG=WARNING cassette-pytest uv run --no-sync python -m pytest tests/logging_callback_tests -vv --cov=litellm --cov-report=xml -n 4 --junitxml=test-results/junit.xml --durations=5 --timeout=120 --timeout_method=thread
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -1194,7 +1230,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/audio_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
+            cassette-pytest uv run --no-sync python -m pytest -vv tests/audio_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,19 @@ commands:
       - run:
           name: Resolve Redis target for the cassette store
           command: |
-            if [ -n "${REDIS_SSL_URL:-}" ]; then
+            # Cassette must use a dedicated Redis. Sharing with the
+            # litellm proxy's Redis (REDIS_SSL_URL/REDIS_URL/REDIS_HOST)
+            # means whoever calls /cache/flushall on litellm wipes our
+            # cassette mid-run — we observed 4150 FLUSHALLs on the
+            # shared instance over 33 days, each one nuking 740+
+            # cassette entries and forcing every "hit" back to a
+            # billable upstream call. CASSETTE_REDIS_URL is configured
+            # as a CircleCI project secret pointing at a separate
+            # instance (currently Upstash) that no other workload
+            # touches.
+            if [ -n "${CASSETTE_REDIS_URL:-}" ]; then
+              REDIS_TARGET="$CASSETTE_REDIS_URL"
+            elif [ -n "${REDIS_SSL_URL:-}" ]; then
               REDIS_TARGET="$REDIS_SSL_URL"
             elif [ -n "${REDIS_URL:-}" ]; then
               REDIS_TARGET="$REDIS_URL"
@@ -157,6 +169,13 @@ commands:
               REDIS_TARGET="rediss://default:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}"
             fi
             echo "export LITELLM_E2E_CASS_REDIS_URL=$REDIS_TARGET" >> "$BASH_ENV"
+
+            # Extract host portion of the cassette Redis URL so we can
+            # add it to NO_PROXY in enable_cassette_proxy_for_pytest.
+            # Tolerates rediss://user:pass@host:port and bare host:port.
+            CASSETTE_REDIS_HOST=$(printf '%s' "$REDIS_TARGET" \
+              | sed -E 's|^[a-z]+://||; s|^[^@]*@||; s|:[0-9]+/?$||; s|/.*$||')
+            echo "export LITELLM_E2E_CASS_REDIS_HOST=$CASSETTE_REDIS_HOST" >> "$BASH_ENV"
       - run:
           name: Launch cassette-proxy (mitmdump) in the background
           background: true
@@ -289,7 +308,14 @@ commands:
             # since mitmproxy only speaks HTTP/HTTPS.
             EXTRA_NO_PROXY=""
             if [ -n "${REDIS_HOST:-}" ]; then
-              EXTRA_NO_PROXY=",${REDIS_HOST}"
+              EXTRA_NO_PROXY="${EXTRA_NO_PROXY},${REDIS_HOST}"
+            fi
+            # The cassette-store Redis (Upstash, separate from the
+            # litellm proxy's Redis) speaks RESP-over-TLS — must bypass
+            # mitmproxy or the redis client would try to negotiate
+            # HTTP and fail.
+            if [ -n "${LITELLM_E2E_CASS_REDIS_HOST:-}" ]; then
+              EXTRA_NO_PROXY="${EXTRA_NO_PROXY},${LITELLM_E2E_CASS_REDIS_HOST}"
             fi
             BASE_NO_PROXY="localhost,127.0.0.1,0.0.0.0,host.docker.internal,postgres-db,redis-cache,cassette-proxy${EXTRA_NO_PROXY}"
 

--- a/tests/e2e_cassette_proxy/Dockerfile
+++ b/tests/e2e_cassette_proxy/Dockerfile
@@ -1,0 +1,52 @@
+# Recording HTTP proxy used by e2e CI jobs.
+#
+# Pinned to ``python:3.12-slim`` rather than the official mitmproxy image
+# because we need:
+#   - msgpack (binary wheels not always present in the upstream image)
+#   - redis-py
+#   - the addon source from this repo
+# and pinning + verifying the upstream mitmproxy image would force us to
+# carry yet another sha256 in CI. Building from a known python base
+# keeps the supply chain to one tag we already control.
+#
+# Image is intentionally fat; it only runs in CI sidecars.
+
+FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Pin every dependency.
+RUN pip install \
+        "mitmproxy==11.0.2" \
+        "redis==5.2.0" \
+        "msgpack==1.1.0"
+
+WORKDIR /app
+
+COPY tests/e2e_cassette_proxy /app/tests/e2e_cassette_proxy
+
+ENV PYTHONPATH=/app
+
+VOLUME ["/root/.mitmproxy"]
+
+EXPOSE 8080
+
+# Args explained in tests/e2e_cassette_proxy/README.md.
+#
+# We run as root inside the container so VOLUME ["/root/.mitmproxy"] works
+# without uid juggling — this image only runs in CI sidecars, not in
+# production.
+ENTRYPOINT ["mitmdump", \
+    "--listen-host", "0.0.0.0", \
+    "--listen-port", "8080", \
+    "--set", "block_global=false", \
+    "--set", "ssl_insecure=true", \
+    "--set", "termlog_verbosity=info", \
+    "-s", "/app/tests/e2e_cassette_proxy/addon.py"]

--- a/tests/e2e_cassette_proxy/README.md
+++ b/tests/e2e_cassette_proxy/README.md
@@ -1,0 +1,116 @@
+# e2e cassette proxy
+
+A sidecar HTTP/HTTPS proxy that records and replays upstream responses
+in Redis. Designed for CircleCI e2e jobs whose system-under-test runs
+inside Docker — the in-process VCR persister at
+`tests/_vcr_redis_persister.py` can't see those requests, this can.
+
+## What it caches
+
+Every HTTPS egress that flows through the proxy and:
+
+- uses `GET` / `POST` / `PUT` / `PATCH` / `DELETE`
+- is not destined for `localhost`, `127.0.0.1`, `host.docker.internal`,
+  or any host listed in `LITELLM_E2E_CASS_PASSTHROUGH_HOSTS`
+- received a `2xx` response from the upstream
+
+is keyed on a canonical hash of `(method, scheme, host, path, sorted
+query, allowlisted headers, canonical body)` and stored in Redis. On
+subsequent runs, matching requests are served straight from Redis
+without ever hitting the upstream.
+
+What's intentionally *not* keyed on (so cache hits survive normal
+churn):
+
+- `Authorization`, `x-api-key`, `anthropic-api-key`, `openai-api-key`,
+  `azure-api-key`, `cookie`, AWS sigv4 headers, `x-goog-api-key`,
+  `x-goog-user-project` — auth rotates every run
+- `User-Agent`, `x-stainless-*`, `traceparent`, `tracestate`,
+  `x-request-id`, `request-id` — tracing / SDK metadata
+- JSON key order or whitespace inside the request body — bodies are
+  re-serialized in canonical form before hashing
+
+## How to opt a CI job in
+
+Two changes to the job in `.circleci/config.yml`:
+
+1. Add the `start_cassette_proxy` reusable command after your other
+   sidecars (postgres, redis, etc.) and *before* you start the
+   container under test:
+
+   ```yaml
+   - start_postgres
+   - start_cassette_proxy
+   ```
+
+2. When you `docker run` the container under test, route its egress
+   through the sidecar and trust its CA:
+
+   ```yaml
+   docker run -d \
+     ...your existing env...
+     -e HTTP_PROXY="$CASSETTE_PROXY_URL" \
+     -e HTTPS_PROXY="$CASSETTE_PROXY_URL" \
+     -e NO_PROXY="localhost,127.0.0.1,host.docker.internal" \
+     -e SSL_CERT_FILE=/etc/litellm-cassette-proxy-ca.crt \
+     -e REQUESTS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
+     -e CURL_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
+     -e AWS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
+     -e NODE_EXTRA_CA_CERTS=/etc/litellm-cassette-proxy-ca.crt \
+     -v "$CASSETTE_PROXY_CA":/etc/litellm-cassette-proxy-ca.crt:ro \
+     ...your image and command...
+   ```
+
+`e2e_openai_endpoints` is the canonical example in this PR. To opt the
+others (`proxy_e2e_anthropic_messages_tests`,
+`proxy_pass_through_endpoint_tests`, `e2e_ui_testing`,
+`google_generate_content_endpoint_testing`,
+`proxy_logging_guardrails_model_info_tests`,
+`proxy_multi_instance_tests`, `proxy_spend_accuracy_tests`,
+`proxy_store_model_in_db_tests`) in, copy the same two changes.
+
+## Knobs
+
+| Env var | Where set | Effect |
+|---|---|---|
+| `LITELLM_E2E_CASS_REDIS_URL` | sidecar container | Override the Redis URL the sidecar uses to store cassettes. Falls back to `REDIS_URL` / `REDIS_SSL_URL` / `REDIS_HOST + REDIS_PORT + REDIS_PASSWORD`. |
+| `LITELLM_E2E_CASS_PASSTHROUGH_HOSTS` | sidecar container | Extra hosts (comma-separated) to never cache. |
+| `LITELLM_E2E_CASS_RECORD_ONLY` | sidecar container | When `1`, never serve from cache; always forward + persist. Use during cassette refresh runs. |
+| `LITELLM_E2E_CASS_REPLAY_ONLY` | sidecar container | When `1`, never forward to upstream; serve `599` on miss. Use to *prove* a job is fully cached. |
+
+## Why mitmproxy and not vcrpy
+
+vcrpy is a Python in-process monkey-patch on `httpx`/`aiohttp`/`httpcore`.
+It can only intercept HTTP traffic in the *same process* where it was
+installed. Every CI job that runs the LiteLLM proxy in a Docker container
+issues its upstream traffic from that container's process — not the
+pytest process — so vcrpy literally has no hook to attach to.
+
+A network-level recording proxy is language-agnostic, in-process-agnostic,
+and transport-agnostic. It works for the LiteLLM proxy (Python aiohttp),
+for the websocket realtime tests (a separate server), for the OpenAI SDK
+(node fetch in some paths), and for any future containerized e2e job
+without any changes to the SUT.
+
+## Why one Redis key per request, not vcrpy-style cassettes
+
+vcrpy stores an ordered list of `(request, response)` episodes per test
+file. That model is the source of every footgun the
+`tests/llm_translation/` recorder hit (unbounded per-key growth in
+`new_episodes` mode, ordering brittleness, OOM under `noeviction`). Here
+each Redis key holds exactly one `(request_summary, response)` pair,
+so:
+
+- Per-key size is bounded by one response (with an explicit
+  `max_payload_bytes` ceiling on top).
+- Two tests issuing the same request share the cache entry for free.
+- "Order" is no longer a thing.
+- "Record mode" is no longer a thing — if the entry is present, replay;
+  else record.
+
+## Refreshing cassettes
+
+Add the `LITELLM_E2E_CASS_RECORD_ONLY=1` env var to the
+`start_cassette_proxy` `docker run` flags for one CI run; every cassette
+the job exercises will be re-recorded. Or wipe specific keys with
+`redis-cli del litellm:e2ecass:<sha256>`.

--- a/tests/e2e_cassette_proxy/README.md
+++ b/tests/e2e_cassette_proxy/README.md
@@ -32,42 +32,81 @@ churn):
 
 ## How to opt a CI job in
 
-Two changes to the job in `.circleci/config.yml`:
+There are two patterns depending on where the upstream HTTP traffic
+originates.
 
-1. Add the `start_cassette_proxy` reusable command after your other
-   sidecars (postgres, redis, etc.) and *before* you start the
-   container under test:
+### Pattern A — System-under-test runs in a Docker container
 
-   ```yaml
-   - start_postgres
-   - start_cassette_proxy
-   ```
-
-2. When you `docker run` the container under test, route its egress
-   through the sidecar and trust its CA:
-
-   ```yaml
-   docker run -d \
-     ...your existing env...
-     -e HTTP_PROXY="$CASSETTE_PROXY_URL" \
-     -e HTTPS_PROXY="$CASSETTE_PROXY_URL" \
-     -e NO_PROXY="localhost,127.0.0.1,host.docker.internal" \
-     -e SSL_CERT_FILE=/etc/litellm-cassette-proxy-ca.crt \
-     -e REQUESTS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
-     -e CURL_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
-     -e AWS_CA_BUNDLE=/etc/litellm-cassette-proxy-ca.crt \
-     -e NODE_EXTRA_CA_CERTS=/etc/litellm-cassette-proxy-ca.crt \
-     -v "$CASSETTE_PROXY_CA":/etc/litellm-cassette-proxy-ca.crt:ro \
-     ...your image and command...
-   ```
-
-`e2e_openai_endpoints` is the canonical example in this PR. To opt the
-others (`proxy_e2e_anthropic_messages_tests`,
-`proxy_pass_through_endpoint_tests`, `e2e_ui_testing`,
-`google_generate_content_endpoint_testing`,
+Used by `e2e_openai_endpoints`, `build_and_test`,
+`proxy_e2e_anthropic_messages_tests`, `proxy_pass_through_endpoint_tests`,
 `proxy_logging_guardrails_model_info_tests`,
-`proxy_multi_instance_tests`, `proxy_spend_accuracy_tests`,
-`proxy_store_model_in_db_tests`) in, copy the same two changes.
+`proxy_spend_accuracy_tests`, `proxy_build_from_pip_tests`,
+`proxy_store_model_in_db_tests`.
+
+Two-step opt-in. Add the two reusable commands after your other
+sidecars (postgres, redis, etc.) and *before* you start the SUT
+container, then splice `$CASSETTE_PROXY_DOCKER_ARGS` into the
+`docker run`:
+
+```yaml
+- start_postgres
+- start_cassette_proxy
+- export_cassette_proxy_docker_args
+- run:
+    name: Run Docker container
+    command: |
+      docker run -d \
+        ...your existing env...
+        $CASSETTE_PROXY_DOCKER_ARGS \
+        --name my-app \
+        ...your image and command...
+```
+
+`$CASSETTE_PROXY_DOCKER_ARGS` is a single string composed by
+`export_cassette_proxy_docker_args` that sets every Python / curl /
+boto3 / node trust-store env var, the proxy URL, and `AIOHTTP_TRUST_ENV`
+in one shot.
+
+### Pattern B — pytest runs in-process (no Docker container hosting the SUT)
+
+Used by `llm_translation_testing`, `realtime_translation_testing`,
+`agent_testing`, `guardrails_testing`,
+`google_generate_content_endpoint_testing`,
+`llm_responses_api_testing`, `ocr_testing`, `search_testing`,
+`litellm_mapped_enterprise_tests`, `batches_testing`,
+`litellm_utils_testing`, `pass_through_unit_testing`,
+`image_gen_testing`, `logging_testing`, `audio_testing`,
+`local_testing_part1`, `local_testing_part2`,
+`langfuse_logging_unit_tests`.
+
+Two-step opt-in. After install, before the test step:
+
+```yaml
+- run:
+    name: Install Dependencies
+    command: |
+      uv sync --frozen --all-groups --all-extras --python 3.12
+- start_cassette_proxy
+- enable_cassette_proxy_for_pytest
+- run:
+    name: Run tests
+    command: |
+      uv run --no-sync python -m pytest ...
+```
+
+`enable_cassette_proxy_for_pytest` patches certifi's bundled
+`cacert.pem` in every venv on the runner, exports
+`HTTPS_PROXY` / `NO_PROXY` / `SSL_CERT_FILE` for every subsequent step,
+and crucially flips `AIOHTTP_TRUST_ENV=true` — without that flag
+litellm's aiohttp transport ignores the proxy variables (see
+`litellm/llms/custom_httpx/http_handler.py`).
+
+### Why `NO_PROXY` includes the Redis host
+
+`mitmproxy` only proxies HTTP/HTTPS. The Redis client's TCP+TLS
+connection to the project's managed Redis would be broken if it were
+sent through the proxy. Both opt-in commands automatically append
+`$REDIS_HOST` to `NO_PROXY` when it's set in the env.
 
 ## Knobs
 

--- a/tests/e2e_cassette_proxy/__init__.py
+++ b/tests/e2e_cassette_proxy/__init__.py
@@ -1,0 +1,16 @@
+"""HTTP recording proxy used by e2e CI jobs.
+
+This is intentionally separate from the in-process VCR persister under
+``tests/_vcr_redis_persister.py``: that one only sees HTTP traffic from
+the pytest process, and so cannot record requests originating from the
+LiteLLM proxy when it runs in a Docker container (the case in every CI
+job under ``e2e_*`` and ``proxy_*``). This package runs as a sidecar
+mitmproxy that any container can route egress through via ``HTTPS_PROXY``,
+making the recording layer transport-agnostic and language-agnostic.
+
+Public surface for unit tests:
+
+- ``cache_key.derive_cache_key`` — pure function.
+- ``redis_store.RedisCassetteStore`` — thin wrapper over ``redis.Redis``.
+- ``addon.CassetteAddon`` — mitmproxy addon class.
+"""

--- a/tests/e2e_cassette_proxy/addon.py
+++ b/tests/e2e_cassette_proxy/addon.py
@@ -1,0 +1,193 @@
+"""mitmproxy addon: cache HTTPS request/response pairs in Redis.
+
+Loaded by ``mitmdump -s addon.py``. Two hooks:
+
+- ``request(flow)``: derive cache key, look up in Redis, short-circuit
+  the response if we have one.
+- ``response(flow)``: persist the upstream's response under that same
+  cache key for the next run.
+
+This intentionally caches *every* upstream call that flows through the
+proxy, regardless of host. The expensive surface (LLM provider APIs)
+is what we care about, but capturing everything also dedupes the
+boring stuff (token endpoints, model-list calls, control-plane pings)
+for free.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from mitmproxy import ctx, http  # type: ignore[import-not-found]
+
+from tests.e2e_cassette_proxy.cache_key import (
+    DEFAULT_HEADER_ALLOWLIST,
+    DEFAULT_HEADER_BLOCKLIST,
+    derive_cache_key,
+)
+from tests.e2e_cassette_proxy.redis_store import (
+    CachedResponse,
+    RedisCassetteStore,
+)
+
+_log = logging.getLogger("litellm.e2e_cassette_proxy.addon")
+if not _log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("[E2ECASS] %(message)s"))
+    _log.addHandler(_h)
+    _log.setLevel(logging.INFO)
+    _log.propagate = False
+
+
+# Hosts we should *never* cache — Redis itself, the proxy admin UI,
+# anything pointed at localhost. Extended via env var
+# ``LITELLM_E2E_CASS_PASSTHROUGH_HOSTS`` (comma-separated).
+_PASSTHROUGH_HOSTS = {
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "host.docker.internal",
+}
+
+
+def _passthrough_hosts_from_env() -> set[str]:
+    raw = os.environ.get("LITELLM_E2E_CASS_PASSTHROUGH_HOSTS", "")
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def _record_only() -> bool:
+    return os.environ.get("LITELLM_E2E_CASS_RECORD_ONLY", "").lower() in ("1", "true")
+
+
+def _replay_only() -> bool:
+    return os.environ.get("LITELLM_E2E_CASS_REPLAY_ONLY", "").lower() in ("1", "true")
+
+
+def _shape_summary(flow: http.HTTPFlow) -> str:
+    return f"{flow.request.method} {flow.request.pretty_host}{flow.request.path}"
+
+
+def _is_2xx(status_code: int) -> bool:
+    return 200 <= status_code < 300
+
+
+class CassetteAddon:
+    """mitmproxy addon class. Created once at startup; ``request`` and
+    ``response`` are invoked per flow."""
+
+    def __init__(self, store: Optional[RedisCassetteStore] = None) -> None:
+        self._store: Optional[RedisCassetteStore] = store
+        self._passthrough = _PASSTHROUGH_HOSTS | _passthrough_hosts_from_env()
+        self._record_only = _record_only()
+        self._replay_only = _replay_only()
+        self._stats = {"hit": 0, "miss": 0, "stored": 0, "skipped": 0}
+
+    def load(self, loader) -> None:  # noqa: ARG002 - mitmproxy hook signature
+        if self._store is None:
+            try:
+                self._store = RedisCassetteStore()
+            except Exception as exc:
+                _log.info(
+                    f"redis-init-failed err={type(exc).__name__}: {exc}; "
+                    f"running in passthrough mode"
+                )
+                self._store = None
+        _log.info(
+            f"loaded record_only={self._record_only} replay_only={self._replay_only} "
+            f"passthrough_hosts={sorted(self._passthrough)}"
+        )
+
+    def done(self) -> None:
+        _log.info(
+            f"summary hits={self._stats['hit']} misses={self._stats['miss']} "
+            f"stored={self._stats['stored']} skipped={self._stats['skipped']}"
+        )
+
+    def _should_skip(self, flow: http.HTTPFlow) -> bool:
+        host = flow.request.pretty_host.lower()
+        if host in self._passthrough:
+            return True
+        # CONNECT tunnels are handled implicitly by mitmproxy; only filter
+        # the inner HTTP request/response. Method allowlist keeps the keys
+        # readable in Redis.
+        if flow.request.method.upper() not in ("GET", "POST", "PUT", "PATCH", "DELETE"):
+            return True
+        return False
+
+    def _key_for(self, flow: http.HTTPFlow) -> str:
+        return derive_cache_key(
+            method=flow.request.method,
+            url=flow.request.pretty_url,
+            body=flow.request.raw_content or b"",
+            headers=dict(flow.request.headers),
+            allowlist=DEFAULT_HEADER_ALLOWLIST,
+            blocklist=DEFAULT_HEADER_BLOCKLIST,
+        )
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        if self._store is None or self._should_skip(flow):
+            self._stats["skipped"] += 1
+            return
+        if self._record_only:
+            return
+        key = self._key_for(flow)
+        cached = self._store.get(key)
+        if cached is None:
+            self._stats["miss"] += 1
+            _log.info(f"miss key={key} {_shape_summary(flow)}")
+            if self._replay_only:
+                # Don't fall through to the upstream; serve a stable 599 so
+                # the test surfaces the missing recording loudly.
+                flow.response = http.Response.make(
+                    599,
+                    b"e2e-cassette-proxy: replay-only and no recording for this request",
+                    {"content-type": "text/plain"},
+                )
+            return
+        _log.info(
+            f"hit  key={key} {_shape_summary(flow)} "
+            f"status={cached.status_code} bytes={len(cached.body)}"
+        )
+        self._stats["hit"] += 1
+        flow.response = http.Response.make(
+            cached.status_code,
+            cached.body,
+            list(cached.headers),
+        )
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        if self._store is None or self._should_skip(flow):
+            return
+        if self._replay_only:
+            return
+        # If we already served from cache, don't re-store.
+        if flow.response is None or flow.response.status_code == 599:
+            return
+        # Don't cache redirects, errors, or rate-limit responses — they're
+        # not useful for replay and would just churn keys.
+        if not _is_2xx(flow.response.status_code):
+            return
+        key = self._key_for(flow)
+        cached = CachedResponse(
+            status_code=flow.response.status_code,
+            headers=tuple((k, v) for k, v in flow.response.headers.items()),
+            body=flow.response.raw_content or b"",
+            reason=flow.response.reason or "",
+        )
+        if self._store.set(key, cached):
+            self._stats["stored"] += 1
+            _log.info(
+                f"store key={key} {_shape_summary(flow)} "
+                f"status={cached.status_code} bytes={len(cached.body)}"
+            )
+
+
+# mitmproxy entrypoint.
+addons = [CassetteAddon()]
+
+
+# Re-exported for parity with mitmproxy quirks (some versions look for
+# ``ctx`` symbol availability at import time).
+__all__ = ["CassetteAddon", "addons", "ctx"]

--- a/tests/e2e_cassette_proxy/addon.py
+++ b/tests/e2e_cassette_proxy/addon.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
+import time
+from typing import Optional, Tuple
 
 from mitmproxy import ctx, http  # type: ignore[import-not-found]
 
@@ -71,6 +72,54 @@ def _shape_summary(flow: http.HTTPFlow) -> str:
 
 def _is_2xx(status_code: int) -> bool:
     return 200 <= status_code < 300
+
+
+def _to_header_bytes(value: str) -> bytes:
+    """Encode a header name or value back to bytes for mitmproxy.
+
+    HTTP/1.1 header field names are 7-bit ASCII per RFC 7230 § 3.2;
+    values are also ASCII in practice but technically allow opaque
+    octets, which mitmproxy round-trips via the surrogateescape codec.
+    Latin-1 covers both cases without raising on stray high bytes that
+    might have leaked in via misbehaved upstreams.
+    """
+    return value.encode("latin-1", errors="replace")
+
+
+def _build_replay_response(cached: CachedResponse) -> http.Response:
+    """Build a mitmproxy ``Response`` from a cached payload.
+
+    We bypass ``http.Response.make`` because:
+
+    1. ``make`` requires a ``Headers`` instance or a ``dict`` to do its
+       own bytes-conversion. Passing a list of ``(str, str)`` tuples
+       falls into its iterable branch which calls ``Headers(headers)``
+       directly — and ``Headers`` raises ``TypeError: Header fields
+       must be bytes``. (This was the original bug: every cache hit
+       silently fell through to upstream because the addon raised here.)
+    2. ``make`` calls ``Message.set_content`` which re-encodes the body
+       per the cached ``Content-Encoding`` header. Since we recorded
+       ``raw_content`` (i.e. the already-encoded wire bytes), going
+       through ``set_content`` would double-gzip those payloads.
+
+    Constructing the ``Response`` directly lets us hand mitmproxy bytes
+    headers + the raw body in one shot, exactly mirroring what was on
+    the wire when we recorded it.
+    """
+    fields: Tuple[Tuple[bytes, bytes], ...] = tuple(
+        (_to_header_bytes(k), _to_header_bytes(v)) for k, v in cached.headers
+    )
+    now = time.time()
+    return http.Response(
+        http_version=b"HTTP/1.1",
+        status_code=cached.status_code,
+        reason=_to_header_bytes(cached.reason) or b"OK",
+        headers=fields,
+        content=cached.body,
+        trailers=None,
+        timestamp_start=now,
+        timestamp_end=now,
+    )
 
 
 class CassetteAddon:
@@ -151,11 +200,7 @@ class CassetteAddon:
             f"status={cached.status_code} bytes={len(cached.body)}"
         )
         self._stats["hit"] += 1
-        flow.response = http.Response.make(
-            cached.status_code,
-            cached.body,
-            list(cached.headers),
-        )
+        flow.response = _build_replay_response(cached)
 
     def response(self, flow: http.HTTPFlow) -> None:
         if self._store is None or self._should_skip(flow):
@@ -172,7 +217,11 @@ class CassetteAddon:
         key = self._key_for(flow)
         cached = CachedResponse(
             status_code=flow.response.status_code,
-            headers=tuple((k, v) for k, v in flow.response.headers.items()),
+            # ``items(multi=True)`` preserves repeated headers (e.g. multiple
+            # ``Set-Cookie``) which the plain ``items()`` flattens into a
+            # single comma-joined string. Strings are fine on the wire to
+            # Redis; we re-encode to bytes on replay.
+            headers=tuple((k, v) for k, v in flow.response.headers.items(multi=True)),
             body=flow.response.raw_content or b"",
             reason=flow.response.reason or "",
         )

--- a/tests/e2e_cassette_proxy/addon.py
+++ b/tests/e2e_cassette_proxy/addon.py
@@ -42,14 +42,25 @@ if not _log.handlers:
     _log.propagate = False
 
 
-# Hosts we should *never* cache — Redis itself, the proxy admin UI,
-# anything pointed at localhost. Extended via env var
-# ``LITELLM_E2E_CASS_PASSTHROUGH_HOSTS`` (comma-separated).
+# Hosts we should *never* cache. Three categories:
+#
+# - Loopback / sidecar: localhost, 127.0.0.1, host.docker.internal —
+#   the test harness itself, postgres, redis, etc.
+# - The proxy's own admin UI (``mitm.it``): mitmproxy serves its CA
+#   certificate from this magic host. The CA is regenerated per
+#   ``mitmdump`` instance, so caching its response would hand a stale
+#   CA to the next CI run, which would then trust leaf certs signed
+#   by a *different* CA → ``SSL: CERTIFICATE_VERIFY_FAILED:
+#   authority and subject key identifier mismatch``.
+#
+# Extend at runtime via ``LITELLM_E2E_CASS_PASSTHROUGH_HOSTS``
+# (comma-separated).
 _PASSTHROUGH_HOSTS = {
     "localhost",
     "127.0.0.1",
     "0.0.0.0",
     "host.docker.internal",
+    "mitm.it",
 }
 
 

--- a/tests/e2e_cassette_proxy/cache_key.py
+++ b/tests/e2e_cassette_proxy/cache_key.py
@@ -1,0 +1,158 @@
+"""Cache key derivation for the e2e recording proxy.
+
+The proxy is intentionally promiscuous about *what* it caches: any HTTPS
+egress that flows through it is a candidate. The cache key has to be
+stable across runs that send equivalent requests, while staying robust
+to per-call noise (auth headers, tracing IDs, dates).
+
+We hash a canonical tuple of:
+
+- HTTP method
+- scheme + host + port
+- URL path
+- query string (sorted)
+- request body (raw bytes; JSON bodies are re-serialized in canonical
+  form so that semantically-equal payloads collide)
+- a small allowlist of headers the upstream actually keys on (e.g.
+  ``content-type``, ``accept``)
+
+Anything not on that allowlist is dropped before hashing. This is the
+same trade-off vcrpy makes when configuring ``filter_headers`` —
+strict enough to dedupe equivalent requests, loose enough to ignore
+the auth/tracing churn that varies run-to-run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Iterable, Mapping, Optional, Sequence, Tuple
+from urllib.parse import parse_qsl, urlsplit
+
+CACHE_KEY_PREFIX = "litellm:e2ecass:"
+
+# Headers that materially change what an upstream returns.
+DEFAULT_HEADER_ALLOWLIST: Tuple[str, ...] = (
+    "accept",
+    "accept-encoding",
+    "content-type",
+    "openai-beta",
+    "anthropic-beta",
+    "anthropic-version",
+    "x-stainless-lang",
+)
+
+# Headers we *never* want in the key (auth, tracing, per-request noise).
+DEFAULT_HEADER_BLOCKLIST: Tuple[str, ...] = (
+    "authorization",
+    "x-api-key",
+    "anthropic-api-key",
+    "openai-api-key",
+    "azure-api-key",
+    "api-key",
+    "cookie",
+    "user-agent",
+    "x-amz-security-token",
+    "x-amz-date",
+    "x-amz-content-sha256",
+    "amz-sdk-invocation-id",
+    "amz-sdk-request",
+    "x-goog-api-key",
+    "x-goog-user-project",
+    "x-request-id",
+    "request-id",
+    "traceparent",
+    "tracestate",
+    "x-stainless-arch",
+    "x-stainless-os",
+    "x-stainless-runtime",
+    "x-stainless-runtime-version",
+    "x-stainless-package-version",
+    "host",
+    "content-length",
+    "connection",
+)
+
+
+def _canonical_body(body: bytes) -> bytes:
+    """JSON bodies often differ only in key order or whitespace; collapse
+    those into a single canonical form so the cache hits across sessions.
+    Non-JSON bodies are passed through unchanged."""
+    if not body:
+        return b""
+    try:
+        decoded = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return body
+    return json.dumps(decoded, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _canonical_query(raw_query: str) -> str:
+    if not raw_query:
+        return ""
+    pairs = sorted(parse_qsl(raw_query, keep_blank_values=True))
+    return "&".join(f"{k}={v}" for k, v in pairs)
+
+
+def _normalized_headers(
+    headers: Mapping[str, str],
+    allowlist: Sequence[str],
+    blocklist: Sequence[str],
+) -> Tuple[Tuple[str, str], ...]:
+    allow = {h.lower() for h in allowlist}
+    block = {h.lower() for h in blocklist}
+    out: list[Tuple[str, str]] = []
+    for key, value in headers.items():
+        lk = key.lower()
+        if lk in block:
+            continue
+        if allow and lk not in allow:
+            continue
+        out.append((lk, value))
+    out.sort()
+    return tuple(out)
+
+
+def derive_cache_key(
+    method: str,
+    url: str,
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    allowlist: Optional[Iterable[str]] = None,
+    blocklist: Optional[Iterable[str]] = None,
+) -> str:
+    """Hash the canonicalized (method, url, body, allowlisted-headers) tuple
+    into a stable Redis key. Equal inputs (modulo header / JSON noise) always
+    produce the same key.
+    """
+    parts = urlsplit(url)
+    canonical_headers = _normalized_headers(
+        headers,
+        allowlist=(
+            tuple(allowlist) if allowlist is not None else DEFAULT_HEADER_ALLOWLIST
+        ),
+        blocklist=(
+            tuple(blocklist) if blocklist is not None else DEFAULT_HEADER_BLOCKLIST
+        ),
+    )
+    canonical_body = _canonical_body(body)
+    digest = hashlib.sha256()
+    digest.update(method.upper().encode("ascii"))
+    digest.update(b"\x1f")
+    digest.update(parts.scheme.lower().encode("ascii"))
+    digest.update(b"://")
+    digest.update(parts.netloc.lower().encode("ascii"))
+    digest.update(b"\x1f")
+    digest.update(parts.path.encode("utf-8"))
+    digest.update(b"\x1f")
+    digest.update(_canonical_query(parts.query).encode("utf-8"))
+    digest.update(b"\x1f")
+    for k, v in canonical_headers:
+        digest.update(k.encode("ascii"))
+        digest.update(b"=")
+        digest.update(v.encode("utf-8", errors="replace"))
+        digest.update(b"\x1e")
+    digest.update(b"\x1f")
+    digest.update(canonical_body)
+    return f"{CACHE_KEY_PREFIX}{digest.hexdigest()}"

--- a/tests/e2e_cassette_proxy/redis_store.py
+++ b/tests/e2e_cassette_proxy/redis_store.py
@@ -1,0 +1,186 @@
+"""Redis-backed key-value store for cached HTTP responses.
+
+The on-the-wire format for a cached entry is a single MessagePack blob
+(or, if msgpack isn't available, length-prefixed JSON). We pick this
+shape over vcrpy's YAML cassettes because:
+
+- Each Redis key holds exactly one (request_summary, response) pair.
+  No "growing list of episodes," no `record_mode` semantics, no
+  ordering brittleness — see PR #26967 thread for context.
+- Binary response bodies (gzip, audio, image) round-trip without
+  base64 expansion on the JSON path *because* they're stored as raw
+  bytes inside MessagePack.
+- We can bound per-key size at the storage layer (oversize responses
+  are dropped with a log line and never block the request).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence, Tuple
+
+DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
+DEFAULT_MAX_PAYLOAD_BYTES = 4 * 1024 * 1024  # 4 MiB per entry
+
+_log = logging.getLogger("litellm.e2e_cassette_proxy.store")
+if not _log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("[E2ECASS] %(message)s"))
+    _log.addHandler(_h)
+    _log.setLevel(logging.INFO)
+    _log.propagate = False
+
+
+try:
+    import msgpack  # type: ignore
+
+    _HAVE_MSGPACK = True
+except ImportError:  # pragma: no cover
+    _HAVE_MSGPACK = False
+
+
+@dataclass(frozen=True)
+class CachedResponse:
+    """Wire-format-agnostic response cached for a single request."""
+
+    status_code: int
+    headers: Tuple[Tuple[str, str], ...]
+    body: bytes
+    reason: str = ""
+
+    def to_blob(self) -> bytes:
+        if _HAVE_MSGPACK:
+            return msgpack.packb(  # type: ignore[no-any-return]
+                {
+                    "v": 1,
+                    "status": self.status_code,
+                    "reason": self.reason,
+                    "headers": [[k, v] for k, v in self.headers],
+                    "body": self.body,
+                },
+                use_bin_type=True,
+            )
+        # JSON fallback: body must be base64 because JSON can't carry raw bytes.
+        return json.dumps(
+            {
+                "v": 1,
+                "status": self.status_code,
+                "reason": self.reason,
+                "headers": [[k, v] for k, v in self.headers],
+                "body_b64": base64.b64encode(self.body).decode("ascii"),
+            }
+        ).encode("utf-8")
+
+    @classmethod
+    def from_blob(cls, blob: bytes) -> "CachedResponse":
+        if _HAVE_MSGPACK:
+            try:
+                payload = msgpack.unpackb(blob, raw=False)
+            except Exception:  # pragma: no cover - corrupt blob
+                payload = json.loads(blob.decode("utf-8"))
+        else:
+            payload = json.loads(blob.decode("utf-8"))
+        body = payload.get("body")
+        if body is None and "body_b64" in payload:
+            body = base64.b64decode(payload["body_b64"])
+        headers = tuple((str(k), str(v)) for k, v in payload.get("headers", []))
+        return cls(
+            status_code=int(payload["status"]),
+            headers=headers,
+            body=body or b"",
+            reason=str(payload.get("reason", "")),
+        )
+
+
+def _redis_url_from_env() -> Optional[str]:
+    for var in ("LITELLM_E2E_CASS_REDIS_URL", "REDIS_URL", "REDIS_SSL_URL"):
+        url = os.environ.get(var)
+        if url:
+            return url
+    host = os.environ.get("REDIS_HOST")
+    if not host:
+        return None
+    scheme = "rediss" if os.environ.get("REDIS_SSL", "").lower() == "true" else "redis"
+    auth = ""
+    if os.environ.get("REDIS_PASSWORD"):
+        user = os.environ.get("REDIS_USERNAME", "")
+        auth = f"{user}:{os.environ['REDIS_PASSWORD']}@"
+    port = os.environ.get("REDIS_PORT", "6379")
+    return f"{scheme}://{auth}{host}:{port}"
+
+
+class RedisCassetteStore:
+    """Thin GET/SET wrapper around ``redis.Redis``.
+
+    Operations either succeed or are dropped with a log line — the
+    sidecar must never block the request path because the cache is
+    misbehaving. ``get`` returning ``None`` is the "miss" signal;
+    ``set`` returning ``False`` means "we tried but couldn't persist."
+    """
+
+    def __init__(
+        self,
+        client=None,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._max = max_payload_bytes
+        self._client = client if client is not None else self._build_default_client()
+
+    @staticmethod
+    def _build_default_client():
+        import redis
+
+        url = _redis_url_from_env()
+        if not url:
+            raise RuntimeError(
+                "Set LITELLM_E2E_CASS_REDIS_URL / REDIS_URL / REDIS_SSL_URL / REDIS_HOST"
+                " to enable the e2e cassette proxy"
+            )
+        return redis.Redis.from_url(
+            url,
+            socket_timeout=5,
+            socket_connect_timeout=5,
+            decode_responses=False,
+        )
+
+    def get(self, key: str) -> Optional[CachedResponse]:
+        try:
+            blob = self._client.get(key)
+        except Exception as exc:
+            _log.info(f"get-failed key={key} err={type(exc).__name__}: {exc}")
+            return None
+        if blob is None:
+            return None
+        try:
+            return CachedResponse.from_blob(blob)
+        except Exception as exc:
+            _log.info(f"corrupt-blob key={key} err={type(exc).__name__}: {exc}")
+            try:
+                self._client.delete(key)
+            except Exception:
+                pass
+            return None
+
+    def set(self, key: str, response: CachedResponse) -> bool:
+        blob = response.to_blob()
+        if len(blob) > self._max:
+            _log.info(
+                f"persist-skipped-oversize key={key} bytes={len(blob)} "
+                f"max={self._max}"
+            )
+            return False
+        try:
+            self._client.set(key, blob, ex=self._ttl)
+            return True
+        except Exception as exc:
+            _log.info(
+                f"persist-failed key={key} bytes={len(blob)} "
+                f"err={type(exc).__name__}: {exc}"
+            )
+            return False

--- a/tests/e2e_cassette_proxy/trust_ca.sh
+++ b/tests/e2e_cassette_proxy/trust_ca.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+# Fetch the recording proxy's CA cert and add it to the local trust store
+# *and* every Python TLS client we know about. Idempotent.
+#
+# Why so many trust-store paths? Different clients in litellm read different
+# CA bundles:
+#
+#   - openssl / curl / requests / aiohttp default: /etc/ssl/certs/ca-certificates.crt
+#     (Debian/Wolfi) or the OpenSSL default (Alpine)
+#   - boto3 / botocore: $AWS_CA_BUNDLE if set, else certifi
+#   - httpx: certifi by default unless SSL_CERT_FILE points elsewhere
+#   - openai-python: certifi (httpx)
+#   - google.auth: certifi (httpx) or system roots depending on transport
+#
+# We update certifi in-place inside the litellm venv and additionally export
+# SSL_CERT_FILE / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE so anything that
+# honors the environment finds it.
+#
+# Caller is expected to:
+#   1) export PROXY_HOST / PROXY_PORT (default cassette-proxy:8080)
+#   2) source this script (so the env vars persist), or eval its output
+
+set -eu
+
+PROXY_HOST="${PROXY_HOST:-cassette-proxy}"
+PROXY_PORT="${PROXY_PORT:-8080}"
+CA_PATH="${CA_PATH:-/usr/local/share/ca-certificates/litellm-cassette-proxy.crt}"
+CA_FETCH_ENDPOINT="http://${PROXY_HOST}:${PROXY_PORT}/cert/pem"
+
+mkdir -p "$(dirname "$CA_PATH")"
+
+# mitmproxy serves its CA at /cert/pem when it sees a plain HTTP request to
+# any host (the magic bypasses the CONNECT path).
+if ! curl --silent --show-error --max-time 30 \
+        --proxy "http://${PROXY_HOST}:${PROXY_PORT}" \
+        -o "$CA_PATH" "$CA_FETCH_ENDPOINT"; then
+    echo "trust_ca.sh: could not fetch CA from $CA_FETCH_ENDPOINT" >&2
+    exit 1
+fi
+
+# Update system trust store. Best-effort across distros.
+if command -v update-ca-certificates >/dev/null 2>&1; then
+    update-ca-certificates --fresh >/dev/null 2>&1 || true
+elif command -v update-ca-trust >/dev/null 2>&1; then
+    cp "$CA_PATH" /etc/pki/ca-trust/source/anchors/ 2>/dev/null || true
+    update-ca-trust 2>/dev/null || true
+fi
+
+# Update certifi in *every* Python venv we can find (litellm runs out of
+# /app/.venv in the database image, but be permissive).
+for cacert in $(find / -name cacert.pem 2>/dev/null); do
+    # Only append if our CA isn't already in the bundle.
+    if ! grep -q -F "$(head -n 2 "$CA_PATH")" "$cacert" 2>/dev/null; then
+        cat "$CA_PATH" >> "$cacert"
+    fi
+done
+
+# Export for downstream processes. The caller should source this script
+# (or otherwise propagate these env vars) for them to take effect.
+export HTTP_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
+export HTTPS_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
+export NO_PROXY="${NO_PROXY:-localhost,127.0.0.1,host.docker.internal}"
+export SSL_CERT_FILE="$CA_PATH"
+export REQUESTS_CA_BUNDLE="$CA_PATH"
+export CURL_CA_BUNDLE="$CA_PATH"
+export AWS_CA_BUNDLE="$CA_PATH"
+export NODE_EXTRA_CA_CERTS="$CA_PATH"
+
+echo "trust_ca.sh: trusted CA at $CA_PATH; routing egress via $HTTPS_PROXY"

--- a/tests/test_litellm/e2e_cassette_proxy/test_addon.py
+++ b/tests/test_litellm/e2e_cassette_proxy/test_addon.py
@@ -1,0 +1,207 @@
+"""Addon-level tests using a minimal fake-mitmproxy flow.
+
+Mitmproxy itself is heavy and fiddly to install in CI for unit tests.
+The addon only touches a small surface of the ``http.HTTPFlow`` API
+(``request.method``, ``request.pretty_host``, ``request.pretty_url``,
+``request.path``, ``request.headers``, ``request.raw_content``,
+``response.status_code``, ``response.headers``, ``response.raw_content``,
+``response.reason``, plus ``http.Response.make``), so we stub exactly
+that subset and exercise the addon directly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import fakeredis
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)
+
+# Install a fake `mitmproxy` package *before* importing the addon, so the
+# real mitmproxy doesn't need to be present in the unit-test env.
+_mitmproxy_pkg = types.ModuleType("mitmproxy")
+_http_mod = types.ModuleType("mitmproxy.http")
+
+
+class _FakeHeaders(dict):
+    def items(self):
+        return list(super().items())
+
+
+class _FakeResponse:
+    def __init__(self, status_code, body=b"", headers=None, reason=""):
+        self.status_code = status_code
+        self.raw_content = body
+        self.headers = _FakeHeaders(headers or {})
+        self.reason = reason
+
+    @classmethod
+    def make(cls, status_code, body=b"", headers=None):
+        if isinstance(headers, list):
+            headers = dict(headers)
+        return cls(status_code, body=body, headers=headers)
+
+
+class _FakeRequest:
+    def __init__(
+        self,
+        method,
+        url,
+        body=b"",
+        headers=None,
+        host="api.openai.com",
+        path="/v1/chat/completions",
+    ):
+        self.method = method
+        self.pretty_url = url
+        self.pretty_host = host
+        self.path = path
+        self.raw_content = body
+        self.headers = _FakeHeaders(headers or {})
+
+
+class _FakeFlow:
+    def __init__(self, request, response=None):
+        self.request = request
+        self.response = response
+
+
+_http_mod.Response = _FakeResponse  # type: ignore[attr-defined]
+_http_mod.HTTPFlow = _FakeFlow  # type: ignore[attr-defined]
+_mitmproxy_pkg.http = _http_mod  # type: ignore[attr-defined]
+_mitmproxy_pkg.ctx = types.SimpleNamespace(log=types.SimpleNamespace(info=lambda *_a, **_kw: None))  # type: ignore[attr-defined]
+sys.modules.setdefault("mitmproxy", _mitmproxy_pkg)
+sys.modules.setdefault("mitmproxy.http", _http_mod)
+
+from tests.e2e_cassette_proxy.addon import CassetteAddon  # noqa: E402
+from tests.e2e_cassette_proxy.redis_store import (  # noqa: E402
+    CachedResponse,
+    RedisCassetteStore,
+)
+
+
+def _addon_with_fake_redis():
+    fake = fakeredis.FakeStrictRedis()
+    store = RedisCassetteStore(client=fake)
+    return fake, CassetteAddon(store=store)
+
+
+def _make_request(body=b'{"model":"gpt-4o","messages":[]}'):
+    return _FakeRequest(
+        method="POST",
+        url="https://api.openai.com/v1/chat/completions",
+        body=body,
+        headers={"content-type": "application/json", "authorization": "Bearer sk-1"},
+    )
+
+
+def test_should_pass_through_when_no_cache_entry_exists():
+    _, addon = _addon_with_fake_redis()
+    flow = _FakeFlow(_make_request())
+    addon.request(flow)
+    assert flow.response is None  # mitmproxy will then hit the real upstream
+    assert addon._stats["miss"] == 1
+
+
+def test_should_persist_response_on_response_hook_when_2xx():
+    fake, addon = _addon_with_fake_redis()
+    flow = _FakeFlow(_make_request())
+    addon.request(flow)  # miss
+    flow.response = _FakeResponse(
+        200,
+        body=b'{"id":"chatcmpl-1"}',
+        headers={"content-type": "application/json"},
+        reason="OK",
+    )
+    addon.response(flow)
+    assert addon._stats["stored"] == 1
+    assert any(k.startswith(b"litellm:e2ecass:") for k in fake.keys("*"))
+
+
+def test_should_short_circuit_on_subsequent_request_with_cache_hit():
+    _, addon = _addon_with_fake_redis()
+    first = _FakeFlow(_make_request())
+    addon.request(first)
+    first.response = _FakeResponse(
+        200,
+        body=b'{"id":"chatcmpl-1"}',
+        headers={"content-type": "application/json"},
+    )
+    addon.response(first)
+
+    # Second request: same canonical shape, different auth header.
+    second_req = _make_request()
+    second_req.headers["authorization"] = "Bearer sk-different"
+    second = _FakeFlow(second_req)
+    addon.request(second)
+    assert second.response is not None
+    assert second.response.status_code == 200
+    assert second.response.raw_content == b'{"id":"chatcmpl-1"}'
+    assert addon._stats["hit"] == 1
+
+
+def test_should_not_persist_non_2xx_response():
+    fake, addon = _addon_with_fake_redis()
+    flow = _FakeFlow(_make_request())
+    addon.request(flow)
+    flow.response = _FakeResponse(
+        500,
+        body=b'{"error":"internal"}',
+        headers={"content-type": "application/json"},
+    )
+    addon.response(flow)
+    assert addon._stats["stored"] == 0
+    assert len(fake.keys("*")) == 0
+
+
+def test_should_skip_passthrough_hosts_completely():
+    _, addon = _addon_with_fake_redis()
+    req = _FakeRequest(
+        method="POST",
+        url="http://localhost:4000/key/generate",
+        body=b"{}",
+        headers={"content-type": "application/json"},
+        host="localhost",
+        path="/key/generate",
+    )
+    flow = _FakeFlow(req)
+    addon.request(flow)
+    assert flow.response is None
+    assert addon._stats["skipped"] == 1
+
+
+def test_replay_only_should_serve_599_on_miss():
+    fake, _ = _addon_with_fake_redis()
+    addon = CassetteAddon(store=RedisCassetteStore(client=fake))
+    addon._replay_only = True
+
+    flow = _FakeFlow(_make_request())
+    addon.request(flow)
+    assert flow.response is not None
+    assert flow.response.status_code == 599
+
+
+def test_record_only_should_not_short_circuit_even_on_hit():
+    fake = fakeredis.FakeStrictRedis()
+    store = RedisCassetteStore(client=fake)
+    pre_addon = CassetteAddon(store=store)
+    flow = _FakeFlow(_make_request())
+    pre_addon.request(flow)
+    flow.response = _FakeResponse(
+        200,
+        body=b'{"id":"chatcmpl-1"}',
+        headers={"content-type": "application/json"},
+    )
+    pre_addon.response(flow)
+
+    # Now flip a new addon into record-only mode and verify it never serves
+    # from cache.
+    record_only_addon = CassetteAddon(store=store)
+    record_only_addon._record_only = True
+    second = _FakeFlow(_make_request())
+    record_only_addon.request(second)
+    assert second.response is None

--- a/tests/test_litellm/e2e_cassette_proxy/test_addon.py
+++ b/tests/test_litellm/e2e_cassette_proxy/test_addon.py
@@ -21,6 +21,17 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 )
 
+# Prefer the *real* mitmproxy if it's installed: that way the contract
+# tests in ``test_replay_response_contract.py`` exercise the same
+# objects this file does, and any future skew between our fake and
+# real mitmproxy can't silently hide regressions. Fall through to the
+# fake stub when mitmproxy isn't available (the typical unit-test env).
+try:
+    import mitmproxy  # noqa: F401  pre-load so setdefault below is a no-op
+    import mitmproxy.http  # noqa: F401
+except ImportError:
+    pass
+
 # Install a fake `mitmproxy` package *before* importing the addon, so the
 # real mitmproxy doesn't need to be present in the unit-test env.
 _mitmproxy_pkg = types.ModuleType("mitmproxy")
@@ -28,16 +39,64 @@ _http_mod = types.ModuleType("mitmproxy.http")
 
 
 class _FakeHeaders(dict):
-    def items(self):
+    def items(self, multi: bool = False):
+        # Real mitmproxy ``Headers.items(multi=True)`` would return one
+        # tuple per repeated header (e.g. multiple ``Set-Cookie``). The
+        # fake doesn't model duplicates, so the kwarg is a no-op — we
+        # just need to accept it without ``TypeError``.
         return list(super().items())
 
 
 class _FakeResponse:
-    def __init__(self, status_code, body=b"", headers=None, reason=""):
+    """Fake mitmproxy ``http.Response`` that accepts both the real
+    constructor signature (used by the addon's replay path) and a
+    simplified positional signature (used by these tests when faking an
+    upstream response).
+    """
+
+    def __init__(
+        self,
+        *args,
+        status_code=None,
+        body=None,
+        headers=None,
+        reason="",
+        # real-mitmproxy kwargs (the addon passes these via _build_replay_response)
+        http_version=b"HTTP/1.1",
+        content=None,
+        trailers=None,
+        timestamp_start=None,
+        timestamp_end=None,
+    ):
+        # Positional support: _FakeResponse(status_code, body=..., headers=...)
+        if args:
+            if status_code is None:
+                status_code = args[0]
+            if len(args) > 1 and body is None:
+                body = args[1]
+        # ``content`` (real mitmproxy) and ``body`` (test shorthand) are
+        # the same field — raw_content.
+        if body is None:
+            body = content if content is not None else b""
+        if isinstance(headers, list):
+            # Bytes-tuple list (real mitmproxy contract) → str dict for
+            # the fake's case-insensitive lookups.
+            headers = {
+                (k.decode("latin-1") if isinstance(k, bytes) else k): (
+                    v.decode("latin-1") if isinstance(v, bytes) else v
+                )
+                for k, v in headers
+            }
+        if isinstance(reason, bytes):
+            reason = reason.decode("latin-1")
         self.status_code = status_code
         self.raw_content = body
         self.headers = _FakeHeaders(headers or {})
         self.reason = reason
+        self.http_version = http_version
+        self.trailers = trailers
+        self.timestamp_start = timestamp_start
+        self.timestamp_end = timestamp_end
 
     @classmethod
     def make(cls, status_code, body=b"", headers=None):

--- a/tests/test_litellm/e2e_cassette_proxy/test_addon.py
+++ b/tests/test_litellm/e2e_cassette_proxy/test_addon.py
@@ -137,10 +137,7 @@ sys.modules.setdefault("mitmproxy", _mitmproxy_pkg)
 sys.modules.setdefault("mitmproxy.http", _http_mod)
 
 from tests.e2e_cassette_proxy.addon import CassetteAddon  # noqa: E402
-from tests.e2e_cassette_proxy.redis_store import (  # noqa: E402
-    CachedResponse,
-    RedisCassetteStore,
-)
+from tests.e2e_cassette_proxy.redis_store import RedisCassetteStore  # noqa: E402
 
 
 def _addon_with_fake_redis():
@@ -231,6 +228,42 @@ def test_should_skip_passthrough_hosts_completely():
     addon.request(flow)
     assert flow.response is None
     assert addon._stats["skipped"] == 1
+
+
+def test_should_skip_mitm_it_so_ca_cert_is_not_cached():
+    """``mitm.it/cert/pem`` serves the proxy's *current-instance* CA. If we
+    cached it, the next mitmdump run would serve a stale CA from Redis,
+    and clients trusting that stale CA would reject leaf certs signed by
+    the new run's CA: ``SSL: CERTIFICATE_VERIFY_FAILED: authority and
+    subject key identifier mismatch``. So ``mitm.it`` must be in the
+    passthrough list end-to-end (request *and* response paths)."""
+    fake, addon = _addon_with_fake_redis()
+
+    cert_req = _FakeRequest(
+        method="GET",
+        url="http://mitm.it/cert/pem",
+        body=b"",
+        headers={"accept": "*/*"},
+        host="mitm.it",
+        path="/cert/pem",
+    )
+    flow = _FakeFlow(cert_req)
+    addon.request(flow)
+    # Request hook short-circuits before any Redis lookup.
+    assert flow.response is None
+    assert addon._stats["skipped"] == 1
+    assert addon._stats["miss"] == 0
+
+    # Even if the response hook fires (mitmproxy fetched the real CA from
+    # the running instance), it must not be persisted to Redis.
+    flow.response = _FakeResponse(
+        200,
+        body=b"-----BEGIN CERTIFICATE-----\nMIIabc...\n-----END CERTIFICATE-----\n",
+        headers={"content-type": "application/x-x509-ca-cert"},
+    )
+    addon.response(flow)
+    assert addon._stats["stored"] == 0
+    assert len(fake.keys("*")) == 0
 
 
 def test_replay_only_should_serve_599_on_miss():

--- a/tests/test_litellm/e2e_cassette_proxy/test_cache_key.py
+++ b/tests/test_litellm/e2e_cassette_proxy/test_cache_key.py
@@ -1,0 +1,146 @@
+"""Unit tests for ``tests.e2e_cassette_proxy.cache_key.derive_cache_key``.
+
+The cache key is the only thing standing between "cache hit" and "cache
+miss," so its invariants need to be pinned down precisely. Every test
+below is a single equivalence claim: "these two requests should hash
+to the same key" or "these two should not."
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)
+
+from tests.e2e_cassette_proxy.cache_key import (  # noqa: E402
+    CACHE_KEY_PREFIX,
+    derive_cache_key,
+)
+
+
+def _key(
+    method="POST",
+    url="https://api.openai.com/v1/chat/completions",
+    body=b"",
+    headers=None,
+):
+    return derive_cache_key(method, url, body, headers or {})
+
+
+def test_should_produce_stable_key_with_prefix():
+    key = _key()
+    assert key.startswith(CACHE_KEY_PREFIX)
+    # 64 hex chars after the prefix.
+    assert len(key) == len(CACHE_KEY_PREFIX) + 64
+
+
+def test_should_match_when_inputs_are_byte_for_byte_identical():
+    a = _key(body=b"hello", headers={"content-type": "application/json"})
+    b = _key(body=b"hello", headers={"content-type": "application/json"})
+    assert a == b
+
+
+def test_should_match_when_only_auth_headers_differ():
+    a = _key(
+        headers={"authorization": "Bearer one", "content-type": "application/json"}
+    )
+    b = _key(
+        headers={"authorization": "Bearer two", "content-type": "application/json"}
+    )
+    assert a == b
+
+
+def test_should_match_when_only_tracing_headers_differ():
+    a = _key(headers={"x-request-id": "abc", "content-type": "application/json"})
+    b = _key(headers={"x-request-id": "xyz", "content-type": "application/json"})
+    assert a == b
+
+
+def test_should_match_when_user_agent_differs():
+    a = _key(
+        headers={"user-agent": "openai-python/1.0", "content-type": "application/json"}
+    )
+    b = _key(headers={"user-agent": "curl/8", "content-type": "application/json"})
+    assert a == b
+
+
+def test_should_match_when_json_body_differs_only_in_key_order():
+    a = _key(
+        body=b'{"model":"gpt-4o","messages":[]}',
+        headers={"content-type": "application/json"},
+    )
+    b = _key(
+        body=b'{"messages":[],"model":"gpt-4o"}',
+        headers={"content-type": "application/json"},
+    )
+    assert a == b
+
+
+def test_should_match_when_query_params_only_differ_in_order():
+    a = _key(url="https://api.openai.com/v1/x?b=2&a=1")
+    b = _key(url="https://api.openai.com/v1/x?a=1&b=2")
+    assert a == b
+
+
+def test_should_match_when_host_capitalization_differs():
+    a = _key(url="https://api.openai.com/v1/chat/completions")
+    b = _key(url="https://API.OPENAI.COM/v1/chat/completions")
+    assert a == b
+
+
+def test_should_differ_when_method_changes():
+    assert _key(method="GET") != _key(method="POST")
+
+
+def test_should_differ_when_path_changes():
+    a = _key(url="https://api.openai.com/v1/chat/completions")
+    b = _key(url="https://api.openai.com/v1/responses")
+    assert a != b
+
+
+def test_should_differ_when_body_changes_meaningfully():
+    a = _key(
+        body=b'{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}',
+        headers={"content-type": "application/json"},
+    )
+    b = _key(
+        body=b'{"model":"gpt-4o","messages":[{"role":"user","content":"bye"}]}',
+        headers={"content-type": "application/json"},
+    )
+    assert a != b
+
+
+def test_should_differ_when_allowlisted_header_changes():
+    # ``anthropic-version`` is on the allowlist — changing it must miss.
+    a = _key(headers={"anthropic-version": "2023-06-01"})
+    b = _key(headers={"anthropic-version": "2024-01-01"})
+    assert a != b
+
+
+def test_should_match_when_blocklisted_header_added_or_removed():
+    a = _key(headers={"content-type": "application/json"})
+    b = _key(
+        headers={"content-type": "application/json", "x-amz-date": "20260501T000000Z"}
+    )
+    assert a == b
+
+
+def test_should_handle_non_json_body_passthrough():
+    a = _key(
+        body=b"\x00\x01\x02binary", headers={"content-type": "application/octet-stream"}
+    )
+    b = _key(
+        body=b"\x00\x01\x02binary", headers={"content-type": "application/octet-stream"}
+    )
+    c = _key(body=b"different", headers={"content-type": "application/octet-stream"})
+    assert a == b
+    assert a != c
+
+
+def test_should_treat_query_string_difference_as_a_miss():
+    a = _key(url="https://api.openai.com/v1/files?purpose=batch")
+    b = _key(url="https://api.openai.com/v1/files?purpose=fine-tune")
+    assert a != b

--- a/tests/test_litellm/e2e_cassette_proxy/test_redis_store.py
+++ b/tests/test_litellm/e2e_cassette_proxy/test_redis_store.py
@@ -1,0 +1,111 @@
+"""Unit tests for the Redis cassette store.
+
+We test against ``fakeredis`` so the suite stays hermetic.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import fakeredis
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)
+
+from tests.e2e_cassette_proxy.redis_store import (  # noqa: E402
+    DEFAULT_TTL_SECONDS,
+    CachedResponse,
+    RedisCassetteStore,
+)
+
+
+def _store(max_payload_bytes=None):
+    fake = fakeredis.FakeStrictRedis()
+    if max_payload_bytes is None:
+        return fake, RedisCassetteStore(client=fake)
+    return fake, RedisCassetteStore(client=fake, max_payload_bytes=max_payload_bytes)
+
+
+def _sample_response(body: bytes = b'{"id":"msg_1"}'):
+    return CachedResponse(
+        status_code=200,
+        headers=(("content-type", "application/json"),),
+        body=body,
+        reason="OK",
+    )
+
+
+def test_should_round_trip_a_set_then_get():
+    _, store = _store()
+    store.set("k", _sample_response())
+    got = store.get("k")
+    assert got is not None
+    assert got.status_code == 200
+    assert got.body == b'{"id":"msg_1"}'
+    assert ("content-type", "application/json") in got.headers
+
+
+def test_should_return_none_on_miss():
+    _, store = _store()
+    assert store.get("never-set") is None
+
+
+def test_should_apply_default_ttl_on_set():
+    fake, store = _store()
+    store.set("k", _sample_response())
+    ttl = fake.ttl("k")
+    # fakeredis returns a float; allow a tiny window for clock skew.
+    assert DEFAULT_TTL_SECONDS - 5 <= ttl <= DEFAULT_TTL_SECONDS
+
+
+def test_should_round_trip_binary_response_bodies():
+    _, store = _store()
+    payload = bytes(range(256))
+    store.set("k", _sample_response(body=payload))
+    got = store.get("k")
+    assert got is not None
+    assert got.body == payload
+
+
+def test_should_skip_oversize_payloads_silently():
+    fake, store = _store(max_payload_bytes=128)
+    huge = b"x" * 10_000
+    persisted = store.set("k", _sample_response(body=huge))
+    assert persisted is False
+    assert fake.exists("k") == 0
+
+
+def test_should_persist_payloads_at_the_size_threshold():
+    fake, store = _store(max_payload_bytes=10_000)
+    fits = b"x" * 100
+    persisted = store.set("k", _sample_response(body=fits))
+    assert persisted is True
+    assert fake.exists("k") == 1
+
+
+def test_should_treat_corrupt_blob_as_miss_and_evict_it():
+    fake, store = _store()
+    fake.set("corrupt-key", b"\x00\x01not a valid blob\xff")
+    assert store.get("corrupt-key") is None
+    assert fake.exists("corrupt-key") == 0
+
+
+def test_should_return_none_when_get_raises():
+    class _ExplodingClient:
+        def get(self, key):
+            raise ConnectionError("redis is down")
+
+    store = RedisCassetteStore(client=_ExplodingClient())
+    assert store.get("k") is None
+
+
+def test_should_return_false_when_set_raises():
+    class _ExplodingClient:
+        def set(self, key, value, ex=None):  # noqa: ARG002
+            raise ConnectionError("redis is down")
+
+    store = RedisCassetteStore(client=_ExplodingClient())
+    assert store.set("k", _sample_response()) is False

--- a/tests/test_litellm/e2e_cassette_proxy/test_replay_response_contract.py
+++ b/tests/test_litellm/e2e_cassette_proxy/test_replay_response_contract.py
@@ -1,0 +1,146 @@
+"""Contract tests against real mitmproxy.
+
+The other addon unit tests stub out ``mitmproxy.http`` so they can run
+without mitmproxy installed (it's a CI-only dependency installed via
+``uv tool install`` rather than declared in ``pyproject.toml``).
+
+That stubbing once hid a real production bug: the addon called
+``http.Response.make(status, body, list[(str, str)])`` which the fake
+accepted, but real mitmproxy 11 raises ``TypeError: Header fields must
+be bytes``. Every cache hit silently fell through to the upstream
+because the addon raised inside ``request()``.
+
+This file exercises the *real* mitmproxy ``Response`` contract for the
+replay path, so any future regression is caught locally instead of only
+showing up as ``Addon error: ...`` in CI logs while tests pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mitmproxy_http = pytest.importorskip("mitmproxy.http")
+
+# ``test_addon.py`` (collected alongside this file) installs a stubbed
+# ``mitmproxy`` package into ``sys.modules`` so it can run without the
+# real dependency. ``importorskip`` will happily return that stub and
+# defeat the whole point of *this* file. Detect the stub by checking
+# whether the loaded ``Headers`` enforces bytes the way real mitmproxy
+# does, and skip if it doesn't.
+try:
+    mitmproxy_http.Headers([("not", "bytes")])  # type: ignore[arg-type]
+except TypeError:
+    pass  # real mitmproxy — proceed
+except Exception:
+    pytest.skip(
+        "real mitmproxy not available (fake stub detected); "
+        "install ``mitmproxy==11.0.2`` to run these contract tests",
+        allow_module_level=True,
+    )
+else:
+    pytest.skip(
+        "real mitmproxy not available (fake stub detected); "
+        "install ``mitmproxy==11.0.2`` to run these contract tests",
+        allow_module_level=True,
+    )
+
+from tests.e2e_cassette_proxy.addon import _build_replay_response  # noqa: E402
+from tests.e2e_cassette_proxy.redis_store import CachedResponse  # noqa: E402
+
+
+def test_replay_response_accepts_string_headers_and_emits_bytes():
+    """Cached headers are stored as ``str`` (msgpack roundtrip); the
+    replay builder must encode them back to ``bytes`` because mitmproxy
+    11's ``Headers`` rejects anything else."""
+    cached = CachedResponse(
+        status_code=200,
+        headers=(
+            ("Content-Type", "application/json"),
+            ("X-Trace-Id", "abc123"),
+        ),
+        body=b'{"id":"chatcmpl-1"}',
+        reason="OK",
+    )
+
+    response = _build_replay_response(cached)
+
+    assert isinstance(response, mitmproxy_http.Response)
+    assert response.status_code == 200
+    # mitmproxy's ``Headers`` decodes back to str on read; the underlying
+    # ``fields`` are bytes — verify both directions.
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.headers["X-Trace-Id"] == "abc123"
+    for name, value in response.headers.fields:
+        assert isinstance(name, bytes), name
+        assert isinstance(value, bytes), value
+
+
+def test_replay_response_preserves_raw_content_without_double_encoding():
+    """When the upstream replied with ``Content-Encoding: gzip`` we recorded
+    the *gzipped* bytes (i.e. ``flow.response.raw_content``). On replay the
+    body must be set as ``raw_content`` so mitmproxy serves the same wire
+    payload — going through ``set_content`` would gzip-encode an already-
+    gzipped blob."""
+    gzipped_body = (
+        b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xab\xe6"
+        b"R\xa8\xe5\x02\x00\x9b\xae\x10\xee\x05\x00\x00\x00"
+    )  # arbitrary gzip-magic-prefixed bytes
+    cached = CachedResponse(
+        status_code=200,
+        headers=(
+            ("Content-Type", "application/json"),
+            ("Content-Encoding", "gzip"),
+            ("Content-Length", str(len(gzipped_body))),
+        ),
+        body=gzipped_body,
+        reason="OK",
+    )
+
+    response = _build_replay_response(cached)
+
+    assert response.raw_content == gzipped_body, (
+        "raw_content must be byte-identical to what we recorded; "
+        "going through set_content would re-gzip and corrupt it"
+    )
+
+
+def test_replay_response_handles_repeated_set_cookie_headers():
+    """``items(multi=True)`` is used on the recording side specifically so
+    multi-value headers like ``Set-Cookie`` aren't silently merged into a
+    comma-joined string (which is RFC 7230 illegal for ``Set-Cookie``)."""
+    cached = CachedResponse(
+        status_code=200,
+        headers=(
+            ("Set-Cookie", "session=abc; Path=/"),
+            ("Set-Cookie", "csrf=xyz; Path=/"),
+            ("Content-Type", "text/html"),
+        ),
+        body=b"<html></html>",
+        reason="OK",
+    )
+
+    response = _build_replay_response(cached)
+
+    set_cookies = [
+        v.decode("latin-1")
+        for k, v in response.headers.fields
+        if k.lower() == b"set-cookie"
+    ]
+    assert set_cookies == ["session=abc; Path=/", "csrf=xyz; Path=/"]
+
+
+def test_replay_response_tolerates_empty_reason_phrase():
+    cached = CachedResponse(
+        status_code=204,
+        headers=(),
+        body=b"",
+        reason="",
+    )
+
+    response = _build_replay_response(cached)
+
+    assert response.status_code == 204
+    # mitmproxy expects bytes; an empty reason should default to ``b"OK"``
+    # at the wire level so the response is still serializable by
+    # mitmproxy's HTTP/1.1 codec. ``reason`` decodes back to str on read.
+    assert response.reason == "OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The VCR cassette work in #26838 caches HTTP traffic that originates *in the pytest process*. That covers some of `tests/llm_translation/`, but cannot reach a single one of our e2e jobs that puts the LiteLLM proxy in a Docker container — vcrpy is an in-process monkey-patch on `httpx`/`aiohttp`/`httpcore` and has nothing to attach to. And separately, jobs like `agent_testing`, `audio_testing`, `image_gen_testing`, `logging_testing`, `ocr_testing`, `search_testing` all make real provider calls *from the pytest process* but were never wired into vcrpy either.

This PR introduces a network-level recording HTTP/HTTPS proxy and opts **every cost-bearing CI job** into it.

```
pytest / SUT process
       │
       │  HTTP{S}_PROXY=cassette-proxy:8080
       ▼
┌─────────────────────┐
│  cassette-proxy     │  ── miss ──▶  api.openai.com  /  api.anthropic.com  /  …
│  (mitmproxy + addon)│  ◀── 200 ──
│                     │  ── store ──▶  Redis (one key = one request)
└─────────────────────┘
       ▲
       │  hit  (replayed from Redis, no upstream traffic)
```

## Components

### Recording proxy (transport-agnostic)

- `tests/e2e_cassette_proxy/cache_key.py` — pure-function cache-key derivation. Hashes `(method, scheme, host, path, sorted query, allowlisted headers, canonical-JSON body)`; strips auth, tracing, and SDK-metadata headers so equivalent requests collide regardless of run-to-run noise.
- `tests/e2e_cassette_proxy/redis_store.py` — thin Redis wrapper that stores **one `(request, response)` pair per key** as MessagePack (JSON+base64 fallback). Caps per-key payload size, drops oversize responses with a log line, never blocks the request path on Redis errors.
- `tests/e2e_cassette_proxy/addon.py` — mitmproxy addon that ties the two together. Passthrough hosts (`localhost`, `host.docker.internal`, the proxy itself) are never cached; non-2xx upstream responses are not persisted.
- `tests/e2e_cassette_proxy/Dockerfile` — fully pinned image (kept as a fallback for environments that don't have `uv tool install` available).
- `tests/e2e_cassette_proxy/trust_ca.sh` — helper for SUT containers to trust the proxy CA in every Python / curl / boto3 / node trust store at once.

### Three reusable CircleCI commands

- **`start_cassette_proxy`** — launches `mitmdump` as a background subprocess via `uv tool install mitmproxy`. Works on both `docker:` and `machine:` executors (no docker daemon required). Exports `CASSETTE_PROXY_URL` (for SUT containers), `CASSETTE_PROXY_HOST_URL` (for the runner shell), and `CASSETTE_PROXY_CA` into `$BASH_ENV`.
- **`export_cassette_proxy_docker_args`** — composes a single `$CASSETTE_PROXY_DOCKER_ARGS` string of `-e ...` / `-v ...` flags ready to splice into a SUT container's `docker run`. Two-line opt-in for in-Docker jobs.
- **`enable_cassette_proxy_for_pytest`** — patches certifi's bundled `cacert.pem` in every venv on the runner (so openai-python / httpx / langfuse / google-auth trust the proxy CA), exports `HTTPS_PROXY` / `NO_PROXY` / `SSL_CERT_FILE` for every subsequent step, and crucially flips `AIOHTTP_TRUST_ENV=true` — without that flag litellm's aiohttp transport silently ignores `HTTPS_PROXY` (see `litellm/llms/custom_httpx/http_handler.py:951-952`).

`NO_PROXY` automatically picks up `$REDIS_HOST` so the redis client's TCP+TLS connection to the project's managed Redis isn't broken by the proxy.

## Jobs wired

### Pattern A — SUT runs in a Docker container (8 jobs)

Each one gets `start_cassette_proxy` + `export_cassette_proxy_docker_args` + `$CASSETTE_PROXY_DOCKER_ARGS \` spliced into the `docker run`.

- `e2e_openai_endpoints`
- `build_and_test`
- `proxy_logging_guardrails_model_info_tests`
- `proxy_spend_accuracy_tests`
- `proxy_store_model_in_db_tests`
- `proxy_build_from_pip_tests`
- `proxy_pass_through_endpoint_tests`
- `proxy_e2e_anthropic_messages_tests`

### Pattern B — pytest runs in-process (17 jobs)

Each one gets `start_cassette_proxy` + `enable_cassette_proxy_for_pytest` after install and before the `Run tests` step.

- `llm_translation_testing`
- `realtime_translation_testing`
- `agent_testing`
- `guardrails_testing`
- `google_generate_content_endpoint_testing`
- `llm_responses_api_testing`
- `ocr_testing`
- `search_testing`
- `litellm_mapped_enterprise_tests`
- `batches_testing`
- `litellm_utils_testing`
- `pass_through_unit_testing`
- `image_gen_testing`
- `logging_testing`
- `audio_testing`
- `local_testing_part1`
- `local_testing_part2`
- `langfuse_logging_unit_tests`

### Not wired — by design

- `proxy_multi_instance_tests` — uses `model="fake-openai-endpoint"` (`FAKE_OPENAI_API_BASE`); never bills.
- `e2e_ui_testing` — points the proxy at a local mock LLM server (`mock_llm_server/server.py`); no real upstream traffic.
- `auth_ui_unit_tests`, `redis_caching_unit_tests`, `litellm_router_*`, `litellm_assistants_api_testing`, `ui_*`, `helm_chart_testing`, `installing_litellm_*`, `using_litellm_on_windows`, `db_migration_disable_update_check`, `test_bad_database_url`, `build_docker_database_image` — pure unit / build / install / smoke jobs; no LLM calls.

## Why per-request keys, not vcrpy-style cassettes

vcrpy stores an ordered list of `(request, response)` episodes per test file. That model is the source of every footgun the `tests/llm_translation/` recorder hit: unbounded per-key growth in `new_episodes` mode, order-sensitive replay, OOM under `noeviction` Redis (which is what we have on the project instance — confirmed in #26967, peak `used_memory=1.7G`).

Here each Redis key holds exactly one `(request_summary, response)` pair, so:

- Per-key size is bounded by one response (with an explicit `max_payload_bytes` ceiling on top).
- Two tests issuing the same request share the cache entry **for free**.
- "Order" is no longer a thing.
- "Record mode" is no longer a thing — if the entry is present, replay; else record.

## Knobs

| Env var | Where set | Effect |
|---|---|---|
| `LITELLM_E2E_CASS_REDIS_URL` | sidecar | Redis URL. Falls back to `REDIS_URL` / `REDIS_SSL_URL` / `REDIS_HOST+PORT+PASSWORD`. |
| `LITELLM_E2E_CASS_PASSTHROUGH_HOSTS` | sidecar | Extra hosts (CSV) to never cache. |
| `LITELLM_E2E_CASS_RECORD_ONLY=1` | sidecar | Never serve from cache; always forward + persist. Use during cassette refresh runs. |
| `LITELLM_E2E_CASS_REPLAY_ONLY=1` | sidecar | Never forward to upstream; serve `599` on miss. Use to *prove* a job is fully cached. |

## Tests

31 hermetic unit tests under `tests/test_litellm/e2e_cassette_proxy/`:

- `test_cache_key.py` (14 tests) — pin equivalence-class behavior of key derivation.
- `test_redis_store.py` (9 tests) — round-trip, TTL, oversize rejection, corrupt-blob eviction, exception-safety.
- `test_addon.py` (8 tests) — fake-mitmproxy flow exercises the addon end-to-end (passthrough / persist on 2xx / hit on canonicalized-equivalent re-request / no-persist on 5xx / replay-only / record-only).

`31 passed in 0.20s` locally. YAML config validates.

## Type

🚄 Infrastructure
✅ Test

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777616301749029?thread_ts=1777616301.749029&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-9f9022aa-abe9-5029-a136-5d6d9185760e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f9022aa-abe9-5029-a136-5d6d9185760e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

