### PR TITLE
[Fix] Tests: Align Bedrock count-tokens endpoint assertions with URL-encoded model id

### DIFF
--- a/tests/litellm_utils_tests/test_bedrock_token_counter.py
+++ b/tests/litellm_utils_tests/test_bedrock_token_counter.py
@@ -130,7 +130,7 @@ class TestBedrockCountTokensEndpoint:
         )
         assert (
             url
-            == "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.nova-lite-v1:0/count-tokens"
+            == "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.nova-lite-v1%3A0/count-tokens"
         )
 
     def test_api_base_overrides_default(self):
@@ -141,7 +141,7 @@ class TestBedrockCountTokensEndpoint:
             aws_region_name="us-east-1",
             api_base=custom_base,
         )
-        assert url == f"{custom_base}/model/amazon.nova-lite-v1:0/count-tokens"
+        assert url == f"{custom_base}/model/amazon.nova-lite-v1%3A0/count-tokens"
 
     def test_aws_bedrock_runtime_endpoint_overrides_default(self):
         handler = self._make_handler()
@@ -153,7 +153,7 @@ class TestBedrockCountTokensEndpoint:
             aws_region_name="eu-west-1",
             aws_bedrock_runtime_endpoint=custom_endpoint,
         )
-        assert url == f"{custom_endpoint}/model/amazon.nova-lite-v1:0/count-tokens"
+        assert url == f"{custom_endpoint}/model/amazon.nova-lite-v1%3A0/count-tokens"
 
     def test_api_base_takes_priority_over_aws_bedrock_runtime_endpoint(self):
         handler = self._make_handler()
@@ -165,7 +165,7 @@ class TestBedrockCountTokensEndpoint:
             api_base=api_base,
             aws_bedrock_runtime_endpoint=runtime_endpoint,
         )
-        assert url == f"{api_base}/model/amazon.nova-lite-v1:0/count-tokens"
+        assert url == f"{api_base}/model/amazon.nova-lite-v1%3A0/count-tokens"
 
     def test_env_var_overrides_default(self, monkeypatch):
         monkeypatch.setenv(


### PR DESCRIPTION
## Summary
- The endpoint builder `BedrockCountTokensConfig.get_bedrock_count_tokens_endpoint` percent-encodes the model id as a single path segment (introduced in d4dd865b1a — path-traversal hardening).
- Four assertions in `TestBedrockCountTokensEndpoint` predate that fix and still expect the raw `amazon.nova-lite-v1:0` in the URL, so they now fail (e.g. [job 1597616](https://app.circleci.com/pipelines/github/BerriAI/litellm/76069/workflows/9bf954fd-1382-4513-9872-8cec58c87bf7/jobs/1597616/tests)).
- Update the four assertions to expect `amazon.nova-lite-v1%3A0`, matching production behavior already covered by `test_count_tokens_endpoint_encodes_model_id` in `tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py`.

No production code change.

## Test plan
- [x] `uv run pytest tests/litellm_utils_tests/test_bedrock_token_counter.py::TestBedrockCountTokensEndpoint -v` — all 5 pass locally
- [ ] CI green