### PR TITLE
feat(neosantara): Add Neosantara provider for OpenAI-like features

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 | [Moonshot (`moonshot`)](https://docs.litellm.ai/docs/providers/moonshot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Morph (`morph`)](https://docs.litellm.ai/docs/providers/morph) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Nebius AI Studio (`nebius`)](https://docs.litellm.ai/docs/providers/nebius) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [Neosantara (`neosantara`)](https://docs.litellm.ai/docs/providers/openai_compatible) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [NLP Cloud (`nlp_cloud`)](https://docs.litellm.ai/docs/providers/nlp_cloud) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Novita AI (`novita`)](https://novita.ai/models/llm?utm_source=github_litellm&utm_medium=github_readme&utm_campaign=github_link) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Nscale (`nscale`)](https://docs.litellm.ai/docs/providers/nscale) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -114,5 +114,14 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "neosantara": {
+    "base_url": "https://api.neosantara.xyz/v1",
+    "api_key_env": "NEOSANTARA_API_KEY",
+    "api_base_env": "NEOSANTARA_API_BASE",
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3329,6 +3329,7 @@ class LlmProviders(str, Enum):
     POE = "poe"
     CHUTES = "chutes"
     XIAOMI_MIMO = "xiaomi_mimo"
+    NEOSANTARA = "neosantara"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/tests/litellm/llms/openai_like/test_neosantara_provider.py
+++ b/tests/litellm/llms/openai_like/test_neosantara_provider.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the Neosantara OpenAI-like provider.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+)
+
+from litellm.llms.openai_like.dynamic_config import create_config_class
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+NEOSANTARA_BASE_URL = "https://api.neosantara.xyz/v1"
+
+
+def _get_config():
+    provider = JSONProviderRegistry.get("neosantara")
+    assert provider is not None
+    config_class = create_config_class(provider)
+    return config_class()
+
+
+def test_neosantara_provider_registered():
+    provider = JSONProviderRegistry.get("neosantara")
+    assert provider is not None
+    assert provider.base_url == NEOSANTARA_BASE_URL
+    assert provider.api_key_env == "NEOSANTARA_API_KEY"
+    assert provider.api_base_env == "NEOSANTARA_API_BASE"
+    assert "/v1/responses" in provider.supported_endpoints
+
+
+def test_neosantara_resolves_env_api_key(monkeypatch):
+    config = _get_config()
+    monkeypatch.setenv("NEOSANTARA_API_KEY", "test-key")
+    api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+    assert api_base == NEOSANTARA_BASE_URL
+    assert api_key == "test-key"
+
+
+def test_neosantara_complete_url_appends_endpoint():
+    config = _get_config()
+    url = config.get_complete_url(
+        api_base=NEOSANTARA_BASE_URL,
+        api_key="test-key",
+        model="neosantara/claude-4.5-sonnet",
+        optional_params={},
+        litellm_params={},
+        stream=False,
+    )
+    assert url == f"{NEOSANTARA_BASE_URL}/chat/completions"
+
+
+def test_neosantara_provider_resolution(monkeypatch):
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    monkeypatch.delenv("NEOSANTARA_API_KEY", raising=False)
+    model, provider, api_key, api_base = get_llm_provider(
+        model="neosantara/claude-4.5-sonnet",
+        custom_llm_provider=None,
+        api_base=None,
+        api_key=None,
+    )
+
+    assert model == "claude-4.5-sonnet"
+    assert provider == "neosantara"
+    assert api_base == NEOSANTARA_BASE_URL
+    assert api_key is None
+
+
+def test_neosantara_provider_config_manager():
+    from litellm import LlmProviders
+    from litellm.utils import ProviderConfigManager
+
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="claude-4.5-sonnet", provider=LlmProviders.NEOSANTARA
+    )
+
+    assert config is not None
+    assert config.custom_llm_provider == "neosantara"


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

This is re pull request from previous pull added neosantara provider at Litellm

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
Test outputs (local targeted validation):
  - tests/litellm/llms/openai_like/test_neosantara_provider.py → 5 passed
  - tests/litellm/llms/openai_like/test_assemblyai_provider.py +
    test_abliteration_provider.py → 8 passed
  - tests/local_testing/test_get_llm_provider.py → 29 passed
  Notes:
  - make lint did not pass due to pre-existing Black formatting diffs in
    enterprise files unrelated to this PR.
  - make test-unit crashed in this environment with Illegal instruction
    during polars import (cloudzero test collection), not from Neosantara
    changes.

## Type
🆕 New Feature
✅  Test
📖 Documentation

## Changes

  - Added new OpenAI-like JSON provider: neosantara in litellm/llms/
    openai_like/providers.json
      - base_url: https://api.neosantara.xyz/v1
      - api_key_env: NEOSANTARA_API_KEY
      - api_base_env: NEOSANTARA_API_BASE
      - supported_endpoints: ["/v1/chat/completions", "/v1/responses"]
  - Added NEOSANTARA to LlmProviders enum (litellm/types/utils.py)
  - Added Neosantara row in Supported Providers table (README.md)
  - Added provider unit tests:
      - tests/litellm/llms/openai_like/test_neosantara_provider.py
      - covers registration, env key resolution, chat URL construction,
        provider routing resolution, and ProviderConfigManager path