### PR TITLE
fix(vertex_ai): surface generated image bytes in message.content for Gemini chat-completions

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2266,10 +2266,28 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     ] = audio_response
                     chat_completion_message["content"] = None  # OpenAI spec
                 if image_response is not None:
-                    # Handle image response - combine with text content into structured format
+                    # Existing: stash images for the Responses-API bridge
+                    # consumer (see
+                    # litellm.responses.litellm_completion_transformation
+                    # .transformation._extract_image_generation_output_items).
                     cast(Dict[str, Any], chat_completion_message)[
                         "images"
                     ] = image_response
+                    # When Gemini returns an image-only response (no text
+                    # part), `content` stays None and OpenAI Chat-Completions
+                    # clients reading `message.content` see nothing — even
+                    # though tokens were billed. Surface the first image as a
+                    # `data:image/...;base64,...` URI in `content` to match
+                    # litellm's documented `modalities=["image","text"]`
+                    # passthrough convention. Text takes priority if also
+                    # present (handled by the `content is not None` branch
+                    # below).
+                    if content is None and image_response:
+                        first_image_url = image_response[0].get(
+                            "image_url", {}
+                        ).get("url")
+                        if first_image_url:
+                            chat_completion_message["content"] = first_image_url
                 if content is not None:
                     chat_completion_message["content"] = content
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -1459,6 +1459,116 @@ def test_vertex_ai_process_candidates_with_grounding_metadata():
     assert len(result[0]) == 1
 
 
+def test_vertex_ai_process_candidates_image_only_response_sets_content():
+    """When Gemini returns an image-only response (no text part) under
+    `modalities=["image","text"]`, `message.content` must contain the image
+    as a `data:<mime>;base64,...` URI so OpenAI Chat-Completions clients
+    that read `message.content` receive the image. The image should also
+    remain in `message.images` for the Responses-API bridge consumer.
+
+    Before the fix, `message.content` stayed `None` and the image silently
+    disappeared, even though Gemini billed completion tokens.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    # Minimal but valid base64 PNG bytes (1x1 transparent pixel) — content
+    # doesn't need to decode for this test, only the wrapping shape matters.
+    fake_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4"
+        "2mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    )
+
+    model_response = ModelResponse()
+    VertexGeminiConfig._process_candidates(
+        _candidates=[
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": fake_b64,
+                            }
+                        }
+                    ],
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    # _process_candidates appends; the populated choice is the last one.
+    assert model_response.choices, "expected choices to be populated"
+    msg = model_response.choices[-1].message
+
+    # The fix: content is now the data URI rather than None.
+    assert isinstance(msg.content, str), (
+        f"expected message.content to be a data URI string; got "
+        f"{type(msg.content).__name__}: {msg.content!r}"
+    )
+    assert msg.content.startswith("data:image/png;base64,"), (
+        f"expected data:image/png;base64,... prefix; got: {msg.content[:60]!r}"
+    )
+    assert fake_b64 in msg.content
+
+    # Backward compat: images field still populated for the Responses bridge.
+    images = getattr(msg, "images", None)
+    assert images, "expected message.images to also be populated"
+    assert len(images) == 1
+    assert images[0].get("image_url", {}).get("url", "").startswith(
+        "data:image/png;base64,"
+    )
+
+
+def test_vertex_ai_process_candidates_text_and_image_response():
+    """When Gemini returns BOTH text and an image, `content` should be the
+    text (the existing/established behavior) and `images` should carry the
+    image. This guards against the image-only fix accidentally clobbering
+    text content."""
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    fake_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4"
+        "2mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    )
+
+    model_response = ModelResponse()
+    VertexGeminiConfig._process_candidates(
+        _candidates=[
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {"text": "Here is the image you requested."},
+                        {
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": fake_b64,
+                            }
+                        },
+                    ],
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    msg = model_response.choices[-1].message
+    # Text takes priority - content is the text, not the image data URI.
+    assert msg.content == "Here is the image you requested."
+    images = getattr(msg, "images", None)
+    assert images and len(images) == 1
+
+
 def test_vertex_ai_tool_call_id_format():
     """
     Test that tool call IDs have the correct format and length.


