### PR TITLE
[Fix] Tests: Move Misplaced Import in Lazy OpenAPI Snapshot Test

### DIFF
--- a/tests/test_litellm/proxy/test_lazy_openapi_snapshot.py
+++ b/tests/test_litellm/proxy/test_lazy_openapi_snapshot.py
@@ -1,6 +1,8 @@
 import sys
 from types import ModuleType, SimpleNamespace
 
+from litellm.proxy._lazy_openapi_snapshot import _normalize_operation_ids
+
 
 def test_generate_snapshot_uses_shared_operation_id_reservations(monkeypatch):
     from litellm.proxy import _lazy_openapi_snapshot
@@ -80,7 +82,6 @@ def test_generate_snapshot_uses_shared_operation_id_reservations(monkeypatch):
     assert fragments["feature-b"]["paths"]["/feature-b/items"]["get"]["tags"] == [
         "feature-b"
     ]
-from litellm.proxy._lazy_openapi_snapshot import _normalize_operation_ids
 
 
 def test_normalize_operation_ids_uses_each_http_method():


### PR DESCRIPTION
## Summary

- The GitHub merge conflict resolver concatenated both test sets correctly when PR #26963 merged, but left `from litellm.proxy._lazy_openapi_snapshot import _normalize_operation_ids` stranded between functions on line 83 instead of at the top of the file.
- Moved the import up with the other module-level imports.

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/test_lazy_openapi_snapshot.py -v` — all 3 tests pass