### PR TITLE
helm: skip proxy startup prisma db push when migrations Job is enabled

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -131,6 +131,16 @@ spec:
             {{- with .Values.extraEnvVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.migrationJob.enabled }}
+            # Schema updates are owned by the dedicated migrations Job; skip
+            # the proxy's startup `prisma db push` so N replicas don't race
+            # one DB on every rollout. Placed last (after envVars and
+            # extraEnvVars) so this override can't be silently shadowed by a
+            # user-supplied DISABLE_SCHEMA_UPDATE under last-wins duplicate-env
+            # semantics — same pattern the migrations Job uses.
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "true"
+            {{- end }}
           envFrom:
           {{- range .Values.environmentSecrets }}
             - secretRef:


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->
Resolves LIT-2694

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->
This chart was deployed on an EKS cluster with 3 replicas of the gateway + a migration job
*Without this fix, all pods run migrations by default*
<img width="1409" height="807" alt="Screenshot 2026-05-05 at 11 36 54 AM" src="https://github.com/user-attachments/assets/101eab89-175b-4fa5-bed3-d8b4ef7ae787" />

*With this fix, only the migration pod runs migrations by default*
<img width="1347" height="658" alt="Screenshot 2026-05-05 at 11 12 31 AM" src="https://github.com/user-attachments/assets/42b40897-1527-4d9e-a2ad-5faaed0b365f" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
*Summary*
- Adds `DISABLE_SCHEMA_UPDATE=true` to the proxy Deployment whenever `migrationJob.enabled=true`, so the dedicated migrations Job is the sole owner of schema updates.
- Without this, every proxy replica runs `prisma db push` on startup and races against the migrations Job (and against each other) on every rollout
- Gated on migrationJob.enabled so deployments that disable the dedicated Job keep the existing fallback behavior (proxy runs migrations itself).

*Behavior*
- `migrationJob.enabled=true` (default): proxy Deployment gets `DISABLE_SCHEMA_UPDATE=true`; migrations Job keeps its hardcoded `DISABLE_SCHEMA_UPDATE=false` and runs the migration.
- `migrationJob.enabled=false`: `DISABLE_SCHEMA_UPDATE` is unset on the proxy.