### PR TITLE
Fix render smoke test module docstring

### DIFF
--- a/litellm/proxy/types_utils/utils.py
+++ b/litellm/proxy/types_utils/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for loading proxy type-related instances and annotations."""
+
 import asyncio
 import importlib
 import importlib.util

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -1,7 +1,9 @@
+import ast
 import datetime as real_datetime
 import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
@@ -18,6 +20,12 @@ sys.path.insert(
 from unittest.mock import MagicMock
 
 from litellm.proxy.utils import get_custom_url, join_paths
+
+
+def test_proxy_types_utils_has_module_docstring():
+    path = Path("litellm/proxy/types_utils/utils.py")
+    module = ast.parse(path.read_text())
+    assert ast.get_docstring(module)
 
 
 def test_get_custom_url(monkeypatch):


### PR DESCRIPTION
## Summary
`litellm/proxy/types_utils/utils.py` was missing the module docstring required by the render smoke test. Added a one-line module docstring describing the proxy type utility helpers and a regression test that asserts the docstring remains present.

## Repro
On the starting ref (`litellm_internal_staging`), run:

```bash
python3 - <<'PY'
import ast
from pathlib import Path
path = Path('litellm/proxy/types_utils/utils.py')
module = ast.parse(path.read_text())
assert ast.get_docstring(module), f'{path} is missing a module docstring'
PY
```

Observed before the fix:

```text
AssertionError: litellm/proxy/types_utils/utils.py is missing a module docstring
```

## Evidence
Could not host image evidence via gist because `$SHIN_GITHUB_TOKEN` lacks the required `gist` scope (`HTTP 404: This API operation needs the "gist" scope`). Verbatim terminal transcript fallback:

```text
$ python3 -m pytest tests/test_litellm/proxy/test_proxy_utils.py -vv
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /workspace
configfile: pyproject.toml
plugins: anyio-4.13.0
collecting ... collected 22 items

tests/test_litellm/proxy/test_proxy_utils.py::test_enrich_http_exception_callback_without_guardrail_name_noop PASSED [  4%]
tests/test_litellm/proxy/test_proxy_utils.py::test_enrich_http_exception_non_http_exception_noop PASSED [  9%]
tests/test_litellm/proxy/test_proxy_utils.py::test_enrich_http_exception_setdefault_does_not_overwrite PASSED [ 13%]
tests/test_litellm/proxy/test_proxy_utils.py::test_enrich_http_exception_string_detail_noop PASSED [ 18%]
tests/test_litellm/proxy/test_proxy_utils.py::test_enrich_http_exception_with_guardrail_context_dict_detail PASSED [ 22%]
tests/test_litellm/proxy/test_proxy_utils.py::test_get_custom_url PASSED [ 27%]
tests/test_litellm/proxy/test_proxy_utils.py::test_get_model_group_info_order PASSED [ 31%]
tests/test_litellm/proxy/test_proxy_utils.py::test_get_projected_spend_over_limit_day_one PASSED [ 36%]
tests/test_litellm/proxy/test_proxy_utils.py::test_get_projected_spend_over_limit_december PASSED [ 40%]
tests/test_litellm/proxy/test_proxy_utils.py::test_get_projected_spend_over_limit_includes_current_spend PASSED [ 45%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_both_empty PASSED [ 50%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_empty_base PASSED [ 54%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_empty_route PASSED [ 59%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_nested_path PASSED [ 63%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_no_duplication PASSED [ 68%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_normal_join PASSED [ 72%]
tests/test_litellm/proxy/test_proxy_utils.py::test_join_paths_with_trailing_slash PASSED [ 77%]
tests/test_litellm/proxy/test_proxy_utils.py::test_proxy_only_error_false_for_non_llm_non_info_route PASSED [ 81%]
tests/test_litellm/proxy/test_proxy_utils.py::test_proxy_only_error_false_for_other_error_type PASSED [ 86%]
tests/test_litellm/proxy/test_proxy_utils.py::test_proxy_only_error_true_for_info_route PASSED [ 90%]
tests/test_litellm/proxy/test_proxy_utils.py::test_proxy_only_error_true_for_llm_route PASSED [ 95%]
tests/test_litellm/proxy/test_proxy_utils.py::test_proxy_types_utils_has_module_docstring PASSED [100%]

======================== 22 passed, 2 warnings in 1.83s ========================
```

## Tests
- `python3 - <<'PY' ... ast.get_docstring(...) ... PY` — passes after the fix.
- `python3 -m pytest tests/test_litellm/proxy/test_proxy_utils.py::test_proxy_types_utils_has_module_docstring -vv` — passed.
- `python3 -m pytest tests/test_litellm/proxy/test_proxy_utils.py -vv` — 22 passed, 2 warnings.
- `make test-unit` — ran 5,159 passing tests before stopping on 2 unrelated live OpenAI authentication failures (`invalid_api_key`) in `tests/test_litellm/interactions/test_litellm_responses_bridge.py::TestLiteLLMResponsesBridge::test_acreate_simple` and `tests/test_litellm/test_compression.py::test_embedding_scorer`.
