### PR TITLE
fix: guard end_user_id or-fallback with disable_end_user_cost_tracking flag

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -295,9 +295,10 @@ def get_logging_payload(  # noqa: PLR0915
             or standard_logging_payload["metadata"].get("user_api_key_hash")
             or ""
         )
-        end_user_id = end_user_id or standard_logging_payload["metadata"].get(
-            "user_api_key_end_user_id"
-        )
+        if not litellm.disable_end_user_cost_tracking:
+            end_user_id = end_user_id or standard_logging_payload["metadata"].get(
+                "user_api_key_end_user_id"
+            )
     # BUG FIX: Don't overwrite api_key when standard_logging_payload is None
     # The api_key was already extracted from metadata (line 243) and hashed (lines 256-259)
     request_tags = (

--- a/tests/logging_callback_tests/test_spend_logs.py
+++ b/tests/logging_callback_tests/test_spend_logs.py
@@ -558,3 +558,60 @@ def test_truncation_preserves_beginning_and_end():
     kept_chars = expected_start_chars + expected_end_chars
     expected_skipped = total_chars - kept_chars
     assert str(expected_skipped) in truncated_content
+
+
+def test_disable_end_user_cost_tracking_blocks_or_fallback():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/27038
+
+    When litellm.disable_end_user_cost_tracking=True, the or-fallback inside
+    get_logging_payload() must not repopulate end_user from
+    standard_logging_payload["metadata"]["user_api_key_end_user_id"].
+    """
+    original = litellm.disable_end_user_cost_tracking
+    try:
+        litellm.disable_end_user_cost_tracking = True
+
+        input_args: dict = {
+            "kwargs": {
+                "model": "gpt-3.5-turbo",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "litellm_params": {
+                    "metadata": {
+                        "user_api_key": "fake_key",
+                        "user_api_key_end_user_id": "should-be-blocked",
+                    }
+                },
+                "standard_logging_object": {
+                    "metadata": {
+                        "user_api_key_end_user_id": "should-be-blocked",
+                    },
+                    "request_tags": [],
+                    "model_map_information": {"tpm": 0, "rpm": 0},
+                },
+            },
+            "response_obj": litellm.ModelResponse(
+                id="chatcmpl-test-disable-end-user",
+                choices=[
+                    litellm.Choices(
+                        finish_reason="stop",
+                        index=0,
+                        message=litellm.Message(content="Hi", role="assistant"),
+                    )
+                ],
+                model="gpt-3.5-turbo",
+                usage=litellm.Usage(
+                    completion_tokens=1, prompt_tokens=1, total_tokens=2
+                ),
+            ),
+            "start_time": datetime.datetime.now(),
+            "end_time": datetime.datetime.now(),
+        }
+
+        payload: SpendLogsPayload = get_logging_payload(**input_args)
+
+        assert payload["end_user"] == "", (
+            f"Expected end_user='' when disable_end_user_cost_tracking=True, got {payload['end_user']!r}"
+        )
+    finally:
+        litellm.disable_end_user_cost_tracking = original


### PR DESCRIPTION
## Summary

`get_logging_payload()` in `spend_tracking_utils.py` uses an `or`-fallback to populate `end_user_id` from `standard_logging_payload["metadata"]["user_api_key_end_user_id"]`. This runs unconditionally, so even when `litellm.disable_end_user_cost_tracking=True` causes `get_end_user_id_for_cost_tracking()` to return `None`, the fallback immediately re-populates it — leaking end-user IDs into SpendLogs.

Fix: wrap the or-fallback in `if not litellm.disable_end_user_cost_tracking:` so the flag is honored end-to-end.

## Issue

Closes #27038

## Changes

- `litellm/proxy/spend_tracking/spend_tracking_utils.py`: wrap the `end_user_id` or-fallback in a `disable_end_user_cost_tracking` guard (3-line change)
- `tests/logging_callback_tests/test_spend_logs.py`: add `test_disable_end_user_cost_tracking_blocks_or_fallback` to verify `end_user` is `""` when the flag is set

## Local verification

```
$ ruff check litellm/proxy/spend_tracking/spend_tracking_utils.py
All checks passed!

$ python -m pytest tests/logging_callback_tests/test_spend_logs.py -x
======================== 10 passed in 6.56s ========================
```

=== LOCAL_TEST_PASSED ===

## Risk

Low. The change only adds a conditional guard around an existing fallback. All 10 existing spend-log tests continue to pass. The guard uses the same `litellm.disable_end_user_cost_tracking` attribute already checked by `get_end_user_id_for_cost_tracking()`, so behavior is consistent with the rest of the cost-tracking path.
