### PR TITLE
ci(circleci): enable Rerun Failed Tests for all pytest jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/local_testing -x --junitxml=test-results/junit.xml --durations=5 -k "langfuse"
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -k \"langfuse\""
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -395,7 +403,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/proxy_admin_ui_tests -x --junitxml=test-results/junit.xml --durations=5 -n 2
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/proxy_admin_ui_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 2"
           no_output_timeout: 15m
 
       # Store test results
@@ -471,7 +487,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/router_unit_tests -x --junitxml=test-results/junit.xml --durations=5 -n 4
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/router_unit_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 4"
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -495,7 +519,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest tests/local_testing/ -v -k "assistants" -x --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -k \"assistants\""
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -528,14 +560,19 @@ jobs:
             # Add --timeout to kill hanging tests after 120s (2 min)
             # Add --durations=20 to show 20 slowest tests for debugging
             # Subdirectories with dedicated jobs (maintain this list as new jobs are added)
-            IGNORE_DIRS=(
-              "tests/llm_translation/realtime"
-            )
-            IGNORE_ARGS=""
-            for dir in "${IGNORE_DIRS[@]}"; do
-              IGNORE_ARGS="$IGNORE_ARGS --ignore=$dir"
-            done
-            uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5
+            mkdir -p test-results
+            # Glob excludes the realtime/ subdirectory since it has its own job
+            TEST_FILES=$(circleci tests glob "tests/llm_translation/**/test_*.py" | grep -v "^tests/llm_translation/realtime/")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v \
+                --junitxml=test-results/junit.xml \
+                --durations=20 \
+                -n 4 \
+                --timeout=120 --timeout_method=thread \
+                --retries 2 --retry-delay 5 \
+                --max-worker-restart=5"
           no_output_timeout: 15m
 
       # Store test results
@@ -560,7 +597,17 @@ jobs:
           command: |
             # Add --timeout to kill hanging tests after 120s (2 min)
             # Add --durations=20 to show 20 slowest tests for debugging
-            uv run --no-sync python -m pytest -vv tests/llm_translation/realtime --cov=litellm --cov-report=xml -v --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/llm_translation/realtime/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=20 \
+                -n 4 \
+                --timeout=120 --timeout_method=thread"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -593,7 +640,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/agent_tests --ignore=tests/agent_tests/local_only_agent_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/agent_tests/**/test_*.py" | grep -v "^tests/agent_tests/local_only_agent_tests/")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -626,7 +681,18 @@ jobs:
       - run:
           name: Run tests
           command: |
