### PR TITLE
fix: ensure that redirect uri allows for same-origin for ui setups

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -12,6 +12,7 @@ from litellm.llms.custom_httpx.http_handler import (
 )
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     TOKEN_NO_CACHE_HEADERS,
+    get_request_base_url,
     validate_trusted_redirect_uri,
 )
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
@@ -27,51 +28,6 @@ from litellm.types.mcp_server.mcp_server_manager import MCPServer
 router = APIRouter(
     tags=["mcp"],
 )
-
-
-def get_request_base_url(request: Request) -> str:
-    """
-    Get the base URL for the request, considering X-Forwarded-* headers.
-
-    X-Forwarded-Proto / X-Forwarded-Host / X-Forwarded-Port are only honoured
-    when the request comes from a configured trusted proxy
-    (``use_x_forwarded_for`` enabled AND caller in ``mcp_trusted_proxy_ranges``).
-    Otherwise the request's literal ``base_url`` is returned, so an
-    untrusted caller cannot poison OAuth-discovery / redirect_uri values
-    by injecting headers.
-
-    Args:
-        request: FastAPI Request object
-
-    Returns:
-        The reconstructed base URL (e.g., "https://proxy.example.com")
-    """
-    base_url = str(request.base_url).rstrip("/")
-    parsed = urlparse(base_url)
-
-    if not IPAddressUtils.is_request_from_trusted_proxy(request):
-        return base_url
-
-    x_forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    x_forwarded_host = request.headers.get("X-Forwarded-Host")
-    x_forwarded_port = request.headers.get("X-Forwarded-Port")
-
-    scheme = x_forwarded_proto if x_forwarded_proto else parsed.scheme
-
-    if x_forwarded_host:
-        # X-Forwarded-Host may already include port (e.g., "example.com:8080")
-        if ":" in x_forwarded_host and not x_forwarded_host.startswith("["):
-            netloc = x_forwarded_host
-        elif x_forwarded_port:
-            netloc = f"{x_forwarded_host}:{x_forwarded_port}"
-        else:
-            netloc = x_forwarded_host
-    else:
-        netloc = parsed.netloc
-        if x_forwarded_port and ":" not in netloc:
-            netloc = f"{netloc}:{x_forwarded_port}"
-
-    return urlunparse((scheme, netloc, parsed.path, "", "", ""))
 
 
 def encode_state_with_base_url(

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -2,13 +2,61 @@
 (BYOK + discoverable / pass-through OAuth proxy)."""
 
 from ipaddress import ip_address
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from fastapi import HTTPException, Request
+
+from litellm._logging import verbose_logger
+from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 
 # RFC 6749 §5.1 / OAuth 2.1 draft-15 §4.1.3: token-endpoint responses
 # must not be cached — both success and error bodies may reveal secrets.
 TOKEN_NO_CACHE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
+
+def get_request_base_url(request: Request) -> str:
+    """
+    Get the base URL for the request, considering X-Forwarded-* headers.
+
+    X-Forwarded-Proto / X-Forwarded-Host / X-Forwarded-Port are only honoured
+    when the request comes from a configured trusted proxy
+    (``use_x_forwarded_for`` enabled AND caller in ``mcp_trusted_proxy_ranges``).
+    Otherwise the request's literal ``base_url`` is returned, so an
+    untrusted caller cannot poison OAuth-discovery / redirect_uri values
+    by injecting headers.
+
+    Args:
+        request: FastAPI Request object
+
+    Returns:
+        The reconstructed base URL (e.g., "https://proxy.example.com")
+    """
+    base_url = str(request.base_url).rstrip("/")
+    parsed = urlparse(base_url)
+
+    if not IPAddressUtils.is_request_from_trusted_proxy(request):
+        return base_url
+
+    x_forwarded_proto = request.headers.get("X-Forwarded-Proto")
+    x_forwarded_host = request.headers.get("X-Forwarded-Host")
+    x_forwarded_port = request.headers.get("X-Forwarded-Port")
+
+    scheme = x_forwarded_proto if x_forwarded_proto else parsed.scheme
+
+    if x_forwarded_host:
+        # X-Forwarded-Host may already include port (e.g., "example.com:8080")
+        if ":" in x_forwarded_host and not x_forwarded_host.startswith("["):
+            netloc = x_forwarded_host
+        elif x_forwarded_port:
+            netloc = f"{x_forwarded_host}:{x_forwarded_port}"
+        else:
+            netloc = x_forwarded_host
+    else:
+        netloc = parsed.netloc
+        if x_forwarded_port and ":" not in netloc:
+            netloc = f"{netloc}:{x_forwarded_port}"
+
+    return urlunparse((scheme, netloc, parsed.path, "", "", ""))
 
 
 def validate_loopback_redirect_uri(redirect_uri: str) -> None:
@@ -66,11 +114,6 @@ def validate_trusted_redirect_uri(request: Request, redirect_uri: str) -> None:
     support native clients should keep
     :func:`validate_loopback_redirect_uri`.
     """
-    # Lazy import to avoid circular dependency with discoverable_endpoints.
-    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-        get_request_base_url,
-    )
-
     try:
         parsed = urlparse(redirect_uri)
     except ValueError:
