### PR TITLE
fix(azure): omit model from deployment image gen and image edit bodies

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -44,6 +44,7 @@ from .common_utils import (
     select_azure_base_url_or_endpoint,
 )
 from .image_generation import get_azure_image_generation_config
+from .image_generation.http_utils import azure_deployment_image_generation_json_body
 
 
 class AzureOpenAIAssistantsAPIConfig:
@@ -132,22 +133,6 @@ def _check_dynamic_azure_params(
 class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     def __init__(self) -> None:
         super().__init__()
-
-    @staticmethod
-    def azure_deployment_image_generation_json_body(api_base: str, data: dict) -> dict:
-        """
-        JSON body for Azure OpenAI image generation HTTP calls.
-
-        For ``.../openai/deployments/{deployment}/images/generations``, routing uses
-        the deployment in the URL only; sending ``model`` in the body (especially the
-        deployment name) breaks some models (e.g. gpt-image-2). See LiteLLM #26316.
-
-        Provider-style URLs (e.g. ``/providers/...`` for FLUX on Azure AI) keep all
-        keys so non–OpenAI-deployment payloads still work.
-        """
-        if "images/generations" in api_base and "/openai/deployments/" in api_base:
-            return {k: v for k, v in data.items() if k != "model"}
-        return data
 
     def make_sync_azure_openai_chat_completion_request(
         self,
@@ -982,9 +967,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 content=json.dumps(result).encode("utf-8"),
                 request=httpx.Request(method="POST", url="https://api.openai.com/v1"),
             )
-        request_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
-            api_base, data
-        )
+        request_json = azure_deployment_image_generation_json_body(api_base, data)
         return await async_handler.post(
             url=api_base,
             json=request_json,
@@ -1104,9 +1087,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 content=json.dumps(result).encode("utf-8"),
                 request=httpx.Request(method="POST", url="https://api.openai.com/v1"),
             )
-        request_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
-            api_base, data
-        )
+        request_json = azure_deployment_image_generation_json_body(api_base, data)
         return sync_handler.post(
             url=api_base,
             json=request_json,

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -133,6 +133,22 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     def __init__(self) -> None:
         super().__init__()
 
+    @staticmethod
+    def azure_deployment_image_generation_json_body(api_base: str, data: dict) -> dict:
+        """
+        JSON body for Azure OpenAI image generation HTTP calls.
+
+        For ``.../openai/deployments/{deployment}/images/generations``, routing uses
+        the deployment in the URL only; sending ``model`` in the body (especially the
+        deployment name) breaks some models (e.g. gpt-image-2). See LiteLLM #26316.
+
+        Provider-style URLs (e.g. ``/providers/...`` for FLUX on Azure AI) keep all
+        keys so non–OpenAI-deployment payloads still work.
+        """
+        if "images/generations" in api_base and "/openai/deployments/" in api_base:
+            return {k: v for k, v in data.items() if k != "model"}
+        return data
+
     def make_sync_azure_openai_chat_completion_request(
         self,
         azure_client: Union[AzureOpenAI, OpenAI],
@@ -966,9 +982,12 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 content=json.dumps(result).encode("utf-8"),
                 request=httpx.Request(method="POST", url="https://api.openai.com/v1"),
             )
+        request_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
+            api_base, data
+        )
         return await async_handler.post(
             url=api_base,
-            json=data,
+            json=request_json,
             headers=headers,
         )
 
@@ -1085,9 +1104,12 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 content=json.dumps(result).encode("utf-8"),
                 request=httpx.Request(method="POST", url="https://api.openai.com/v1"),
             )
+        request_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
+            api_base, data
+        )
         return sync_handler.post(
             url=api_base,
-            json=data,
+            json=request_json,
             headers=headers,
         )
 

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -1,13 +1,10 @@
-from typing import Dict, Optional, Tuple, cast
+from typing import Dict, Optional, cast
 
 import httpx
