### PR TITLE
fix(mcp-semantic-filter): use chat schema when expanding tools for /v1/chat/completions

### DIFF
--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -64,12 +64,19 @@ class SemanticToolFilterHook(CustomLogger):
         self,
         tools: List[Any],
         user_api_key_dict: "UserAPIKeyAuth",
+        target_format: str = "chat",
     ) -> List[Dict[str, Any]]:
         """
         Expand MCP references to actual tool definitions.
 
         Reuses LiteLLM_Proxy_MCP_Handler._process_mcp_tools_to_openai_format
         which internally does: parse -> fetch -> filter -> deduplicate -> transform
+
+        Args:
+            tools: List of tool objects which may include MCP references.
+            user_api_key_dict: User auth for access control.
+            target_format: "chat" for ChatCompletions nested ``function`` schema
+                (default), "responses" for Responses API flat schema.
         """
         from litellm.responses.mcp.litellm_proxy_mcp_handler import (
             LiteLLM_Proxy_MCP_Handler,
@@ -87,7 +94,9 @@ class SemanticToolFilterHook(CustomLogger):
             openai_tools,
             _,
         ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_to_openai_format(
-            user_api_key_auth=user_api_key_dict, mcp_tools_with_litellm_proxy=mcp_tools
+            user_api_key_auth=user_api_key_dict,
+            mcp_tools_with_litellm_proxy=mcp_tools,
+            target_format=target_format,  # type: ignore[arg-type]
         )
 
         # Convert Pydantic models to dicts for compatibility
@@ -171,7 +180,12 @@ class SemanticToolFilterHook(CustomLogger):
             )
 
             try:
-                expanded_tools = await self._expand_mcp_tools(tools, user_api_key_dict)
+                # Use "chat" schema (nested function key) for chat completions;
+                # Responses API endpoints expect the flat format.
+                _target_format = "responses" if call_type == "aresponses" else "chat"
+                expanded_tools = await self._expand_mcp_tools(
+                    tools, user_api_key_dict, target_format=_target_format
+                )
 
                 if not expanded_tools:
                     verbose_proxy_logger.warning(
@@ -293,11 +307,15 @@ class SemanticToolFilterHook(CustomLogger):
 
         tool_names = []
         for tool in tools:
-            name = (
-                tool.get("name", "")
-                if isinstance(tool, dict)
-                else getattr(tool, "name", "")
-            )
+            if isinstance(tool, dict):
+                # ChatCompletions format: {"type": "function", "function": {"name": ...}}
+                # Responses API format:   {"type": "function", "name": ...}
+                func = tool.get("function")
+                name = (
+                    func.get("name", "") if isinstance(func, dict) else tool.get("name", "")
+                )
+            else:
+                name = getattr(tool, "name", "")
             if name:
                 tool_names.append(name)
 

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -388,6 +388,7 @@ class LiteLLM_Proxy_MCP_Handler:
         user_api_key_auth: Any,
         mcp_tools_with_litellm_proxy: List[ToolParam],
         litellm_trace_id: Optional[str] = None,
+        target_format: Literal["responses", "chat"] = "responses",
     ) -> tuple[List[Any], dict[str, str]]:
         """
         Centralized method to process MCP tools through the complete pipeline.
@@ -396,6 +397,8 @@ class LiteLLM_Proxy_MCP_Handler:
             user_api_key_auth: User authentication info for access control
             mcp_tools_with_litellm_proxy: ToolParam objects with server_url starting with "litellm_proxy"
             litellm_trace_id: Optional trace ID for linking list_mcp_tools spend logs to parent request
+            target_format: "chat" for ChatCompletions format (nested ``function`` key),
+                "responses" for Responses API flat format. Default: "responses".
 
         Returns:
             List of tools in OpenAI format ready to be sent to the LLM
@@ -411,7 +414,7 @@ class LiteLLM_Proxy_MCP_Handler:
         )
 
         openai_tools = LiteLLM_Proxy_MCP_Handler._transform_mcp_tools_to_openai(
-            deduplicated_mcp_tools
+            deduplicated_mcp_tools, target_format=target_format
         )
 
         return openai_tools, tool_server_map


### PR DESCRIPTION
## Summary

When `mcp_semantic_tool_filter` is enabled and a request comes in through `/v1/chat/completions`, the hook expands MCP tool references and places them back into `data["tools"]`. The expanded tools were in **Responses API flat format** (`{"type":"function","name":...}`) rather than **ChatCompletions nested format** (`{"type":"function","function":{...}}`), causing strict OpenAI-compatible backends (LM Studio, etc.) to return `400 BadRequest` with `"path":[0,"function"],"message":"Required"`.

## Root cause

`SemanticToolFilterHook._expand_mcp_tools` called `LiteLLM_Proxy_MCP_Handler._process_mcp_tools_to_openai_format` without specifying `target_format`, which defaults to `"responses"`. That path calls `transform_mcp_tool_to_openai_responses_api_tool` (flat `FunctionToolParam`) instead of `transform_mcp_tool_to_openai_tool` (nested `ChatCompletionToolParam`).

## Fix

**`litellm_proxy_mcp_handler.py`** — add `target_format: Literal["responses","chat"] = "responses"` to `_process_mcp_tools_to_openai_format` and thread it through to `_transform_mcp_tools_to_openai`.

**`hook.py`** — in `async_pre_call_hook`, detect `call_type` and pass `target_format="chat"` for `completion`/`acompletion` calls (default) and `target_format="responses"` only for `aresponses`. Also update `_get_tool_names_csv` to extract `name` from both the nested (`function.name`) and flat (`name`) schemas.

Fixes #27105