### PR TITLE
Add VSCode launch configuration for LiteLLM proxy debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "LiteLLM proxy (debug)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/litellm/proxy/proxy_cli.py",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "--host",
+                "0.0.0.0",
+                "--config",
+                "test-config/dev_config.yaml",
+                "--port",
+                "4000",
+                "--num_workers",
+                "1"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ]
+}


### PR DESCRIPTION
# Debugging the LiteLLM proxy (concurrent / in-flight requests)

This workspace includes a VS Code / Cursor launch configuration (**LiteLLM proxy (debug)**) that starts the gateway under **`debugpy`**. Use it when you need **breakpoints**, **single-stepping**, and **variable inspection** while traffic hits the proxy—not only for one-shot scripts.

## Why use this?

Many gateway bugs only show up **inside a real request lifecycle**: caches warm across calls, auth runs mid-flight, Redis vs in-memory backends diverge, and logs alone don’t tell you **which branch actually executed** or **what structure lived in locals**. Running the proxy under the debugger lets you stop **exactly** at cache lookups, Prisma/Redis touches, or auth helpers and confirm assumptions (e.g. “did this path populate the user API-key cache from Redis?”). One concrete example: an issue where the **user API key cache did not reflect the Redis-backed cache** was tracked down by stepping through the auth/cache path under live requests—much faster than printf archaeology across workers. For multi-layer failures like that, this setup is often the quickest way to **prove** root cause before shipping a fix.

## What you get

- **Python breakpoints** anywhere in `litellm/` (handlers, routing, providers, passthrough, DB paths).
- **Pause on exceptions** (configure in the debugger UI) to catch failures deep in a request path.
- **`justMyCode`: false** so you can step into library code when necessary (e.g. FastAPI, httpx).

The proxy is still a **long-lived HTTP server**: many clients may send overlapping requests. The debugger attaches to **one OS process**; understanding how that interacts with concurrency avoids confusing sessions.

## Recommended settings for stepping through requests

| Setting | Why |
|--------|-----|
| **`--num_workers 1`** | Workers map to processes; multiple workers mean multiple interpreters—your breakpoints only bind to the **debugged** process. One worker keeps **all HTTP handling** in the process you launched under the debugger. |
| **Controlled load** | With concurrency, several requests may hit the same code path while one thread/coro is paused. Prefer **one client at a time** while stepping, or tools that serialize calls, until you trust your breakpoints. |
| **Async-aware stepping** | Much of the proxy is **async**. Use **step over / step into** on async boundaries carefully; stack traces may jump between tasks. Breaking on **small sync helpers** or **entrypoints** often stays clearer than stepping every `await`. |

## “Many requests / in-flight” debugging

When **many requests are in flight**:

1. **Only one breakpoint hit is active per pause** — other requests keep accumulating in the event loop / thread pool until they hit code guarded by locks or until you resume.
2. **Inspect `asyncio` tasks or threads** from the debugger’s **CALL STACK / Threads** panel to see **which request** triggered the stop (correlation IDs, request paths in locals, logging context).
3. For **race-style bugs**, combine debugging with **logging** or **conditional breakpoints** (e.g. break only when `request_id == …`) so you don’t stop unrelated traffic.

This workflow is a **development debugger**, not a production observability tool: it trades throughput for inspectability.

## Launch entrypoint

The debug configuration runs:

- **Program:** `litellm/proxy/proxy_cli.py`
- **Working directory:** workspace root
- **Typical args:** `--host 0.0.0.0`, `--config test-config/dev_config.yaml`, `--port 4000`, `--num_workers 1`

Adjust `--config` / `--port` for your environment.

## Comments in `launch.json`

`launch.json` is edited as **JSON with Comments** in VS Code / Cursor; you may use `//` or `/* */` above configurations or arguments.

## Related checklist (PRs)

When contributing fixes verified via this setup, mention in the PR:

- Proxy debug session + breakpoint location (or exception pause).
- Single-worker assumption if relevant to reproduction.
- Any limitation (e.g. multi-worker not covered).
