### PR TITLE
fix(ui): drop duplicate /v2/team/list fetch racing OldTeams' paginated fetch

### DIFF
--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -8,6 +8,7 @@ import AgentsPanel from "@/components/agents";
 import BudgetPanel from "@/components/budgets/budget_panel";
 import CacheDashboard from "@/components/cache_dashboard";
 import ClaudeCodePluginsPanel from "@/components/claude_code_plugins";
+import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { CostTrackingSettings } from "@/components/CostTrackingSettings";
 import GeneralSettings from "@/components/general_settings";
@@ -351,6 +352,11 @@ function CreateKeyPageContent() {
   useEffect(() => {
     if (accessToken && userID && userRole) {
       fetchUserModels(userID, userRole, accessToken, setUserModels);
+    }
+    if (accessToken && userID && userRole) {
+      v2TeamListCall(accessToken, 1, 100, {
+        userID: userRole !== "Admin" && userRole !== "Admin Viewer" ? userID : null,
+      }).then((response) => setTeams(response.teams ?? [])).catch(console.error);
     }
     if (accessToken) {
       fetchOrganizations(accessToken, setOrganizations);

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -8,7 +8,6 @@ import AgentsPanel from "@/components/agents";
 import BudgetPanel from "@/components/budgets/budget_panel";
 import CacheDashboard from "@/components/cache_dashboard";
 import ClaudeCodePluginsPanel from "@/components/claude_code_plugins";
-import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { CostTrackingSettings } from "@/components/CostTrackingSettings";
 import GeneralSettings from "@/components/general_settings";
@@ -352,11 +351,6 @@ function CreateKeyPageContent() {
   useEffect(() => {
     if (accessToken && userID && userRole) {
       fetchUserModels(userID, userRole, accessToken, setUserModels);
-    }
-    if (accessToken && userID && userRole) {
-      v2TeamListCall(accessToken, 1, 100, {
-        userID: userRole !== "Admin" && userRole !== "Admin Viewer" ? userID : null,
-      }).then((response) => setTeams(response.teams ?? [])).catch(console.error);
     }
     if (accessToken) {
       fetchOrganizations(accessToken, setOrganizations);

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -197,6 +197,7 @@ const Teams: React.FC<TeamProps> = ({
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [totalTeams, setTotalTeams] = useState(0);
+  const [paginatedTeams, setPaginatedTeams] = useState<Team[] | null>(null);
   const [currentOrg, setCurrentOrg] = useState<Organization | null>(null);
   const [currentOrgForCreateTeam, setCurrentOrgForCreateTeam] = useState<Organization | null>(null);
   const [filters, setFilters] = useState<FilterState>({
@@ -240,7 +241,7 @@ const Teams: React.FC<TeamProps> = ({
           sortOrder: sortOrder || null,
         },
       );
-      setTeams(response.teams ?? []);
+      setPaginatedTeams(response.teams ?? []);
       setTotalTeams(response.total ?? 0);
     } catch (err: any) {
       setFetchError(err?.message || "Failed to fetch teams");
@@ -659,7 +660,7 @@ const Teams: React.FC<TeamProps> = ({
           sortOrder: newFilters.sort_order || null,
         },
       );
-      setTeams(response.teams ?? []);
+      setPaginatedTeams(response.teams ?? []);
       setTotalTeams(response.total ?? 0);
     } catch (error) {
       console.error("Error fetching teams:", error);
@@ -863,7 +864,7 @@ const Teams: React.FC<TeamProps> = ({
     },
   ], [userRole, perTeamInfo, organizationsData, organizations]);
 
-  const displayTeams = useMemo(() => teams ?? [], [teams]);
+  const displayTeams = useMemo(() => paginatedTeams ?? [], [paginatedTeams]);
 
   const renderTeamsContent = () => {
     if (isLoading) {


### PR DESCRIPTION
## Summary
- The Teams page (`/?page=teams`, rendered by `OldTeams.tsx`) had two mount-effects writing the same `teams` state with different page sizes: `app/page.tsx` fired `v2TeamListCall(page=1, page_size=100)` and `OldTeams.tsx` fired `fetchTeamsV2()` with `page_size=10`. Whichever response resolved last won — manifesting as "loads 10, refresh loads 10 more" (or vice versa) depending on the race.
- `OldTeams` already owns its own paginated team-fetching state (`currentPage`, `pageSize`, `totalTeams`) and is the only consumer of `teams` on this route. Removing the redundant page-level fetch fixes the race; pagination, sort, and filter all keep working through `OldTeams`'s own handlers.

## screenshots 
on refresh we have the right amoutn of teams 
<img width="1487" height="746" alt="Screenshot 2026-05-05 at 3 21 36 PM" src="https://github.com/user-attachments/assets/39747f7b-f29c-44cf-85df-627440a9752e" />


## Test plan
- [x] Reproduced live in Chrome DevTools: before fix, network tab shows 3 team list requests on mount (v1, v2 size=10, v2 size=100); table sometimes renders 10, sometimes 19 across reloads.
- [x] After fix: only one v2 list request fires per page navigation. Table renders exactly 10 rows on page 1 with pagination chip "19 teams • 1/2 • 10/page".
- [x] Verified page 2 shows the remaining 9 rows and the next-page button is disabled.
- [ ] CI: TypeScript compile + UI vitest suite.