### PR TITLE
Fix Prometheus remaining rate limit gauges

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1396,6 +1396,36 @@ class PrometheusLogger(CustomLogger):
             amount=float(response_cost),
         )
 
+    @staticmethod
+    def _coerce_prometheus_gauge_value(value: Any) -> Any:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return value
+
+    @staticmethod
+    def _get_virtual_key_rate_limit_value(
+        metadata: dict,
+        metadata_key: str,
+        additional_headers: Optional[dict],
+        header_key: str,
+    ) -> Any:
+        if metadata_key in metadata and metadata[metadata_key] is not None:
+            return PrometheusLogger._coerce_prometheus_gauge_value(
+                metadata[metadata_key]
+            )
+
+        if (
+            additional_headers is not None
+            and header_key in additional_headers
+            and additional_headers[header_key] is not None
+        ):
+            return PrometheusLogger._coerce_prometheus_gauge_value(
+                additional_headers[header_key]
+            )
+
+        return sys.maxsize
+
     def _set_virtual_key_rate_limit_metrics(
         self,
         user_api_key: Optional[str],
@@ -1416,11 +1446,25 @@ class PrometheusLogger(CustomLogger):
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
-        remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
+        standard_logging_payload = kwargs.get("standard_logging_object") or {}
+        hidden_params = standard_logging_payload.get("hidden_params", {})
+        additional_headers = (
+            hidden_params.get("additional_headers", {})
+            if isinstance(hidden_params, dict)
+            else {}
         )
-        remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
+
+        remaining_requests = self._get_virtual_key_rate_limit_value(
+            metadata=metadata,
+            metadata_key=remaining_requests_variable_name,
+            additional_headers=additional_headers,
+            header_key="x-ratelimit-model_per_key-remaining-requests",
+        )
+        remaining_tokens = self._get_virtual_key_rate_limit_value(
+            metadata=metadata,
+            metadata_key=remaining_tokens_variable_name,
+            additional_headers=additional_headers,
+            header_key="x-ratelimit-model_per_key-remaining-tokens",
         )
 
         self.litellm_remaining_api_key_requests_for_model.labels(

--- a/tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py
+++ b/tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py
@@ -1,0 +1,107 @@
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import PrometheusLogger
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+    yield
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+def test_virtual_key_rate_limit_metrics_read_model_per_key_headers():
+    prometheus_logger = PrometheusLogger()
+    requests_metric = MagicMock()
+    tokens_metric = MagicMock()
+    requests_labeled_metric = MagicMock()
+    tokens_labeled_metric = MagicMock()
+    requests_metric.labels.return_value = requests_labeled_metric
+    tokens_metric.labels.return_value = tokens_labeled_metric
+    prometheus_logger.litellm_remaining_api_key_requests_for_model = requests_metric
+    prometheus_logger.litellm_remaining_api_key_tokens_for_model = tokens_metric
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="hashed-key",
+        user_api_key_alias="test-key",
+        kwargs={
+            "litellm_params": {"metadata": {"model_group": "gpt-4"}},
+            "standard_logging_object": {
+                "hidden_params": {
+                    "additional_headers": {
+                        "x-ratelimit-model_per_key-remaining-requests": "12",
+                        "x-ratelimit-model_per_key-remaining-tokens": "345",
+                    }
+                }
+            },
+        },
+        metadata={"model_group": "gpt-4"},
+        model_id="model-id",
+    )
+
+    requests_labeled_metric.set.assert_called_once_with(12)
+    tokens_labeled_metric.set.assert_called_once_with(345)
+
+
+def test_virtual_key_rate_limit_metrics_preserve_zero_remaining_values():
+    prometheus_logger = PrometheusLogger()
+    requests_metric = MagicMock()
+    tokens_metric = MagicMock()
+    requests_labeled_metric = MagicMock()
+    tokens_labeled_metric = MagicMock()
+    requests_metric.labels.return_value = requests_labeled_metric
+    tokens_metric.labels.return_value = tokens_labeled_metric
+    prometheus_logger.litellm_remaining_api_key_requests_for_model = requests_metric
+    prometheus_logger.litellm_remaining_api_key_tokens_for_model = tokens_metric
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="hashed-key",
+        user_api_key_alias="test-key",
+        kwargs={"litellm_params": {"metadata": {"model_group": "gpt-4"}}},
+        metadata={
+            "model_group": "gpt-4",
+            "litellm-key-remaining-requests-gpt-4": 0,
+            "litellm-key-remaining-tokens-gpt-4": 0,
+        },
+        model_id="model-id",
+    )
+
+    requests_labeled_metric.set.assert_called_once_with(0)
+    tokens_labeled_metric.set.assert_called_once_with(0)
+
+
+def test_virtual_key_rate_limit_metrics_default_to_sys_maxsize_when_missing():
+    prometheus_logger = PrometheusLogger()
+    requests_metric = MagicMock()
+    tokens_metric = MagicMock()
+    requests_labeled_metric = MagicMock()
+    tokens_labeled_metric = MagicMock()
+    requests_metric.labels.return_value = requests_labeled_metric
+    tokens_metric.labels.return_value = tokens_labeled_metric
+    prometheus_logger.litellm_remaining_api_key_requests_for_model = requests_metric
+    prometheus_logger.litellm_remaining_api_key_tokens_for_model = tokens_metric
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="hashed-key",
+        user_api_key_alias="test-key",
+        kwargs={"litellm_params": {"metadata": {"model_group": "gpt-4"}}},
+        metadata={"model_group": "gpt-4"},
+        model_id="model-id",
+    )
+
+    requests_labeled_metric.set.assert_called_once_with(sys.maxsize)
+    tokens_labeled_metric.set.assert_called_once_with(sys.maxsize)


### PR DESCRIPTION
## Summary
Prometheus virtual key model-per-key RPM/TPM gauges were only reading the legacy metadata keys, so responses that carried the remaining limits in hidden additional headers fell back to sys.maxsize. This change reads the `x-ratelimit-model_per_key-remaining-{requests,tokens}` headers when the metadata keys are absent and preserves explicit zero remaining values.

## Repro
On the starting ref, run:

```bash
.venv/bin/python -m pytest tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py::test_virtual_key_rate_limit_metrics_read_model_per_key_headers -q
```

The test fails because the gauge receives `9223372036854775807` instead of the header value (`12`).

## Evidence
![prometheus rate limit tests](https://tmpfiles.org/dl/36703451/shin-evidence.png)

## Tests
- `tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py::test_virtual_key_rate_limit_metrics_read_model_per_key_headers` failed before the fix with `Actual: set(9223372036854775807)`.
- `.venv/bin/python -m pytest tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py -q` -> `3 passed in 0.22s`.
- `.venv/bin/python -m pytest tests/test_litellm/integrations/test_prometheus_missing_metrics.py tests/test_litellm/integrations/test_prometheus_labels.py tests/test_litellm/integrations/test_prometheus_virtual_key_rate_limits.py -q` -> `20 passed in 0.53s`.
- `PATH="/workspace/.venv/bin:$PATH" make test-unit-integrations` -> `861 passed, 1 skipped`; one unrelated live OpenAI websearch test failed due an invalid API key.
- `PATH="/workspace/.venv/bin:$PATH" make test` was attempted and stopped during collection with unrelated environment/live-provider setup errors.
