### PR TITLE
fix(vertex-ai): set response=null on batch error entries per OpenAI spec

### DIFF
--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -731,25 +731,13 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
         has_error = bool(status)
 
         if has_error:
-            # Return error response in OpenAI format
             return {
                 "id": f"batch_req_{uuid.uuid4()}",
                 "custom_id": custom_id,
-                "response": {
-                    "status_code": 400,
-                    "request_id": "",
-                    "body": {
-                        "error": {
-                            "message": status,
-                            "type": "vertex_ai_error",
-                            "code": "vertex_ai_error",
-                        }
-                    },
-                },
+                "response": None,
                 "error": {
-                    "message": status,
-                    "type": "vertex_ai_error",
                     "code": "vertex_ai_error",
+                    "message": status,
                 },
             }
 
@@ -789,25 +777,13 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             }
 
         except Exception as e:
-            # If transformation fails, return error
             return {
                 "id": f"batch_req_{uuid.uuid4()}",
                 "custom_id": custom_id,
-                "response": {
-                    "status_code": 500,
-                    "request_id": "",
-                    "body": {
-                        "error": {
-                            "message": f"Failed to transform response: {str(e)}",
-                            "type": "transformation_error",
-                            "code": "transformation_error",
-                        }
-                    },
-                },
+                "response": None,
                 "error": {
-                    "message": f"Failed to transform response: {str(e)}",
-                    "type": "transformation_error",
                     "code": "transformation_error",
+                    "message": f"Failed to transform response: {str(e)}",
                 },
             }
 

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
@@ -439,6 +439,53 @@ class TestVertexBatchOutputTransformation:
         assert result["error"]["code"] == "vertex_ai_error"
         assert result["custom_id"] == "request-error"
 
+    def test_transform_exception_path_sets_response_null(self, config):
+        """
+        The except-Exception branch in _transform_single_vertex_batch_output_to_openai
+        must also emit response=null per the OpenAI Batch output spec. The outer
+        _try_transform path swallows exceptions and falls back to original content,
+        so this test invokes the single-line transformer directly with a vertex_gemini_config
+        stub that raises during transformation.
+        """
+        from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+            VertexGeminiConfig,
+        )
+
+        vertex_output = {
+            "status": "",
+            "processed_time": "2024-11-01T18:13:16.826+00:00",
+            "request": {
+                "contents": [{"role": "user", "parts": [{"text": "Hello world!"}]}],
+                "labels": {"litellm_custom_id": "request-boom"},
+            },
+            "response": {"modelVersion": "gemini-2.0-flash-001@default"},
+        }
+
+        class _RaisingGeminiConfig(VertexGeminiConfig):
+            def _transform_google_generate_content_to_openai_model_response(
+                self, *args, **kwargs
+            ):
+                raise ValueError("simulated transform failure")
+
+        mock_response = httpx.Response(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            request=httpx.Request(method="POST", url="https://example.com"),
+        )
+
+        result = config._transform_single_vertex_batch_output_to_openai(
+            vertex_output=vertex_output,
+            vertex_gemini_config=_RaisingGeminiConfig(),
+            logging_obj=MagicMock(),
+            mock_httpx_response=mock_response,
+        )
+
+        assert result["response"] is None
+        assert result["error"] is not None
+        assert result["error"]["code"] == "transformation_error"
+        assert "simulated transform failure" in result["error"]["message"]
+        assert result["custom_id"] == "request-boom"
+
     def test_transform_vertex_batch_output_legacy_labels_only_sanitized(self, config):
         """Older LiteLLM batches only stored litellm_custom_id (sanitized); read path still works."""
         vertex_output = {

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
@@ -431,10 +431,12 @@ class TestVertexBatchOutputTransformation:
         )
         result = json.loads(transformed_content.decode("utf-8"))
 
-        # Verify error format
-        assert result["response"]["status_code"] == 400
+        # Per OpenAI Batch output spec, error entries set response to null
+        # and populate the top-level error object.
+        assert result["response"] is None
         assert result["error"] is not None
         assert "Invalid request" in result["error"]["message"]
+        assert result["error"]["code"] == "vertex_ai_error"
         assert result["custom_id"] == "request-error"
 
     def test_transform_vertex_batch_output_legacy_labels_only_sanitized(self, config):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fast-follow to #25627. The Vertex batch output transformer was emitting both a populated `response` and a populated `error` for failed batch entries. Per the OpenAI Batch output spec, those fields are mutually exclusive — on error, `response` MUST be `null`. This broke any consumer using the canonical `result["response"] is None` check to detect failures (they would see a truthy `{status_code: 400/500, body: {error: ...}}` object and treat failures as successes).

cc @Sameerlite — flagged by Greptile on #25627 as the unresolved P1; isolated to the error path.

## Changes
- `litellm/llms/vertex_ai/files/transformation.py`: both error returns in `_transform_single_vertex_batch_output_to_openai` (status-error path and transform-exception path) now set `response: None` and put the error solely in the top-level `error` object (`code` + `message`).
- `tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py`: `test_transform_error_vertex_batch_output` now asserts `result["response"] is None` and `result["error"]["code"] == "vertex_ai_error"`.

## Test
`uv run pytest tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py` — 36 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777709566427739?thread_ts=1777709566.427739&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-5eff5bff-4432-5443-b803-0f88b77e46dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eff5bff-4432-5443-b803-0f88b77e46dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

