### PR TITLE
chore(caching): isolate semantic cache by tenant scope

### DIFF
--- a/litellm/caching/_tenant_scope.py
+++ b/litellm/caching/_tenant_scope.py
@@ -1,0 +1,43 @@
+"""Tenant-scope extraction for cache backends (VERIA-54).
+
+The standard cache backends (Redis/in-memory/S3) hash the proxy-injected
+metadata into the cache key, so two callers from different teams produce
+different keys and cannot cross-read entries. Semantic caches operate on
+prompt embeddings rather than the cache key, so they have no implicit
+isolation — a caller from team B can read team A's cached response just
+by sending a similar prompt.
+
+This helper extracts a stable scope identifier from the same metadata
+fields the standard cache uses. Both semantic backends key their storage
+and retrieval on this scope so cross-tenant lookups become impossible.
+"""
+
+from typing import Any, Dict, Optional
+
+# Canonical order so two callers with the same (team, user, org) tuple
+# always produce the same scope string.
+_TENANT_FIELDS = (
+    "user_api_key_team_id",
+    "user_api_key_user_id",
+    "user_api_key_org_id",
+)
+
+
+def get_tenant_scope(kwargs: Dict[str, Any]) -> Optional[str]:
+    """Return a stable scope identifier from proxy-injected metadata.
+
+    Returns ``None`` when no scope is present (master key, direct SDK use,
+    no proxy), in which case callers should fall back to the legacy
+    shared cache pool — preserving BC for non-multi-tenant deployments.
+    """
+    metadata = kwargs.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return None
+    parts = []
+    for field in _TENANT_FIELDS:
+        value = metadata.get(field)
+        if isinstance(value, str) and value:
+            parts.append(value)
+    if not parts:
+        return None
+    return "|".join(parts)

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -28,7 +28,20 @@ _NO_TENANT_SCOPE = ""
 
 
 def _qdrant_tenant_filter(scope: str) -> dict:
-    """Qdrant query filter that constrains a search to a single scope."""
+    """Qdrant query filter that constrains a search to a single scope.
+
+    For the no-tenant sentinel ``""``, also match points that have no
+    ``tenant_scope`` field at all — those were stored before this fix
+    landed and would otherwise become silent cache misses on upgrade,
+    invalidating the entire pre-existing Qdrant cache.
+    """
+    if not scope:
+        return {
+            "should": [
+                {"key": "tenant_scope", "match": {"value": ""}},
+                {"is_empty": {"key": "tenant_scope"}},
+            ]
+        }
     return {"must": [{"key": "tenant_scope", "match": {"value": scope}}]}
 
 

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -18,7 +18,18 @@ from litellm._logging import print_verbose
 from litellm.constants import QDRANT_SCALAR_QUANTILE, QDRANT_VECTOR_SIZE
 from litellm.types.utils import EmbeddingResponse
 
+from ._tenant_scope import get_tenant_scope
 from .base_cache import BaseCache
+
+# Sentinel stored in payload when no proxy-injected tenant scope is
+# present; querying with the same sentinel keeps direct-SDK callers
+# (master key, no proxy) sharing a single legacy pool.
+_NO_TENANT_SCOPE = ""
+
+
+def _qdrant_tenant_filter(scope: str) -> dict:
+    """Qdrant query filter that constrains a search to a single scope."""
+    return {"must": [{"key": "tenant_scope", "match": {"value": scope}}]}
 
 
 class QdrantSemanticCache(BaseCache):
@@ -202,6 +213,7 @@ class QdrantSemanticCache(BaseCache):
                     "id": str(uuid.uuid4()),
                     "vector": embedding,
                     "payload": {
+                        "tenant_scope": get_tenant_scope(kwargs) or _NO_TENANT_SCOPE,
                         "text": prompt,
                         "response": value,
                     },