-from httpx._types import RequestFiles
 
 import litellm
 from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import FileTypes
-from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import _add_path_to_api_base
 
 
@@ -100,32 +97,7 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
 
         return str(final_url)
 
-    def transform_image_edit_request(
-        self,
-        model: str,
-        prompt: Optional[str],
-        image: Optional[FileTypes],
-        image_edit_optional_request_params: Dict,
-        litellm_params: GenericLiteLLMParams,
-        headers: dict,
-    ) -> Tuple[Dict, RequestFiles]:
-        data, files = super().transform_image_edit_request(
-            model=model,
-            prompt=prompt,
-            image=image,
-            image_edit_optional_request_params=image_edit_optional_request_params,
-            litellm_params=litellm_params,
-            headers=headers,
-        )
-        litellm_params_dict = (
-            litellm_params.model_dump(exclude_none=True)
-            if hasattr(litellm_params, "model_dump")
-            else dict(litellm_params)
-        )
-        resolved_url = self.get_complete_url(
-            model=model,
-            api_base=litellm_params_dict.get("api_base"),
-            litellm_params=litellm_params_dict,
-        )
-        data = self.azure_deployment_image_edit_form_data(data, resolved_url)
-        return data, files
+    def finalize_image_edit_multipart_data(
+        self, data: dict, resolved_request_url: str
+    ) -> dict:
+        return self.azure_deployment_image_edit_form_data(data, resolved_request_url)

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -97,7 +97,7 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
 
         return str(final_url)
 
