### PR TITLE
chore(security): validate AWS region in Bedrock Mantle URL

### DIFF
--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -6,6 +6,7 @@ AmazonAnthropicClaudeMessagesConfig. Overrides only the URL and model-prefix
 stripping that are specific to the bedrock-mantle endpoint.
 """
 
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
@@ -21,6 +22,14 @@ else:
     LiteLLMLoggingObj = Any
 
 MANTLE_ENDPOINT_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1/messages"
+
+# AWS region names are documented as ``[a-z]{2}(-gov|-iso[a-z]?)?-[a-z]+-\d+``
+# (e.g. ``us-east-1``, ``us-gov-east-1``, ``us-isob-east-1``). Lowercase
+# alphanumerics + hyphens covers every known region, and refuses anything
+# that could break out of the URL authority — including ``@`` (userinfo),
+# ``/`` (path), ``:`` (port), ``%`` (percent-encoded delimiters), and ``.``
+# (subdomain hop). VERIA-88.
+_AWS_REGION_PATTERN = re.compile(r"^[a-z0-9-]+$")
 
 
 class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
@@ -41,6 +50,17 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
         stream: Optional[bool] = None,
     ) -> str:
         region = self._get_aws_region_name(optional_params=optional_params, model=model)
+        # ``aws_region_name`` originates from user-supplied ``optional_params``
+        # and is interpolated directly into the URL authority. Without
+        # validation, a value like ``us-east-1@attacker.example`` makes the
+        # URL parser treat ``bedrock-mantle.us-east-1`` as basic-auth
+        # userinfo and routes the SigV4-signed request (with the operator's
+        # AWS access-key-ID in the headers) to the attacker. VERIA-88.
+        if not _AWS_REGION_PATTERN.fullmatch(region or ""):
+            raise ValueError(
+                "Invalid AWS region for Bedrock Mantle: must match "
+                "[a-z0-9-]+ (e.g. 'us-east-1')"
+            )
         return MANTLE_ENDPOINT_TEMPLATE.format(region=region)
 
     def transform_anthropic_messages_request(

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -103,3 +103,79 @@ def test_mantle_transform_request_strips_prefix_and_adds_model():
     )
     assert request["model"] == "anthropic.claude-mythos-preview"
     assert "mantle/" not in request["model"]
+
+
+# ── VERIA-88: aws_region_name SSRF guard ──────────────────────────────────────
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "malicious_region",
+    [
+        # ``@`` makes the URL parser treat ``bedrock-mantle.us-east-1`` as
+        # basic-auth userinfo and ``attacker.example`` as the target host.
+        "us-east-1@attacker.example",
+        # ``/`` injects path components (and could break out of the
+        # authority entirely with a leading ``//``).
+        "us-east-1/foo",
+        "us-east-1//attacker.example",
+        # Percent-encoded ``@``/``/`` reach ``httpx``'s URL parser intact.
+        "us-east-1%40attacker.example",
+        # Subdomain hop — ``.api.aws`` tail in the template is a single
+        # label, not the full registered domain. ``foo.attacker.example``
+        # rewrites the host completely.
+        "us-east-1.attacker",
+        # Userinfo with port + path.
+        "us-east-1:80@attacker.example/foo",
+        # Whitespace / control chars.
+        " us-east-1",
+        "us-east-1 ",
+        "us-east-1\nHost: attacker.example",
+        # Empty / missing.
+        "",
+    ],
+)
+def test_mantle_messages_url_rejects_malicious_region(malicious_region):
+    """``aws_region_name`` is interpolated directly into the URL authority.
+    Any character that lets the value escape the ``{region}`` slot would
+    redirect the SigV4-signed request (with the operator's AWS access-key
+    in the headers) to the attacker. VERIA-88."""
+    config = AmazonMantleMessagesConfig()
+    with pytest.raises(ValueError, match="Invalid AWS region"):
+        config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={"aws_region_name": malicious_region},
+            litellm_params={},
+        )
+
+
+@pytest.mark.parametrize(
+    "valid_region",
+    [
+        "us-east-1",
+        "us-west-2",
+        "eu-west-3",
+        "ap-northeast-1",
+        # AWS GovCloud and ISO partitions.
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-isob-east-1",
+        # Future regions with longer numeric suffixes.
+        "us-east-10",
+    ],
+)
+def test_mantle_messages_url_accepts_valid_region(valid_region):
+    """Every documented AWS region shape must continue to work."""
+    config = AmazonMantleMessagesConfig()
+    url = config.get_complete_url(
+        api_base=None,
+        api_key=None,
+        model="mantle/anthropic.claude-mythos-preview",
+        optional_params={"aws_region_name": valid_region},
+        litellm_params={},
+    )
+    assert url == f"https://bedrock-mantle.{valid_region}.api.aws/v1/messages"


### PR DESCRIPTION
## Relevant issues

n/a — operational hardening.

## Pre-Submission checklist

- [x] I have added tests in [\`tests/test_litellm/\`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm).
- [x] My PR passes \`make test-unit\` on the affected paths.
- [x] My PR's scope is one validator at one call site.
- [ ] I have requested a Greptile review by commenting \`@greptileai\` and received a Confidence Score of at least 4/5 before requesting a maintainer review.

## Type

🐛 Bug Fix

## Changes

The Bedrock Mantle (Claude Mythos Preview) \`/messages\` endpoint constructs its outbound URL via:

\`\`\`python
MANTLE_ENDPOINT_TEMPLATE = "https://bedrock-mantle.{region}.api.aws/v1/messages"
region = self._get_aws_region_name(optional_params=optional_params, model=model)
return MANTLE_ENDPOINT_TEMPLATE.format(region=region)
\`\`\`

\`aws_region_name\` is user-supplied via \`optional_params\` and the proxy merges user-provided params over deployment configuration, so the user controls the value. A region like \`us-east-1@attacker.example\` produces:

\`\`\`
https://bedrock-mantle.us-east-1@attacker.example.api.aws/v1/messages
\`\`\`

…which the URL parser reads as basic-auth userinfo \`bedrock-mantle.us-east-1@attacker.example\` against host \`api.aws\` — except more interestingly, a value like \`us-east-1@attacker.example/\` makes the host \`attacker.example\` directly. The proxy then SigV4-signs the request using the operator's AWS credentials and sends the prompt body + the operator's access-key-ID (in the \`Authorization\` header) to the attacker's server.

## Fix

A single \`re.fullmatch(r"^[a-z0-9-]+$", region)\` at the construction site, scoped to the one file that has the bug. The pattern:
- Accepts every documented AWS region: commercial (\`us-east-1\`, \`eu-west-3\`, \`ap-northeast-1\`), GovCloud (\`us-gov-east-1\`), ISO partitions (\`us-isob-east-1\`), and future numeric-suffixed regions (\`us-east-10\`).
- Rejects \`@\` (userinfo), \`/\` (path), \`:\` (port), \`%\` (percent-encoded delimiters), \`.\` (subdomain hop), and whitespace / control chars (CRLF header smuggling).

I deliberately scope the validator narrowly to \`mantle_transformation.py\` rather than the shared \`_get_aws_region_name\` helper (which is used by all Bedrock paths) — the bug is specific to URL-template construction, and broadening risks regressions on Bedrock SigV4 paths that currently accept exotic region values.

## Backwards compat

| Path | Impact |
|---|---|
| Standard region values (\`us-east-1\`, etc.) | Zero — pattern accepts every documented AWS region shape |
| GovCloud / ISO partition deployments | Zero — pattern accepts \`us-gov-*\`, \`us-iso*-*\` |
| Future regions with longer numerics (\`us-east-10\`) | Zero — pattern accepts |
| Caller passing exotic region values (e.g. ARNs) into Mantle | Now errors with a descriptive message. None known. |
| All other Bedrock routes (Invoke, Converse, etc.) | Zero — fix scoped to Mantle only |

## Tests

\`tests/test_litellm/llms/bedrock/test_mantle.py\`:
- 9 parametrized malicious-region cases (userinfo injection, path injection, percent-encoded variants, CRLF, subdomain hop, empty string).
- 8 parametrized valid-region cases (commercial, GovCloud, ISO, numeric-suffixed).

27/27 in the file pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)