### PR TITLE
Fix Prometheus model-per-key rate limit gauges

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1416,12 +1416,21 @@ class PrometheusLogger(CustomLogger):
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
-        remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
-        )
-        remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
-        )
+        standard_logging_payload = kwargs.get("standard_logging_object") or {}
+        hidden_params = standard_logging_payload.get("hidden_params") or {}
+        additional_headers = hidden_params.get("additional_headers") or {}
+
+        remaining_requests = metadata.get(remaining_requests_variable_name)
+        if remaining_requests is None:
+            remaining_requests = additional_headers.get(
+                "x-ratelimit-model_per_key-remaining-requests", sys.maxsize
+            )
+
+        remaining_tokens = metadata.get(remaining_tokens_variable_name)
+        if remaining_tokens is None:
+            remaining_tokens = additional_headers.get(
+                "x-ratelimit-model_per_key-remaining-tokens", sys.maxsize
+            )
 
         self.litellm_remaining_api_key_requests_for_model.labels(
             _sanitize_prometheus_label_value(user_api_key),

--- a/tests/test_litellm/integrations/test_prometheus_rate_limit_headers.py
+++ b/tests/test_litellm/integrations/test_prometheus_rate_limit_headers.py
@@ -1,0 +1,117 @@
+import sys
+from typing import Dict, Optional
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import PrometheusLogger
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+    yield
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+
+
+def _get_metric_value(metric_name: str, labels: Dict[str, Optional[str]]) -> float:
+    for metric in REGISTRY.collect():
+        for sample in metric.samples:
+            if sample.name != metric_name:
+                continue
+            if all(sample.labels.get(key) == value for key, value in labels.items()):
+                return sample.value
+
+    raise AssertionError(f"Unable to find {metric_name} with labels {labels}")
+
+
+def test_virtual_key_rate_limit_metrics_read_model_per_key_remaining_headers():
+    prometheus_logger = PrometheusLogger()
+    model_group = "gpt-4o-mini"
+    model_id = "model-id-123"
+    user_api_key = "hashed-key"
+    user_api_key_alias = "test-key"
+    metadata = {"model_group": model_group}
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key=user_api_key,
+        user_api_key_alias=user_api_key_alias,
+        kwargs={
+            "litellm_params": {"metadata": metadata},
+            "standard_logging_object": {
+                "hidden_params": {
+                    "additional_headers": {
+                        "x-ratelimit-model_per_key-remaining-requests": 17,
+                        "x-ratelimit-model_per_key-remaining-tokens": 329,
+                    }
+                }
+            },
+        },
+        metadata=metadata,
+        model_id=model_id,
+    )
+
+    labels = {
+        "hashed_api_key": user_api_key,
+        "api_key_alias": user_api_key_alias,
+        "model": model_group,
+        "model_id": model_id,
+    }
+
+    assert (
+        _get_metric_value("litellm_remaining_api_key_requests_for_model", labels) == 17
+    )
+    assert (
+        _get_metric_value("litellm_remaining_api_key_tokens_for_model", labels) == 329
+    )
+    assert (
+        _get_metric_value("litellm_remaining_api_key_requests_for_model", labels)
+        != sys.maxsize
+    )
+
+
+def test_virtual_key_rate_limit_metrics_prefer_metadata_over_remaining_headers():
+    prometheus_logger = PrometheusLogger()
+    model_group = "gpt-4o-mini"
+    model_id = "model-id-123"
+    user_api_key = "hashed-key"
+    user_api_key_alias = "test-key"
+    metadata = {
+        "model_group": model_group,
+        f"litellm-key-remaining-requests-{model_group}": 11,
+        f"litellm-key-remaining-tokens-{model_group}": 22,
+    }
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key=user_api_key,
+        user_api_key_alias=user_api_key_alias,
+        kwargs={
+            "litellm_params": {"metadata": metadata},
+            "standard_logging_object": {
+                "hidden_params": {
+                    "additional_headers": {
+                        "x-ratelimit-model_per_key-remaining-requests": 17,
+                        "x-ratelimit-model_per_key-remaining-tokens": 329,
+                    }
+                }
+            },
+        },
+        metadata=metadata,
+        model_id=model_id,
+    )
+
+    labels = {
+        "hashed_api_key": user_api_key,
+        "api_key_alias": user_api_key_alias,
+        "model": model_group,
+        "model_id": model_id,
+    }
+
+    assert (
+        _get_metric_value("litellm_remaining_api_key_requests_for_model", labels) == 11
+    )
+    assert _get_metric_value("litellm_remaining_api_key_tokens_for_model", labels) == 22


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Fixes Prometheus model-per-key remaining RPM/TPM gauge fallback from additional headers.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`/tmp/shin-evidence.png` was generated outside the repository, but `$SHIN_GITHUB_TOKEN` cannot host it as a gist because GitHub returned: `This API operation needs the "gist" scope.` No evidence image/video/binary file was added to the repository.

Fallback terminal transcript:

```text
# Reproduced before the fix
uv run pytest tests/test_litellm/integrations/test_prometheus_rate_limit_headers.py -q
FAILED test_virtual_key_rate_limit_metrics_read_model_per_key_remaining_headers
AssertionError: assert 9.223372036854776e+18 == 17
where 9.223372036854776e+18 = _get_metric_value('litellm_remaining_api_key_requests_for_model', ...)

# Verified after the fix
uv run pytest tests/test_litellm/integrations/test_prometheus_rate_limit_headers.py -q
..                                                                       [100%]
2 passed in 0.15s

# Related Prometheus checks
uv run pytest tests/test_litellm/integrations/test_prometheus_rate_limit_headers.py tests/test_litellm/integrations/test_prometheus_missing_metrics.py tests/test_litellm/integrations/test_prometheus_none_metadata.py -q
........                                                                 [100%]
8 passed in 0.27s

# Lint
uv run ruff check litellm/integrations/prometheus.py tests/test_litellm/integrations/test_prometheus_rate_limit_headers.py
All checks passed!

# Full unit target
PATH="$HOME/.local/bin:$PATH" make test-unit
2 failed, 4551 passed, 41 skipped, 249 warnings in 71.03s
Failures were live OpenAI 401 invalid_api_key errors in:
- tests/test_litellm/interactions/test_litellm_responses_bridge.py::TestLiteLLMResponsesBridge::test_acreate_simple
- tests/test_litellm/test_compression.py::test_embedding_scorer
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Reproduces the Prometheus gauge bug where model-per-key remaining requests/tokens read `sys.maxsize` when only `x-ratelimit-model_per_key-remaining-*` headers are present.
- Falls back to those model-per-key rate-limit headers when legacy metadata keys are absent.
- Adds regression tests for header fallback and metadata precedence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01d91b2c-083b-4196-b5be-f87b289070bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01d91b2c-083b-4196-b5be-f87b289070bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

