### PR TITLE
Fix: add web search request Prometheus metric

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -162,6 +162,14 @@ class PrometheusLogger(CustomLogger):
                 labelnames=self.get_labels_for_metric("litellm_output_tokens_metric"),
             )
 
+            self.litellm_web_search_requests_metric = self._counter_factory(
+                "litellm_web_search_requests_metric",
+                "Total number of web search requests made by built-in tools",
+                labelnames=self.get_labels_for_metric(
+                    "litellm_web_search_requests_metric"
+                ),
+            )
+
             # Remaining Budget for Team
             self.litellm_remaining_team_budget_metric = self._gauge_factory(
                 "litellm_remaining_team_budget_metric",
@@ -1153,6 +1161,12 @@ class PrometheusLogger(CustomLogger):
             label_context=label_context,
         )
 
+        self._increment_web_search_request_metrics(
+            standard_logging_payload=standard_logging_payload,  # type: ignore
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+
         # remaining budget metrics
         await self._increment_remaining_budget_metrics(
             user_api_team=user_api_team,
@@ -1262,6 +1276,56 @@ class PrometheusLogger(CustomLogger):
             label_context=label_context,
             amount=float(standard_logging_payload["completion_tokens"]),
         )
+
+    def _increment_web_search_request_metrics(
+        self,
+        standard_logging_payload: StandardLoggingPayload,
+        enum_values: UserAPIKeyLabelValues,
+        label_context: Optional[PrometheusLabelFactoryContext] = None,
+    ) -> None:
+        web_search_requests = self._get_web_search_requests_from_standard_payload(
+            standard_logging_payload
+        )
+        if web_search_requests is None or web_search_requests <= 0:
+            return
+
+        PrometheusLogger._inc_labeled_counter(
+            self,
+            self.litellm_web_search_requests_metric,
+            "litellm_web_search_requests_metric",
+            enum_values,
+            label_context=label_context,
+            amount=float(web_search_requests),
+        )
+
+    @staticmethod
+    def _get_web_search_requests_from_standard_payload(
+        standard_logging_payload: StandardLoggingPayload,
+    ) -> Optional[int]:
+        usage_object = standard_logging_payload.get("metadata", {}).get(
+            "usage_object"
+        ) or standard_logging_payload.get("hidden_params", {}).get("usage_object")
+        if not isinstance(usage_object, dict):
+            return None
+
+        web_search_requests = usage_object.get("web_search_requests")
+        if web_search_requests is None:
+            server_tool_use = usage_object.get("server_tool_use")
+            if isinstance(server_tool_use, dict):
+                web_search_requests = server_tool_use.get("web_search_requests")
+
+        if web_search_requests is None:
+            prompt_tokens_details = usage_object.get("prompt_tokens_details")
+            if isinstance(prompt_tokens_details, dict):
+                web_search_requests = prompt_tokens_details.get("web_search_requests")
+
+        if web_search_requests is None:
+            return None
+
+        try:
+            return int(web_search_requests)
+        except (TypeError, ValueError):
+            return None
 
     def _increment_cache_metrics(
         self,

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -197,6 +197,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_deployment_latency_per_output_token",
     "litellm_requests_metric",
     "litellm_spend_metric",
+    "litellm_web_search_requests_metric",
     "litellm_total_tokens_metric",
     "litellm_input_tokens_metric",
     "litellm_output_tokens_metric",
@@ -410,6 +411,8 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
+
+    litellm_web_search_requests_metric = litellm_spend_metric
 
     litellm_input_tokens_metric = [
         UserAPIKeyLabelNames.END_USER.value,
@@ -658,6 +661,7 @@ class PrometheusMetricLabels:
             "litellm_deployment_latency_per_output_token",
             "litellm_requests_metric",
             "litellm_spend_metric",
+            "litellm_web_search_requests_metric",
             "litellm_input_tokens_metric",
             "litellm_total_tokens_metric",
             "litellm_output_tokens_metric",

--- a/tests/test_litellm/integrations/test_prometheus_web_search_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_web_search_metrics.py
@@ -129,3 +129,29 @@ async def test_prometheus_tracks_web_search_requests_from_server_tool_use(
     }
 
     assert samples["litellm_web_search_requests_metric_total"] == 3.0
+
+
+@pytest.mark.parametrize(
+    "usage_object, expected_requests",
+    [
+        ({"web_search_requests": 2}, 2),
+        ({"prompt_tokens_details": {"web_search_requests": 4}}, 4),
+        ({"server_tool_use": {"web_search_requests": "5"}}, 5),
+        ({"server_tool_use": {"web_search_requests": 0}}, 0),
+        ({"server_tool_use": {"web_search_requests": "not-an-int"}}, None),
+    ],
+)
+def test_get_web_search_requests_from_standard_payload(
+    usage_object,
+    expected_requests,
+):
+    standard_logging_payload = _create_standard_logging_payload(
+        usage_object=usage_object
+    )
+
+    assert (
+        PrometheusLogger._get_web_search_requests_from_standard_payload(
+            standard_logging_payload
+        )
+        == expected_requests
+    )

--- a/tests/test_litellm/integrations/test_prometheus_web_search_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_web_search_metrics.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta
+
+import pytest
+from prometheus_client import REGISTRY
+
+import litellm
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.utils import (
+    StandardLoggingHiddenParams,
+    StandardLoggingMetadata,
+    StandardLoggingModelInformation,
+    StandardLoggingPayload,
+)
+
+
+@pytest.fixture
+def prometheus_logger() -> PrometheusLogger:
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+    return PrometheusLogger()
+
+
+def _create_standard_logging_payload(usage_object: dict) -> StandardLoggingPayload:
+    return StandardLoggingPayload(
+        id="test_id",
+        trace_id="test_trace_id",
+        litellm_call_id="test_call_id",
+        call_type="completion",
+        stream=False,
+        response_cost=0.1,
+        cost_breakdown=None,
+        response_cost_failure_debug_info=None,
+        status="success",
+        status_fields={},
+        total_tokens=30,
+        prompt_tokens=20,
+        completion_tokens=10,
+        startTime=1234567890.0,
+        endTime=1234567891.0,
+        completionStartTime=1234567890.5,
+        response_time=1.0,
+        model_map_information=StandardLoggingModelInformation(
+            model_map_key="claude-sonnet-4", model_map_value=None
+        ),
+        model="claude-sonnet-4",
+        model_id="model-123",
+        model_group="anthropic-claude",
+        custom_llm_provider="anthropic",
+        api_base="https://api.anthropic.com",
+        metadata=StandardLoggingMetadata(
+            user_api_key_hash="test_hash",
+            user_api_key_alias="test_alias",
+            user_api_key_team_id="test_team",
+            user_api_key_user_id="test_user",
+            user_api_key_user_email="test@example.com",
+            user_api_key_team_alias="test_team_alias",
+            user_api_key_org_id=None,
+            user_api_key_org_alias=None,
+            spend_logs_metadata=None,
+            requester_ip_address="127.0.0.1",
+            requester_metadata=None,
+            user_api_key_end_user_id="test_end_user",
+            usage_object=usage_object,
+        ),
+        cache_hit=None,
+        cache_key=None,
+        saved_cache_cost=0.0,
+        request_tags=[],
+        end_user=None,
+        requester_ip_address="127.0.0.1",
+        user_agent=None,
+        messages=[{"role": "user", "content": "What changed today?"}],
+        response={"choices": [{"message": {"content": "Search summary"}}]},
+        error_str=None,
+        error_information=None,
+        model_parameters={"stream": False},
+        hidden_params=StandardLoggingHiddenParams(
+            model_id="model-123",
+            cache_key=None,
+            api_base="https://api.anthropic.com",
+            response_cost="0.1",
+            litellm_overhead_time_ms=None,
+            additional_headers=None,
+            batch_models=None,
+            litellm_model_name="claude-sonnet-4",
+            usage_object=usage_object,
+        ),
+        guardrail_information=None,
+        standard_built_in_tools_params=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prometheus_tracks_web_search_requests_from_server_tool_use(
+    prometheus_logger,
+):
+    standard_logging_payload = _create_standard_logging_payload(
+        usage_object={"server_tool_use": {"web_search_requests": 3}}
+    )
+    kwargs = {
+        "model": "claude-sonnet-4",
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "test_key",
+                "user_api_key_user_id": "test_user",
+                "user_api_key_team_id": "test_team",
+                "user_api_key_end_user_id": "test_end_user",
+            }
+        },
+        "start_time": datetime.now(),
+        "completion_start_time": datetime.now(),
+        "api_call_start_time": datetime.now(),
+        "end_time": datetime.now() + timedelta(seconds=1),
+        "standard_logging_object": standard_logging_payload,
+    }
+
+    await prometheus_logger.async_log_success_event(
+        kwargs,
+        response_obj={},
+        start_time=kwargs["start_time"],
+        end_time=kwargs["end_time"],
+    )
+
+    samples = {
+        sample.name: sample.value
+        for metric in REGISTRY.collect()
+        for sample in metric.samples
+    }
+
+    assert samples["litellm_web_search_requests_metric_total"] == 3.0


### PR DESCRIPTION
## Summary
Assumption: the ambiguous issue was asking for web-search usage to be tracked as a separate Prometheus metric instead of being inferred from the spend metric. Prometheus now registers `litellm_web_search_requests_metric` and increments it from standard usage metadata (`server_tool_use.web_search_requests`, `prompt_tokens_details.web_search_requests`, or top-level `web_search_requests`) without changing spend accounting.

## Repro
On the starting ref, add/run the regression test in `tests/test_litellm/integrations/test_prometheus_web_search_metrics.py` that logs a standard payload with `usage_object={"server_tool_use": {"web_search_requests": 3}}` and asserts `litellm_web_search_requests_metric_total == 3.0`:

```bash
$ uv run pytest tests/test_litellm/integrations/test_prometheus_web_search_metrics.py -q
F                                                                        [100%]
KeyError: 'litellm_web_search_requests_metric_total'
1 failed in 2.85s
```

## Evidence
Could not create the requested gist-hosted screenshot/GIF because `$SHIN_GITHUB_TOKEN` can push branches but does not have the GitHub `gist` scope:

```bash
$ GH_TOKEN="$SHIN_GITHUB_TOKEN" gh gist create /tmp/shin-evidence.svg --public
X Failed to create gist: HTTP 404: Not Found (https://api.github.com/gists)
This API operation needs the "gist" scope. To request it, run:  gh auth refresh -h github.com -s gist
```

Terminal evidence from the fixed branch:

```bash
$ uv run pytest tests/test_litellm/integrations/test_prometheus_web_search_metrics.py tests/test_litellm/integrations/test_prometheus_metric_name_consistency.py tests/test_litellm/integrations/test_prometheus_missing_metrics.py -q
.............                                                            [100%]
13 passed in 8.85s
```

## Tests
- Added `tests/test_litellm/integrations/test_prometheus_web_search_metrics.py`.
- `uv run pytest tests/test_litellm/integrations/test_prometheus_web_search_metrics.py tests/test_litellm/integrations/test_prometheus_metric_name_consistency.py tests/test_litellm/integrations/test_prometheus_missing_metrics.py -q` -> 13 passed.
- `PATH="$HOME/.local/bin:$PATH" make test-unit` -> 4,552 passed before stopping on two unrelated OpenAI 401 failures from invalid environment credentials in `tests/test_litellm/interactions/test_litellm_responses_bridge.py::TestLiteLLMResponsesBridge::test_acreate_simple` and `tests/test_litellm/test_compression.py::test_embedding_scorer`.
