### PR TITLE
Fix runtime policy attachment initialization

### DIFF
--- a/litellm/proxy/policy_engine/attachment_registry.py
+++ b/litellm/proxy/policy_engine/attachment_registry.py
@@ -220,6 +220,7 @@ class AttachmentRegistry:
             attachment: PolicyAttachment object to add
         """
         self._attachments.append(attachment)
+        self._initialized = True
         verbose_proxy_logger.debug(f"Added attachment for policy: {attachment.policy}")
 
     def remove_attachments_for_policy(self, policy_name: str) -> int:

--- a/litellm/proxy/policy_engine/policy_registry.py
+++ b/litellm/proxy/policy_engine/policy_registry.py
@@ -226,6 +226,7 @@ class PolicyRegistry:
             policy: Policy object to add
         """
         self._policies[policy_name] = policy
+        self._initialized = True
         verbose_proxy_logger.debug(f"Added/updated policy: {policy_name}")
 
     def remove_policy(self, policy_name: str) -> bool:

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2871,6 +2871,7 @@ async def test_api_created_global_policy_applies_to_new_key_without_restart():
     policy_registry = get_policy_registry()
     attachment_registry = get_attachment_registry()
     policy_registry._policies = {}
+    policy_registry._policies_by_id = {}
     policy_registry._initialized = False
     attachment_registry._attachments = []
     attachment_registry._initialized = False
@@ -2894,6 +2895,7 @@ async def test_api_created_global_policy_applies_to_new_key_without_restart():
         assert "runtime-global-policy" in data["metadata"]["applied_policies"]
     finally:
         policy_registry._policies = {}
+        policy_registry._policies_by_id = {}
         policy_registry._initialized = False
         attachment_registry._attachments = []
         attachment_registry._initialized = False

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2847,6 +2847,59 @@ async def test_add_guardrails_from_policy_engine_accepts_dynamic_policies_and_po
 
 
 @pytest.mark.asyncio
+async def test_api_created_global_policy_applies_to_new_key_without_restart():
+    """
+    Regression: policies created at runtime via policy builder must apply
+    immediately when attached globally, even if the server started with no
+    initialized policy config.
+    """
+    from litellm.proxy.policy_engine.attachment_registry import get_attachment_registry
+    from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+    from litellm.types.proxy.policy_engine import (
+        Policy,
+        PolicyAttachment,
+        PolicyGuardrails,
+    )
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {},
+    }
+    user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+    policy_registry = get_policy_registry()
+    attachment_registry = get_attachment_registry()
+    policy_registry._policies = {}
+    policy_registry._initialized = False
+    attachment_registry._attachments = []
+    attachment_registry._initialized = False
+
+    try:
+        policy_registry.add_policy(
+            "runtime-global-policy",
+            Policy(guardrails=PolicyGuardrails(add=["runtime-guardrail"])),
+        )
+        attachment_registry.add_attachment(
+            PolicyAttachment(policy="runtime-global-policy", scope="*")
+        )
+
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        assert "runtime-guardrail" in data["metadata"]["guardrails"]
+        assert "runtime-global-policy" in data["metadata"]["applied_policies"]
+    finally:
+        policy_registry._policies = {}
+        policy_registry._initialized = False
+        attachment_registry._attachments = []
+        attachment_registry._initialized = False
+
+
+@pytest.mark.asyncio
 async def test_add_guardrails_from_policy_engine_policy_version_by_id():
     """
     Test that add_guardrails_from_policy_engine executes a specific policy version


### PR DESCRIPTION
Resolves LIT-2770
Description
This PR fixes a policy engine issue where policies created at runtime through the policy builder could fail to apply after creating a global attachment and then generating a key.

The policy and attachment were added to the in-memory registries, but the registries could still be marked as uninitialized. When a request used the new key, the policy engine saw the registry as uninitialized and skipped policy matching, so the global policy was not applied.

Cause
Runtime-created policies and attachments updated the registry contents but did not update the registry initialization state.

This meant a proxy that started with no initialized policy config could later have valid policies and attachments in memory, while still reporting is_initialized() == False.

Fix
Mark registries initialized when adding runtime objects:

PolicyRegistry.add_policy() now sets _initialized = True
AttachmentRegistry.add_attachment() now sets _initialized = True
Added a regression test covering:

Policy builder policy → global attachment → new key/request → policy guardrail applies without restart.

<img width="1221" height="703" alt="Screenshot 2026-05-01 at 5 31 45 PM" src="https://github.com/user-attachments/assets/097937b5-3c8a-40e8-997d-c5c3d92fd31c" />

<img width="1485" height="846" alt="Screenshot 2026-05-01 at 5 32 09 PM" src="https://github.com/user-attachments/assets/79ea310b-a825-4ef1-be4e-620f17a333d9" />

<img width="1492" height="825" alt="Screenshot 2026-05-01 at 5 32 19 PM" src="https://github.com/user-attachments/assets/05fbf3c7-bbf2-486b-aa4c-6258b0bc36c5" />
