### PR TITLE
Fix responses tool conversion for chat bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1384,17 +1384,31 @@ class LiteLLMCompletionResponsesConfig:
                 )
             elif tool.get("type") == "function":
                 typed_tool = cast(FunctionToolParam, tool)
+                function_dict = cast(Dict[str, Any], tool.get("function") or {})
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
-                parameters = dict(typed_tool.get("parameters", {}) or {})
+                parameters = dict(
+                    function_dict.get("parameters")
+                    or typed_tool.get("parameters", {})
+                    or {}
+                )
                 if not parameters or "type" not in parameters:
                     parameters["type"] = "object"
+                strict = (
+                    function_dict.get("strict")
+                    if function_dict.get("strict") is not None
+                    else typed_tool.get("strict", False)
+                )
                 chat_completion_tool: Dict[str, Any] = {
                     "type": "function",
                     "function": {
-                        "name": typed_tool.get("name") or "",
-                        "description": typed_tool.get("description") or "",
+                        "name": function_dict.get("name")
+                        or typed_tool.get("name")
+                        or "",
+                        "description": function_dict.get("description")
+                        or typed_tool.get("description")
+                        or "",
                         "parameters": parameters,
-                        "strict": typed_tool.get("strict", False) or False,
+                        "strict": strict or False,
                     },
                 }
                 if tool.get("cache_control"):
@@ -1408,6 +1422,8 @@ class LiteLLMCompletionResponsesConfig:
                 chat_completion_tools.append(
                     cast(ChatCompletionToolParam, chat_completion_tool)
                 )
+            elif tool.get("type") in {"custom", "shell"}:
+                continue
             else:
                 chat_completion_tools.append(
                     cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool)

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1189,6 +1189,57 @@ class TestToolTransformation:
         assert "allowed_callers" not in result_tool
         assert "input_examples" not in result_tool
 
+    def test_transform_function_tools_reads_chat_completion_style_function_fields(self):
+        """Chat Completion-style nested function tools should keep their metadata."""
+        function_tool = {
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+                "strict": True,
+            },
+        }
+
+        (
+            result_tools,
+            _,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[function_tool]
+        )
+
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["type"] == "function"
+        assert result_tool["function"] == function_tool["function"]
+
+    def test_transform_unsupported_responses_api_tool_types_are_dropped(self):
+        """Responses-only tool types should not be forwarded to Chat Completions APIs."""
+        tools = [
+            {"type": "custom", "name": "shell", "description": "Run shell commands"},
+            {"type": "shell", "name": "shell"},
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object"},
+            },
+        ]
+
+        (
+            result_tools,
+            _,
+        ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+
+        assert len(result_tools) == 1
+        assert result_tools[0]["type"] == "function"
+        assert result_tools[0]["function"]["name"] == "get_weather"
+
     def test_transform_code_execution_tools(self):
         """Test that code_execution tools are passed through as-is"""
         code_execution_tool = {


### PR DESCRIPTION
## Summary
The Responses API to Chat Completions bridge only read function tool metadata from top-level Responses-format fields and forwarded Responses-only `custom`/`shell` tools to downstream Chat Completions providers. This fixes nested Chat Completions-style function tools by reading `function.name`/`description`/`parameters`/`strict` when present, and drops unsupported `custom` and `shell` tool types during the bridge conversion.

## Repro
On the starting ref, run:

```bash
python -m pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation::test_transform_function_tools_reads_chat_completion_style_function_fields tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation::test_transform_unsupported_responses_api_tool_types_are_dropped -q
```

Before the fix, the nested function tool produced an empty function name/description/default parameters and `custom`/`shell` tools remained in the transformed tools list.

## Evidence
Could not host screenshot/GIF evidence as requested because the provided `$SHIN_GITHUB_TOKEN` lacks the GitHub `gist` scope required to create externally hosted evidence, and binary evidence files must not be committed to the repo. Verbatim terminal evidence from the passing focused test run:

```text
................                                                         [100%]
=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1434
  /workspace/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1434
  /workspace/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
16 passed, 2 warnings in 0.23s
```

## Tests
- `python -m pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation::test_transform_function_tools_reads_chat_completion_style_function_fields tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation::test_transform_unsupported_responses_api_tool_types_are_dropped -q` -> 2 passed
- `python -m black --check litellm/responses/litellm_completion_transformation/transformation.py tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` -> 2 files unchanged
- `python -m pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation -q` -> 16 passed
- `python -m pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py -q` -> 64 passed
- `make test-unit` -> environment/credential-dependent failure after `4552 passed, 41 skipped`: two existing tests attempted OpenAI calls with an invalid API key and returned 401 (`test_litellm_responses_bridge.py::TestLiteLLMResponsesBridge::test_acreate_simple`, `test_compression.py::test_embedding_scorer`).
