### PR TITLE
fix(mcp): include registration_endpoint in root /mcp OAuth discovery metadata

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/byok_oauth_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/byok_oauth_endpoints.py
@@ -6,11 +6,14 @@ LiteLLM runs a minimal OAuth 2.1 authorization code flow.  The "authorization pa
 just a form that asks the user for their API key — not a full identity-provider OAuth.
 
 Endpoints implemented here:
-  GET  /.well-known/oauth-authorization-server      — OAuth authorization server metadata
-  GET  /.well-known/oauth-protected-resource         — OAuth protected resource metadata
   GET  /v1/mcp/oauth/authorize                       — Shows HTML form to collect the API key
   POST /v1/mcp/oauth/authorize                       — Stores temp auth code and redirects
   POST /v1/mcp/oauth/token                           — Exchanges code for a bearer JWT token
+
+OAuth metadata discovery (`/.well-known/oauth-authorization-server` and
+`/.well-known/oauth-protected-resource`) is owned by `discoverable_endpoints.py`,
+which resolves a single OAuth2 MCP server for the root path and always emits
+`registration_endpoint` for dynamic client registration.
 """
 
 import base64
@@ -27,9 +30,6 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._experimental.mcp_server.db import store_user_credential
-from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-    get_request_base_url,
-)
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     TOKEN_NO_CACHE_HEADERS,
     validate_loopback_redirect_uri,
@@ -590,39 +590,6 @@ def _build_authorize_html(
 </script>
 </body>
 </html>"""
