### PR TITLE
fix(core_helpers): map vLLM 'repetition' finish_reason to 'stop'

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -95,6 +95,8 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "sensitive": "content_filter",
     # Bedrock
     "guardrail_intervened": "content_filter",
+    # vLLM (server-side RepetitionDetectionParams cuts off contiguous loops)
+    "repetition": "stop",
     # OpenAI passthrough
     "stop": "stop",
     "length": "length",

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -143,6 +143,15 @@ class TestMapFinishReasonZhipu:
         assert map_finish_reason("sensitive") == "content_filter"
 
 
+class TestMapFinishReasonVLLM:
+    def test_repetition(self):
+        # vLLM emits "repetition" when its server-side
+        # ``RepetitionDetectionParams`` cuts off a request stuck in a
+        # contiguous-token loop. Map to "stop" so consumers don't see the
+        # "Unmapped finish_reason 'repetition'" warning on every such row.
+        assert map_finish_reason("repetition") == "stop"
+
+
 class TestMapFinishReasonOpenAIPassthrough:
     @pytest.mark.parametrize(
         "reason", ["stop", "length", "tool_calls", "function_call", "content_filter"]


### PR DESCRIPTION
## Summary

vLLM's `RepetitionDetectionParams` terminates a generation when the server detects a contiguous-token loop and returns `finish_reason: "repetition"`. This value is missing from `_FINISH_REASON_MAP`, so every affected row emits:

```
WARNING - core_helpers.py:108 - Unmapped finish_reason 'repetition', defaulting to 'stop'
```

In a long benchmark run with RD enabled this floods logs with one warning per affected row.

This PR makes the existing `stop` fallback explicit so the warning stops firing. `stop` is consistent with the file's convention of reserving `length` for token-capacity reasons (`max_tokens`, `compaction`, `MAX_TOKENS`) and routing other server-side cut-offs and error states (`network_error`, `MALFORMED_RESPONSE`, `TOO_MANY_TOOL_CALLS`, `ERROR`) to `stop`.

## Changes

- `litellm/litellm_core_utils/core_helpers.py`: register `"repetition": "stop"`
- `tests/test_litellm/litellm_core_utils/test_core_helpers.py`: add `TestMapFinishReasonVLLM.test_repetition`

## Note

Replaces #27100, which accumulated unrelated commits during a base-branch retarget. This branch is cut fresh from `litellm_oss_staging` with only the intended fix commit.