### PR TITLE
fix(proxy): respect store_model_in_db=False during periodic DB model sync

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4964,7 +4964,7 @@ class ProxyConfig:
         - Check if model id's in router already
         - If not, add to router
         """
-        global llm_router, llm_model_list, master_key, general_settings
+        global llm_router, llm_model_list, master_key, general_settings, store_model_in_db
 
         try:
             # warm the config cache so the per-param reads below all hit
@@ -4980,8 +4980,21 @@ class ProxyConfig:
                 ],
             )
 
-            # Only load models from DB if "models" is in supported_db_objects (or if supported_db_objects is not set)
-            if self._should_load_db_object(object_type="models"):
+            # Only load models from DB if:
+            #   1. store_model_in_db is enabled (the flag's documented purpose is
+            #      "allow saving / managing models in DB"); when disabled, the
+            #      DB must not be the source of truth for models, otherwise a
+            #      stale row in LiteLLM_ProxyModelTable can silently replace
+            #      models defined in config.yaml on every periodic sync.
+            #   2. "models" is in supported_db_objects (or supported_db_objects
+            #      is not set, preserving the existing fine-grained gate).
+            store_model_in_db_enabled = (
+                general_settings.get("store_model_in_db", False) is True
+                or store_model_in_db
+            )
+            if store_model_in_db_enabled and self._should_load_db_object(
+                object_type="models"
+            ):
                 new_models = await self._get_models_from_db(prisma_client=prisma_client)
 
                 # update llm router

--- a/tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py
+++ b/tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py
@@ -1,0 +1,210 @@
+"""
+Test that ProxyConfig.add_deployment honours store_model_in_db.
+
+Regression test for: when store_model_in_db is False the periodic DB sync
+must not pull models from LiteLLM_ProxyModelTable. Previously the gate was
+only on `_should_load_db_object("models")` (default-on), so a stray UI-added
+row could replace config.yaml models on every sync — silently wiping out
+deployments declared in config.
+
+Documented behaviour of `store_model_in_db`:
+"Allow saving / managing models in DB" — when disabled, the DB is not the
+source of truth for models.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from litellm.proxy.proxy_server import ProxyConfig
+
+
+class TestAddDeploymentStoreModelInDB:
+    """Test add_deployment respects store_model_in_db before reading DB models."""
+
+    @pytest.mark.asyncio
+    async def test_skips_db_model_load_when_store_model_in_db_false(self):
+        """When store_model_in_db=False (config.yaml), no DB sync of models."""
+        proxy_config = ProxyConfig()
+
+        with (
+            patch.object(
+                proxy_config,
+                "_get_models_from_db",
+                new_callable=AsyncMock,
+            ) as mock_get_models,
+            patch.object(
+                proxy_config,
+                "_update_llm_router",
+                new_callable=AsyncMock,
+            ) as mock_update_router,
+            patch.object(
+                proxy_config,
+                "_init_non_llm_objects_in_db",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prefetch_config_params",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.get_config_param",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.general_settings",
+                {"store_model_in_db": False},
+            ),
+            patch("litellm.proxy.proxy_server.store_model_in_db", False),
+        ):
+            await proxy_config.add_deployment(
+                prisma_client=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+
+            mock_get_models.assert_not_called()
+            mock_update_router.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_loads_db_models_when_store_model_in_db_true(self):
+        """When store_model_in_db=True (config.yaml), DB sync runs as before."""
+        proxy_config = ProxyConfig()
+
+        db_models = [MagicMock(model_id="db-id-1", model_name="some-model")]
+
+        with (
+            patch.object(
+                proxy_config,
+                "_get_models_from_db",
+                new_callable=AsyncMock,
+                return_value=db_models,
+            ) as mock_get_models,
+            patch.object(
+                proxy_config,
+                "_update_llm_router",
+                new_callable=AsyncMock,
+            ) as mock_update_router,
+            patch.object(
+                proxy_config,
+                "_init_non_llm_objects_in_db",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prefetch_config_params",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.get_config_param",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.general_settings",
+                {"store_model_in_db": True},
+            ),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+        ):
+            await proxy_config.add_deployment(
+                prisma_client=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+
+            mock_get_models.assert_called_once()
+            mock_update_router.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_loads_db_models_when_module_global_true(self):
+        """
+        Env var path (STORE_MODEL_IN_DB=True) sets the module-level
+        `store_model_in_db` global. Must still trigger DB sync even when
+        general_settings does not explicitly set the key.
+        """
+        proxy_config = ProxyConfig()
+
+        with (
+            patch.object(
+                proxy_config,
+                "_get_models_from_db",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_get_models,
+            patch.object(
+                proxy_config,
+                "_update_llm_router",
+                new_callable=AsyncMock,
+            ) as mock_update_router,
+            patch.object(
+                proxy_config,
+                "_init_non_llm_objects_in_db",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prefetch_config_params",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.get_config_param",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+        ):
+            await proxy_config.add_deployment(
+                prisma_client=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+
+            mock_get_models.assert_called_once()
+            mock_update_router.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_supported_db_objects_gate_still_applies(self):
+        """
+        Even with store_model_in_db=True, an explicit supported_db_objects list
+        that omits "models" must still skip the DB sync. This preserves the
+        existing fine-grained gate.
+        """
+        proxy_config = ProxyConfig()
+
+        with (
+            patch.object(
+                proxy_config,
+                "_get_models_from_db",
+                new_callable=AsyncMock,
+            ) as mock_get_models,
+            patch.object(
+                proxy_config,
+                "_update_llm_router",
+                new_callable=AsyncMock,
+            ) as mock_update_router,
+            patch.object(
+                proxy_config,
+                "_init_non_llm_objects_in_db",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prefetch_config_params",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.get_config_param",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.general_settings",
+                {
+                    "store_model_in_db": True,
+                    "supported_db_objects": ["mcp", "guardrails"],
+                },
+            ),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+        ):
+            await proxy_config.add_deployment(
+                prisma_client=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+
+            mock_get_models.assert_not_called()
+            mock_update_router.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Reproduces on `main`. Did not find an existing issue tracking this specific symptom — happy to file one if maintainers prefer the issue-first flow.

## Summary

When `general_settings.store_model_in_db: False` is set in `config.yaml`, the periodic DB sync (`ProxyConfig.add_deployment`) still reads models from `LiteLLM_ProxyModelTable` and replaces the in-memory router state. A stray row in that table — left over from a UI add before the flag was toggled, or from a previous deployment — silently wipes config-defined models from `/v1/models` on every sync cycle.

The flag's documented purpose is "allow saving / managing models in DB". When disabled, the DB should not be the source of truth for models. `/model/new` already enforces this on writes (`store_model_in_db is True` check at `model_management_endpoints.py`). This PR brings reads in line with the same semantic.

## Root cause

`add_deployment` only gates DB model loading on `_should_load_db_object("models")`, which defaults to `True` when `general_settings.supported_db_objects` is unset (the common case). The `store_model_in_db` flag is not consulted on the read path:

```python
# proxy_server.py (before)
if self._should_load_db_object(object_type="models"):
    new_models = await self._get_models_from_db(prisma_client=prisma_client)
    await self._update_llm_router(new_models=new_models, ...)
```

`_update_llm_router` then calls `_delete_deployment` with the DB list, which removes any router deployment whose ID isn't in the combined DB+config ID list. In practice, config-recomputed IDs don't always match the IDs originally registered at startup (for reasons orthogonal to this PR), and YAML deployments end up deleted.

## Fix

Add `store_model_in_db` to the read-path gate. When the flag is `False`, the DB sync is skipped entirely — `config.yaml` is the sole source of truth for models. When `True`, behavior is unchanged.

```python
# proxy_server.py (after)
store_model_in_db_enabled = (
    general_settings.get("store_model_in_db", False) is True
    or store_model_in_db
)
if store_model_in_db_enabled and self._should_load_db_object(
    object_type="models"
):
    new_models = await self._get_models_from_db(prisma_client=prisma_client)
    await self._update_llm_router(new_models=new_models, ...)
```

The dual check (`general_settings` dict + module-level `store_model_in_db`) mirrors the existing pattern at `proxy_server.py:2834-2835`, which honors both the env var path (`STORE_MODEL_IN_DB=True`) and the config.yaml path.

The `_should_load_db_object` gate is preserved for users who set `store_model_in_db: True` but want fine-grained control via `supported_db_objects`.

## Reproduction

1. `config.yaml`:
   ```yaml
   general_settings:
     store_model_in_db: false
   model_list:
     - model_name: my-azure
       litellm_params:
         model: azure/gpt-4o
         api_base: https://example.openai.azure.com
         api_key: os.environ/AZURE_API_KEY
         api_version: "2024-10-21"
   ```
2. Insert any row into `LiteLLM_ProxyModelTable` (e.g. via `/model/new` while the flag was previously `True`, or by direct SQL).
3. Start the proxy. Logs show `my-azure` loaded; `GET /v1/models` initially includes it.
4. Wait one sync cycle (default ~10s).
5. `GET /v1/models` no longer includes `my-azure` — only the DB row remains.

After this PR, `my-azure` stays in `/v1/models` indefinitely, regardless of what's in `LiteLLM_ProxyModelTable`.

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py`
- [x] My PR passes all unit tests in the touched area (4 new tests + 5 adjacent tests in `test_update_llm_router_resilience.py` and `test_should_load_db_object_with_supported_db_objects` all green)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Tests

`tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py` covers:

1. `store_model_in_db=False` (config) → no DB sync of models
2. `store_model_in_db=True` (config) → DB sync runs as before
3. Module-level `store_model_in_db=True` (env var path) → DB sync runs
4. `store_model_in_db=True` + `supported_db_objects=["mcp"]` → DB sync still skipped (existing fine-grained gate preserved)

```
tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py::TestAddDeploymentStoreModelInDB::test_loads_db_models_when_module_global_true PASSED
tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py::TestAddDeploymentStoreModelInDB::test_loads_db_models_when_store_model_in_db_true PASSED
tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py::TestAddDeploymentStoreModelInDB::test_skips_db_model_load_when_store_model_in_db_false PASSED
tests/test_litellm/proxy/test_add_deployment_store_model_in_db.py::TestAddDeploymentStoreModelInDB::test_supported_db_objects_gate_still_applies PASSED
```

## Type

- Bug Fix

## Backward compatibility

Default behavior (no `store_model_in_db` set, or `store_model_in_db: True`) is unchanged. Only deployments that explicitly set `store_model_in_db: False` see new behavior — and that new behavior matches the documented intent of the flag.

## Out of scope (follow-up)

There is a separate, deeper issue with config-vs-DB model coexistence even when `store_model_in_db: True`: `_delete_deployment` recomputes config model IDs via `_generate_model_id` using `litellm_params` with `os.environ/` values already resolved, which doesn't always match the IDs registered at startup, leading to YAML deployments being treated as orphans. That requires a more invasive change (deployment origin tracking, or making `_generate_model_id` invariant under env interpolation) and is best handled in a separate PR with maintainer input on the desired semantics.