### PR TITLE
Build Admin UI from source in every Docker image and on PyPI publish

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -121,6 +121,21 @@ jobs:
           version: "0.10.9"
           enable-cache: false
 
+      - name: Set up Node.js for Admin UI build
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/litellm-dashboard/package-lock.json
+
+      - name: Build Admin UI
+        # The Next.js bundle under litellm/proxy/_experimental/out is no longer
+        # checked into the repository; build it here so it gets packaged into
+        # the published wheel/sdist.
+        run: |
+          chmod +x docker/build_admin_ui.sh
+          ./docker/build_admin_ui.sh
+
       - name: Copy model prices backup
         run: cp model_prices_and_context_window.json litellm/model_prices_and_context_window_backup.json
 

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY --from=uvbin /uv /usr/local/bin/uv
 COPY --from=uvbin /uvx /usr/local/bin/uvx
 
-RUN apk add --no-cache gcc python3-dev musl-dev nodejs npm libsndfile
+RUN apk add --no-cache bash gcc python3-dev musl-dev nodejs npm libsndfile
 
 ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
     UV_PROJECT_ENVIRONMENT=/app/.venv \

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -38,6 +38,9 @@ RUN uv sync --frozen --no-install-project --no-install-workspace --no-default-gr
 # Copy full source tree
 COPY . .
 
+# Build Admin UI before final sync
+RUN sed -i 's/\r$//' docker/build_admin_ui.sh && chmod +x docker/build_admin_ui.sh && ./docker/build_admin_ui.sh
+
 # Install project and workspace packages (fast - deps already cached)
 RUN uv sync --frozen --no-default-groups --no-editable \
     --extra proxy \

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -24,7 +24,8 @@ RUN for i in 1 2 3; do \
         curl \
         openssl \
         libsndfile \
-        nodejs && break || sleep 5; \
+        nodejs \
+        npm && break || sleep 5; \
     done
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
@@ -55,22 +56,19 @@ COPY . .
 # Set non-root flag for build time consistency
 ENV LITELLM_NON_ROOT=true
 
-# Stage the pre-built Admin UI from the checked-in Next.js static export.
-# _experimental/out/ is regenerated as part of the release runbook.
-# Restructure extensionless routes (foo.html -> foo/index.html) to match the layout
-# proxy_server.py expects, and drop a readiness marker.
+# Build the Admin UI from source. The pre-built Next.js bundle is no longer
+# checked into the repository — build_admin_ui.sh produces it and writes to
+# litellm/proxy/_experimental/out (already restructured for /ui routes).
+RUN sed -i 's/\r$//' docker/build_admin_ui.sh && chmod +x docker/build_admin_ui.sh && \
+    ./docker/build_admin_ui.sh
+
+# Stage the freshly built Admin UI for the runtime stage. The build script
+# already restructured extensionless routes (foo.html -> foo/index.html) to
+# match the layout proxy_server.py expects; we just drop a readiness marker.
 RUN mkdir -p /var/lib/litellm/ui /var/lib/litellm/assets && \
     cp -r /app/litellm/proxy/_experimental/out/. /var/lib/litellm/ui/ && \
     cp /app/litellm/proxy/logo.jpg /var/lib/litellm/assets/logo.jpg && \
-    ( cd /var/lib/litellm/ui && \
-      for html_file in *.html; do \
-        if [ "$html_file" != "index.html" ] && [ -f "$html_file" ]; then \
-          folder_name="${html_file%.html}" && \
-          mkdir -p "$folder_name" && \
-          mv "$html_file" "$folder_name/index.html"; \
-        fi; \
-      done && \
-      touch .litellm_ui_ready )
+    touch /var/lib/litellm/ui/.litellm_ui_ready
 
 RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
     if [ "$PROXY_EXTRAS_SOURCE" = "published" ]; then \

--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -1,73 +1,49 @@
 #!/bin/bash
 
-# # try except this script
-# set -e
+# Builds the Admin UI Next.js bundle and publishes it to
+# litellm/proxy/_experimental/out so the proxy can serve it.
+#
+# This script is invoked from every UI-bearing Dockerfile and from the
+# release pipeline. The pre-built bundle is no longer checked into the
+# repository, so this script must run successfully whenever the
+# resulting Docker image / Python wheel needs to ship the dashboard.
 
-# print current dir 
-echo
+set -e
+
 pwd
 