-    def finalize_image_edit_multipart_data(
+    def finalize_image_edit_request_data(
         self, data: dict, resolved_request_url: str
     ) -> dict:
         return self.azure_deployment_image_edit_form_data(data, resolved_request_url)

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, cast
+from typing import Optional, cast
 
 import httpx
 

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -1,14 +1,30 @@
-from typing import Optional, cast
+from typing import Dict, Optional, Tuple, cast
 
 import httpx
+from httpx._types import RequestFiles
 
 import litellm
 from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import FileTypes
+from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import _add_path_to_api_base
 
 
 class AzureImageEditConfig(OpenAIImageEditConfig):
+    @staticmethod
+    def azure_deployment_image_edit_form_data(data: dict, request_url: str) -> dict:
+        """
+        Azure OpenAI ``.../openai/deployments/{deployment}/images/edits`` routes by
+        deployment in the URL; including ``model`` in multipart fields can break
+        the same way as image generations (LiteLLM #26316).
+
+        Non-deployment edit URLs keep ``model`` when present.
+        """
+        if "images/edits" in request_url and "/openai/deployments/" in request_url:
+            return {k: v for k, v in data.items() if k != "model"}
+        return data
+
     def validate_environment(
         self,
         headers: dict,
@@ -83,3 +99,33 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
         final_url = httpx.URL(new_url).copy_with(params=query_params)
 
         return str(final_url)
+
+    def transform_image_edit_request(
+        self,
+        model: str,
+        prompt: Optional[str],
+        image: Optional[FileTypes],
+        image_edit_optional_request_params: Dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Tuple[Dict, RequestFiles]:
+        data, files = super().transform_image_edit_request(
+            model=model,
+            prompt=prompt,
+            image=image,
+            image_edit_optional_request_params=image_edit_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        litellm_params_dict = (
+            litellm_params.model_dump(exclude_none=True)
+            if hasattr(litellm_params, "model_dump")
+            else dict(litellm_params)
+        )
+        resolved_url = self.get_complete_url(
+            model=model,
+            api_base=litellm_params_dict.get("api_base"),
+            litellm_params=litellm_params_dict,
+        )
+        data = self.azure_deployment_image_edit_form_data(data, resolved_url)
+        return data, files

--- a/litellm/llms/azure/image_generation/__init__.py
+++ b/litellm/llms/azure/image_generation/__init__.py
@@ -6,11 +6,13 @@ from litellm.llms.base_llm.image_generation.transformation import (
 from .dall_e_2_transformation import AzureDallE2ImageGenerationConfig
 from .dall_e_3_transformation import AzureDallE3ImageGenerationConfig
 from .gpt_transformation import AzureGPTImageGenerationConfig
+from .http_utils import azure_deployment_image_generation_json_body
 
 __all__ = [
     "AzureDallE2ImageGenerationConfig",
     "AzureDallE3ImageGenerationConfig",
     "AzureGPTImageGenerationConfig",
+    "azure_deployment_image_generation_json_body",
 ]
 
 

--- a/litellm/llms/azure/image_generation/http_utils.py
+++ b/litellm/llms/azure/image_generation/http_utils.py
@@ -1,0 +1,17 @@
+"""HTTP helpers for Azure OpenAI image generation (REST, not SDK)."""
+
+
+def azure_deployment_image_generation_json_body(api_base: str, data: dict) -> dict:
+    """
+    Build the JSON body for Azure OpenAI image generation POSTs.
+
+    For ``.../openai/deployments/{deployment}/images/generations``, routing uses the
+    deployment in the URL only; sending ``model`` in the body (especially the deployment
+    name) breaks some models (e.g. gpt-image-2). See LiteLLM #26316.
+
+    Provider-style URLs (e.g. ``/providers/...`` for FLUX on Azure AI) keep all keys
+    so non–OpenAI-deployment payloads still work.
+    """
+    if "images/generations" in api_base and "/openai/deployments/" in api_base:
+        return {k: v for k, v in data.items() if k != "model"}
+    return data

--- a/litellm/llms/base_llm/image_edit/transformation.py
+++ b/litellm/llms/base_llm/image_edit/transformation.py
@@ -102,6 +102,15 @@ class BaseImageEditConfig(ABC):
     ) -> Tuple[Dict, RequestFiles]:
         pass
 
+    def finalize_image_edit_multipart_data(
+        self, data: dict, resolved_request_url: str
+    ) -> dict:
+        """
+        Adjust non-file form fields after ``transform_image_edit_request`` using the
+        exact URL that will be used for the HTTP POST (same string as ``get_complete_url``).
+        """
+        return data
+
     @abstractmethod
     def transform_image_edit_response(
         self,

--- a/litellm/llms/base_llm/image_edit/transformation.py
+++ b/litellm/llms/base_llm/image_edit/transformation.py
@@ -102,12 +102,15 @@ class BaseImageEditConfig(ABC):
     ) -> Tuple[Dict, RequestFiles]:
         pass
 
-    def finalize_image_edit_multipart_data(
+    def finalize_image_edit_request_data(
         self, data: dict, resolved_request_url: str
     ) -> dict:
         """
-        Adjust non-file form fields after ``transform_image_edit_request`` using the
-        exact URL that will be used for the HTTP POST (same string as ``get_complete_url``).
+        Last pass on the request dict after ``transform_image_edit_request``, using the
+        exact URL string used for the HTTP POST (same as ``get_complete_url`` output).
+
+        The handler sends this dict as ``data=`` for multipart providers or ``json=``
+        for JSON-only providers; default implementation returns ``data`` unchanged.
         """
         return data
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5579,7 +5579,7 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             headers=headers,
         )
-        data = image_edit_provider_config.finalize_image_edit_multipart_data(
+        data = image_edit_provider_config.finalize_image_edit_request_data(
             data, api_base
         )
 
@@ -5680,7 +5680,7 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             headers=headers,
         )
-        data = image_edit_provider_config.finalize_image_edit_multipart_data(
+        data = image_edit_provider_config.finalize_image_edit_request_data(
             data, api_base
         )
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5579,6 +5579,9 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             headers=headers,
         )
+        data = image_edit_provider_config.finalize_image_edit_multipart_data(
+            data, api_base
+        )
 
         ## LOGGING
         logging_obj.pre_call(
@@ -5676,6 +5679,9 @@ class BaseLLMHTTPHandler:
             image_edit_optional_request_params=image_edit_optional_request_params,
             litellm_params=litellm_params,
             headers=headers,
+        )
+        data = image_edit_provider_config.finalize_image_edit_multipart_data(
+            data, api_base
         )
 
         ## LOGGING

--- a/tests/image_gen_tests/request_payloads/azure_gpt_image_1.json
+++ b/tests/image_gen_tests/request_payloads/azure_gpt_image_1.json
@@ -1,4 +1,3 @@
 {
-  "model": "gpt-image-1",
   "prompt": "test prompt"
 }

--- a/tests/image_gen_tests/test_image_edits.py
+++ b/tests/image_gen_tests/test_image_edits.py
@@ -244,7 +244,7 @@ async def test_openai_image_edit_with_bytesio():
 @pytest.mark.asyncio
 async def test_azure_image_edit_litellm_sdk():
     """Test Azure image edit with mocked httpx request to validate request body and URL"""
-    from litellm import image_edit, aimage_edit
+    from litellm import aimage_edit
 
     # Mock response for Azure image edit
     mock_response = {
@@ -316,12 +316,11 @@ async def test_azure_image_edit_litellm_sdk():
                 list(form_data.keys()) if hasattr(form_data, "keys") else "Not a dict",
             )
 
-            # Validate that model and prompt are in the form data
-            assert "model" in form_data, "model should be in form data"
-            assert "prompt" in form_data, "prompt should be in form data"
+            # Deployment is in the URL path; Azure rejects model in multipart for this route.
             assert (
-                form_data["model"] == "gpt-image-1"
-            ), f"Expected model 'gpt-image-1', got {form_data['model']}"
+                "model" not in form_data
+            ), "model must not be in form data for Azure /openai/deployments/.../images/edits"
+            assert "prompt" in form_data, "prompt should be in the form data"
             assert (
                 prompt.strip() in form_data["prompt"]
             ), f"Expected prompt to contain '{prompt.strip()}'"

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -393,6 +393,7 @@ async def test_aiml_image_generation_with_dynamic_api_key():
 
 @pytest.mark.asyncio
 async def test_azure_image_generation_request_body():
+    """Azure deployment URL selects the model; JSON body omits ``model`` (#26316)."""
     from litellm import aimage_generation
 
     test_dir = os.path.dirname(__file__)

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -1,0 +1,43 @@
+from litellm.llms.azure.image_edit.transformation import AzureImageEditConfig
+from litellm.types.router import GenericLiteLLMParams
+
+
+def test_azure_deployment_image_edit_form_data_strips_model():
+    url = (
+        "https://example.openai.azure.com/openai/deployments/my-dep/"
+        "images/edits?api-version=2025-02-01-preview"
+    )
+    data = {"model": "my-dep", "prompt": "x", "n": 1}
+    out = AzureImageEditConfig.azure_deployment_image_edit_form_data(data, url)
+    assert "model" not in out
+    assert out == {"prompt": "x", "n": 1}
+
+
+def test_azure_deployment_image_edit_form_data_keeps_model_non_deployment_url():
+    url = "https://api.openai.com/v1/images/edits"
+    data = {"model": "gpt-image-1", "prompt": "x"}
+    out = AzureImageEditConfig.azure_deployment_image_edit_form_data(data, url)
+    assert out == data
+
+
+def test_azure_transform_image_edit_request_omits_model_for_deployment():
+    config = AzureImageEditConfig()
+    model = "gpt-image-2-dep"
+    prompt = "add a hat"
+    image = b"fake_png_bytes"
+    litellm_params = GenericLiteLLMParams(
+        api_base="https://example.openai.azure.com",
+        api_version="2025-02-01-preview",
+    )
+    data, files = config.transform_image_edit_request(
+        model=model,
+        prompt=prompt,
+        image=image,
+        image_edit_optional_request_params={"n": 1},
+        litellm_params=litellm_params,
+        headers={},
+    )
+    assert "model" not in data
+    assert data.get("prompt") == prompt
+    assert data.get("n") == 1
+    assert len(files) >= 1

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -20,7 +20,8 @@ def test_azure_deployment_image_edit_form_data_keeps_model_non_deployment_url():
     assert out == data
 
 
-def test_azure_transform_image_edit_request_omits_model_for_deployment():
+def test_azure_finalize_image_edit_strips_model_after_openai_transform():
+    """OpenAI transform still includes model; finalize uses the real request URL."""
     config = AzureImageEditConfig()
     model = "gpt-image-2-dep"
     prompt = "add a hat"
@@ -37,7 +38,14 @@ def test_azure_transform_image_edit_request_omits_model_for_deployment():
         litellm_params=litellm_params,
         headers={},
     )
-    assert "model" not in data
-    assert data.get("prompt") == prompt
-    assert data.get("n") == 1
+    assert data.get("model") == model
+    resolved = config.get_complete_url(
+        model=model,
+        api_base=litellm_params.api_base,
+        litellm_params=litellm_params.model_dump(exclude_none=True),
+    )
+    data_out = config.finalize_image_edit_multipart_data(data, resolved)
+    assert "model" not in data_out
+    assert data_out.get("prompt") == prompt
+    assert data_out.get("n") == 1
     assert len(files) >= 1

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -44,7 +44,7 @@ def test_azure_finalize_image_edit_strips_model_after_openai_transform():
         api_base=litellm_params.api_base,
         litellm_params=litellm_params.model_dump(exclude_none=True),
     )
-    data_out = config.finalize_image_edit_multipart_data(data, resolved)
+    data_out = config.finalize_image_edit_request_data(data, resolved)
     assert "model" not in data_out
     assert data_out.get("prompt") == prompt
     assert data_out.get("n") == 1

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -12,6 +12,9 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import litellm
 from litellm.llms.azure.azure import AzureChatCompletion
+from litellm.llms.azure.image_generation.http_utils import (
+    azure_deployment_image_generation_json_body,
+)
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.azure.image_generation import (
     AzureDallE3ImageGenerationConfig,
@@ -41,7 +44,7 @@ def test_azure_deployment_image_generation_json_body():
         "images/generations?api-version=2025-04-01-preview"
     )
     data = {"model": "my-dep", "prompt": "x", "n": 1}
-    out = AzureChatCompletion.azure_deployment_image_generation_json_body(api, data)
+    out = azure_deployment_image_generation_json_body(api, data)
     assert "model" not in out
     assert out == {"prompt": "x", "n": 1}
 
@@ -50,7 +53,7 @@ def test_azure_providers_image_generation_json_body_keeps_model():
     """Non-deployment routes (e.g. FLUX on Azure AI) keep the payload unchanged."""
     api = "https://example.services.ai.azure.com/providers/blackforestlabs/v1/flux-2-pro?api-version=preview"
     data = {"model": "flux.2-pro", "prompt": "x"}
-    out = AzureChatCompletion.azure_deployment_image_generation_json_body(api, data)
+    out = azure_deployment_image_generation_json_body(api, data)
     assert out == data
 
 

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -12,6 +12,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import litellm
 from litellm.llms.azure.azure import AzureChatCompletion
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.azure.image_generation import (
     AzureDallE3ImageGenerationConfig,
     get_azure_image_generation_config,
@@ -312,26 +313,21 @@ def test_azure_image_generation_base_model_vs_deployment_name():
 
     optional_params = {"n": 1, "size": "1024x1024"}
 
-    # Mock the HTTP request to capture what gets sent
+    mock_http_response = MagicMock()
+    mock_http_response.status_code = 200
+    mock_http_response.json.return_value = {
+        "created": 1234567890,
+        "data": [{"url": "https://example.com/image.png", "revised_prompt": prompt}],
+    }
+
     with patch.object(
-        azure_chat_completion,
-        "make_sync_azure_httpx_request",
-        return_value=MagicMock(
-            json=lambda: {
-                "created": 1234567890,
-                "data": [
-                    {"url": "https://example.com/image.png", "revised_prompt": prompt}
-                ],
-            }
-        ),
-    ) as mock_request:
-        # Mock logging object
+        HTTPHandler, "post", return_value=mock_http_response
+    ) as mock_post:
         logging_obj = MagicMock()
         logging_obj.pre_call = MagicMock()
         logging_obj.post_call = MagicMock()
 
-        # Call the image_generation method
-        response = azure_chat_completion.image_generation(
+        azure_chat_completion.image_generation(
             prompt=prompt,
             timeout=60.0,
             optional_params=optional_params,
@@ -344,34 +340,21 @@ def test_azure_image_generation_base_model_vs_deployment_name():
             litellm_params=litellm_params,
         )
 
-        # Verify the mock was called
-        assert mock_request.called, "HTTP request should have been made"
-
-        # Get the call arguments
-        call_kwargs = mock_request.call_args.kwargs
-
-        # Verify the URL uses the deployment name (not base_model)
-        api_base_used = call_kwargs.get("api_base", "")
-        assert model in api_base_used, (
-            f"URL should contain deployment name '{model}', "
-            f"but got: {api_base_used}"
-        )
-        assert base_model not in api_base_used or base_model == model, (
+        assert mock_post.called, "HTTPHandler.post should be invoked"
+        post_kwargs = mock_post.call_args.kwargs
+        url_used = post_kwargs.get("url", "")
+        assert (
+            model in url_used
+        ), f"URL should contain deployment name '{model}', but got: {url_used}"
+        assert base_model not in url_used or base_model == model, (
             f"URL should NOT contain base_model '{base_model}' when it differs from deployment name, "
-            f"but got: {api_base_used}"
+            f"but got: {url_used}"
         )
 
-        # Verify the HTTP JSON body omits model (deployment is only in the URL)
-        request_data = call_kwargs.get("data", {})
-        wire_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
-            api_base_used, request_data
-        )
+        wire_json = post_kwargs.get("json") or {}
         assert (
             "model" not in wire_json
         ), f"Azure deployment image gen must not send 'model' in JSON body; got keys: {list(wire_json)}"
-        assert request_data.get("model") == base_model  # internal dict unchanged
-
-        # Verify other fields are correct on the wire payload
         assert wire_json.get("prompt") == prompt
         assert wire_json.get("n") == 1
         assert wire_json.get("size") == "1024x1024"
@@ -402,27 +385,24 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
         "api_version": api_version,
     }
 
-    # Mock the HTTP request to capture what gets sent
-    with patch.object(
-        azure_chat_completion,
-        "make_async_azure_httpx_request",
-        new_callable=AsyncMock,
-        return_value=MagicMock(
-            json=lambda: {
-                "created": 1234567890,
-                "data": [
-                    {"url": "https://example.com/image.png", "revised_prompt": prompt}
-                ],
-            }
-        ),
-    ) as mock_request:
-        # Mock logging object
+    mock_http_response = MagicMock()
+    mock_http_response.status_code = 200
+    mock_http_response.json.return_value = {
+        "created": 1234567890,
+        "data": [{"url": "https://example.com/image.png", "revised_prompt": prompt}],
+    }
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_http_response)
+
+    with patch(
+        "litellm.llms.azure.azure.get_async_httpx_client", return_value=mock_client
+    ):
         logging_obj = MagicMock()
         logging_obj.pre_call = MagicMock()
         logging_obj.post_call = MagicMock()
 
