### PR TITLE
feat(ui): allow setting router fallbacks on key edit

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -98,6 +98,7 @@ export interface KeyResponse {
   budget_limits?: Array<{ budget_duration: string; max_budget: number; reset_at?: string }>;
   auto_rotate?: boolean;
   rotation_interval?: string;
+  router_settings?: Record<string, unknown> | null;
   last_rotation_at?: string;
   key_rotation_at?: string;
   next_rotation_at?: string;

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -84,6 +84,34 @@ vi.mock("../common_components/AccessGroupSelector", () => ({
   ),
 }));
 
+// Test stand-in for RouterSettingsAccordion: exposes the initial value and lets
+// tests trigger an onChange without rendering its full tabbed UI / network deps.
+vi.mock("../common_components/RouterSettingsAccordion", () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+  }: {
+    value?: { router_settings: Record<string, unknown> };
+    onChange?: (v: { router_settings: Record<string, unknown> }) => void;
+  }) => (
+    <div data-testid="router-settings-accordion">
+      <pre data-testid="router-settings-value">{JSON.stringify(value ?? null)}</pre>
+      <button
+        type="button"
+        data-testid="router-settings-set-fallbacks"
+        onClick={() =>
+          onChange?.({
+            router_settings: { fallbacks: [{ "gpt-4": ["gpt-3.5-turbo"] }] },
+          })
+        }
+      >
+        set fallbacks
+      </button>
+    </div>
+  ),
+}));
+
 describe("KeyEditView", () => {
   const MOCK_KEY_DATA: KeyResponse = {
     token: "test-token-123",
@@ -98,6 +126,8 @@ describe("KeyEditView", () => {
     config: {},
     user_id: "default_user_id",
     team_id: null,
+    project_id: null,
+    last_active: null,
     max_parallel_requests: 10,
     metadata: {
       logging: [],
@@ -585,6 +615,132 @@ describe("KeyEditView", () => {
     if (resolveSubmit) {
       resolveSubmit();
     }
+  });
+
+  describe("router settings", () => {
+    it("should render the router settings section when accessToken is provided", async () => {
+      renderWithProviders(
+        <KeyEditView
+          keyData={MOCK_KEY_DATA}
+          onCancel={() => {}}
+          onSubmit={async () => {}}
+          accessToken="test-token"
+          userID="test-user"
+          userRole="admin"
+          premiumUser={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Router Settings")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("router-settings-accordion")).toBeInTheDocument();
+    });
+
+    it("should not render the router settings section when accessToken is missing", async () => {
+      renderWithProviders(
+        <KeyEditView
+          keyData={MOCK_KEY_DATA}
+          onCancel={() => {}}
+          onSubmit={async () => {}}
+          accessToken=""
+          userID=""
+          userRole=""
+          premiumUser={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Save Changes")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("router-settings-accordion")).not.toBeInTheDocument();
+    });
+
+    it("should initialize the accordion from keyData.router_settings", async () => {
+      const keyDataWithRouterSettings = {
+        ...MOCK_KEY_DATA,
+        router_settings: { fallbacks: [{ "gpt-4": ["gpt-3.5-turbo"] }] },
+      };
+
+      renderWithProviders(
+        <KeyEditView
+          keyData={keyDataWithRouterSettings}
+          onCancel={() => {}}
+          onSubmit={async () => {}}
+          accessToken="test-token"
+          userID="test-user"
+          userRole="admin"
+          premiumUser={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("router-settings-value")).toBeInTheDocument();
+      });
+      const value = JSON.parse(screen.getByTestId("router-settings-value").textContent || "null");
+      expect(value).toEqual({
+        router_settings: { fallbacks: [{ "gpt-4": ["gpt-3.5-turbo"] }] },
+      });
+    });
+
+    it("should pass router_settings through to onSubmit when the user sets them", async () => {
+      const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <KeyEditView
+          keyData={MOCK_KEY_DATA}
+          onCancel={() => {}}
+          onSubmit={onSubmitMock}
+          accessToken="test-token"
+          userID="test-user"
+          userRole="admin"
+          premiumUser={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("router-settings-set-fallbacks")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("router-settings-set-fallbacks"));
+      await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalled();
+      });
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect(callArgs.router_settings).toEqual({
+        fallbacks: [{ "gpt-4": ["gpt-3.5-turbo"] }],
+      });
+    });
+
+    it("should omit router_settings from onSubmit when the user does not touch them", async () => {
+      const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <KeyEditView
+          keyData={MOCK_KEY_DATA}
+          onCancel={() => {}}
+          onSubmit={onSubmitMock}
+          accessToken="test-token"
+          userID="test-user"
+          userRole="admin"
+          premiumUser={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalled();
+      });
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("router_settings" in callArgs).toBe(false);
+    });
   });
 
   describe("organization dropdown", () => {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -5,11 +5,14 @@ import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings"
 import PolicySelector from "@/components/policies/PolicySelector";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { TextInput, Button as TremorButton } from "@tremor/react";
-import { Form, Input, Select, Switch, Tooltip } from "antd";
+import { Collapse, Form, Input, Select, Switch, Tooltip } from "antd";
 import { useEffect, useState } from "react";
 import { rolesWithWriteAccess } from "../../utils/roles";
 import AgentSelector from "../agent_management/AgentSelector";
 import AccessGroupSelector from "../common_components/AccessGroupSelector";
+import RouterSettingsAccordion, {
+  RouterSettingsAccordionValue,
+} from "../common_components/RouterSettingsAccordion";
 import { mapInternalToDisplayNames } from "../callback_info_helpers";
 import KeyLifecycleSettings from "../common_components/KeyLifecycleSettings";
 import PassThroughRoutesSelector from "../common_components/PassThroughRoutesSelector";
@@ -107,6 +110,14 @@ export function KeyEditView({
   const [isKeySaving, setIsKeySaving] = useState(false);
   const [budgetLimits, setBudgetLimits] = useState<BudgetWindowEntry[]>(
     Array.isArray(keyData.budget_limits) ? keyData.budget_limits : []
+  );
+  // Router settings (fallbacks, retries, etc.) — local edit state only.
+  // Initialized once from keyData; the editor remounts on each open
+  // (key_info_view conditionally renders KeyEditView), so no sync effect is needed.
+  const [routerSettings, setRouterSettings] = useState<RouterSettingsAccordionValue | null>(
+    keyData.router_settings && Object.keys(keyData.router_settings).length > 0
+      ? { router_settings: keyData.router_settings as RouterSettingsAccordionValue["router_settings"] }
+      : null,
   );
   const { data: organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const { data: projects } = useProjects();
@@ -282,6 +293,14 @@ export function KeyEditView({
       // Include multi-window budget limits (filter out incomplete entries)
       const validWindows = budgetLimits.filter((w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined);
       values.budget_limits = validWindows.length > 0 ? validWindows : undefined;
+
+      // Include router_settings (fallbacks, retries, etc.) when set; send {} to clear.
+      if (routerSettings?.router_settings) {
+        const hasValues = Object.values(routerSettings.router_settings).some(
+          (v) => v !== null && v !== undefined && v !== "",
+        );
+        values.router_settings = hasValues ? routerSettings.router_settings : {};
+      }
 
       await onSubmit(values);
     } finally {
@@ -723,6 +742,25 @@ export function KeyEditView({
       <Form.Item label="Metadata" name="metadata">
         <Input.TextArea rows={10} />
       </Form.Item>
+
+      {accessToken && (
+        <Collapse
+          className="mb-4"
+          items={[
+            {
+              key: "router-settings",
+              label: <b>Router Settings</b>,
+              children: (
+                <RouterSettingsAccordion
+                  accessToken={accessToken}
+                  value={routerSettings || undefined}
+                  onChange={setRouterSettings}
+                />
+              ),
+            },
+          ]}
+        />
+      )}
 
       {/* Auto-Rotation Settings */}
       <div className="mb-4">

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -750,6 +750,7 @@ export function KeyEditView({
             {
               key: "router-settings",
               label: <b>Router Settings</b>,
+              forceRender: true,
               children: (
                 <RouterSettingsAccordion
                   accessToken={accessToken}


### PR DESCRIPTION
## Summary

The key edit view exposed every other key-level setting but omitted `router_settings`, so users couldn't change fallbacks / retries / etc. on an existing key from the UI even though `/key/update` already accepted them. Now both the create and edit flows surface the same `RouterSettingsAccordion`.

- Adds the existing `RouterSettingsAccordion` to `KeyEditView`, wrapped in an antd `Collapse` (collapsed by default, `forceRender: true` so user input survives toggling).
- Initializes from `keyData.router_settings` once on mount — the editor remounts on every Edit click in `KeyInfoView`, so no prop-sync `useEffect` is needed.
- Merges `router_settings` into the submitted form values when the user has set anything; sends `{}` to clear; omits the key entirely when the user never touched the section.
- Adds `router_settings?: Record<string, unknown> | null` to `KeyResponse`.

## Test plan

- [x] `vitest run src/components/templates/key_edit_view.test.tsx` — 26/26 pass, including 5 new tests covering: section renders only with accessToken, initializes from keyData, flows changes through onSubmit, omits when untouched.
- [ ] Manual: open an existing key in the dashboard → Edit Settings → expand "Router Settings" → set a fallback → Save → reopen and confirm the fallback is preserved.
- [ ] Manual: edit a key without setting router settings → Save → confirm `/key/update` payload does not include `router_settings`.