### PR TITLE
fix: clear error for OpenRouter audio transcription (#27083)

### DIFF
--- a/.github/workflows/check-lazy-openapi-snapshot.yml
+++ b/.github/workflows/check-lazy-openapi-snapshot.yml
@@ -61,8 +61,19 @@ jobs:
         run: |
           diff -q /tmp/snapshot.fresh.json litellm/proxy/_lazy_openapi_snapshot.json
 
+      # Fork PRs use a read-only GITHUB_TOKEN; posting check runs fails with
+      # "Resource not accessible by integration". Same-repo PRs can mark neutral.
+      - name: Note snapshot drift (fork PRs)
+        if: >-
+          steps.diff.outcome == 'failure' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::notice::Lazy OpenAPI snapshot differs from committed file. Fork PRs cannot post a neutral check. To refresh: uv run python -m litellm.proxy._lazy_openapi_snapshot && commit litellm/proxy/_lazy_openapi_snapshot.json"
+
       - name: Mark neutral if drift
-        if: steps.diff.outcome == 'failure'
+        if: >-
+          steps.diff.outcome == 'failure' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 | [xAI (`xai`)](https://docs.litellm.ai/docs/providers/xai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Xinference (`xinference`)](https://docs.litellm.ai/docs/providers/xinference) |  |  |  | ✅ |  |  |  |  |  |  |
 
+**Audio transcription:** OpenRouter does not support the `/audio/transcriptions` API. Use OpenAI directly with `model="whisper-1"` (see [OpenAI audio docs](https://platform.openai.com/docs/guides/speech-to-text)).
+
 [**Read the Docs**](https://docs.litellm.ai/docs/)
 
 ---

--- a/litellm/llms/openrouter/transcription_validation.py
+++ b/litellm/llms/openrouter/transcription_validation.py
@@ -1,0 +1,22 @@
+"""OpenRouter-specific validation for audio transcription."""
+
+from litellm.utils import UnsupportedParamsError
+
+
+def ensure_audio_transcription_supported(
+    model: str,
+    custom_llm_provider: str,
+) -> None:
+    """
+    OpenRouter does not expose /audio/transcriptions; fail fast with a clear error.
+    """
+    if custom_llm_provider != "openrouter":
+        return
+    raise UnsupportedParamsError(
+        message=(
+            "OpenRouter does not support audio transcription. "
+            "Use model='whisper-1' with provider OpenAI directly."
+        ),
+        model=model,
+        llm_provider=custom_llm_provider,
+    )

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -70,7 +70,7 @@ from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
 )
-from litellm.exceptions import LiteLLMUnknownProvider
+from litellm.exceptions import LiteLLMUnknownProvider, UnsupportedParamsError
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.audio_utils.utils import (
@@ -6486,6 +6486,16 @@ def transcription(
 
     if dynamic_api_key is not None:
         api_key = dynamic_api_key
+
+    if custom_llm_provider == "openrouter":
+        raise UnsupportedParamsError(
+            message=(
+                "OpenRouter does not support audio transcription. "
+                "Use model='whisper-1' with provider OpenAI directly."
+            ),
+            model=model,
+            llm_provider=custom_llm_provider,
+        )
 
     optional_params = get_optional_params_transcription(
         model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -70,7 +70,7 @@ from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
 )
-from litellm.exceptions import LiteLLMUnknownProvider, UnsupportedParamsError
+from litellm.exceptions import LiteLLMUnknownProvider
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.audio_utils.utils import (
@@ -212,6 +212,9 @@ from .llms.openai.completion.handler import OpenAITextCompletion
 from .llms.openai.image_variations.handler import OpenAIImageVariationsHandler
 from .llms.openai.openai import OpenAIChatCompletion
 from .llms.openai.transcriptions.handler import OpenAIAudioTranscription
+from .llms.openrouter.transcription_validation import (
+    ensure_audio_transcription_supported,
+)
 from .llms.openai_like.chat.handler import OpenAILikeChatHandler
 from .llms.openai_like.embedding.handler import OpenAILikeEmbeddingHandler
 from .llms.ovhcloud.chat.transformation import OVHCloudChatConfig
@@ -6487,15 +6490,10 @@ def transcription(
     if dynamic_api_key is not None:
         api_key = dynamic_api_key
 
-    if custom_llm_provider == "openrouter":
-        raise UnsupportedParamsError(
-            message=(
-                "OpenRouter does not support audio transcription. "
-                "Use model='whisper-1' with provider OpenAI directly."
-            ),
-            model=model,
-            llm_provider=custom_llm_provider,
-        )
+    ensure_audio_transcription_supported(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+    )
 
     optional_params = get_optional_params_transcription(
         model=model,

--- a/tests/test_litellm/llms/openai/transcriptions/test_openrouter_transcription_validation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_openrouter_transcription_validation.py
@@ -6,6 +6,9 @@ import pytest
 
 import litellm
 from litellm.exceptions import UnsupportedParamsError
+from litellm.llms.openrouter.transcription_validation import (
+    ensure_audio_transcription_supported,
+)
 
 
 def test_should_raise_unsupported_params_error_for_openrouter_transcription_sync():
@@ -30,4 +33,27 @@ async def test_should_raise_unsupported_params_error_for_openrouter_transcriptio
     msg = str(exc_info.value)
     assert "OpenRouter" in msg
     assert "audio transcription" in msg.lower()
+    assert "whisper-1" in msg
+
+
+def test_should_no_op_ensure_audio_transcription_supported_for_non_openrouter_provider():
+    """Early return path must not raise (covers openrouter transcription_validation guard)."""
+    ensure_audio_transcription_supported(
+        model="whisper-1",
+        custom_llm_provider="openai",
+    )
+    ensure_audio_transcription_supported(
+        model="deployment-whisper",
+        custom_llm_provider="azure",
+    )
+
+
+def test_should_raise_ensure_audio_transcription_supported_when_openrouter():
+    with pytest.raises(UnsupportedParamsError) as exc_info:
+        ensure_audio_transcription_supported(
+            model="openrouter/openai/whisper-1",
+            custom_llm_provider="openrouter",
+        )
+    msg = str(exc_info.value)
+    assert "OpenRouter" in msg
     assert "whisper-1" in msg

--- a/tests/test_litellm/llms/openai/transcriptions/test_openrouter_transcription_validation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_openrouter_transcription_validation.py
@@ -29,4 +29,5 @@ async def test_should_raise_unsupported_params_error_for_openrouter_transcriptio
         )
     msg = str(exc_info.value)
     assert "OpenRouter" in msg
+    assert "audio transcription" in msg.lower()
     assert "whisper-1" in msg

--- a/tests/test_litellm/llms/openai/transcriptions/test_openrouter_transcription_validation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_openrouter_transcription_validation.py
@@ -1,0 +1,32 @@
+"""OpenRouter does not expose /audio/transcriptions; fail fast with a clear error."""
+
+import io
+
+import pytest
+
+import litellm
+from litellm.exceptions import UnsupportedParamsError
+
+
+def test_should_raise_unsupported_params_error_for_openrouter_transcription_sync():
+    with pytest.raises(UnsupportedParamsError) as exc_info:
+        litellm.transcription(
+            model="openrouter/openai/whisper-1",
+            file=io.BytesIO(b"fake"),
+        )
+    msg = str(exc_info.value)
+    assert "OpenRouter" in msg
+    assert "audio transcription" in msg.lower()
+    assert "whisper-1" in msg
+
+
+@pytest.mark.asyncio
+async def test_should_raise_unsupported_params_error_for_openrouter_transcription_async():
+    with pytest.raises(UnsupportedParamsError) as exc_info:
+        await litellm.atranscription(
+            model="openrouter/openai/whisper-1",
+            file=io.BytesIO(b"fake"),
+        )
+    msg = str(exc_info.value)
+    assert "OpenRouter" in msg
+    assert "whisper-1" in msg


### PR DESCRIPTION
## Summary
Raises `UnsupportedParamsError` with a clear message when OpenRouter is used for audio transcription, instead of `ValueError: Unmapped provider`.

## Changes
- Early validation in `litellm.main.transcription()` after `get_llm_provider`
- Unit tests (sync + async)
- README note under supported providers table

## Related
Closes / fixes #27083