### PR TITLE
fix(proxy): wire general_settings url-validation settings to litellm globals

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4060,6 +4060,15 @@ class ProxyConfig:
                 raise ValueError(
                     "allowed_ips is an Enterprise Feature. Please add a valid LITELLM_LICENSE to your envionment."
                 )
+            ## URL VALIDATION SETTINGS ##
+            _user_url_validation = general_settings.get("user_url_validation", None)
+            if _user_url_validation is not None:
+                litellm.user_url_validation = bool(_user_url_validation)
+            _user_url_allowed_hosts = general_settings.get(
+                "user_url_allowed_hosts", None
+            )
+            if _user_url_allowed_hosts is not None:
+                litellm.user_url_allowed_hosts = list(_user_url_allowed_hosts)
             ## BUDGET RESCHEDULER ##
             proxy_budget_rescheduler_min_time = general_settings.get(
                 "proxy_budget_rescheduler_min_time", proxy_budget_rescheduler_min_time

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4074,7 +4074,10 @@ class ProxyConfig:
                 "user_url_allowed_hosts", None
             )
             if _user_url_allowed_hosts is not None:
-                litellm.user_url_allowed_hosts = list(_user_url_allowed_hosts)
+                if isinstance(_user_url_allowed_hosts, str):
+                    litellm.user_url_allowed_hosts = [_user_url_allowed_hosts]
+                else:
+                    litellm.user_url_allowed_hosts = list(_user_url_allowed_hosts)
             ## BUDGET RESCHEDULER ##
             proxy_budget_rescheduler_min_time = general_settings.get(
                 "proxy_budget_rescheduler_min_time", proxy_budget_rescheduler_min_time

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4063,7 +4063,13 @@ class ProxyConfig:
             ## URL VALIDATION SETTINGS ##
             _user_url_validation = general_settings.get("user_url_validation", None)
             if _user_url_validation is not None:
-                litellm.user_url_validation = bool(_user_url_validation)
+                if isinstance(_user_url_validation, str):
+                    litellm.user_url_validation = (
+                        _user_url_validation.strip().lower()
+                        not in ("false", "0", "no", "off")
+                    )
+                else:
+                    litellm.user_url_validation = bool(_user_url_validation)
             _user_url_allowed_hosts = general_settings.get(
                 "user_url_allowed_hosts", None
             )

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -316,3 +316,57 @@ async def test_json_logs_calls_turn_on_json():
         # Cleanup
         os.unlink(temp_file_path)
         litellm.json_logs = False
+
+
+@pytest.mark.asyncio
+async def test_general_settings_url_validation_wired_to_litellm():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/26599
+
+    user_url_validation and user_url_allowed_hosts set in general_settings must be
+    propagated to litellm module globals so that url_utils.validate_url /
+    safe_get / async_safe_get honour them at runtime.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "general_settings": {
+            "user_url_validation": False,
+            "user_url_allowed_hosts": ["10.80.1.20", "internal.corp"],
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    original_validation = litellm.user_url_validation
+    original_hosts = litellm.user_url_allowed_hosts
+
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=None,
+            config_file_path=temp_file_path,
+        )
+
+        assert litellm.user_url_validation is False, (
+            "user_url_validation from general_settings should set litellm.user_url_validation"
+        )
+        assert litellm.user_url_allowed_hosts == ["10.80.1.20", "internal.corp"], (
+            "user_url_allowed_hosts from general_settings should set litellm.user_url_allowed_hosts"
+        )
+    finally:
+        os.unlink(temp_file_path)
+        litellm.user_url_validation = original_validation
+        litellm.user_url_allowed_hosts = original_hosts

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -360,13 +360,77 @@ async def test_general_settings_url_validation_wired_to_litellm():
             config_file_path=temp_file_path,
         )
 
-        assert litellm.user_url_validation is False, (
-            "user_url_validation from general_settings should set litellm.user_url_validation"
-        )
-        assert litellm.user_url_allowed_hosts == ["10.80.1.20", "internal.corp"], (
-            "user_url_allowed_hosts from general_settings should set litellm.user_url_allowed_hosts"
-        )
+        assert (
+            litellm.user_url_validation is False
+        ), "user_url_validation from general_settings should set litellm.user_url_validation"
+        assert litellm.user_url_allowed_hosts == [
+            "10.80.1.20",
+            "internal.corp",
+        ], "user_url_allowed_hosts from general_settings should set litellm.user_url_allowed_hosts"
     finally:
         os.unlink(temp_file_path)
         litellm.user_url_validation = original_validation
         litellm.user_url_allowed_hosts = original_hosts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+    ],
