### PR TITLE
Fix team member budget enforcement without user row

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3516,7 +3516,6 @@ async def _check_team_member_budget(
     if (
         team_object is not None
         and team_object.team_id is not None
-        and user_object is not None
         and valid_token is not None
         and valid_token.user_id is not None
     ):

--- a/tests/test_litellm/proxy/auth/test_team_member_budget.py
+++ b/tests/test_litellm/proxy/auth/test_team_member_budget.py
@@ -307,6 +307,76 @@ async def test_team_member_budget_check_no_team_membership():
 
 
 @pytest.mark.asyncio
+async def test_team_member_budget_check_uses_token_user_when_user_object_missing():
+    """Team-member budget must be enforced from the key's user_id across regenerated keys."""
+    request_body = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+
+    team_object = LiteLLM_TeamTable(
+        team_id="test-team-1",
+        team_alias="Test Team",
+        spend=0.0,
+        max_budget=None,
+    )
+    valid_token = UserAPIKeyAuth(
+        token="new-regenerated-token",
+        user_id="test-user-1",
+        team_id="test-team-1",
+        models=["gpt-3.5-turbo"],
+    )
+    team_membership = LiteLLM_TeamMembership(
+        user_id="test-user-1",
+        team_id="test-team-1",
+        spend=0.0000002,
+        litellm_budget_table=LiteLLM_BudgetTable(
+            max_budget=0.0000001,
+        ),
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_prisma_client = MagicMock()
+    mock_user_api_key_cache = MagicMock()
+    mock_proxy_logging_obj = MagicMock()
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_membership",
+            new_callable=AsyncMock,
+            return_value=team_membership,
+        ) as mock_get_team_membership,
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_user_api_key_cache),
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await common_checks(
+                request_body=request_body,
+                team_object=team_object,
+                user_object=None,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route="/chat/completions",
+                llm_router=None,
+                proxy_logging_obj=mock_proxy_logging_obj,
+                valid_token=valid_token,
+                request=mock_request,
+            )
+
+        mock_get_team_membership.assert_any_await(
+            user_id="test-user-1",
+            team_id="test-team-1",
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=mock_user_api_key_cache,
+            proxy_logging_obj=mock_proxy_logging_obj,
+        )
+        assert "Budget has been exceeded" in str(exc_info.value)
+        assert "test-user-1" in str(exc_info.value)
+        assert "test-team-1" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_team_member_budget_check_personal_key_not_team():
     """Test that team member budget check is skipped for personal keys (no team)."""
     request_body = {

--- a/tests/test_litellm/proxy/auth/test_team_member_budget.py
+++ b/tests/test_litellm/proxy/auth/test_team_member_budget.py
@@ -307,8 +307,8 @@ async def test_team_member_budget_check_no_team_membership():
 
 
 @pytest.mark.asyncio
-async def test_team_member_budget_check_uses_token_user_when_user_object_missing():
-    """Team-member budget must be enforced from the key's user_id across regenerated keys."""
+async def test_team_member_budget_check_blocks_regenerated_key_after_old_key_exhausts_budget():
+    """Deleting an exhausted key and creating a new key must not reset a user's team budget."""
     request_body = {
         "model": "gpt-3.5-turbo",
         "messages": [{"role": "user", "content": "test"}],
@@ -320,7 +320,10 @@ async def test_team_member_budget_check_uses_token_user_when_user_object_missing
         spend=0.0,
         max_budget=None,
     )
-    valid_token = UserAPIKeyAuth(
+    # The spend below represents usage accumulated by an earlier key that was
+    # later deleted. The new key must still be checked against the same
+    # user/team membership spend instead of receiving a fresh per-key budget.
+    regenerated_token = UserAPIKeyAuth(
         token="new-regenerated-token",
         user_id="test-user-1",
         team_id="test-team-1",
@@ -360,7 +363,7 @@ async def test_team_member_budget_check_uses_token_user_when_user_object_missing
                 route="/chat/completions",
                 llm_router=None,
                 proxy_logging_obj=mock_proxy_logging_obj,
-                valid_token=valid_token,
+                valid_token=regenerated_token,
                 request=mock_request,
             )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Team-member budget enforcement was incorrectly gated on a loaded user table row, so a team key carrying `user_id` and `team_id` could skip per-member budget checks if `user_object` was missing from the auth context. The fix enforces the team-member budget whenever the token itself has a user/team binding, keeping spend checks tied to `(user_id, team_id)` across regenerated keys.

`user_object` can be `None` even when `valid_token.user_id` is set: both the legacy auth builder and centralized common-check fetch path intentionally swallow non-auth DB/cache lookup errors for `get_user_object(..., user_id_upsert=False)` and continue with `user_obj=None` so token-recorded limits can still be checked. The old team-member guard accidentally treated that missing user row/context as a reason to skip the membership budget entirely.

## Repro
This reproduces the reported bypass in a focused unit test:

1. A team member has a team-member budget of `0.0000001`.
2. An earlier key for `user_id=test-user-1` in `team_id=test-team-1` has already accumulated `0.0000002` spend on the team membership row.
3. That old key is deleted and a new/regenerated team key is used with the same `user_id` + `team_id`.
4. On the starting ref / old guard, if `user_object` is missing from the auth context, `common_checks()` skips `_check_team_member_budget()` and the new key is allowed instead of raising `BudgetExceededError`.

Command on the old guard:

```bash
uv run pytest tests/test_litellm/proxy/auth/test_team_member_budget.py::test_team_member_budget_check_blocks_regenerated_key_after_old_key_exhausts_budget -q
```

## Evidence
Before-fix repro video:

<a href="https://cursor.com/agents/bc-aa089c71-db45-42b8-a2b1-c25a79a6288a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam_budget_repro_before_fix_terminal.mp4"><img src="https://cursor.com/artifacts/c/art-cbcff4c7-d45b-47d4-8383-3b5e31367f42" alt="team_budget_repro_before_fix_terminal.mp4" /></a>

After-fix verification video:

<a href="https://cursor.com/agents/bc-aa089c71-db45-42b8-a2b1-c25a79a6288a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam_budget_fix_after_terminal.mp4"><img src="https://cursor.com/artifacts/c/art-e5154446-f65b-4690-91a1-11b13bf6785e" alt="team_budget_fix_after_terminal.mp4" /></a>

Video review verified the first recording shows the old guard failing with `Failed: DID NOT RAISE <class 'litellm.exceptions.BudgetExceededError'>`, and the second recording shows the focused repro test passing after restoring `HEAD`, followed by related budget tests passing.

## Tests
- Added `test_team_member_budget_check_blocks_regenerated_key_after_old_key_exhausts_budget` in `tests/test_litellm/proxy/auth/test_team_member_budget.py`.
- Ran `uv run pytest tests/test_litellm/proxy/auth/test_team_member_budget.py -q` -> 6 passed.
- Ran `uv run pytest tests/test_litellm/proxy/auth/test_team_member_budget.py tests/test_litellm/proxy/auth/test_multi_budget_windows.py tests/test_litellm/proxy/test_budget_reservation.py -q` -> 39 passed.
- Ran `uv run black litellm/proxy/auth/auth_checks.py tests/test_litellm/proxy/auth/test_team_member_budget.py`.

## Customer validation questions
- Are they using per-member `team_member_budget`, team `max_budget`, or a key `max_budget`/`budget_id` when they say “team budget”?
- Was the replacement key created via `/key/generate`, `/key/service-account/generate`, the UI, or SSO/CLI flow?
- For the old key and new key, what do `/key/info` show for `team_id`, `user_id`, `key_max_budget`, `budget_id`, and `budget_duration`?
- Did the new key keep the same `team_id` and `user_id` as the deleted key?
- Are there proxy logs around the request containing `Unable to get user from db/cache`, `centralized auth: user fetch swallowed`, or missing/stale user rows?
- Was Redis spend tracking enabled, and did `spend:team_member:<user_id>:<team_id>` exist after the old key exhausted budget?
- For Okta, what were the relevant group/team claims before and after the group change, and should SSO team sync be additive-only or authoritative removal as well?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa089c71-db45-42b8-a2b1-c25a79a6288a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa089c71-db45-42b8-a2b1-c25a79a6288a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

