### PR TITLE
feat(utils): sanitize OpenAI tool names

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1961,8 +1961,6 @@ if TYPE_CHECKING:
 
     bedrock_tool_name_mappings: InMemoryCache
 
-    openai_tool_name_mappings: InMemoryCache
-
     # Azure exception class (lazy-loaded)
     from litellm.llms.azure.common_utils import AzureOpenAIError
 
@@ -2054,18 +2052,6 @@ def __getattr__(name: str) -> Any:
 
             _globals["bedrock_tool_name_mappings"] = _bedrock_tool_name_mappings
         return _globals["bedrock_tool_name_mappings"]
-
-    if name == "openai_tool_name_mappings":
-        from ._lazy_imports import _get_litellm_globals
-
-        _globals = _get_litellm_globals()
-        if "openai_tool_name_mappings" not in _globals:
-            from .litellm_core_utils.openai_tool_name_mapping import (
-                openai_tool_name_mappings as _openai_tool_name_mappings,
-            )
-
-            _globals["openai_tool_name_mappings"] = _openai_tool_name_mappings
-        return _globals["openai_tool_name_mappings"]
 
     # Lazy load AzureOpenAIError exception class
     if name == "AzureOpenAIError":

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1961,6 +1961,8 @@ if TYPE_CHECKING:
 
     bedrock_tool_name_mappings: InMemoryCache
 
+    openai_tool_name_mappings: InMemoryCache
+
     # Azure exception class (lazy-loaded)
     from litellm.llms.azure.common_utils import AzureOpenAIError
 
@@ -2052,6 +2054,18 @@ def __getattr__(name: str) -> Any:
 
             _globals["bedrock_tool_name_mappings"] = _bedrock_tool_name_mappings
         return _globals["bedrock_tool_name_mappings"]
