### PR TITLE
fix(proxy): preserve HTTP operations when injecting WebSocket stubs i…

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1057,6 +1057,52 @@ vertex_live_passthrough_vertex_base = VertexBase()
 from fastapi.routing import APIWebSocketRoute
 
 
+def _inject_websocket_stubs_into_openapi_schema(
+    openapi_schema: dict, websocket_routes: list
+) -> dict:
+    """
+    Add a synthetic GET stub for each WebSocket route so it appears in Swagger UI.
+
+    Merges into any existing path entry rather than replacing it — a WebSocket route
+    that shares its path with an HTTP route must not erase the HTTP operation. If
+    a "get" operation is already documented on the path, the WebSocket stub is
+    skipped to preserve the real GET.
+    """
+    for route in websocket_routes:
+        base_path = route.path.split("{")[0].rstrip("?")
+
+        parameters = []
+        try:
+            if hasattr(route, "dependant") and route.dependant is not None:
+                # Handle both FastAPI <0.120 and >=0.120
+                query_params = getattr(route.dependant, "query_params", [])
+                if query_params:
+                    for param in query_params:
+                        parameters.append(
+                            {
+                                "name": param.name,
+                                "in": "query",
+                                "required": param.required,
+                                "schema": {"type": "string"},
+                            }
+                        )
+        except (AttributeError, TypeError):
+            pass
+
+        path_entry = openapi_schema["paths"].setdefault(base_path, {})
+        if "get" not in path_entry:
+            path_entry["get"] = {
+                "summary": f"WebSocket: {route.name or base_path}",
+                "description": "WebSocket connection endpoint",
+                "operationId": f"websocket_{route.name or base_path.replace('/', '_')}",
+                "parameters": parameters,
+                "responses": {"101": {"description": "WebSocket Protocol Switched"}},
+                "tags": ["WebSocket"],
+            }
+
+    return openapi_schema
+
+
 def get_openapi_schema():
     if app.openapi_schema:
         return app.openapi_schema
@@ -1079,43 +1125,11 @@ def get_openapi_schema():
         route for route in app.routes if isinstance(route, APIWebSocketRoute)
     ]
 
-    # Add each WebSocket route to the schema
-    for route in websocket_routes:
-        # Get the base path without query parameters
-        base_path = route.path.split("{")[0].rstrip("?")
-
-        # Extract parameters from the route
-        parameters = []
-        try:
-            if hasattr(route, "dependant") and route.dependant is not None:
-                # Handle both FastAPI <0.120 and >=0.120
-                query_params = getattr(route.dependant, "query_params", [])
-                if query_params:
-                    for param in query_params:
-                        parameters.append(
-                            {
-                                "name": param.name,
-                                "in": "query",
-                                "required": param.required,
-                                "schema": {
-                                    "type": "string"
-                                },  # You can make this more specific if needed
-                            }
-                        )
-        except (AttributeError, TypeError):
-            # If we can't access query_params, continue without them
-            pass
-
-        openapi_schema["paths"][base_path] = {
-            "get": {
-                "summary": f"WebSocket: {route.name or base_path}",
-                "description": "WebSocket connection endpoint",
-                "operationId": f"websocket_{route.name or base_path.replace('/', '_')}",
-                "parameters": parameters,
-                "responses": {"101": {"description": "WebSocket Protocol Switched"}},
-                "tags": ["WebSocket"],
-            }
-        }
+    # Add a synthetic GET stub for each so they render in Swagger UI,
+    # without clobbering existing HTTP operations on the same path.
+    openapi_schema = _inject_websocket_stubs_into_openapi_schema(
+        openapi_schema, websocket_routes
+    )
 
     # Add LLM API request schema bodies for documentation
     from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec

--- a/tests/test_litellm/proxy/test_openapi_schema_validation.py
+++ b/tests/test_litellm/proxy/test_openapi_schema_validation.py
@@ -140,3 +140,110 @@ class TestCredentialEndpointsOpenAPISchema:
         assert (
             "credential_name" in sig.parameters
         ), "get_credential_by_name must have a credential_name parameter"
