### PR TITLE
feat(pricing): add Voyage v4 embedding model pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -33828,6 +33828,30 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-4-large": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-4-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",


### PR DESCRIPTION
## Summary

Adds three new Voyage AI v4 embedding models to `model_prices_and_context_window.json`:

| Model | Cost per token | Context window |
|-------|---------------|----------------|
| `voyage/voyage-4-large` | 1.2e-7 ($0.12/1M) | 32,000 |
| `voyage/voyage-4` | 6e-8 ($0.06/1M) | 32,000 |
| `voyage/voyage-4-lite` | 2e-8 ($0.02/1M) | 32,000 |

Pricing sourced from the [Voyage AI pricing page](https://docs.voyageai.com/docs/pricing).

## Motivation

Voyage released their v4 embedding family (which supersedes v3.5). Without entries in the cost table, LiteLLM cannot track spend for these models.

## Test plan

- [ ] `python3 -c "import json; data = json.load(open('model_prices_and_context_window.json')); print([k for k in data if 'voyage-4' in k])"` confirms the three keys are present and the file remains valid JSON
- [ ] `import litellm; print(litellm.model_cost['voyage/voyage-4'])` returns the expected entry after the file is bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)