### PR TITLE
fix(anthropic_messages): strip non-user_id keys from metadata before forwarding

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -262,6 +262,22 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if not _has_advisor:
             messages = strip_advisor_blocks_from_messages(messages)  # type: ignore[assignment]
 
+        # Final guard: the Anthropic Messages API only documents `user_id` inside
+        # `metadata`. Vertex AI / Azure AI mirror this and 400 on any other key
+        # (e.g. `tags` injected by key/team/project metadata or deployment-level
+        # routing tags). Strip everything except `user_id` here so the same
+        # safeguard applies to the unified `/v1/messages` flow as the
+        # chat/completions flow does in AnthropicConfig.transform_request.
+        _metadata = anthropic_messages_optional_request_params.get("metadata")
+        if isinstance(_metadata, dict):
+            _user_id = _metadata.get("user_id")
+            if _user_id is not None:
+                anthropic_messages_optional_request_params["metadata"] = {
+                    "user_id": _user_id
+                }
+            else:
+                anthropic_messages_optional_request_params.pop("metadata", None)
+
         anthropic_messages_request: AnthropicMessagesRequest = AnthropicMessagesRequest(
             messages=messages,
             max_tokens=max_tokens,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_metadata_filter.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_metadata_filter.py
@@ -1,0 +1,65 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+from litellm.types.router import GenericLiteLLMParams
+
+
+def _transform(metadata):
+    config = AnthropicMessagesConfig()
+    optional_params = {"max_tokens": 100, "metadata": metadata}
+    return config.transform_anthropic_messages_request(
+        model="claude-opus-4-7",
+        messages=[{"role": "user", "content": "hi"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+
+def test_metadata_strips_non_user_id_keys():
+    """
+    LiteLLM injects routing/budget tags into metadata. The Anthropic Messages
+    API (and Vertex AI / Azure AI mirrors) only accept `user_id` inside
+    `metadata` and 400 on any other key. Verify the unified `/v1/messages` flow
+    strips non-`user_id` keys before forwarding upstream.
+    """
+    request = _transform({"user_id": "claudio", "tags": ["team:foo"], "ip": "1.2.3.4"})
+
+    assert request["metadata"] == {"user_id": "claudio"}
+
+
+def test_metadata_dropped_when_only_disallowed_keys():
+    request = _transform({"tags": ["team:foo"]})
+
+    assert "metadata" not in request
+
+
+def test_metadata_dropped_when_user_id_is_none():
+    request = _transform({"user_id": None, "tags": ["team:foo"]})
+
+    assert "metadata" not in request
+
+
+def test_metadata_passes_through_when_only_user_id():
+    request = _transform({"user_id": "claudio"})
+
+    assert request["metadata"] == {"user_id": "claudio"}
+
+
+def test_no_metadata_field_is_no_op():
+    config = AnthropicMessagesConfig()
+    optional_params = {"max_tokens": 100}
+    request = config.transform_anthropic_messages_request(
+        model="claude-opus-4-7",
+        messages=[{"role": "user", "content": "hi"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert "metadata" not in request

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -1,3 +1,4 @@
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 import { useCredentials } from "@/app/(dashboard)/hooks/credentials/useCredentials";
 import { useModelCostMap } from "@/app/(dashboard)/hooks/models/useModelCostMap";
 import { useModelsInfo } from "@/app/(dashboard)/hooks/models/useModels";
@@ -92,10 +93,17 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
     return Array.from(allModelGroups).sort();
   }, [modelDataResponse?.data]);
 
+  // Unified access groups created via the Access Groups page (stored in
+  // LiteLLM_AccessGroupTable). These are managed independently of legacy
+  // per-deployment model_info.access_groups but should still appear anywhere
+  // the UI offers a "Model Access Group" picker, so admins can attach a
+  // freshly-added model to a unified group on the spot.
+  const { data: unifiedAccessGroupsData } = useAccessGroups();
+
   const availableModelAccessGroups = useMemo(() => {
-    if (!modelDataResponse?.data) return [];
+    if (!modelDataResponse?.data && !unifiedAccessGroupsData) return [];
     const allModelAccessGroups = new Set<string>();
-    for (const model of modelDataResponse.data) {
+    for (const model of modelDataResponse?.data ?? []) {
       const modelInfo = model.model_info;
       if (modelInfo?.access_groups) {
         for (const group of modelInfo.access_groups) {
@@ -103,8 +111,13 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
         }
       }
     }
-    return Array.from(allModelAccessGroups);
-  }, [modelDataResponse?.data]);
+    for (const group of unifiedAccessGroupsData ?? []) {
+      if (group?.access_group_name) {
+        allModelAccessGroups.add(group.access_group_name);
+      }
+    }
+    return Array.from(allModelAccessGroups).sort();
+  }, [modelDataResponse?.data, unifiedAccessGroupsData]);
 
   const allModelsOnProxy = useMemo<string[]>(() => {
     if (!modelDataResponse?.data) return [];

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, screen, waitFor, renderWithProviders } from "../../../tests/test-utils";
+import { act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Form } from "antd";
 import type { UploadProps } from "antd/es/upload";
@@ -97,6 +98,29 @@ vi.mock("@/app/(dashboard)/hooks/tags/useTags", () => ({
     data: { tag1: ["model1", "model2"] },
     isLoading: false,
     error: null,
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/accessGroups/useAccessGroups", () => ({
+  useAccessGroups: vi.fn().mockReturnValue({
+    data: [
+      {
+        access_group_id: "ag-1",
+        access_group_name: "engineering",
+        description: null,
+        access_model_names: [],
+        access_mcp_server_ids: [],
+        access_agent_ids: [],
+        assigned_team_ids: [],
+        assigned_key_ids: [],
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: null,
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: null,
+      },
+    ],
+    isLoading: false,
+    isError: false,
   }),
 }));
 
@@ -272,6 +296,27 @@ describe("AddModelForm", () => {
     });
 
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("should merge unified access groups (from /v1/access_group) with legacy model_info.access_groups in the dropdown", async () => {
+    const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+    mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("proxy_admin", "user-1", true));
+
+    const props = createTestProps("proxy_admin", "user-1", false);
+
+    renderWithProviders(<AddModelForm {...props} />);
+
+    await screen.findByText("Provider");
+
+    const accessGroupCombo = await screen.findByRole("combobox", { name: /Model Access Group/i });
+    await act(async () => {
+      await userEvent.click(accessGroupCombo);
+    });
+
+    // legacy entries from modelAvailableCall + unified group from useAccessGroups
+    expect(await screen.findByTitle("model-group-1")).toBeInTheDocument();
+    expect(await screen.findByTitle("model-group-2")).toBeInTheDocument();
+    expect(await screen.findByTitle("engineering")).toBeInTheDocument();
   });
 
   it("should handle non-admin, non-team-admin users - should not see team selection or switch", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -1,6 +1,7 @@
 import { useProviderFields } from "@/app/(dashboard)/hooks/providers/useProviderFields";
 import { useGuardrails } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
 import { useTags } from "@/app/(dashboard)/hooks/tags/useTags";
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 import { all_admin_roles, isUserTeamAdminForAnyTeam } from "@/utils/roles";
 import { Switch, Text } from "@tremor/react";
 import type { FormInstance } from "antd";
@@ -66,6 +67,11 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   const { data: guardrailsData } = useGuardrails();
   const guardrailsList = guardrailsData?.guardrails.map((g) => g.guardrail_name);
   const { data: tagsList, isLoading: isTagsLoading, error: tagsError } = useTags();
+  // Unified access groups (managed via /v1/access_group). These are stored in
+  // LiteLLM_AccessGroupTable, separate from the legacy per-deployment
+  // model_info.access_groups returned by /models. Both sources need to feed
+  // the dropdown so admins can attach a model to either kind.
+  const { data: unifiedAccessGroups } = useAccessGroups();
 
   const handleTestConnection = async () => {
     setIsTestingConnection(true);
@@ -74,17 +80,31 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   };
 
   const [isTeamOnly, setIsTeamOnly] = useState<boolean>(false);
-  const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  // Legacy access groups discovered from existing deployments' model_info.access_groups.
+  const [legacyModelAccessGroups, setLegacyModelAccessGroups] = useState<string[]>([]);
   // Team admin specific state
   const [teamAdminSelectedTeam, setTeamAdminSelectedTeam] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchModelAccessGroups = async () => {
       const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
-      setModelAccessGroups(response["data"].map((model: any) => model["id"]));
+      setLegacyModelAccessGroups(response["data"].map((model: any) => model["id"]));
     };
     fetchModelAccessGroups();
   }, [accessToken]);
+
+  // Merge unified access group names with the legacy list, deduplicated and
+  // sorted. Without this, groups created on the Access Groups page never
+  // appear here and admins have to free-type them from memory.
+  const modelAccessGroups = useMemo<string[]>(() => {
+    const merged = new Set<string>(legacyModelAccessGroups);
+    for (const group of unifiedAccessGroups ?? []) {
+      if (group?.access_group_name) {
+        merged.add(group.access_group_name);
+      }
+    }
+    return Array.from(merged).sort();
+  }, [legacyModelAccessGroups, unifiedAccessGroups]);
 
   const sortedProviderMetadata: ProviderCreateInfo[] = useMemo(() => {
     if (!providerMetadata) {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Card, Form, Button, Tooltip, Typography, Select as AntdSelect, Modal, Radio, Badge, Space } from "antd";
 import type { FormInstance } from "antd";
 import { Text, TextInput } from "@tremor/react";
@@ -11,6 +11,7 @@ import RouterConfigBuilder from "./RouterConfigBuilder";
 import ComplexityRouterConfig from "./ComplexityRouterConfig";
 import NotificationManager from "../molecules/notifications_manager";
 import { ThunderboltOutlined, BranchesOutlined } from "@ant-design/icons";
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 
 interface AddAutoRouterTabProps {
   form: FormInstance;
@@ -36,7 +37,17 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
   const [isTestingConnection, setIsTestingConnection] = useState<boolean>(false);
   const [connectionTestId, setConnectionTestId] = useState<string>("");
 
-  const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  const [legacyModelAccessGroups, setLegacyModelAccessGroups] = useState<string[]>([]);
+  const { data: unifiedAccessGroups } = useAccessGroups();
+  const modelAccessGroups = useMemo<string[]>(() => {
+    const merged = new Set<string>(legacyModelAccessGroups);
+    for (const group of unifiedAccessGroups ?? []) {
+      if (group?.access_group_name) {
+        merged.add(group.access_group_name);
+      }
+    }
+    return Array.from(merged).sort();
+  }, [legacyModelAccessGroups, unifiedAccessGroups]);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const [showCustomDefaultModel, setShowCustomDefaultModel] = useState<boolean>(false);
   const [showCustomEmbeddingModel, setShowCustomEmbeddingModel] = useState<boolean>(false);
@@ -58,7 +69,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
   useEffect(() => {
     const fetchModelAccessGroups = async () => {
       const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
-      setModelAccessGroups(response["data"].map((model: any) => model["id"]));
+      setLegacyModelAccessGroups(response["data"].map((model: any) => model["id"]));
     };
     fetchModelAccessGroups();
   }, [accessToken]);

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Modal, Form, Button, Select as AntdSelect } from "antd";
 import { Text, TextInput } from "@tremor/react";
 import { modelAvailableCall, modelPatchUpdateCall } from "../networking";
 import { fetchAvailableModels, ModelGroup } from "../playground/llm_calls/fetch_models";
 import RouterConfigBuilder from "../add_model/RouterConfigBuilder";
 import NotificationsManager from "../molecules/notifications_manager";
+import { useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 
 interface EditAutoRouterModalProps {
   isVisible: boolean;
@@ -25,7 +26,17 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
 }) => {
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
-  const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  const [legacyModelAccessGroups, setLegacyModelAccessGroups] = useState<string[]>([]);
+  const { data: unifiedAccessGroups } = useAccessGroups();
+  const modelAccessGroups = useMemo<string[]>(() => {
+    const merged = new Set<string>(legacyModelAccessGroups);
+    for (const group of unifiedAccessGroups ?? []) {
+      if (group?.access_group_name) {
+        merged.add(group.access_group_name);
+      }
+    }
+    return Array.from(merged).sort();
+  }, [legacyModelAccessGroups, unifiedAccessGroups]);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const [showCustomDefaultModel, setShowCustomDefaultModel] = useState<boolean>(false);
   const [showCustomEmbeddingModel, setShowCustomEmbeddingModel] = useState<boolean>(false);
@@ -42,7 +53,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
       if (!accessToken) return;
       try {
         const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
-        setModelAccessGroups(response["data"].map((model: any) => model["id"]));
+        setLegacyModelAccessGroups(response["data"].map((model: any) => model["id"]));
       } catch (error) {
         console.error("Error fetching model access groups:", error);
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Anthropic Messages API only accepts `user_id` inside `metadata`, and Vertex AI / Azure AI Anthropic mirror that contract — they 400 with `metadata.tags: Extra inputs are not permitted` on any other key.

PR #24661 added this filter to the chat/completions path (`AnthropicConfig.transform_request`), but the unified `/v1/messages` endpoint (used by Claude Code via `ANTHROPIC_BASE_URL`) goes through `AnthropicMessagesConfig.transform_anthropic_messages_request`, which had no equivalent guard. Routing/budget tags injected by key/team/project metadata or deployment-level routing therefore leaked into the outgoing `metadata` dict and broke requests against Vertex AI Anthropic.

This PR applies the same final-strip filter in the unified messages transform so the safeguard covers both code paths, and adds a unit test in `tests/test_litellm/` covering the filter behavior.

### Files touched

- `litellm/llms/anthropic/experimental_pass_through/messages/transformation.py` — strip non-`user_id` keys from `metadata` before forwarding.
- `tests/test_litellm/.../test_anthropic_messages_metadata_filter.py` — new unit test for the filter.

> Note: this branch also carries a previously-merged UI fix commit (`f969eb8c48` — include unified access groups in Add Model dropdown, LIT-2783) which is part of the source branch; the primary change of this PR is the anthropic messages metadata fix above.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778030122552229?thread_ts=1778030122.552229&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-2462cbec-5a8b-5759-8570-a34a7243ae2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2462cbec-5a8b-5759-8570-a34a7243ae2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

