### PR TITLE
fix(usage_ai_chat): route through llm_router so proxy model aliases work

### DIFF
--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -438,6 +438,17 @@ async def _acompletion(**kwargs: Any) -> Any:
     from litellm.proxy.proxy_server import llm_router
 
     if llm_router is not None:
+        # Honor `pass_through_all_models`: if the model isn't managed by the
+        # router, fall back to litellm.acompletion just like route_llm_request
+        # does. Otherwise proxies that route some models via the router but
+        # allow pass-through for everything else would 400 here.
+        model = kwargs.get("model")
+        if (
+            llm_router.router_general_settings.pass_through_all_models
+            and model not in llm_router.model_names
+            and not llm_router.has_model_id(model or "")
+        ):
+            return await litellm.acompletion(**kwargs)
         return await llm_router.acompletion(**kwargs)
     return await litellm.acompletion(**kwargs)
 

--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -426,6 +426,22 @@ def _sse(event: SSEEvent) -> str:
     return f"data: {json.dumps(event)}\n\n"
 
 
+async def _acompletion(**kwargs: Any) -> Any:
+    """Run completion through the proxy router so model aliases and credentials
+    configured in the proxy's ``model_list`` are honored. Falls back to
+    ``litellm.acompletion`` directly when no router is initialized — primarily
+    for unit tests that don't bootstrap a full proxy. Without this, the AI
+    chat endpoint dispatches straight to OpenAI using ``OPENAI_API_KEY`` from
+    the env, breaking every deployment whose credentials live in the proxy
+    config (Bedrock, Azure, Anthropic-only setups, etc.).
+    """
+    from litellm.proxy.proxy_server import llm_router
+
+    if llm_router is not None:
+        return await llm_router.acompletion(**kwargs)
+    return await litellm.acompletion(**kwargs)
+
+
 def _resolve_fetch_kwargs(
     fn_name: str,
     fn_args: Dict[str, str],
@@ -524,7 +540,7 @@ async def _stream_final_response(
     """Stream the final LLM response after tool results are appended."""
     yield _sse({"type": "status", "message": "Analyzing results..."})
 
-    response = await litellm.acompletion(
+    response = await _acompletion(
         model=model,
         messages=chat_messages,
         stream=True,
@@ -555,7 +571,7 @@ async def stream_usage_ai_chat(
     try:
         yield _sse({"type": "status", "message": "Thinking..."})
         tools = get_tools_for_role(is_admin)
-        response = await litellm.acompletion(
+        response = await _acompletion(
             model=resolved_model,
             messages=chat_messages,
             tools=tools,

--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -443,10 +443,12 @@ async def _acompletion(**kwargs: Any) -> Any:
         # does. Otherwise proxies that route some models via the router but
         # allow pass-through for everything else would 400 here.
         model = kwargs.get("model")
+        model_group_alias = llm_router.model_group_alias or {}
         if (
             llm_router.router_general_settings.pass_through_all_models
             and model not in llm_router.model_names
             and not llm_router.has_model_id(model or "")
+            and model not in model_group_alias
         ):
             return await litellm.acompletion(**kwargs)
         return await llm_router.acompletion(**kwargs)

--- a/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
+++ b/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
@@ -466,3 +466,74 @@ class TestUsageAiChatServiceAccountGuard:
                 is_admin=False,
             )
         assert "Endpoint-level guard missing" in str(exc_info.value)
+
+
+class TestUsageAiChatRouterDispatch:
+    """
+    Regression: the AI chat endpoint must dispatch through the proxy's
+    llm_router when one is configured, so model aliases and credentials from
+    the proxy config (Bedrock, Azure, etc.) are honored. The previous code
+    called litellm.acompletion directly, which only worked when OPENAI_API_KEY
+    happened to be set on the proxy env.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_llm_router_when_configured(self):
+        from litellm.proxy import proxy_server
+
+        mock_router = MagicMock()
+        mock_router.acompletion = AsyncMock()
+
+        mock_no_tools_response = MagicMock()
+        mock_no_tools_response.choices = [MagicMock()]
+        mock_no_tools_response.choices[0].message.tool_calls = None
+        mock_no_tools_response.choices[0].message.content = "Hello from router."
+        mock_router.acompletion.return_value = mock_no_tools_response
+
+        original_router = getattr(proxy_server, "llm_router", None)
+        try:
+            proxy_server.llm_router = mock_router
+            events = []
+            async for event in stream_usage_ai_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                model="my-proxy-alias",
+                user_id="user-123",
+                is_admin=True,
+            ):
+                events.append(event)
+        finally:
+            proxy_server.llm_router = original_router
+
+        mock_router.acompletion.assert_awaited_once()
+        call_kwargs = mock_router.acompletion.await_args.kwargs
+        assert call_kwargs["model"] == "my-proxy-alias"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_litellm_when_no_router(self):
+        from litellm.proxy import proxy_server
+
+        mock_no_tools_response = MagicMock()
+        mock_no_tools_response.choices = [MagicMock()]
+        mock_no_tools_response.choices[0].message.tool_calls = None
+        mock_no_tools_response.choices[0].message.content = "Hello."
+
+        original_router = getattr(proxy_server, "llm_router", None)
+        try:
+            proxy_server.llm_router = None
+            with patch(
+                "litellm.proxy.management_endpoints.usage_endpoints.ai_usage_chat.litellm"
+            ) as mock_litellm:
+                mock_litellm.acompletion = AsyncMock(
+                    return_value=mock_no_tools_response
+                )
+                events = []
+                async for event in stream_usage_ai_chat(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="gpt-4o-mini",
+                    user_id="user-123",
+                    is_admin=True,
+                ):
+                    events.append(event)
+                mock_litellm.acompletion.assert_awaited_once()
+        finally:
+            proxy_server.llm_router = original_router


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Ask AI panel in the Usage UI called `litellm.acompletion` directly, which bypasses the proxy's `model_list` and dispatches straight to OpenAI using `OPENAI_API_KEY` from the environment. Any deployment whose model credentials live exclusively in the proxy config (Bedrock, Azure, Anthropic-only setups, etc.) hit `AuthenticationError` on every request, surfaced to the user as the generic *"An internal error occurred."*

This PR introduces a small `_acompletion` helper in `ai_usage_chat.py` that:

- Looks up `llm_router` from `proxy_server` first and dispatches through `llm_router.acompletion` when a router is initialized — so model aliases and credentials configured in the proxy config are honored.
- Falls back to `litellm.acompletion` only when no router is available (primarily so unit tests that don't bootstrap a full proxy continue to work).

Both call sites in the streaming chat flow (`stream_usage_ai_chat` and `_stream_final_response`) now go through this helper.

### Files changed

- `litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py`
- `tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py`

### Tests

Added a new `TestUsageAiChatRouterDispatch` class covering both branches:

1. `test_uses_llm_router_when_configured` — when `proxy_server.llm_router` is set, the chat endpoint calls `llm_router.acompletion` with the requested model alias.
2. `test_falls_back_to_litellm_when_no_router` — when no router is configured, the endpoint falls back to `litellm.acompletion` (the previous behavior).

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778076910441419?thread_ts=1778076910.441419&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-2a28e45d-25f6-5bd7-90d8-381a7956f924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a28e45d-25f6-5bd7-90d8-381a7956f924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

