### PR TITLE
fix: handle /mcp without trailing slash by adding explicit route

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14959,6 +14959,27 @@ async def _stream_mcp_asgi_response(
 ########################################################
 
 
+# Bare /mcp route — without this, Starlette's Mount("/mcp", ...) issues a 307
+# redirect from /mcp to /mcp/ which drops the request body and breaks MCP
+# clients that don't follow redirects.  This explicit route handles /mcp
+# directly so both /mcp and /mcp/ work identically.
+@app.api_route(
+    "/mcp",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+)
+async def bare_mcp_route(request: Request):
+    """Forward bare /mcp requests to the MCP streamable-HTTP handler."""
+    from litellm.proxy._experimental.mcp_server.server import (
+        handle_streamable_http_mcp,
+    )
+
+    scope = dict(request.scope)
+    scope["path"] = "/mcp"
+    return await _stream_mcp_asgi_response(
+        handle_streamable_http_mcp, scope, request.receive
+    )
+
+
 # Toolset-namespaced MCP routes - handle /toolset/{toolset_name}/mcp
 # Must be declared BEFORE /{mcp_server_name}/mcp to avoid being swallowed by the catchall.
 @app.api_route(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_bare_route.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_bare_route.py
@@ -1,0 +1,28 @@
+"""
+Test that /mcp (without trailing slash) is explicitly registered on the parent
+FastAPI app so it is handled directly instead of falling through to Starlette's
+Mount redirect (307 /mcp -> /mcp/).
+"""
+
+import pytest
+from starlette.routing import Route
+
+
+def test_should_have_bare_mcp_route_on_parent_app():
+    """The parent proxy app must have an explicit /mcp route so that requests
+    to /mcp (no trailing slash) are handled directly rather than redirected."""
+    from litellm.proxy.proxy_server import app
+
+    mcp_routes = [
+        r
+        for r in app.routes
+        if isinstance(r, Route) and getattr(r, "path", "") == "/mcp"
+    ]
+    assert len(mcp_routes) == 1, (
+        "Expected exactly one explicit /mcp Route on the parent app; "
+        f"found {len(mcp_routes)}"
+    )
+
+    route = mcp_routes[0]
+    assert "GET" in route.methods
+    assert "POST" in route.methods


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Fixes the issue where `/mcp` (without trailing slash) doesn't work but `/mcp/` does.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When the MCP sub-app is mounted via `app.mount("/mcp", mcp_app)`, Starlette issues a 307 redirect from `/mcp` to `/mcp/`. This drops the request body and breaks MCP clients that don't follow redirects.

**Fix:** Added an explicit `@app.api_route("/mcp", ...)` on the parent FastAPI app that forwards requests directly to the MCP streamable-HTTP handler via the existing `_stream_mcp_asgi_response` helper. This ensures both `/mcp` and `/mcp/` work identically without any redirect.

**Files changed:**
- `litellm/proxy/proxy_server.py` — Added `bare_mcp_route` handler before the toolset/dynamic MCP routes
- `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_bare_route.py` — Unit test verifying the explicit `/mcp` route exists on the parent app with correct HTTP methods
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C09MMPFRN7M/p1777952932169309?thread_ts=1777952932.169309&cid=C09MMPFRN7M)

<div><a href="https://cursor.com/agents/bc-cbc8f802-46d7-53f3-9c7e-84f2127ed804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbc8f802-46d7-53f3-9c7e-84f2127ed804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