-
-# only run this step for litellm enterprise, we run this if enterprise/enterprise_ui/_enterprise.json exists
-if [ ! -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
-    echo "Admin UI - using default LiteLLM UI"
-    exit 0
+# Apply the enterprise color palette when present so OSS and enterprise
+# images can share this build script.
+if [ -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
+    echo "Using enterprise UI color palette"
+    cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
+else
+    echo "Using default LiteLLM UI color palette"
 fi
 
-echo "Building Custom Admin UI..."
-
-# Install dependencies
-# Check if we are on macOS
-if [[ "$(uname)" == "Darwin" ]]; then
-    # Install dependencies using Homebrew
-    if ! command -v brew &> /dev/null; then
-        echo "Error: Homebrew not found. Please install Homebrew and try again."
-        exit 1
-    fi
-    brew update
-    brew install curl
-else
-    # Assume Linux, try using apt-get
-    if command -v apt-get &> /dev/null; then
-        apt-get update
-        apt-get install -y curl
-    elif command -v apk &> /dev/null; then
-        # Try using apk if apt-get is not available
-        apk update
-        apk add curl
-    else
-        echo "Error: Unsupported package manager. Cannot install dependencies."
-        exit 1
-    fi
-fi
-NVM_VERSION="v0.40.4"
-NVM_CHECKSUM="4b7412c49960c7d31e8df72da90c1fb5b8cccb419ac99537b737028d497aba4f"
-NVM_SCRIPT=$(mktemp)
-trap 'rm -f "$NVM_SCRIPT"' EXIT
-curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" -o "$NVM_SCRIPT"
-if command -v sha256sum &>/dev/null; then
-  echo "${NVM_CHECKSUM}  ${NVM_SCRIPT}" | sha256sum -c -
-elif command -v shasum &>/dev/null; then
-  echo "${NVM_CHECKSUM}  ${NVM_SCRIPT}" | shasum -a 256 -c -
-else
-  echo "No sha256 tool found; cannot verify nvm checksum"; exit 1
-fi || { echo "nvm checksum verification failed"; exit 1; }
-bash "$NVM_SCRIPT"
-source ~/.nvm/nvm.sh
-nvm install v18.17.0
-nvm use v18.17.0
-
-# copy _enterprise.json from this directory to /ui/litellm-dashboard, and rename it to ui_colors.json
-cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
-
-# cd in to /ui/litellm-dashboard
 cd ui/litellm-dashboard
 
-# ensure have access to build_ui.sh
-chmod +x ./build_ui.sh
+# Use a deterministic install when a lockfile is present.
+if [ -f package-lock.json ]; then
+    npm ci
+else
+    npm install
+fi
 
-# run ./build_ui.sh
-./build_ui.sh
+npm run build
 
-# return to root directory
+destination_dir="../../litellm/proxy/_experimental/out"
+mkdir -p "$destination_dir"
+rm -rf "$destination_dir"/*
+cp -r ./out/. "$destination_dir"/
+rm -rf ./out
+
+# Restructure HTML so extensionless routes work (e.g. /ui/login).
+# Next.js export produces login.html; the proxy expects login/index.html.
+find "$destination_dir" -name '*.html' ! -name 'index.html' | while read -r htmlfile; do
+    target_dir="${htmlfile%.html}"
+    mkdir -p "$target_dir"
+    mv "$htmlfile" "$target_dir/index.html"
+done
+
 cd ../..

--- a/ui/litellm-dashboard/build_release_ui.sh
+++ b/ui/litellm-dashboard/build_release_ui.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
 set -e
 
-destination_dir="../../litellm/proxy/_experimental/out"
+# This script used to rebuild the UI and commit the resulting Next.js
+# bundle into git so the proxy could ship a pre-built dashboard.
+#
+# The bundle is no longer checked into the repository — it is rebuilt
+# from source by the Dockerfiles and by the PyPI publish workflow. This
+# script now simply triggers a local build (the canonical entry point is
+# `docker/build_admin_ui.sh`) for developers who want to preview the
+# production-flavoured UI without booting a Docker image.
 
-chmod +x ./build_ui.sh
-./build_ui.sh
-
-commit_message="chore: update Next.js build artifacts ($(date -u +"%Y-%m-%d %H:%M UTC"), node $(node -v))"
-
-if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-  git add -f "$destination_dir"/
-
-  if ! git diff --cached --quiet; then
-    git commit -m "$commit_message"
-    echo "Git commit created."
-  else
-    echo "No changes to commit."
-  fi
-else
-  echo "Not a git repository. Skipping commit."
-fi
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec "$repo_root/docker/build_admin_ui.sh"

--- a/ui/litellm-dashboard/build_release_ui.sh
+++ b/ui/litellm-dashboard/build_release_ui.sh
@@ -11,4 +11,5 @@ set -e
 # production-flavoured UI without booting a Docker image.
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
 exec "$repo_root/docker/build_admin_ui.sh"

--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -42,18 +42,24 @@ npm run build
 if [ $? -eq 0 ]; then
   echo "Build successful. Copying files..."
 
-  # echo current dir
   echo
   pwd
 
-  # Specify the destination directory
   destination_dir="../../litellm/proxy/_experimental/out"
 
-  # Remove existing files in the destination directory
+  # The pre-built bundle is no longer checked into the repository, so the
+  # destination may not exist on a fresh checkout. Create it before copying.
+  mkdir -p "$destination_dir"
   rm -rf "$destination_dir"/*
 
-  # Copy the contents of the output directory to the specified destination
-  cp -r ./out/* "$destination_dir"
+  cp -r ./out/. "$destination_dir"/
+
+  # Restructure HTML so extensionless routes work (login.html -> login/index.html)
+  find "$destination_dir" -name '*.html' ! -name 'index.html' | while read -r htmlfile; do
+    target_dir="${htmlfile%.html}"
+    mkdir -p "$target_dir"
+    mv "$htmlfile" "$target_dir/index.html"
+  done
 
   rm -rf ./out
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Prep work for removing the checked-in `litellm/proxy/_experimental/out/` Next.js bundle (suggested in `#litellm-senior-engineers` Slack). That removal will land as a separate PR; this one only wires the build pipelines so the removal is safe to apply.

This PR is split out from #27135 specifically so it stays under Greptile's 500-file review limit (the bundle removal alone deletes ~675 generated files).

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket -->

## Summary

Functionally a no-op for any consumer of LiteLLM: every artifact-producing pipeline (Docker images, PyPI wheel/sdist) still ships a fully built Admin UI. The change is that those pipelines now produce the bundle from source instead of relying on a pre-built copy at `litellm/proxy/_experimental/out/`.

### What changed

- **`docker/build_admin_ui.sh`** — rewritten so it always builds the UI (no more enterprise-only early exit), `cd`s into `ui/litellm-dashboard`, runs `npm ci && npm run build`, copies the static export into `litellm/proxy/_experimental/out`, and restructures `foo.html → foo/index.html` so extensionless `/ui/<route>` requests resolve. Drops the embedded `nvm` install — every Dockerfile that calls this script already provides `nodejs`/`npm`.
- **`docker/Dockerfile.alpine`** — now invokes `build_admin_ui.sh` (it was the only OSS Dockerfile that didn't).
- **`docker/Dockerfile.non_root`** — now invokes `build_admin_ui.sh` instead of staging a checked-in bundle. Added `npm` to the apk install. Dropped the bespoke `*.html → */index.html` restructure loop (the build script handles it) but still writes `.litellm_ui_ready` so `proxy_server.py:_is_ui_pre_restructured()` short-circuits the rewrite at startup.
- **`.github/workflows/publish_to_pypi.yml`** — added a Node.js setup step + UI build before `uv build` so the published wheel/sdist still carries the dashboard. The `uv` build backend packages files present on disk (it does not gate on git tracking), so this is sufficient once the bundle is no longer committed.
- **`ui/litellm-dashboard/build_ui.sh`** — `mkdir -p` the destination (it will not pre-exist on a fresh checkout once the bundle is removed) and apply the same HTML restructuring as the Docker pipeline.
- **`ui/litellm-dashboard/build_release_ui.sh`** — no longer commits artifacts to git; just delegates to `docker/build_admin_ui.sh`.

The other Dockerfiles (`Dockerfile`, `Dockerfile.database`, `Dockerfile.dev`) already call `docker/build_admin_ui.sh`, so they pick up the new always-build behavior for free. `docker/Dockerfile.custom_ui` does its own inline `npm run build` and is unchanged.

### Coverage matrix

| Surface                                  | UI built by                               |
|------------------------------------------|-------------------------------------------|
| `Dockerfile`                             | `docker/build_admin_ui.sh` (existing)     |
| `Dockerfile.alpine`                      | `docker/build_admin_ui.sh` (**new**)      |
| `Dockerfile.database`                    | `docker/build_admin_ui.sh` (existing)     |
| `Dockerfile.dev`                         | `docker/build_admin_ui.sh` (existing)     |
| `Dockerfile.non_root`                    | `docker/build_admin_ui.sh` (**new**)      |
| `Dockerfile.custom_ui`                   | inline `npm run build` (unchanged)        |
| PyPI publish (`uv build`)                | new Node setup + `build_admin_ui.sh` step |
| CircleCI `ui_build` job                  | `ui/litellm-dashboard/build_ui.sh` (existing) |
| CircleCI `e2e_ui_testing` job            | inline `npm run build` (existing)         |

### Follow-up

Once this lands, a follow-up PR will `git rm -rf litellm/proxy/_experimental/out/` and add it to `.gitignore`. That PR will be ~675 deleted files plus a one-line `.gitignore` change — too large for Greptile to review, but mechanically trivial after this PR makes the build pipelines self-sufficient.

## Pre-Submission checklist

- [ ] I have added testing in the `tests/test_litellm/` directory — _N/A: this is a build/release infra change. Existing tests in `tests/test_litellm/proxy/test_proxy_server.py` exercise the runtime UI mount path (using `tmp_path` fixtures, not the real `_experimental/out`), so they continue to pass with or without the checked-in bundle._
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure
🧹 Refactoring

## Changes

Single commit, 6 files changed (+87 / -97). All changes are in `docker/`, `.github/workflows/`, and `ui/litellm-dashboard/*.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B0KTS7U8K/p1777930741777359?thread_ts=1777930741.777359&cid=C0B0KTS7U8K)

<div><a href="https://cursor.com/agents/bc-fcb09706-4fe4-559f-841f-f86fa04fe18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcb09706-4fe4-559f-841f-f86fa04fe18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