+)
+async def test_general_settings_url_validation_string_value(raw_value, expected):
+    """
+    A quoted string value for user_url_validation in YAML must be interpreted
+    as a boolean rather than always coerced to True via bool(str). Otherwise
+    operators who write `user_url_validation: "false"` silently keep
+    validation enabled.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "general_settings": {
+            "user_url_validation": raw_value,
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    original_validation = litellm.user_url_validation
+
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=None,
+            config_file_path=temp_file_path,
+        )
+
+        assert litellm.user_url_validation is expected, (
+            f"user_url_validation={raw_value!r} should resolve to {expected}, "
+            f"got {litellm.user_url_validation!r}"
+        )
+    finally:
+        os.unlink(temp_file_path)
+        litellm.user_url_validation = original_validation

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -434,3 +434,52 @@ async def test_general_settings_url_validation_string_value(raw_value, expected)
     finally:
         os.unlink(temp_file_path)
         litellm.user_url_validation = original_validation
+
+
+@pytest.mark.asyncio
+async def test_general_settings_url_allowed_hosts_bare_string():
+    """
+    A bare string value for user_url_allowed_hosts in YAML must be wrapped in
+    a one-element list rather than passed through list(...), which would split
+    it into characters. Operators following the SSRFError hint may write
+    `user_url_allowed_hosts: internal.corp` and reasonably expect that single
+    host to be allowlisted.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "general_settings": {
+            "user_url_allowed_hosts": "internal.corp",
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    original_hosts = litellm.user_url_allowed_hosts
+
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=None,
+            config_file_path=temp_file_path,
+        )
+
+        assert litellm.user_url_allowed_hosts == ["internal.corp"], (
+            "Bare-string user_url_allowed_hosts must be wrapped as a one-element "
+            f"list, not split into characters. Got {litellm.user_url_allowed_hosts!r}"
+        )
+    finally:
+        os.unlink(temp_file_path)
+        litellm.user_url_allowed_hosts = original_hosts


### PR DESCRIPTION
## Summary

PR #25906 added `user_url_validation` and `user_url_allowed_hosts` as `litellm` module globals and wired them into `url_utils.validate_url` / `safe_get` / `async_safe_get`. However, the config-loading code only sets `litellm.*` globals from the `litellm_settings` YAML section; there was no corresponding read from `general_settings`. As a result, operators who follow the in-code documentation (and the hint in the `SSRFError` message: _"add the host to `user_url_allowed_hosts` in general_settings"_) found that their config had no effect at runtime. This patch reads both settings from `general_settings` and applies them to `litellm.user_url_validation` / `litellm.user_url_allowed_hosts` during startup, matching the documented behavior.

## Issue

Fixes #26599

## Local verification

```bash
# Run new regression test
python -m pytest tests/proxy_unit_tests/test_proxy_config_unit_test.py::test_general_settings_url_validation_wired_to_litellm -xvs

# Run full url_utils unit-test suite
python -m pytest tests/test_litellm/litellm_core_utils/test_url_utils.py -v
```

Last lines of output:
```
tests/proxy_unit_tests/test_proxy_config_unit_test.py::test_general_settings_url_validation_wired_to_litellm PASSED
...
65 passed in 2.92s

=== LOCAL_TEST_PASSED ===
```

## Risk

Minimal. The change is additive — it only applies the two settings when they are explicitly present in `general_settings`; if absent, the existing `litellm` module defaults (`user_url_validation=True`, `user_url_allowed_hosts=[]`) are preserved unchanged. Operators who were already using `litellm_settings` for these keys continue to work as before. The only observable change is that `general_settings`-based configs that were previously silently ignored now take effect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF-related URL validation toggles and allowlists; while scoped and only applied when explicitly configured, misconfiguration could weaken protections or change outbound fetch behavior.
> 
> **Overview**
> Wires `general_settings.user_url_validation` and `general_settings.user_url_allowed_hosts` into `litellm.user_url_validation` / `litellm.user_url_allowed_hosts` during proxy startup so runtime URL fetching honors the documented settings.
> 
> Adds regression tests ensuring these keys propagate correctly, and that YAML edge cases are handled safely (string booleans like `"false"` parse correctly, and a bare-string host is wrapped as a single-element list rather than split into characters).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf57ba6b941fa1037fa8581a6b102dc29bd97c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->