### PR TITLE
Fix Prometheus virtual key rate-limit gauges

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1416,11 +1416,17 @@ class PrometheusLogger(CustomLogger):
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
-        remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
+        remaining_requests = self._get_virtual_key_rate_limit_remaining_value(
+            metadata=metadata,
+            metadata_key=remaining_requests_variable_name,
+            kwargs=kwargs,
+            rate_limit_type="requests",
         )
-        remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
+        remaining_tokens = self._get_virtual_key_rate_limit_remaining_value(
+            metadata=metadata,
+            metadata_key=remaining_tokens_variable_name,
+            kwargs=kwargs,
+            rate_limit_type="tokens",
         )
 
         self.litellm_remaining_api_key_requests_for_model.labels(
@@ -1436,6 +1442,37 @@ class PrometheusLogger(CustomLogger):
             _sanitize_prometheus_label_value(model_group),
             _sanitize_prometheus_label_value(model_id),
         ).set(remaining_tokens)
+
+    @staticmethod
+    def _get_virtual_key_rate_limit_remaining_value(
+        metadata: dict,
+        metadata_key: str,
+        kwargs: dict,
+        rate_limit_type: Literal["requests", "tokens"],
+    ) -> Any:
+        metadata_value = metadata.get(metadata_key)
+        if metadata_value is not None:
+            return metadata_value
+
+        standard_logging_payload = kwargs.get("standard_logging_object") or {}
+        hidden_params = (
+            standard_logging_payload.get("hidden_params", {})
+            if isinstance(standard_logging_payload, dict)
+            else {}
+        )
+        additional_headers = (
+            hidden_params.get("additional_headers", {})
+            if isinstance(hidden_params, dict)
+            else {}
+        )
+        if isinstance(additional_headers, dict):
+            header_value = additional_headers.get(
+                f"x-ratelimit-model_per_key-remaining-{rate_limit_type}"
+            )
+            if header_value is not None:
+                return header_value
+
+        return sys.maxsize
 
     def _set_latency_metrics(
         self,

--- a/tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py
+++ b/tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py
@@ -1,0 +1,90 @@
+import sys
+from unittest.mock import MagicMock
+
+from litellm.integrations.prometheus import PrometheusLogger
+
+
+def test_virtual_key_rate_limit_metrics_read_model_per_key_headers():
+    model_group = "openrouter/google/gemini-2.0-flash-001"
+    requests_gauge = MagicMock()
+    tokens_gauge = MagicMock()
+    requests_metric = MagicMock()
+    tokens_metric = MagicMock()
+    requests_metric.labels.return_value = requests_gauge
+    tokens_metric.labels.return_value = tokens_gauge
+
+    logger = PrometheusLogger.__new__(PrometheusLogger)
+    logger.litellm_remaining_api_key_requests_for_model = requests_metric
+    logger.litellm_remaining_api_key_tokens_for_model = tokens_metric
+
+    logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="hashed-key",
+        user_api_key_alias="alias",
+        kwargs={
+            "litellm_params": {
+                "metadata": {
+                    "model_group": model_group,
+                },
+            },
+            "standard_logging_object": {
+                "hidden_params": {
+                    "additional_headers": {
+                        "x-ratelimit-model_per_key-remaining-requests": 123,
+                        "x-ratelimit-model_per_key-remaining-tokens": 456,
+                    },
+                },
+            },
+        },
+        metadata={
+            "model_group": model_group,
+        },
+        model_id="model-id",
+    )
+
+    requests_gauge.set.assert_called_once_with(123)
+    tokens_gauge.set.assert_called_once_with(456)
+    assert requests_gauge.set.call_args.args[0] != sys.maxsize
+    assert tokens_gauge.set.call_args.args[0] != sys.maxsize
+
+
+def test_virtual_key_rate_limit_metrics_prefer_metadata_values():
+    model_group = "openrouter/google/gemini-2.0-flash-001"
+    requests_gauge = MagicMock()
+    tokens_gauge = MagicMock()
+    requests_metric = MagicMock()
+    tokens_metric = MagicMock()
+    requests_metric.labels.return_value = requests_gauge
+    tokens_metric.labels.return_value = tokens_gauge
+
+    logger = PrometheusLogger.__new__(PrometheusLogger)
+    logger.litellm_remaining_api_key_requests_for_model = requests_metric
+    logger.litellm_remaining_api_key_tokens_for_model = tokens_metric
+
+    logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="hashed-key",
+        user_api_key_alias="alias",
+        kwargs={
+            "litellm_params": {
+                "metadata": {
+                    "model_group": model_group,
+                },
+            },
+            "standard_logging_object": {
+                "hidden_params": {
+                    "additional_headers": {
+                        "x-ratelimit-model_per_key-remaining-requests": 123,
+                        "x-ratelimit-model_per_key-remaining-tokens": 456,
+                    },
+                },
+            },
+        },
+        metadata={
+            "model_group": model_group,
+            f"litellm-key-remaining-requests-{model_group}": 0,
+            f"litellm-key-remaining-tokens-{model_group}": 1,
+        },
+        model_id="model-id",
+    )
+
+    requests_gauge.set.assert_called_once_with(0)
+    tokens_gauge.set.assert_called_once_with(1)


### PR DESCRIPTION
## Summary
Prometheus virtual-key RPM/TPM gauges only read legacy metadata keys, so model-per-key limiter values stored in response hidden additional headers fell back to sys.maxsize. This resolves the remaining request/token values from metadata first, then from x-ratelimit-model_per_key-remaining-* headers while preserving zero values.

## Repro
On the starting ref, run:
```
~/.local/bin/uv run pytest tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py -vv
```
The repro test observes the bug as: `Expected: set(123)`, `Actual: set(9223372036854775807)` for the Prometheus remaining-requests gauge when only hidden_params.additional_headers contains `x-ratelimit-model_per_key-remaining-requests`.

## Evidence
![evidence](https://tmpfiles.org/dl/36702513/shin-evidence.png)

## Tests
Added `tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py` for hidden-header fallback and metadata precedence.

Ran and passed:
```
~/.local/bin/uv run pytest tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py tests/test_litellm/proxy/common_utils/test_callback_utils.py tests/test_litellm/integrations/test_prometheus_missing_metrics.py -vv
# 11 passed
~/.local/bin/uv run ruff check litellm/integrations/prometheus.py tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py
# All checks passed
```

Attempted full unit suite:
```
~/.local/bin/uv run pytest tests/test_litellm/ -x -vv -n 4
```
After installing missing local test dependencies (numpy, google-cloud-aiplatform, google-genai), the run reached `5070 passed, 40 skipped` before stopping on unrelated environment failures: invalid live OpenAI API key in `test_litellm_responses_bridge.py::TestLiteLLMResponsesBridge::test_acreate_simple` and missing local timezone data for `US/Eastern` in `test_duration_parser.py::TestStandardizedResetTime::test_dst_fall_back`.