@@ -90,9 +133,14 @@ def validate_trusted_redirect_uri(request: Request, redirect_uri: str) -> None:
             and parsed.netloc.lower() == proxy_base.netloc.lower()
         ):
             return
-    except Exception:
-        # If we can't determine the proxy's origin, fall through to loopback.
-        pass
+    except Exception as exc:
+        # If we can't determine the proxy's origin, fall through to
+        # loopback. Log so the failure is diagnosable in production.
+        verbose_logger.warning(
+            "validate_trusted_redirect_uri: could not determine proxy origin, "
+            "falling back to loopback-only check. error=%s",
+            exc,
+        )
 
     host = (parsed.hostname or "").lower()
     if host == "localhost":

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py
@@ -1150,9 +1150,11 @@ def test_validate_trusted_redirect_uri_accepts_same_origin():
         validate_trusted_redirect_uri,
     )
 
-    req = _mock_request_with_base_url("https://llm.atko.ai/")
+    req = _mock_request_with_base_url("https://proxy.example.com/")
     # Should not raise.
-    validate_trusted_redirect_uri(req, "https://llm.atko.ai/ui/mcp/oauth/callback")
+    validate_trusted_redirect_uri(
+        req, "https://proxy.example.com/ui/mcp/oauth/callback"
+    )
 
 
 def test_validate_trusted_redirect_uri_accepts_loopback():
@@ -1161,7 +1163,7 @@ def test_validate_trusted_redirect_uri_accepts_loopback():
         validate_trusted_redirect_uri,
     )
 
-    req = _mock_request_with_base_url("https://llm.atko.ai/")
+    req = _mock_request_with_base_url("https://proxy.example.com/")
     validate_trusted_redirect_uri(req, "http://127.0.0.1:3000/cb")
     validate_trusted_redirect_uri(req, "http://localhost:3000/cb")
 
@@ -1172,7 +1174,7 @@ def test_validate_trusted_redirect_uri_rejects_external_origin():
         validate_trusted_redirect_uri,
     )
 
-    req = _mock_request_with_base_url("https://llm.atko.ai/")
+    req = _mock_request_with_base_url("https://proxy.example.com/")
     with pytest.raises(HTTPException) as exc:
         validate_trusted_redirect_uri(req, "https://attacker.example.com/cb")
     assert exc.value.status_code == 400
@@ -1184,9 +1186,9 @@ def test_validate_trusted_redirect_uri_rejects_scheme_mismatch():
         validate_trusted_redirect_uri,
     )
 
-    req = _mock_request_with_base_url("https://llm.atko.ai/")
+    req = _mock_request_with_base_url("https://proxy.example.com/")
     with pytest.raises(HTTPException) as exc:
-        validate_trusted_redirect_uri(req, "http://llm.atko.ai/ui/callback")
+        validate_trusted_redirect_uri(req, "http://proxy.example.com/ui/callback")
     assert exc.value.status_code == 400
 
 
@@ -1195,7 +1197,7 @@ def test_validate_trusted_redirect_uri_rejects_fragment():
         validate_trusted_redirect_uri,
     )
 
-    req = _mock_request_with_base_url("https://llm.atko.ai/")
+    req = _mock_request_with_base_url("https://proxy.example.com/")
     with pytest.raises(HTTPException) as exc:
-        validate_trusted_redirect_uri(req, "https://llm.atko.ai/ui/cb#code=1")
+        validate_trusted_redirect_uri(req, "https://proxy.example.com/ui/cb#code=1")
     assert exc.value.status_code == 400

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1955,21 +1955,24 @@ async def test_oauth_callback_accepts_same_origin_ui_redirect():
         "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
     ) as mock_decode:
         mock_decode.return_value = {
-            "base_url": "https://llm.atko.ai/ui/mcp/oauth/callback",
+            "base_url": "https://proxy.example.com/ui/mcp/oauth/callback",
             "original_state": "state-123",
             "code_challenge": None,
             "code_challenge_method": None,
-            "client_redirect_uri": "https://llm.atko.ai/ui/mcp/oauth/callback",
+            "client_redirect_uri": "https://proxy.example.com/ui/mcp/oauth/callback",
         }
 
         response = await callback(
-            request=_mock_callback_request(base_url="https://llm.atko.ai/"),
+            request=_mock_callback_request(base_url="https://proxy.example.com/"),
             code="auth-code-123",
             state="encrypted_state",
         )
 
     assert response.status_code == 302
-    assert "https://llm.atko.ai/ui/mcp/oauth/callback" in response.headers["location"]
+    assert (
+        "https://proxy.example.com/ui/mcp/oauth/callback"
+        in response.headers["location"]
+    )
     assert "code=auth-code-123" in response.headers["location"]
     assert "state=state-123" in response.headers["location"]
 


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

