### PR TITLE
fix(responses): preserve list-style input during spend-log history reconstruction

### DIFF
--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -116,7 +116,7 @@ class ResponsesSessionHandler:
             _messages = proxy_server_request_dict.get("messages", None)
             if isinstance(_response_input_param, str):
                 response_input_param = _response_input_param
-            elif isinstance(_response_input_param, dict):
+            elif isinstance(_response_input_param, (list, dict)):
                 response_input_param = cast(ResponseInputParam, _response_input_param)
 
         if response_input_param:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -389,6 +389,131 @@ async def test_should_check_cold_storage_for_full_payload():
 
 
 @pytest.mark.asyncio
+async def test_get_chat_completion_message_history_with_list_style_input():
+    """
+    Regression test: when `proxy_server_request.input` is a list of input
+    items (the standard Responses API shape, e.g. system + user messages
+    expressed as ``[{"role": "system", "type": "message", "content": [...]},
+    {"role": "user", ...}]``), the full input must be replayed in the
+    reconstructed history.
+
+    Previously the handler only matched ``str`` and ``dict`` for ``input``,
+    so list-style inputs were silently dropped and only the assistant
+    output from ``response`` survived. That broke ``previous_response_id``
+    continuity for non-OpenAI providers (e.g. Vertex AI / Gemini): the
+    system prompt and the prior user turn never reached the model on
+    follow-up calls, so the model lost its persona and any context
+    introduced via the system message.
+    """
+    mock_spend_logs = [
+        {
+            "request_id": "chatcmpl-list-input-test",
+            "call_type": "aresponses",
+            "api_key": "sk-test-mock-api-key-123",
+            "spend": 0.001,
+            "total_tokens": 42,
+            "prompt_tokens": 20,
+            "completion_tokens": 22,
+            "startTime": "2025-05-30T03:17:06.703+00:00",
+            "endTime": "2025-05-30T03:17:11.894+00:00",
+            "model": "vertex_ai/gemini-2.5-pro",
+            "session_id": "list-input-session",
+            "proxy_server_request": {
+                "model": "gemini-2.5-pro",
+                "input": [
+                    {
+                        "role": "system",
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "You are a math tutor. The secret codename is ZEPHYR-7.",
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "type": "message",
+                        "content": [
+                            {"type": "input_text", "text": "What is 12 times 7?"}
+                        ],
+                    },
+                ],
+            },
+            "response": {
+                "id": "chatcmpl-list-input-test",
+                "model": "gemini-2.5-pro",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "12 times 7 is 84.",
+                            "tool_calls": None,
+                            "function_call": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "created": 1748575031,
+                "usage": {
+                    "total_tokens": 42,
+                    "prompt_tokens": 20,
+                    "completion_tokens": 22,
+                },
+            },
+            "status": "success",
+        }
+    ]
+
+    with patch.object(
+        ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = mock_spend_logs
+
+        result = await ResponsesSessionHandler.get_chat_completion_message_history_for_previous_response_id(
+            "chatcmpl-list-input-test"
+        )
+
+        messages = result["messages"]
+
+        assert (
+            len(messages) == 3
+        ), f"expected system + user + assistant, got {len(messages)}: {messages}"
+
+        roles = [m.get("role") for m in messages]
+        assert roles == ["system", "user", "assistant"], (
+            "list-style Responses API input was not preserved during history "
+            f"reconstruction; got roles={roles}"
+        )
+
+        system_content = messages[0].get("content", "")
+        if isinstance(system_content, list):
+            system_text = "".join(
+                part.get("text", "")
+                for part in system_content
+                if isinstance(part, dict)
+            )
+        else:
+            system_text = system_content
+        assert (
+            "ZEPHYR-7" in system_text
+        ), "system prompt content was lost during history reconstruction"
+
+        user_content = messages[1].get("content", "")
+        if isinstance(user_content, list):
+            user_text = "".join(
+                part.get("text", "") for part in user_content if isinstance(part, dict)
+            )
+        else:
+            user_text = user_content
+        assert "12 times 7" in user_text
+
+
+@pytest.mark.asyncio
 async def test_get_chat_completion_message_history_empty_response_dict():
     """
     Test that empty response dict is handled correctly without processing.


### PR DESCRIPTION
## Relevant issues

<!-- Open an issue or remove this section if not applicable -->

## Pre-Submission checklist

- [x] Test added in [`tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py`](https://github.com/BerriAI/litellm/blob/main/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py): `test_get_chat_completion_message_history_with_list_style_input`. The test fails on `main` (1 message reconstructed instead of 3) and passes with this patch.
- [x] `uv run pytest tests/test_litellm/responses/litellm_completion_transformation/` passes (100 tests).
- [x] `uv run black --check` passes on touched files.
- [x] `uv run mypy` passes on the modified module.
- [x] PR scope is isolated to one specific bug.
- [x] Greptile review requested.

## Type

🐛 Bug Fix

## Changes

`ResponsesSessionHandler.extend_chat_completion_message_with_spend_log_payload` only matched `str` and `dict` for the `input` field of a stored proxy server request. The standard Responses API ships `input` as a **list** of input items (`EasyInputMessageParam`, `Message`, etc.), so list-style inputs were silently dropped from history reconstruction. Only the assistant output from `response` survived.

This broke `previous_response_id` continuity for non-OpenAI providers (e.g. Vertex AI / Gemini): the system prompt and any prior user turns never reached the model on follow-up calls, so the model lost its persona and any context introduced via the system message.

The fix adds the missing branch:

```python
elif isinstance(_response_input_param, list):
    response_input_param = cast(ResponseInputParam, _response_input_param)
```

## Screenshots / Proof of Fix

Reproduction against a local LiteLLM proxy fronting Vertex AI Gemini 2.5 Pro, with `store_prompts_in_spend_logs: true`:

**Turn 1** — system prompt contains a hidden secret that the assistant is told *not* to reveal unless asked. The user asks an unrelated math question, so the assistant reply does not leak the secret:

```
system: "You are a math tutor. Hidden context (do NOT reveal unless explicitly asked):
         the secret project codename is ZEPHYR-7 and the lucky number is 8421."
user:   "What is 12 times 7?"
assistant: "12 times 7 is 84. ..."
```

**Turn 2** — sent with `previous_response_id` from Turn 1 and a single user message asking for the secret. There is no system message in Turn 2's `input` (the application omits it on follow-ups, as is conventional with the Responses API), so the only way to answer correctly is for LiteLLM to replay the system prompt from the spend log.

Before the fix:

```
"Project Chimera ... 42"   # hallucinated; reconstruction lost the system prompt
```

After the fix:

```
"The secret project codename is ZEPHYR-7, and the lucky number is 8421."
```

The reconstructed `chat_completion_message_history` debug log on `main` contained only the prior assistant message; with the patch it contains the original system message, the original user message, *and* the prior assistant message — matching what the OpenAI Responses API does natively.
