### PR TITLE
fix(reasoning_effort): raise BadRequestError(400) on invalid effort values

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -794,6 +794,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     def _map_reasoning_effort(
         reasoning_effort: Optional[Union[REASONING_EFFORT, str]],
         model: str,
+        llm_provider: str = "anthropic",
     ) -> Optional[AnthropicThinkingParam]:
         if reasoning_effort is None or reasoning_effort == "none":
             return None
@@ -824,7 +825,14 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 budget_tokens=DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET,
             )
         else:
-            raise ValueError(f"Unmapped reasoning effort: {reasoning_effort}")
+            raise litellm.BadRequestError(
+                message=(
+                    f"Invalid reasoning_effort value: {reasoning_effort!r}. "
+                    f"Must be one of: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'."
+                ),
+                model=model,
+                llm_provider=llm_provider,
+            )
 
     def _extract_json_schema_from_response_format(
         self, value: Optional[dict]
@@ -1089,7 +1097,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 optional_params["thinking"] = value
             elif param == "reasoning_effort" and isinstance(value, str):
                 optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
-                    reasoning_effort=value, model=model
+                    reasoning_effort=value,
+                    model=model,
+                    llm_provider=self.custom_llm_provider or "anthropic",
                 )
                 # For Claude 4.6+ models, effort is controlled via output_config,
                 # not thinking budget_tokens. Map reasoning_effort to output_config.
@@ -1529,10 +1539,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             return
         effort = output_config.get("effort")
         valid_efforts = ["high", "medium", "low", "xhigh", "max"]
+        provider = self.custom_llm_provider or "anthropic"
         if effort and effort not in valid_efforts:
-            raise ValueError(
-                f"Invalid effort value: {effort}. Must be one of: "
-                f"'high', 'medium', 'low', 'xhigh', 'max'"
+            raise litellm.BadRequestError(
+                message=(
+                    f"Invalid effort value: {effort!r}. Must be one of: "
+                    f"'high', 'medium', 'low', 'xhigh', 'max'."
+                ),
+                model=model,
+                llm_provider=provider,
             )
         # ``max`` is for Opus 4.6+ output effort (not Sonnet 4.6, not Opus 4.5).
         # Accept known Opus 4.6/4.7 id patterns and/or ``supports_max_reasoning_effort``
@@ -1542,14 +1557,22 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             or self._is_opus_4_7_model(model)
             or self._supports_effort_level(model, "max")
         ):
