### PR TITLE
fix(prometheus): fall back to v3 limiter additional_headers for per-key remaining gauges

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1171,6 +1171,7 @@ class PrometheusLogger(CustomLogger):
             kwargs=kwargs,
             metadata=_metadata,
             model_id=enum_values.model_id,
+            standard_logging_payload=standard_logging_payload,
         )
 
         # set latency metrics
@@ -1402,24 +1403,54 @@ class PrometheusLogger(CustomLogger):
         kwargs: dict,
         metadata: dict,
         model_id: Optional[str] = None,
+        standard_logging_payload: Optional[StandardLoggingPayload] = None,
     ):
         from litellm.proxy.common_utils.callback_utils import (
             get_model_group_from_litellm_kwargs,
         )
 
         # Set remaining rpm/tpm for API Key + model
-        # see parallel_request_limiter.py - variables are set there
+        # The legacy parallel_request_limiter writes the per-key remaining
+        # counters into request metadata under
+        #   "litellm-key-remaining-{requests,tokens}-{model_group}".
+        # parallel_request_limiter_v3 instead publishes them on the response
+        # under hidden_params.additional_headers as
+        #   "x-ratelimit-model_per_key-remaining-{requests,tokens}".
+        # Read both, preferring metadata, so the gauges work with either
+        # limiter implementation. Without this fallback the v3 path always
+        # falls through to sys.maxsize (~9.22e18) and DataDog/Prometheus
+        # show that placeholder instead of the real remaining value.
         model_group = get_model_group_from_litellm_kwargs(kwargs)
         remaining_requests_variable_name = (
             f"litellm-key-remaining-requests-{model_group}"
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
+        additional_headers: dict = {}
+        if standard_logging_payload is not None:
+            hidden_params = (
+                standard_logging_payload.get("hidden_params") or {}
+                if isinstance(standard_logging_payload, dict)
+                else {}
+            )
+            additional_headers = hidden_params.get("additional_headers") or {}
+
+        fallback_remaining_requests = additional_headers.get(
+            "x-ratelimit-model_per_key-remaining-requests"
+        )
+        fallback_remaining_tokens = additional_headers.get(
+            "x-ratelimit-model_per_key-remaining-tokens"
+        )
+
         remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
+            metadata.get(remaining_requests_variable_name)
+            or fallback_remaining_requests
+            or sys.maxsize
         )
         remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
