### PR TITLE
Fix: Handle multipart/form-data with binary files in pass-through endpoint

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -60,8 +60,8 @@ from litellm.proxy.utils import get_server_root_path, normalize_route_for_root_p
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.custom_http import httpxSpecialProvider
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
-    EndpointType,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    EndpointType,
     PassthroughStandardLoggingPayload,
 )
 
@@ -1192,22 +1192,18 @@ async def _parse_request_data_by_content_type(
             # Handle requests with no body (e.g., DELETE requests)
             pass
     elif "multipart/form-data" in content_type:
-        # ✅ Try to parse as JSON first (handles misconfigured clients sending JSON with multipart content-type)
-        # If that fails, skip parsing - pass_through_request will handle actual multipart
-        try:
-            body = await request.json()
-            # Successfully parsed as JSON - treat as JSON body
-            query_params_data = body.get("query_params")
-            custom_body_data = body.get("custom_body")
-            stream = body.get("stream")
-            # If custom_body is not set, use the entire body
-            if custom_body_data is None and body:
-                custom_body_data = body
-        except (json.JSONDecodeError, Exception):
-            # Not JSON - this is actual multipart data
-            # Skip parsing here to avoid consuming the request body stream
-            # make_multipart_http_request will handle it
-            pass
+        # ✅ Skip parsing for multipart/form-data - let make_multipart_http_request handle it
+        #
+        # CRITICAL: Do NOT call request.json() or request.body() here for multipart requests.
+        # Binary files (PDFs, images, etc.) cannot be decoded as UTF-8 and will cause:
+        # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position X: invalid continuation byte
+        #
+        # The pass_through_request function checks is_multipart and calls make_multipart_http_request
+        # which properly handles multipart/form-data with files.
+        #
+        # Edge case: If a misconfigured client sends JSON with multipart content-type,
+        # that client needs to fix their Content-Type header.
+        pass
 
     elif "application/x-www-form-urlencoded" in content_type:
         # ✅ Handle URL-encoded form data

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -18,6 +18,7 @@ sys.path.insert(
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     HttpPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    _parse_request_data_by_content_type,
     pass_through_request,
 )
 from litellm.proxy.pass_through_endpoints.success_handler import (
@@ -2618,3 +2619,106 @@ def test_get_response_headers_strips_server_and_date():
     assert lowered["content-type"] == "application/json"
     assert lowered["x-request-id"] == "req_abc"
     assert lowered["anthropic-ratelimit-requests-remaining"] == "100"
+
+
+# Test _parse_request_data_by_content_type with multipart/form-data containing binary files
+@pytest.mark.asyncio
+async def test_parse_request_data_multipart_binary_file():
+    """
+    Test that _parse_request_data_by_content_type correctly handles multipart/form-data
+    with binary files (e.g., PDF uploads) without raising UnicodeDecodeError.
+
+    This is a regression test for the issue where calling request.json() on multipart
+    form-data with binary content caused:
+    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position X: invalid continuation byte
+    """
+    # Create a mock request with multipart/form-data content type
+    request = MagicMock(spec=Request)
+
+    # Simulate a PDF file upload with multipart/form-data
+    # PDF files contain binary data that cannot be decoded as UTF-8
+    pdf_header = b"%PDF-1.4\n"  # Standard PDF header
+    binary_content = pdf_header + bytes([0xC4, 0x80, 0x81, 0x82])  # Binary data that fails UTF-8
+
+    request.headers = Headers({
+        "content-type": "multipart/form-data; boundary=--------------------------7oKZJmK2xoAobYu7SoXyay"
+    })
+
+    # Mock the form data to simulate a file upload
+    file_content = binary_content
+    file = BytesIO(file_content)
+    headers = Headers({"content-type": "application/pdf"})
+    upload_file = UploadFile(file=file, filename="document.pdf", headers=headers)
+    upload_file.read = AsyncMock(return_value=file_content)
+
+    form_data = {"file": upload_file, "field1": "value1"}
+    request.form = AsyncMock(return_value=form_data)
+
+    # Mock query_params
+    request.query_params = QueryParams({})
+
+    # This should NOT raise UnicodeDecodeError
+    # Before the fix, calling request.json() on multipart data would fail
+    query_params_data, custom_body_data, file_data, stream = await _parse_request_data_by_content_type(
+        request
+    )
+
+    # For multipart/form-data, the function should skip parsing and return None for all fields
+    # The actual multipart handling is done by make_multipart_http_request
+    assert query_params_data is None
+    assert custom_body_data is None
+    assert file_data is None
+    assert stream is None
+
+
+# Test _parse_request_data_by_content_type with JSON (should still work)
+@pytest.mark.asyncio
+async def test_parse_request_data_json():
+    """
+    Test that _parse_request_data_by_content_type still correctly handles JSON requests.
+    """
+    request = MagicMock(spec=Request)
+    request.headers = Headers({"content-type": "application/json"})
+
+    mock_body = {
+        "query_params": {"param1": "value1"},
+        "custom_body": {"key": "value"},
+        "stream": True
+    }
+    request.json = AsyncMock(return_value=mock_body)
+    request.query_params = QueryParams({})
+
+    query_params_data, custom_body_data, file_data, stream = await _parse_request_data_by_content_type(
+        request
+    )
+
+    assert query_params_data == {"param1": "value1"}
+    assert custom_body_data == {"key": "value"}
+    assert stream is True
+    assert file_data is None
+
+
+# Test _parse_request_data_by_content_type with application/x-www-form-urlencoded
+@pytest.mark.asyncio
+async def test_parse_request_data_form_urlencoded():
+    """
+    Test that _parse_request_data_by_content_type correctly handles URL-encoded form data.
+    """
+    request = MagicMock(spec=Request)
+    request.headers = Headers({"content-type": "application/x-www-form-urlencoded"})
+
+    form_data = {
+        "query_params": '{"param1": "value1"}',
+        "custom_body": '{"key": "value"}'
+    }
+    request.form = AsyncMock(return_value=form_data)
+    request.query_params = QueryParams({})
+
+    query_params_data, custom_body_data, file_data, stream = await _parse_request_data_by_content_type(
+        request
+    )
+
+    assert query_params_data == '{"param1": "value1"}'
+    assert custom_body_data == '{"key": "value"}'
+    assert file_data is None
+    assert stream is None


### PR DESCRIPTION
## Description
Fixes UnicodeDecodeError when uploading binary files (PDFs, images, etc.) via pass-through endpoints with multipart/form-data content type.

### Issue
When sending binary files through a LiteLLM pass-through endpoint with `Content-Type: multipart/form-data`, the server returns a 500 error:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position 165: invalid continuation byte
```

### Root Cause
The `_parse_request_data_by_content_type()` function was attempting to parse the request body as JSON using `await request.json()` even for multipart/form-data requests. This caused FastAPI to try decoding binary file content as UTF-8, which fails for non-text files.

### Fix
Skip JSON parsing for multipart/form-data requests entirely. The actual multipart handling is already correctly performed by `make_multipart_http_request()` which is called later in the request processing pipeline.

### Changes
- Modified `_parse_request_data_by_content_type()` to skip parsing for multipart/form-data
- Added 3 regression tests for multipart binary files, JSON, and form-urlencoded
- All existing tests continue to pass

### Testing
- New test `test_parse_request_data_multipart_binary_file` verifies binary file uploads work
- Tests `test_parse_request_data_json` and `test_parse_request_data_form_urlencoded` ensure no regression
- All existing pass-through endpoint tests continue to pass

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### Before the fix:
Sending a PDF file via pass-through endpoint with `Content-Type: multipart/form-data` caused:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position 165: invalid continuation byte
```

### After the fix:
- Test `test_parse_request_data_multipart_binary_file` passes ✅
- Binary files (PDFs, images) are now correctly forwarded without attempting JSON parsing
- Existing JSON and form-urlencoded requests continue to work as expected

### Test output:
```
tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_parse_request_data_multipart_binary_file PASSED
tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_parse_request_data_json PASSED
tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_parse_request_data_form_urlencoded PASSED
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

~~🆕 New Feature~~
🐛 Bug Fix
~~🧹 Refactoring~~
~~📖 Documentation~~
~~🚄 Infrastructure~~
~~✅ Test~~

## Changes

```
litellm/proxy/pass_through_endpoints/pass_through_endpoints.py:
  - Modified `_parse_request_data_by_content_type()` to skip JSON parsing for multipart/form-data requests
  - Added detailed comments explaining why binary files cannot be decoded as UTF-8

tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py:
  - Added `test_parse_request_data_multipart_binary_file` - regression test for binary file uploads
  - Added `test_parse_request_data_json` - ensures no regression for JSON requests
  - Added `test_parse_request_data_form_urlencoded` - ensures no regression for form-urlencoded requests