### PR TITLE
[Fix] CI: Enable VCR replay for test_azure_o_series

### DIFF
--- a/tests/llm_translation/conftest.py
+++ b/tests/llm_translation/conftest.py
@@ -36,7 +36,6 @@ _controller_terminal_reporter = None
 # silently win, so respx-using files opt out of the auto-marker.
 _RESPX_CONFLICTING_FILES = frozenset(
     {
-        "test_azure_o_series.py",
         "test_gpt4o_audio.py",
         "test_nvidia_nim.py",
         "test_openai.py",

--- a/tests/llm_translation/test_azure_o_series.py
+++ b/tests/llm_translation/test_azure_o_series.py
@@ -11,7 +11,6 @@ sys.path.insert(
 
 import httpx
 import pytest
-from respx import MockRouter
 
 import litellm
 from litellm import Choices, Message, ModelResponse


### PR DESCRIPTION
## Summary

- `test_azure_o_series.py` was in conftest's `_RESPX_CONFLICTING_FILES`, opting it out of the VCR auto-marker. The only `respx` reference in the file is an unused `from respx import MockRouter`. Drop both the dead import and the conflict-set entry so the existing VCR cassette infrastructure records on first run and replays thereafter.
- Fixes a recurring \`worker 'gwN' crashed while running 'tests/llm_translation/test_azure_o_series.py::TestAzureOpenAIO3Mini::*'\` failure mode in \`llm_translation_testing\`. Each Azure o3-mini call takes 60–95s (no cassette → live API + reasoning-model latency); under nine parallel xdist workers some calls cross \`--timeout=120\`, and \`--timeout_method=thread\` cannot preempt blocked C-level socket reads, so the worker goes silent and xdist marks it \`node down: Not properly terminated\`. After 5 such crashes (\`--max-worker-restart=5\`) the run aborts.

## Test plan

- [x] `pytest tests/llm_translation/test_azure_o_series.py --collect-only` → 48 tests collected, no import errors.
- [x] Mocked subset runs green locally (`test_azure_o3_streaming`, `test_azure_o_series_routing`, `test_openai_o_series_max_retries_0`, `test_azure_o1_series_response_format_extra_params`, `test_override_fake_stream`, `test_reasoning_effort`, `test_developer_role_translation`, `test_completion_o_series_models_temperature`) — 8 passed in 1.12s.
- [x] Confirmed `_VCR_AUTO_MARKER_SKIP_FILES` no longer includes `test_azure_o_series.py`.
- [x] `black` clean.
- [ ] CCI `llm_translation_testing` records cassettes on first run, replays on subsequent runs.