### PR TITLE
Add utils module docstring

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for LiteLLM core request handling and provider support."""
+
 # from __future__ import annotations must be the first non-comment statement
 from __future__ import annotations
 

--- a/tests/test_litellm/test_utils_module_docstring.py
+++ b/tests/test_litellm/test_utils_module_docstring.py
@@ -1,0 +1,11 @@
+import ast
+from pathlib import Path
+
+
+def test_utils_module_has_docstring():
+    utils_path = Path(__file__).parents[2] / "litellm" / "utils.py"
+    module = ast.parse(utils_path.read_text())
+
+    assert ast.get_docstring(module) == (
+        "Utility helpers for LiteLLM core request handling and provider support."
+    )


### PR DESCRIPTION
## Summary
`litellm/utils.py` did not have a module docstring, so `ast.get_docstring()` returned `None`. Added a tiny one-line module docstring and a focused regression test that parses the file and asserts the docstring value.

## Repro
On the starting ref (`litellm_internal_staging`), run:

```bash
python3 - <<'PY_REPRO'
import ast
from pathlib import Path
path = Path('litellm/utils.py')
module = ast.parse(path.read_text())
docstring = ast.get_docstring(module)
print(f'{path}: module docstring = {docstring!r}')
if docstring is None:
    raise SystemExit('missing module docstring')
PY_REPRO
```

Observed before the fix:

```text
litellm/utils.py: module docstring = None
missing module docstring
```

## Evidence
Could not create the requested gist-hosted screenshot/GIF URL because `$SHIN_GITHUB_TOKEN` does not have the required `gist` scope (`HTTP 404: Not Found ... This API operation needs the "gist" scope`). Fallback terminal transcript:

```text
$ python3 -m pytest tests/test_litellm/test_utils_module_docstring.py -vv
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /workspace
configfile: pyproject.toml
plugins: anyio-4.13.0
collecting ... collected 1 item

tests/test_litellm/test_utils_module_docstring.py::test_utils_module_has_docstring PASSED [100%]

======================== 1 passed, 2 warnings in 0.15s =========================

$ python3 - <<'PY_VERIFY'
import ast
from pathlib import Path
path = Path('litellm/utils.py')
module = ast.parse(path.read_text())
docstring = ast.get_docstring(module)
print(f'{path}: module docstring = {docstring!r}')
if docstring is None:
    raise SystemExit('missing module docstring')
PY_VERIFY
litellm/utils.py: module docstring = 'Utility helpers for LiteLLM core request handling and provider support.'
```

## Tests
- `python3 -m black --target-version py312 litellm/utils.py tests/test_litellm/test_utils_module_docstring.py` - passed, no changes.
- `python3 -m pytest tests/test_litellm/test_utils_module_docstring.py -vv` - passed (`1 passed`).
- `python3 -m pytest -x -q` - attempted full suite; collection stops in existing `cookbook/litellm_router_load_test/test_loadtest_openai_client.py` because Azure OpenAI credentials are not configured (`Missing credentials... AZURE_OPENAI_API_KEY or AZURE_OPENAI_AD_TOKEN`).
