### PR TITLE
fix(prometheus): read remaining tokens/requests from additional_headers when v3 limiter populates them

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1416,11 +1416,43 @@ class PrometheusLogger(CustomLogger):
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
+        remaining_requests = metadata.get(remaining_requests_variable_name)
+        remaining_tokens = metadata.get(remaining_tokens_variable_name)
+
+        # Fallback: parallel_request_limiter_v3 does not write the
+        # `litellm-key-remaining-{tokens,requests}-{model_group}` keys into
+        # metadata. Instead it surfaces the same values on the response under
+        # `hidden_params.additional_headers` as
+        # `x-ratelimit-model_per_key-remaining-{tokens,requests}` (see
+        # litellm/proxy/hooks/parallel_request_limiter_v3.py
+        # async_post_call_success_hook). Read from there so the
+        # `litellm_remaining_api_key_{requests,tokens}_for_model` gauges report
+        # real values instead of `sys.maxsize` (~9.22e18) on v3.
+        if remaining_requests is None or remaining_tokens is None:
+            try:
+                additional_headers = (
+                    (kwargs.get("standard_logging_object") or {})
+                    .get("hidden_params", {})
+                    .get("additional_headers")
+                ) or {}
+            except AttributeError:
+                additional_headers = {}
+            if remaining_requests is None:
+                remaining_requests = additional_headers.get(
+                    "x-ratelimit-model_per_key-remaining-requests"
+                )
+            if remaining_tokens is None:
+                remaining_tokens = additional_headers.get(
+                    "x-ratelimit-model_per_key-remaining-tokens"
+                )
+
+        # Final fallback: report sys.maxsize when no rate limit info available,
+        # preserving prior behavior for keys without per-model TPM/RPM limits.
         remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
+            sys.maxsize if remaining_requests is None else remaining_requests
         )
         remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
+            sys.maxsize if remaining_tokens is None else remaining_tokens
         )
 
         self.litellm_remaining_api_key_requests_for_model.labels(


### PR DESCRIPTION
## 🤖 shin-watcher

# Confidence score: 5/5

> **Why?**
> Reproduced the exact symptom (`litellm_remaining_api_key_{requests,tokens}_for_model` reporting `9.223372036854776e+18` = `sys.maxsize`) end-to-end against a running proxy with `prometheus` enabled, applied a one-function fix in `prometheus.py`, restarted the proxy, and re-scraped `/metrics` to confirm the gauges now report the real remaining values from `hidden_params.additional_headers["x-ratelimit-model_per_key-remaining-{tokens,requests}"]` (the keys populated by `parallel_request_limiter_v3`).

---

### Reported issue

> Monitoring the remaining tokens and requests via `litellm_remaining_api_key_tokens_for_model` / `litellm_remaining_api_key_requests_for_model` shows `9e18` in DataDog — the value used when `prometheus.py` does not find the keys in `kwargs`. The values are actually present, but under `x-ratelimit-model_per_key-remaining-{tokens,requests}` in `hidden_params.additional_headers`. `prometheus.py` only looks for them in `metadata` under `litellm-key-remaining-{tokens,requests}-{model_group}`.

### Root cause

- `litellm/integrations/prometheus.py:1419-1425` (pre-fix) — `_set_virtual_key_rate_limit_metrics` reads exclusively from `metadata`:

  ```python
  remaining_requests = (
      metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
  )
  remaining_tokens = (
      metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
  )
  ```

- The legacy `parallel_request_limiter.py` writes `litellm-key-remaining-{tokens,requests}-{model_group}` into `data["metadata"]` (parallel_request_limiter.py:340-341), so the original code path worked.
- The v3 limiter (`parallel_request_limiter_v3.py:async_post_call_success_hook`) does **not** populate `metadata`. It writes the values onto the response under:

  ```
  response._hidden_params["additional_headers"]["x-ratelimit-model_per_key-remaining-tokens"]
  response._hidden_params["additional_headers"]["x-ratelimit-model_per_key-remaining-requests"]
  ```

  These travel into `kwargs["standard_logging_object"]["hidden_params"]["additional_headers"]` for prometheus, but `_set_virtual_key_rate_limit_metrics` never reads them — so on v3 the `… or sys.maxsize` branch always wins and the gauges emit `9.22e18`.

### Fix summary

`litellm/integrations/prometheus.py — _set_virtual_key_rate_limit_metrics`:

1. First read the legacy `metadata["litellm-key-remaining-{tokens,requests}-{model_group}"]` keys (preserves the v1 path).
2. If either is missing, fall back to `kwargs["standard_logging_object"]["hidden_params"]["additional_headers"]["x-ratelimit-model_per_key-remaining-{tokens,requests}"]` (the v3 path).
3. If both sources are absent (no per-key/per-model TPM/RPM limit configured), keep the prior `sys.maxsize` behavior.

### E2E evidence (running proxy on `http://localhost:5001`)

Repro setup: proxy started with `callbacks: [prometheus, repro_callback.repro_v3_shape]`. The repro callback simulates what the v3 limiter produces — empty metadata, but `additional_headers["x-ratelimit-model_per_key-remaining-{requests,tokens}"] = 47, 9930` — and then prometheus' `_set_virtual_key_rate_limit_metrics` is invoked through the same proxy success path that production uses. Then `GET /metrics` is scraped from the running uvicorn.

**BEFORE** — `/metrics` from running proxy:
```
litellm_remaining_api_key_requests_for_model{api_key_alias="datadog-key",hashed_api_key="sk-virtual-key-abc",model="fake-openai",model_id="model-id-123"} 9.223372036854776e+18
litellm_remaining_api_key_tokens_for_model{api_key_alias="datadog-key",hashed_api_key="sk-virtual-key-abc",model="fake-openai",model_id="model-id-123"}   9.223372036854776e+18
```

**AFTER** — `/metrics` from running proxy:
```
litellm_remaining_api_key_requests_for_model{api_key_alias="datadog-key",hashed_api_key="sk-virtual-key-abc",model="fake-openai",model_id="model-id-123"} 47.0
litellm_remaining_api_key_tokens_for_model{api_key_alias="datadog-key",hashed_api_key="sk-virtual-key-abc",model="fake-openai",model_id="model-id-123"}   9930.0
```

### QA checklist

- [x] `/metrics` BEFORE shows `9.22e+18` for both gauges with v3-shaped kwargs → confirms reported DataDog symptom.
- [x] `/metrics` AFTER shows `47.0` (requests) and `9930.0` (tokens) — the values from `additional_headers`.
- [x] Prior behavior preserved when neither source is populated (master_key path still emits `sys.maxsize`, unchanged).
- [x] Fallback short-circuits per-field — if metadata has only one of the two keys, the other still falls back to additional_headers.
- [ ] (suggested follow-up) add a regression test under `tests/test_litellm/integrations/test_prometheus.py` exercising both code paths (metadata-only and additional_headers-only).

### Notes

- The header keys come from `parallel_request_limiter_v3.async_post_call_success_hook` which writes `x-ratelimit-{descriptor_key}-{remaining|limit}-{tokens|requests}` into `_hidden_params["additional_headers"]`. For per-key per-model limits, `descriptor_key == "model_per_key"`. They survive `StandardLoggingPayloadSetup.get_additional_headers` verbatim because they are not in `StandardLoggingAdditionalHeaders.__annotations__` (the typed-key normalization path).
- The fix only changes lookup logic; no new dependencies, no migrations, no changes to public API.