-            LITELLM_LOG=WARNING uv run --no-sync python -m pytest tests/guardrails_tests -vv --cov=litellm --cov-report=xml --junitxml=test-results/junit.xml --durations=5 -n 2 --timeout=120 --timeout_method=thread
+            mkdir -p test-results
+            export LITELLM_LOG=WARNING
+            TEST_FILES=$(circleci tests glob "tests/guardrails_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 2 \
+                --timeout=120 --timeout_method=thread"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -660,7 +726,16 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/unified_google_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 --retries 3 --retry-delay 5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/unified_google_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                --retries 3 --retry-delay 5"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -702,7 +777,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/llm_responses_api_testing -x --junitxml=test-results/junit.xml --durations=5 -n 8
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/llm_responses_api_testing/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 8"
           no_output_timeout: 15m
 
       # Store test results
@@ -725,7 +808,16 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/ocr_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/ocr_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 4"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -758,7 +850,16 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/search_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/search_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 4"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -793,7 +894,15 @@ jobs:
           name: Run enterprise tests
           command: |
             uv run --no-sync python -m prisma generate
-            uv run --no-sync python -m pytest -v tests/enterprise -x --junitxml=test-results/junit-enterprise.xml --durations=10 -n 4
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/enterprise/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit-enterprise.xml \
+                --durations=10 \
+                -n 4"
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -815,7 +924,16 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/batches_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 -n 2
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/batches_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 2"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -848,7 +966,16 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/litellm_utils_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5 -n 2
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/litellm_utils_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 2"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -882,7 +1009,16 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/pass_through_unit_tests --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5 -n 4
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/pass_through_unit_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 4"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -916,7 +1052,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/image_gen_tests -n 4 -x --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/image_gen_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -n 4"
           no_output_timeout: 15m
       # Store test results
       - store_test_results:
@@ -939,7 +1083,18 @@ jobs:
       - run:
           name: Run tests
           command: |
-            LITELLM_LOG=WARNING uv run --no-sync python -m pytest tests/logging_callback_tests -vv --cov=litellm --cov-report=xml -n 4 --junitxml=test-results/junit.xml --durations=5 --timeout=120 --timeout_method=thread
+            mkdir -p test-results
+            export LITELLM_LOG=WARNING
+            TEST_FILES=$(circleci tests glob "tests/logging_callback_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv \
+                --cov=litellm --cov-report=xml \
+                -n 4 \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                --timeout=120 --timeout_method=thread"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -972,7 +1127,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/audio_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/audio_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
       - run:
           name: Rename the coverage files
@@ -1012,14 +1175,19 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv \
+            mkdir -p test-results
+            TEST_FILES=$(printf "%s\n" \
               tests/local_testing/test_dual_cache.py \
               tests/local_testing/test_redis_batch_optimizations.py \
-              tests/local_testing/test_router_utils.py \
-              --cov=litellm --cov-report=xml \
-              -x -s -v --junitxml=test-results/junit.xml \
-              --durations=5 -n 2 \
-              --reruns 2 --reruns-delay 1
+              tests/local_testing/test_router_utils.py)
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --cov=litellm --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 -n 2 \
+                --reruns 2 --reruns-delay 1"
           no_output_timeout: 20m
       - run:
           name: Rename the coverage files
@@ -1260,8 +1428,17 @@ jobs:
       - run:
           name: Run Basic Proxy Startup Tests (Health Readiness and Chat Completion)
           command: |
-            uv run --no-sync python -m pytest -v tests/basic_proxy_startup_tests -x --junitxml=test-results/junit-2.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/basic_proxy_startup_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit-2.xml \
+                --durations=5"
           no_output_timeout: 15m
+      - store_test_results:
+          path: test-results
 
   build_and_test:
     machine:
@@ -1331,7 +1508,18 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -s -v tests/*.py -x --junitxml=test-results/junit.xml -n 4 --durations=5 --ignore=tests/otel_tests --ignore=tests/spend_tracking_tests --ignore=tests/pass_through_tests --ignore=tests/proxy_admin_ui_tests --ignore=tests/load_tests --ignore=tests/llm_translation --ignore=tests/llm_responses_api_testing --ignore=tests/mcp_tests --ignore=tests/guardrails_tests --ignore=tests/image_gen_tests --ignore=tests/pass_through_unit_tests
+            mkdir -p test-results
+            # Original used `tests/*.py` (top-level only); the `--ignore=...`
+            # flags were vestigial since shell globbing did not descend into
+            # subdirectories. Replicate by globbing only top-level test files.
+            TEST_FILES=$(circleci tests glob "tests/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -s -v -x \
+                --junitxml=test-results/junit.xml \
+                -n 4 \
+                --durations=5"
           no_output_timeout: 15m
 
       # Store test results
@@ -1406,7 +1594,14 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -s -vv tests/openai_endpoints_tests --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/openai_endpoints_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -s -vv \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
 
       # Store test results
@@ -1475,7 +1670,14 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/otel_tests --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/otel_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
             # Clean up first container
       - run:
@@ -1518,7 +1720,14 @@ jobs:
       - run:
           name: Run second round of tests
           command: |
-            uv run --no-sync python -m pytest -v tests/basic_proxy_startup_tests -x --junitxml=test-results/junit-2.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/basic_proxy_startup_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit-2.xml \
+                --durations=5"
           no_output_timeout: 15m
 
       # Store test results
@@ -1587,8 +1796,17 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/spend_tracking_tests -x --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/spend_tracking_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
+      - store_test_results:
+          path: test-results
       - run:
           name: Stop and remove first container
           when: always
@@ -1676,7 +1894,14 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/multi_instance_e2e_tests -x --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/multi_instance_e2e_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
             # Clean up first container
       # Store test results
@@ -1732,7 +1957,14 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/store_model_in_db_tests -x --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/store_model_in_db_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
       - run:
           name: Stop and remove containers
@@ -1805,9 +2037,18 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -vv tests/basic_proxy_startup_tests -x --junitxml=test-results/junit-2.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/basic_proxy_startup_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x \
+                --junitxml=test-results/junit-2.xml \
+                --durations=5"
           no_output_timeout: 15m
             # Clean up first container
+      - store_test_results:
+          path: test-results
       - run:
           name: Stop and remove first container
           command: |
@@ -1940,7 +2181,14 @@ jobs:
       - run:
           name: Run tests
           command: |
-            uv run --no-sync python -m pytest -v tests/pass_through_tests/ -x --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+            TEST_FILES=$(circleci tests glob "tests/pass_through_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -v -x \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
 
       # Store test results
@@ -1997,9 +2245,16 @@ jobs:
       - run:
           name: Run Claude Agent SDK E2E Tests
           command: |
+            mkdir -p test-results
             export LITELLM_PROXY_URL="http://localhost:4000"
             export LITELLM_API_KEY="sk-1234"
-            uv run --no-sync python -m pytest -vv tests/proxy_e2e_anthropic_messages_tests/ -x -s --junitxml=test-results/junit.xml --durations=5
+            TEST_FILES=$(circleci tests glob "tests/proxy_e2e_anthropic_messages_tests/**/test_*.py")
+            echo "$TEST_FILES" | circleci tests run \
+              --verbose \
+              --command="xargs uv run --no-sync python -m pytest \
+                -vv -x -s \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 15m
 
       # Store test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1675,7 +1675,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
               --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
-                -v -x \
+                -v \
                 --junitxml=test-results/junit.xml \
                 --durations=5"
           no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
@@ -407,7 +407,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/proxy_admin_ui_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
@@ -491,7 +491,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/router_unit_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
@@ -523,7 +523,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
@@ -565,7 +565,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/llm_translation/**/test_*.py" | grep -v "^tests/llm_translation/realtime/")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v \
                 --junitxml=test-results/junit.xml \
                 --durations=20 \
@@ -601,7 +601,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/llm_translation/realtime/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -644,7 +644,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/agent_tests/**/test_*.py" | grep -v "^tests/agent_tests/local_only_agent_tests/")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -686,7 +686,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/guardrails_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -730,7 +730,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/unified_google_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -781,7 +781,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/llm_responses_api_testing/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
@@ -812,7 +812,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/ocr_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -854,7 +854,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/search_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -898,7 +898,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/enterprise/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit-enterprise.xml \
                 --durations=10 \
@@ -928,7 +928,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/batches_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -970,7 +970,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/litellm_utils_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -1013,7 +1013,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/pass_through_unit_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -1056,7 +1056,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/image_gen_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
@@ -1088,7 +1088,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/logging_callback_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm --cov-report=xml \
                 -n 4 \
@@ -1131,7 +1131,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/audio_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -1182,7 +1182,7 @@ jobs:
               tests/local_testing/test_router_utils.py)
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --cov=litellm --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -1432,7 +1432,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/basic_proxy_startup_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit-2.xml \
                 --durations=5"
