### PR TITLE
feat(proxy): add health_check_reasoning_effort for model health checks

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -36,6 +36,11 @@ ADMIN_ONLY_HEALTH_DISPLAY_PARAMS = ("api_base", "api_version")
 
 MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
 
+# Health-check modes that forward `reasoning_effort` to the provider (chat-style calls).
+_HEALTH_CHECK_MODES_SUPPORTING_REASONING_EFFORT = frozenset(
+    (None, "chat", "completion")
+)
+
 
 def _get_process_rss_mb() -> Optional[float]:
     """
@@ -374,6 +379,12 @@ def _update_litellm_params_for_health_check(
     _resolved_max_tokens = _resolve_health_check_max_tokens(model_info, litellm_params)
     if _resolved_max_tokens is not None:
         litellm_params["max_tokens"] = _resolved_max_tokens
+
+    # Per-model reasoning effort for health checks only (e.g. reasoning_effort=none).
+    if model_info.get("mode", None) in _HEALTH_CHECK_MODES_SUPPORTING_REASONING_EFFORT:
+        _hc_reasoning_effort = model_info.get("health_check_reasoning_effort", None)
+        if _hc_reasoning_effort is not None:
+            litellm_params["reasoning_effort"] = _hc_reasoning_effort
 
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -240,6 +240,12 @@ def test_update_litellm_params_health_check_reasoning_effort():
     )
     assert out.get("reasoning_effort") == "none"
 
+    model_info = {"mode": "completion", "health_check_reasoning_effort": "low"}
+    out = _update_litellm_params_for_health_check(
+        model_info, {"model": "openai/gpt-5", "api_key": "x"}
+    )
+    assert out.get("reasoning_effort") == "low"
+
     model_info = {
         "health_check_reasoning_effort": {"effort": "none", "summary": "auto"},
     }

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -225,3 +225,37 @@ def test_wildcard_ignores_reasoning_split_model_info(monkeypatch):
     litellm_params = {"model": "openai/*"}
 
     assert _resolve_health_check_max_tokens(model_info, litellm_params) is None
+
+
+def test_update_litellm_params_health_check_reasoning_effort():
+    """model_info.health_check_reasoning_effort sets reasoning_effort for chat-style health checks."""
+    model_info = {"health_check_reasoning_effort": "low"}
+    litellm_params = {"model": "openai/gpt-5", "api_key": "x"}
+    out = _update_litellm_params_for_health_check(model_info, dict(litellm_params))
+    assert out.get("reasoning_effort") == "low"
+
+    model_info = {"mode": "chat", "health_check_reasoning_effort": "none"}
+    out = _update_litellm_params_for_health_check(
+        model_info, {"model": "openai/gpt-5", "api_key": "x"}
+    )
+    assert out.get("reasoning_effort") == "none"
+
+    model_info = {
+        "health_check_reasoning_effort": {"effort": "none", "summary": "auto"},
+    }
+    out = _update_litellm_params_for_health_check(
+        model_info, {"model": "openai/gpt-5.1", "api_key": "x"}
+    )
+    assert out.get("reasoning_effort") == {"effort": "none", "summary": "auto"}
+
+    model_info = {"mode": "embedding", "health_check_reasoning_effort": "low"}
+    out = _update_litellm_params_for_health_check(
+        model_info, {"model": "text-embedding-3-small", "api_key": "x"}
+    )
+    assert "reasoning_effort" not in out
+
+    model_info = {}
+    out = _update_litellm_params_for_health_check(
+        model_info, {"model": "openai/gpt-4o", "api_key": "x"}
+    )
+    assert "reasoning_effort" not in out


### PR DESCRIPTION
## Summary
Adds optional `model_info.health_check_reasoning_effort` so proxy health checks can set `reasoning_effort` (e.g. `none`) on chat-style probes only—useful for reasoning models where probes should minimize cost/latency.

## Config
```yaml
model_info:
  health_check_reasoning_effort: none
```

Applied when `mode` is unset (chat), `chat`, `completion`,  skipped for all other modes for now

## Tests
- `tests/test_litellm/proxy/test_health_check_max_tokens.py::test_update_litellm_params_health_check_reasoning_effort`

<img width="1319" height="151" alt="image" src="https://github.com/user-attachments/assets/b0f6ba40-6726-47ce-aff9-406d311063ca" />

Docs: https://github.com/BerriAI/litellm-docs/pull/71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, gated parameter addition limited to health-check request construction, with unit tests covering supported/unsupported modes.
> 
> **Overview**
> Adds optional `model_info.health_check_reasoning_effort` so proxy health checks can forward `reasoning_effort` on chat-style probe requests (mode `None`, `chat`, or `completion`), while skipping other modes.
> 
> Extends the health-check max-tokens test suite with coverage ensuring `reasoning_effort` is set when configured (including dict values) and omitted for unsupported modes or absent config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a5e77adf632da7018c525dd8213e40473339f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->