### PR TITLE
fix(proxy): union x-litellm-tags with static team/key tags instead of overwriting

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1541,7 +1541,15 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     )
 
     if tags is not None and _admin_allow_client_tags:
-        data[_metadata_variable_name]["tags"] = tags
+        # Union caller-supplied tags with the static team/key/project tags
+        # already merged into `data[_metadata_variable_name]["tags"]` above.
+        # Plain assignment here would overwrite admin-defined static tags,
+        # forcing an all-or-nothing trade-off between admin and caller tags.
+        # `_merge_tags` deduplicates, so callers cannot poison the list.
+        data[_metadata_variable_name]["tags"] = LiteLLMProxyRequestSetup._merge_tags(
+            request_tags=data[_metadata_variable_name].get("tags"),
+            tags_to_add=tags,
+        )
     elif tags is not None:
         verbose_proxy_logger.warning(
             "Ignored caller-supplied tags from header/root body: this "

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1026,6 +1026,118 @@ async def test_add_litellm_data_to_request_preserves_user_tags_when_team_opts_in
 
 
 @pytest.mark.asyncio
+async def test_add_litellm_data_to_request_unions_caller_tags_with_static_key_tags():
+    """Caller-supplied tags must UNION with the static tags from key metadata
+    (not overwrite them) when allow_client_tags=True.
+
+    Regression test: prior behavior assigned the caller-supplied list directly
+    to data["metadata"]["tags"], wiping out the static admin-controlled tags
+    (e.g. team/owner/env) that had been merged in earlier in the function. That
+    forced an all-or-nothing trade-off — admin context vs. per-request context —
+    which broke spend-attribution use cases that need both in `request_tags`.
+    """
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "metadata": {"tags": ["caller-tag-1", "caller-tag-2"]},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={
+            "tags": ["static-key-tag", "shared-tag"],
+            "allow_client_tags": True,
+        },
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    final_tags = updated["metadata"].get("tags") or []
+    # Static admin tags survive
+    assert "static-key-tag" in final_tags
+    assert "shared-tag" in final_tags
+    # Caller-supplied tags are added
+    assert "caller-tag-1" in final_tags
+    assert "caller-tag-2" in final_tags
+    # Deduplicated (shared-tag appears once even if it shows up on both sides)
+    assert final_tags.count("shared-tag") == 1
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_unions_caller_tags_with_static_team_tags():
+    """Team-level static tags must also be unioned with caller-supplied tags
+    when allow_client_tags=True (not just key-level)."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "metadata": {"tags": ["caller-only"]},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={},
+        team_metadata={
+            "tags": ["team-static-1", "team-static-2"],
+            "allow_client_tags": True,
+        },
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    final_tags = updated["metadata"].get("tags") or []
+    assert "team-static-1" in final_tags
+    assert "team-static-2" in final_tags
+    assert "caller-only" in final_tags
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_user_spend_and_budget():
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 


### PR DESCRIPTION
## Summary

When `allow_client_tags: true` is set on a key or team, caller-supplied tags arriving via the `x-litellm-tags` header (or root-body `tags`) overwrote the static team / key / project tags that had just been merged into `data["metadata"]["tags"]` earlier in `add_litellm_data_to_request`. That forced an all-or-nothing trade-off — admin-controlled context (team, owner, env) **or** caller-supplied per-request context (e.g. tenant id), never both.

This change replaces the plain assignment with the existing `_merge_tags()` helper (already used a few hundred lines above for the key/team/project static-tag merges) so caller tags **union with** rather than **replace** the static admin tags. `_merge_tags()` deduplicates, so callers cannot poison the list — no security change vs. today.

Fixes #27134

## Why this matters

Cost-attribution / billing pipelines that read `request_tags` from `/spend/logs/v2` rely on it carrying both:
- Static admin context identifying the workload/team/owner (from key or team metadata) — needed to group spend by service/owner.
- Dynamic per-request context like a tenant id — sent as `x-litellm-tags: tenant:<id>` so it varies per call.

`/spend/logs/v2` only persists the top-level `request_tags`; it does not expose `metadata.requester_custom_headers` or anything else from the StandardLoggingPayload. So losing either side from `request_tags` breaks downstream attribution. There is no other field in the spend-logs response to fall back to without writing a custom logger.

## Diff

`litellm/proxy/litellm_pre_call_utils.py` (the only behavioral change):

```diff
     if tags is not None and _admin_allow_client_tags:
-        data[_metadata_variable_name]["tags"] = tags
+        # Union caller-supplied tags with the static team/key/project tags
+        # already merged into `data[_metadata_variable_name]["tags"]` above.
+        # Plain assignment here would overwrite admin-defined static tags,
+        # forcing an all-or-nothing trade-off between admin and caller tags.
+        # `_merge_tags` deduplicates, so callers cannot poison the list.
+        data[_metadata_variable_name]["tags"] = LiteLLMProxyRequestSetup._merge_tags(
+            request_tags=data[_metadata_variable_name].get("tags"),
+            tags_to_add=tags,
+        )
     elif tags is not None:
         verbose_proxy_logger.warning(
             "Ignored caller-supplied tags from header/root body: this "
             "key/team does not have `allow_client_tags: true` in its metadata."
         )
```

## Tests

Added two regression tests in `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`:

- `test_add_litellm_data_to_request_unions_caller_tags_with_static_key_tags` — key has both static `metadata.tags` and `allow_client_tags: true`; asserts the resulting `metadata.tags` contains the union, with shared tags deduplicated.
- `test_add_litellm_data_to_request_unions_caller_tags_with_static_team_tags` — same shape, but static tags live in `team_metadata`.

Existing `allow_client_tags` and tag-strip tests continue to pass:

```
tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_add_litellm_data_to_request_preserves_user_tags_when_key_opts_in PASSED
tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_add_litellm_data_to_request_preserves_user_tags_when_team_opts_in PASSED
tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_add_litellm_data_to_request_strips_user_tags_without_permission PASSED
tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_add_litellm_data_to_request_unions_caller_tags_with_static_key_tags PASSED
tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_add_litellm_data_to_request_unions_caller_tags_with_static_team_tags PASSED
... (13 total, all passed)
```

## Pre-Submission checklist

- [x] Tests added covering the new behavior
- [x] No public API change; no docs update needed
- [x] Existing tests still pass
- [x] `_merge_tags()` deduplicates, preserving the existing security gate