### PR TITLE
[Fix] Docker: Pin Wolfi And Uv To Multi-Arch Index Digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:733b4042187702f832f7fdecb3aff14a61b288c4ca37af188bb5715c1caebaf8
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin
 

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -3,7 +3,7 @@ ARG LITELLM_BUILD_IMAGE=python:3.11-alpine@sha256:f07e2ace46f560f09a6eeec7b4913b
 
 # Runtime image
 ARG LITELLM_RUNTIME_IMAGE=python:3.11-alpine@sha256:f07e2ace46f560f09a6eeec7b4913b80ee99546e749ef82342a419a326620856
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:733b4042187702f832f7fdecb3aff14a61b288c4ca37af188bb5715c1caebaf8
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin
 

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,9 +1,9 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:733b4042187702f832f7fdecb3aff14a61b288c4ca37af188bb5715c1caebaf8
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,7 +3,7 @@ ARG LITELLM_BUILD_IMAGE=python:3.13-slim@sha256:739e7213785e88c0f702dcdc12c0973a
 
 # Runtime image
 ARG LITELLM_RUNTIME_IMAGE=python:3.13-slim@sha256:739e7213785e88c0f702dcdc12c0973afcbd606dbf021a589cab77d6b00b579d
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:733b4042187702f832f7fdecb3aff14a61b288c4ca37af188bb5715c1caebaf8
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin
 

--- a/docker/Dockerfile.health_check
+++ b/docker/Dockerfile.health_check
@@ -1,4 +1,4 @@
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:733b4042187702f832f7fdecb3aff14a61b288c4ca37af188bb5715c1caebaf8
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 FROM $UV_IMAGE AS uvbin
 
 FROM python:3.13-slim@sha256:739e7213785e88c0f702dcdc12c0973afcbd606dbf021a589cab77d6b00b579d

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -1,8 +1,8 @@
 # Base images
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
 ARG PROXY_EXTRAS_SOURCE=published
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:733b4042187702f832f7fdecb3aff14a61b288c4ca37af188bb5715c1caebaf8
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin
 


### PR DESCRIPTION
## What

Pin `wolfi-base` and `uv` to their **multi-arch image-index** digests in `Dockerfile`, `docker/Dockerfile.database`, and `docker/Dockerfile.non_root`.

## Why

The previous pins resolved to **single-platform amd64** manifests, not the OCI index. When buildx was asked to build for `linux/amd64,linux/arm64`, it pulled the same amd64 base for both targets, and the published image index advertised an `arm64` entry whose layers were byte-identical to the `amd64` entry. Effect for users: `docker pull --platform=linux/arm64 ghcr.io/berriai/litellm:v1.83.14-stable` got them an amd64 binary.

Quick reproduction against the affected tag:

```
$ docker manifest inspect ghcr.io/berriai/litellm:v1.83.14-stable | jq '.manifests[] | select(.platform.architecture!="unknown") | {arch: .platform.architecture, digest}'
```

Then fetch each per-platform manifest and diff `.layers[].digest` -- they're identical, which is the smoking gun.

## Fix

Replace the per-platform digests with the corresponding image-index digests:

| Image | Old (per-platform amd64) | New (image index) |
|---|---|---|
| `cgr.dev/chainguard/wolfi-base` | `sha256:f26d42a15d09…` | `sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31` |
| `ghcr.io/astral-sh/uv:0.11.7` | `sha256:733b40421877…` | `sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a` |

### How the new digests were resolved

Both digests came from `docker buildx imagetools inspect <ref>`, which returns the **image-index** digest (multi-arch). For comparison, `docker pull` + `docker inspect` returns the **per-platform** digest of whatever platform the host pulled, which is how the broken pins slipped in.

```
$ docker buildx imagetools inspect cgr.dev/chainguard/wolfi-base:latest --format '{{.Manifest.Digest}}'
sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31

$ docker buildx imagetools inspect cgr.dev/chainguard/wolfi-base:latest | grep Platform
  Platform:  linux/amd64
  Platform:  linux/arm64

$ docker buildx imagetools inspect ghcr.io/astral-sh/uv:0.11.7 --format '{{.Manifest.Digest}}'
sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a

$ docker buildx imagetools inspect ghcr.io/astral-sh/uv:0.11.7 | grep Platform
  Platform:    linux/amd64
  Platform:    unknown/unknown   (attestation manifest)
  Platform:    linux/arm64
  Platform:    unknown/unknown   (attestation manifest)
```

The `mediaType` of each new digest is `application/vnd.oci.image.index.v1+json`, the per-platform manifests it contains are accessible at `cgr.dev/v2/chainguard/wolfi-base/manifests/sha256:3258be47…` and `ghcr.io/v2/astral-sh/uv/manifests/sha256:240fb85a…` respectively (verified directly via the registry API).

## Test plan

- [ ] Cut a non-stable test build off this branch and confirm the published index has distinct `amd64` and `arm64` per-platform manifests with **non-overlapping** layer digest sets.
- [ ] `docker run --platform=linux/arm64 <built-tag> uname -m` returns `aarch64`.
- [ ] `docker run --platform=linux/amd64 <built-tag> uname -m` returns `x86_64`.
- [ ] All three variants (`litellm`, `litellm-database`, `litellm-non_root`) verified.

## Follow-ups (separate)

- Add a post-build verification step in `project-releaser/.github/workflows/build-and-push.yml` that fails the release if any two per-platform manifests share a layer digest -- prevents this class of bug from shipping again.
- Cut a `v1.83.14-stable.patch.1` (or `v1.83.15-stable`) once this lands, so existing arm64 users on `v1.83.14-stable` can move off a wrong-arch image.