### PR TITLE
fix(utils): OpenAI tool name sanitize + per-request restore

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -71,6 +71,20 @@ def _normalize_images_for_message(
     return normalized
 
 
+def _map_tool_call_dict_openai_names_to_user(tc: dict) -> dict:
+    """Restore client tool names when this completion rewrote them for OpenAI."""
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        restore_openai_tool_name_for_user,
+    )
+
+    fn = tc.get("function")
+    if isinstance(fn, dict) and fn.get("name"):
+        restored = restore_openai_tool_name_for_user(fn["name"])
+        if restored != fn["name"]:
+            return {**tc, "function": {**fn, "name": restored}}
+    return tc
+
+
 def _safe_convert_created_field(created_value) -> int:
     """
     Safely convert a 'created' field value to an integer.
@@ -546,6 +560,8 @@ def convert_to_model_response_object(  # noqa: PLR0915
                 if tool_calls is not None:
                     _openai_tool_calls = []
                     for _tc in tool_calls:
+                        if isinstance(_tc, dict):
+                            _tc = _map_tool_call_dict_openai_names_to_user(_tc)
                         _openai_tc = ChatCompletionMessageToolCall(**_tc)
                         _openai_tool_calls.append(_openai_tc)
                     fixed_tool_calls = _handle_invalid_parallel_tool_calls(

--- a/litellm/litellm_core_utils/openai_tool_name_mapping.py
+++ b/litellm/litellm_core_utils/openai_tool_name_mapping.py
@@ -1,0 +1,76 @@
+"""
+Per-request mapping from OpenAI-safe tool names back to client-supplied names.
+
+OpenAI's Chat Completions API requires tools[].function.name to match
+``^[a-zA-Z0-9_-]+$``. For providers that enforce this, we rewrite outbound tool
+names and keep sanitized -> original in a ContextVar dict for this completion only
+(never a process-wide cache).
+
+Restore in ``convert_dict_to_response`` only affects names present in the current
+request's mapping, so other providers and concurrent requests are unaffected.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Dict, Optional
+
+_CTX: contextvars.ContextVar[Optional[Dict[str, str]]] = contextvars.ContextVar(
+    "litellm_openai_tool_name_mapping", default=None
+)
+
+# Providers where the upstream Chat Completions API applies OpenAI tool-name validation.
+_OPENAI_TOOL_NAME_VALIDATION_PROVIDERS = frozenset(
+    {
+        "openai",
+        "azure",
+        "azure_ai",
+        "custom_openai",
+        "text-completion-openai",
+        "groq",
+        "deepinfra",
+        "together_ai",
+        "fireworks_ai",
+        "nvidia_nim",
+        "github_copilot",
+        "perplexity",
+        "xai",
+    }
+)
+
+
+def should_sanitize_openai_tool_names(litellm_provider: str) -> bool:
+    return litellm_provider in _OPENAI_TOOL_NAME_VALIDATION_PROVIDERS
+
+
+def begin_openai_tool_name_mapping_scope() -> None:
+    """Reset mapping for this completion (call once at the start of completion())."""
+    _CTX.set({})
+
+
+def _store(sanitized: str, original: str) -> None:
+    if sanitized == original:
+        return
+    m = _CTX.get()
+    if m is None:
+        m = {}
+        _CTX.set(m)
+    m[sanitized] = original
+
+
+def get_openai_tool_name(response_tool_name: str) -> str:
+    m = _CTX.get()
+    if m is not None and response_tool_name in m:
+        return m[response_tool_name]
+    return response_tool_name
+
+
+def restore_openai_tool_name_for_user(sanitized_name: Optional[str]) -> Optional[str]:
+    if sanitized_name is None:
+        return None
+    return get_openai_tool_name(sanitized_name)
+
+
+def store_openai_tool_name_mapping(sanitized: str, original: str) -> None:
+    """Record a rewrite when ``validate_and_fix_openai_tools`` sanitizes a name."""
+    _store(sanitized, original)

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -2,6 +2,9 @@ import base64
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
+from litellm.litellm_core_utils.openai_tool_name_mapping import (
+    restore_openai_tool_name_for_user,
+)
 from litellm.types.llms.openai import (
     ChatCompletionAssistantContentValue,
     ChatCompletionAudioDelta,
@@ -293,10 +296,12 @@ class ChunkProcessor:
             if tool_call_data["id"] and tool_call_data["name"]:
                 combined_arguments = "".join(tool_call_data["arguments"]) or "{}"
 
+                display_name = restore_openai_tool_name_for_user(tool_call_data["name"])
+
                 # Build function - provider_specific_fields should be on tool_call level, not function level
                 function = Function(
                     arguments=combined_arguments,
-                    name=tool_call_data["name"],
+                    name=display_name,
                 )
 
                 # Prepare params for ChatCompletionMessageToolCall

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -160,6 +160,10 @@ from litellm.utils import (
 
 from ._logging import verbose_logger
 from .caching.caching import disable_cache, enable_cache, update_cache
+from .litellm_core_utils.openai_tool_name_mapping import (
+    begin_openai_tool_name_mapping_scope,
+    should_sanitize_openai_tool_names,
+)
 from .litellm_core_utils.core_helpers import safe_deep_copy
 from .litellm_core_utils.fallback_utils import (
     async_completion_with_fallbacks,
@@ -1160,7 +1164,24 @@ def completion(  # type: ignore # noqa: PLR0915
         raise ValueError("model param not passed in.")
     # validate messages
     messages = validate_and_fix_openai_messages(messages=messages)
-    tools = validate_and_fix_openai_tools(tools=tools)
+    begin_openai_tool_name_mapping_scope()
+    try:
+        _, _litellm_provider_for_tools, _, _ = get_llm_provider(
+            model=model,
+            custom_llm_provider=kwargs.get("custom_llm_provider"),
+            api_base=kwargs.get("api_base") or base_url,
+            api_key=kwargs.get("api_key") or api_key,
+            litellm_params=kwargs.get("litellm_params"),
+        )
+        _sanitize_openai_fn_tool_names = should_sanitize_openai_tool_names(
+            _litellm_provider_for_tools
+        )
+    except Exception:
+        _sanitize_openai_fn_tool_names = False
+    tools = validate_and_fix_openai_tools(
+        tools=tools,
+        sanitize_openai_function_tool_names=_sanitize_openai_fn_tool_names,
+    )
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7874,18 +7874,93 @@ def validate_and_fix_openai_messages(messages: List):
     return validate_chat_completion_user_messages(messages=new_messages)
 
 
-def validate_and_fix_openai_tools(tools: Optional[List]) -> Optional[List[dict]]:
+_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH = 64
+
+
+def _sanitize_openai_function_tool_name(name: str, index: int) -> str:
     """
-    Ensure tools is List[dict] and not List[BaseModel]
+    Normalize function.name to match OpenAI's pattern ^[a-zA-Z0-9_-]+$ and length cap.
     """
-    new_tools = []
+    if name is None or (isinstance(name, str) and not str(name).strip()):
+        return f"litellm_unnamed_tool_{index}"
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", str(name).strip())
+    if not cleaned:
+        return f"litellm_unnamed_tool_{index}"
+    return cleaned[:_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH]
+
+
+def _make_unique_openai_tool_name(base: str, used_names: set[str]) -> str:
+    candidate = base
+    n = 0
+    while candidate in used_names:
+        n += 1
+        suffix = f"_{n}"
+        room = _OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH - len(suffix)
+        if room < 1:
+            candidate = suffix[:_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH]
+        else:
+            candidate = (base[:room] + suffix)[:_OPENAI_FUNCTION_TOOL_NAME_MAX_LENGTH]
+    used_names.add(candidate)
+    return candidate
+
+
+def _maybe_fix_openai_function_tool_name(
+    tool_dict: dict, index: int, used_names: set[str]
+) -> None:
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        store_openai_tool_name_mapping,
+    )
+
+    fn = tool_dict.get("function")
+    if not isinstance(fn, dict):
+        return
+    tool_type = tool_dict.get("type")
+    if tool_type is not None and tool_type != "function":
+        return
+    raw = fn.get("name")
+    raw_original = str(raw) if raw is not None else ""
+    base = _sanitize_openai_function_tool_name(
+        str(raw) if raw is not None else "", index
+    )
+    unique = _make_unique_openai_tool_name(base, used_names)
+    fn["name"] = unique
+    if unique != raw_original:
+        store_openai_tool_name_mapping(unique, raw_original)
+
+
+def validate_and_fix_openai_tools(
+    tools: Optional[List],
+    *,
+    sanitize_openai_function_tool_names: bool = False,
+) -> Optional[List[dict]]:
+    """
+    Ensure tools is List[dict] and not List[BaseModel].
+
+    When ``sanitize_openai_function_tool_names`` is True (OpenAI-compatible
+    providers only), rewrites function names to ``^[a-zA-Z0-9_-]+$`` (max 64 chars).
+    """
     if tools is None:
         return tools
-    for tool in tools:
+    if not sanitize_openai_function_tool_names:
+        new_tools: List[dict] = []
+        for tool in tools:
+            if isinstance(tool, BaseModel):
+                new_tools.append(tool.model_dump())
+            elif isinstance(tool, dict):
+                new_tools.append(tool)
+        return new_tools
+
+    new_tools = []
+    used_names: set[str] = set()
+    for idx, tool in enumerate(tools):
         if isinstance(tool, BaseModel):
-            new_tools.append(tool.model_dump())
+            tool_dict = tool.model_dump()
         elif isinstance(tool, dict):
-            new_tools.append(tool)
+            tool_dict = copy.deepcopy(tool)
+        else:
+            continue
+        _maybe_fix_openai_function_tool_name(tool_dict, idx, used_names)
+        new_tools.append(tool_dict)
     return new_tools
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2904,9 +2904,9 @@ def test_gemini_embedding_2_ga_in_cost_map():
         assert info.get("input_cost_per_audio_per_second") == 0.00016
         assert info.get("input_cost_per_video_per_second") == 0.00079
         if provider in ("vertex_ai-embedding-models", "vertex_ai"):
-            assert info.get("uses_embed_content") is True, (
-                f"{key} must have uses_embed_content=true for correct Vertex AI routing"
-            )
+            assert (
+                info.get("uses_embed_content") is True
+            ), f"{key} must have uses_embed_content=true for correct Vertex AI routing"
 
 
 def test_gemini_lyria_3_preview_models_in_cost_map():
@@ -3983,3 +3983,132 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+def test_validate_and_fix_openai_tools_skips_name_rewrite_when_disabled():
+    from litellm.utils import validate_and_fix_openai_tools
+
+    tools_in = [
+        {
+            "type": "function",
+            "function": {
+                "name": "a.b",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    out = validate_and_fix_openai_tools(
+        tools=tools_in, sanitize_openai_function_tool_names=False
+    )
+    assert out is not None
+    assert out[0]["function"]["name"] == "a.b"
+
+
+def test_validate_and_fix_openai_tools_sanitizes_when_enabled():
+    from litellm.utils import validate_and_fix_openai_tools
+
+    tools_in = [
+        {
+            "type": "function",
+            "function": {
+                "name": "invalid.name",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    original_name = tools_in[0]["function"]["name"]
+    out = validate_and_fix_openai_tools(
+        tools=tools_in, sanitize_openai_function_tool_names=True
+    )
+    assert out is not None
+    assert out[0]["function"]["name"] == "invalid_name"
+    assert original_name == "invalid.name"
+
+
+def test_openai_tool_name_mapping_per_request_context():
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        begin_openai_tool_name_mapping_scope,
+        restore_openai_tool_name_for_user,
+    )
+    from litellm.utils import validate_and_fix_openai_tools
+
+    begin_openai_tool_name_mapping_scope()
+    validate_and_fix_openai_tools(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "invalid.name.at.index.71",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        sanitize_openai_function_tool_names=True,
+    )
+    assert (
+        restore_openai_tool_name_for_user("invalid_name_at_index_71")
+        == "invalid.name.at.index.71"
+    )
+    begin_openai_tool_name_mapping_scope()
+    assert (
+        restore_openai_tool_name_for_user("invalid_name_at_index_71")
+        == "invalid_name_at_index_71"
+    )
+
+
+def test_convert_to_model_response_restores_openai_tool_call_names_when_mapped():
+    from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+        convert_to_model_response_object,
+    )
+    from litellm.litellm_core_utils.openai_tool_name_mapping import (
+        begin_openai_tool_name_mapping_scope,
+    )
+    from litellm.types.utils import ModelResponse
+    from litellm.utils import validate_and_fix_openai_tools
+
+    begin_openai_tool_name_mapping_scope()
+    validate_and_fix_openai_tools(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "plugin.subtool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        sanitize_openai_function_tool_names=True,
+    )
+    response_object = {
+        "id": "test",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "plugin_subtool",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    out = convert_to_model_response_object(
+        response_object=response_object,
+        model_response_object=ModelResponse(),
+        response_type="completion",
+    )
+    assert out.choices[0].message.tool_calls is not None
+    assert out.choices[0].message.tool_calls[0].function.name == "plugin.subtool"


### PR DESCRIPTION
## Summary
OpenAI Chat Completions reject tool `function.name` values outside `^[a-zA-Z0-9_-]+$`. This PR:

- Sanitizes names only for **OpenAI-style providers** (whitelist via `get_llm_provider` + `should_sanitize_openai_tool_names`).
- Keeps **per-request** sanitized→original mapping in a **ContextVar** (no process-wide cache).
- Restores client-facing names in `convert_to_model_response_object` and streaming chunk assembly when a mapping exists for this request.

## Tests
`tests/test_litellm/test_utils.py`: disabled vs enabled sanitize, context reset after `begin_`, convert restore.

Split from health-check work so this can land independently.

Made with [Cursor](https://cursor.com)