### PR TITLE
docs: add proxy health auth and key generation notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ Start the proxy with a config file:
 uv run litellm --config dev_config.yaml --port 4000
 ```
 
-The proxy takes ~15-20 seconds to fully start (it runs Prisma migrations on boot). Wait for `/health` to return before sending requests. Without a PostgreSQL `DATABASE_URL`, the proxy connects to a default Neon dev database embedded in the `litellm-proxy-extras` package.
+The proxy takes ~15-20 seconds to fully start (it runs Prisma migrations on boot). Wait for `/health` to return before sending requests. The `/health` endpoint requires the `Authorization: Bearer <master_key>` header (e.g. `sk-1234` from `dev_config.yaml`). Without a PostgreSQL `DATABASE_URL`, the proxy connects to a default Neon dev database embedded in the `litellm-proxy-extras` package. Note: key generation (`/key/generate`) requires a real database connection and will fail with the default Neon fallback.
 
 ### Running tests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Environment setup documentation improvement for Cloud Agents.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Added non-obvious clarifications to `AGENTS.md` under Cursor Cloud specific instructions:

- The `/health` endpoint requires `Authorization: Bearer <master_key>` header (e.g. `sk-1234` from `dev_config.yaml`)
- Key generation (`/key/generate`) requires a real database connection and will fail with the default Neon fallback

These notes help future Cloud Agents avoid confusion when testing the proxy server.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44f224d1-19bf-4151-9c82-67a3e97d3282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44f224d1-19bf-4151-9c82-67a3e97d3282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

