### PR TITLE
fix(exceptions): handle non-integer status_code in MidStreamFallbackError

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -955,7 +955,12 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         is_pre_first_chunk: bool = False,
     ):
         original_status = getattr(original_exception, "status_code", None)
-        self.status_code = int(original_status) if original_status is not None else 503
+        try:
+            self.status_code = (
+                int(original_status) if original_status is not None else 503
+            )
+        except (ValueError, TypeError):
+            self.status_code = 503
         self.message = f"litellm.MidStreamFallbackError: {message}"
         self.model = model
         self.llm_provider = llm_provider
@@ -997,7 +1002,12 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         )
 
         # Restore the propagated status and original response/request objects
-        self.status_code = int(original_status) if original_status is not None else 503
+        try:
+            self.status_code = (
+                int(original_status) if original_status is not None else 503
+            )
+        except (ValueError, TypeError):
+            self.status_code = 503
         self.response = _saved_response
         self.request = _saved_request
         self.message = _saved_message

--- a/tests/test_litellm/test_exception_header_preservation.py
+++ b/tests/test_litellm/test_exception_header_preservation.py
@@ -254,6 +254,27 @@ class TestExceptionAttributes:
         assert midstream_fallback.response.status_code == 503
         assert str(midstream_fallback.response.request.url) == "https://openai.com/v1/"
 
+    def test_midstream_fallback_error_non_integer_status_code(self):
+        """
+        MidStreamFallbackError must not crash when original_exception.status_code
+        is a non-integer string (e.g. 'litellm_error'). Before the fix, int()
+        raised ValueError and the error handler returned HTTP 500 instead of
+        engaging the fallback chain.
+        """
+
+        class _FakeException(Exception):
+            status_code = "litellm_error"
+
+        midstream_error = MidStreamFallbackError(
+            message="stream broke",
+            model="gpt-4o-mini",
+            llm_provider="openai",
+            original_exception=_FakeException("boom"),
+        )
+
+        assert midstream_error.status_code == 503
+        assert midstream_error.response.status_code == 503
+
 
 class TestProxyHeaderExtraction:
     """Test that proxy correctly extracts headers from exceptions."""


### PR DESCRIPTION
Fixes #26913

## Problem

`MidStreamFallbackError.__init__` calls `int(original_status)` on the `status_code` attribute of the original exception. In some code paths, particularly when a `CustomLLM` handler raises `RateLimitError` during streaming, the `status_code` attribute resolves to a non-integer string (e.g. `'litellm_error'`). This makes `int()` throw `ValueError`, crashing the error handler with HTTP 500 instead of triggering the fallback chain.

The crash happens in two places inside `__init__`:
1. Line 958: initial assignment
2. Line 1000: restoration after `super().__init__()` overwrites the value

## Fix

Wrap both `int()` calls with `try/except (ValueError, TypeError)` and default to `503` when conversion fails. This lets `MidStreamFallbackError` be constructed normally and the fallback chain engages as intended.

```python
# Before (crashes when original_status is 'litellm_error'):
self.status_code = int(original_status) if original_status is not None else 503

# After:
try:
    self.status_code = int(original_status) if original_status is not None else 503
except (ValueError, TypeError):
    self.status_code = 503
```

## Testing

Added `test_midstream_fallback_error_non_integer_status_code` in `tests/test_litellm/test_exception_header_preservation.py` which constructs `MidStreamFallbackError` with a fake exception whose `status_code` is `'litellm_error'` (the exact failing case) and asserts `status_code == 503`.