### PR TITLE
[Fix] Docker: Remove Hardcoded Prisma Binary Target For Multi-Arch Builds

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -32,7 +32,6 @@ ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     PATH="/app/.venv/bin:${PATH}" \
     LITELLM_NON_ROOT=true \
     PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x" \
     XDG_CACHE_HOME=/app/.cache
 
 # Copy dependency metadata first for layer caching
@@ -114,7 +113,6 @@ COPY --from=builder /app/docker/supervisord.conf /etc/supervisord.conf
 
 ENV PATH="/app/.venv/bin:${PATH}" \
     PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x" \
     HOME=/app \
     LITELLM_NON_ROOT=true \
     XDG_CACHE_HOME=/app/.cache \


### PR DESCRIPTION
## Summary

- `PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x"` was hardcoded in [docker/Dockerfile.non_root](docker/Dockerfile.non_root) by #17695. On a `buildx linux/arm64` leg this forces prisma to download the amd64 `schema-engine` into an arm64 image, so `prisma migrate deploy` fails at startup with `Could not find schema-engine binary` (path `schema-engine-linux-arm64-openssl-3.0.x`).
- Removing the env lets prisma auto-detect per build platform: amd64 builds still resolve to `debian-openssl-3.0.x` (Wolfi auto-detect falls back to debian — same binary as before, no image-byte change), and arm64 builds now correctly fetch `linux-arm64-openssl-3.0.x`.
- The offline-cache pre-warm goal of #17695 is preserved — `prisma generate` + the `COPY /app/.cache` into runtime + `PRISMA_OFFLINE_MODE=true` are untouched. Only which binaries fill the cache changes.

Fixes #19458

## Test plan

- [ ] `docker buildx build --platform linux/amd64 -f docker/Dockerfile.non_root .` succeeds
- [ ] `docker buildx build --platform linux/arm64 -f docker/Dockerfile.non_root .` succeeds
- [ ] On the arm64 image: `ls /app/.cache/prisma-python/binaries/node_modules/@prisma/engines/` shows `schema-engine-linux-arm64-openssl-3.0.x` (not `-debian-`)
- [ ] On the arm64 image: `prisma migrate deploy` runs without `Could not find schema-engine binary`
- [ ] On the amd64 image: image bytes / behavior unchanged from current main