@@ -1515,7 +1515,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -s -v -x \
                 --junitxml=test-results/junit.xml \
                 -n 4 \
@@ -1598,7 +1598,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/openai_endpoints_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -s -vv \
                 --junitxml=test-results/junit.xml \
                 --durations=5"
@@ -1724,7 +1724,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/basic_proxy_startup_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit-2.xml \
                 --durations=5"
@@ -1800,7 +1800,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/spend_tracking_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5"
@@ -1898,7 +1898,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/multi_instance_e2e_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5"
@@ -1961,7 +1961,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/store_model_in_db_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5"
@@ -2041,7 +2041,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/basic_proxy_startup_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x \
                 --junitxml=test-results/junit-2.xml \
                 --durations=5"
@@ -2185,7 +2185,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/pass_through_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v -x \
                 --junitxml=test-results/junit.xml \
                 --durations=5"
@@ -2251,7 +2251,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/proxy_e2e_anthropic_messages_tests/**/test_*.py")
             echo "$TEST_FILES" | circleci tests run \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv -x -s \
                 --junitxml=test-results/junit.xml \
                 --durations=5"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

n/a — internal CI improvement.

## Linear ticket

Resolves LIT-2840

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — n/a, this PR only modifies `.circleci/config.yml`. The change is validated by `circleci config validate`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🚄 Infrastructure

## Changes

CircleCI's [Rerun Failed Tests](https://circleci.com/docs/guides/test/rerun-failed-tests/) button only appears on jobs that:

1. Use `circleci tests run` (not plain `pytest …` or `circleci tests split`),
2. Upload JUnit XML via `store_test_results`, and
3. Emit `file` / `classname` attributes in that JUnit XML (pytest does this by default).

