### PR TITLE
fix(ui): coerce MCP cost values defensively before .toFixed (closes #27095)

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_cost_config.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_cost_config.tsx
@@ -3,6 +3,7 @@ import { Tooltip, InputNumber, Collapse, Badge } from "antd";
 import { InfoCircleOutlined, DollarOutlined, ToolOutlined } from "@ant-design/icons";
 import { Card, Title, Text } from "@tremor/react";
 import { MCPServerCostInfo } from "./types";
+import { toFiniteNumber } from "../../utils/numberUtils";
 
 interface MCPServerCostConfigProps {
   value?: MCPServerCostInfo;
@@ -130,29 +131,32 @@ const MCPServerCostConfig: React.FC<MCPServerCostConfigProps> = ({
           )}
         </div>
 
-        {(value.default_cost_per_query ||
-          (value.tool_name_to_cost_per_query && Object.keys(value.tool_name_to_cost_per_query).length > 0)) && (
-          <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <Text className="text-blue-800 font-medium">Cost Summary:</Text>
-            <div className="mt-2 space-y-1">
-              {value.default_cost_per_query && (
-                <Text className="text-blue-700">
-                  • Default cost: ${value.default_cost_per_query.toFixed(4)} per query
-                </Text>
-              )}
-              {value.tool_name_to_cost_per_query &&
-                Object.entries(value.tool_name_to_cost_per_query).map(
-                  ([toolName, cost]) =>
-                    cost !== null &&
-                    cost !== undefined && (
-                      <Text key={toolName} className="text-blue-700">
-                        • {toolName}: ${cost.toFixed(4)} per query
-                      </Text>
-                    ),
+        {(() => {
+          // Coerce defensively: values may arrive as stringified numbers from
+          // JSONB / YAML imports / antd InputNumber emitting strings.
+          const summaryDefaultCost = toFiniteNumber(value.default_cost_per_query);
+          const summaryToolCosts: Array<[string, number]> = Object.entries(
+            value.tool_name_to_cost_per_query ?? {},
+          )
+            .map(([name, raw]): [string, number | null] => [name, toFiniteNumber(raw)])
+            .filter((entry): entry is [string, number] => entry[1] !== null);
+          if (summaryDefaultCost === null && summaryToolCosts.length === 0) return null;
+          return (
+            <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+              <Text className="text-blue-800 font-medium">Cost Summary:</Text>
+              <div className="mt-2 space-y-1">
+                {summaryDefaultCost !== null && (
+                  <Text className="text-blue-700">• Default cost: ${summaryDefaultCost.toFixed(4)} per query</Text>
                 )}
+                {summaryToolCosts.map(([toolName, cost]) => (
+                  <Text key={toolName} className="text-blue-700">
+                    • {toolName}: ${cost.toFixed(4)} per query
+                  </Text>
+                ))}
+              </div>
             </div>
-          </div>
-        )}
+          );
+        })()}
       </div>
     </Card>
   );

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_cost_display.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_cost_display.tsx
@@ -1,16 +1,22 @@
 import React from "react";
 import { Text } from "@tremor/react";
 import { MCPServerCostInfo } from "./types";
+import { toFiniteNumber } from "../../utils/numberUtils";
 
 interface MCPServerCostDisplayProps {
   costConfig?: MCPServerCostInfo | null;
 }
 
 const MCPServerCostDisplay: React.FC<MCPServerCostDisplayProps> = ({ costConfig }) => {
-  const hasDefaultCost =
-    costConfig?.default_cost_per_query !== undefined && costConfig?.default_cost_per_query !== null;
-  const hasToolCosts =
-    costConfig?.tool_name_to_cost_per_query && Object.keys(costConfig.tool_name_to_cost_per_query).length > 0;
+  // Cost values arrive from JSONB / YAML / antd InputNumber and may be
+  // stringified numbers — coerce defensively so `.toFixed(...)` is safe.
+  const defaultCost = toFiniteNumber(costConfig?.default_cost_per_query);
+  const toolCosts: Array<[string, number]> = Object.entries(costConfig?.tool_name_to_cost_per_query ?? {})
+    .map(([name, raw]): [string, number | null] => [name, toFiniteNumber(raw)])
+    .filter((entry): entry is [string, number] => entry[1] !== null);
+
+  const hasDefaultCost = defaultCost !== null;
+  const hasToolCosts = toolCosts.length > 0;
   const hasCostConfig = hasDefaultCost || hasToolCosts;
 
   if (!hasCostConfig) {
@@ -30,29 +36,23 @@ const MCPServerCostDisplay: React.FC<MCPServerCostDisplayProps> = ({ costConfig 
   return (
     <div className="mt-6 pt-6 border-t border-gray-200">
       <div className="space-y-4">
-        {hasDefaultCost &&
-          costConfig?.default_cost_per_query !== undefined &&
-          costConfig?.default_cost_per_query !== null && (
-            <div>
-              <Text className="font-medium">Default Cost per Query</Text>
-              <div className="text-green-600 font-mono">${costConfig.default_cost_per_query.toFixed(4)}</div>
-            </div>
-          )}
+        {hasDefaultCost && defaultCost !== null && (
+          <div>
+            <Text className="font-medium">Default Cost per Query</Text>
+            <div className="text-green-600 font-mono">${defaultCost.toFixed(4)}</div>
+          </div>
+        )}
 
-        {hasToolCosts && costConfig?.tool_name_to_cost_per_query && (
+        {hasToolCosts && (
           <div>
             <Text className="font-medium">Tool-Specific Costs</Text>
             <div className="mt-2 space-y-2">
-              {Object.entries(costConfig.tool_name_to_cost_per_query).map(
-                ([toolName, cost]) =>
-                  cost !== null &&
-                  cost !== undefined && (
-                    <div key={toolName} className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
-                      <Text className="font-medium">{toolName}</Text>
-                      <Text className="text-green-600 font-mono">${cost.toFixed(4)} per query</Text>
-                    </div>
-                  ),
-              )}
+              {toolCosts.map(([toolName, cost]) => (
+                <div key={toolName} className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                  <Text className="font-medium">{toolName}</Text>
+                  <Text className="text-green-600 font-mono">${cost.toFixed(4)} per query</Text>
+                </div>
+              ))}
             </div>
           </div>
         )}
@@ -60,17 +60,11 @@ const MCPServerCostDisplay: React.FC<MCPServerCostDisplayProps> = ({ costConfig 
         <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
           <Text className="text-blue-800 font-medium">Cost Summary:</Text>
           <div className="mt-2 space-y-1">
-            {hasDefaultCost &&
-              costConfig?.default_cost_per_query !== undefined &&
-              costConfig?.default_cost_per_query !== null && (
-                <Text className="text-blue-700">
-                  • Default cost: ${costConfig.default_cost_per_query.toFixed(4)} per query
-                </Text>
-              )}
-            {hasToolCosts && costConfig?.tool_name_to_cost_per_query && (
-              <Text className="text-blue-700">
-                • {Object.keys(costConfig.tool_name_to_cost_per_query).length} tool(s) with custom pricing
-              </Text>
+            {hasDefaultCost && defaultCost !== null && (
+              <Text className="text-blue-700">• Default cost: ${defaultCost.toFixed(4)} per query</Text>
+            )}
+            {hasToolCosts && (
+              <Text className="text-blue-700">• {toolCosts.length} tool(s) with custom pricing</Text>
             )}
           </div>
         </div>

--- a/ui/litellm-dashboard/src/utils/numberUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/numberUtils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { toFiniteNumber } from "./numberUtils";
+
+describe("toFiniteNumber", () => {
+  it("returns finite numbers unchanged", () => {
+    expect(toFiniteNumber(0)).toBe(0);
+    expect(toFiniteNumber(0.005)).toBe(0.005);
+    expect(toFiniteNumber(-1.25)).toBe(-1.25);
+    expect(toFiniteNumber(1e-9)).toBe(1e-9);
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(toFiniteNumber(NaN)).toBeNull();
+    expect(toFiniteNumber(Infinity)).toBeNull();
+    expect(toFiniteNumber(-Infinity)).toBeNull();
+  });
+
+  it("parses stringified numbers", () => {
+    expect(toFiniteNumber("0.005")).toBe(0.005);
+    expect(toFiniteNumber("42")).toBe(42);
+    expect(toFiniteNumber("-1.25")).toBe(-1.25);
+    expect(toFiniteNumber("1e-9")).toBe(1e-9);
+    expect(toFiniteNumber("  3.14 ")).toBe(3.14);
+  });
+
+  it("rejects empty / whitespace-only strings", () => {
+    expect(toFiniteNumber("")).toBeNull();
+    expect(toFiniteNumber("   ")).toBeNull();
+    expect(toFiniteNumber("\t\n")).toBeNull();
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(toFiniteNumber("abc")).toBeNull();
+    expect(toFiniteNumber("0.005 USD")).toBeNull();
+    expect(toFiniteNumber("NaN")).toBeNull();
+    expect(toFiniteNumber("Infinity")).toBeNull();
+  });
+
+  it("returns null for null / undefined", () => {
+    expect(toFiniteNumber(null)).toBeNull();
+    expect(toFiniteNumber(undefined)).toBeNull();
+  });
+
+  it("returns null for non-string non-number values", () => {
+    expect(toFiniteNumber({})).toBeNull();
+    expect(toFiniteNumber([])).toBeNull();
+    expect(toFiniteNumber(true)).toBeNull();
+    expect(toFiniteNumber(false)).toBeNull();
+  });
+
+  it("regression for litellm#27095: stringified cost survives without crashing", () => {
+    // This is the exact shape seen in mcp_info JSONB column when the value is
+    // serialized as a string instead of a number.
+    const stringifiedCost = "0.005";
+    const coerced = toFiniteNumber(stringifiedCost);
+    expect(coerced).not.toBeNull();
+    expect(coerced!.toFixed(4)).toBe("0.0050");
+  });
+});

--- a/ui/litellm-dashboard/src/utils/numberUtils.ts
+++ b/ui/litellm-dashboard/src/utils/numberUtils.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared numeric coercion utility.
+ *
+ * Cost values (e.g. MCP server `default_cost_per_query` and per-tool overrides)
+ * are typed as `number | null` in the UI, but values arriving from the backend
+ * — JSONB columns, YAML/JSON config import paths, or `antd`'s `InputNumber`
+ * which can emit `string` for some precision/locale combinations — may be
+ * stringified numbers. Calling numeric methods like `.toFixed(...)` on those
+ * crashes the page.
+ *
+ * Use `toFiniteNumber` to coerce defensively before formatting.
+ */
+
+/**
+ * Coerce an unknown value to a finite number, or `null` if it cannot be.
+ *
+ * - `number`: returns the value if finite (rejects `NaN` / `±Infinity`).
+ * - `string`: trimmed and parsed via `Number(...)` if non-empty; rejects
+ *   results that aren't finite (e.g. empty, whitespace, `"abc"`).
+ * - everything else (`null`, `undefined`, objects, booleans): `null`.
+ */
+export const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};


### PR DESCRIPTION
### Summary

The MCP server settings view crashed with `Uncaught TypeError: e.default_cost_per_query.toFixed is not a function` whenever `mcp_info.mcp_server_cost_info.default_cost_per_query` (or any per-tool cost) landed in the JSONB column as a string instead of a number. Reported with full root-cause in #27095.

This PR coerces cost values defensively at every `.toFixed(...)` site in the two affected components, so one malformed value no longer blocks the whole settings page.

### Why the crash happens

- `MCPServerCostInfo` is a TypedDict (`litellm/types/mcp.py`) — no runtime validation, so the JSONB column round-trips whatever is written, including strings.
- antd's `InputNumber` `onChange` real signature is `(number | string | null) => void`; the local handler in `mcp_server_cost_config.tsx` types it as `(number | null)` and writes the raw value, so the UI itself can persist a string.
- Other write paths (YAML/JSON config import, direct API call, hand-edited DB rows) can also land non-numeric values.
- Display components called `.toFixed(4)` directly, so one malformed cost crashed the whole page.

### Fix

Add a small shared `toFiniteNumber` helper in `src/utils/numberUtils.ts` (per CLAUDE.md: *"Shared utility functions belong in `src/utils/`"*), and use it before every `.toFixed(...)` callsite in the two components — five total:

- `mcp_server_cost_display.tsx` — default cost render (line 38), per-tool cost render (line 52), default cost in summary (line 67)
- `mcp_server_cost_config.tsx` — default cost in summary (line 140), per-tool cost in summary (line 149)

Non-numeric / non-finite inputs (including stringified gibberish, `NaN`, `Infinity`, `null`, `undefined`, objects) coerce to `null`; the corresponding row is skipped instead of crashing.

### Tests

8 new vitest cases in `numberUtils.test.ts` cover finite/non-finite numbers, parseable/unparseable strings, whitespace-only strings, null/undefined, and non-string/non-number values. The last case is an explicit regression test for #27095:

```ts
it("regression for litellm#27095: stringified cost survives without crashing", () => {
  const stringifiedCost = "0.005";
  const coerced = toFiniteNumber(stringifiedCost);
  expect(coerced).not.toBeNull();
  expect(coerced!.toFixed(4)).toBe("0.0050");
});
```

```text
$ npx vitest run src/utils/numberUtils.test.ts
 ✓ src/utils/numberUtils.test.ts (8 tests) 3ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

`npx tsc --noEmit` reports no new errors in the touched files. (The repo has pre-existing tsc errors in unrelated test files like `returnUrlUtils.test.ts`, `roles.test.ts`, `top_key_view.test.tsx`, `useLogFilterLogic.min.test.tsx` — those are out of scope here.)

### Out of scope (intentional)

- **Backend Pydantic validation of `MCPServerCostInfo`.** Reporter mentions converting the TypedDict to a Pydantic model so the proxy rejects non-numeric writes at the boundary. That's a more complete fix but a separate concern with a larger surface; happy to send a follow-up PR if you'd like.
- **antd `InputNumber` typing in `mcp_server_cost_config.tsx`.** The local `handleDefaultCostChange(defaultCost: number | null)` signature is too narrow for antd's actual `(number | string | null)` emission. Tightening that properly means changing the function signatures and ripples through callers — defensive coercion at the render boundary is the smaller, safer fix for the symptom users are seeing today.
- **Migration off `@tremor/react`.** CLAUDE.md notes the project is migrating to `antd`, but these files already use tremor and the bug fix doesn't require touching imports. Out of scope.

### PR template checklist

- [x] At least 1 test added (`ui/litellm-dashboard/src/utils/numberUtils.test.ts`, 8 cases)
- [x] Touched files type-check cleanly with `tsc --noEmit`
- [x] No raw SQL / no Prisma changes / no schema impact
- [x] No new `@tremor/react` imports introduced
- [x] Followed CLAUDE.md guidance on shared util placement (`src/utils/numberUtils.ts`)

Reported and root-caused by @marty-sullivan in #27095.