### PR TITLE
fix(auth): prevent privilege escalation via common_checks DB fallback

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2518,7 +2518,7 @@ async def get_org_object(
         cache_key = "org_id:{}:with_budget".format(org_id)
 
     # check if in cache
-    cached_org_obj = user_api_key_cache.async_get_cache(key=cache_key)
+    cached_org_obj = await user_api_key_cache.async_get_cache(key=cache_key)
     if cached_org_obj is not None:
         if isinstance(cached_org_obj, dict):
             return LiteLLM_OrganizationTable(**cached_org_obj)

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1931,8 +1931,11 @@ async def user_api_key_auth(
     # restrictions, and team access controls.
     #
     # Defence-in-depth: authorization-denial exceptions (ProxyException,
-    # HTTPException, BudgetExceededError) are re-raised so the caller
-    # gets a proper 4xx.  DB-connectivity exceptions are logged and the
+    # HTTPException, BudgetExceededError) are propagated as proper
+    # ProxyException/HTTPException so the caller gets a proper 4xx.
+    # BudgetExceededError is wrapped in ProxyException because only
+    # ProxyException and HTTPException have FastAPI exception handlers.
+    # DB-connectivity exceptions are logged and the
     # *original* authenticated token is preserved — the request proceeds
     # with whatever limits are already encoded on the token, rather than
     # being upgraded to an unrestricted fallback.
@@ -1943,8 +1946,18 @@ async def user_api_key_auth(
             request_data=request_data,
             route=route,
         )
-    except (HTTPException, ProxyException, litellm.BudgetExceededError):
-        # Authorization denial — propagate as-is so the caller gets 4xx.
+    except (HTTPException, ProxyException, litellm.BudgetExceededError) as e:
+        # Authorization denial — propagate as ProxyException so FastAPI's
+        # exception handler can render a proper 4xx response.
+        # BudgetExceededError must be wrapped because only ProxyException
+        # and HTTPException have registered FastAPI exception handlers.
+        if isinstance(e, litellm.BudgetExceededError):
+            raise ProxyException(
+                message=e.message,
+                type=ProxyErrorTypes.budget_exceeded,
+                param=None,
+                code=400,
+            )
         raise
     except Exception as e:
         # Transient / DB error during authorization checks.  Instead of

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1920,10 +1920,22 @@ async def user_api_key_auth(
     RouteChecks.should_call_route(route=route, valid_token=user_api_key_auth_obj)
 
     # Single authorization point. Builder paths MUST NOT call common_checks.
-    # Route through the same exception handler the builder uses so
-    # authorization failures (ProxyException, or plain Exception from
-    # admin-only-route / model-access / budget checks) surface as
-    # ProxyException consistently with pre-refactor behavior.
+    #
+    # IMPORTANT: common_checks exceptions are handled separately from
+    # builder exceptions.  The builder's _handle_authentication_error may
+    # issue a DB-unavailable fallback token — that is correct when the
+    # builder itself cannot look up the key.  But if the builder already
+    # returned a *valid, restricted* token and common_checks subsequently
+    # fails due to a transient DB error, replacing that token with an
+    # unrestricted fallback would silently strip budget limits, model
+    # restrictions, and team access controls.
+    #
+    # Defence-in-depth: authorization-denial exceptions (ProxyException,
+    # HTTPException, BudgetExceededError) are re-raised so the caller
+    # gets a proper 4xx.  DB-connectivity exceptions are logged and the
+    # *original* authenticated token is preserved — the request proceeds
+    # with whatever limits are already encoded on the token, rather than
+    # being upgraded to an unrestricted fallback.
     try:
         await _run_centralized_common_checks(
             user_api_key_auth_obj=user_api_key_auth_obj,
@@ -1931,15 +1943,37 @@ async def user_api_key_auth(
             request_data=request_data,
             route=route,
         )
+    except (HTTPException, ProxyException, litellm.BudgetExceededError):
+        # Authorization denial — propagate as-is so the caller gets 4xx.
+        raise
     except Exception as e:
-        return await UserAPIKeyAuthExceptionHandler._handle_authentication_error(
-            e=e,
-            request=request,
-            request_data=request_data,
-            route=route,
-            parent_otel_span=user_api_key_auth_obj.parent_otel_span,
-            api_key=api_key,
-        )
+        # Transient / DB error during authorization checks.  Instead of
+        # replacing the authenticated token with an unrestricted fallback
+        # (which would be a privilege-escalation vector), keep the
+        # *original* token so model-access, team, and budget restrictions
+        # encoded on it remain in effect.
+        from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
+
+        if PrismaDBExceptionHandler.is_database_connection_error(e):
+            verbose_proxy_logger.warning(
+                "common_checks: DB unavailable during authorization "
+                "checks — proceeding with original token restrictions "
+                "intact (NOT issuing fallback). error=%s",
+                str(e),
+            )
+            # Fall through: return user_api_key_auth_obj below with
+            # its original restrictions preserved.
+        else:
+            # Non-DB error (e.g. coding bug) — route through the
+            # existing handler so it surfaces as ProxyException.
+            return await UserAPIKeyAuthExceptionHandler._handle_authentication_error(
+                e=e,
+                request=request,
+                request_data=request_data,
+                route=route,
+                parent_otel_span=user_api_key_auth_obj.parent_otel_span,
+                api_key=api_key,
+            )
 
     end_user_id = get_end_user_id_from_request_body(
         request_data, _safe_get_request_headers(request)


### PR DESCRIPTION
## Relevant issues

Defence-in-depth hardening for the authorization centralization in #26279.

## What changed

**1. Separate exception handling for `common_checks` vs builder (user_api_key_auth.py)**

PR #26279 centralized all authorization checks into `_run_centralized_common_checks`, which is called *after* the builder returns an authenticated token. However, the `except` block routes DB errors through the same `_handle_authentication_error` used by the builder — which can issue an unrestricted `INTERNAL_USER` fallback token when `allow_requests_on_db_unavailable=True`.

This creates a privilege-escalation risk: if a DB connectivity error occurs during `common_checks` (budget/team/org lookups), the already-authenticated, *restricted* token is replaced with an unrestricted fallback — silently stripping budget limits, model restrictions, and team access controls.

Current code mitigates this because all Prisma calls inside `common_checks` have individual `try/except` wrappers. But the shared exception path is a defence-in-depth violation: a single future unwrapped DB call would re-open the bypass.

**Fix:** Authorization denials (`ProxyException`, `HTTPException`, `BudgetExceededError`) propagate as 4xx unchanged. DB connectivity errors during `common_checks` now preserve the *original* authenticated token instead of issuing a fallback. Other exceptions still route through the existing handler.

**2. Missing `await` on `async_get_cache` in `get_org_object` (auth_checks.py)**

`get_org_object` calls `user_api_key_cache.async_get_cache()` without `await`, so the cache lookup always returns a coroutine object (truthy) but never the actual cached value. Every request hits the database. Added the missing `await`.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.
- [x] Changes are minimal and focused on the security fix.

## Tests

The exception-handling change is a pure control-flow hardening — existing tests continue to pass. The `await` fix improves performance but doesn't change correctness.