### PR TITLE
fix(agentic): preserve custom api_base/api_key in agentic follow-up requests

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -771,15 +771,15 @@ class WebSearchInterceptionLogger(CustomLogger):
         followup_kwargs = dict(request_patch.kwargs)
         if _followup_api_key is not None:
             followup_kwargs.pop("api_key", None)
+            followup_kwargs["api_key"] = _followup_api_key
         if _followup_api_base is not None:
             followup_kwargs.pop("api_base", None)
+            followup_kwargs["api_base"] = _followup_api_base
 
         return await anthropic_messages.acreate(
             max_tokens=max_tokens,
             messages=request_patch.messages,
             model=request_patch.model or model,
-            **({"api_key": _followup_api_key} if _followup_api_key else {}),
-            **({"api_base": _followup_api_base} if _followup_api_base else {}),
             **optional_params,
             **followup_kwargs,
         )

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -755,10 +755,23 @@ class WebSearchInterceptionLogger(CustomLogger):
         if max_tokens is None:
             max_tokens = cast(int, kwargs.get("max_tokens", 1024))
 
+        # Pass api_key/api_base from agentic_loop_params so follow-up requests
+        # route to the same backend instead of falling back to api.anthropic.com
+        _followup_api_key: Optional[str] = None
+        _followup_api_base: Optional[str] = None
+        if logging_obj is not None:
+            agentic_params = logging_obj.model_call_details.get(
+                "agentic_loop_params", {}
+            )
+            _followup_api_key = agentic_params.get("api_key")
+            _followup_api_base = agentic_params.get("api_base")
+
         return await anthropic_messages.acreate(
             max_tokens=max_tokens,
             messages=request_patch.messages,
             model=request_patch.model or model,
+            api_key=_followup_api_key,
+            api_base=_followup_api_base,
             **optional_params,
             **request_patch.kwargs,
         )

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -766,14 +766,22 @@ class WebSearchInterceptionLogger(CustomLogger):
             _followup_api_key = agentic_params.get("api_key")
             _followup_api_base = agentic_params.get("api_base")
 