-            raise ValueError(
-                f"effort='max' is not supported by this model. Got model: {model}"
+            raise litellm.BadRequestError(
+                message=(
+                    f"effort='max' is not supported by this model. Got model: {model}"
+                ),
+                model=model,
+                llm_provider=provider,
             )
         # ``xhigh`` is data-driven via ``supports_xhigh_reasoning_effort`` so
         # enabling it for a new model is a pure model-map change.
         if effort == "xhigh" and not self._supports_effort_level(model, "xhigh"):
-            raise ValueError(
-                f"effort='xhigh' is not supported by this model. Got model: {model}"
+            raise litellm.BadRequestError(
+                message=(
+                    f"effort='xhigh' is not supported by this model. Got model: {model}"
+                ),
+                model=model,
+                llm_provider=provider,
             )
         data["output_config"] = output_config
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1540,7 +1540,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         effort = output_config.get("effort")
         valid_efforts = ["high", "medium", "low", "xhigh", "max"]
         provider = self.custom_llm_provider or "anthropic"
-        if effort and effort not in valid_efforts:
+        if effort is not None and effort not in valid_efforts:
             raise litellm.BadRequestError(
                 message=(
                     f"Invalid effort value: {effort!r}. Must be one of: "

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -450,7 +450,9 @@ class AmazonConverseConfig(BaseConfig):
         else:
             # Anthropic and other models: convert to thinking parameter
             optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
-                reasoning_effort=reasoning_effort, model=model
+                reasoning_effort=reasoning_effort,
+                model=model,
+                llm_provider="bedrock",
             )
 
     @staticmethod

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -331,7 +331,9 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
 
         if "reasoning_effort" in non_default_params and "claude" in model:
             optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
-                reasoning_effort=non_default_params.get("reasoning_effort"), model=model
+                reasoning_effort=non_default_params.get("reasoning_effort"),
+                model=model,
+                llm_provider="databricks",
             )
             optional_params.pop("reasoning_effort", None)
         ## handle thinking tokens

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3676,15 +3676,45 @@ def test_invalid_reasoning_effort_raises_bad_request(invalid_effort):
     assert "Invalid reasoning_effort value" in str(exc_info.value)
 
 
-@pytest.mark.parametrize("invalid_effort", ["disabled", "invalid", "garbage"])
+@pytest.mark.parametrize("invalid_effort", ["disabled", "invalid", "garbage", ""])
 def test_invalid_output_config_effort_raises_bad_request(invalid_effort):
-    """Invalid output_config.effort values raise litellm.BadRequestError (HTTP 400)."""
+    """Invalid output_config.effort values raise litellm.BadRequestError (HTTP 400).
+
+    Empty string is included to verify it does not get silently forwarded
+    to the provider (which would 400 with a less actionable message)."""
     config = AnthropicConfig()
     with pytest.raises(litellm.BadRequestError) as exc_info:
         config.transform_request(
             model="claude-opus-4-7",
             messages=[{"role": "user", "content": "hi"}],
             optional_params={"output_config": {"effort": invalid_effort}},
+            litellm_params={},
+            headers={},
+        )
+    assert exc_info.value.status_code == 400
+    assert "Invalid effort value" in str(exc_info.value)
+
+
+def test_empty_reasoning_effort_46_raises_bad_request():
+    """`reasoning_effort=""` on 4.6/4.7 models flows through the OpenAI param
+    mapping into `output_config.effort=""` and must be caught client-side
+    rather than forwarded as `effort=""` (which the provider 400s with a
+    less actionable error)."""
+    config = AnthropicConfig()
+    optional_params: dict = {}
+    config.map_openai_params(
+        non_default_params={"reasoning_effort": ""},
+        optional_params=optional_params,
+        model="claude-opus-4-7",
+        drop_params=False,
+    )
+    # On 4.6/4.7 the mapper builds {"effort": ""}; transform_request must
+    # reject it before sending to the provider.
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config.transform_request(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
             litellm_params={},
             headers={},
         )

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -8,6 +8,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
+import litellm
 from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
@@ -1631,8 +1632,8 @@ def test_effort_validation():
         )
         assert result["output_config"]["effort"] == effort
 
-    # Invalid value should raise error
-    with pytest.raises(ValueError, match="Invalid effort value"):
+    # Invalid value should raise BadRequestError (HTTP 400)
+    with pytest.raises(litellm.BadRequestError, match="Invalid effort value"):
         optional_params = {"output_config": {"effort": "invalid"}}
         config.transform_request(
             model="claude-opus-4-5-20251101",
@@ -1688,7 +1689,7 @@ def test_max_effort_rejected_for_opus_45():
     messages = [{"role": "user", "content": "Test"}]
 
     with pytest.raises(
-        ValueError, match="effort='max' is not supported by this model"
+        litellm.BadRequestError, match="effort='max' is not supported by this model"
     ):
         optional_params = {"output_config": {"effort": "max"}}
         config.transform_request(
@@ -2252,7 +2253,7 @@ def test_max_effort_rejected_for_sonnet_46():
     messages = [{"role": "user", "content": "Test"}]
 
     with pytest.raises(
-        ValueError, match="effort='max' is not supported by this model"
+        litellm.BadRequestError, match="effort='max' is not supported by this model"
     ):
         config.transform_request(
             model="claude-sonnet-4-6-20260219",
@@ -3657,3 +3658,79 @@ def test_strip_advisor_blocks_no_op_when_no_advisor_blocks():
     original_content = [dict(b) for b in messages[1]["content"]]
     result = strip_advisor_blocks_from_messages(messages)
     assert result[1]["content"] == original_content
+
+
+@pytest.mark.parametrize("invalid_effort", ["disabled", "invalid", "", "garbage"])
+def test_invalid_reasoning_effort_raises_bad_request(invalid_effort):
+    """Invalid reasoning_effort values raise litellm.BadRequestError (HTTP 400),
+    not ValueError (which surfaces as APIConnectionError 500)."""
+    config = AnthropicConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config.map_openai_params(
+            non_default_params={"reasoning_effort": invalid_effort},
+            optional_params={},
+            model="claude-haiku-4-5",
+            drop_params=False,
+        )
+    assert exc_info.value.status_code == 400
+    assert "Invalid reasoning_effort value" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("invalid_effort", ["disabled", "invalid", "garbage"])
+def test_invalid_output_config_effort_raises_bad_request(invalid_effort):
+    """Invalid output_config.effort values raise litellm.BadRequestError (HTTP 400)."""
+    config = AnthropicConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config.transform_request(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"output_config": {"effort": invalid_effort}},
+            litellm_params={},
+            headers={},
+        )
+    assert exc_info.value.status_code == 400
+    assert "Invalid effort value" in str(exc_info.value)
+
+
+def test_unsupported_xhigh_raises_bad_request():
+    """`xhigh` on a model that does not advertise xhigh support raises 400."""
+    config = AnthropicConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config.transform_request(
+            model="claude-sonnet-4-6-20260219",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"output_config": {"effort": "xhigh"}},
+            litellm_params={},
+            headers={},
+        )
+    assert exc_info.value.status_code == 400
+    assert "xhigh" in str(exc_info.value)
+    assert "not supported by this model" in str(exc_info.value)
+
+
+def test_unsupported_max_raises_bad_request():
+    """`max` on a non-Opus-4.6+ model raises 400."""
+    config = AnthropicConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config.transform_request(
+            model="claude-opus-4-5-20251101",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"output_config": {"effort": "max"}},
+            litellm_params={},
+            headers={},
+        )
+    assert exc_info.value.status_code == 400
+    assert "max" in str(exc_info.value)
+
+
+def test_bad_request_carries_provider_anthropic():
+    """Default provider attribution is `anthropic`."""
+    config = AnthropicConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config.map_openai_params(
+            non_default_params={"reasoning_effort": "garbage"},
+            optional_params={},
+            model="claude-haiku-4-5",
+            drop_params=False,
+        )
+    assert exc_info.value.llm_provider == "anthropic"

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4400,3 +4400,19 @@ def test_transform_response_does_not_leak_body_on_parse_failure():
     msg = str(exc_info.value)
     assert "secret content" not in msg
     assert "Error converting to valid response block" in msg
+
+
+@pytest.mark.parametrize("invalid_effort", ["disabled", "invalid", "garbage"])
+def test_bedrock_converse_invalid_reasoning_effort_raises_bad_request(invalid_effort):
+    """Bedrock Converse routes invalid `reasoning_effort` to a 400 BadRequestError
+    with `llm_provider="bedrock"`, not a 500 APIConnectionError."""
+    config = AmazonConverseConfig()
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        config._handle_reasoning_effort_parameter(
+            model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            reasoning_effort=invalid_effort,
+            optional_params={},
+        )
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.llm_provider == "bedrock"
+    assert "Invalid reasoning_effort value" in str(exc_info.value)


### PR DESCRIPTION
## What does this PR do?

Convert `ValueError` raises in `AnthropicConfig._map_reasoning_effort` and `AnthropicConfig._apply_output_config` to `litellm.BadRequestError(400)` with proper `llm_provider` attribution and the valid enum in the error message.

Before this PR, invalid `reasoning_effort` values (`"disabled"`, `"invalid"`, `""`, anything not in the OpenAI enum) and unsupported `xhigh`/`max` on gated models raised `ValueError`, which bubbled up to clients as `litellm.APIConnectionError 500`. After: clients get a clean `BadRequestError 400` listing the valid enum.

Discovered while doing the full sweep on PR #27039 — see [the matrix in that QA comment](https://github.com/BerriAI/litellm/pull/27039#issuecomment-4363363610) (item 4 under "pre-existing bugs surfaced").

## Sites

- `litellm/llms/anthropic/chat/transformation.py`
  - `_map_reasoning_effort`: add optional `llm_provider` kwarg (default `"anthropic"`); replace `ValueError("Unmapped reasoning effort: ...")` with `litellm.BadRequestError(400)`.
  - `_apply_output_config`: replace 3 `ValueError` raises (invalid enum, unsupported `max`, unsupported `xhigh`); provider derived from `self.custom_llm_provider` so Azure/Vertex/Bedrock-Invoke inherit the correct attribution via the existing class overrides.
  - `map_openai_params` updated to thread `self.custom_llm_provider or "anthropic"` into `_map_reasoning_effort`.
- `litellm/llms/bedrock/chat/converse_transformation.py`: `_handle_reasoning_effort_parameter` passes `llm_provider="bedrock"`.
- `litellm/llms/databricks/chat/transformation.py`: passes `llm_provider="databricks"`.

## Tests

- `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py`: 3 existing `pytest.raises(ValueError, ...)` assertions updated to `litellm.BadRequestError`. 6 new parametrized tests covering invalid `reasoning_effort` values, invalid `output_config.effort` values, unsupported `xhigh`, unsupported `max`, default provider attribution.
- `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`: 1 new parametrized test verifying Bedrock Converse path raises `BadRequestError` with `llm_provider="bedrock"`.

All 1205 tests in `tests/test_litellm/llms/{anthropic,bedrock,databricks}/` pass with `-n 4`. `uv run black .` and `uv run ruff check .` clean.

## Manual QA

Will follow up with the same proxy-curl matrix used on #27039, confirming `disabled`/`invalid`/`""` now return clean 400s with the valid enum across Anthropic, Azure, Bedrock Converse + Invoke, Vertex.

## Relevant issues

LIT-2758