-
-
-# ---------------------------------------------------------------------------
-# OAuth metadata discovery endpoints
-# ---------------------------------------------------------------------------
-
-
-@router.get("/.well-known/oauth-authorization-server", include_in_schema=False)
-async def oauth_authorization_server_metadata(request: Request) -> JSONResponse:
-    """RFC 8414 Authorization Server Metadata for the BYOK OAuth flow."""
-    base_url = get_request_base_url(request)
-    return JSONResponse(
-        {
-            "issuer": base_url,
-            "authorization_endpoint": f"{base_url}/v1/mcp/oauth/authorize",
-            "token_endpoint": f"{base_url}/v1/mcp/oauth/token",
-            "response_types_supported": ["code"],
-            "grant_types_supported": ["authorization_code"],
-            "code_challenge_methods_supported": ["S256"],
-        }
-    )
-
-
-@router.get("/.well-known/oauth-protected-resource", include_in_schema=False)
-async def oauth_protected_resource_metadata(request: Request) -> JSONResponse:
-    """RFC 9728 Protected Resource Metadata pointing back at this server."""
-    base_url = get_request_base_url(request)
-    return JSONResponse(
-        {
-            "resource": base_url,
-            "authorization_servers": [base_url],
-        }
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py
@@ -93,30 +93,6 @@ def unauthenticated_client():
 
 
 # ---------------------------------------------------------------------------
-# OAuth metadata endpoints
-# ---------------------------------------------------------------------------
-
-
-def test_oauth_authorization_server_metadata(client):
-    resp = client.get("/.well-known/oauth-authorization-server")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "issuer" in data
-    assert data["authorization_endpoint"].endswith("/v1/mcp/oauth/authorize")
-    assert data["token_endpoint"].endswith("/v1/mcp/oauth/token")
-    assert "S256" in data["code_challenge_methods_supported"]
-
-
-def test_oauth_protected_resource_metadata(client):
-    resp = client.get("/.well-known/oauth-protected-resource")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "resource" in data
-    assert "authorization_servers" in data
-    assert len(data["authorization_servers"]) == 1
-
-
-# ---------------------------------------------------------------------------
 # Authorization GET endpoint
 # ---------------------------------------------------------------------------
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1771,6 +1771,77 @@ async def test_discovery_root_includes_server_name_prefix():
 
 
 @pytest.mark.asyncio
+async def test_root_well_known_handlers_not_shadowed_by_byok_router():
+    """Regression: when both BYOK and discoverable routers are mounted (as in
+    production via _lazy_features.py), the discoverable handler must own the
+    root /.well-known/oauth-authorization-server and /.well-known/oauth-protected-resource
+    paths so dynamic client registration metadata is advertised.
+
+    Bug: prior to the fix, byok_oauth_endpoints.py declared duplicate handlers at
+    these root paths and was registered first via _lazy_features.py — so its
+    trimmed payload (no `registration_endpoint`) shadowed the correct one and
+    broke MCP client OAuth at the unified /mcp URL.
+    """
+    try:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from litellm.proxy._experimental.mcp_server.byok_oauth_endpoints import (
+            router as byok_router,
+        )
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            router as discoverable_router,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP routers not available")
+
+    global_mcp_server_manager.registry.clear()
+    oauth2_server = _create_oauth2_server()
+    global_mcp_server_manager.registry[oauth2_server.server_id] = oauth2_server
+
+    app = FastAPI()
+    # Mount in the same order as _lazy_features.py: BYOK first, discoverable second.
+    # If a future change reintroduces a shadowing handler in BYOK, this ordering
+    # is what would mask it in production — so we reproduce it here.
+    app.include_router(byok_router)
+    app.include_router(discoverable_router)
+    client = TestClient(app)
+
+    try:
+        # /.well-known/oauth-authorization-server — must include registration_endpoint
+        resp = client.get("/.well-known/oauth-authorization-server")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "registration_endpoint" in data, (
+            "Root oauth-authorization-server response is missing "
+            "registration_endpoint — MCP clients will fail dynamic client "
+            "registration. Likely a duplicate handler shadowing "
+            "discoverable_endpoints.py."
+        )
+        # Discoverable's authorize/token endpoints — NOT BYOK's API-key-form ones.
+        assert not data["authorization_endpoint"].endswith(
+            "/v1/mcp/oauth/authorize"
+        ), "BYOK metadata is shadowing discoverable at the root path."
+        assert not data["token_endpoint"].endswith(
+            "/v1/mcp/oauth/token"
+        ), "BYOK metadata is shadowing discoverable at the root path."
+
+        # /.well-known/oauth-protected-resource — resource must point at /mcp.
+        resp = client.get("/.well-known/oauth-protected-resource")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["resource"].endswith("/mcp"), (
+            "BYOK protected-resource handler is shadowing discoverable at the "
+            "root path (resource should be base_url/mcp, not base_url)."
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+
+@pytest.mark.asyncio
 async def test_discovery_root_does_not_expose_private_server_for_external_client():
     """Root discovery must use caller visibility before adding server-specific metadata."""
     try:


### PR DESCRIPTION
## Relevant issues

Reported by a customer via Slack. No matching open GitHub issue. While investigating I came across some related-but-distinct OAuth-discovery issues that don't share root causes with this one: #19977 (closed), #20495, #17232.

## Linear ticket

n/a

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

### What the customer hit (before)

`GET /.well-known/oauth-authorization-server` at the proxy root returned a metadata document missing `registration_endpoint`, so Claude Code (and any MCP client doing dynamic client registration) bailed at the discovery step:

```json
{
  "issuer": "http://localhost:4000",
  "authorization_endpoint": "http://localhost:4000/v1/mcp/oauth/authorize",
  "token_endpoint": "http://localhost:4000/v1/mcp/oauth/token",
  "response_types_supported": ["code"],
  "grant_types_supported": ["authorization_code"],
  "code_challenge_methods_supported": ["S256"]
}
```

Claude Code surfaced this as: `SDK auth failed: Incompatible auth server: does not support dynamic client registration`. Per-server discovery paths (`/.well-known/oauth-authorization-server/{server}`) were unaffected, which is why the customer's per-server URLs continued to work.

### After the fix

Same `GET /.well-known/oauth-authorization-server` against a proxy with the patched code, two seeded OAuth2 MCP servers, otherwise identical setup:

```json
{
  "issuer": "http://localhost:4000",
  "authorization_endpoint": "http://localhost:4000/authorize",
  "token_endpoint": "http://localhost:4000/token",
  "response_types_supported": ["code"],
  "scopes_supported": [],
  "grant_types_supported": ["authorization_code", "refresh_token"],
  "code_challenge_methods_supported": ["S256"],
  "token_endpoint_auth_methods_supported": ["client_secret_post"],
  "registration_endpoint": "http://localhost:4000/register"
}
```

Claude Code now accepts the metadata, `POST /register` succeeds, and the SDK proceeds to open the OAuth authorize URL — i.e. the dynamic-client-registration step is no longer the failure surface. The `dynamic client registration` substring is gone from the error text on `claude mcp list`, and the SDK reaches `/authorize` with a fully formed PKCE+code request.

`/.well-known/oauth-protected-resource` similarly improves at the root: `resource` now points at `…/mcp` instead of the bare base URL, matching the discoverable handler's correct shape.

## Type

🐛 Bug Fix

## Changes

### Root cause

Two FastAPI routers declared a \`GET /.well-known/oauth-authorization-server\` handler at the same root path:

- \`litellm/proxy/_experimental/mcp_server/byok_oauth_endpoints.py\` (around line 600) — \`oauth_authorization_server_metadata\` returned BYOK API-key-form metadata, with no \`registration_endpoint\`.
- \`litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py\` (around line 921) — \`oauth_authorization_server_mcp\` returns the correct DCR-aware metadata via \`_build_oauth_authorization_server_response\` (which always includes \`registration_endpoint\`).

`_lazy_features.py` registers `mcp_byok_oauth` before `mcp_discoverable`, and FastAPI resolves duplicate routes first-match-wins — so the BYOK handler shadowed the correct one at the root path. The same shadowing applied to `/.well-known/oauth-protected-resource`. Per-server `.well-known/*` paths only exist on the discoverable router, which is why they were unaffected.

### What this PR does

- Deletes the two duplicated \`/.well-known/*\` handlers from \`byok_oauth_endpoints.py\` (plus their now-unused \`get_request_base_url\` import) so the discoverable router owns those root paths. The discoverable response builder already handles the no-server-name root case via \`_resolve_oauth2_server_for_root_endpoints\`. BYOK retains its actual flow endpoints (\`/v1/mcp/oauth/authorize\`, \`/v1/mcp/oauth/token\`) — those are not duplicated.
- Updates the BYOK module docstring to drop the two removed lines and note where discovery now lives, so a future contributor doesn't reintroduce the duplicate.
- Adds a regression test \`test_root_well_known_handlers_not_shadowed_by_byok_router\` in \`tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py\` that mounts both routers in the same order as \`_lazy_features.py\` and asserts discoverable wins at the root path. The existing per-router tests miss this collision because they each mount only one router.
- Removes \`test_oauth_authorization_server_metadata\` and \`test_oauth_protected_resource_metadata\` from \`tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py\` — they pinned the deleted handlers' shape and would either fail or test removed code if kept.

All 98 tests in the two affected test files pass locally (\`uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py\`).

### Out of scope (worth flagging for reviewers)

- **Multi-OAuth2-server resolution at root \`/authorize\` and \`/token\`**. When a deployment has more than one OAuth2 MCP server registered and a client hits the unified \`/mcp\` URL, \`_resolve_oauth2_server_for_root_endpoints\` returns \`None\` due to ambiguity, and the root \`/authorize\` handler 404s with \`MCP server not found\` (\`discoverable_endpoints.py:585\`). That behavior is pre-existing on \`litellm_internal_staging\` — this PR doesn't introduce or alter it. With this PR, MCP clients reach that path instead of bailing earlier on DCR; whether the unified URL should support multi-server OAuth flows at all is a separate design question. Happy to open a follow-up issue if reviewers think it's worth tackling.
- **BYOK-aware root metadata for BYOK-only deployments**. Discoverable's resolver filters on \`auth_type == oauth2\`, so a BYOK-only deployment hitting the unified \`/.well-known/*\` root will get discoverable's no-server-prefix shape instead of BYOK's. The root \`/authorize\`/\`/token\` will then 404 in this case too — but per-server BYOK paths (the actual integration pattern for BYOK) are unaffected. This might also be a good follow-up if it matters in practice; it didn't seem worth widening this PR's surface to address.