### PR TITLE
fix(oci): handle missing tool call id in non-streaming responses

### DIFF
--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import hashlib
 import json
+import uuid
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -1001,6 +1002,16 @@ class OCIChatConfig(BaseConfig):
         raw_response: httpx.Response,
     ) -> ModelResponse:
         """Handle generic OCI response format."""
+        # OCI GENERIC apiFormat (Gemini, Meta, xAI) may not return 'id' on tool calls
+        chat_response = json.get("chatResponse", {})
+        for choice in chat_response.get("choices", []):
+            message = choice.get("message", {})
+            for tool_call in message.get("toolCalls") or []:
+                if "id" not in tool_call:
+                    tool_call["id"] = f"call_{uuid.uuid4().hex[:24]}"
+                if "arguments" not in tool_call:
+                    tool_call["arguments"] = ""
+
         try:
             completion_response = OCICompletionResponse(**json)
         except TypeError as e:

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -591,6 +591,85 @@ class TestOCIChatConfig:
         assert usage.completion_tokens == 20  # type: ignore
         assert usage.total_tokens == 30  # type: ignore
 
+    def test_transform_response_with_tool_calls_missing_id(self):
+        """
+        Tests that a response with tool calls missing the 'id' field is handled correctly.
+        OCI GENERIC apiFormat (Gemini, Meta, xAI) may not return 'id' on tool calls.
+        The fix should generate a synthetic id to avoid Pydantic validation errors.
+        """
+        config = OCIChatConfig()
+        created_time = (
+            datetime.datetime.now(datetime.timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        mock_oci_response = {
+            "modelId": TEST_MODEL_NAME,
+            "modelVersion": "1.0",
+            "chatResponse": {
+                "apiFormat": "GENERIC",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "ASSISTANT",
+                            "content": None,
+                            "toolCalls": [
+                                {
+                                    # Note: 'id' field is intentionally missing
+                                    "type": "FUNCTION",
+                                    "name": "get_weather",
+                                    "arguments": '{"location": "São Paulo, BR"}',
+                                }
+                            ],
+                        },
+                        "finishReason": "stop",
+                    }
+                ],
+                "timeCreated": created_time,
+                "usage": {
+                    "promptTokens": 10,
+                    "completionTokens": 20,
+                    "totalTokens": 30,
+                },
+            },
+        }
+        response = httpx.Response(status_code=200, json=mock_oci_response)
+        model_response = ModelResponse(
+            choices=[litellm.Choices(index=0, message=litellm.Message())]
+        )
+
+        result = config.transform_response(
+            model=TEST_MODEL_NAME,
+            raw_response=response,
+            model_response=model_response,
+            logging_obj={},  # type: ignore
+            request_data={},
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            encoding={},
+        )
+
+        # Should not raise an exception
+        assert isinstance(result, ModelResponse)
+        assert len(result.choices) == 1
+
+        choice = result.choices[0]
+        message = choice.message
+        assert hasattr(message, "tool_calls")
+        assert isinstance(message.tool_calls, list)
+        assert len(message.tool_calls) == 1
+
+        # The tool_call should have a generated id (starting with "call_")
+        tool_call = message.tool_calls[0]
+        assert isinstance(tool_call, litellm.utils.ChatCompletionMessageToolCall)
+        assert tool_call.id is not None
+        assert tool_call.id.startswith("call_")
+        assert tool_call.type == "function"
+        assert tool_call.function["name"] == "get_weather"
+        assert tool_call.function["arguments"] == '{"location": "São Paulo, BR"}'
+
 
 class TestOCISignerSupport:
     """Tests for OCI SDK Signer integration."""


### PR DESCRIPTION
## Context

I'm a Senior Engineer at StaryaAI, an Oracle partner company. We run LiteLLM in production as our LLM Gateway, routing requests to multiple providers including OCI Generative AI.

We encountered a blocking issue when using tool calling with OCI models (Gemini, Meta Llama, xAI Grok) in non-streaming mode.

---

## The Problem

When calling OCI Generative AI models with tools enabled (non-streaming), requests fail with:

```
litellm.APIConnectionError: 1 validation error for OCICompletionResponse
chatResponse.choices.0.message.toolCalls.0.id
  Field required [type=missing, input_value={'type': 'FUNCTION', 'name': '...', 'arguments': '...'}, input_type=dict]
```

**The OCI API returns tool calls like this** (note: no `id` field):
```json
{
  "toolCalls": [
    {
      "type": "FUNCTION",
      "name": "get_weather",
      "arguments": "{\"location\": \"São Paulo\"}"
    }
  ]
}
```

**But LiteLLM's Pydantic model `OCIToolCall` requires `id` as a mandatory field**, causing validation to fail before the response can be processed.

---

## Root Cause Analysis

The OCI Generative AI API uses two `apiFormat` values:
- `COHERE` — for Cohere models (command-r, etc.)
- `GENERIC` — for all other models (Meta Llama, xAI Grok, Google Gemini)

The **GENERIC apiFormat does not include `id` in tool call responses**. This is a known behavior of the OCI API.

**Streaming already handles this correctly** in `_handle_generic_stream_chunk` (lines 1457-1462):
```python
if dict_chunk.get("message") and dict_chunk["message"].get("toolCalls"):
    for tool_call in dict_chunk["message"]["toolCalls"]:
        if "arguments" not in tool_call:
            tool_call["arguments"] = ""
        if "id" not in tool_call:
            tool_call["id"] = ""
```

**Non-streaming (`_handle_generic_response`) was missing this handling**, causing the Pydantic validation error.

---

## The Fix

This PR adds the same missing field handling to `_handle_generic_response` that already exists for streaming:

```python
# Fix missing required fields in tool calls before Pydantic validation
# OCI GENERIC apiFormat (Gemini, Meta, xAI) may not return 'id' on tool calls
chat_response = json.get("chatResponse", {})
for choice in chat_response.get("choices", []):
    message = choice.get("message", {})
    for tool_call in message.get("toolCalls") or []:
        if "id" not in tool_call:
            tool_call["id"] = f"call_{uuid.uuid4().hex[:24]}"
        if "arguments" not in tool_call:
            tool_call["arguments"] = ""
```

**Key difference from streaming fix**: We generate a proper UUID-based id (`call_abc123...`) instead of an empty string, which is more compatible with downstream code that may rely on unique tool call ids.

---

## Related Issues

- **Fixes #18654** — OCI Provider: Pydantic validation error with tool calls (open since Nov 2025)
- **Related to #25177** — Larger OCI integration PR that also addresses this issue

This is a **minimal, focused fix** to unblock tool calling with OCI models. PR #25177 is comprehensive but large; this PR provides a quick fix for teams blocked by this issue while the larger PR is reviewed.

---

## Files Changed

| File | Change |
|------|--------|
| `litellm/llms/oci/chat/transformation.py` | Add missing field handling in `_handle_generic_response` |
| `tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py` | Add test for tool calls with missing id |