### PR TITLE
fix(deepseek): update reasoning_effort handling no thinking

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -56,9 +56,12 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
                 # DeepSeek only accepts {"type": "enabled"}, ignore budget_tokens
                 optional_params["thinking"] = {"type": "enabled"}
 
-        # Handle reasoning_effort - map to thinking enabled
-        elif reasoning_effort is not None and reasoning_effort != "none":
-            optional_params["thinking"] = {"type": "enabled"}
+        # Handle reasoning_effort - map to thinking enabled/disabled
+        elif reasoning_effort is not None:
+            if reasoning_effort != "none":
+                optional_params["thinking"] = {"type": "enabled"}
+            else:
+                optional_params["thinking"] = {"type": "disabled"}
 
         return optional_params
 

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -49,12 +49,11 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
 
         # Handle thinking parameter - accept {"type": "enabled"} or {"type": "disabled"}
         if thinking_value is not None:
-            if isinstance(thinking_value, dict) and thinking_value.get(
-                "type"
-            ) in ("enabled", "disabled"):
-                optional_params["thinking"] = {
-                    "type": thinking_value["type"]
-                }
+            if isinstance(thinking_value, dict) and thinking_value.get("type") in (
+                "enabled",
+                "disabled",
+            ):
+                optional_params["thinking"] = {"type": thinking_value["type"]}
 
         # Handle reasoning_effort - map to thinking enabled/disabled
         elif reasoning_effort is not None:

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -47,14 +47,14 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         thinking_value = optional_params.pop("thinking", None)
         reasoning_effort = optional_params.pop("reasoning_effort", None)
 
-        # Handle thinking parameter - only accept {"type": "enabled"}
+        # Handle thinking parameter - accept {"type": "enabled"} or {"type": "disabled"}
         if thinking_value is not None:
-            if (
-                isinstance(thinking_value, dict)
-                and thinking_value.get("type") == "enabled"
-            ):
-                # DeepSeek only accepts {"type": "enabled"}, ignore budget_tokens
-                optional_params["thinking"] = {"type": "enabled"}
+            if isinstance(thinking_value, dict) and thinking_value.get(
+                "type"
+            ) in ("enabled", "disabled"):
+                optional_params["thinking"] = {
+                    "type": thinking_value["type"]
+                }
 
         # Handle reasoning_effort - map to thinking enabled/disabled
         elif reasoning_effort is not None:

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -139,6 +139,20 @@ class TestDeepSeekThinkingParams:
         # thinking should be set, reasoning_effort should not override
         assert result["thinking"] == {"type": "enabled"}
 
+    def test_map_thinking_disabled(self):
+        """Test that thinking={"type": "disabled"} is passed through correctly."""
+        non_default_params = {"thinking": {"type": "disabled"}}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+
     def test_invalid_thinking_type_ignored(self):
         """Test that invalid thinking type values are ignored."""
         non_default_params = {"thinking": {"type": "invalid"}}

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -93,8 +93,8 @@ class TestDeepSeekThinkingParams:
 
         assert result["thinking"] == {"type": "enabled"}
 
-    def test_map_reasoning_effort_none_does_not_enable_thinking(self):
-        """Test that reasoning_effort='none' does not enable thinking."""
+    def test_map_reasoning_effort_none_disables_thinking(self):
+        """Test that reasoning_effort='none' sets thinking to disabled."""
         non_default_params = {"reasoning_effort": "none"}
         optional_params = {}
 
@@ -105,7 +105,7 @@ class TestDeepSeekThinkingParams:
             drop_params=False,
         )
 
-        assert "thinking" not in result
+        assert result["thinking"] == {"type": "disabled"}
 
     def test_map_reasoning_effort_null_does_not_enable_thinking(self):
         """Test that reasoning_effort=None does not enable thinking."""


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

Can not disable thinking for deepseek. According https://api-docs.deepseek.com/guides/thinking_mode we need to pass {"thinking": {"type": "disabled"}} when we dont want to


## Changes
