### PR TITLE
Fix Redis key generation to be stable across working directories

### DIFF
--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -13,6 +13,8 @@ CASSETTE_REDIS_URL_ENV = "CASSETTE_REDIS_URL"
 VCR_VERBOSE_ENV = "LITELLM_VCR_VERBOSE"
 MAX_EPISODES_PER_CASSETTE = 50
 
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 _log = logging.getLogger(__name__)
 _passed_by_cassette_key: dict[str, bool] = {}
 
@@ -22,7 +24,11 @@ def mark_test_outcome_for_cassette(cassette_path: str, passed: bool) -> None:
 
 
 def redis_key_for(cassette_path: str) -> str:
-    rel = os.path.relpath(str(cassette_path))
+    abs_path = os.path.abspath(str(cassette_path))
+    try:
+        rel = os.path.relpath(abs_path, start=_REPO_ROOT)
+    except ValueError:
+        rel = os.path.basename(abs_path)
     if rel.endswith(".yaml"):
         rel = rel[: -len(".yaml")]
     rel = rel.replace("/cassettes/", "/").lstrip("./")

--- a/tests/llm_translation/test_vcr_redis_persister.py
+++ b/tests/llm_translation/test_vcr_redis_persister.py
@@ -81,6 +81,31 @@ def test_redis_key_normalizes_path_passed_by_pytest_recording():
     )
 
 
+def test_redis_key_is_stable_across_working_directories(tmp_path, monkeypatch):
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    abs_cassette = os.path.join(
+        repo_root,
+        "tests/llm_translation/cassettes/test_anthropic/test_streaming.yaml",
+    )
+
+    monkeypatch.chdir(repo_root)
+    key_from_root = redis_key_for(abs_cassette)
+
+    monkeypatch.chdir(os.path.join(repo_root, "tests", "llm_translation"))
+    key_from_subdir = redis_key_for(abs_cassette)
+
+    monkeypatch.chdir(tmp_path)
+    key_from_tmp = redis_key_for(abs_cassette)
+
+    assert key_from_root == key_from_subdir == key_from_tmp
+    assert (
+        key_from_root
+        == "litellm:vcr:cassette:tests/llm_translation/test_anthropic/test_streaming"
+    )
+
+
 class _FlakyRedis:
     def __init__(self, inner, fail_on: str):
         self._inner = inner


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have added testing in the tests directory
- [x] My PR's scope is isolated - fixes Redis key stability issue
- [x] Added comprehensive test case for the fix

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem
The `redis_key_for()` function was generating different Redis keys for the same cassette file depending on the current working directory. This caused cache misses and inconsistent behavior when tests were run from different directories.

### Solution
Modified `redis_key_for()` in `tests/_vcr_redis_persister.py` to:
1. Convert the cassette path to an absolute path first
2. Calculate the relative path from the repository root (stored in `_REPO_ROOT`) instead of the current working directory
3. Handle edge cases where the path is outside the repo root by falling back to the basename

### Testing
Added `test_redis_key_is_stable_across_working_directories()` in `tests/llm_translation/test_vcr_redis_persister.py` that:
- Verifies the Redis key is identical when generated from the repo root, a subdirectory, and a temporary directory
- Confirms the key format matches the expected pattern: `litellm:vcr:cassette:tests/llm_translation/test_anthropic/test_streaming`

This ensures VCR cassette caching works reliably regardless of where tests are executed from.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777677963675299?thread_ts=1777677963.675299&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-9e481710-7451-5ec4-bcc6-4e539ff3d88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e481710-7451-5ec4-bcc6-4e539ff3d88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

