### PR TITLE
fix(secret_managers): contain oidc/env_path file reads to allowlisted dirs (CWE-22)

### DIFF
--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -255,10 +255,12 @@ def get_secret(  # noqa: PLR0915
             return oidc_token
         elif oidc_provider == "env_path":
             # Load token from a file path specified in an environment variable
+            # within an allowed credential directory.
             token_file_path = os.getenv(oidc_aud)
             if token_file_path is None:
                 raise ValueError(f"Environment variable {oidc_aud} not found")
-            with open(token_file_path, "r") as f:
+            safe_path = _resolve_oidc_file_path(token_file_path)
+            with open(safe_path, "r") as f:
                 oidc_token = f.read()
                 return oidc_token
         else:

--- a/tests/litellm_utils_tests/test_secret_manager.py
+++ b/tests/litellm_utils_tests/test_secret_manager.py
@@ -199,13 +199,14 @@ def test_oidc_file(monkeypatch):
         assert secret_val == secret_value
 
 
-def test_oidc_env_path():
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+def test_oidc_env_path(monkeypatch):
+    # Create a temporary file inside a directory added to the allowlist.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        monkeypatch.setenv("LITELLM_OIDC_ALLOWED_CREDENTIAL_DIRS", temp_dir)
+        temp_file_path = os.path.join(temp_dir, "token.txt")
         secret_value = "secret-" + uuid4().hex
-        temp_file.write(secret_value)
-        temp_file.flush()
-        temp_file_path = temp_file.name
+        with open(temp_file_path, "w") as temp_file:
+            temp_file.write(secret_value)
 
         # Create a unique environment variable name
         env_var_name = "OIDC_TEST_PATH_" + uuid4().hex
@@ -221,6 +222,21 @@ def test_oidc_env_path():
         assert secret_val == secret_value
 
         del os.environ[env_var_name]
+
+
+def test_oidc_env_path_rejects_paths_outside_allowed_dirs(monkeypatch):
+    with tempfile.TemporaryDirectory() as allowed_dir:
+        monkeypatch.setenv("LITELLM_OIDC_ALLOWED_CREDENTIAL_DIRS", allowed_dir)
+        with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+            temp_file.write("do-not-read")
+            temp_file.flush()
+            env_var_name = "OIDC_TEST_PATH_" + uuid4().hex
+            monkeypatch.setenv(env_var_name, temp_file.name)
+
+            with pytest.raises(
+                ValueError, match="outside the allowed credential directories"
+            ):
+                get_secret(f"oidc/env_path/{env_var_name}")
 
 
 def test_google_secret_manager():


### PR DESCRIPTION
## Summary

This PR closes a path-traversal / arbitrary file read in `get_secret()` (`litellm/secret_managers/main.py`). The existing `oidc/file/` branch already calls `_resolve_oidc_file_path()` to enforce that token files live inside an allowlisted directory, but the sibling `oidc/env_path/` branch does not — it `open()`s whatever path the resolved environment variable points at without any containment check. The fix routes that path through the same allowlist helper.

- **CWE:** CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **File / function:** `litellm/secret_managers/main.py` → `get_secret()`, `oidc/env_path/` branch (around line 257 pre-fix)
- **Severity:** High in proxy deployments (authenticated arbitrary file read → token exfiltration)

## Vulnerability details

`get_secret()` is reachable from request-supplied secret references (e.g. `azure_ad_token`, `aws_web_identity_token`) of the form `oidc/env_path/<ENV_NAME>`. In that branch the code does:

```python
token_file_path = os.getenv(oidc_aud)
...
with open(token_file_path, "r") as f:
    oidc_token = f.read()
```

There is no validation that `token_file_path` resolves inside an allowed credential directory, in contrast to the adjacent `oidc/file/` branch which already calls `_resolve_oidc_file_path()`. Any environment variable visible to the proxy process (including ones whose names a caller can pick) can therefore be coerced into reading an arbitrary on-disk file. The contents are then sent outbound as an OIDC bearer token to an attacker-influenceable Azure tenant / AWS STS endpoint and are commonly surfaced in error responses and logs, providing a practical exfiltration channel for the bytes that were read.

Data flow:

1. Authenticated proxy caller submits a request body containing `azure_ad_token` / `aws_web_identity_token` (`litellm/main.py` pops these from kwargs).
2. The string is passed into `get_secret()`.
3. The `oidc/env_path/` branch reads the file and the contents leave the host as a credential or via error/log output.

## Fix

Reuse the existing allowlist helper:

```python
safe_path = _resolve_oidc_file_path(token_file_path)
with open(safe_path, "r") as f:
    ...
```

`_resolve_oidc_file_path()` requires absolute paths, calls `os.path.realpath()`, and verifies `os.path.commonpath([resolved, allowed]) == allowed` against directories from `LITELLM_OIDC_ALLOWED_CREDENTIAL_DIRS` (defaulting to `/var/run/secrets` and `/run/secrets`). This matches the behaviour already enforced for `oidc/file/` and is the smallest possible change — no new helpers, no API changes, no behaviour change for token files that legitimately live under the standard container credential mount points.

## Tests

Added `test_oidc_env_path_rejects_paths_outside_allowed_dirs` and updated `test_oidc_env_path` to set `LITELLM_OIDC_ALLOWED_CREDENTIAL_DIRS` so the happy path still passes:

- `test_oidc_env_path` — env var points at a file inside an allowlisted temp dir → returns the token (positive path still works).
- `test_oidc_env_path_rejects_paths_outside_allowed_dirs` — env var points at a file outside the allowlist → `ValueError("...outside the allowed credential directories")`.

Both tests pass locally with `pytest tests/litellm_utils_tests/test_secret_manager.py -k oidc_env_path`.

## Adversarial review

Before submitting we tried to disprove this. The main candidates for an existing mitigation were (a) request-level filtering of `azure_ad_token` / `aws_web_identity_token` and (b) some upstream sanitiser in front of `get_secret()`. Neither exists today: those fields are popped straight from kwargs in `litellm/main.py` and forwarded into `get_secret()`, and the `env_path` branch is the only one of the three OIDC sub-branches that lacks a containment check — so the fix is genuinely closing a gap rather than hardening something already defended. Proxy auth (`user_api_key_auth`) is required to reach the sink, but a normal API-key holder otherwise has no way to read host files such as `/etc/passwd` or mounted secrets, so this does grant new capability.

One related call site, `litellm/proxy/auth/rds_iam_token.py:80`, also opens an `aws_web_identity_token` path directly, but that value comes from server-side configuration rather than a request body, so it is out of scope for this fix and is best addressed separately if maintainers want to harden it too.

cc @lewiswigmore