Three jobs in this repo were already migrated (`local_testing_part1`, `local_testing_part2`, `litellm_router_testing`). The rest of the pytest-based jobs were still invoking `pytest …` directly, so Rerun Failed Tests was disabled for them. This PR migrates every remaining pytest job that uploads JUnit results to use `circleci tests run`.

### Per-job changes

For each job, the test-running step is rewritten from:

```bash
uv run --no-sync python -m pytest -v tests/<dir> -x --junitxml=test-results/junit.xml ...
```

to:

```bash
mkdir -p test-results
TEST_FILES=$(circleci tests glob "tests/<dir>/**/test_*.py")
echo "$TEST_FILES" | circleci tests run \
  --verbose \
  --command="xargs uv run --no-sync python -m pytest \
    ... <same flags> ..."
```

All original pytest flags are preserved (`-n N`, `--timeout`, `--retries`, `--cov`, `--reruns`, `-k "..."`, etc.). Job names, resource classes, and workflow wiring are untouched.

Migrated jobs:

- `langfuse_logging_unit_tests`
- `auth_ui_unit_tests`
- `litellm_router_unit_testing`
- `litellm_assistants_api_testing`
- `llm_translation_testing`
- `realtime_translation_testing`
- `agent_testing`
- `guardrails_testing`
- `google_generate_content_endpoint_testing`
- `llm_responses_api_testing`
- `ocr_testing`
- `search_testing`
- `litellm_mapped_enterprise_tests`
- `batches_testing`
- `litellm_utils_testing`
- `pass_through_unit_testing`
- `image_gen_testing`
- `logging_testing`
- `audio_testing`
- `redis_caching_unit_tests`
- `db_migration_disable_update_check`
- `build_and_test`
- `e2e_openai_endpoints`
- `proxy_logging_guardrails_model_info_tests` (both pytest steps in the job)
- `proxy_spend_accuracy_tests`
- `proxy_multi_instance_tests`
- `proxy_store_model_in_db_tests`
- `proxy_build_from_pip_tests`
- `proxy_pass_through_endpoint_tests`
- `proxy_e2e_anthropic_messages_tests`

### Notes / non-trivial bits

- **`llm_translation_testing`**: previously used a dynamic `IGNORE_DIRS=("tests/llm_translation/realtime")` shell array to build `--ignore=...` flags. After migration we don't pass `tests/llm_translation` as a directory to pytest — we pass an explicit list of files from the glob. So we now filter the glob output with `grep -v "^tests/llm_translation/realtime/"` to preserve the same exclusion.
- **`build_and_test`**: original `tests/*.py` shell glob only matched top-level files in `tests/`, which made the long list of `--ignore=tests/<subdir>` flags vestigial. Replaced with `circleci tests glob "tests/test_*.py"` (top-level only) and dropped the now-unused `--ignore` flags.
- **`redis_caching_unit_tests`**: the original passed three explicit test files. We now feed those three paths into `circleci tests run` via `printf` so rerun can target the right ones.
- **`proxy_spend_accuracy_tests`, `proxy_build_from_pip_tests`, `db_migration_disable_update_check`**: these jobs ran pytest but were missing `store_test_results`, so Rerun Failed Tests would not have worked even with `circleci tests run`. Added the missing `store_test_results` step.
- **Jobs not migrated (intentional):**
  - `using_litellm_on_windows`, `installing_litellm_on_python*`: smoke tests that don't upload JUnit XML.
  - `helm_chart_testing`, `test_bad_database_url`: not pytest-based.
  - `ui_unit_tests`, `e2e_ui_testing`: Vitest / Playwright; out of scope for this PR.
  - The Ruby/Node steps inside `proxy_pass_through_endpoint_tests` (only the Python pytest step in that job is migrated).

### Validation

- `python3 -c "import yaml; yaml.safe_load(open('.circleci/config.yml'))"` → OK, 44 jobs parsed.
- `circleci config validate .circleci/config.yml` → `Config file at .circleci/config.yml is valid.`
- The first push of this branch will exercise the new `circleci tests run` invocations across the full workflow.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1777942536496479?thread_ts=1777942536.496479&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-d29179c5-03ee-5ac0-80f1-50a95a4d7fe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d29179c5-03ee-5ac0-80f1-50a95a4d7fe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

