### PR TITLE
fix(prometheus): read per-key remaining tokens/requests from additional_headers (Grafana/DataDog 9e18 fix)

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1416,12 +1416,51 @@ class PrometheusLogger(CustomLogger):
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
-        remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
+        # The proxy v3 parallel_request_limiter writes the per-key/per-model
+        # remaining values into the response's hidden_params.additional_headers
+        # (see parallel_request_limiter_v3.async_post_call_success_hook), under
+        # keys like ``x-ratelimit-model_per_key-remaining-{requests,tokens}``.
+        # The older metadata keys (``litellm-key-remaining-{requests,tokens}-<model_group>``)
+        # are not populated on the success path, so reading only from ``metadata``
+        # caused these gauges to fall back to ``sys.maxsize`` (~9e18) in DataDog.
+        # Prefer the headers, fall back to metadata for backwards compatibility.
+        additional_headers: dict = {}
+        standard_logging_payload = kwargs.get("standard_logging_object") or {}
+        if isinstance(standard_logging_payload, dict):
+            _hidden_params = standard_logging_payload.get("hidden_params") or {}
+            if isinstance(_hidden_params, dict):
+                additional_headers = _hidden_params.get("additional_headers") or {}
+
+        def _coerce_int(value: Any) -> Optional[int]:
+            if value is None:
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+
+        remaining_requests_header = _coerce_int(
+            additional_headers.get("x-ratelimit-model_per_key-remaining-requests")
         )
-        remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
+        remaining_tokens_header = _coerce_int(
+            additional_headers.get("x-ratelimit-model_per_key-remaining-tokens")
         )
+
+        if remaining_requests_header is not None:
+            remaining_requests = remaining_requests_header
+        else:
+            remaining_requests = (
+                metadata.get(remaining_requests_variable_name, sys.maxsize)
+                or sys.maxsize
+            )
+
+        if remaining_tokens_header is not None:
+            remaining_tokens = remaining_tokens_header
+        else:
+            remaining_tokens = (
+                metadata.get(remaining_tokens_variable_name, sys.maxsize)
+                or sys.maxsize
+            )
 
         self.litellm_remaining_api_key_requests_for_model.labels(
             _sanitize_prometheus_label_value(user_api_key),


### PR DESCRIPTION
## Summary

The Prometheus gauges `litellm_remaining_api_key_requests_for_model` and `litellm_remaining_api_key_tokens_for_model` always reported `sys.maxsize` (~9.2e18, displayed as `9e18` in Grafana / DataDog) for users who set per-key TPM/RPM limits.

**Root cause** — `PrometheusLogger._set_virtual_key_rate_limit_metrics` in `litellm/integrations/prometheus.py` looked for the values in `metadata` under `litellm-key-remaining-{requests,tokens}-{model_group}`, but the proxy v3 parallel-request limiter writes them into `response._hidden_params["additional_headers"]` (see `parallel_request_limiter_v3.async_post_call_success_hook`) under `x-ratelimit-model_per_key-remaining-{requests,tokens}`. Because the metadata keys are never populated on the success path, the `metadata.get(..., sys.maxsize)` fallback always fired.

Reported on Slack:
> "DataDog was constantly displaying '9e18', which appears to be `sys.maxsize`… the values are available, but under the keys x-ratelimit-model_per_key-remaining-{tokens/requests} in the hidden_params.additional_headers."

## Fix

Prefer the values from `kwargs["standard_logging_object"]["hidden_params"]["additional_headers"]`; keep the existing metadata path as a fallback.

## Repro / verification

Standalone repro that builds the same kwargs shape produced by the v3 limiter (response only has values in `additional_headers`):

BEFORE (unpatched main):
```
requests_for_model -> [9223372036854775807]
tokens_for_model   -> [9223372036854775807]
BUG REPRODUCED: gauge fell back to sys.maxsize
```

AFTER (this PR):
```
requests_for_model -> [7]
tokens_for_model   -> [1234]
FIX VERIFIED
```

Screenshots are attached to the originating Slack thread / shin-watcher run.

## Backwards compatibility

* Metadata path is still honored as a fallback.
* No existing call sites change.
* No new dependencies.
