### PR TITLE
test(responses): replace legacy `claude-4-sonnet-20250514` alias in multiturn tool-call test

### DIFF
--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -89,7 +89,7 @@ def test_multiturn_tool_calls():
                 "type": "message",
             }
         ],
-        model="anthropic/claude-4-sonnet-20250514",
+        model="anthropic/claude-haiku-4-5-20251001",
         instructions="You are a helpful coding assistant.",
         tools=[shell_tool],
     )
@@ -115,7 +115,7 @@ def test_multiturn_tool_calls():
 
     # Use await with asyncio.run for the async function
     follow_up_response = litellm.responses(
-        model="anthropic/claude-4-sonnet-20250514",
+        model="anthropic/claude-haiku-4-5-20251001",
         previous_response_id=response_id,
         input=[
             {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Follow-up to #27031. PR #27074 (and any other PR going through `llm_responses_api_testing` on CircleCI) hits this on every run.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test

## Changes

`tests/llm_responses_api_testing/test_anthropic_responses_api.py::test_multiturn_tool_calls` is failing reliably on PR CI with:

```
litellm.NotFoundError: AnthropicException - {"type":"error","error":{"type":"not_found_error","message":"model: claude-4-sonnet-20250514"}}
```

(see [job 1603363](https://app.circleci.com/pipelines/github/BerriAI/litellm/76211/workflows/4ad4cb79-14bd-491d-8bcd-3a993b190d9d/jobs/1603363) on PR #27074).

`claude-4-sonnet-20250514` is a non-canonical alias of `claude-sonnet-4-20250514`. Anthropic's main API no longer resolves the legacy form under freshly issued keys, so the request 404s before reaching any new code on the PR. The recent main-branch run on 2026-05-01 still passed because it was using an older API key — the failure correlates to which key CircleCI hands the job, not to PR #27074's diff.

PR #27031 ("[Test] Anthropic: Replace Legacy Claude-4-Sonnet Alias With Haiku 4.5") already swept three live tests pinned to this alias to `claude-haiku-4-5-20251001`, but missed `test_multiturn_tool_calls` because it lives under `tests/llm_responses_api_testing/` rather than `tests/local_testing/`. This PR completes the migration for the responses-API test, using the same target snapshot:

- Capability superset for what this test exercises (multi-turn tool calling).
- No upcoming deprecation date.
- Cheaper per-token.

Two-line change, both occurrences of the model string in the same test function.

## Test plan

The fix only replaces a model string; verification is "the responses API CircleCI job stops reporting `not_found_error: claude-4-sonnet-20250514` for `test_multiturn_tool_calls`". The next CI run on this branch will exercise it end-to-end against the live Anthropic API.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777793807732009?thread_ts=1777793807.732009&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-aba63406-87df-5e69-a39b-5da363b09574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aba63406-87df-5e69-a39b-5da363b09574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

