### PR TITLE
fix(ui): include unified access groups in Add Model dropdown (LIT-2783)

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -1,3 +1,4 @@
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 import { useCredentials } from "@/app/(dashboard)/hooks/credentials/useCredentials";
 import { useModelCostMap } from "@/app/(dashboard)/hooks/models/useModelCostMap";
 import { useModelsInfo } from "@/app/(dashboard)/hooks/models/useModels";
@@ -92,10 +93,17 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
     return Array.from(allModelGroups).sort();
   }, [modelDataResponse?.data]);
 
+  // Unified access groups created via the Access Groups page (stored in
+  // LiteLLM_AccessGroupTable). These are managed independently of legacy
+  // per-deployment model_info.access_groups but should still appear anywhere
+  // the UI offers a "Model Access Group" picker, so admins can attach a
+  // freshly-added model to a unified group on the spot.
+  const { data: unifiedAccessGroupsData } = useAccessGroups();
+
   const availableModelAccessGroups = useMemo(() => {
-    if (!modelDataResponse?.data) return [];
+    if (!modelDataResponse?.data && !unifiedAccessGroupsData) return [];
     const allModelAccessGroups = new Set<string>();
-    for (const model of modelDataResponse.data) {
+    for (const model of modelDataResponse?.data ?? []) {
       const modelInfo = model.model_info;
       if (modelInfo?.access_groups) {
         for (const group of modelInfo.access_groups) {
@@ -103,8 +111,13 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
         }
       }
     }
-    return Array.from(allModelAccessGroups);
-  }, [modelDataResponse?.data]);
+    for (const group of unifiedAccessGroupsData ?? []) {
+      if (group?.access_group_name) {
+        allModelAccessGroups.add(group.access_group_name);
+      }
+    }
+    return Array.from(allModelAccessGroups).sort();
+  }, [modelDataResponse?.data, unifiedAccessGroupsData]);
 
   const allModelsOnProxy = useMemo<string[]>(() => {
     if (!modelDataResponse?.data) return [];

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, screen, waitFor, renderWithProviders } from "../../../tests/test-utils";
+import { act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Form } from "antd";
 import type { UploadProps } from "antd/es/upload";
@@ -97,6 +98,29 @@ vi.mock("@/app/(dashboard)/hooks/tags/useTags", () => ({
     data: { tag1: ["model1", "model2"] },
     isLoading: false,
     error: null,
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/accessGroups/useAccessGroups", () => ({
+  useAccessGroups: vi.fn().mockReturnValue({
+    data: [
+      {
+        access_group_id: "ag-1",
+        access_group_name: "engineering",
+        description: null,
+        access_model_names: [],
+        access_mcp_server_ids: [],
+        access_agent_ids: [],
+        assigned_team_ids: [],
+        assigned_key_ids: [],
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: null,
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: null,
+      },
+    ],
+    isLoading: false,
+    isError: false,
   }),
 }));
 
@@ -272,6 +296,27 @@ describe("AddModelForm", () => {
     });
 
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("should merge unified access groups (from /v1/access_group) with legacy model_info.access_groups in the dropdown", async () => {
+    const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+    mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("proxy_admin", "user-1", true));
+
+    const props = createTestProps("proxy_admin", "user-1", false);
+
+    renderWithProviders(<AddModelForm {...props} />);
+
+    await screen.findByText("Provider");
+
+    const accessGroupCombo = await screen.findByRole("combobox", { name: /Model Access Group/i });
+    await act(async () => {
+      await userEvent.click(accessGroupCombo);
+    });
+
+    // legacy entries from modelAvailableCall + unified group from useAccessGroups
+    expect(await screen.findByTitle("model-group-1")).toBeInTheDocument();
+    expect(await screen.findByTitle("model-group-2")).toBeInTheDocument();
+    expect(await screen.findByTitle("engineering")).toBeInTheDocument();
   });
 
   it("should handle non-admin, non-team-admin users - should not see team selection or switch", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -1,6 +1,7 @@
 import { useProviderFields } from "@/app/(dashboard)/hooks/providers/useProviderFields";
 import { useGuardrails } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
 import { useTags } from "@/app/(dashboard)/hooks/tags/useTags";
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 import { all_admin_roles, isUserTeamAdminForAnyTeam } from "@/utils/roles";
 import { Switch, Text } from "@tremor/react";
 import type { FormInstance } from "antd";
@@ -66,6 +67,11 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   const { data: guardrailsData } = useGuardrails();
   const guardrailsList = guardrailsData?.guardrails.map((g) => g.guardrail_name);
   const { data: tagsList, isLoading: isTagsLoading, error: tagsError } = useTags();
+  // Unified access groups (managed via /v1/access_group). These are stored in
+  // LiteLLM_AccessGroupTable, separate from the legacy per-deployment
+  // model_info.access_groups returned by /models. Both sources need to feed
+  // the dropdown so admins can attach a model to either kind.
+  const { data: unifiedAccessGroups } = useAccessGroups();
 
   const handleTestConnection = async () => {
     setIsTestingConnection(true);
@@ -74,17 +80,31 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   };
 
   const [isTeamOnly, setIsTeamOnly] = useState<boolean>(false);
-  const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  // Legacy access groups discovered from existing deployments' model_info.access_groups.
+  const [legacyModelAccessGroups, setLegacyModelAccessGroups] = useState<string[]>([]);
   // Team admin specific state
   const [teamAdminSelectedTeam, setTeamAdminSelectedTeam] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchModelAccessGroups = async () => {
       const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
-      setModelAccessGroups(response["data"].map((model: any) => model["id"]));
+      setLegacyModelAccessGroups(response["data"].map((model: any) => model["id"]));
     };
     fetchModelAccessGroups();
   }, [accessToken]);
