### PR TITLE
docs: clarify ollama_chat usage to avoid empty responses

### DIFF
--- a/docs/my-website/docs/providers/ollama.md
+++ b/docs/my-website/docs/providers/ollama.md
@@ -12,6 +12,10 @@ LiteLLM supports all models from [Ollama](https://github.com/ollama/ollama)
 
 We recommend using [ollama_chat](#using-ollama-apichat) for better responses.
 
+In chat-based workflows (e.g. TUI or interactive agents), using `ollama/...` may lead to unexpected behavior such as empty responses (`{}`) or missing outputs.
+
+For consistent and stable behavior, use `ollama_chat/...` when working with chat-based models.
+
 :::
 
 ## Pre-requisites


### PR DESCRIPTION
## Relevant issues

N/A

## Type

📖 Documentation

## Changes

Improve Ollama provider documentation by clarifying that using `ollama/...` in chat-based workflows (e.g. TUI or agents) may lead to empty responses (`{}`) or missing outputs.

Recommend using `ollama_chat/...` for consistent and stable behavior.

## Screenshots / Proof of Fix

N/A (documentation-only change)