@@ -239,6 +251,9 @@ class QdrantSemanticCache(BaseCache):
 
         data = {
             "vector": embedding,
+            "filter": _qdrant_tenant_filter(
+                get_tenant_scope(kwargs) or _NO_TENANT_SCOPE
+            ),
             "params": {
                 "quantization": {
                     "ignore": False,
@@ -332,6 +347,7 @@ class QdrantSemanticCache(BaseCache):
                     "id": str(uuid.uuid4()),
                     "vector": embedding,
                     "payload": {
+                        "tenant_scope": get_tenant_scope(kwargs) or _NO_TENANT_SCOPE,
                         "text": prompt,
                         "response": value,
                     },
@@ -386,6 +402,9 @@ class QdrantSemanticCache(BaseCache):
 
         data = {
             "vector": embedding,
+            "filter": _qdrant_tenant_filter(
+                get_tenant_scope(kwargs) or _NO_TENANT_SCOPE
+            ),
             "params": {
                 "quantization": {
                     "ignore": False,

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -22,6 +22,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 )
 from litellm.types.utils import EmbeddingResponse
 
+from ._tenant_scope import get_tenant_scope
 from .base_cache import BaseCache
 
 
@@ -109,6 +110,16 @@ class RedisSemanticCache(BaseCache):
         # Initialize the Redis vectorizer and cache
         cache_vectorizer = CustomTextVectorizer(self._get_embedding)
 
+        # State for tenant-scoped indexes (VERIA-54). The default
+        # ``self.llmcache`` serves direct-SDK / no-proxy requests where
+        # no scope is present; per-tenant requests get their own index
+        # via ``_get_cache_for_scope`` so cross-tenant lookups become
+        # impossible by construction (no shared schema, no shared keys).
+        self._index_name_base = index_name
+        self._redis_url = redis_url
+        self._cache_vectorizer = cache_vectorizer
+        self._tenant_caches: Dict[str, "SemanticCache"] = {}
+
         self.llmcache = SemanticCache(
             name=index_name,
             redis_url=redis_url,
@@ -116,6 +127,38 @@ class RedisSemanticCache(BaseCache):
             distance_threshold=self.distance_threshold,
             overwrite=False,
         )
+
+    def _get_cache_for_scope(self, tenant_scope: Optional[str]) -> Any:
+        """Return the ``SemanticCache`` instance for a tenant scope.
+
+        ``None`` returns the default index (BC for callers without proxy
+        metadata). Any non-None scope gets its own RedisVL index, lazily
+        created on first use so two tenants share no keys, no schema,
+        and no vector neighborhood.
+        """
+        if tenant_scope is None:
+            return self.llmcache
+        cached = self._tenant_caches.get(tenant_scope)
+        if cached is not None:
+            return cached
+        from hashlib import sha256
+
+        from redisvl.extensions.llmcache import SemanticCache
+
+        # Hash the scope so the Redis index name is always a valid
+        # identifier (team_ids and user_ids can contain characters that
+        # RedisVL rejects in index names).
+        scope_hash = sha256(tenant_scope.encode("utf-8")).hexdigest()[:16]
+        scoped_name = f"{self._index_name_base}:tenant:{scope_hash}"
+        scoped = SemanticCache(
+            name=scoped_name,
+            redis_url=self._redis_url,
+            vectorizer=self._cache_vectorizer,
+            distance_threshold=self.distance_threshold,
+            overwrite=False,
+        )
+        self._tenant_caches[tenant_scope] = scoped
+        return scoped
 
     def _get_ttl(self, **kwargs) -> Optional[int]:
         """
@@ -206,12 +249,13 @@ class RedisSemanticCache(BaseCache):
             prompt = get_str_from_messages(messages)
             value_str = str(value)
 
+            llmcache = self._get_cache_for_scope(get_tenant_scope(kwargs))
             # Get TTL and store in Redis semantic cache
             ttl = self._get_ttl(**kwargs)
             if ttl is not None:
-                self.llmcache.store(prompt, value_str, ttl=int(ttl))
+                llmcache.store(prompt, value_str, ttl=int(ttl))
             else:
-                self.llmcache.store(prompt, value_str)
+                llmcache.store(prompt, value_str)
         except Exception as e:
             print_verbose(
                 f"Error setting {value_str or value} in the Redis semantic cache: {str(e)}"
@@ -238,8 +282,9 @@ class RedisSemanticCache(BaseCache):
                 return None
 
             prompt = get_str_from_messages(messages)
+            llmcache = self._get_cache_for_scope(get_tenant_scope(kwargs))
             # Check the cache for semantically similar prompts
-            results = self.llmcache.check(prompt=prompt)
+            results = llmcache.check(prompt=prompt)
 
             # Return None if no similar prompts found
             if not results:
@@ -341,17 +386,18 @@ class RedisSemanticCache(BaseCache):
             # Generate embedding for the value (response) to cache
             prompt_embedding = await self._get_async_embedding(prompt, **kwargs)
 
+            llmcache = self._get_cache_for_scope(get_tenant_scope(kwargs))
             # Get TTL and store in Redis semantic cache
             ttl = self._get_ttl(**kwargs)
             if ttl is not None:
-                await self.llmcache.astore(
+                await llmcache.astore(
                     prompt,
                     value_str,
                     vector=prompt_embedding,  # Pass through custom embedding
                     ttl=ttl,
                 )
             else:
-                await self.llmcache.astore(
+                await llmcache.astore(
                     prompt,
                     value_str,
                     vector=prompt_embedding,  # Pass through custom embedding
@@ -385,8 +431,9 @@ class RedisSemanticCache(BaseCache):
             # Generate embedding for the prompt
             prompt_embedding = await self._get_async_embedding(prompt, **kwargs)
 
+            llmcache = self._get_cache_for_scope(get_tenant_scope(kwargs))
             # Check the cache for semantically similar prompts
-            results = await self.llmcache.acheck(prompt=prompt, vector=prompt_embedding)
+            results = await llmcache.acheck(prompt=prompt, vector=prompt_embedding)
 
             # handle results / cache hit
             if not results:

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -13,6 +13,8 @@ import ast
 import asyncio
 import json
 import os
+import threading
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import litellm
@@ -24,6 +26,12 @@ from litellm.types.utils import EmbeddingResponse
 
 from ._tenant_scope import get_tenant_scope
 from .base_cache import BaseCache
+
+# Cap on distinct ``(team, user, org)`` scopes whose ``SemanticCache``
+# instances we keep alive. Each instance holds its own RedisVL
+# connection pool, so an unbounded dict eventually exhausts Redis
+# connections in deployments with many transient tenants.
+_TENANT_CACHE_LRU_SIZE = 256
 
 
 class RedisSemanticCache(BaseCache):
@@ -115,10 +123,15 @@ class RedisSemanticCache(BaseCache):
         # no scope is present; per-tenant requests get their own index
         # via ``_get_cache_for_scope`` so cross-tenant lookups become
         # impossible by construction (no shared schema, no shared keys).
+        # Bounded LRU prevents connection-pool exhaustion when the set of
+        # distinct tenant scopes is large; lock makes lazy creation safe
+        # under concurrent first-touches.
         self._index_name_base = index_name
         self._redis_url = redis_url
         self._cache_vectorizer = cache_vectorizer
-        self._tenant_caches: Dict[str, "SemanticCache"] = {}
+        self._tenant_caches: "OrderedDict[str, SemanticCache]" = OrderedDict()
+        self._tenant_caches_lock = threading.Lock()
+        self._tenant_caches_lru_size = _TENANT_CACHE_LRU_SIZE
 
         self.llmcache = SemanticCache(
             name=index_name,
@@ -134,13 +147,26 @@ class RedisSemanticCache(BaseCache):
         ``None`` returns the default index (BC for callers without proxy
         metadata). Any non-None scope gets its own RedisVL index, lazily
         created on first use so two tenants share no keys, no schema,
-        and no vector neighborhood.
+        and no vector neighborhood. Bounded LRU evicts the least-recently-
+        used scoped instance when the cap is hit. Double-checked locking
+        prevents two concurrent first-touches from creating two indexes.
         """
         if tenant_scope is None:
             return self.llmcache
-        cached = self._tenant_caches.get(tenant_scope)
-        if cached is not None:
-            return cached
+
+        # Fast path: already present. Take the lock just to update LRU
+        # ordering (the dict op itself is atomic in CPython but
+        # ``move_to_end`` plus eviction need a consistent view).
+        with self._tenant_caches_lock:
+            cached = self._tenant_caches.get(tenant_scope)
+            if cached is not None:
+                self._tenant_caches.move_to_end(tenant_scope)
+                return cached
+
+        # Slow path: build the new instance OUTSIDE the lock so its
+        # Redis ping/index-existence check doesn't block other tenants'
+        # cache hits. We may race with another thread and waste one
+        # extra construction; the loser's instance is then discarded.
         from hashlib import sha256
 
         from redisvl.extensions.llmcache import SemanticCache
@@ -150,15 +176,23 @@ class RedisSemanticCache(BaseCache):
         # RedisVL rejects in index names).
         scope_hash = sha256(tenant_scope.encode("utf-8")).hexdigest()[:16]
         scoped_name = f"{self._index_name_base}:tenant:{scope_hash}"
-        scoped = SemanticCache(
+        new_instance = SemanticCache(
             name=scoped_name,
             redis_url=self._redis_url,
             vectorizer=self._cache_vectorizer,
             distance_threshold=self.distance_threshold,
             overwrite=False,
         )
-        self._tenant_caches[tenant_scope] = scoped
-        return scoped
+
+        with self._tenant_caches_lock:
+            existing = self._tenant_caches.get(tenant_scope)
+            if existing is not None:
+                self._tenant_caches.move_to_end(tenant_scope)
+                return existing
+            self._tenant_caches[tenant_scope] = new_instance
+            while len(self._tenant_caches) > self._tenant_caches_lru_size:
+                self._tenant_caches.popitem(last=False)
+            return new_instance
 
     def _get_ttl(self, **kwargs) -> Optional[int]:
         """

--- a/tests/test_litellm/caching/test_semantic_cache_tenant_isolation.py
+++ b/tests/test_litellm/caching/test_semantic_cache_tenant_isolation.py
@@ -173,7 +173,11 @@ def test_qdrant_get_cache_filters_by_tenant_scope(monkeypatch):
     }
 
 
-def test_qdrant_get_cache_no_tenant_uses_sentinel_filter(monkeypatch):
+def test_qdrant_get_cache_no_tenant_filter_includes_legacy_points(monkeypatch):
+    """Greptile P1 follow-up: pre-existing Qdrant points have no
+    ``tenant_scope`` field. The no-tenant filter must match them via
+    ``is_empty`` so an upgrade doesn't silently invalidate the entire
+    pre-existing cache."""
     cache = _make_qdrant_cache()
     monkeypatch.setattr(
         "litellm.embedding", lambda **kw: {"data": [{"embedding": [0.1, 0.2]}]}
@@ -183,9 +187,11 @@ def test_qdrant_get_cache_no_tenant_uses_sentinel_filter(monkeypatch):
     cache.get_cache(key="k", messages=[{"role": "user", "content": "hi"}])
 
     body = _qdrant_search_args(cache)
-    # Sentinel ``""`` so callers without a tenant scope share their own
-    # legacy pool but never see tenant entries.
-    assert body["filter"]["must"][0]["match"]["value"] == ""
+    # ``should`` clauses are OR'd: match either the explicit sentinel
+    # OR points that have no ``tenant_scope`` field at all (legacy data).
+    should = body["filter"]["should"]
+    assert {"key": "tenant_scope", "match": {"value": ""}} in should
+    assert {"is_empty": {"key": "tenant_scope"}} in should
 
 
 # ── Redis semantic cache ──────────────────────────────────────────────────────
@@ -193,6 +199,9 @@ def test_qdrant_get_cache_no_tenant_uses_sentinel_filter(monkeypatch):
 
 def _make_redis_cache():
     """Build a RedisSemanticCache without touching the real Redis."""
+    import threading
+    from collections import OrderedDict
+
     from litellm.caching.redis_semantic_cache import RedisSemanticCache
 
     cache = RedisSemanticCache.__new__(RedisSemanticCache)
@@ -202,7 +211,9 @@ def _make_redis_cache():
     cache._index_name_base = "litellm_semantic_cache_index"
     cache._redis_url = "redis://localhost:6379"
     cache._cache_vectorizer = MagicMock()
-    cache._tenant_caches = {}
+    cache._tenant_caches = OrderedDict()
+    cache._tenant_caches_lock = threading.Lock()
+    cache._tenant_caches_lru_size = 256
     # Default (no-tenant) index — callers without proxy metadata route here.
     cache.llmcache = MagicMock()
     cache.llmcache.store = MagicMock()
@@ -328,6 +339,112 @@ async def test_redis_async_set_cache_routes_through_tenant_index():
 
     fake_scoped.astore.assert_awaited_once()
     cache.llmcache.astore.assert_not_called()
+
+
+def test_redis_tenant_caches_lru_evicts_oldest(fake_redisvl_module):
+    """Greptile P1 follow-up: ``_tenant_caches`` must be bounded so a
+    stream of distinct tenants doesn't exhaust Redis connections.
+    Eviction is FIFO (oldest by last access) so hot tenants stay warm."""
+    cache = _make_redis_cache()
+    cache._tenant_caches_lru_size = 3
+
+    instances = []
+
+    def fake_ctor(**kwargs):
+        m = MagicMock()
+        m.store = MagicMock()
+        instances.append(m)
+        return m
+
+    with patch("redisvl.extensions.llmcache.SemanticCache", side_effect=fake_ctor):
+        for scope in ["a", "b", "c", "d"]:
+            cache.set_cache(
+                key="k",
+                value="v",
+                messages=[{"role": "user", "content": "hi"}],
+                metadata={"user_api_key_team_id": scope},
+            )
+
+    assert len(instances) == 4
+    assert "a" not in cache._tenant_caches  # evicted
+    assert set(cache._tenant_caches) == {"b", "c", "d"}
+
+
+def test_redis_tenant_caches_lru_keeps_recently_used(fake_redisvl_module):
+    """Touching tenant ``a`` must move it to the back of the LRU so the
+    next eviction picks an older entry."""
+    cache = _make_redis_cache()
+    cache._tenant_caches_lru_size = 3
+
+    def fake_ctor(**kwargs):
+        m = MagicMock()
+        m.store = MagicMock()
+        return m
+
+    with patch("redisvl.extensions.llmcache.SemanticCache", side_effect=fake_ctor):
+        for scope in ["a", "b", "c"]:
+            cache.set_cache(
+                key="k",
+                value="v",
+                messages=[{"role": "user", "content": "hi"}],
+                metadata={"user_api_key_team_id": scope},
+            )
+        # Touch ``a`` again so it's no longer the oldest.
+        cache.set_cache(
+            key="k",
+            value="v",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"user_api_key_team_id": "a"},
+        )
+        # Insert a fourth scope — should evict ``b`` (now the oldest).
+        cache.set_cache(
+            key="k",
+            value="v",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"user_api_key_team_id": "d"},
+        )
+
+    assert "b" not in cache._tenant_caches
+    assert set(cache._tenant_caches) == {"a", "c", "d"}
+
+
+def test_redis_tenant_caches_concurrent_first_touch_no_duplicate(
+    fake_redisvl_module,
+):
+    """Greptile P2 follow-up: two concurrent first-touches for the same
+    tenant must not both end up in ``_tenant_caches``. Double-checked
+    locking inside ``_get_cache_for_scope`` discards the loser."""
+    import threading
+
+    cache = _make_redis_cache()
+    barrier = threading.Barrier(2)
+    constructed = []
+
+    def fake_ctor(**kwargs):
+        # Wait until both threads are about to construct so the race is
+        # observable; then return distinct instances.
+        barrier.wait(timeout=2.0)
+        m = MagicMock()
+        constructed.append(m)
+        return m
+
+    results = []
+
+    def race():
+        with patch("redisvl.extensions.llmcache.SemanticCache", side_effect=fake_ctor):
+            results.append(cache._get_cache_for_scope("team-a"))
+
+    t1 = threading.Thread(target=race)
+    t2 = threading.Thread(target=race)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Both threads got the *same* instance — the loser's construction
+    # was discarded by the double-check inside the lock.
+    assert results[0] is results[1]
+    assert len(cache._tenant_caches) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/caching/test_semantic_cache_tenant_isolation.py
+++ b/tests/test_litellm/caching/test_semantic_cache_tenant_isolation.py
@@ -1,0 +1,348 @@
+"""
+VERIA-54: Cross-tenant data leakage in semantic caching.
+
+Both Redis and Qdrant semantic caches used to ignore tenant metadata —
+two callers from different teams could retrieve each other's cached
+responses by sending semantically similar prompts. These tests assert
+that cross-tenant lookups are now isolated, while same-tenant requests
+continue to share, and no-tenant callers (master key, direct SDK use)
+fall back to the legacy shared pool.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.caching._tenant_scope import get_tenant_scope
+
+
+@pytest.fixture
+def fake_redisvl_module():
+    """Inject a stub ``redisvl.extensions.llmcache`` so tests don't need
+    the real redisvl install. The stub's ``SemanticCache`` is a placeholder
+    that individual tests replace via ``patch`` on the real attribute."""
+    real = sys.modules.get("redisvl.extensions.llmcache")
+    real_parent = sys.modules.get("redisvl.extensions")
+    real_grandparent = sys.modules.get("redisvl")
+    if real is None:
+        stub = types.ModuleType("redisvl.extensions.llmcache")
+        stub.SemanticCache = MagicMock
+        sys.modules["redisvl.extensions.llmcache"] = stub
+        sys.modules.setdefault(
+            "redisvl.extensions", types.ModuleType("redisvl.extensions")
+        )
+        sys.modules.setdefault("redisvl", types.ModuleType("redisvl"))
+    yield
+    # Restore (or leave alone if it was already real).
+    if real is None:
+        sys.modules.pop("redisvl.extensions.llmcache", None)
+        if real_parent is None:
+            sys.modules.pop("redisvl.extensions", None)
+        if real_grandparent is None:
+            sys.modules.pop("redisvl", None)
+
+
+# ── get_tenant_scope ──────────────────────────────────────────────────────────
+
+
+def test_get_tenant_scope_team_id_only():
+    assert (
+        get_tenant_scope({"metadata": {"user_api_key_team_id": "team-a"}}) == "team-a"
+    )
+
+
+def test_get_tenant_scope_combines_team_user_org():
+    """Order is canonical so two callers always produce the same scope."""
+    assert (
+        get_tenant_scope(
+            {
+                "metadata": {
+                    "user_api_key_team_id": "team-a",
+                    "user_api_key_user_id": "user-1",
+                    "user_api_key_org_id": "org-x",
+                }
+            }
+        )
+        == "team-a|user-1|org-x"
+    )
+
+
+def test_get_tenant_scope_none_when_no_metadata():
+    assert get_tenant_scope({}) is None
+    assert get_tenant_scope({"metadata": None}) is None
+    assert get_tenant_scope({"metadata": {}}) is None
+
+
+def test_get_tenant_scope_none_for_non_dict_metadata():
+    assert get_tenant_scope({"metadata": "not-a-dict"}) is None
+
+
+def test_get_tenant_scope_skips_empty_strings():
+    assert (
+        get_tenant_scope(
+            {
+                "metadata": {
+                    "user_api_key_team_id": "",
+                    "user_api_key_user_id": "user-1",
+                }
+            }
+        )
+        == "user-1"
+    )
+
+
+# ── Qdrant semantic cache ─────────────────────────────────────────────────────
+
+
+def _make_qdrant_cache():
+    from litellm.caching.qdrant_semantic_cache import QdrantSemanticCache
+
+    cache = QdrantSemanticCache.__new__(QdrantSemanticCache)
+    cache.qdrant_api_base = "https://qdrant.example.com"
+    cache.collection_name = "test"
+    cache.headers = {}
+    cache.embedding_model = "text-embedding-3-small"
+    cache.similarity_threshold = 0.8
+    cache.sync_client = MagicMock()
+    cache.async_client = MagicMock()
+    return cache
+
+
+def _qdrant_set_args(cache):
+    """Return the JSON body the most recent ``put`` was called with."""
+    return cache.sync_client.put.call_args.kwargs["json"]
+
+
+def _qdrant_search_args(cache):
+    return cache.sync_client.post.call_args.kwargs["json"]
+
+
+def test_qdrant_set_cache_attaches_tenant_scope(monkeypatch):
+    cache = _make_qdrant_cache()
+    fake_embedding = MagicMock()
+    fake_embedding.__getitem__.side_effect = lambda k: (
+        [{"embedding": [0.1, 0.2]}] if k == "data" else None
+    )
+    monkeypatch.setattr(
+        "litellm.embedding", lambda **kw: {"data": [{"embedding": [0.1, 0.2]}]}
+    )
+
+    cache.set_cache(
+        key="cache-key",
+        value="cached-response",
+        messages=[{"role": "user", "content": "hi"}],
+        metadata={"user_api_key_team_id": "team-a"},
+    )
+
+    body = _qdrant_set_args(cache)
+    payload = body["points"][0]["payload"]
+    assert payload["tenant_scope"] == "team-a"
+
+
+def test_qdrant_set_cache_uses_sentinel_when_no_tenant(monkeypatch):
+    """No proxy metadata → the legacy shared pool."""
+    cache = _make_qdrant_cache()
+    monkeypatch.setattr(
+        "litellm.embedding", lambda **kw: {"data": [{"embedding": [0.1, 0.2]}]}
+    )
+
+    cache.set_cache(key="k", value="v", messages=[{"role": "user", "content": "hi"}])
+
+    body = _qdrant_set_args(cache)
+    assert body["points"][0]["payload"]["tenant_scope"] == ""
+
+
+def test_qdrant_get_cache_filters_by_tenant_scope(monkeypatch):
+    cache = _make_qdrant_cache()
+    monkeypatch.setattr(
+        "litellm.embedding", lambda **kw: {"data": [{"embedding": [0.1, 0.2]}]}
+    )
+    cache.sync_client.post.return_value.json.return_value = {"result": []}
+
+    cache.get_cache(
+        key="cache-key",
+        messages=[{"role": "user", "content": "hi"}],
+        metadata={"user_api_key_team_id": "team-a"},
+    )
+
+    body = _qdrant_search_args(cache)
+    assert body["filter"] == {
+        "must": [{"key": "tenant_scope", "match": {"value": "team-a"}}]
+    }
+
+
+def test_qdrant_get_cache_no_tenant_uses_sentinel_filter(monkeypatch):
+    cache = _make_qdrant_cache()
+    monkeypatch.setattr(
+        "litellm.embedding", lambda **kw: {"data": [{"embedding": [0.1, 0.2]}]}
+    )
+    cache.sync_client.post.return_value.json.return_value = {"result": []}
+
+    cache.get_cache(key="k", messages=[{"role": "user", "content": "hi"}])
+
+    body = _qdrant_search_args(cache)
+    # Sentinel ``""`` so callers without a tenant scope share their own
+    # legacy pool but never see tenant entries.
+    assert body["filter"]["must"][0]["match"]["value"] == ""
+
+
+# ── Redis semantic cache ──────────────────────────────────────────────────────
+
+
+def _make_redis_cache():
+    """Build a RedisSemanticCache without touching the real Redis."""
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    cache.similarity_threshold = 0.8
+    cache.distance_threshold = 0.2
+    cache.embedding_model = "text-embedding-3-small"
+    cache._index_name_base = "litellm_semantic_cache_index"
+    cache._redis_url = "redis://localhost:6379"
+    cache._cache_vectorizer = MagicMock()
+    cache._tenant_caches = {}
+    # Default (no-tenant) index — callers without proxy metadata route here.
+    cache.llmcache = MagicMock()
+    cache.llmcache.store = MagicMock()
+    cache.llmcache.check = MagicMock(return_value=[])
+    cache.llmcache.astore = AsyncMock()
+    cache.llmcache.acheck = AsyncMock(return_value=[])
+    return cache
+
+
+def test_redis_no_tenant_uses_default_index():
+    """Direct-SDK callers (no proxy metadata) keep using the existing
+    index — no schema migration, no data loss for upgrading deployments."""
+    cache = _make_redis_cache()
+    cache.set_cache(key="k", value="v", messages=[{"role": "user", "content": "hi"}])
+    cache.llmcache.store.assert_called_once()
+    assert cache._tenant_caches == {}
+
+
+def test_redis_tenant_scoped_index_lazy_created(fake_redisvl_module):
+    """First request from a tenant lazy-creates a per-tenant
+    ``SemanticCache`` whose Redis index name is derived from the scope."""
+    cache = _make_redis_cache()
+    fake_scoped_cache = MagicMock()
+    fake_scoped_cache.store = MagicMock()
+    fake_scoped_cache.check = MagicMock(return_value=[])
+
+    with patch(
+        "redisvl.extensions.llmcache.SemanticCache",
+        return_value=fake_scoped_cache,
+    ) as mock_ctor:
+        cache.set_cache(
+            key="k",
+            value="v",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"user_api_key_team_id": "team-a"},
+        )
+
+    # Tenant index name embeds the scope hash (deterministic, stable).
+    call_kwargs = mock_ctor.call_args.kwargs
+    assert call_kwargs["name"].startswith("litellm_semantic_cache_index:tenant:")
+    assert call_kwargs["name"] != "litellm_semantic_cache_index"
+    # Default cache untouched.
+    cache.llmcache.store.assert_not_called()
+    # Tenant cache used.
+    fake_scoped_cache.store.assert_called_once()
+    # Subsequent calls reuse the same instance — no constructor re-run.
+    cache.set_cache(
+        key="k2",
+        value="v2",
+        messages=[{"role": "user", "content": "hi again"}],
+        metadata={"user_api_key_team_id": "team-a"},
+    )
+    assert mock_ctor.call_count == 1
+    assert fake_scoped_cache.store.call_count == 2
+
+
+def test_redis_two_tenants_get_distinct_indexes(fake_redisvl_module):
+    """Cross-tenant isolation: scope ``team-a`` must never look at
+    scope ``team-b``'s index."""
+    cache = _make_redis_cache()
+
+    instances = []
+
+    def fake_ctor(**kwargs):
+        m = MagicMock()
+        m.store = MagicMock()
+        m.check = MagicMock(return_value=[])
+        m._litellm_index_name = kwargs["name"]
+        instances.append(m)
+        return m
+
+    with patch("redisvl.extensions.llmcache.SemanticCache", side_effect=fake_ctor):
+        cache.set_cache(
+            key="k",
+            value="v-a",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"user_api_key_team_id": "team-a"},
+        )
+        cache.set_cache(
+            key="k",
+            value="v-b",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"user_api_key_team_id": "team-b"},
+        )
+
+    assert len(instances) == 2
+    assert instances[0]._litellm_index_name != instances[1]._litellm_index_name
+    instances[0].store.assert_called_once_with("hi", "v-a")
+    instances[1].store.assert_called_once_with("hi", "v-b")
+
+
+def test_redis_get_cache_routes_through_tenant_index():
+    """Tenant-A querying must hit team-A's index, not the default pool."""
+    cache = _make_redis_cache()
+    fake_scoped = MagicMock()
+    fake_scoped.check = MagicMock(return_value=[])
+    cache._tenant_caches["team-a"] = fake_scoped
+
+    cache.get_cache(
+        key="k",
+        messages=[{"role": "user", "content": "hi"}],
+        metadata={"user_api_key_team_id": "team-a"},
+    )
+
+    fake_scoped.check.assert_called_once()
+    cache.llmcache.check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redis_async_set_cache_routes_through_tenant_index():
+    cache = _make_redis_cache()
+    fake_scoped = MagicMock()
+    fake_scoped.astore = AsyncMock()
+    cache._tenant_caches["team-a"] = fake_scoped
+    cache._get_async_embedding = AsyncMock(return_value=[0.1, 0.2])
+
+    await cache.async_set_cache(
+        key="k",
+        value="v",
+        messages=[{"role": "user", "content": "hi"}],
+        metadata={"user_api_key_team_id": "team-a"},
+    )
+
+    fake_scoped.astore.assert_awaited_once()
+    cache.llmcache.astore.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redis_async_get_cache_routes_through_tenant_index():
+    cache = _make_redis_cache()
+    fake_scoped = MagicMock()
+    fake_scoped.acheck = AsyncMock(return_value=[])
+    cache._tenant_caches["team-a"] = fake_scoped
+    cache._get_async_embedding = AsyncMock(return_value=[0.1, 0.2])
+
+    await cache.async_get_cache(
+        key="k",
+        messages=[{"role": "user", "content": "hi"}],
+        metadata={"user_api_key_team_id": "team-a"},
+    )
+
+    fake_scoped.acheck.assert_awaited_once()
+    cache.llmcache.acheck.assert_not_called()


### PR DESCRIPTION
## Relevant issues

n/a — operational hardening.

## Pre-Submission checklist

- [x] I have added tests in [\`tests/test_litellm/\`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm).
- [x] My PR passes \`make test-unit\` on the affected paths.
- [x] My PR's scope is isolated to tenant scoping in the two semantic-cache backends.
- [ ] I have requested a Greptile review by commenting \`@greptileai\` and received a Confidence Score of at least 4/5 before requesting a maintainer review.

## Type

🐛 Bug Fix

## Changes

Both \`RedisSemanticCache\` and \`QdrantSemanticCache\` ignored the proxy-injected tenant metadata when storing and retrieving cache entries. The standard cache backends (Redis exact-match, in-memory, S3) get isolation implicitly because team/user/org IDs are part of the request parameters that get hashed into the cache key. The semantic caches retrieve based on prompt embedding similarity, so two callers from different teams could retrieve each other's cached LLM responses by sending semantically similar prompts.

### New helper

\`litellm/caching/_tenant_scope.py:get_tenant_scope(kwargs) -> Optional[str]\` extracts a stable scope identifier from \`metadata.user_api_key_team_id\`, \`user_api_key_user_id\`, \`user_api_key_org_id\` (joined with \`|\` in canonical order). Returns \`None\` when no scope is present (master key, direct SDK use) so callers can fall back to the legacy shared pool.

### Qdrant — filter-based isolation

- \`set_cache\` / \`async_set_cache\`: added \`tenant_scope\` to the point payload.
- \`get_cache\` / \`async_get_cache\`: added \`query_filter\` constraining the search to one scope.
- Sentinel \`\"\"\` for no-tenant callers so they keep sharing among themselves but never see tenant entries.

### Redis — index-per-tenant isolation

- Each tenant scope gets its own RedisVL \`SemanticCache\` instance, lazy-created on first use. The Redis index name embeds a SHA-256 prefix of the scope so it's always a valid identifier.
- The default \`self.llmcache\` continues to serve no-tenant callers — **no schema migration, no data loss for upgrading deployments**.
- All four sync/async set/get paths route through \`_get_cache_for_scope\`.

### Tests

15 mock-only unit tests in \`tests/test_litellm/caching/test_semantic_cache_tenant_isolation.py\`:
- Helper coverage: scope from team-only, combined team+user+org, none, non-dict metadata, empty strings.
- Qdrant: payload carries \`tenant_scope\` on store, search filters by exact scope on retrieve, sentinel \`\"\"\` for no-tenant.
- Redis: no-tenant uses default index, tenant requests lazy-create scoped index, two tenants get distinct indexes, sync+async set+get all route correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)