### PR TITLE
fix(sso): /sso/debug/callback shows full JWT claims + parsed fields

### DIFF
--- a/litellm/proxy/common_utils/html_forms/jwt_display_template.py
+++ b/litellm/proxy/common_utils/html_forms/jwt_display_template.py
@@ -197,11 +197,20 @@ jwt_display_template = """
                 </svg>
                 Authentication Successful
             </div>
-            <p>The SSO authentication completed successfully. Below is the information returned by the provider.</p>
+            <p>The SSO authentication completed successfully. Two sections are shown below:
+            <strong>Parsed by proxy</strong> (the fields LiteLLM extracted using your config-driven mappings — e.g. <code>team_id</code>, <code>team_alias</code>, <code>user_role</code>, <code>extra_fields</code>) and <strong>Raw claims</strong> (the complete claim set returned by your IdP / id_token).</p>
         </div>
         
-        <div class="data-container" id="userData">
-            <!-- Data will be inserted here by JavaScript -->
+        <h3 style="margin:20px 0 8px 0;color:#1e293b;">Parsed by proxy</h3>
+        <p class="subtitle" style="text-align:left;margin:0 0 8px 0;">What LiteLLM mapped out of the IdP response using your SSO config (env vars, role/team mappings, JWT claim paths).</p>
+        <div class="data-container" id="parsedData">
+            <!-- Parsed fields go here -->
+        </div>
+
+        <h3 style="margin:20px 0 8px 0;color:#1e293b;">Raw claims from IdP</h3>
+        <p class="subtitle" style="text-align:left;margin:0 0 8px 0;">The full unmodified claim set returned by the IdP (userinfo endpoint and/or id_token). Use this to confirm which fields are actually being delivered.</p>
+        <div class="data-container" id="rawData">
+            <!-- Raw claims go here -->
         </div>
         
         <div class="info-box">
@@ -233,38 +242,74 @@ jwt_display_template = """
     </div>
 
     <script>
-        // This will be populated with the actual data from the server
+        // This will be populated with the actual data from the server.
+        // Shape: { parsed_by_proxy: {...}, raw_claims: {...} }
+        // (legacy shape — a flat object — is also handled for backwards compat).
         const userData = SSO_DATA;
