### PR TITLE
Fix typo in lowest_tpm_rpm.py"

### DIFF
--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -80,7 +80,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.error(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -151,7 +151,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.exception(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )


### PR DESCRIPTION
Small typo fix only: occurred spelling in string and comment text.