### PR TITLE
fix(vertex): forward system prompt to partner model token counter

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1082,6 +1082,7 @@ class VertexAITokenCounter(BaseTokenCounter):
                 vertex_project=vertex_project,
                 vertex_location=vertex_location,
                 vertex_credentials=vertex_credentials,
+                system=system,
             )
 
             if result is not None:

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
@@ -277,6 +277,7 @@ class VertexAIPartnerModels(VertexBase):
         vertex_project=None,
         vertex_location=None,
         vertex_credentials=None,
+        system=None,
     ):
         """
         Count tokens for Vertex AI partner models (Anthropic Claude, Mistral, etc.)
@@ -318,6 +319,8 @@ class VertexAIPartnerModels(VertexBase):
                 "model": model,
                 "messages": messages,
             }
+            if system is not None:
+                request_data["system"] = system
 
             # Prepare litellm_params with credentials
             _litellm_params = litellm_params.copy()


### PR DESCRIPTION
## Summary

`/v1/messages/count_tokens` against a Vertex AI partner model (e.g. `vertex_ai/claude-sonnet-4-6`) returned `input_tokens` that ignored the `system` prompt entirely. The same request against `azure_ai/` and `bedrock/` Claude correctly accounted for the system prompt.

## Root cause

The `system` parameter was received by `VertexAITokenCounter.count_tokens` (`litellm/llms/vertex_ai/common_utils.py`) but was never forwarded downstream:

1. `common_utils.py:1142` — `partner_models_handler.count_tokens()` was called without the `system` argument even though it was available in scope.
2. `vertex_ai_partner_models/main.py:317` — `VertexAIPartnerModels.count_tokens` built `request_data = {"model": model, "messages": messages}` without a `system` key, so even if the caller had passed it, it would have been dropped before reaching the Anthropic count-tokens endpoint on Vertex AI.

`VertexAIPartnerModelsTokenCounter.handle_count_tokens_request` posts `request_data` directly to the Vertex AI endpoint, which accepts and correctly counts `system` tokens when the field is present.

## Fix

**`common_utils.py`** — pass `system=system` when calling `partner_models_handler.count_tokens()`.

**`vertex_ai_partner_models/main.py`** — add `system=None` to the `count_tokens` signature and include `request_data["system"] = system` when `system` is not `None`.

No changes needed in `handler.py` — it already passes `request_data` through as-is.

Fixes #27113