-        # Call the aimage_generation method
-        response = await azure_chat_completion.aimage_generation(
+        await azure_chat_completion.aimage_generation(
             data=data,
             model_response=None,
             azure_client_params=azure_client_params,
@@ -430,30 +410,14 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
             input=[],
             logging_obj=logging_obj,
             headers={},
-            model=model,  # Pass the deployment name
+            model=model,
             timeout=60.0,
         )
 
-        # Verify the mock was called
-        assert mock_request.called, "HTTP request should have been made"
-
-        # Get the call arguments
-        call_kwargs = mock_request.call_args.kwargs
-
-        # Verify the URL uses the deployment name (not base_model)
-        api_base_used = call_kwargs.get("api_base", "")
-        assert model in api_base_used, (
-            f"URL should contain deployment name '{model}', "
-            f"but got: {api_base_used}"
-        )
-        assert base_model not in api_base_used or base_model == model, (
-            f"URL should NOT contain base_model '{base_model}' when it differs from deployment name, "
-            f"but got: {api_base_used}"
-        )
-
-        request_data = call_kwargs.get("data", {})
-        wire_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
-            api_base_used, request_data
-        )
+        assert mock_client.post.called
+        post_kwargs = mock_client.post.call_args.kwargs
+        url_used = post_kwargs.get("url", "")
+        assert model in url_used
+        wire_json = post_kwargs.get("json") or {}
         assert "model" not in wire_json