+            metadata.get(remaining_tokens_variable_name)
+            or fallback_remaining_tokens
+            or sys.maxsize
         )
 
         self.litellm_remaining_api_key_requests_for_model.labels(

--- a/tests/test_litellm/integrations/test_prometheus_v3_remaining_headers.py
+++ b/tests/test_litellm/integrations/test_prometheus_v3_remaining_headers.py
@@ -1,0 +1,97 @@
+"""
+Regression test for: Prometheus per-key remaining gauges show 9e18 (sys.maxsize)
+when parallel_request_limiter_v3 is in use.
+
+The v3 limiter publishes remaining counters on the response under
+hidden_params.additional_headers as
+    "x-ratelimit-model_per_key-remaining-{requests,tokens}"
+rather than into request metadata under
+    "litellm-key-remaining-{requests,tokens}-{model_group}".
+
+prometheus.py must read both, otherwise DataDog / Prometheus display
+sys.maxsize (~9.22e18) instead of the real remaining values.
+"""
+import os
+import sys
+
+import pytest
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.integrations.prometheus import PrometheusLogger
+
+
+@pytest.fixture(scope="function")
+def prometheus_logger():
+    for c in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(c)
+        except Exception:
+            pass
+    return PrometheusLogger()
+
+
+class TestVirtualKeyRateLimitMetricsV3Headers:
+    def _call(self, logger, *, metadata, additional_headers):
+        kwargs = {
+            "litellm_params": {
+                "metadata": {"model_group": "gpt-4o"},
+                "model_group": "gpt-4o",
+            },
+            "model": "gpt-4o",
+        }
+        slp = {
+            "hidden_params": {"additional_headers": additional_headers}
+        }
+        logger._set_virtual_key_rate_limit_metrics(
+            user_api_key="hashed-key",
+            user_api_key_alias="alias",
+            kwargs=kwargs,
+            metadata=metadata,
+            model_id="m1",
+            standard_logging_payload=slp,
+        )
+        labels = ("hashed-key", "alias", "gpt-4o", "m1")
+        req = logger.litellm_remaining_api_key_requests_for_model.labels(*labels)._value.get()
+        tok = logger.litellm_remaining_api_key_tokens_for_model.labels(*labels)._value.get()
+        return req, tok
+
+    def test_falls_back_to_v3_additional_headers(self, prometheus_logger):
+        """When metadata lacks legacy keys but v3 headers are set, use them."""
+        metadata = {"model_group": "gpt-4o"}  # no litellm-key-remaining-*
+        headers = {
+            "x-ratelimit-model_per_key-remaining-tokens": 1234,
+            "x-ratelimit-model_per_key-remaining-requests": 7,
+        }
+        req, tok = self._call(
+            prometheus_logger, metadata=metadata, additional_headers=headers
+        )
+        assert req == 7
+        assert tok == 1234
+        assert req < 1e18 and tok < 1e18, "must not be sys.maxsize"
+
+    def test_metadata_keys_take_precedence(self, prometheus_logger):
+        """If legacy metadata keys are present, prefer them (back-compat)."""
+        metadata = {
+            "model_group": "gpt-4o",
+            "litellm-key-remaining-requests-gpt-4o": 11,
+            "litellm-key-remaining-tokens-gpt-4o": 2222,
+        }
+        headers = {
+            "x-ratelimit-model_per_key-remaining-tokens": 99,
+            "x-ratelimit-model_per_key-remaining-requests": 99,
+        }
+        req, tok = self._call(
+            prometheus_logger, metadata=metadata, additional_headers=headers
+        )
+        assert req == 11
+        assert tok == 2222
+
+    def test_no_signals_falls_back_to_maxsize(self, prometheus_logger):
+        """Preserve old behaviour: when nothing is set, default to sys.maxsize."""
+        req, tok = self._call(
+            prometheus_logger, metadata={"model_group": "gpt-4o"}, additional_headers={}
+        )
+        assert req == float(sys.maxsize)
+        assert tok == float(sys.maxsize)


### PR DESCRIPTION
## Summary

`litellm_remaining_api_key_requests_for_model` and `litellm_remaining_api_key_tokens_for_model` display `9.22e18` (≈ `sys.maxsize`) in DataDog/Prometheus for users running on `parallel_request_limiter_v3`.

### Root cause

`PrometheusLogger._set_virtual_key_rate_limit_metrics` (`litellm/integrations/prometheus.py:1399`) reads per-key remaining counters from request `metadata` under

```
litellm-key-remaining-{requests,tokens}-{model_group}
```

and falls back to `sys.maxsize` when those keys are missing.

The legacy `parallel_request_limiter` is the only writer of those metadata keys. `parallel_request_limiter_v3` instead publishes the values on the response under `hidden_params.additional_headers`:

```
x-ratelimit-model_per_key-remaining-{tokens,requests}
x-ratelimit-model_per_key-limit-{tokens,requests}
```

(see `litellm/proxy/hooks/parallel_request_limiter_v3.py:2222-2230`)

So when v3 is in use, the gauges always fall through to `sys.maxsize`, which Prometheus exports as `9.223372036854776e+18` and DataDog renders as `9e18`.

### Fix

Thread `standard_logging_payload` into `_set_virtual_key_rate_limit_metrics` and read `hidden_params.additional_headers["x-ratelimit-model_per_key-remaining-{requests,tokens}"]` as a fallback. Metadata is preferred for back-compat with the legacy limiter.

### Reproduction

```python
metadata = {"model_group": "gpt-4o"}  # no legacy keys
slp = {"hidden_params": {"additional_headers": {
    "x-ratelimit-model_per_key-remaining-tokens": 1234,
    "x-ratelimit-model_per_key-remaining-requests": 7,
}}}
```

| | Before | After |
|---|---|---|
| `litellm_remaining_api_key_requests_for_model` | `9.22e18` | `7` |
| `litellm_remaining_api_key_tokens_for_model`   | `9.22e18` | `1234` |

### Tests

Added `tests/test_litellm/integrations/test_prometheus_v3_remaining_headers.py` covering:

1. v3 headers populate the gauges when metadata keys are absent
2. Legacy metadata keys take precedence (back-compat)
3. With neither signal present the gauge defaults to `sys.maxsize` (preserves old behaviour)

```
pytest tests/test_litellm/integrations/test_prometheus_v3_remaining_headers.py -v
3 passed in 0.14s
```

Existing prometheus tests (`test_prometheus_none_metadata.py`, `test_prometheus_missing_metrics.py`, `test_prometheus_labels.py`) — 20 passed, no regressions.

---

🤖 Drafted by `shin-watcher` from a Slack bug report. Marked draft for human review.
