### PR TITLE
[Fix] Team UI: handle legacy dict shape for metadata.guardrails

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -57,9 +57,6 @@ import {
 import TeamMembersComponent from "./TeamMemberTab";
 import { TeamVirtualKeysTable } from "./TeamVirtualKeysTable";
 
-const safeGuardrailsList = (m: any): string[] =>
-  Array.isArray(m?.guardrails) ? (m.guardrails as string[]) : [];
-
 export interface TeamMembership {
   user_id: string;
   team_id: string;
@@ -656,10 +653,12 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   const { team_info: info } = teamData;
 
   const initialKillSwitchOn = info.metadata?.disable_global_guardrails === true;
-  const optedOutGlobals = new Set<string>(info.metadata?.opted_out_global_guardrails || []);
-  const nonGlobalOptIns: string[] = safeGuardrailsList(info.metadata).filter(
-    (n: string) => !globalGuardrailNames.has(n),
+  const optedOutGlobals = new Set<string>(
+    Array.isArray(info.metadata?.opted_out_global_guardrails) ? info.metadata.opted_out_global_guardrails : [],
   );
+  const nonGlobalOptIns: string[] = (
+    Array.isArray(info.metadata?.guardrails) ? info.metadata.guardrails : []
+  ).filter((n: string) => !globalGuardrailNames.has(n));
   const effectiveGuardrails: string[] = initialKillSwitchOn
     ? nonGlobalOptIns
     : [
@@ -818,8 +817,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                 <Card>
                   <GuardrailSettingsView
                     globalGuardrailNames={globalGuardrailNames}
-                    teamGuardrails={safeGuardrailsList(info.metadata)}
-                    optedOutGlobalGuardrails={info.metadata?.opted_out_global_guardrails || []}
+                    teamGuardrails={Array.isArray(info.metadata?.guardrails) ? info.metadata.guardrails : []}
+                    optedOutGlobalGuardrails={Array.isArray(info.metadata?.opted_out_global_guardrails) ? info.metadata.opted_out_global_guardrails : []}
                     killSwitchOn={initialKillSwitchOn}
                     variant="inline"
                   />
@@ -1622,8 +1621,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                     <GuardrailSettingsView
                       globalGuardrailNames={globalGuardrailNames}
-                      teamGuardrails={safeGuardrailsList(info.metadata)}
-                      optedOutGlobalGuardrails={info.metadata?.opted_out_global_guardrails || []}
+                      teamGuardrails={Array.isArray(info.metadata?.guardrails) ? info.metadata.guardrails : []}
+                      optedOutGlobalGuardrails={Array.isArray(info.metadata?.opted_out_global_guardrails) ? info.metadata.opted_out_global_guardrails : []}
                       killSwitchOn={initialKillSwitchOn}
                       variant="inline"
                       className="pt-4 border-t border-gray-200"

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -57,6 +57,9 @@ import {
 import TeamMembersComponent from "./TeamMemberTab";
 import { TeamVirtualKeysTable } from "./TeamVirtualKeysTable";
 
+const safeGuardrailsList = (m: any): string[] =>
+  Array.isArray(m?.guardrails) ? (m.guardrails as string[]) : [];
+
 export interface TeamMembership {
   user_id: string;
   team_id: string;
@@ -654,7 +657,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
   const initialKillSwitchOn = info.metadata?.disable_global_guardrails === true;
   const optedOutGlobals = new Set<string>(info.metadata?.opted_out_global_guardrails || []);
-  const nonGlobalOptIns: string[] = (info.metadata?.guardrails || []).filter(
+  const nonGlobalOptIns: string[] = safeGuardrailsList(info.metadata).filter(
     (n: string) => !globalGuardrailNames.has(n),
   );
   const effectiveGuardrails: string[] = initialKillSwitchOn
@@ -815,7 +818,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                 <Card>
                   <GuardrailSettingsView
                     globalGuardrailNames={globalGuardrailNames}
-                    teamGuardrails={info.metadata?.guardrails || []}
+                    teamGuardrails={safeGuardrailsList(info.metadata)}
                     optedOutGlobalGuardrails={info.metadata?.opted_out_global_guardrails || []}
                     killSwitchOn={initialKillSwitchOn}
                     variant="inline"
@@ -1619,7 +1622,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                     <GuardrailSettingsView
                       globalGuardrailNames={globalGuardrailNames}
-                      teamGuardrails={info.metadata?.guardrails || []}
+                      teamGuardrails={safeGuardrailsList(info.metadata)}
                       optedOutGlobalGuardrails={info.metadata?.opted_out_global_guardrails || []}
                       killSwitchOn={initialKillSwitchOn}
                       variant="inline"


### PR DESCRIPTION
## Summary

Clicking into a team whose `metadata.guardrails` is stored as a dict (e.g. `{"modify_guardrails": false}`) instead of a `string[]` crashes the team detail page with `TypeError: ((intermediate value) || []).filter is not a function`.

Adds inline `Array.isArray(...)` guards at the six read sites in `TeamInfo.tsx` for `info.metadata.guardrails` and `info.metadata.opted_out_global_guardrails`. Affected teams now load cleanly; saving the form heals the row. Root-cause follow-up tracked in [LIT-31](https://linear.app/litellm/issue/LIT-31).

## Screenshots
<img width="1468" height="720" alt="Screenshot 2026-05-05 at 1 39 11 PM" src="https://github.com/user-attachments/assets/f75d32b7-b1e9-41b6-b108-4e535b852e74" />

<img width="1468" height="715" alt="Screenshot 2026-05-05 at 1 38 50 PM" src="https://github.com/user-attachments/assets/751840af-4e65-420c-94cc-26fc834070a1" />