+
+
+class TestWebSocketStubInjection:
+    """
+    Regression test for the v1.82.3 bug where adding a WebSocket route on a path
+    that already had an HTTP route silently dropped the HTTP operation from the
+    OpenAPI schema.
+
+    Related case: 2026-05-05-madhu-swagger-responses-missing
+    """
+
+    def _make_fake_ws_route(self, path: str, name: str = "fake_ws"):
+        """Minimal stand-in for fastapi.routing.APIWebSocketRoute for the helper's purposes."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(path=path, name=name, dependant=None)
+
+    def test_websocket_stub_does_not_clobber_existing_post(self):
+        """
+        When a WebSocket route shares its path with an existing POST operation,
+        the POST must survive — the WebSocket stub is added alongside, not on top.
+        """
+        from litellm.proxy.proxy_server import (
+            _inject_websocket_stubs_into_openapi_schema,
+        )
+
+        schema = {
+            "paths": {
+                "/v1/responses": {
+                    "post": {"summary": "responses_api", "operationId": "responses_api"}
+                }
+            }
+        }
+        ws_routes = [self._make_fake_ws_route("/v1/responses", name="responses_ws")]
+
+        result = _inject_websocket_stubs_into_openapi_schema(schema, ws_routes)
+
+        assert (
+            "post" in result["paths"]["/v1/responses"]
+        ), "POST operation must be preserved when a WebSocket route shares the path"
+        assert (
+            result["paths"]["/v1/responses"]["post"]["operationId"] == "responses_api"
+        )
+        assert (
+            "get" in result["paths"]["/v1/responses"]
+        ), "WebSocket stub should also be added under 'get'"
+        assert result["paths"]["/v1/responses"]["get"]["tags"] == ["WebSocket"]
+
+    def test_websocket_stub_added_when_path_is_new(self):
+        """
+        When a WebSocket route's path is not already in the schema, the stub
+        creates a fresh entry — preserving the original behavior for WebSocket-only
+        paths.
+        """
+        from litellm.proxy.proxy_server import (
+            _inject_websocket_stubs_into_openapi_schema,
+        )
+
+        schema = {"paths": {}}
+        ws_routes = [self._make_fake_ws_route("/ws_only", name="ws_only")]
+
+        result = _inject_websocket_stubs_into_openapi_schema(schema, ws_routes)
+
+        assert "/ws_only" in result["paths"]
+        assert "get" in result["paths"]["/ws_only"]
+        assert result["paths"]["/ws_only"]["get"]["tags"] == ["WebSocket"]
+
+    def test_websocket_stub_skipped_when_existing_get(self):
+        """
+        If a real GET is already documented on the path, the WebSocket stub is
+        skipped — a real operation always wins over the synthetic stub. This
+        closes the same trap for future GET-vs-WebSocket collisions.
+        """
+        from litellm.proxy.proxy_server import (
+            _inject_websocket_stubs_into_openapi_schema,
+        )
+
+        schema = {
+            "paths": {
+                "/health": {
+                    "get": {"summary": "health_check", "operationId": "real_get"}
+                }
+            }
+        }
+        ws_routes = [self._make_fake_ws_route("/health", name="health_ws")]
+
+        result = _inject_websocket_stubs_into_openapi_schema(schema, ws_routes)
+
+        assert (
+            result["paths"]["/health"]["get"]["operationId"] == "real_get"
+        ), "Real GET must take precedence over WebSocket stub"
+
+    def test_responses_post_routes_registered_on_router(self):
+        """
+        Sanity check: the three POST routes for the responses API are still wired
+        on the responses router. Guards against accidental removal at the source.
+        """
+        from litellm.proxy.response_api_endpoints.endpoints import router
+
+        post_paths = {
+            route.path
+            for route in router.routes
+            if hasattr(route, "methods")
+            and "POST" in (route.methods or set())
+            and route.path in {"/v1/responses", "/responses", "/openai/v1/responses"}
+        }
+        assert post_paths == {"/v1/responses", "/responses", "/openai/v1/responses"}


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Starting v1.82.x, `POST /v1/responses` and `POST /responses` disappeared from Swagger UI even though both routes still serve traffic.

**Before the fix** — Swagger UI's `responses` tag, with the two POST entries missing (only `POST /openai/v1/responses` is visible at the top, since it doesn't have a WebSocket twin):

<img width="1220" height="773" alt="before" src="https://github.com/user-attachments/assets/9a50e584-17f1-4c52-aceb-8b7bdaa4cd34" />

**After the fix** — same view, both `POST /v1/responses` and `POST /responses` restored alongside `POST /openai/v1/responses`:
<img width="1166" height="854" alt="after" src="https://github.com/user-attachments/assets/92c87708-63e0-408d-a441-b737e957d26d" />


**JSON-level proof** from probing `/openapi.json` before and after:

```
--- presence of POST per path ---     (before fix)
  POST /v1/responses             NO
  POST /responses                NO
  POST /openai/v1/responses      YES

--- presence of POST per path ---     (after fix)
  POST /v1/responses             YES
  POST /responses                YES
  POST /openai/v1/responses      YES
```

The routes themselves were registered and serving traffic in both states — this was a documentation-layer bug, not a routing one.

## Type

🐛 Bug Fix

## Changes

### What was wrong

`get_openapi_schema()` in `litellm/proxy/proxy_server.py` injects a synthetic GET stub for every WebSocket route so it shows up in Swagger UI. The injection was a wholesale dict assignment:

```python
openapi_schema["paths"][base_path] = {
    "get": { ... websocket stub ... }
}
```

Before v1.82.x every WebSocket path was unique, so this never bit. v1.82.x added `@router.websocket("/v1/responses")` and `@router.websocket("/responses")` — paths that already had `@router.post(...)` registered. The wholesale assignment overwrote the existing path entry, dropping the POST operation from the served OpenAPI schema entirely. `POST /openai/v1/responses` stayed visible only because it has no WebSocket twin.

A vanilla FastAPI app with the same `@app.post(...)` + `@app.websocket(...)` pair on the same path produces a correct OpenAPI schema (FastAPI's own `get_openapi()` skips WebSocket routes by design), so the regression was entirely in LiteLLM's custom WebSocket-injection.

### What this changes

- Extract the WebSocket-stub loop into a module-level helper `_inject_websocket_stubs_into_openapi_schema(openapi_schema, websocket_routes)` so it can be unit-tested in isolation.
- Replace the wholesale assignment with `setdefault(base_path, {})` (gets the existing entry or creates an empty one — never clobbers) plus a `if "get" not in path_entry` guard (skips the synthetic stub if a real GET is already documented). This restores the missing POST entries and also closes the same trap for any future GET-vs-WebSocket path collision.
- For paths with no HTTP twin (every WebSocket path before v1.82.x and the future norm), behavior is unchanged — `setdefault({})` creates a fresh entry, then the same stub gets written.

### Tests

New `TestWebSocketStubInjection` class in `tests/test_litellm/proxy/test_openapi_schema_validation.py` with 4 unit tests:

1. `test_websocket_stub_does_not_clobber_existing_post` — when a WebSocket route shares a path with a POST, the POST survives and the GET stub is added alongside.
2. `test_websocket_stub_added_when_path_is_new` — WebSocket-only paths still get a fresh `{"get": stub}` entry (no behavior change).
3. `test_websocket_stub_skipped_when_existing_get` — a real GET takes precedence over the synthetic stub (closes the same trap for future GET collisions).
4. `test_responses_post_routes_registered_on_router` — sanity check that `/v1/responses`, `/responses`, and `/openai/v1/responses` are still wired with POST on the responses router. Guards against silent removal at the source.

### Files touched

- `litellm/proxy/proxy_server.py` — extract helper + switch to `setdefault` merge
- `tests/test_litellm/proxy/test_openapi_schema_validation.py` — add `TestWebSocketStubInjection` class

### Verification

- `tests/test_litellm/proxy/test_openapi_schema_validation.py` — 11 passed (7 existing + 4 new)
- `tests/test_litellm/proxy/test_lazy_openapi_snapshot.py` and `tests/mcp_tests/test_openapi_spec_path_url.py` — passed (adjacent OpenAPI tests, no regressions)
- `make lint-ruff` — clean
- `uv run black` — clean
- End-to-end against a running proxy: probing `/openapi.json` shows both missing POSTs flip from `NO` to `YES`; control endpoint and HTTP-route-alive checks unchanged; Swagger UI at `/docs` renders the restored entries under the `responses` tag (see screenshots above).