+
+    if name == "openai_tool_name_mappings":
+        from ._lazy_imports import _get_litellm_globals
+
+        _globals = _get_litellm_globals()
+        if "openai_tool_name_mappings" not in _globals:
+            from .litellm_core_utils.openai_tool_name_mapping import (
+                openai_tool_name_mappings as _openai_tool_name_mappings,
+            )
+
+            _globals["openai_tool_name_mappings"] = _openai_tool_name_mappings
+        return _globals["openai_tool_name_mappings"]
 
     # Lazy load AzureOpenAIError exception class
     if name == "AzureOpenAIError":

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -72,7 +72,7 @@ def _normalize_images_for_message(
 
 
 def _map_tool_call_dict_openai_names_to_user(tc: dict) -> dict:
-    """Restore client tool names when LiteLLM sanitized outbound tools for OpenAI."""
+    """Restore client tool names when this completion rewrote them for OpenAI."""
     from litellm.litellm_core_utils.openai_tool_name_mapping import (
         restore_openai_tool_name_for_user,
     )

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -71,6 +71,20 @@ def _normalize_images_for_message(
     return normalized
 
 
+def _map_tool_call_dict_openai_names_to_user(tc: dict) -> dict:
+    """Restore client tool names when LiteLLM sanitized outbound tools for OpenAI."""
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        restore_openai_tool_name_for_user,
+    )
+
+    fn = tc.get("function")
+    if isinstance(fn, dict) and fn.get("name"):
+        restored = restore_openai_tool_name_for_user(fn["name"])
+        if restored != fn["name"]:
+            return {**tc, "function": {**fn, "name": restored}}
+    return tc
+
+
 def _safe_convert_created_field(created_value) -> int:
     """
     Safely convert a 'created' field value to an integer.
@@ -546,6 +560,8 @@ def convert_to_model_response_object(  # noqa: PLR0915
                 if tool_calls is not None:
                     _openai_tool_calls = []
                     for _tc in tool_calls:
+                        if isinstance(_tc, dict):
+                            _tc = _map_tool_call_dict_openai_names_to_user(_tc)
                         _openai_tc = ChatCompletionMessageToolCall(**_tc)
                         _openai_tool_calls.append(_openai_tc)
                     fixed_tool_calls = _handle_invalid_parallel_tool_calls(

--- a/litellm/litellm_core_utils/openai_tool_name_mapping.py
+++ b/litellm/litellm_core_utils/openai_tool_name_mapping.py
@@ -50,10 +50,23 @@ def should_sanitize_openai_tool_names(litellm_provider: str) -> bool:
     return litellm_provider in _OPENAI_TOOL_NAME_VALIDATION_PROVIDERS
 
 
-def begin_openai_tool_name_mapping_scope() -> None:
-    """Reset both mappings for this completion (call once at the start of completion())."""
-    _CTX.set({})
-    _CTX_REV.set({})
+def begin_openai_tool_name_mapping_scope(*, force_reset: bool = False) -> None:
+    """Initialise (or reset) both mapping dicts for one completion request.
+
+    Idempotent by default: if the ContextVar already holds a dict this is a
+    no-op.  This matters for async streaming where ``acompletion`` calls this
+    function in the *outer* async context before ``contextvars.copy_context()``
+    so that both the executor and the stream consumer share the same dict
+    objects by reference.  The inner ``completion()`` call then sees a non-None
+    dict and skips the reset, preserving the shared reference.
+
+    Pass ``force_reset=True`` only when you explicitly want a clean slate
+    (e.g. in tests).
+    """
+    if force_reset or _CTX.get() is None:
+        _CTX.set({})
+    if force_reset or _CTX_REV.get() is None:
+        _CTX_REV.set({})
 
 
 def _store(sanitized: str, original: str) -> None:

--- a/litellm/litellm_core_utils/openai_tool_name_mapping.py
+++ b/litellm/litellm_core_utils/openai_tool_name_mapping.py
@@ -1,0 +1,36 @@
+"""
+Mapping from OpenAI-safe tool names back to client-supplied names.
+
+OpenAI requires tools[].function.name to match ^[a-zA-Z0-9_-]+$. LiteLLM sanitizes
+outbound requests and stores sanitized -> original in an in-memory cache (same pattern
+as litellm.bedrock_tool_name_mappings / make_valid_bedrock_tool_name).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from litellm.caching.in_memory_cache import InMemoryCache
+
+# Mirrors bedrock_tool_name_mappings in llms/bedrock/chat/invoke_handler.py
+openai_tool_name_mappings: InMemoryCache = InMemoryCache(
+    max_size_in_memory=50, default_ttl=600
+)
+
+
+def get_openai_tool_name(response_tool_name: str) -> str:
+    """
+    If LiteLLM sanitized the outbound tool name, map the API response name back to the original.
+
+    Same idea as get_bedrock_tool_name for Bedrock toolSpec names.
+    """
+    if response_tool_name in openai_tool_name_mappings.cache_dict:
+        response_tool_name = openai_tool_name_mappings.cache_dict[response_tool_name]
+    return response_tool_name
+
+
+def restore_openai_tool_name_for_user(sanitized_name: Optional[str]) -> Optional[str]:
+    """Nullable wrapper used when normalizing tool_calls from responses."""
+    if sanitized_name is None:
+        return None
+    return get_openai_tool_name(sanitized_name)

--- a/litellm/litellm_core_utils/openai_tool_name_mapping.py
+++ b/litellm/litellm_core_utils/openai_tool_name_mapping.py
@@ -1,13 +1,17 @@
 """
-Per-request mapping from OpenAI-safe tool names back to client-supplied names.
+Per-request mapping between client-supplied tool names and their OpenAI-safe forms.
 
 OpenAI's Chat Completions API requires tools[].function.name to match
 ``^[a-zA-Z0-9_-]+$``. For providers that enforce this, we rewrite outbound tool
-names and keep sanitized -> original in a ContextVar dict for this completion only
-(never a process-wide cache).
+names and keep two ContextVar dicts for this completion only (never a process-wide
+cache):
 
-Restore in ``convert_dict_to_response`` only affects names present in the current
-request's mapping, so other providers and concurrent requests are unaffected.
+  _CTX      – sanitized  → original   (used on the response path)
+  _CTX_REV  – original   → sanitized  (used to rewrite tool_choice before the request)
+
+Using the pre-built reverse map for tool_choice guarantees that collision suffixes
+(e.g. "a_b_1") added by _make_unique_openai_tool_name are respected instead of
+being recomputed independently.
 """
 
 from __future__ import annotations
@@ -17,6 +21,9 @@ from typing import Dict, Optional
 
 _CTX: contextvars.ContextVar[Optional[Dict[str, str]]] = contextvars.ContextVar(
     "litellm_openai_tool_name_mapping", default=None
+)
+_CTX_REV: contextvars.ContextVar[Optional[Dict[str, str]]] = contextvars.ContextVar(
+    "litellm_openai_tool_name_mapping_rev", default=None
 )
 
 # Providers where the upstream Chat Completions API applies OpenAI tool-name validation.
@@ -44,8 +51,9 @@ def should_sanitize_openai_tool_names(litellm_provider: str) -> bool:
 
 
 def begin_openai_tool_name_mapping_scope() -> None:
-    """Reset mapping for this completion (call once at the start of completion())."""
+    """Reset both mappings for this completion (call once at the start of completion())."""
     _CTX.set({})
+    _CTX_REV.set({})
 
 
 def _store(sanitized: str, original: str) -> None:
@@ -56,6 +64,11 @@ def _store(sanitized: str, original: str) -> None:
         m = {}
         _CTX.set(m)
     m[sanitized] = original
+    r = _CTX_REV.get()
+    if r is None:
+        r = {}
+        _CTX_REV.set(r)
+    r[original] = sanitized
 
 
 def get_openai_tool_name(response_tool_name: str) -> str:
@@ -74,3 +87,16 @@ def restore_openai_tool_name_for_user(sanitized_name: Optional[str]) -> Optional
 def store_openai_tool_name_mapping(sanitized: str, original: str) -> None:
     """Record a rewrite when ``validate_and_fix_openai_tools`` sanitizes a name."""
     _store(sanitized, original)
+
+
+def get_sanitized_tool_name(original_name: str) -> str:
+    """Return the sanitized (outbound) name for *original_name* if it was rewritten.
+
+    Used to rewrite ``tool_choice.function.name`` after ``validate_and_fix_openai_tools``
+    has run, so that collision suffixes added by ``_make_unique_openai_tool_name`` are
+    respected rather than recomputed independently.
+    """
+    r = _CTX_REV.get()
+    if r is not None and original_name in r:
+        return r[original_name]
+    return original_name

--- a/litellm/litellm_core_utils/openai_tool_name_mapping.py
+++ b/litellm/litellm_core_utils/openai_tool_name_mapping.py
@@ -1,36 +1,76 @@
 """
-Mapping from OpenAI-safe tool names back to client-supplied names.
+Per-request mapping from OpenAI-safe tool names back to client-supplied names.
 
-OpenAI requires tools[].function.name to match ^[a-zA-Z0-9_-]+$. LiteLLM sanitizes
-outbound requests and stores sanitized -> original in an in-memory cache (same pattern
-as litellm.bedrock_tool_name_mappings / make_valid_bedrock_tool_name).
+OpenAI's Chat Completions API requires tools[].function.name to match
+``^[a-zA-Z0-9_-]+$``. For providers that enforce this, we rewrite outbound tool
+names and keep sanitized -> original in a ContextVar dict for this completion only
+(never a process-wide cache).
+
+Restore in ``convert_dict_to_response`` only affects names present in the current
+request's mapping, so other providers and concurrent requests are unaffected.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+import contextvars
+from typing import Dict, Optional
 
-from litellm.caching.in_memory_cache import InMemoryCache
+_CTX: contextvars.ContextVar[Optional[Dict[str, str]]] = contextvars.ContextVar(
+    "litellm_openai_tool_name_mapping", default=None
+)
 
-# Mirrors bedrock_tool_name_mappings in llms/bedrock/chat/invoke_handler.py
-openai_tool_name_mappings: InMemoryCache = InMemoryCache(
-    max_size_in_memory=50, default_ttl=600
+# Providers where the upstream Chat Completions API applies OpenAI tool-name validation.
+_OPENAI_TOOL_NAME_VALIDATION_PROVIDERS = frozenset(
+    {
+        "openai",
+        "azure",
+        "azure_ai",
+        "custom_openai",
+        "text-completion-openai",
+        "groq",
+        "deepinfra",
+        "together_ai",
+        "fireworks_ai",
+        "nvidia_nim",
+        "github_copilot",
+        "perplexity",
+        "xai",
+    }
 )
 
 
-def get_openai_tool_name(response_tool_name: str) -> str:
-    """
-    If LiteLLM sanitized the outbound tool name, map the API response name back to the original.
+def should_sanitize_openai_tool_names(litellm_provider: str) -> bool:
+    return litellm_provider in _OPENAI_TOOL_NAME_VALIDATION_PROVIDERS
 
-    Same idea as get_bedrock_tool_name for Bedrock toolSpec names.
-    """
-    if response_tool_name in openai_tool_name_mappings.cache_dict:
-        response_tool_name = openai_tool_name_mappings.cache_dict[response_tool_name]
+
+def begin_openai_tool_name_mapping_scope() -> None:
+    """Reset mapping for this completion (call once at the start of completion())."""
+    _CTX.set({})
+
+
+def _store(sanitized: str, original: str) -> None:
+    if sanitized == original:
+        return
+    m = _CTX.get()
+    if m is None:
+        m = {}
+        _CTX.set(m)
+    m[sanitized] = original
+
+
+def get_openai_tool_name(response_tool_name: str) -> str:
+    m = _CTX.get()
+    if m is not None and response_tool_name in m:
+        return m[response_tool_name]
     return response_tool_name
 
 
 def restore_openai_tool_name_for_user(sanitized_name: Optional[str]) -> Optional[str]:
-    """Nullable wrapper used when normalizing tool_calls from responses."""
     if sanitized_name is None:
         return None
     return get_openai_tool_name(sanitized_name)
+
+
+def store_openai_tool_name_mapping(sanitized: str, original: str) -> None:
+    """Record a rewrite when ``validate_and_fix_openai_tools`` sanitizes a name."""
+    _store(sanitized, original)

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -6,6 +6,9 @@ from litellm.types.llms.openai import (
     ChatCompletionAssistantContentValue,
     ChatCompletionAudioDelta,
 )
+from litellm.litellm_core_utils.openai_tool_name_mapping import (
+    restore_openai_tool_name_for_user,
+)
 from litellm.types.utils import (
     ChatCompletionAudioResponse,
     ChatCompletionMessageToolCall,
@@ -293,10 +296,12 @@ class ChunkProcessor:
             if tool_call_data["id"] and tool_call_data["name"]:
                 combined_arguments = "".join(tool_call_data["arguments"]) or "{}"
 
+                display_name = restore_openai_tool_name_for_user(tool_call_data["name"])
+
                 # Build function - provider_specific_fields should be on tool_call level, not function level
                 function = Function(
                     arguments=combined_arguments,
-                    name=tool_call_data["name"],
+                    name=display_name,
                 )
 
                 # Prepare params for ChatCompletionMessageToolCall

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -9,9 +9,6 @@ from litellm.types.llms.openai import (
     ChatCompletionAssistantContentValue,
     ChatCompletionAudioDelta,
 )
-from litellm.litellm_core_utils.openai_tool_name_mapping import (
-    restore_openai_tool_name_for_user,
-)
 from litellm.types.utils import (
     ChatCompletionAudioResponse,
     ChatCompletionMessageToolCall,

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -2,6 +2,9 @@ import base64
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
+from litellm.litellm_core_utils.openai_tool_name_mapping import (
+    restore_openai_tool_name_for_user,
+)
 from litellm.types.llms.openai import (
     ChatCompletionAssistantContentValue,
     ChatCompletionAudioDelta,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1167,7 +1167,6 @@ def completion(  # type: ignore # noqa: PLR0915
         raise ValueError("model param not passed in.")
     # validate messages
     messages = validate_and_fix_openai_messages(messages=messages)
-    tools = validate_and_fix_openai_tools(tools=tools)
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1189,9 +1189,11 @@ def completion(  # type: ignore # noqa: PLR0915
     ):
         _fn = tool_choice.get("function")
         if isinstance(_fn, dict) and isinstance(_fn.get("name"), str):
-            from litellm.utils import _sanitize_openai_function_tool_name as _san_name
+            from litellm.litellm_core_utils.openai_tool_name_mapping import (
+                get_sanitized_tool_name as _get_sanitized,
+            )
 
-            _sanitized_tc_name = _san_name(_fn["name"], -1)
+            _sanitized_tc_name = _get_sanitized(_fn["name"])
             if _sanitized_tc_name != _fn["name"]:
                 tool_choice = {
                     **tool_choice,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1182,6 +1182,21 @@ def completion(  # type: ignore # noqa: PLR0915
         tools=tools,
         sanitize_openai_function_tool_names=_sanitize_openai_fn_tool_names,
     )
+    if (
+        _sanitize_openai_fn_tool_names
+        and isinstance(tool_choice, dict)
+        and tool_choice.get("type") == "function"
+    ):
+        _fn = tool_choice.get("function")
+        if isinstance(_fn, dict) and isinstance(_fn.get("name"), str):
+            from litellm.utils import _sanitize_openai_function_tool_name as _san_name
+
+            _sanitized_tc_name = _san_name(_fn["name"], -1)
+            if _sanitized_tc_name != _fn["name"]:
+                tool_choice = {
+                    **tool_choice,
+                    "function": {**_fn, "name": _sanitized_tc_name},
+                }
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1164,6 +1164,20 @@ def completion(  # type: ignore # noqa: PLR0915
         raise ValueError("model param not passed in.")
     # validate messages
     messages = validate_and_fix_openai_messages(messages=messages)
+    tools = validate_and_fix_openai_tools(tools=tools)
+    # validate tool_choice
+    tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
+    # validate optional params
+    stop = validate_openai_optional_params(stop=stop)
+    # normalize camelCase thinking keys (e.g. budgetTokens -> budget_tokens)
+    thinking = validate_and_fix_thinking_param(thinking=thinking)
+
+    ######### unpacking kwargs #####################
+    args = locals()
+
+    # OpenAI tool-name sanitization — must run AFTER args = locals() so that the
+    # intermediate provider-detection variables are never captured by locals() and
+    # never forwarded as extra keys to the upstream API (e.g. Bedrock).
     begin_openai_tool_name_mapping_scope()
     try:
         _, _litellm_provider_for_tools, _, _ = get_llm_provider(
@@ -1178,7 +1192,7 @@ def completion(  # type: ignore # noqa: PLR0915
         )
     except Exception:
         _sanitize_openai_fn_tool_names = False
-    tools = validate_and_fix_openai_tools(
+    args["tools"] = tools = validate_and_fix_openai_tools(
         tools=tools,
         sanitize_openai_function_tool_names=_sanitize_openai_fn_tool_names,
     )
@@ -1195,19 +1209,10 @@ def completion(  # type: ignore # noqa: PLR0915
 
             _sanitized_tc_name = _get_sanitized(_fn["name"])
             if _sanitized_tc_name != _fn["name"]:
-                tool_choice = {
+                args["tool_choice"] = tool_choice = {
                     **tool_choice,
                     "function": {**_fn, "name": _sanitized_tc_name},
                 }
-    # validate tool_choice
-    tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
-    # validate optional params
-    stop = validate_openai_optional_params(stop=stop)
-    # normalize camelCase thinking keys (e.g. budgetTokens -> budget_tokens)
-    thinking = validate_and_fix_thinking_param(thinking=thinking)
-
-    ######### unpacking kwargs #####################
-    args = locals()
 
     skip_mcp_handler = kwargs.pop("_skip_mcp_handler", False)
     if not skip_mcp_handler and tools:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -160,6 +160,10 @@ from litellm.utils import (
 
 from ._logging import verbose_logger
 from .caching.caching import disable_cache, enable_cache, update_cache
+from .litellm_core_utils.openai_tool_name_mapping import (
+    begin_openai_tool_name_mapping_scope,
+    should_sanitize_openai_tool_names,
+)
 from .litellm_core_utils.core_helpers import safe_deep_copy
 from .litellm_core_utils.fallback_utils import (
     async_completion_with_fallbacks,
@@ -1160,7 +1164,24 @@ def completion(  # type: ignore # noqa: PLR0915
         raise ValueError("model param not passed in.")
     # validate messages
     messages = validate_and_fix_openai_messages(messages=messages)
-    tools = validate_and_fix_openai_tools(tools=tools)
+    begin_openai_tool_name_mapping_scope()
+    try:
+        _, _litellm_provider_for_tools, _, _ = get_llm_provider(
+            model=model,
+            custom_llm_provider=kwargs.get("custom_llm_provider"),
+            api_base=kwargs.get("api_base") or base_url,
+            api_key=kwargs.get("api_key") or api_key,
+            litellm_params=kwargs.get("litellm_params"),
+        )
+        _sanitize_openai_fn_tool_names = should_sanitize_openai_tool_names(
+            _litellm_provider_for_tools
+        )
+    except Exception:
+        _sanitize_openai_fn_tool_names = False
+    tools = validate_and_fix_openai_tools(
+        tools=tools,
+        sanitize_openai_function_tool_names=_sanitize_openai_fn_tool_names,
+    )
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -611,6 +611,9 @@ async def acompletion(  # noqa: PLR0915
         # Use a partial function to pass your keyword arguments
         func = partial(completion, **completion_kwargs, **kwargs)
 
+        # Initialise the OpenAI tool-name mapping scope in the *outer* async
+        begin_openai_tool_name_mapping_scope()
+
         # Add the context to the function
         ctx = contextvars.copy_context()
         func_with_context = partial(ctx.run, func)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7880,7 +7880,6 @@ _OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH = 64
 def _sanitize_openai_function_tool_name(name: str, index: int) -> str:
     """
     Normalize function.name to match OpenAI's pattern ^[a-zA-Z0-9_-]+$ and length cap.
-    See: OpenAI Chat Completions tools[].function.name validation.
     """
     if name is None or (isinstance(name, str) and not str(name).strip()):
         return f"litellm_unnamed_tool_{index}"
@@ -7891,7 +7890,6 @@ def _sanitize_openai_function_tool_name(name: str, index: int) -> str:
 
 
 def _make_unique_openai_tool_name(base: str, used_names: set[str]) -> str:
-    """Disambiguate sanitized names when multiple tools map to the same string."""
     candidate = base
     n = 0
     while candidate in used_names:
@@ -7910,7 +7908,7 @@ def _maybe_fix_openai_function_tool_name(
     tool_dict: dict, index: int, used_names: set[str]
 ) -> None:
     from litellm.litellm_core_utils.openai_tool_name_mapping import (
-        openai_tool_name_mappings,
+        store_openai_tool_name_mapping,
     )
 
     fn = tool_dict.get("function")
@@ -7927,19 +7925,32 @@ def _maybe_fix_openai_function_tool_name(
     unique = _make_unique_openai_tool_name(base, used_names)
     fn["name"] = unique
     if unique != raw_original:
-        openai_tool_name_mappings.set_cache(key=unique, value=raw_original)
+        store_openai_tool_name_mapping(unique, raw_original)
 
 
-def validate_and_fix_openai_tools(tools: Optional[List]) -> Optional[List[dict]]:
+def validate_and_fix_openai_tools(
+    tools: Optional[List],
+    *,
+    sanitize_openai_function_tool_names: bool = False,
+) -> Optional[List[dict]]:
     """
     Ensure tools is List[dict] and not List[BaseModel].
 
-    Sanitizes OpenAI function tool names to match ^[a-zA-Z0-9_-]+$ (max 64 chars),
-    disambiguates collisions, and does not mutate caller-provided dicts.
+    When ``sanitize_openai_function_tool_names`` is True (OpenAI-compatible
+    providers only), rewrites function names to ``^[a-zA-Z0-9_-]+$`` (max 64 chars).
     """
     if tools is None:
         return tools
-    new_tools: List[dict] = []
+    if not sanitize_openai_function_tool_names:
+        new_tools: List[dict] = []
+        for tool in tools:
+            if isinstance(tool, BaseModel):
+                new_tools.append(tool.model_dump())
+            elif isinstance(tool, dict):
+                new_tools.append(tool)
+        return new_tools
+
+    new_tools = []
     used_names: set[str] = set()
     for idx, tool in enumerate(tools):
         if isinstance(tool, BaseModel):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7874,18 +7874,82 @@ def validate_and_fix_openai_messages(messages: List):
     return validate_chat_completion_user_messages(messages=new_messages)
 
 
+_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH = 64
+
+
+def _sanitize_openai_function_tool_name(name: str, index: int) -> str:
+    """
+    Normalize function.name to match OpenAI's pattern ^[a-zA-Z0-9_-]+$ and length cap.
+    See: OpenAI Chat Completions tools[].function.name validation.
+    """
+    if name is None or (isinstance(name, str) and not str(name).strip()):
+        return f"litellm_unnamed_tool_{index}"
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", str(name).strip())
+    if not cleaned:
+        return f"litellm_unnamed_tool_{index}"
+    return cleaned[:_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH]
+
+
+def _make_unique_openai_tool_name(base: str, used_names: set[str]) -> str:
+    """Disambiguate sanitized names when multiple tools map to the same string."""
+    candidate = base
+    n = 0
+    while candidate in used_names:
+        n += 1
+        suffix = f"_{n}"
+        room = _OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH - len(suffix)
+        if room < 1:
+            candidate = suffix[:_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH]
+        else:
+            candidate = (base[:room] + suffix)[:_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH]
+    used_names.add(candidate)
+    return candidate
+
+
+def _maybe_fix_openai_function_tool_name(
+    tool_dict: dict, index: int, used_names: set[str]
+) -> None:
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        openai_tool_name_mappings,
+    )
+
+    fn = tool_dict.get("function")
+    if not isinstance(fn, dict):
+        return
+    tool_type = tool_dict.get("type")
+    if tool_type is not None and tool_type != "function":
+        return
+    raw = fn.get("name")
+    raw_original = str(raw) if raw is not None else ""
+    base = _sanitize_openai_function_tool_name(
+        str(raw) if raw is not None else "", index
+    )
+    unique = _make_unique_openai_tool_name(base, used_names)
+    fn["name"] = unique
+    if unique != raw_original:
+        openai_tool_name_mappings.set_cache(key=unique, value=raw_original)
+
+
 def validate_and_fix_openai_tools(tools: Optional[List]) -> Optional[List[dict]]:
     """
-    Ensure tools is List[dict] and not List[BaseModel]
+    Ensure tools is List[dict] and not List[BaseModel].
+
+    Sanitizes OpenAI function tool names to match ^[a-zA-Z0-9_-]+$ (max 64 chars),
+    disambiguates collisions, and does not mutate caller-provided dicts.
     """
-    new_tools = []
     if tools is None:
         return tools
-    for tool in tools:
+    new_tools: List[dict] = []
+    used_names: set[str] = set()
+    for idx, tool in enumerate(tools):
         if isinstance(tool, BaseModel):
-            new_tools.append(tool.model_dump())
+            tool_dict = tool.model_dump()
         elif isinstance(tool, dict):
-            new_tools.append(tool)
+            tool_dict = copy.deepcopy(tool)
+        else:
+            continue
+        _maybe_fix_openai_function_tool_name(tool_dict, idx, used_names)
+        new_tools.append(tool_dict)
     return new_tools
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7918,13 +7918,13 @@ def _maybe_fix_openai_function_tool_name(
     if tool_type is not None and tool_type != "function":
         return
     raw = fn.get("name")
-    raw_original = str(raw) if raw is not None else ""
+    raw_original = str(raw) if raw is not None else None
     base = _sanitize_openai_function_tool_name(
         str(raw) if raw is not None else "", index
     )
     unique = _make_unique_openai_tool_name(base, used_names)
     fn["name"] = unique
-    if unique != raw_original:
+    if raw_original and unique != raw_original:
         store_openai_tool_name_mapping(unique, raw_original)
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3985,27 +3985,7 @@ class TestValidateAndFixThinkingParam:
         assert "budget_tokens" not in thinking
 
 
-def test_validate_and_fix_openai_tools_sanitizes_invalid_names():
-    from litellm.utils import validate_and_fix_openai_tools
-
-    tools_in = [
-        {
-            "type": "function",
-            "function": {
-                "name": "invalid.name",
-                "description": "x",
-                "parameters": {"type": "object", "properties": {}},
-            },
-        }
-    ]
-    original_name = tools_in[0]["function"]["name"]
-    out = validate_and_fix_openai_tools(tools=tools_in)
-    assert out is not None
-    assert out[0]["function"]["name"] == "invalid_name"
-    assert original_name == "invalid.name"
-
-
-def test_validate_and_fix_openai_tools_dedupes_colliding_names():
+def test_validate_and_fix_openai_tools_skips_name_rewrite_when_disabled():
     from litellm.utils import validate_and_fix_openai_tools
 
     tools_in = [
@@ -4015,50 +3995,74 @@ def test_validate_and_fix_openai_tools_dedupes_colliding_names():
                 "name": "a.b",
                 "parameters": {"type": "object", "properties": {}},
             },
-        },
-        {
-            "type": "function",
-            "function": {
-                "name": "a/b",
-                "parameters": {"type": "object", "properties": {}},
-            },
-        },
+        }
     ]
-    out = validate_and_fix_openai_tools(tools=tools_in)
-    assert out[0]["function"]["name"] == "a_b"
-    assert out[1]["function"]["name"] == "a_b_1"
-
-
-def test_openai_tool_name_mapping_restore_roundtrip():
-    from litellm.litellm_core_utils.openai_tool_name_mapping import (
-        restore_openai_tool_name_for_user,
+    out = validate_and_fix_openai_tools(
+        tools=tools_in, sanitize_openai_function_tool_names=False
     )
+    assert out is not None
+    assert out[0]["function"]["name"] == "a.b"
+
+
+def test_validate_and_fix_openai_tools_sanitizes_when_enabled():
     from litellm.utils import validate_and_fix_openai_tools
 
     tools_in = [
         {
             "type": "function",
             "function": {
-                "name": "invalid.name.at.index.71",
+                "name": "invalid.name",
                 "parameters": {"type": "object", "properties": {}},
             },
         }
     ]
-    out = validate_and_fix_openai_tools(tools=tools_in)
-    assert out[0]["function"]["name"] == "invalid_name_at_index_71"
+    original_name = tools_in[0]["function"]["name"]
+    out = validate_and_fix_openai_tools(
+        tools=tools_in, sanitize_openai_function_tool_names=True
+    )
+    assert out is not None
+    assert out[0]["function"]["name"] == "invalid_name"
+    assert original_name == "invalid.name"
+
+        begin_openai_tool_name_mapping_scope,
+    )
+    from litellm.utils import validate_and_fix_openai_tools
+
+    begin_openai_tool_name_mapping_scope()
+    validate_and_fix_openai_tools(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "invalid.name.at.index.71",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        sanitize_openai_function_tool_names=True,
+    )
     assert (
         restore_openai_tool_name_for_user("invalid_name_at_index_71")
         == "invalid.name.at.index.71"
     )
+    begin_openai_tool_name_mapping_scope()
+    assert (
+        restore_openai_tool_name_for_user("invalid_name_at_index_71")
+        == "invalid_name_at_index_71"
+    )
 
 
-def test_convert_to_model_response_restores_openai_tool_call_names():
+def test_convert_to_model_response_restores_openai_tool_call_names_when_mapped():
     from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
         convert_to_model_response_object,
+    )
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        begin_openai_tool_name_mapping_scope,
     )
     from litellm.types.utils import ModelResponse
     from litellm.utils import validate_and_fix_openai_tools
 
+    begin_openai_tool_name_mapping_scope()
     validate_and_fix_openai_tools(
         tools=[
             {
@@ -4068,7 +4072,8 @@ def test_convert_to_model_response_restores_openai_tool_call_names():
                     "parameters": {"type": "object", "properties": {}},
                 },
             }
-        ]
+        ],
+        sanitize_openai_function_tool_names=True,
     )
     response_object = {
         "id": "test",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4032,7 +4032,7 @@ def test_openai_tool_name_mapping_per_request_context():
     )
     from litellm.utils import validate_and_fix_openai_tools
 
-    begin_openai_tool_name_mapping_scope()
+    begin_openai_tool_name_mapping_scope(force_reset=True)
     validate_and_fix_openai_tools(
         tools=[
             {
@@ -4049,7 +4049,8 @@ def test_openai_tool_name_mapping_per_request_context():
         restore_openai_tool_name_for_user("invalid_name_at_index_71")
         == "invalid.name.at.index.71"
     )
-    begin_openai_tool_name_mapping_scope()
+    # Simulate a second request: force_reset=True clears the mapping.
+    begin_openai_tool_name_mapping_scope(force_reset=True)
     assert (
         restore_openai_tool_name_for_user("invalid_name_at_index_71")
         == "invalid_name_at_index_71"
@@ -4066,7 +4067,7 @@ def test_convert_to_model_response_restores_openai_tool_call_names_when_mapped()
     from litellm.types.utils import ModelResponse
     from litellm.utils import validate_and_fix_openai_tools
 
-    begin_openai_tool_name_mapping_scope()
+    begin_openai_tool_name_mapping_scope(force_reset=True)
     validate_and_fix_openai_tools(
         tools=[
             {
@@ -4121,7 +4122,7 @@ def test_tool_choice_function_name_sanitized_with_tools():
     )
     from litellm.utils import validate_and_fix_openai_tools
 
-    begin_openai_tool_name_mapping_scope()
+    begin_openai_tool_name_mapping_scope(force_reset=True)
     validate_and_fix_openai_tools(
         tools=[
             {
@@ -4152,7 +4153,7 @@ def test_tool_choice_function_name_uses_collision_suffix():
     )
     from litellm.utils import validate_and_fix_openai_tools
 
-    begin_openai_tool_name_mapping_scope()
+    begin_openai_tool_name_mapping_scope(force_reset=True)
     validate_and_fix_openai_tools(
         tools=[
             {
@@ -4175,3 +4176,41 @@ def test_tool_choice_function_name_uses_collision_suffix():
     # "a.b" → "a_b"; "a/b" also sanitizes to "a_b" but gets suffix → "a_b_1"
     assert get_sanitized_tool_name("a.b") == "a_b"
     assert get_sanitized_tool_name("a/b") == "a_b_1"
+
+
+def test_begin_scope_is_idempotent_shared_reference():
+    """begin_openai_tool_name_mapping_scope must not replace the dict when already set.
+
+    This simulates the async-streaming path: the outer acompletion() call
+    initialises the scope (sets _CTX = {}), copy_context() copies the
+    reference, and then the inner completion() call must not clobber it with a
+    new empty dict — otherwise mutations from the executor are invisible to the
+    stream consumer in the outer context.
+    """
+    import contextvars
+
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        _CTX,
+        begin_openai_tool_name_mapping_scope,
+        restore_openai_tool_name_for_user,
+        store_openai_tool_name_mapping,
+    )
+
+    # Outer context initialises the scope (simulates acompletion pre-copy_context).
+    begin_openai_tool_name_mapping_scope(force_reset=True)
+    outer_dict = _CTX.get()
+    assert outer_dict is not None
+
+    # Inner context (executor) calls begin_openai_tool_name_mapping_scope again
+    # and then writes a mapping — simulates what completion() does.
+    def inner():
+        begin_openai_tool_name_mapping_scope()  # must be a no-op (no force_reset)
+        inner_dict = _CTX.get()
+        assert inner_dict is outer_dict, "inner call must not replace the shared dict"
+        store_openai_tool_name_mapping("my_tool", "my.tool")
+
+    ctx = contextvars.copy_context()
+    ctx.run(inner)
+
+    # The outer context must see the mapping written by the inner context.
+    assert restore_openai_tool_name_for_user("my_tool") == "my.tool"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2904,9 +2904,9 @@ def test_gemini_embedding_2_ga_in_cost_map():
         assert info.get("input_cost_per_audio_per_second") == 0.00016
         assert info.get("input_cost_per_video_per_second") == 0.00079
         if provider in ("vertex_ai-embedding-models", "vertex_ai"):
-            assert info.get("uses_embed_content") is True, (
-                f"{key} must have uses_embed_content=true for correct Vertex AI routing"
-            )
+            assert (
+                info.get("uses_embed_content") is True
+            ), f"{key} must have uses_embed_content=true for correct Vertex AI routing"
 
 
 def test_gemini_lyria_3_preview_models_in_cost_map():
@@ -3983,3 +3983,123 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+def test_validate_and_fix_openai_tools_sanitizes_invalid_names():
+    from litellm.utils import validate_and_fix_openai_tools
+
+    tools_in = [
+        {
+            "type": "function",
+            "function": {
+                "name": "invalid.name",
+                "description": "x",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    original_name = tools_in[0]["function"]["name"]
+    out = validate_and_fix_openai_tools(tools=tools_in)
+    assert out is not None
+    assert out[0]["function"]["name"] == "invalid_name"
+    assert original_name == "invalid.name"
+
+
+def test_validate_and_fix_openai_tools_dedupes_colliding_names():
+    from litellm.utils import validate_and_fix_openai_tools
+
+    tools_in = [
+        {
+            "type": "function",
+            "function": {
+                "name": "a.b",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "a/b",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+    out = validate_and_fix_openai_tools(tools=tools_in)
+    assert out[0]["function"]["name"] == "a_b"
+    assert out[1]["function"]["name"] == "a_b_1"
+
+
+def test_openai_tool_name_mapping_restore_roundtrip():
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        restore_openai_tool_name_for_user,
+    )
+    from litellm.utils import validate_and_fix_openai_tools
+
+    tools_in = [
+        {
+            "type": "function",
+            "function": {
+                "name": "invalid.name.at.index.71",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    out = validate_and_fix_openai_tools(tools=tools_in)
+    assert out[0]["function"]["name"] == "invalid_name_at_index_71"
+    assert (
+        restore_openai_tool_name_for_user("invalid_name_at_index_71")
+        == "invalid.name.at.index.71"
+    )
+
+
+def test_convert_to_model_response_restores_openai_tool_call_names():
+    from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+        convert_to_model_response_object,
+    )
+    from litellm.types.utils import ModelResponse
+    from litellm.utils import validate_and_fix_openai_tools
+
+    validate_and_fix_openai_tools(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "plugin.subtool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+    )
+    response_object = {
+        "id": "test",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "plugin_subtool",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    out = convert_to_model_response_object(
+        response_object=response_object,
+        model_response_object=ModelResponse(),
+        response_type="completion",
+    )
+    assert out.choices[0].message.tool_calls is not None
+    assert out.choices[0].message.tool_calls[0].function.name == "plugin.subtool"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4117,8 +4117,9 @@ def test_convert_to_model_response_restores_openai_tool_call_names_when_mapped()
 def test_tool_choice_function_name_sanitized_with_tools():
     from litellm.litellm_core_utils.openai_tool_name_mapping import (
         begin_openai_tool_name_mapping_scope,
+        get_sanitized_tool_name,
     )
-    from litellm.utils import _sanitize_openai_function_tool_name, validate_and_fix_openai_tools
+    from litellm.utils import validate_and_fix_openai_tools
 
     begin_openai_tool_name_mapping_scope()
     validate_and_fix_openai_tools(
@@ -4133,11 +4134,44 @@ def test_tool_choice_function_name_sanitized_with_tools():
         ],
         sanitize_openai_function_tool_names=True,
     )
-    # Simulate what main.py does for tool_choice
+    # main.py uses get_sanitized_tool_name (reverse map) — not a re-computation
     tool_choice = {"type": "function", "function": {"name": "my.tool"}}
     _fn = tool_choice["function"]
-    sanitized = _sanitize_openai_function_tool_name(_fn["name"], -1)
+    sanitized = get_sanitized_tool_name(_fn["name"])
     if sanitized != _fn["name"]:
         tool_choice = {**tool_choice, "function": {**_fn, "name": sanitized}}
 
     assert tool_choice["function"]["name"] == "my_tool"
+
+
+def test_tool_choice_function_name_uses_collision_suffix():
+    """tool_choice pointing at the second of two colliding names must use the '_1' suffix."""
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        begin_openai_tool_name_mapping_scope,
+        get_sanitized_tool_name,
+    )
+    from litellm.utils import validate_and_fix_openai_tools
+
+    begin_openai_tool_name_mapping_scope()
+    validate_and_fix_openai_tools(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "a.b",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "a/b",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ],
+        sanitize_openai_function_tool_names=True,
+    )
+    # "a.b" → "a_b"; "a/b" also sanitizes to "a_b" but gets suffix → "a_b_1"
+    assert get_sanitized_tool_name("a.b") == "a_b"
+    assert get_sanitized_tool_name("a/b") == "a_b_1"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4024,7 +4024,11 @@ def test_validate_and_fix_openai_tools_sanitizes_when_enabled():
     assert out[0]["function"]["name"] == "invalid_name"
     assert original_name == "invalid.name"
 
+
+def test_openai_tool_name_mapping_per_request_context():
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
         begin_openai_tool_name_mapping_scope,
+        restore_openai_tool_name_for_user,
     )
     from litellm.utils import validate_and_fix_openai_tools
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4112,3 +4112,32 @@ def test_convert_to_model_response_restores_openai_tool_call_names_when_mapped()
     )
     assert out.choices[0].message.tool_calls is not None
     assert out.choices[0].message.tool_calls[0].function.name == "plugin.subtool"
+
+
+def test_tool_choice_function_name_sanitized_with_tools():
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        begin_openai_tool_name_mapping_scope,
+    )
+    from litellm.utils import _sanitize_openai_function_tool_name, validate_and_fix_openai_tools
+
+    begin_openai_tool_name_mapping_scope()
+    validate_and_fix_openai_tools(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "my.tool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        sanitize_openai_function_tool_names=True,
+    )
+    # Simulate what main.py does for tool_choice
+    tool_choice = {"type": "function", "function": {"name": "my.tool"}}
+    _fn = tool_choice["function"]
+    sanitized = _sanitize_openai_function_tool_name(_fn["name"], -1)
+    if sanitized != _fn["name"]:
+        tool_choice = {**tool_choice, "function": {**_fn, "name": sanitized}}
+
+    assert tool_choice["function"]["name"] == "my_tool"


### PR DESCRIPTION
## Summary
- `validate_and_fix_openai_tools` rewrites `function.name` to match OpenAI`s `^[a-zA-Z0-9_-]+$` pattern (max 64 chars), with collision suffixes when needed.
- Adds `openai_tool_name_mappings` (`InMemoryCache`, same defaults as Bedrock`s `bedrock_tool_name_mappings`) and `get_openai_tool_name` to map API response tool names back to client-supplied names.
- Restores names in `convert_to_model_response_object` and streaming chunk combination.
- Lazy-loads `litellm.openai_tool_name_mappings` in `__init__.py`.

## Tests
- `tests/test_litellm/test_utils.py`: sanitize, dedupe, roundtrip, and `convert_to_model_response_object` restore.


<img width="1305" height="767" alt="image" src="https://github.com/user-attachments/assets/030d6f63-e4d6-48d1-becc-177e58a749bd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/response tool-call handling by rewriting `tools[].function.name` (and `tool_choice`) for OpenAI-compatible providers and then restoring names on the response/streaming path; this can affect tool selection and downstream integrations if mappings are wrong or contexts leak.
> 
> **Overview**
> Adds per-request OpenAI tool-name sanitization for OpenAI-compatible providers by rewriting `tools[].function.name` to `^[a-zA-Z0-9_-]+$` (64-char cap) and deduping collisions with suffixes, while recording a ContextVar mapping for round-tripping.
> 
> Updates `completion()` to enable sanitization only for providers that enforce OpenAI validation, rewrite `tool_choice.function.name` using the stored reverse map, and restores original tool names in both non-streaming (`convert_to_model_response_object`) and streaming chunk combination (`ChunkProcessor.get_combined_tool_content`). Adds tests covering sanitization on/off, per-request scope reset, tool-call name restoration, and collision suffix behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0df19af2138e5c95a16dba34f55c6067fc38df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->