### PR TITLE
feat(anthropic): preserve compaction iteration usage through OpenAI-shape conversion

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1789,6 +1789,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         )
         total_tokens = prompt_tokens + completion_tokens
 
+        iterations: Optional[List[dict]] = None
+        if "iterations" in _usage and _usage["iterations"] is not None:
+            iterations = _usage["iterations"]
+
         usage = Usage(
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
@@ -1807,6 +1811,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             ),
             inference_geo=inference_geo,
             speed=speed,
+            **({"iterations": iterations} if iterations is not None else {}),
         )
         return usage
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3657,3 +3657,65 @@ def test_strip_advisor_blocks_no_op_when_no_advisor_blocks():
     original_content = [dict(b) for b in messages[1]["content"]]
     result = strip_advisor_blocks_from_messages(messages)
     assert result[1]["content"] == original_content
+
+
+def test_calculate_usage_compaction_iterations():
+    """
+    Verify that compaction iteration usage data is preserved through calculate_usage.
+
+    When compaction fires, Anthropic includes usage.iterations[] with per-iteration
+    token totals. The top-level input_tokens/output_tokens only reflect non-compaction
+    iterations. The iterations array provides the data needed for accurate billing.
+
+    See: https://github.com/BerriAI/litellm/issues/27060
+    """
+    config = AnthropicConfig()
+
+    usage_object = {
+        "input_tokens": 50,
+        "output_tokens": 100,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "iterations": [
+            {
+                "iteration_type": "compaction",
+                "input_tokens": 5000,
+                "output_tokens": 200,
+            },
+            {
+                "iteration_type": "message",
+                "input_tokens": 50,
+                "output_tokens": 100,
+            },
+        ],
+    }
+    usage = config.calculate_usage(usage_object=usage_object, reasoning_content=None)
+
+    # Top-level tokens reflect only non-compaction iterations (Anthropic behavior)
+    assert usage.prompt_tokens == 50
+    assert usage.completion_tokens == 100
+    assert usage.total_tokens == 150
+
+    # Iterations array is preserved for accurate billing
+    assert hasattr(usage, "iterations")
+    assert usage.iterations is not None
+    assert len(usage.iterations) == 2
+    assert usage.iterations[0]["iteration_type"] == "compaction"
+    assert usage.iterations[0]["input_tokens"] == 5000
+    assert usage.iterations[1]["iteration_type"] == "message"
+    assert usage.iterations[1]["input_tokens"] == 50
+
+
+def test_calculate_usage_no_iterations():
+    """Verify calculate_usage works normally when iterations is not present."""
+    config = AnthropicConfig()
+
+    usage_object = {
+        "input_tokens": 100,
+        "output_tokens": 200,
+    }
+    usage = config.calculate_usage(usage_object=usage_object, reasoning_content=None)
+
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 200
+    assert not hasattr(usage, "iterations") or usage.get("iterations") is None

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3718,4 +3718,4 @@ def test_calculate_usage_no_iterations():
 
     assert usage.prompt_tokens == 100
     assert usage.completion_tokens == 200
-    assert not hasattr(usage, "iterations") or usage.get("iterations") is None
+    assert not hasattr(usage, "iterations")


### PR DESCRIPTION
## Summary

Preserves Anthropic's compaction `usage.iterations[]` array through the OpenAI-shape conversion, enabling clients to calculate accurate billable totals when compaction fires.

**Problem:** When compaction is active, Anthropic's top-level `input_tokens`/`output_tokens` only reflect the final (non-compaction) iteration. The `iterations` array contains per-iteration totals needed for accurate billing. This data was previously dropped during the OpenAI-shape conversion.

**Fix:** Extract `iterations` from the Anthropic usage response in `calculate_usage()` and pass it through to the `Usage` object. It becomes accessible as `usage.iterations` on the response, following the same pattern used for `inference_geo` and `speed`.

```python
response = litellm.completion(model="anthropic/claude-sonnet-4-20250514", ...)
if hasattr(response.usage, "iterations"):
    total_input = sum(i["input_tokens"] for i in response.usage.iterations)
    total_output = sum(i["output_tokens"] for i in response.usage.iterations)
```

Works for both sync responses and streaming (via `_handle_usage` → `calculate_usage`).

## Test plan

- [x] Added `test_calculate_usage_compaction_iterations` — verifies iterations are preserved
- [x] Added `test_calculate_usage_no_iterations` — verifies no regression when iterations absent
- [x] All existing `calculate_usage` tests pass

## Link to tracking issue

Fixes #27060