+
+  // Merge unified access group names with the legacy list, deduplicated and
+  // sorted. Without this, groups created on the Access Groups page never
+  // appear here and admins have to free-type them from memory.
+  const modelAccessGroups = useMemo<string[]>(() => {
+    const merged = new Set<string>(legacyModelAccessGroups);
+    for (const group of unifiedAccessGroups ?? []) {
+      if (group?.access_group_name) {
+        merged.add(group.access_group_name);
+      }
+    }
+    return Array.from(merged).sort();
+  }, [legacyModelAccessGroups, unifiedAccessGroups]);
 
   const sortedProviderMetadata: ProviderCreateInfo[] = useMemo(() => {
     if (!providerMetadata) {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Card, Form, Button, Tooltip, Typography, Select as AntdSelect, Modal, Radio, Badge, Space } from "antd";
 import type { FormInstance } from "antd";
 import { Text, TextInput } from "@tremor/react";
@@ -11,6 +11,7 @@ import RouterConfigBuilder from "./RouterConfigBuilder";
 import ComplexityRouterConfig from "./ComplexityRouterConfig";
 import NotificationManager from "../molecules/notifications_manager";
 import { ThunderboltOutlined, BranchesOutlined } from "@ant-design/icons";
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 
 interface AddAutoRouterTabProps {
   form: FormInstance;
@@ -36,7 +37,17 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
   const [isTestingConnection, setIsTestingConnection] = useState<boolean>(false);
   const [connectionTestId, setConnectionTestId] = useState<string>("");
 
-  const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  const [legacyModelAccessGroups, setLegacyModelAccessGroups] = useState<string[]>([]);
+  const { data: unifiedAccessGroups } = useAccessGroups();
+  const modelAccessGroups = useMemo<string[]>(() => {
+    const merged = new Set<string>(legacyModelAccessGroups);
+    for (const group of unifiedAccessGroups ?? []) {
+      if (group?.access_group_name) {
+        merged.add(group.access_group_name);
+      }
+    }
+    return Array.from(merged).sort();
+  }, [legacyModelAccessGroups, unifiedAccessGroups]);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const [showCustomDefaultModel, setShowCustomDefaultModel] = useState<boolean>(false);
   const [showCustomEmbeddingModel, setShowCustomEmbeddingModel] = useState<boolean>(false);
@@ -58,7 +69,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
   useEffect(() => {
     const fetchModelAccessGroups = async () => {
       const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
-      setModelAccessGroups(response["data"].map((model: any) => model["id"]));
+      setLegacyModelAccessGroups(response["data"].map((model: any) => model["id"]));
     };
     fetchModelAccessGroups();
   }, [accessToken]);

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Modal, Form, Button, Select as AntdSelect } from "antd";
 import { Text, TextInput } from "@tremor/react";
 import { modelAvailableCall, modelPatchUpdateCall } from "../networking";
 import { fetchAvailableModels, ModelGroup } from "../playground/llm_calls/fetch_models";
 import RouterConfigBuilder from "../add_model/RouterConfigBuilder";
 import NotificationsManager from "../molecules/notifications_manager";
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 
 interface EditAutoRouterModalProps {
   isVisible: boolean;
@@ -25,7 +26,17 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
 }) => {
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
-  const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  const [legacyModelAccessGroups, setLegacyModelAccessGroups] = useState<string[]>([]);
+  const { data: unifiedAccessGroups } = useAccessGroups();
+  const modelAccessGroups = useMemo<string[]>(() => {
+    const merged = new Set<string>(legacyModelAccessGroups);
+    for (const group of unifiedAccessGroups ?? []) {
+      if (group?.access_group_name) {
+        merged.add(group.access_group_name);
+      }
+    }
+    return Array.from(merged).sort();
+  }, [legacyModelAccessGroups, unifiedAccessGroups]);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const [showCustomDefaultModel, setShowCustomDefaultModel] = useState<boolean>(false);
   const [showCustomEmbeddingModel, setShowCustomEmbeddingModel] = useState<boolean>(false);
@@ -42,7 +53,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
       if (!accessToken) return;
       try {
         const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
-        setModelAccessGroups(response["data"].map((model: any) => model["id"]));
+        setLegacyModelAccessGroups(response["data"].map((model: any) => model["id"]));
       } catch (error) {
         console.error("Error fetching model access groups:", error);
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Fixes the symptom in LIT-2783: "Model Access Groups are missing in the Add Model flow."

## Linear ticket

Resolves LIT-2783

## Summary

The "Model Access Group" picker in the Add Model flow only listed legacy access groups discovered from existing deployments' `model_info.access_groups` (returned by `/models?only_model_access_groups=true`). Unified access groups created through the **Access Groups** page — which are stored in `LiteLLM_AccessGroupTable` and served by `/v1/access_group` — were never merged in.

So if an admin created an access group like `Engineering` from the Access Groups page and then went to add a model, `Engineering` did not appear in the dropdown and they had to type it from memory (and any typo silently created a brand-new, disconnected group).

## Fix

Pull both sources and merge them into one deduped, sorted list everywhere the picker appears:

- `add_model/AddModelForm.tsx` — call `useAccessGroups()` and union with the legacy `/models` response
- `add_model/add_auto_router_tab.tsx` — same merge for the Add Auto Router tab
- `edit_auto_router/edit_auto_router_modal.tsx` — same merge for the auto router edit modal
- `models-and-endpoints/ModelsAndEndpointsView.tsx` — `availableModelAccessGroups` (which feeds `ModelInfoView`'s edit dropdown and the All Models filter) now folds unified group names in too

`useAccessGroups` is already gated on admin role internally, so non-admins see exactly the same list they did before.

## Tests

Adds an `AddModelForm.test.tsx` case that opens the dropdown and asserts the legacy entries (`model-group-1`, `model-group-2`) **and** a mocked unified group (`engineering`) all appear. All 7 tests in the file pass, and all 114 tests across `add_model/`, `model_info_view`, and `models-and-endpoints/` pass.

```bash
cd ui/litellm-dashboard && npx vitest run \
  src/components/add_model/ \
  src/components/model_info_view.test.tsx \
  src/app/\(dashboard\)/models-and-endpoints/
# Test Files  14 passed (14)
#      Tests  114 passed (114)
```

## Pre-Submission checklist

- [x] I have added testing in `ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx` (UI-only fix, so the test sits with the rest of the AddModelForm tests rather than `tests/test_litellm/`)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- `ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx`
- `ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx`
- `ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx`
- `ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx`
- `ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777920083423529?thread_ts=1777920083.423529&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-7de08de5-d600-5955-aedb-68c9111964bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7de08de5-d600-5955-aedb-68c9111964bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

