### PR TITLE
refactor(anthropic,bedrock): hoist drop_params output_config warning to a single constant

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -113,6 +113,12 @@ REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT: Dict[str, str] = {
     "max": "max",
 }
 
+DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING = (
+    "Dropping unsupported `output_config` for model=%s "
+    "(drop_params=True). Effort is only supported on Opus 4.5+, "
+    "Sonnet 4.6+, and Mythos Preview."
+)
+
 
 class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     """
@@ -1632,9 +1638,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             return
         if litellm.drop_params is True and not self._model_supports_effort_param(model):
             litellm.verbose_logger.warning(
-                "Dropping unsupported `output_config` for model=%s "
-                "(drop_params=True). Effort is only supported on Opus 4.5+, "
-                "Sonnet 4.6+, and Mythos Preview.",
+                DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
                 model,
             )
             optional_params.pop("output_config", None)

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -32,6 +32,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     _bedrock_tools_pt,
 )
 from litellm.llms.anthropic.chat.transformation import (
+    DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
     REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT,
     AnthropicConfig,
 )
@@ -1282,9 +1283,7 @@ class AmazonConverseConfig(BaseConfig):
                     and not AnthropicConfig._model_supports_effort_param(model)
                 ):
                     litellm.verbose_logger.warning(
-                        "Dropping unsupported `output_config` for model=%s "
-                        "(drop_params=True). Effort is only supported on "
-                        "Opus 4.5+, Sonnet 4.6+, and Mythos Preview.",
+                        DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
                         model,
                     )
                 else:

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -16,7 +16,10 @@ import litellm
 from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
 from litellm.constants import BEDROCK_MIN_THINKING_BUDGET_TOKENS
 from litellm.litellm_core_utils.litellm_logging import verbose_logger
-from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+from litellm.llms.anthropic.chat.transformation import (
+    DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
+    AnthropicConfig,
+)
 from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
@@ -588,9 +591,7 @@ class AmazonAnthropicClaudeMessagesConfig(
             and not AnthropicConfig._model_supports_effort_param(model)
         ):
             verbose_logger.warning(
-                "Dropping unsupported `output_config` for model=%s "
-                "(drop_params=True). Effort is only supported on Opus 4.5+, "
-                "Sonnet 4.6+, and Mythos Preview.",
+                DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
                 model,
             )
             anthropic_messages_request.pop("output_config", None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Title

refactor(anthropic,bedrock): hoist drop_params output_config warning to a single constant

## Relevant issues

Follow-up to Michael's review on #27074.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory — n/a, pure refactor; no behavior change. Existing 99 anthropic/bedrock `output_config` / `drop_params` / `effort` tests still pass.
- [x] I have added a screenshot of my new test passing locally — n/a
- [x] My PR passes all unit tests on `make test-unit` — targeted run: `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py` + `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py` filtered to `drop_params or output_config or effort` → **99 passed, 214 deselected in 1.96s**.
- [x] My PR's scope is as isolated as possible — single-purpose refactor.

## Type

🧹 Refactoring

## Changes

The same `verbose_logger.warning("Dropping unsupported \`output_config\` for model=%s ...")` literal was duplicated across three call sites:

- `litellm/llms/anthropic/chat/transformation.py`
- `litellm/llms/bedrock/chat/converse_transformation.py`
- `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py`

Each one carried the same "Effort is only supported on Opus 4.5+, Sonnet 4.6+, and Mythos Preview." model-list copy. A future copy edit (e.g. when Sonnet 4.7 lands) would have to be repeated three times and one site would inevitably drift.

Extracted `DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING` as a module-level constant in `litellm/llms/anthropic/chat/transformation.py` (next to the existing `REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT` mapping) and import it from both bedrock sites. The two bedrock files already import other symbols from `anthropic/chat/transformation.py`, so no new import edges are introduced.

No behavior change — the emitted log message is byte-identical.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777925273993499?thread_ts=1777925273.993499&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-98b940b0-8bd6-575a-a7ff-733a674ad354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98b940b0-8bd6-575a-a7ff-733a674ad354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

