### PR TITLE
Include model name + configured TPM/RPM in priority rate-limit 429 errors

### DIFF
--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -485,6 +485,8 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                                 "error": f"Model capacity reached for {model}. "
                                 f"Priority: {priority}, "
                                 f"Rate limit type: {status['rate_limit_type']}, "
+                                f"Model TPM: {model_group_info.tpm}, "
+                                f"Model RPM: {model_group_info.rpm}, "
                                 f"Remaining: {status['limit_remaining']}"
                             },
                             headers={
@@ -504,8 +506,11 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                             status_code=429,
                             detail={
                                 "error": f"Priority-based rate limit exceeded. "
+                                f"Model: {model}, "
                                 f"Priority: {priority}, "
                                 f"Rate limit type: {status['rate_limit_type']}, "
+                                f"Model TPM: {model_group_info.tpm}, "
+                                f"Model RPM: {model_group_info.rpm}, "
                                 f"Remaining: {status['limit_remaining']}, "
                                 f"Model saturation: {saturation:.1%}"
                             },


### PR DESCRIPTION
## Why

Reported in Slack on v83.7-stable. The priority-based rate-limit 429 doesn't tell the operator which model was hit or what its configured limit is, so they can't tell whether the **priority allocation** needs tuning or whether the **model TPM** is just too small.

**Current message:**
```
429: {'error': 'Priority-based rate limit exceeded. Priority: prod,
                Rate limit type: tokens, Remaining: -664145,
                Model saturation: 86.3%'}
```

**After this PR:**
```
429: {'error': 'Priority-based rate limit exceeded. Model: gpt-4o,
                Priority: prod, Rate limit type: tokens,
                Model TPM: 4000000, Model RPM: 10000,
                Remaining: -664145, Model saturation: 86.3%'}
```

## What changed

Pure error-message change — no schema, headers, or control-flow impact.

`litellm/proxy/hooks/dynamic_rate_limiter_v3.py` → `_check_rate_limits()`:

- **Priority-based 429** (`descriptor_key == "priority_model"`): added `Model: {model}`, `Model TPM: {model_group_info.tpm}`, `Model RPM: {model_group_info.rpm}`.
- **Model-capacity 429** (`descriptor_key == "model_saturation_check"`): added `Model TPM` / `Model RPM` (model name was already there).

Both `model` and `model_group_info` are already in scope in `_check_rate_limits`, so this is a string-formatting-only diff.

## Testing

- `python -m py_compile` → syntax OK
- No existing tests assert on the exact text of these 429 messages (they assert on `status_code=429`, headers, and the dict shape), so this should be backwards-compatible. Happy to add a test locking in the new format if you'd like — just say the word.

## Notes for reviewer

- Considered also including the priority's reserved TPM/RPM (`model_group_info.tpm * priority_weight`), but `priority_weight` isn't in scope in this function and threading it through felt out of proportion for an error-string change. Can be a follow-up if useful.
- Branch targets `litellm_internal_staging` per request.

🤖 Authored by [shin-watcher](https://github.com/BerriAI/shin-builder-oss) on behalf of @ishaan-jaff.