### PR TITLE
[Fix] Allow non-admin compliance path reads

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -656,6 +656,13 @@ class LiteLLMRoutes(enum.Enum):
         "/health/services",
     ] + info_routes
 
+    # Stateless validators on caller-supplied log data; source logs are
+    # already accessible via spend_tracking_routes, so no scope expansion.
+    compliance_check_routes = [
+        "/compliance/eu-ai-act",
+        "/compliance/gdpr",
+    ]
+
     # Routes in `global_spend_tracking_routes` return proxy-wide spend across
     # every team, customer, and api_key. They are intentionally NOT included
     # here — non-admin roles must not see other tenants' spend. Admin roles go
@@ -675,9 +682,10 @@ class LiteLLMRoutes(enum.Enum):
         ]
         + spend_tracking_routes
         + key_management_routes
+        + compliance_check_routes
     )
 
-    internal_user_view_only_routes = spend_tracking_routes
+    internal_user_view_only_routes = spend_tracking_routes + compliance_check_routes
 
     self_managed_routes = [
         "/team/member_add",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -685,7 +685,7 @@ class LiteLLMRoutes(enum.Enum):
         + compliance_check_routes
     )
 
-    internal_user_view_only_routes = spend_tracking_routes + compliance_check_routes
+    internal_user_view_only_routes = spend_tracking_routes
 
     self_managed_routes = [
         "/team/member_add",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -53,6 +53,39 @@ def test_non_admin_config_update_route_rejected():
     assert "Your role=internal_user" in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    "role",
+    [
+        LitellmUserRoles.INTERNAL_USER.value,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+    ],
+)
+@pytest.mark.parametrize(
+    "route",
+    ["/compliance/eu-ai-act", "/compliance/gdpr"],
+)
+def test_compliance_routes_open_to_non_admin_roles(role, route):
+    """Compliance routes are stateless validators on caller-supplied log data
+    — both non-admin internal_user roles can call them."""
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=role,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=role)
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=role,
+        route=route,
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
 def test_proxy_admin_viewer_config_update_route_rejected():
     """Test that proxy admin viewer users are rejected when trying to call /config/update"""
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -54,19 +54,13 @@ def test_non_admin_config_update_route_rejected():
 
 
 @pytest.mark.parametrize(
-    "role",
-    [
-        LitellmUserRoles.INTERNAL_USER.value,
-        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
-    ],
-)
-@pytest.mark.parametrize(
     "route",
     ["/compliance/eu-ai-act", "/compliance/gdpr"],
 )
-def test_compliance_routes_open_to_non_admin_roles(role, route):
+def test_compliance_routes_open_to_internal_user(route):
     """Compliance routes are stateless validators on caller-supplied log data
-    — both non-admin internal_user roles can call them."""
+    - non-admin internal_user roles can call them."""
+    role = LitellmUserRoles.INTERNAL_USER.value
     user_obj = LiteLLM_UserTable(
         user_id="test_user",
         user_email="test@example.com",
@@ -84,6 +78,34 @@ def test_compliance_routes_open_to_non_admin_roles(role, route):
         valid_token=valid_token,
         request_data={},
     )
+
+
+@pytest.mark.parametrize(
+    "route",
+    ["/compliance/eu-ai-act", "/compliance/gdpr"],
+)
+def test_compliance_routes_blocked_for_internal_user_view_only(route):
+    """Deprecated internal_user_viewer role must not gain compliance route access."""
+    role = LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=role,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=role)
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    with pytest.raises(Exception) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=role,
+            route=route,
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+    assert "Only proxy admin can be used" in str(exc_info.value)
 
 
 def test_proxy_admin_viewer_config_update_route_rejected():


### PR DESCRIPTION
## Relevant issues

The logs page logs an error every 15 seconds that a non-admin user stays on the page and has a row-information side panel open. This is because compliance, for relevant requests, was gated to only be viewable to admins on the backend, even though compliance is included in the request information for every user when present. This PR allows internal users to see compliance so there aren't a flood of errors because a page was left open.

## Linear ticket

Resolves LIT-2760.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<img width="504" height="46" alt="Screenshot 2026-05-05 at 2 31 15 PM" src="https://github.com/user-attachments/assets/f914f11a-9b52-4e2c-b1dc-ea3a245f9107" />

## Type

🐛 Bug Fix
✅ Test

## Changes
_types file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RBAC route allowlists; mistakes could unintentionally broaden access, though the change is narrowly scoped to two stateless compliance endpoints and covered by tests.
> 
> **Overview**
> Allows non-admin `internal_user` callers to access the compliance validation endpoints (`/compliance/eu-ai-act`, `/compliance/gdpr`) by adding them to `LiteLLMRoutes.internal_user_routes`.
> 
> Adds route-check tests to ensure these endpoints are **permitted** for `INTERNAL_USER` and **still denied** for the deprecated `INTERNAL_USER_VIEW_ONLY` role.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f55549308514ceb8d349e9f244794f958f6403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->