-        assert request_data.get("model") == base_model
+        assert data.get("model") == base_model

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -33,6 +33,26 @@ def test_azure_image_generation_config(received_model, expected_config):
     )
 
 
+def test_azure_deployment_image_generation_json_body():
+    """Deployment-scoped Azure image URL must not send ``model`` in JSON."""
+    api = (
+        "https://example.openai.azure.com/openai/deployments/my-dep/"
+        "images/generations?api-version=2025-04-01-preview"
+    )
+    data = {"model": "my-dep", "prompt": "x", "n": 1}
+    out = AzureChatCompletion.azure_deployment_image_generation_json_body(api, data)
+    assert "model" not in out
+    assert out == {"prompt": "x", "n": 1}
+
+
+def test_azure_providers_image_generation_json_body_keeps_model():
+    """Non-deployment routes (e.g. FLUX on Azure AI) keep the payload unchanged."""
+    api = "https://example.services.ai.azure.com/providers/blackforestlabs/v1/flux-2-pro?api-version=preview"
+    data = {"model": "flux.2-pro", "prompt": "x"}
+    out = AzureChatCompletion.azure_deployment_image_generation_json_body(api, data)
+    assert out == data
+
+
 def test_azure_image_generation_flattens_extra_body():
     """
     Test that Azure image generation correctly flattens extra_body parameters.
@@ -260,20 +280,17 @@ def test_azure_image_generation_drop_params_false_raises_error():
 
 def test_azure_image_generation_base_model_vs_deployment_name():
     """