+        # Avoid duplicate keyword arguments if request_patch.kwargs already
+        # contains api_key or api_base.
+        followup_kwargs = dict(request_patch.kwargs)
+        if _followup_api_key is not None:
+            followup_kwargs.pop("api_key", None)
+        if _followup_api_base is not None:
+            followup_kwargs.pop("api_base", None)
+
         return await anthropic_messages.acreate(
             max_tokens=max_tokens,
             messages=request_patch.messages,
             model=request_patch.model or model,
-            api_key=_followup_api_key,
-            api_base=_followup_api_base,
+            **({"api_key": _followup_api_key} if _followup_api_key else {}),
+            **({"api_base": _followup_api_base} if _followup_api_base else {}),
             **optional_params,
-            **request_patch.kwargs,
+            **followup_kwargs,
         )
 
     async def _build_anthropic_request_patch(

--- a/litellm/llms/anthropic/count_tokens/token_counter.py
+++ b/litellm/llms/anthropic/count_tokens/token_counter.py
@@ -54,8 +54,9 @@ class AnthropicTokenCounter(BaseTokenCounter):
         deployment = deployment or {}
         litellm_params = deployment.get("litellm_params", {})
 
-        # Get Anthropic API key from deployment config or environment
+        # Get Anthropic API key and api_base from deployment config or environment
         api_key = litellm_params.get("api_key")
+        api_base = litellm_params.get("api_base")
         if not api_key:
             api_key = os.getenv("ANTHROPIC_API_KEY")
 
@@ -63,11 +64,19 @@ class AnthropicTokenCounter(BaseTokenCounter):
             verbose_logger.warning("No Anthropic API key found for token counting")
             return None
 
+        # Build count_tokens endpoint from api_base if available
+        count_tokens_api_base: Optional[str] = None
+        if api_base:
+            # e.g. https://api.lkeap.cloud.tencent.com/plan/anthropic -> https://api.lkeap.cloud.tencent.com/plan/anthropic/v1/messages/count_tokens
+            base = api_base.rstrip("/")
+            count_tokens_api_base = f"{base}/v1/messages/count_tokens"
+
         try:
             result = await anthropic_count_tokens_handler.handle_count_tokens_request(
                 model=model_to_use,
                 messages=messages,
                 api_key=api_key,
+                api_base=count_tokens_api_base,
                 tools=tools,
                 system=system,
             )

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -379,7 +379,9 @@ def anthropic_messages_handler(
             agentic_loop_params["api_key"] = dynamic_api_key
         if dynamic_api_base is not None:
             agentic_loop_params["api_base"] = dynamic_api_base
-        litellm_logging_obj.model_call_details["agentic_loop_params"] = agentic_loop_params
+        litellm_logging_obj.model_call_details["agentic_loop_params"] = (
+            agentic_loop_params
+        )
 
         # Check if stream was converted for WebSearch interception
         # This is set in the async wrapper above when stream=True is converted to stream=False

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -368,10 +368,18 @@ def anthropic_messages_handler(
     # Store agentic loop params in logging object for agentic hooks
     # This provides original request context needed for follow-up calls
     if litellm_logging_obj is not None:
-        litellm_logging_obj.model_call_details["agentic_loop_params"] = {
+        agentic_loop_params: Dict[str, Any] = {
             "model": original_model,
             "custom_llm_provider": custom_llm_provider,
         }
+        # Preserve api_base and api_key so that agentic hooks (e.g. websearch
+        # interception follow-up requests) can reuse the same credentials
+        # instead of falling back to defaults (api.anthropic.com / ANTHROPIC_API_KEY).
+        if dynamic_api_key is not None:
+            agentic_loop_params["api_key"] = dynamic_api_key
+        if dynamic_api_base is not None:
+            agentic_loop_params["api_base"] = dynamic_api_base
+        litellm_logging_obj.model_call_details["agentic_loop_params"] = agentic_loop_params
 
         # Check if stream was converted for WebSearch interception
         # This is set in the async wrapper above when stream=True is converted to stream=False

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -4683,8 +4683,10 @@ class BaseLLMHTTPHandler:
         # api_key or api_base, so agentic credentials take precedence.
         if agentic_api_key is not None:
             kwargs_for_followup.pop("api_key", None)
+            kwargs_for_followup["api_key"] = agentic_api_key
         if agentic_api_base is not None:
             kwargs_for_followup.pop("api_base", None)
+            kwargs_for_followup["api_base"] = agentic_api_base
 
         return await anthropic_messages.acreate(
             **{
@@ -4692,8 +4694,6 @@ class BaseLLMHTTPHandler:
                 "messages": patch.messages,
                 "model": patch.model or full_model_name,
                 "stream": stream,
-                **({"api_key": agentic_api_key} if agentic_api_key else {}),
-                **({"api_base": agentic_api_base} if agentic_api_base else {}),
                 **optional_params,
                 **kwargs_for_followup,
             }

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -4642,11 +4642,15 @@ class BaseLLMHTTPHandler:
             raise ValueError("Agentic loop plan missing patched messages")
 
         full_model_name = model
+        agentic_api_key: Optional[str] = None
+        agentic_api_base: Optional[str] = None
         if logging_obj is not None:
             agentic_params = logging_obj.model_call_details.get(
                 "agentic_loop_params", {}
             )
             full_model_name = cast(str, agentic_params.get("model", model))
+            agentic_api_key = agentic_params.get("api_key")
+            agentic_api_base = agentic_params.get("api_base")
 
         optional_params = dict(anthropic_messages_optional_request_params)
         optional_params.update(patch.optional_params)
@@ -4681,6 +4685,8 @@ class BaseLLMHTTPHandler:
                 "messages": patch.messages,
                 "model": patch.model or full_model_name,
                 "stream": stream,
+                **({"api_key": agentic_api_key} if agentic_api_key else {}),
+                **({"api_base": agentic_api_base} if agentic_api_base else {}),
                 **optional_params,
                 **kwargs_for_followup,
             }

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -4679,6 +4679,13 @@ class BaseLLMHTTPHandler:
         kwargs_for_followup["max_agentic_loops"] = max_loops
         kwargs_for_followup["_agentic_loop_fingerprints"] = fingerprints + [fingerprint]
 
+        # Avoid duplicate keyword arguments if patch.kwargs already contains
+        # api_key or api_base, so agentic credentials take precedence.
+        if agentic_api_key is not None:
+            kwargs_for_followup.pop("api_key", None)
+        if agentic_api_base is not None:
+            kwargs_for_followup.pop("api_base", None)
+
         return await anthropic_messages.acreate(
             **{
                 "max_tokens": max_tokens,

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_thinking_constraint.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_thinking_constraint.py
@@ -45,6 +45,21 @@ def _make_logging_obj(
     return obj
 
 
+def _make_logging_obj_with_credentials(
+    model: str = "bedrock/us.anthropic.claude-opus-4-6-v1",
+) -> MagicMock:
+    obj = MagicMock()
+    obj.model_call_details = {
+        "agentic_loop_params": {
+            "model": model,
+            "custom_llm_provider": "bedrock",
+            "api_key": "sk-test-agentic-key",
+            "api_base": "https://custom.provider.host/plan/anthropic",
+        },
+    }
+    return obj
+
+
 # ---------------------------------------------------------------------------
 # M1-I1 / M1-I3: max_tokens validation against thinking.budget_tokens
 # ---------------------------------------------------------------------------
@@ -473,3 +488,79 @@ class TestFollowUpErrorScenarios:
         # But ALL proxy metadata must be preserved
         assert captured_kwargs.get("metadata") == proxy_metadata
         assert captured_kwargs.get("litellm_call_id") == "call-abc-123"
+
+
+# ---------------------------------------------------------------------------
+# Credentials forwarding from agentic_loop_params
+# ---------------------------------------------------------------------------
+
+
+class TestAgenticLoopCredentialsForwarding:
+    """Verify api_key and api_base from agentic_loop_params are forwarded
+    to the follow-up acreate() call so third-party Anthropic-compatible
+    providers (e.g. Tencent Cloud) receive the correct endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_api_key_and_api_base_forwarded_from_agentic_loop_params(self):
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def _fake_acreate(**kw):
+            captured_kwargs.update(kw)
+            return MagicMock()
+
+        with (
+            patch(
+                "litellm.integrations.websearch_interception.handler.anthropic_messages.acreate",
+                side_effect=_fake_acreate,
+            ),
+            patch.object(logger, "_execute_search", return_value="search result"),
+        ):
+            await logger._execute_agentic_loop(
+                model="us.anthropic.claude-opus-4-6-v1",
+                messages=[{"role": "user", "content": "hi"}],
+                tool_calls=_make_tool_calls(),
+                thinking_blocks=[],
+                anthropic_messages_optional_request_params={"max_tokens": 4096},
+                logging_obj=_make_logging_obj_with_credentials(),
+                stream=False,
+                kwargs={},
+            )
+
+        assert captured_kwargs.get("api_key") == "sk-test-agentic-key"
+        assert (
+            captured_kwargs.get("api_base")
+            == "https://custom.provider.host/plan/anthropic"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_forwarded_when_agentic_params_missing(self):
+        """When agentic_loop_params lacks api_key/api_base, neither key should appear
+        in the follow-up call kwargs (avoiding None overrides)."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def _fake_acreate(**kw):
+            captured_kwargs.update(kw)
+            return MagicMock()
+
+        with (
+            patch(
+                "litellm.integrations.websearch_interception.handler.anthropic_messages.acreate",
+                side_effect=_fake_acreate,
+            ),
+            patch.object(logger, "_execute_search", return_value="search result"),
+        ):
+            await logger._execute_agentic_loop(
+                model="us.anthropic.claude-opus-4-6-v1",
+                messages=[{"role": "user", "content": "hi"}],
+                tool_calls=_make_tool_calls(),
+                thinking_blocks=[],
+                anthropic_messages_optional_request_params={"max_tokens": 4096},
+                logging_obj=_make_logging_obj(),
+                stream=False,
+                kwargs={},
+            )
+
+        assert "api_key" not in captured_kwargs
+        assert "api_base" not in captured_kwargs

--- a/tests/test_litellm/llms/anthropic/count_tokens/test_count_tokens_api_base.py
+++ b/tests/test_litellm/llms/anthropic/count_tokens/test_count_tokens_api_base.py
@@ -1,0 +1,161 @@
+"""
+Tests for Anthropic CountTokens API custom api_base handling.
+
+Verifies that AnthropicTokenCounter correctly builds the count_tokens endpoint
+from a custom api_base instead of hardcoding api.anthropic.com.
+"""
+
+import os
+import sys
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
+)
+
+from litellm.llms.anthropic.count_tokens.token_counter import AnthropicTokenCounter
+
+
+class TestCountTokensApiBase:
+    """Verify api_base is correctly extracted from litellm_params and used to build endpoint URL."""
+
+    @pytest.mark.asyncio
+    async def test_custom_api_base_builds_correct_count_tokens_url(self):
+        """When api_base is provided in litellm_params, count_tokens endpoint should use it."""
+        counter = AnthropicTokenCounter()
+        captured_api_base: Optional[str] = None
+
+        async def _fake_handle_count_tokens_request(
+            model, messages, api_key, api_base=None, **kwargs
+        ):
+            nonlocal captured_api_base
+            captured_api_base = api_base
+            return {"input_tokens": 42}
+
+        with patch(
+            "litellm.llms.anthropic.count_tokens.token_counter.anthropic_count_tokens_handler.handle_count_tokens_request",
+            side_effect=_fake_handle_count_tokens_request,
+        ):
+            result = await counter.count_tokens(
+                model_to_use="claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "hello"}],
+                contents=None,
+                deployment={
+                    "litellm_params": {
+                        "api_key": "sk-test-key",
+                        "api_base": "https://api.lkeap.cloud.tencent.com/plan/anthropic",
+                    }
+                },
+                request_model="claude-3-5-sonnet",
+            )
+
+        assert (
+            captured_api_base
+            == "https://api.lkeap.cloud.tencent.com/plan/anthropic/v1/messages/count_tokens"
+        )
+        assert result is not None
+        assert result.total_tokens == 42
+
+    @pytest.mark.asyncio
+    async def test_api_base_without_trailing_slash(self):
+        """api_base without trailing slash should still produce correct URL."""
+        counter = AnthropicTokenCounter()
+        captured_api_base: Optional[str] = None
+
+        async def _fake_handle_count_tokens_request(
+            model, messages, api_key, api_base=None, **kwargs
+        ):
+            nonlocal captured_api_base
+            captured_api_base = api_base
+            return {"input_tokens": 10}
+
+        with patch(
+            "litellm.llms.anthropic.count_tokens.token_counter.anthropic_count_tokens_handler.handle_count_tokens_request",
+            side_effect=_fake_handle_count_tokens_request,
+        ):
+            await counter.count_tokens(
+                model_to_use="claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "hi"}],
+                contents=None,
+                deployment={
+                    "litellm_params": {
+                        "api_key": "sk-test-key",
+                        "api_base": "https://custom.host/plan/anthropic",
+                    }
+                },
+                request_model="claude-3-5-sonnet",
+            )
+
+        assert (
+            captured_api_base
+            == "https://custom.host/plan/anthropic/v1/messages/count_tokens"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_api_base_uses_default_endpoint(self):
+        """When api_base is not provided, api_base should be None (handler will use default)."""
+        counter = AnthropicTokenCounter()
+        captured_api_base: Optional[str] = None
+
+        async def _fake_handle_count_tokens_request(
+            model, messages, api_key, api_base=None, **kwargs
+        ):
+            nonlocal captured_api_base
+            captured_api_base = api_base
+            return {"input_tokens": 5}
+
+        with patch(
+            "litellm.llms.anthropic.count_tokens.token_counter.anthropic_count_tokens_handler.handle_count_tokens_request",
+            side_effect=_fake_handle_count_tokens_request,
+        ):
+            await counter.count_tokens(
+                model_to_use="claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "hi"}],
+                contents=None,
+                deployment={
+                    "litellm_params": {
+                        "api_key": "sk-test-key",
+                    }
+                },
+                request_model="claude-3-5-sonnet",
+            )
+
+        assert captured_api_base is None
+
+    @pytest.mark.asyncio
+    async def test_api_base_with_trailing_slash_stripped(self):
+        """api_base with trailing slash should have it stripped before appending path."""
+        counter = AnthropicTokenCounter()
+        captured_api_base: Optional[str] = None
+
+        async def _fake_handle_count_tokens_request(
+            model, messages, api_key, api_base=None, **kwargs
+        ):
+            nonlocal captured_api_base
+            captured_api_base = api_base
+            return {"input_tokens": 7}
+
+        with patch(
+            "litellm.llms.anthropic.count_tokens.token_counter.anthropic_count_tokens_handler.handle_count_tokens_request",
+            side_effect=_fake_handle_count_tokens_request,
+        ):
+            await counter.count_tokens(
+                model_to_use="claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "hi"}],
+                contents=None,
+                deployment={
+                    "litellm_params": {
+                        "api_key": "sk-test-key",
+                        "api_base": "https://custom.host/plan/anthropic/",
+                    }
+                },
+                request_model="claude-3-5-sonnet",
+            )
+
+        assert (
+            captured_api_base
+            == "https://custom.host/plan/anthropic/v1/messages/count_tokens"
+        )

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,7 +1,8 @@
 import asyncio
 import os
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -422,3 +423,153 @@ def test_sync_delete_responses_omits_body_for_azure():
     assert captured["url"].endswith(
         "/openai/responses/resp_xyz?api-version=2025-03-01-preview"
     )
+
+
+class TestExecuteAnthropicAgenticPlan:
+    """Verify _execute_anthropic_agentic_plan forwards api_key/api_base
+    from agentic_loop_params to the follow-up anthropic_messages.acreate call."""
+
+    @pytest.mark.asyncio
+    async def test_api_key_and_api_base_forwarded_to_followup(self):
+        handler = BaseLLMHTTPHandler()
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def _fake_acreate(**kw):
+            captured_kwargs.update(kw)
+            return MagicMock()
+
+        from litellm.types.integrations.custom_logger import (
+            AgenticLoopPlan,
+            AgenticLoopRequestPatch,
+        )
+
+        plan = AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(
+                model=None,
+                messages=[{"role": "user", "content": "test"}],
+                max_tokens=1024,
+            ),
+        )
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "agentic_loop_params": {
+                "model": "custom/model-name",
+                "api_key": "sk-agentic-test-key",
+                "api_base": "https://custom.provider.host/v1",
+            }
+        }
+
+        with patch(
+            "litellm.anthropic_interface.messages.acreate",
+            side_effect=_fake_acreate,
+        ):
+            await handler._execute_anthropic_agentic_plan(
+                plan=plan,
+                model="claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "test"}],
+                anthropic_messages_optional_request_params={},
+                kwargs={},
+                logging_obj=logging_obj,
+                depth=0,
+                max_loops=1,
+                fingerprints=[],
+                fingerprint="fp-test",
+            )
+
+        assert captured_kwargs.get("api_key") == "sk-agentic-test-key"
+        assert captured_kwargs.get("api_base") == "https://custom.provider.host/v1"
+        assert captured_kwargs.get("model") == "custom/model-name"
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_when_agentic_loop_params_empty(self):
+        handler = BaseLLMHTTPHandler()
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def _fake_acreate(**kw):
+            captured_kwargs.update(kw)
+            return MagicMock()
+
+        from litellm.types.integrations.custom_logger import (
+            AgenticLoopPlan,
+            AgenticLoopRequestPatch,
+        )
+
+        plan = AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(
+                model=None,
+                messages=[{"role": "user", "content": "test"}],
+                max_tokens=1024,
+            ),
+        )
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "agentic_loop_params": {"model": "custom/model-name"}
+        }
+
+        with patch(
+            "litellm.anthropic_interface.messages.acreate",
+            side_effect=_fake_acreate,
+        ):
+            await handler._execute_anthropic_agentic_plan(
+                plan=plan,
+                model="claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "test"}],
+                anthropic_messages_optional_request_params={},
+                kwargs={},
+                logging_obj=logging_obj,
+                depth=0,
+                max_loops=1,
+                fingerprints=[],
+                fingerprint="fp-test",
+            )
+
+        assert "api_key" not in captured_kwargs
+        assert "api_base" not in captured_kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_logging_obj_uses_original_model(self):
+        handler = BaseLLMHTTPHandler()
+        captured_kwargs: Dict[str, Any] = {}
+
+        async def _fake_acreate(**kw):
+            captured_kwargs.update(kw)
+            return MagicMock()
+
+        from litellm.types.integrations.custom_logger import (
+            AgenticLoopPlan,
+            AgenticLoopRequestPatch,
+        )
+
+        plan = AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(
+                model=None,
+                messages=[{"role": "user", "content": "test"}],
+                max_tokens=1024,
+            ),
+        )
+
+        with patch(
+            "litellm.anthropic_interface.messages.acreate",
+            side_effect=_fake_acreate,
+        ):
+            await handler._execute_anthropic_agentic_plan(
+                plan=plan,
+                model="original-model-name",
+                messages=[{"role": "user", "content": "test"}],
+                anthropic_messages_optional_request_params={},
+                kwargs={},
+                logging_obj=None,
+                depth=0,
+                max_loops=1,
+                fingerprints=[],
+                fingerprint="fp-test",
+            )
+
+        assert captured_kwargs.get("model") == "original-model-name"
+        assert "api_key" not in captured_kwargs
+        assert "api_base" not in captured_kwargs


### PR DESCRIPTION
## Relevant issues

Fixes #26389
Fixes #26323

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Test results for the added/modified test files:

```
$ uv run pytest tests/test_litellm/integrations/websearch_interception/test_websearch_thinking_constraint.py tests/test_litellm/llms/anthropic/count_tokens/test_count_tokens_api_base.py tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -v
============================= 33 passed in 16.06s ==============================
```

## Type

🐛 Bug Fix

## Changes

### Problem

When using third-party Anthropic-compatible providers (e.g. Tencent Cloud, custom proxies) with a custom `api_base`, agentic hooks (`websearch_interception`) and the `count_tokens` handler sent follow-up requests to `api.anthropic.com` instead of the configured endpoint. This caused:

- **401 Unauthorized errors** on follow-up requests (Issue #26389)
- **Deployment cooldown cascades** that blocked all subsequent requests to the affected model
- **Incorrect token counting** falling back to local tiktoken, undercounting by ~34% on tool-heavy prompts (Issue #26323)

### Root cause

Three code locations failed to propagate resolved credentials:

1. **`experimental_pass_through/messages/handler.py`**: `agentic_loop_params` only stored `model` and `custom_llm_provider`, dropping `dynamic_api_key` and `dynamic_api_base`.
2. **`websearch_interception/handler.py`** (legacy path): `_execute_agentic_loop` called `anthropic_messages.acreate()` without `api_key`/`api_base`.
3. **`custom_httpx/llm_http_handler.py`** (`_execute_anthropic_agentic_plan`): same omission for the base-handler agentic path.
4. **`count_tokens/token_counter.py`**: read `api_key` from `litellm_params` but ignored `api_base`.

### Fix

- Persist `api_key` and `api_base` into `agentic_loop_params` when they are resolved via `get_llm_provider()`.
- Forward those credentials in both agentic execution paths (`_execute_anthropic_agentic_plan` and `_execute_agentic_loop`).
- Build the `count_tokens` endpoint URL from `api_base` when available (`{api_base}/v1/messages/count_tokens`).
- **Bonus fix**: prevent `TypeError: multiple values for keyword argument` when `request_patch.kwargs` already contains `api_key`/`api_base` by popping conflicting keys before conditionally injecting credentials.

### Test coverage

| File | Tests added | Coverage |
|------|------------|----------|
| `test_websearch_thinking_constraint.py` | 2 | Credentials forwarded from `agentic_loop_params`; absent when not provided |
| `test_count_tokens_api_base.py` | 4 | Custom `api_base` URL building, trailing-slash handling, default fallback |
| `test_llm_http_handler.py` | 3 | `_execute_anthropic_agentic_plan` credential forwarding, no-creds fallback, original model fallback |

### Related

- PR #26639 addresses the same Issue #26389 for the websearch path only; this PR additionally covers `count_tokens` (Issue #26323) and the base-handler agentic path.