### PR TITLE
Add proxy server module docstring

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1,3 +1,4 @@
+"""FastAPI proxy server for routing and managing LiteLLM requests."""
 import asyncio
 import copy
 import enum


### PR DESCRIPTION
## Summary
`litellm/proxy/proxy_server.py` started directly with imports, so the module had no docstring. Added the requested one-line module docstring describing the FastAPI proxy server's role.

## Repro
On the starting ref (`litellm_internal_staging`), run:

```bash
python3 - <<'PY'
import ast
from pathlib import Path
path = Path('litellm/proxy/proxy_server.py')
docstring = ast.get_docstring(ast.parse(path.read_text()))
print(f'module_docstring={docstring!r}')
if docstring is None:
    raise SystemExit('missing module docstring')
PY
```

Observed before the fix:

```text
module_docstring=None
missing module docstring
```

## Evidence
GitHub rejected gist creation because `$SHIN_GITHUB_TOKEN` lacks the required `gist` scope, so I could not produce the requested gist-hosted image URL. Verbatim evidence transcript:

```text
$ python3 - <<'PY'
import ast
from pathlib import Path
path = Path('litellm/proxy/proxy_server.py')
docstring = ast.get_docstring(ast.parse(path.read_text()))
print(f'module_docstring={docstring!r}')
if docstring != 'FastAPI proxy server for routing and managing LiteLLM requests.':
    raise SystemExit('unexpected or missing module docstring')
print('PASS: module docstring present')
PY
module_docstring='FastAPI proxy server for routing and managing LiteLLM requests.'
PASS: module docstring present

$ python3 -m py_compile litellm/proxy/proxy_server.py && echo 'PASS: proxy_server.py compiles'
PASS: proxy_server.py compiles
```

Gist upload attempt:

```text
$ GH_TOKEN="$SHIN_GITHUB_TOKEN" gh gist create /tmp/shin-evidence.svg --public
- Creating gist shin-evidence.svg
X Failed to create gist: HTTP 404: Not Found (https://api.github.com/gists)
This API operation needs the "gist" scope. To request it, run:  gh auth refresh -h github.com -s gist
```

## Tests
- `python3 - <<'PY' ... ast.get_docstring(...) ... PY` -> passes with `PASS: module docstring present`.
- `python3 -m py_compile litellm/proxy/proxy_server.py` -> passes.
- `make test` -> could not start because this environment has no `uv` executable: `make: uv: No such file or directory`.
