### PR TITLE
Fix: trigger fallbacks on mid-stream httpx.TimeoutException

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2244,7 +2244,7 @@ class CustomStreamWrapper:
                 asyncio.create_task(
                     self.logging_obj.async_failure_handler(e, traceback_exception)
                 )
-            raise e
+            self._handle_stream_fallback_error(e)
         except Exception as e:
             traceback_exception = traceback.format_exc()
             if self.logging_obj is not None:

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -878,6 +878,39 @@ def test_sync_streaming_bad_request_not_midstream(logging_obj: Logging):
     assert "invalid maxOutputTokens" in str(excinfo.value)
 
 
+@pytest.mark.asyncio
+async def test_async_streaming_read_timeout_triggers_midstream_fallback(
+    logging_obj: Logging,
+):
+    """A mid-stream httpx.ReadTimeout must wrap into MidStreamFallbackError so
+    the Router's FallbackStreamWrapper can switch to a fallback model.
+
+    Previously __anext__ caught httpx.TimeoutException and re-raised it raw,
+    which bypassed _handle_stream_fallback_error and prevented stream_timeout
+    from triggering fallbacks the way connection-phase timeout does.
+    """
+    import httpx
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    async def _raise_read_timeout(**kwargs):
+        raise httpx.ReadTimeout("Timeout on reading data from socket")
+
+    response = CustomStreamWrapper(
+        completion_stream=None,
+        model="gpt-4",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        make_call=_raise_read_timeout,
+    )
+
+    with pytest.raises(MidStreamFallbackError) as excinfo:
+        await response.__anext__()
+
+    assert excinfo.value.is_pre_first_chunk is True
+    assert isinstance(excinfo.value.original_exception, Exception)
+
+
 def test_streaming_handler_with_created_time_propagation(
     initialized_custom_stream_wrapper: CustomStreamWrapper, logging_obj: Logging
 ):


### PR DESCRIPTION
## Summary
resolves LIT-2740
- Mid-stream `httpx.ReadTimeout` (e.g. `stream_timeout` firing after 200 OK) now triggers configured fallbacks the same way connection-phase `timeout` already did.
- Previously the async `CustomStreamWrapper.__anext__` caught `httpx.TimeoutException` and re-raised it raw, bypassing `_handle_stream_fallback_error`. The Router's `FallbackStreamWrapper` only reacts to `MidStreamFallbackError`, so mid-stream timeouts never reached the fallback chain — the connection was killed and the raw httpx error surfaced to the client.
- Routes the timeout through `_handle_stream_fallback_error` like every other exception so it wraps into `MidStreamFallbackError` and the Router can switch to the fallback model. The sync `__next__` was already correct (catches `Exception` generically), so no change there.

before - fallback not hit, just a timeout 
<img width="1196" height="822" alt="Screenshot 2026-05-01 at 12 08 54 PM" src="https://github.com/user-attachments/assets/6e744530-5cea-472b-ad54-d020fac63eea" />

after - fallback correctly applied on the timeout, i just didnt have model setup to fallback 
<img width="1361" height="723" alt="Screenshot 2026-05-01 at 12 09 45 PM" src="https://github.com/user-attachments/assets/54140a8e-9487-4a5e-b850-2089a97389ea" />


## Test plan

- [x] New unit test [`test_async_streaming_read_timeout_triggers_midstream_fallback`](tests/test_litellm/litellm_core_utils/test_streaming_handler.py) — `make_call` raises `httpx.ReadTimeout`, asserts `__anext__()` raises `MidStreamFallbackError` with `is_pre_first_chunk=True`.
- [x] Full `tests/test_litellm/litellm_core_utils/test_streaming_handler.py` passes (56 tests).
- [x] Adjacent router/streaming fallback tests pass: `test_completion_streaming_iterator_fallback_on_429`, `test_acompletion_streaming_iterator_edge_cases`, `tests/test_litellm/test_streaming_connection_cleanup.py`.
- [x] End-to-end demo against a stalling mock OpenAI server with `stream_timeout=3s` and a configured fallback:
  - **Before**: raw `httpx.ReadTimeout: Timeout on reading data from socket` escapes to caller.
  - **After**: stream resumes from the fallback deployment — `"Hello from fallback!"` streams cleanly.