### PR TITLE
fix(exceptions): handle non-integer status_code in MidStreamFallbackError

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -955,7 +955,10 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         is_pre_first_chunk: bool = False,
     ):
         original_status = getattr(original_exception, "status_code", None)
-        self.status_code = int(original_status) if original_status is not None else 503
+        try:
+            self.status_code = int(original_status) if original_status is not None else 503
+        except (ValueError, TypeError):
+            self.status_code = 503
         self.message = f"litellm.MidStreamFallbackError: {message}"
         self.model = model
         self.llm_provider = llm_provider
@@ -997,7 +1000,10 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         )
 
         # Restore the propagated status and original response/request objects
-        self.status_code = int(original_status) if original_status is not None else 503
+        try:
+            self.status_code = int(original_status) if original_status is not None else 503
+        except (ValueError, TypeError):
+            self.status_code = 503
         self.response = _saved_response
         self.request = _saved_request
         self.message = _saved_message


### PR DESCRIPTION
Fixes #26913

## Problem

`MidStreamFallbackError.__init__` calls `int(original_status)` on the `status_code` attribute of the original exception. In some code paths, particularly when a `CustomLLM` handler raises `RateLimitError` during streaming, the `status_code` attribute resolves to a non-integer string (e.g. `'litellm_error'`). This makes `int()` throw `ValueError`, crashing the error handler with HTTP 500 instead of triggering the fallback chain.

The crash happens in two places inside `__init__`:
1. Line 958: initial assignment
2. Line 1000: restoration after `super().__init__()` overwrites the value

## Fix

Wrap both `int()` calls with `try/except (ValueError, TypeError)` and default to `503` when conversion fails. This lets `MidStreamFallbackError` be constructed normally and the fallback chain engages as intended.

```python
# Before (crashes when original_status is 'litellm_error'):
self.status_code = int(original_status) if original_status is not None else 503

# After:
try:
    self.status_code = int(original_status) if original_status is not None else 503
except (ValueError, TypeError):
    self.status_code = 503
```

## Testing

The fix is straightforward defensive programming. The existing workaround (catching `RateLimitError` and re-raising as `APIError(status_code=429, ...)`) continues to work; this fix just makes the un-wrapped case not crash.