-        
+
+        function formatValue(value) {
+            if (value === null || value === undefined) return 'null';
+            if (typeof value === 'object') return JSON.stringify(value, null, 2);
+            return String(value);
+        }
+
+        function renderInto(containerId, dataObj) {
+            const container = document.getElementById(containerId);
+            if (!container) return;
+            container.innerHTML = '';
+            if (!dataObj || typeof dataObj !== 'object') {
+                container.textContent = '(empty)';
+                return;
+            }
+            const entries = Object.entries(dataObj);
+            if (entries.length === 0) {
+                container.textContent = '(no fields)';
+                return;
+            }
+            for (const [key, value] of entries) {
+                const row = document.createElement('div');
+                row.className = 'data-row';
+
+                const label = document.createElement('div');
+                label.className = 'data-label';
+                label.textContent = key;
+
+                const dataValue = document.createElement('div');
+                dataValue.className = 'data-value';
+                if (value !== null && typeof value === 'object') {
+                    const pre = document.createElement('pre');
+                    pre.style.margin = '0';
+                    pre.style.whiteSpace = 'pre-wrap';
+                    pre.style.wordBreak = 'break-word';
+                    pre.textContent = JSON.stringify(value, null, 2);
+                    dataValue.appendChild(pre);
+                } else {
+                    dataValue.textContent = formatValue(value);
+                }
+
+                row.appendChild(label);
+                row.appendChild(dataValue);
+                container.appendChild(row);
+            }
+        }
+
         function renderUserData() {
-            const container = document.getElementById('userData');
             const jsonDisplay = document.getElementById('jsonData');
-            
             // Format JSON with indentation for display
             jsonDisplay.textContent = JSON.stringify(userData, null, 2);
-            
-            // Clear container
-            container.innerHTML = '';
-            
-            // Add each key-value pair to the UI
-            for (const [key, value] of Object.entries(userData)) {
-                if (typeof value !== 'object' || value === null) {
-                    const row = document.createElement('div');
-                    row.className = 'data-row';
-                    
-                    const label = document.createElement('div');
-                    label.className = 'data-label';
-                    label.textContent = key;
-                    
-                    const dataValue = document.createElement('div');
-                    dataValue.className = 'data-value';
-                    dataValue.textContent = value !== null ? value : 'null';
-                    
-                    row.appendChild(label);
-                    row.appendChild(dataValue);
-                    container.appendChild(row);
-                }
+
+            let parsed, raw;
+            if (userData && (Object.prototype.hasOwnProperty.call(userData, 'parsed_by_proxy')
+                || Object.prototype.hasOwnProperty.call(userData, 'raw_claims'))) {
+                parsed = userData.parsed_by_proxy || {};
+                raw = userData.raw_claims || {};
+            } else {
+                // Legacy flat shape — show it under "Parsed by proxy".
+                parsed = userData || {};
+                raw = {};
             }
+            renderInto('parsedData', parsed);
+            renderInto('rawData', raw);
         }
         
         function copyToClipboard(elementId) {

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -446,6 +446,40 @@ async def google_login(
         return HTMLResponse(content=html_form, status_code=200)
 
 
+def _to_plain_dict(obj: Any) -> dict:
+    """
+    Convert an SSO/OpenID-style object (or dict) to a plain JSON-serializable
+    dict, preserving lists and nested dicts so the /sso/debug/callback page
+    can show every field the proxy actually parsed.
+    """
+    if obj is None:
+        return {}
+    if isinstance(obj, dict):
+        d = obj
+    elif hasattr(obj, "model_dump"):
+        try:
+            return {k: v for k, v in obj.model_dump().items() if not k.startswith("_")}
+        except Exception:
+            d = getattr(obj, "__dict__", {}) or {}
+    elif hasattr(obj, "__dict__"):
+        d = obj.__dict__
+    else:
+        return {"value": str(obj)}
+
+    out: dict = {}
+    for key, value in d.items():
+        if key.startswith("_"):
+            continue
+        if value is None or isinstance(value, (str, int, float, bool, list, dict)):
+            out[key] = value
+        else:
+            try:
+                out[key] = str(value)
+            except Exception as e:
+                out[key] = f"Complex value (not displayable): {e}"
+    return out
+
+
 def generic_response_convertor(
     response,
     jwt_handler: JWTHandler,
@@ -3774,30 +3808,71 @@ async def debug_sso_callback(request: Request):
     else:
         redirect_url += "/sso/debug/callback"
 
-    result = None
+    result: Any = None
+    raw_claims: Optional[dict] = None
+    parsed_fields: Optional[dict] = None
+
     if google_client_id is not None:
-        result = await GoogleSSOHandler.get_google_callback_response(
+        raw_result = await GoogleSSOHandler.get_google_callback_response(
             request=request,
             google_client_id=google_client_id,
             redirect_url=redirect_url,
             return_raw_sso_response=True,
         )
+        raw_claims = (
+            dict(raw_result) if isinstance(raw_result, dict) else _to_plain_dict(raw_result)
+        )
+        # Build parsed view from raw claims using Google's standard mapping
+        parsed_fields = {
+            "id": raw_claims.get("sub"),
+            "email": raw_claims.get("email"),
+            "first_name": raw_claims.get("given_name"),
+            "last_name": raw_claims.get("family_name"),
+            "display_name": raw_claims.get("name"),
+            "picture": raw_claims.get("picture"),
+            "provider": "google",
+        }
+        result = parsed_fields
     elif microsoft_client_id is not None:
-        result = await MicrosoftSSOHandler.get_microsoft_callback_response(
+        raw_result = await MicrosoftSSOHandler.get_microsoft_callback_response(
             request=request,
             microsoft_client_id=microsoft_client_id,
             redirect_url=redirect_url,
             return_raw_sso_response=True,
         )
-
+        raw_claims = (
+            dict(raw_result) if isinstance(raw_result, dict) else _to_plain_dict(raw_result)
+        )
+        # Re-derive what the proxy would have parsed out of these raw claims
+        ms_team_ids = raw_claims.get(MicrosoftSSOHandler.GRAPH_API_RESPONSE_KEY) or []
+        ms_app_roles = raw_claims.get("app_roles") or []
+        ms_user_role: Optional[LitellmUserRoles] = None
+        for role_str in ms_app_roles:
+            role = get_litellm_user_role(role_str)
+            if role is not None:
+                ms_user_role = role
+                break
+        try:
+            parsed_openid = MicrosoftSSOHandler.openid_from_response(
+                response=raw_claims,
+                team_ids=list(ms_team_ids),
+                user_role=ms_user_role,
+            )
+            parsed_fields = _to_plain_dict(parsed_openid)
+        except Exception as e:
+            parsed_fields = {"error": f"Failed to parse OpenID: {e}"}
+        result = parsed_fields
     elif generic_client_id is not None:
-        result, _, _ = await get_generic_sso_response(
+        parsed_openid, received_response, _ = await get_generic_sso_response(
             request=request,
             jwt_handler=jwt_handler,
             generic_client_id=generic_client_id,
             redirect_url=redirect_url,
             sso_jwt_handler=sso_jwt_handler,
         )
+        raw_claims = received_response or {}
+        parsed_fields = _to_plain_dict(parsed_openid)
+        result = parsed_openid
 
     # If result is None, return a basic error message
     if result is None:
@@ -3806,29 +3881,15 @@ async def debug_sso_callback(request: Request):
             status_code=400,
         )
 
-    # Convert the OpenID object to a dictionary
-    if hasattr(result, "__dict__"):
-        result_dict = result.__dict__
-    else:
-        result_dict = dict(result)
-
-    # Filter out any None values and convert to JSON serializable format
-    filtered_result = {}
-    for key, value in result_dict.items():
-        if value is not None and not key.startswith("_"):
-            if isinstance(value, (str, int, float, bool)) or value is None:
-                filtered_result[key] = value
-            else:
-                try:
-                    # Try to convert to string or another JSON serializable format
-                    filtered_result[key] = str(value)
-                except Exception as e:
-                    filtered_result[key] = f"Complex value (not displayable): {str(e)}"
+    debug_payload = {
+        "parsed_by_proxy": parsed_fields or {},
+        "raw_claims": raw_claims or {},
+    }
 
     # Replace the placeholder in the template with the actual data
     html_content = jwt_display_template.replace(
         "const userData = SSO_DATA;",
-        f"const userData = {json.dumps(filtered_result, indent=2)};",
+        f"const userData = {json.dumps(debug_payload, indent=2, default=str)};",
     )
 
     return HTMLResponse(content=html_content)


### PR DESCRIPTION
## What

`/sso/debug/callback` now returns a structured payload with both views of the SSO response, so operators can confirm exactly which claims their IdP is delivering AND how LiteLLM is mapping them:

```jsonc
{
  "parsed_by_proxy": { /* what the proxy mapped out using its config:
                          id, email, display_name, team_ids, user_role,
                          extra_fields (which contains team_alias, team_id, ...) */ },
  "raw_claims":      { /* the full unmodified userinfo / id_token claim set
                          returned by the IdP (sub, email, groups, team_id,
                          team_alias, custom department fields, iss, aud, ...) */ }
}
```

The HTML debug page now renders **two labelled sections** — *Parsed by proxy* and *Raw claims from IdP* — plus the existing JSON blob.

## Why

Reported on Slack:

> When calling `<proxy url>/sso/debug/callback` on the return from `/sso/debug/login`, it would be nice if the complete JWT claims were shown including how the proxy saw them parsed. Currently we have fields set for different things via the config like `team_alias` and `team_id`, along with others, but they are not shown — we only see id, email, display_name, team_ids, and user_role. The other fields are used, but we can't confirm what we are getting for a user, so it would be ideal to see the complete set of claims along with a section of what was parsed out of them by the proxy.

Today the route does two things wrong:

1. **Generic SSO**: the raw `received_response` returned by `get_generic_sso_response(...)` is captured by closure but immediately discarded (`result, _, _ = ...`). The user only sees the `CustomOpenID` object, never the actual IdP claims.
2. The Python-dict-to-JSON renderer **filters out lists / nested dicts** (`isinstance(value, (str, int, float, bool))`), so even fields the proxy *did* parse — like `team_ids` (list) and `extra_fields` (dict containing `team_alias`, `team_id`, custom claims) — are stringified into `"['x','y']"` or `"{'department': 'R&D'}"`, or dropped entirely.

## How

1. **`litellm/proxy/management_endpoints/ui_sso.py`**
   - New `_to_plain_dict(...)` helper — preserves lists and nested dicts, supports pydantic `model_dump`, falls back to `__dict__`/`str()`.
   - `debug_sso_callback` now captures both:
     - `raw_claims` — the raw response from the IdP (Generic: the previously-discarded `received_response`; Microsoft: the raw graph dict + `graph_api_user_groups` + `app_roles`; Google: the raw OpenID dict).
     - `parsed_fields` — what the proxy mapped (Generic: the `CustomOpenID`; Microsoft: re-derived via `MicrosoftSSOHandler.openid_from_response`; Google: a clean parsed view from the standard claims).
   - Ships a `{"parsed_by_proxy": {...}, "raw_claims": {...}}` payload to the template.

2. **`litellm/proxy/common_utils/html_forms/jwt_display_template.py`**
   - Two new labelled sections in the rendered HTML.
   - JS renderer now correctly handles list / nested-object values (renders them as indented JSON) instead of skipping or stringifying them.
   - Backwards-compatible: legacy flat payloads still render under "Parsed by proxy".

## Evidence

**Before** — only id/email/display_name/team_ids/user_role visible, lists/dicts stringified, raw claims discarded:

```json
{
  "id": "u-42",
  "email": "alice@example.com",
  "display_name": "alice",
  "team_ids": "['engineering', 'platform-leads']",
  "user_role": "internal_user",
  "extra_fields": "{'department': 'R&D'}"
}
```

**After** — both views available, lists & dicts preserved verbatim, full IdP claim set visible (including `team_alias`, `team_id`, `department`, `iss`, `aud`, …):

```json
{
  "parsed_by_proxy": {
    "id": "u-42", "email": "alice@example.com", "display_name": "alice",
    "first_name": "Alice", "last_name": "Smith", "provider": "generic",
    "team_ids": ["engineering", "platform-leads"],
    "user_role": "internal_user",
    "extra_fields": {
      "department": "R&D",
      "team_alias": "Platform Team",
      "team_id": "team-platform"
    }
  },
  "raw_claims": {
    "sub": "u-42", "email": "alice@example.com", "preferred_username": "alice",
    "given_name": "Alice", "family_name": "Smith", "name": "Alice Smith",
    "groups": ["engineering", "platform-leads"],
    "team_id": "team-platform", "team_alias": "Platform Team", "department": "R&D",
    "role": "internal_user",
    "iss": "https://idp.example.com", "aud": "litellm-proxy",
    "exp": 1735689600, "iat": 1735686000
  }
}
```

The patched HTML template was rendered against this payload locally — it produces two tidy sections (*Parsed by proxy* / *Raw claims from IdP*) followed by the existing JSON Representation block.

## Backwards compatibility

- Existing UI: the JSON Representation panel still works.
- The JS handles legacy flat payloads (renders them under "Parsed by proxy").
- No new config or env vars required.
- No public API or auth-flow changes — only the debug endpoint's response *content* is enriched.

---

🤖 Drafted by `shin-watcher` from a Slack request. Marking as draft for human review.