### PR TITLE
feat(qianfan): add official OpenAI-compatible provider support

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -778,6 +778,7 @@ openai_compatible_endpoints: List = [
     "https://ai-gateway.vercel.sh/v1",
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
+    "https://qianfan.baidubce.com/v2",
 ]
 
 
@@ -814,6 +815,7 @@ openai_compatible_providers: List = [
     "novita",
     "meta_llama",
     "publicai",  # PublicAI - JSON-configured provider
+    "qianfan",  # Qianfan - JSON-configured provider
     "synthetic",  # Synthetic - JSON-configured provider
     "apertis",  # Apertis - JSON-configured provider
     "nano-gpt",  # Nano-GPT - JSON-configured provider

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -362,6 +362,9 @@ def get_llm_provider(  # noqa: PLR0915
                     elif endpoint == "https://api.inference.wandb.ai/v1":
                         custom_llm_provider = "wandb"
                         dynamic_api_key = get_secret_str("WANDB_API_KEY")
+                    elif endpoint == "https://qianfan.baidubce.com/v2":
+                        custom_llm_provider = "qianfan"
+                        dynamic_api_key = api_key or get_secret_str("QIANFAN_API_KEY")
 
                     if api_base is not None and not isinstance(api_base, str):
                         raise Exception(

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -11,6 +11,14 @@
       "convert_content_list_to_string": true
     }
   },
+  "qianfan": {
+    "base_url": "https://qianfan.baidubce.com/v2",
+    "api_key_env": "QIANFAN_API_KEY",
+    "api_base_env": "QIANFAN_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
+  },
   "helicone": {
     "base_url": "https://ai-gateway.helicone.ai/",
     "api_key_env": "HELICONE_API_KEY"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3202,6 +3202,7 @@ class LlmProviders(str, Enum):
     OPENAI = "openai"
     CHATGPT = "chatgpt"
     OPENAI_LIKE = "openai_like"  # embedding only
+    QIANFAN = "qianfan"
     JINA_AI = "jina_ai"
     XAI = "xai"
     ZAI = "zai"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1870,6 +1870,15 @@
         "interactions": true
       }
     },
+    "qianfan": {
+      "display_name": "Qianfan (`qianfan`)",
+      "url": "https://docs.litellm.ai/docs/providers/qianfan",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true
+      }
+    },
     "predibase": {
       "display_name": "Predibase (`predibase`)",
       "url": "https://docs.litellm.ai/docs/providers/predibase",

--- a/tests/test_litellm/llms/openai_like/test_qianfan.py
+++ b/tests/test_litellm/llms/openai_like/test_qianfan.py
@@ -1,0 +1,128 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm import Router
+from litellm.llms.openai_like.dynamic_config import create_config_class
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+
+def test_qianfan_in_provider_list():
+    assert "qianfan" in litellm.provider_list
+    assert "qianfan" in litellm.openai_compatible_providers
+    assert LlmProviders.QIANFAN == "qianfan"
+
+
+def test_qianfan_json_config_exists():
+    config = JSONProviderRegistry.get("qianfan")
+
+    assert config is not None
+    assert config.base_url == "https://qianfan.baidubce.com/v2"
+    assert config.api_key_env == "QIANFAN_API_KEY"
+    assert config.api_base_env == "QIANFAN_API_BASE"
+    assert config.param_mappings["max_completion_tokens"] == "max_tokens"
+
+
+def test_qianfan_dynamic_config_defaults():
+    provider = JSONProviderRegistry.get("qianfan")
+    assert provider is not None
+
+    config = create_config_class(provider)()
+    api_base, api_key = config._get_openai_compatible_provider_info(
+        api_base=None, api_key=None
+    )
+
+    assert api_base == "https://qianfan.baidubce.com/v2"
+    assert api_key is None
+    assert config.custom_llm_provider == "qianfan"
+
+
+def test_qianfan_provider_detection_by_prefix():
+    model, provider, _, api_base = litellm.get_llm_provider(
+        model="qianfan/ernie-4.5-turbo-128k"
+    )
+
+    assert provider == "qianfan"
+    assert model == "ernie-4.5-turbo-128k"
+    assert api_base == "https://qianfan.baidubce.com/v2"
+
+
+def test_qianfan_provider_detection_by_api_base_preserves_explicit_key():
+    model, provider, api_key, api_base = litellm.get_llm_provider(
+        model="ernie-4.5-turbo-128k",
+        api_base="https://qianfan.baidubce.com/v2",
+        api_key="test-qianfan-key",
+    )
+
+    assert model == "ernie-4.5-turbo-128k"
+    assert provider == "qianfan"
+    assert api_key == "test-qianfan-key"
+    assert api_base == "https://qianfan.baidubce.com/v2"
+
+
+def test_qianfan_provider_detection_by_api_base_prefers_explicit_key_over_env():
+    with patch.dict(os.environ, {"QIANFAN_API_KEY": "env-qianfan-key"}):
+        model, provider, api_key, api_base = litellm.get_llm_provider(
+            model="ernie-4.5-turbo-128k",
+            api_base="https://qianfan.baidubce.com/v2",
+            api_key="explicit-qianfan-key",
+        )
+
+    assert model == "ernie-4.5-turbo-128k"
+    assert provider == "qianfan"
+    assert api_key == "explicit-qianfan-key"
+    assert api_base == "https://qianfan.baidubce.com/v2"
+
+
+def test_qianfan_router_config():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "qianfan-router-model",
+                "litellm_params": {
+                    "model": "qianfan/ernie-4.5-turbo-128k",
+                    "api_key": "test-key",
+                },
+            }
+        ]
+    )
+
+    assert len(router.model_list) == 1
+    assert router.model_list[0]["model_name"] == "qianfan-router-model"
+    assert router.deployment_names == ["qianfan/ernie-4.5-turbo-128k"]
+
+
+def test_qianfan_provider_config_manager():
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="ernie-4.5-turbo-128k",
+        provider=LlmProviders.QIANFAN,
+    )
+
+    assert config is not None
+    assert config.custom_llm_provider == "qianfan"
+
+
+def test_qianfan_provider_config_manager_maps_max_completion_tokens():
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="ernie-4.5-turbo-128k",
+        provider=LlmProviders.QIANFAN,
+    )
+
+    mapped_params = config.map_openai_params(
+        non_default_params={
+            "max_completion_tokens": 123,
+            "temperature": 0.7,
+        },
+        optional_params={},
+        model="ernie-4.5-turbo-128k",
+        drop_params=False,
+    )
+
+    assert mapped_params["max_tokens"] == 123
+    assert "max_completion_tokens" not in mapped_params
+    assert mapped_params["temperature"] == 0.7


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Targeted local verification:

