### PR TITLE
fix(snowflake): update Cortex endpoint from inference:complete to v1/chat/completions

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -147,12 +147,12 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         stream: Optional[bool] = None,
     ) -> str:
         """
-        If api_base is not provided, use the default DeepSeek /chat/completions endpoint.
+        If api_base is not provided, uses the default Snowflake Cortex /chat/completions endpoint.
         """
 
         api_base = self._get_api_base(api_base, optional_params)
 
-        return f"{api_base}/cortex/inference:complete"
+        return f"{api_base}/cortex/v1/chat/completions"
 
     def _transform_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -393,7 +393,7 @@ class TestSnowFlakeCompletion:
         # account id was used
         assert "AAAA-BBBB" in post_kwargs["url"]
         # is completion
-        assert post_kwargs["url"].endswith("cortex/inference:complete")
+        assert post_kwargs["url"].endswith("cortex/v1/chat/completions")
 
     @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
     def test_snowflake_pat_key_account_id(self, mock_post):


### PR DESCRIPTION
## Summary

Snowflake updated their Cortex REST API. The old inference endpoint has been replaced by a new OpenAI-compatible path:

| | Before | After |
|---|---|---|
| **Endpoint** | `/api/v2/cortex/inference:complete` | `/api/v2/cortex/v1/chat/completions` |
| **Full default URL** | `https://{account}.snowflakecomputing.com/api/v2/cortex/inference:complete` | `https://{account}.snowflakecomputing.com/api/v2/cortex/v1/chat/completions` |

The old URL caused a double-path bug when users provided an `api_base` that already included `/cortex/v1`: the `_get_api_base` normalizer appended `/api/v2` (since it didn't end with that), producing an invalid URL like `...cortex/v1/api/v2/cortex/inference:complete`.

## Changes

- `litellm/llms/snowflake/chat/transformation.py`: update `get_complete_url()` suffix
- Corrected stale docstring (still referred to "DeepSeek")
- `tests/.../test_snowflake_chat_transformation.py`: update endpoint assertion

## Reference

Snowflake Cortex REST API docs: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api

Fixes #27187