### PR TITLE
[Fix] UI: Clear Admin Session Cookies Before Establishing Invited User's Session

### DIFF
--- a/ui/litellm-dashboard/src/app/onboarding/OnboardingForm.test.tsx
+++ b/ui/litellm-dashboard/src/app/onboarding/OnboardingForm.test.tsx
@@ -61,6 +61,8 @@ describe("OnboardingForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/ui";
+    sessionStorage.clear();
   });
 
   it("should render loading view when credentials are loading", () => {
@@ -110,6 +112,58 @@ describe("OnboardingForm", () => {
     render(<OnboardingForm variant="reset_password" />);
 
     expect(screen.getByTestId("form-body")).toHaveAttribute("data-variant", "reset_password");
+  });
+
+  it("should overwrite a prior admin sessionStorage token after successful claim", async () => {
+    // Simulate the prior admin session that the inviter left behind in the same tab.
+    sessionStorage.setItem("token", "ADMIN_SESSION_TOKEN");
+
+    mockUseOnboardingCredentials.mockReturnValue({
+      data: { token: "fake-jwt-token" },
+      isLoading: false,
+      isError: false,
+    });
+    mockClaimToken.mockImplementation((_params, options) => {
+      options.onSuccess({ token: "NEW_USER_TOKEN" });
+    });
+
+    render(<OnboardingForm variant="signup" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    });
+
+    // After signup the new user's token must replace the admin's sessionStorage entry,
+    // otherwise the HttpOnly-fallback path in getCookie() keeps returning the admin token.
+    expect(sessionStorage.getItem("token")).toBe("NEW_USER_TOKEN");
+  });
+
+  it("should set the new token cookie at path=/ui after successful claim", async () => {
+    mockUseOnboardingCredentials.mockReturnValue({
+      data: { token: "fake-jwt-token" },
+      isLoading: false,
+      isError: false,
+    });
+    mockClaimToken.mockImplementation((_params, options) => {
+      options.onSuccess({ token: "NEW_USER_TOKEN" });
+    });
+
+    const cookieSpy = vi.spyOn(document, "cookie", "set");
+    render(<OnboardingForm variant="signup" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    });
+
+    // The /ui path is what storeLoginToken writes to (and what LoginPage reads from);
+    // a cookie at path=/ alone leaves any pre-existing /ui-scoped admin cookie winning.
+    const newTokenCookieAtUiPath = cookieSpy.mock.calls.some(([value]) => {
+      const v = String(value);
+      return v.includes("token=NEW_USER_TOKEN") && v.includes("path=/ui");
+    });
+    expect(newTokenCookieAtUiPath).toBe(true);
+
+    cookieSpy.mockRestore();
   });
 
   it("should show claim error when claim response is missing final token", async () => {

--- a/ui/litellm-dashboard/src/app/onboarding/OnboardingForm.tsx
+++ b/ui/litellm-dashboard/src/app/onboarding/OnboardingForm.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { jwtDecode } from "jwt-decode";
 import { useOnboardingCredentials, useClaimOnboardingToken } from "@/app/(dashboard)/hooks/onboarding/useOnboarding";
 import { getProxyBaseUrl } from "@/components/networking";
+import { clearTokenCookies, storeLoginToken } from "@/utils/cookieUtils";
 import { OnboardingLoadingView } from "./OnboardingLoadingView";
 import { OnboardingErrorView } from "./OnboardingErrorView";
 import { OnboardingFormBody } from "./OnboardingFormBody";
@@ -45,7 +46,12 @@ export function OnboardingForm({ variant }: OnboardingFormProps) {
             setClaimError("Failed to start session. Please try again.");
             return;
           }
-          document.cookie = `token=${data.token}; path=/; SameSite=Lax`;
+          // Invite signup is a principal-change boundary — the prior admin's
+          // cookies/sessionStorage must be invalidated before the new user's
+          // session is established, otherwise getCookie() can fall back to
+          // the inviter's token.
+          clearTokenCookies();
+          storeLoginToken(data.token);
           const proxyBaseUrl = getProxyBaseUrl();
           window.location.href = proxyBaseUrl
             ? `${proxyBaseUrl}/ui/?login=success`


### PR DESCRIPTION
## Summary

Fixes a bug where, after an admin invited a user and the new user clicked "Sign Up" on the invitation URL, the dashboard kept rendering as the original admin instead of the newly created user.

## Root cause

`OnboardingForm.tsx` was writing the new user's session token via a raw `document.cookie = "token=...; path=/; SameSite=Lax"`. The rest of the auth surface (`loginCall`, `exchangeLoginCode`) writes the token via `storeLoginToken`, which (a) writes the cookie at `path=/ui` and (b) mirrors the value into `sessionStorage` (the HttpOnly-fallback path used by `getCookie()`).

That asymmetry caused two problems after invite-signup:

1. The admin's `path=/ui` cookie left over from the inviter's session kept winning path-specificity matching against the new `path=/` cookie.
2. `sessionStorage["token"]` was never updated, so `getCookie()`'s sessionStorage fallback returned the admin's token.

Net effect: dashboard sees admin token instead of the new user's.

## Fix

Treat invite-signup as a principal-change boundary (the new user is a different identity than the inviter). In the `onSuccess` handler:

1. `clearTokenCookies()` — invalidate the inviter's session across cookies + sessionStorage.
2. `storeLoginToken(data.token)` — write the new token via the canonical helper, matching what regular login does.

This brings the invite-signup flow into parity with the worker-switch path in `LoginPage.tsx:72`, which already uses the same `clearTokenCookies()`-before-re-login pattern.

## Test plan

- [x] `vitest run src/app/onboarding/OnboardingForm.test.tsx` — added 2 tests demonstrating the bug; both fail on the broken state, pass after the fix
- [x] `vitest run src/app/onboarding src/utils/cookieUtils.test.ts src/app/(dashboard)/hooks/onboarding` — 52/52 pass (no regression in the onboarding + cookieUtils surface)
- [x] Manual repro: log in as admin, "Add User", open the invitation URL in the same browser, set a password, click "Sign Up" — dashboard should now reflect the newly created user