### PR TITLE
[UI] Rename "Default" key type to "Full Access" and reorder dropdown

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -9,7 +9,7 @@ import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { Accordion, AccordionBody, AccordionHeader, Button, Col, Grid, Text, TextInput, Title } from "@tremor/react";
-import { Button as Button2, Form, Input, Modal, Radio, Select, Switch, Tag, Tooltip } from "antd";
+import { Button as Button2, Form, Input, Modal, Radio, Select, Switch, Tag, Tooltip, Typography } from "antd";
 import debounce from "lodash/debounce";
 import React, { useCallback, useEffect, useState } from "react";
 import { rolesWithWriteAccess } from "../../utils/roles";
@@ -979,28 +979,28 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     }
                   }}
                 >
-                  <Option value="default" label="Default">
-                    <div style={{ padding: "4px 0" }}>
-                      <div style={{ fontWeight: 500 }}>Default</div>
-                      <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
-                        Can call AI APIs + Management routes
-                      </div>
-                    </div>
-                  </Option>
                   <Option value="llm_api" label="AI APIs">
                     <div style={{ padding: "4px 0" }}>
-                      <div style={{ fontWeight: 500 }}>AI APIs</div>
-                      <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
+                      <Typography.Text strong>AI APIs</Typography.Text>
+                      <Typography.Paragraph type="secondary" style={{ fontSize: 11, margin: "2px 0 0" }}>
                         Can call only AI API routes (chat/completions, embeddings, etc.)
-                      </div>
+                      </Typography.Paragraph>
                     </div>
                   </Option>
                   <Option value="management" label="Management">
                     <div style={{ padding: "4px 0" }}>
-                      <div style={{ fontWeight: 500 }}>Management</div>
-                      <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
+                      <Typography.Text strong>Management</Typography.Text>
+                      <Typography.Paragraph type="secondary" style={{ fontSize: 11, margin: "2px 0 0" }}>
                         Can call only management routes (user/team/key management)
-                      </div>
+                      </Typography.Paragraph>
+                    </div>
+                  </Option>
+                  <Option value="default" label="Full Access">
+                    <div style={{ padding: "4px 0" }}>
+                      <Typography.Text strong>Full Access</Typography.Text>
+                      <Typography.Paragraph type="secondary" style={{ fontSize: 11, margin: "2px 0 0" }}>
+                        Can call all routes (AI APIs, Management, and read-only)
+                      </Typography.Paragraph>
                     </div>
                   </Option>
                 </Select>


### PR DESCRIPTION
Resolves LIT-2680.

## Summary

The Create New Key dialog (Virtual Keys page) had a "Default" key-type option that was misleading on two counts:
1. It was **not** the actual default selection — AI APIs is what's preselected.
2. It grants access to **all** routes (AI APIs + Management + read-only), broader than the "AI APIs + Management" description implied.

This PR:
- Renames the option to **Full Access** with an accurate description ("Can call all routes (AI APIs, Management, and read-only)").
- Reorders the dropdown to **AI APIs → Management → Full Access**, matching the actual default selection order.
- Replaces the raw `<div>`-based label/description markup with `antd` `Typography.Text` / `Typography.Paragraph` for consistency with the rest of the UI.

UI-only change. The underlying enum value (`"default"`) is unchanged, so the `/key/generate` API contract and existing keys are unaffected.

## Screenshot 

<img width="751" height="468" alt="Screenshot 2026-05-05 at 11 39 38 AM" src="https://github.com/user-attachments/assets/973c0c6f-6d01-47fa-b2a8-fea07624e0b0" />


## Test plan

- [x] Open the Virtual Keys page, click "Create New Key", and confirm the Key Type dropdown shows AI APIs → Management → Full Access in that order.
- [x] Confirm AI APIs is preselected.
- [x] Select Full Access and create a key; verify it can call both AI API and management routes.
- [x] Verify the same dropdown looks correct when the modal is opened from Tag detail and Project creation flows.