- **Unit tests:** the new `validate_trusted_redirect_uri` tests exercise same-origin accept, loopback accept, external reject, scheme-mismatch reject, and fragment reject. The new callback test exercises the full same-origin redirect path end-to-end. All 6 updated existing callback tests (including the three VERIA-57 regression tests for attacker origins) continue to assert the same rejection/acceptance behaviour under the new validator
- **End-to-end (manual):** in the deployed proxy, open the MCP Servers page, click **Authorize** on an OAuth2 server. Expected: the browser redirects to the MCP provider's authorization URL (e.g. `auth.dovetail.com/authorize?...`) instead of returning `{"detail":"invalid_request"}`. After authorizing on the provider, it redirects back to `<proxy>/callback`, which then 302s to `<proxy>/ui/mcp/oauth/callback?code=...&state=...`, and the UI exchanges the code via `/token` to complete the flow
- **Native MCP client regression:** a loopback `redirect_uri` like `http://127.0.0.1:3000/cb` still works against the discoverable `/authorize` endpoint, covered by the existing `test_authorize_endpoint_accepts_ipv4_loopback_range_and_ipv6_full_form` test which I didn't touch

## Type

🐛 Bug Fix

## Changes

### Root cause

`authorize_with_server` in `litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py` calls `validate_loopback_redirect_uri(redirect_uri)` (added in `ef108e79a1` to defend against VERIA-57 - open-redirect / authorization-code theft). The validator requires `redirect_uri` to be a loopback address (`localhost`, `127.0.0.0/8`, or `::1`). The UI passes `https://llm.atko.ai/ui/mcp/oauth/callback` (a legitimate same-origin callback URL but not loopback) so validation raises `HTTPException(400, "invalid_request")`

The validator was written with only native MCP clients in mind (mcp-inspector, VS Code, Claude Desktop, etc.), which listen on localhost ports per RFC 8252. It didn't account for the proxy's own UI dashboard, which legitimately handles its own OAuth callback on its own HTTPS origin.

The same validation runs a second time at `/callback` via `_get_validated_client_redirect_uri`, so even without the `/authorize` check the full flow would still break at the sink.

### Fix

Introduced `validate_trusted_redirect_uri(request, redirect_uri)` in `oauth_utils.py` that accepts a `redirect_uri` if it is **either**:
1. Same scheme + host(:port) as the proxy's own base URL (derived via `get_request_base_url`, which honors trusted `X-Forwarded-*` headers), **or**
2. A loopback address (preserves the existing native-client behavior)

Switched both validation points in the discoverable OAuth proxy to the new helper:
- `authorize_with_server` - validates before encrypting `redirect_uri` into OAuth state
- `callback` - revalidates at the sink after decrypting state. The handler now takes a `request: Request` parameter so it can compute the proxy's own origin at redirect time

BYOK endpoints (`byok_oauth_endpoints.py`) continue to use `validate_loopback_redirect_uri` since they only serve native MCP clients, where loopback is still the spec-compliant pattern.

### Security analysis

VERIA-57's threat model: an attacker passes an attacker-controlled URL as `redirect_uri`, the proxy encrypts it into state and later 302s the user (with the authorization code attached) to that URL, leaking the code.

- **Loopback path:** unchanged. Same as before
- **Same-origin path:** the attacker's URL would have to be hosted on the proxy's own HTTPS origin (e.g. `https://llm.atko.ai/...`). An attacker who can serve content on that origin has already compromised the proxy; the attack primitive is no longer about code theft. HTTPS + DNS prevent an external attacker from impersonating that origin

Scheme-mismatch (`https`→`http`) on the same host is still rejected; fragments still rejected; unparseable hosts still rejected. All existing regression tests (`test_authorize_endpoint_rejects_non_loopback_redirect_uri`, `test_callback_revalidates_loopback_on_decoded_base_url`, `test_callback_revalidates_loopback_on_decoded_client_redirect_uri`) continue to pass; the cross-origin attacker case (`https://attacker.example.com/cb` against a proxy at `https://litellm.example.com/`) is still a 400

### Files changed

| File | Change |
|---|---|
| `litellm/proxy/_experimental/mcp_server/oauth_utils.py` | Added `validate_trusted_redirect_uri(request, redirect_uri)` helper. |
| `litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py` | `authorize_with_server`, `callback`, and `_get_validated_client_redirect_uri` switched from loopback-only to trusted (same-origin + loopback). `callback` signature now takes `request: Request`. Removed unused `validate_loopback_redirect_uri` import. |
| `tests/test_litellm/proxy/_experimental/mcp_server/test_byok_oauth_endpoints.py` | 5 new unit tests for `validate_trusted_redirect_uri`: accepts same-origin, accepts loopback (localhost and 127.0.0.1), rejects external origin, rejects scheme mismatch, rejects fragment. |
| `tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py` | Added `_mock_callback_request` helper; updated all 6 existing `callback(...)` invocations to pass `request=`; added `test_oauth_callback_accepts_same_origin_ui_redirect` covering the end-to-end UI success path. |