### PR TITLE
fix(anthropic): cap budget->effort at "high" when model does not support "xhigh"

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -179,9 +179,17 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
             return
 
+        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
         budget = int(thinking.get("budget_tokens") or 0)
         if budget >= 24000:
-            effort = "xhigh"
+            # Only use "xhigh" when the model actually supports it (e.g. claude-opus-4-7).
+            # claude-opus-4-6 and claude-sonnet-4-6 support high/medium/low/max but not xhigh.
+            effort = (
+                "xhigh"
+                if AnthropicConfig._supports_effort_level(model, "xhigh")
+                else "high"
+            )
         elif budget >= 10000:
             effort = "high"
         elif budget >= 5000:


### PR DESCRIPTION
## Summary

`_translate_legacy_thinking_for_adaptive_model` mapped `budget_tokens >= 24000` to `effort="xhigh"` for **all** adaptive-thinking models. `claude-opus-4-6` and `claude-sonnet-4-6` support `high / medium / low / max` but **not** `xhigh`, so those requests failed with:

```
invalid_request_error: This model does not support effort level 'xhigh'.
Supported levels: high, low, max, medium.
```

Only `claude-opus-4-7` (and newer models that opt-in) expose `xhigh`.

## Root cause

The budget → effort table was written when adding claude-opus-4.7 support and assumed all adaptive-thinking models would accept the same effort vocabulary. No per-model gate was applied, so every 4.6 model with `budget_tokens >= 24000` (the default for Claude Code extended thinking) hit the 400.

## Fix

Use `AnthropicConfig._supports_effort_level(model, "xhigh")` — the same per-model lookup already used by `_validate_effort_for_model` — to decide whether "xhigh" is valid for the model. Fall back to `"high"` otherwise.

```python
# Before
if budget >= 24000:
    effort = "xhigh"

# After
if budget >= 24000:
    effort = (
        "xhigh"
        if AnthropicConfig._supports_effort_level(model, "xhigh")
        else "high"
    )
```

Fixes #27168