### PR TITLE
fix: register reducto/parse-v3 and reducto/parse-legacy in active model pricing file

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28331,6 +28331,20 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "reducto/parse-legacy": {
+        "litellm_provider": "reducto",
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ]
+    },
+    "reducto/parse-v3": {
+        "litellm_provider": "reducto",
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ]
+    },
     "recraft/recraftv2": {
         "litellm_provider": "recraft",
         "mode": "image_generation",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Bugbot finding on #26569: `reducto/parse-v3` and `reducto/parse-legacy` were only added to the backup pricing file (`litellm/model_prices_and_context_window_backup.json`), so the active `model_prices_and_context_window.json` never registered Reducto as a known OCR model.

This PR mirrors the same two entries into the active `model_prices_and_context_window.json` so both files stay in sync.

## Changes

- Added `reducto/parse-legacy` and `reducto/parse-v3` entries to `model_prices_and_context_window.json` with the same fields used in the backup file (`litellm_provider: "reducto"`, `mode: "ocr"`, `supported_endpoints: ["/v1/ocr"]`).

## Verification

- Validated JSON parses cleanly via `python3 -c "import json; json.load(open(...))"` for both pricing files.

Targets the same head branch as #26569 (`litellm_oss_staging_04_21_2026_2`) so the fix lands in that PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778027309618169?thread_ts=1778027309.618169&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-14618435-ca00-539e-9867-07a22b767632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14618435-ca00-539e-9867-07a22b767632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

