### PR TITLE
fix(responses): handle response.function_call_arguments.done for models without deltas

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1063,6 +1063,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         self, streaming_response, sync_stream: bool, json_mode: Optional[bool] = False
     ):
         super().__init__(streaming_response, sync_stream, json_mode)
+        # Track which tool-call output indices have received streaming delta events.
+        # Used by chunk_parser to decide whether .done carries novel arguments.
+        self._tool_call_has_deltas: set = set()
 
     def _handle_string_chunk(
         self, str_line: Union[str, "BaseModel"]
@@ -1383,6 +1386,52 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         Returns:
             ModelResponseStream: OpenAI-formatted streaming chunk
         """
+        from litellm.types.llms.openai import ChatCompletionToolCallFunctionChunk
+        from litellm.types.utils import (
+            ChatCompletionToolCallChunk,
+            Delta,
+            ModelResponseStream,
+            StreamingChoices,
+        )
+
+        event_type = chunk.get("type", "") if isinstance(chunk, dict) else ""
+        output_index = chunk.get("output_index", 0) if isinstance(chunk, dict) else 0
+
+        if event_type == "response.function_call_arguments.delta":
+            # Record that this output index has received incremental delta events.
+            self._tool_call_has_deltas.add(output_index)
+        elif event_type == "response.function_call_arguments.done":
+            if output_index not in self._tool_call_has_deltas:
+                # No delta events were emitted for this index: the model delivered
+                # the complete arguments only in the .done event (e.g. ChatGPT Spark).
+                # Emit a chunk now so the arguments are not silently dropped.
+                full_args = chunk.get("arguments", "") if isinstance(chunk, dict) else ""
+                if full_args:
+                    return ModelResponseStream(
+                        choices=[
+                            StreamingChoices(
+                                index=0,
+                                delta=Delta(
+                                    tool_calls=[
+                                        ChatCompletionToolCallChunk(
+                                            id=None,
+                                            index=output_index,
+                                            type="function",
+                                            function=ChatCompletionToolCallFunctionChunk(
+                                                name=None,
+                                                arguments=full_args,
+                                            ),
+                                        )
+                                    ]
+                                ),
+                                finish_reason=None,
+                            )
+                        ]
+                    )
+            # If deltas WERE received, fall through: the static method treats .done
+            # as an unhandled event and returns an empty pass-through chunk, which
+            # is correct (args are already in the stream).
+
         verbose_logger.debug(
             f"Chat provider: transform_streaming_response called with chunk: {chunk}"
         )

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -197,3 +197,73 @@ class TestChatGPTResponsesAPITransformation:
         )
 
         assert parsed.output_text == "Hello!"
+
+
+class TestResponsesFunctionArgsDoneHandling:
+    """Tests for response.function_call_arguments.done event handling (issue #27144)."""
+
+    def _make_iterator(self):
+        from unittest.mock import MagicMock
+        from litellm.completion_extras.litellm_responses_transformation.transformation import (
+            OpenAiResponsesToChatCompletionStreamIterator,
+        )
+        # Build a minimal iterator without a real stream
+        obj = object.__new__(OpenAiResponsesToChatCompletionStreamIterator)
+        obj._tool_call_has_deltas = set()
+        return obj
+
+    def test_done_only_emits_arguments(self):
+        """Model sends only .done (no .delta): arguments must appear in output."""
+        iterator = self._make_iterator()
+
+        done_chunk = {
+            "type": "response.function_call_arguments.done",
+            "arguments": '{"a": 5, "b": 7}',
+            "output_index": 1,
+        }
+        result = iterator.chunk_parser(done_chunk)
+
+        tool_calls = result.choices[0].delta.tool_calls
+        assert tool_calls is not None and len(tool_calls) == 1
+        assert tool_calls[0].function.arguments == '{"a": 5, "b": 7}'
+        assert tool_calls[0].index == 1
+
+    def test_done_after_delta_does_not_duplicate(self):
+        """Model sends .delta then .done: arguments must NOT be emitted twice."""
+        iterator = self._make_iterator()
+
+        # First, a delta arrives for output_index=0
+        delta_chunk = {
+            "type": "response.function_call_arguments.delta",
+            "delta": '{"a": 1}',
+            "output_index": 0,
+        }
+        iterator.chunk_parser(delta_chunk)  # consumes delta, marks index 0
+
+        # Now .done arrives for the same index
+        done_chunk = {
+            "type": "response.function_call_arguments.done",
+            "arguments": '{"a": 1}',
+            "output_index": 0,
+        }
+        result = iterator.chunk_parser(done_chunk)
+
+        # Should fall through to the static method pass-through (empty chunk, no args)
+        tool_calls = result.choices[0].delta.tool_calls if result.choices else None
+        assert tool_calls is None or all(
+            tc.function is None or tc.function.arguments in (None, "")
+            for tc in (tool_calls or [])
+        ), "args must not be re-emitted after deltas were already streamed"
+
+    def test_done_without_arguments_is_noop(self):
+        """A .done event with empty arguments should produce an empty chunk."""
+        iterator = self._make_iterator()
+
+        done_chunk = {
+            "type": "response.function_call_arguments.done",
+            "arguments": "",
+            "output_index": 0,
+        }
+        result = iterator.chunk_parser(done_chunk)
+        # Should return a minimal chunk without crashing
+        assert result is not None


### PR DESCRIPTION
## Summary

Some OpenAI-compatible Responses API providers (e.g. ChatGPT Spark / `gpt-5.3-codex`) emit the complete function-call arguments in a single `response.function_call_arguments.done` event, with no preceding `response.function_call_arguments.delta` events. The streaming transform only handled `.delta`; `.done` fell through to the unhandled-event path, silently discarding all arguments and producing `arguments="{}"` in the final response.

## Root cause

`OpenAiResponsesToChatCompletionStreamIterator.chunk_parser` delegated directly to `translate_responses_chunk_to_openai_stream`, which had no branch for `response.function_call_arguments.done` and returned an empty pass-through chunk.

## Fix

Track which `output_index` values have received at least one `.delta` event (`self._tool_call_has_deltas`). In `chunk_parser`:

- When a `.done` event arrives for an index with **no prior deltas**: emit a tool call chunk carrying the full `arguments` string (the args are novel)
- When a `.done` event arrives for an index that **did receive deltas**: fall through to the existing pass-through path (no-op, prevents arg duplication)

## Tests

Added `TestResponsesFunctionArgsDoneHandling` to `tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py`:

- `test_done_only_emits_arguments`: model sends only `.done` — args appear in output
- `test_done_after_delta_does_not_duplicate`: model sends `.delta` then `.done` — args are NOT emitted twice
- `test_done_without_arguments_is_noop`: `.done` with empty args — no crash

Fixes #27144