### PR DESCRIPTION
# fix(vertex_ai): surface generated image bytes in `message.content` for Gemini chat-completions

## Context

When `litellm.completion()` calls Gemini with `modalities=["image","text"]`
and Gemini returns an image-only response (no text part in the candidate),
`_process_candidates` in
`litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`
populates `message.images` with the generated data URI but leaves
`message.content` as `None`.

OpenAI Chat-Completions clients read `message.content` and so silently miss
the image, even though Gemini billed completion tokens for generating it.

The Responses-API bridge handles this correctly today — it reads
`choice.message.images` directly (see
`litellm/responses/litellm_completion_transformation/transformation.py
::_extract_image_generation_output_items`). So `litellm.aresponses(...)`
against the same model returns the image cleanly. Plain
`litellm.completion(...)` callers don't.

Reproduction (without this fix, against `gemini/gemini-2.5-flash-image`):

```python
import litellm
r = litellm.completion(
    model="gemini/gemini-2.5-flash-image",
    messages=[{"role": "user", "content": "Generate a red square"}],
    modalities=["image", "text"],
)
print(r.choices[0].message.content)  # -> None  (bug)
print(r.usage.completion_tokens)      # -> ~1290 (Gemini DID generate the image)
print(r.choices[0].message.images)    # -> [{'image_url': {'url': 'data:image/png;base64,iVBOR...'}}]
```

## Fix

In `_process_candidates`, when `image_response` is populated and `content` is
`None`, set `chat_completion_message["content"]` to the first image's data
URI string.

```python
if image_response is not None:
    cast(Dict[str, Any], chat_completion_message)["images"] = image_response
    if content is None and image_response:
        first_image_url = image_response[0].get("image_url", {}).get("url")
        if first_image_url:
            chat_completion_message["content"] = first_image_url
if content is not None:
    chat_completion_message["content"] = content  # text takes priority
```

This matches litellm's documented `modalities=["image","text"]` passthrough
convention — `message.content` is the `data:image/png;base64,...` URI when
the model returns an image-only response. Behavior is preserved for:

- **Text-only responses** — unchanged, `content` is the text.
- **Text + image responses** — text takes priority (the existing
  `if content is not None` branch), so `content` is the text and `images`
  carries the image.
- **Audio responses** — unchanged, `content` is set to `None` per OpenAI
  spec, audio in `message.audio`.
- **Existing readers of `message.images`** — unchanged, the field is still
  populated.

## Tests

Adds two tests in
`tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py`:

- `test_vertex_ai_process_candidates_image_only_response_sets_content` —
  asserts that an image-only Gemini response produces
  `message.content` as a `data:image/png;base64,...` URI **and**
  preserves `message.images`.
- `test_vertex_ai_process_candidates_text_and_image_response` — asserts
  that when both text and an image are returned, `message.content` is the
  text (not the image data URI), and `message.images` carries the image.

Local verification:

```
$ uv run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py \
    -k "image_only or text_and_image" -v
2 passed in 1.09s
```

End-to-end verification against the live Gemini API:

```python
r = await litellm.acompletion(
    model="gemini/gemini-2.5-flash-image",
    messages=[{"role": "user", "content": "Generate a red square"}],
    modalities=["image", "text"],
    api_key=...,
)
# Before: r.choices[0].message.content = None
# After:  r.choices[0].message.content = "data:image/png;base64,iVBORw..." (1.38 MB)
```

## CLA

Signed at https://cla-assistant.io/BerriAI/litellm prior to opening this PR.

## Files

- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py` —
  fix in `_process_candidates`
- `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py`
  — two regression tests