-    Test that Azure image generation correctly uses base_model in request body
-    but deployment name in the URL.
+    Test that Azure image generation omits ``model`` from the JSON body for
+    deployment URLs while keeping the deployment in the path.
 
-    When base_model is specified in litellm_params, the request should:
-    1. Use base_model (e.g., "gpt-image-1.5") in the JSON request body
-    2. Use the deployment name (e.g., "gpt-image-15") in the URL path
-
-    This is important because Azure expects:
-    - URL: /openai/deployments/{deployment_name}/images/generations
-    - Body: {"model": "{base_model}", ...}
+    Azure OpenAI routes image generation by deployment in the URL; the REST body
+    must not include ``model`` (sending deployment or base model there can break
+    gpt-image-2; see LiteLLM #26316). ``base_model`` in litellm_params is still used
+    internally for logging / hidden params.
 
     Example config:
-      model: azure/gpt-image-15  # deployment name
-      base_model: gpt-image-1.5  # actual model name
+      model: azure/gpt-image-15  # deployment name (URL only)
+      base_model: gpt-image-1.5  # optional, for LiteLLM metadata
     """
     from unittest.mock import MagicMock
 
@@ -344,26 +361,27 @@ def test_azure_image_generation_base_model_vs_deployment_name():
             f"but got: {api_base_used}"
         )
 
-        # Verify the request body uses base_model (not deployment name)
+        # Verify the HTTP JSON body omits model (deployment is only in the URL)
         request_data = call_kwargs.get("data", {})
-        assert request_data.get("model") == base_model, (
-            f"Request body 'model' field should be base_model '{base_model}', "
-            f"but got: {request_data.get('model')}"
+        wire_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
+            api_base_used, request_data
         )
+        assert (
+            "model" not in wire_json
+        ), f"Azure deployment image gen must not send 'model' in JSON body; got keys: {list(wire_json)}"
+        assert request_data.get("model") == base_model  # internal dict unchanged
 
-        # Verify other fields are correct
-        assert request_data.get("prompt") == prompt
-        assert request_data.get("n") == 1
-        assert request_data.get("size") == "1024x1024"
+        # Verify other fields are correct on the wire payload
+        assert wire_json.get("prompt") == prompt
+        assert wire_json.get("n") == 1
+        assert wire_json.get("size") == "1024x1024"
 
 
 @pytest.mark.asyncio
 async def test_azure_aimage_generation_base_model_vs_deployment_name():
     """
-    Test that Azure async image generation correctly uses base_model in request body
-    but deployment name in the URL.
-
-    This is the async version of test_azure_image_generation_base_model_vs_deployment_name.
+    Async variant of test_azure_image_generation_base_model_vs_deployment_name:
+    deployment in URL, no ``model`` in the JSON body sent to Azure.
     """
     from unittest.mock import MagicMock
 
@@ -433,9 +451,9 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
             f"but got: {api_base_used}"
         )
 
-        # Verify the request body uses base_model (not deployment name)
         request_data = call_kwargs.get("data", {})
-        assert request_data.get("model") == base_model, (
-            f"Request body 'model' field should be base_model '{base_model}', "
-            f"but got: {request_data.get('model')}"
+        wire_json = AzureChatCompletion.azure_deployment_image_generation_json_body(
+            api_base_used, request_data
         )
+        assert "model" not in wire_json
+        assert request_data.get("model") == base_model


### PR DESCRIPTION
## Summary
Azure OpenAI selects the model via `/openai/deployments/{deployment}/...` in the URL. Including `model` in the JSON body (image generation) or multipart form fields (image edits) sends the deployment resource name, which Azure rejects for gpt-image-2 (`invalid_value` / model does not exist). This aligns LiteLLM with direct Azure REST calls.

## Changes
- **Image generation** (`azure.py`): POST JSON for deployment-scoped `images/generations` URLs omits `model`; `/providers/...` (e.g. FLUX) unchanged.
- **Image edit** (`azure/image_edit/transformation.py`): multipart `data` omits `model` when the resolved URL is deployment-scoped `images/edits`.

## Tests
- `tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py` — wire payload assertions + helper coverage.
- `tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py` — new tests for form-data stripping and transform.

Fixes  #26539 
Fixes LIT-2757

<img width="1093" height="835" alt="image" src="https://github.com/user-attachments/assets/c285a22a-fdbb-4357-a8b1-8bf650ac8e04" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is narrowly scoped to Azure deployment-style image endpoints and is covered by new/updated tests, but it slightly alters wire payloads for those routes.
> 
> **Overview**
> Azure deployment-scoped image calls now **strip `model` from the outbound payload**: JSON bodies for `.../openai/deployments/.../images/generations` and multipart form fields for `.../openai/deployments/.../images/edits` no longer include `model`, relying on the deployment in the URL instead.
> 
> This adds a provider hook (`finalize_image_edit_multipart_data`) so image-edit providers can adjust form fields after URL resolution, updates request/fixture expectations, and adds targeted tests to assert the on-the-wire payload for both deployment and non-deployment (`/providers/...`) routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c53c71ad6641d3b3a70a6d8659157359d62c6b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->