- `uv run pytest tests/test_litellm/llms/openai_like/test_qianfan.py tests/test_litellm/llms/openai_like/test_xiaomi_mimo.py tests/test_litellm/llms/openai_like/test_json_providers.py -q`
- Result: `21 passed, 5 skipped`

Additional local check:

- `uv run pytest tests/test_litellm/proxy/auth/test_admin_viewer_handler_access.py::test_get_config_callbacks_allows_admin_viewer -q`
- Result: `1 passed`

Provider documentation validation:

- added `qianfan` to `provider_endpoints_support.json`
- `uv run --no-sync python ./tests/code_coverage_tests/check_provider_folders_documented.py`
- Result: `All provider documentation checks passed`

Current suite-level blocker observed locally:

- `make test-unit` currently stops on `tests/test_litellm/proxy/auth/test_admin_viewer_handler_access.py::test_get_config_callbacks_allows_admin_viewer`
- The failure reproduces across full-suite runs but the same test passes in isolation, which suggests an existing suite-level or environment-related issue rather than a Qianfan-specific regression

## Type

🆕 New Feature
✅ Test

## Changes

## Summary

This PR adds official Qianfan support as an OpenAI-compatible provider in LiteLLM.

## What changed

- register `qianfan` in the OpenAI-like JSON provider registry
- set the default Qianfan base URL to `https://qianfan.baidubce.com/v2`
- expose `QIANFAN_API_KEY` and `QIANFAN_API_BASE` provider env vars
- map `max_completion_tokens` to `max_tokens` for Qianfan requests
- add `LlmProviders.QIANFAN`
- add Qianfan to the OpenAI-compatible provider and endpoint allowlists
- detect the official Qianfan `api_base` during provider resolution
- preserve explicit `api_key` precedence when the official Qianfan `api_base` is passed directly
- add targeted tests covering provider registration, detection, router wiring, and parameter mapping
- document `qianfan` in `provider_endpoints_support.json` so it is included in provider coverage validation

## Why

This enables first-class LiteLLM support for Qianfan's OpenAI-compatible API surface without requiring custom provider wiring.

## Reviewer notes

- Scope is intentionally limited to Qianfan provider registration, provider detection, and OpenAI-compatible parameter mapping.
- The provider resolution change follows the existing endpoint-detection pattern and keeps explicit `api_key` precedence over env fallback.
- No broader behavior changes are intended for other OpenAI-compatible providers.
