### PR TITLE
feat(mcp): add OAuth2 token exchange auth

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -366,6 +366,8 @@ class MCPClient:
                     headers["Authorization"] = f"Bearer {self._mcp_auth_value}"
                 elif self.auth_type == MCPAuth.token:
                     headers["Authorization"] = f"token {self._mcp_auth_value}"
+                elif self.auth_type == MCPAuth.oauth2_token_exchange:
+                    headers["Authorization"] = f"Bearer {self._mcp_auth_value}"
             elif isinstance(self._mcp_auth_value, dict):
                 headers.update(self._mcp_auth_value)
         # Note: aws_sigv4 auth is not handled here — SigV4 requires per-request

--- a/litellm/proxy/_experimental/mcp_server/auth/token_exchange.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/token_exchange.py
@@ -1,0 +1,197 @@
+"""
+OAuth 2.0 Token Exchange (RFC 8693) handler for MCP servers.
+
+Exchanges a user's incoming JWT (subject_token) for a scoped access token
+at an IDP's token exchange endpoint.  The exchanged token is then used to
+authenticate requests to the upstream MCP server.
+
+See: https://datatracker.ietf.org/doc/html/rfc8693
+"""
+
+import asyncio
+import hashlib
+import weakref
+from typing import TYPE_CHECKING, Dict, Tuple
+
+import httpx
+
+from litellm._logging import verbose_logger
+from litellm.caching.in_memory_cache import InMemoryCache
+from litellm.constants import (
+    MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL,
+    MCP_OAUTH2_TOKEN_CACHE_MAX_SIZE,
+    MCP_OAUTH2_TOKEN_CACHE_MIN_TTL,
+    MCP_OAUTH2_TOKEN_EXPIRY_BUFFER_SECONDS,
+)
+from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.types.llms.custom_http import httpxSpecialProvider
+
+if TYPE_CHECKING:
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+# RFC 8693 grant type constant
+TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+DEFAULT_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+
+class TokenExchangeHandler:
+    """Handles OAuth 2.0 Token Exchange (RFC 8693) for MCP servers.
+
+    Caches exchanged tokens keyed by ``hash(subject_token + server_id)`` so
+    repeated calls with the same user token skip the IDP round-trip.
+    """
+
+    def __init__(self) -> None:
+        self._cache = InMemoryCache(
+            max_size_in_memory=MCP_OAUTH2_TOKEN_CACHE_MAX_SIZE,
+            default_ttl=MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL,
+        )
+        # WeakValueDictionary so locks are GC'd once no coroutine holds a reference,
+        # preventing unbounded growth with many rotating user tokens.
+        self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+            weakref.WeakValueDictionary()
+        )
+
+    def _get_lock(self, cache_key: str) -> asyncio.Lock:
+        lock = self._locks.get(cache_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[cache_key] = lock
+        return lock
+
+    @staticmethod
+    def _cache_key(subject_token: str, server_id: str) -> str:
+        raw = f"{subject_token}:{server_id}"
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    async def exchange_token(
+        self,
+        subject_token: str,
+        server: "MCPServer",
+    ) -> str:
+        """Exchange *subject_token* for a scoped access token.
+
+        Returns the exchanged ``access_token`` string (suitable for a
+        ``Bearer`` header).
+
+        Raises ``ValueError`` on configuration or IDP errors.
+        """
+        cache_key = self._cache_key(subject_token, server.server_id)
+
+        # Fast path
+        cached = self._cache.get_cache(cache_key)
+        if cached is not None:
+            return cached
+
+        # Slow path — one exchange at a time per (user, server) pair
+        async with self._get_lock(cache_key):
+            cached = self._cache.get_cache(cache_key)
+            if cached is not None:
+                return cached
+
+            token, ttl = await self._do_exchange(subject_token, server)
+            self._cache.set_cache(cache_key, token, ttl=ttl)
+            return token
+
+    async def _do_exchange(
+        self,
+        subject_token: str,
+        server: "MCPServer",
+    ) -> Tuple[str, int]:
+        """POST to the token exchange endpoint with RFC 8693 parameters.
+
+        Returns ``(access_token, ttl_seconds)``.
+        """
+        endpoint = server.token_exchange_endpoint or server.token_url
+        if not endpoint:
+            raise ValueError(
+                f"MCP server '{server.server_id}' has auth_type=oauth2_token_exchange "
+                f"but no token_exchange_endpoint or token_url configured"
+            )
+        if not server.client_id or not server.client_secret:
+            raise ValueError(
+                f"MCP server '{server.server_id}' has auth_type=oauth2_token_exchange "
+                f"but missing client_id or client_secret"
+            )
+
+        data: Dict[str, str] = {
+            "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
+            "subject_token": subject_token,
+            "subject_token_type": server.subject_token_type
+            or DEFAULT_SUBJECT_TOKEN_TYPE,
+            "client_id": server.client_id,
+            "client_secret": server.client_secret,
+        }
+        if server.audience:
+            data["audience"] = server.audience
+        if server.scopes:
+            data["scope"] = " ".join(server.scopes)
+
+        verbose_logger.debug(
+            "Exchanging token for MCP server %s at %s (audience=%s)",
+            server.server_id,
+            endpoint,
+            server.audience,
+        )
+
+        client = get_async_httpx_client(llm_provider=httpxSpecialProvider.MCP)
+        try:
+            response = await client.post(endpoint, data=data)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            verbose_logger.debug(
+                "Token exchange IDP error for MCP server %s (status %d): %s",
+                server.server_id,
+                exc.response.status_code,
+                exc.response.text,
+            )
+            raise ValueError(
+                f"Token exchange for MCP server '{server.server_id}' "
+                f"failed with status {exc.response.status_code}"
+            ) from exc
+
+        body = response.json()
+        if not isinstance(body, dict):
+            raise ValueError(
+                f"Token exchange response for MCP server '{server.server_id}' "
+                f"returned non-object JSON (got {type(body).__name__})"
+            )
+
+        access_token = body.get("access_token")
+        if not access_token:
+            raise ValueError(
+                f"Token exchange response for MCP server '{server.server_id}' "
+                f"missing 'access_token'"
+            )
+
+        raw_expires_in = body.get("expires_in")
+        try:
+            expires_in = (
+                int(raw_expires_in)
+                if raw_expires_in is not None
+                else MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL
+            )
+        except (TypeError, ValueError):
+            expires_in = MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL
+
+        ttl = max(
+            expires_in - MCP_OAUTH2_TOKEN_EXPIRY_BUFFER_SECONDS,
+            MCP_OAUTH2_TOKEN_CACHE_MIN_TTL,
+        )
+
+        verbose_logger.info(
+            "Token exchange succeeded for MCP server %s (expires in %ds)",
+            server.server_id,
+            expires_in,
+        )
+        return access_token, ttl
+
+    def invalidate(self, subject_token: str, server_id: str) -> None:
+        """Remove a cached exchanged token (e.g. after a 401)."""
+        cache_key = self._cache_key(subject_token, server_id)
+        self._cache.delete_cache(cache_key)
+
+
+# Module-level singleton
+mcp_token_exchange_handler = TokenExchangeHandler()

--- a/litellm/proxy/_experimental/mcp_server/auth/token_exchange.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/token_exchange.py
@@ -150,6 +150,17 @@ class TokenExchangeHandler:
                 f"Token exchange for MCP server '{server.server_id}' "
                 f"failed with status {exc.response.status_code}"
             ) from exc
+        except httpx.RequestError as exc:
+            verbose_logger.debug(
+                "Token exchange request error for MCP server %s at %s: %s",
+                server.server_id,
+                endpoint,
+                exc,
+            )
+            raise ValueError(
+                f"Token exchange for MCP server '{server.server_id}' "
+                f"failed while connecting to the token endpoint"
+            ) from exc
 
         body = response.json()
         if not isinstance(body, dict):

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -411,6 +411,15 @@ class MCPServerManager:
                 aws_role_name=server_config.get("aws_role_name", None),
                 aws_session_name=server_config.get("aws_session_name", None),
                 instructions=server_config.get("instructions", None),
+                # Token Exchange (OBO) fields
+                token_exchange_endpoint=server_config.get(
+                    "token_exchange_endpoint", None
+                ),
+                audience=server_config.get("audience", None),
+                subject_token_type=server_config.get(
+                    "subject_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
             )
             self._assign_unique_short_prefix(new_server)
             self.config_mcp_servers[server_id] = new_server
@@ -765,6 +774,17 @@ class MCPServerManager:
             aws_role_name=aws_creds.get("aws_role_name"),
             aws_session_name=aws_creds.get("aws_session_name"),
             instructions=mcp_server.instructions,
+            # Token Exchange (OBO) fields — read from credentials JSON blob
+            token_exchange_endpoint=(
+                credentials_dict.get("token_exchange_endpoint")
+                if credentials_dict
+                else None
+            ),
+            audience=(credentials_dict.get("audience") if credentials_dict else None),
+            subject_token_type=(
+                credentials_dict.get("subject_token_type") if credentials_dict else None
+            )
+            or "urn:ietf:params:oauth:token-type:access_token",
         )
         return new_server
 
@@ -1136,6 +1156,29 @@ class MCPServerManager:
     #########################################################
     # Methods that call the upstream MCP servers
     #########################################################
+    @staticmethod
+    def _extract_bearer_token(
+        oauth2_headers: Optional[Dict[str, str]],
+        raw_headers: Optional[Dict[str, str]],
+    ) -> Optional[str]:
+        """Extract the bare Bearer token from oauth2_headers or raw_headers.
+
+        Returns the token string without the ``Bearer `` prefix, or ``None``
+        if no Authorization header is found.
+        """
+        auth_value: Optional[str] = None
+        if oauth2_headers and "Authorization" in oauth2_headers:
+            auth_value = oauth2_headers["Authorization"]
+        elif raw_headers:
+            # raw_headers may have lowercase keys depending on the ASGI server
+            normalized = {k.lower(): v for k, v in raw_headers.items()}
+            auth_value = normalized.get("authorization")
+        if auth_value:
+            if auth_value.startswith("Bearer "):
+                return auth_value[len("Bearer ") :]
+            return auth_value
+        return None
+
     def _build_stdio_env(
         self,
         server: MCPServer,
@@ -1169,25 +1212,30 @@ class MCPServerManager:
         mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         stdio_env: Optional[Dict[str, str]] = None,
+        subject_token: Optional[str] = None,
     ) -> MCPClient:
         """
         Create an MCPClient instance for the given server.
 
         Auth resolution (single place for all auth logic):
         1. ``mcp_auth_header`` — per-request/per-user override
-        2. OAuth2 client_credentials token — auto-fetched and cached
-        3. ``server.authentication_token`` — static token from config/DB
+        2. OAuth2 Token Exchange (OBO) — exchange user token for scoped token
+        3. OAuth2 client_credentials token — auto-fetched and cached
+        4. ``server.authentication_token`` — static token from config/DB
 
         Args:
             server: The server configuration.
             mcp_auth_header: Optional per-request auth override.
             extra_headers: Additional headers to forward.
             stdio_env: Environment variables for stdio transport.
+            subject_token: Optional user JWT for token exchange (OBO) flow.
 
         Returns:
             Configured MCP client instance.
         """
-        auth_value = await resolve_mcp_auth(server, mcp_auth_header)
+        auth_value = await resolve_mcp_auth(
+            server, mcp_auth_header, subject_token=subject_token
+        )
 
         transport = server.transport or MCPTransport.sse
 
@@ -2534,9 +2582,12 @@ class MCPServerManager:
         if server_auth_header is None:
             server_auth_header = mcp_auth_header
 
-        # oauth2 headers
+        # Extract subject token for OAuth2 Token Exchange (OBO) flow
+        subject_token: Optional[str] = None
         extra_headers: Optional[Dict[str, str]] = None
-        if mcp_server.auth_type == MCPAuth.oauth2:
+        if mcp_server.auth_type == MCPAuth.oauth2_token_exchange:
+            subject_token = self._extract_bearer_token(oauth2_headers, raw_headers)
+        elif mcp_server.auth_type == MCPAuth.oauth2:
             if mcp_server.has_client_credentials:
                 # For M2M OAuth servers, Authorization must come from token fetch.
                 extra_headers = None
@@ -2604,6 +2655,7 @@ class MCPServerManager:
             mcp_auth_header=server_auth_header,
             extra_headers=extra_headers,
             stdio_env=stdio_env,
+            subject_token=subject_token,
         )
 
         call_tool_params = MCPCallToolRequestParams(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1342,15 +1342,21 @@ class MCPServerManager:
 
             stdio_env = self._build_stdio_env(server, raw_headers)
 
-            create_client_kwargs = {
-                "server": server,
-                "mcp_auth_header": mcp_auth_header,
-                "extra_headers": extra_headers,
-                "stdio_env": stdio_env,
-            }
             if subject_token is not None:
-                create_client_kwargs["subject_token"] = subject_token
-            client = await self._create_mcp_client(**create_client_kwargs)
+                client = await self._create_mcp_client(
+                    server=server,
+                    mcp_auth_header=mcp_auth_header,
+                    extra_headers=extra_headers,
+                    stdio_env=stdio_env,
+                    subject_token=subject_token,
+                )
+            else:
+                client = await self._create_mcp_client(
+                    server=server,
+                    mcp_auth_header=mcp_auth_header,
+                    extra_headers=extra_headers,
+                    stdio_env=stdio_env,
+                )
 
             ## HANDLE OPENAPI TOOLS
             if server.spec_path:
@@ -2929,7 +2935,11 @@ class MCPServerManager:
             ) = split_server_prefix_from_name(tool_name)
             normalised_prefix = normalize_server_name(server_name_from_prefix)
             matched_server = prefix_to_server.get(normalised_prefix)
-            if matched_server is not None:
+            if matched_server is not None and (
+                matched_server.has_token_exchange_config
+                or original_tool_name in self.tool_name_to_mcp_server_name_mapping
+                or tool_name in self.tool_name_to_mcp_server_name_mapping
+            ):
                 return matched_server
 
         return None

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1313,6 +1313,7 @@ class MCPServerManager:
         extra_headers: Optional[Dict[str, str]] = None,
         add_prefix: bool = True,
         raw_headers: Optional[Dict[str, str]] = None,
+        subject_token: Optional[str] = None,
     ) -> List[MCPTool]:
         """
         Helper method to get tools from a single MCP server with prefixed names.
@@ -1341,12 +1342,15 @@ class MCPServerManager:
 
             stdio_env = self._build_stdio_env(server, raw_headers)
 
-            client = await self._create_mcp_client(
-                server=server,
-                mcp_auth_header=mcp_auth_header,
-                extra_headers=extra_headers,
-                stdio_env=stdio_env,
-            )
+            create_client_kwargs = {
+                "server": server,
+                "mcp_auth_header": mcp_auth_header,
+                "extra_headers": extra_headers,
+                "stdio_env": stdio_env,
+            }
+            if subject_token is not None:
+                create_client_kwargs["subject_token"] = subject_token
+            client = await self._create_mcp_client(**create_client_kwargs)
 
             ## HANDLE OPENAPI TOOLS
             if server.spec_path:
@@ -2872,8 +2876,8 @@ class MCPServerManager:
         Note: This now handles prefixed tool names
         """
         for server in self.get_registry().values():
-            if server.needs_user_oauth_token:
-                # Skip OAuth2 servers that rely on user-provided tokens
+            if server.needs_user_oauth_token or server.has_token_exchange_config:
+                # Skip servers that rely on request-time user tokens.
                 continue
             tools = await self._get_tools_from_server(server)
             for tool in tools:
@@ -2925,10 +2929,7 @@ class MCPServerManager:
             ) = split_server_prefix_from_name(tool_name)
             normalised_prefix = normalize_server_name(server_name_from_prefix)
             matched_server = prefix_to_server.get(normalised_prefix)
-            if matched_server is not None and (
-                original_tool_name in self.tool_name_to_mcp_server_name_mapping
-                or tool_name in self.tool_name_to_mcp_server_name_mapping
-            ):
+            if matched_server is not None:
                 return matched_server
 
         return None

--- a/litellm/proxy/_experimental/mcp_server/oauth2_token_cache.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth2_token_cache.py
@@ -115,6 +115,11 @@ class MCPOAuth2TokenCache(InMemoryCache):
                 f"OAuth2 token request for MCP server '{server.server_id}' "
                 f"failed with status {exc.response.status_code}"
             ) from exc
+        except httpx.RequestError as exc:
+            raise ValueError(
+                f"OAuth2 token request for MCP server '{server.server_id}' "
+                f"failed: {exc}"
+            ) from exc
 
         body = response.json()
 
@@ -283,18 +288,9 @@ async def resolve_mcp_auth(
             return await mcp_token_exchange_handler.exchange_token(
                 subject_token, server
             )
-        # No subject_token — fall back to client_credentials using the same client
-        # credentials and token_url so M2M scenarios still work.
-        if server.client_id and server.client_secret and server.token_url:
-            token, _ = await mcp_oauth2_token_cache._fetch_token(server)
-            return token
-        # OBO configured but no subject_token and missing client credentials — warn
-        # rather than silently proceeding unauthenticated.
-        verbose_logger.warning(
-            "MCP server '%s' is configured for token exchange (OBO) but no subject_token "
-            "was provided and client credentials (client_id/client_secret/token_url) are "
-            "incomplete. The request will proceed without authentication.",
-            server.server_id,
+        raise ValueError(
+            f"MCP server '{server.server_id}' is configured for OAuth2 token "
+            "exchange, but no subject_token was provided"
         )
     if server.has_client_credentials:
         return await mcp_oauth2_token_cache.async_get_token(server)

--- a/litellm/proxy/_experimental/mcp_server/oauth2_token_cache.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth2_token_cache.py
@@ -26,6 +26,9 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
+from litellm.proxy._experimental.mcp_server.auth.token_exchange import (
+    mcp_token_exchange_handler,
+)
 from litellm.types.llms.custom_http import httpxSpecialProvider
 
 if TYPE_CHECKING:
@@ -263,16 +266,36 @@ mcp_per_user_token_cache = MCPPerUserTokenCache()
 async def resolve_mcp_auth(
     server: "MCPServer",
     mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+    subject_token: Optional[str] = None,
 ) -> Optional[Union[str, Dict[str, str]]]:
     """Resolve the auth value for an MCP server.
 
     Priority:
     1. ``mcp_auth_header`` — per-request/per-user override
-    2. OAuth2 client_credentials token — auto-fetched and cached
-    3. ``server.authentication_token`` — static token from config/DB
+    2. OAuth2 Token Exchange (OBO / RFC 8693) — exchange user token for scoped token
+    3. OAuth2 client_credentials token — auto-fetched and cached
+    4. ``server.authentication_token`` — static token from config/DB
     """
     if mcp_auth_header:
         return mcp_auth_header
+    if server.has_token_exchange_config:
+        if subject_token:
+            return await mcp_token_exchange_handler.exchange_token(
+                subject_token, server
+            )
+        # No subject_token — fall back to client_credentials using the same client
+        # credentials and token_url so M2M scenarios still work.
+        if server.client_id and server.client_secret and server.token_url:
+            token, _ = await mcp_oauth2_token_cache._fetch_token(server)
+            return token
+        # OBO configured but no subject_token and missing client credentials — warn
+        # rather than silently proceeding unauthenticated.
+        verbose_logger.warning(
+            "MCP server '%s' is configured for token exchange (OBO) but no subject_token "
+            "was provided and client credentials (client_id/client_secret/token_url) are "
+            "incomplete. The request will proceed without authentication.",
+            server.server_id,
+        )
     if server.has_client_credentials:
         return await mcp_oauth2_token_cache.async_get_token(server)
     return server.authentication_token

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1347,19 +1347,23 @@ if MCP_AVAILABLE:
                     )
 
                 try:
-                    get_tools_kwargs = {
-                        "server": server,
-                        "mcp_auth_header": server_auth_header,
-                        "extra_headers": extra_headers,
-                        "add_prefix": True,  # Always add server prefix
-                        "raw_headers": raw_headers,
-                    }
                     if subject_token is not None:
-                        get_tools_kwargs["subject_token"] = subject_token
-
-                    tools = await global_mcp_server_manager._get_tools_from_server(
-                        **get_tools_kwargs
-                    )
+                        tools = await global_mcp_server_manager._get_tools_from_server(
+                            server=server,
+                            mcp_auth_header=server_auth_header,
+                            extra_headers=extra_headers,
+                            add_prefix=True,  # Always add server prefix
+                            raw_headers=raw_headers,
+                            subject_token=subject_token,
+                        )
+                    else:
+                        tools = await global_mcp_server_manager._get_tools_from_server(
+                            server=server,
+                            mcp_auth_header=server_auth_header,
+                            extra_headers=extra_headers,
+                            add_prefix=True,  # Always add server prefix
+                            raw_headers=raw_headers,
+                        )
                     filtered_tools = filter_tools_by_allowed_tools(tools, server)
 
                     filtered_tools = await filter_tools_by_key_team_permissions(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1339,13 +1339,26 @@ if MCP_AVAILABLE:
                         prefetched_creds=_prefetched_oauth_creds,
                     )
 
-                try:
-                    tools = await global_mcp_server_manager._get_tools_from_server(
-                        server=server,
-                        mcp_auth_header=server_auth_header,
-                        extra_headers=extra_headers,
-                        add_prefix=True,  # Always add server prefix
+                subject_token = None
+                if server.has_token_exchange_config:
+                    subject_token = MCPServerManager._extract_bearer_token(
+                        oauth2_headers=oauth2_headers,
                         raw_headers=raw_headers,
+                    )
+
+                try:
+                    get_tools_kwargs = {
+                        "server": server,
+                        "mcp_auth_header": server_auth_header,
+                        "extra_headers": extra_headers,
+                        "add_prefix": True,  # Always add server prefix
+                        "raw_headers": raw_headers,
+                    }
+                    if subject_token is not None:
+                        get_tools_kwargs["subject_token"] = subject_token
+
+                    tools = await global_mcp_server_manager._get_tools_from_server(
+                        **get_tools_kwargs
                     )
                     filtered_tools = filter_tools_by_allowed_tools(tools, server)
 

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -37,6 +37,7 @@ class MCPAuth(str, enum.Enum):
     oauth2 = "oauth2"
     aws_sigv4 = "aws_sigv4"
     token = "token"
+    oauth2_token_exchange = "oauth2_token_exchange"
 
 
 # MCP Literals
@@ -54,6 +55,7 @@ MCPAuthType = Optional[
         MCPAuth.oauth2,
         MCPAuth.aws_sigv4,
         MCPAuth.token,
+        MCPAuth.oauth2_token_exchange,
     ]
 ]
 
@@ -116,6 +118,22 @@ class MCPCredentials(TypedDict, total=False):
 
     aws_session_name: Optional[str]
     """Session name for STS AssumeRole (used in CloudTrail). Not a secret — stored unencrypted."""
+
+    audience: Optional[str]
+    """
+    Target audience for OAuth 2.0 Token Exchange (RFC 8693)
+    """
+
+    token_exchange_endpoint: Optional[str]
+    """
+    IDP token endpoint for OAuth 2.0 Token Exchange (RFC 8693)
+    """
+
+    subject_token_type: Optional[str]
+    """
+    Subject token type for OAuth 2.0 Token Exchange (RFC 8693).
+    Default: urn:ietf:params:oauth:token-type:access_token
+    """
 
 
 class MCPServerCostInfo(TypedDict, total=False):

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -57,6 +57,10 @@ class MCPServer(BaseModel):
     aws_service_name: Optional[str] = None  # defaults to "bedrock-agentcore"
     aws_role_name: Optional[str] = None  # IAM role ARN for STS AssumeRole
     aws_session_name: Optional[str] = None  # session name for CloudTrail auditing
+    # Token Exchange (OBO) fields — RFC 8693
+    token_exchange_endpoint: Optional[str] = None
+    audience: Optional[str] = None
+    subject_token_type: str = "urn:ietf:params:oauth:token-type:access_token"
     # Stdio-specific fields
     command: Optional[str] = None
     args: Optional[List[str]] = None
@@ -127,3 +131,12 @@ class MCPServer(BaseModel):
             return any(h.lower() in auth_header_names for h in self.extra_headers)
 
         return False
+
+    @property
+    def has_token_exchange_config(self) -> bool:
+        """True if this server is configured for OAuth2 token exchange (OBO / RFC 8693)."""
+        return (
+            self.auth_type == MCPAuth.oauth2_token_exchange
+            and bool(self.client_id and self.client_secret)
+            and bool(self.token_exchange_endpoint or self.token_url)
+        )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_token_exchange.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_token_exchange.py
@@ -18,6 +18,7 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
 )
 from litellm.proxy._experimental.mcp_server.oauth2_token_cache import (
+    MCPOAuth2TokenCache,
     resolve_mcp_auth,
 )
 from litellm.proxy._types import MCPTransport
@@ -206,6 +207,27 @@ async def test_exchange_token_http_error():
 
 
 @pytest.mark.asyncio
+async def test_exchange_token_request_error():
+    """Network errors from the IDP are wrapped in a ValueError."""
+    handler = TokenExchangeHandler()
+    server = _obo_server()
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.ConnectError(
+        "DNS failure",
+        request=httpx.Request("POST", server.token_exchange_endpoint),
+    )
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+            return_value=mock_client,
+        ),
+        pytest.raises(ValueError, match="failed while connecting"),
+    ):
+        await handler.exchange_token("bad-jwt", server)
+
+
+@pytest.mark.asyncio
 async def test_exchange_token_missing_access_token():
     """Response without access_token raises ValueError."""
     handler = TokenExchangeHandler()
@@ -267,23 +289,50 @@ async def test_resolve_mcp_auth_with_token_exchange():
 
 
 @pytest.mark.asyncio
-async def test_resolve_mcp_auth_obo_without_subject_token_falls_through():
-    """Without a subject_token, resolve_mcp_auth falls through to client_credentials."""
+async def test_resolve_mcp_auth_obo_without_subject_token_fails_closed():
+    """Without a subject_token, OBO auth fails closed instead of using shared credentials."""
     server = _obo_server(
         token_url="https://auth.example.com/token",
     )
     mock_client = AsyncMock()
     mock_client.post.return_value = _exchange_response("cc-token")
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.oauth2_token_cache.get_async_httpx_client",
-        return_value=mock_client,
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.oauth2_token_cache.get_async_httpx_client",
+            return_value=mock_client,
+        ),
+        pytest.raises(ValueError, match="no subject_token"),
     ):
-        result = await resolve_mcp_auth(server, subject_token=None)
+        await resolve_mcp_auth(server, subject_token=None)
 
-    # Falls through to client_credentials since subject_token is None
-    # The server has client_id/client_secret/token_url so has_client_credentials is True
-    assert result == "cc-token"
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_oauth2_client_credentials_request_error():
+    """OAuth2 client_credentials network errors are wrapped in a ValueError."""
+    token_cache = MCPOAuth2TokenCache()
+    server = _obo_server(
+        auth_type=MCPAuth.oauth2,
+        token_exchange_endpoint=None,
+        token_url="https://auth.example.com/token",
+        oauth2_flow="client_credentials",
+    )
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.ConnectError(
+        "DNS failure",
+        request=httpx.Request("POST", server.token_url),
+    )
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.oauth2_token_cache.get_async_httpx_client",
+            return_value=mock_client,
+        ),
+        pytest.raises(ValueError, match="failed"),
+    ):
+        await token_cache.async_get_token(server)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_token_exchange.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_token_exchange.py
@@ -1,0 +1,421 @@
+"""
+Tests for OAuth 2.0 Token Exchange (RFC 8693) handler for MCP servers.
+
+Covers: exchange flow, caching, error handling, resolve_mcp_auth integration,
+bearer token extraction, and config loading.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.proxy._experimental.mcp_server.auth.token_exchange import (
+    TOKEN_EXCHANGE_GRANT_TYPE,
+    TokenExchangeHandler,
+)
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+    MCPServerManager,
+)
+from litellm.proxy._experimental.mcp_server.oauth2_token_cache import (
+    resolve_mcp_auth,
+)
+from litellm.proxy._types import MCPTransport
+from litellm.types.mcp import MCPAuth
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+
+def _obo_server(**overrides) -> MCPServer:
+    defaults = dict(
+        server_id="srv-obo-1",
+        name="test-obo",
+        url="https://mcp.example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2_token_exchange,
+        client_id="litellm-client-id",
+        client_secret="litellm-client-secret",
+        token_exchange_endpoint="https://idp.example.com/oauth2/token",
+        audience="api://mcp-server",
+        scopes=["mcp.tools.read", "mcp.tools.execute"],
+    )
+    defaults.update(overrides)
+    return MCPServer(**defaults)
+
+
+def _exchange_response(token="exchanged-tok-abc", expires_in=3600):
+    resp = MagicMock()
+    resp.json.return_value = {
+        "access_token": token,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+    }
+    resp.raise_for_status = MagicMock()
+    resp.text = ""
+    return resp
+
+
+# ── Exchange Flow ──
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_success():
+    """Token exchange sends correct RFC 8693 parameters and returns access_token."""
+    handler = TokenExchangeHandler()
+    server = _obo_server()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _exchange_response("scoped-token-1")
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        result = await handler.exchange_token("user-jwt-xyz", server)
+
+    assert result == "scoped-token-1"
+    mock_client.post.assert_called_once()
+
+    _, kwargs = mock_client.post.call_args
+    data = kwargs["data"]
+    assert data["grant_type"] == TOKEN_EXCHANGE_GRANT_TYPE
+    assert data["subject_token"] == "user-jwt-xyz"
+    assert data["subject_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+    assert data["audience"] == "api://mcp-server"
+    assert data["scope"] == "mcp.tools.read mcp.tools.execute"
+    assert data["client_id"] == "litellm-client-id"
+    assert data["client_secret"] == "litellm-client-secret"
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_no_audience():
+    """When audience is None, it is omitted from the request."""
+    handler = TokenExchangeHandler()
+    server = _obo_server(audience=None)
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _exchange_response()
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        await handler.exchange_token("user-jwt", server)
+
+    _, kwargs = mock_client.post.call_args
+    assert "audience" not in kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_no_scopes():
+    """When scopes is None, scope param is omitted from the request."""
+    handler = TokenExchangeHandler()
+    server = _obo_server(scopes=None)
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _exchange_response()
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        await handler.exchange_token("user-jwt", server)
+
+    _, kwargs = mock_client.post.call_args
+    assert "scope" not in kwargs["data"]
+
+
+# ── Caching ──
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_cached():
+    """Second call with same user token uses cache — only 1 HTTP POST."""
+    handler = TokenExchangeHandler()
+    server = _obo_server()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _exchange_response("cached-exchange-tok")
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        t1 = await handler.exchange_token("same-jwt", server)
+        t2 = await handler.exchange_token("same-jwt", server)
+
+    assert t1 == t2 == "cached-exchange-tok"
+    assert mock_client.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_different_user_tokens_not_shared():
+    """Different user JWTs get different exchanged tokens."""
+    handler = TokenExchangeHandler()
+    server = _obo_server()
+    call_count = 0
+
+    async def mock_post(url, data=None):
+        nonlocal call_count
+        call_count += 1
+        resp = MagicMock()
+        resp.json.return_value = {
+            "access_token": f"exchanged-{call_count}",
+            "expires_in": 3600,
+        }
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    mock_client = AsyncMock()
+    mock_client.post = mock_post
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        t1 = await handler.exchange_token("user-a-jwt", server)
+        t2 = await handler.exchange_token("user-b-jwt", server)
+
+    assert t1 == "exchanged-1"
+    assert t2 == "exchanged-2"
+    assert call_count == 2
+
+
+# ── Error Handling ──
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_http_error():
+    """HTTP errors from the IDP are wrapped in a ValueError."""
+    handler = TokenExchangeHandler()
+    server = _obo_server()
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.text = "invalid_grant"
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Bad Request",
+        request=MagicMock(),
+        response=mock_response,
+    )
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+            return_value=mock_client,
+        ),
+        pytest.raises(ValueError, match="failed with status 400"),
+    ):
+        await handler.exchange_token("bad-jwt", server)
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_missing_access_token():
+    """Response without access_token raises ValueError."""
+    handler = TokenExchangeHandler()
+    server = _obo_server()
+    resp = MagicMock()
+    resp.json.return_value = {"token_type": "Bearer"}
+    resp.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = resp
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.auth.token_exchange.get_async_httpx_client",
+            return_value=mock_client,
+        ),
+        pytest.raises(ValueError, match="missing 'access_token'"),
+    ):
+        await handler.exchange_token("jwt", server)
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_missing_endpoint():
+    """Missing token_exchange_endpoint and token_url raises ValueError."""
+    handler = TokenExchangeHandler()
+    server = _obo_server(token_exchange_endpoint=None, token_url=None)
+
+    with pytest.raises(ValueError, match="no token_exchange_endpoint or token_url"):
+        await handler.exchange_token("jwt", server)
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_missing_credentials():
+    """Missing client_id or client_secret raises ValueError."""
+    handler = TokenExchangeHandler()
+    server = _obo_server(client_id=None, client_secret=None)
+    # has_token_exchange_config will be False, so we call _do_exchange directly
+    with pytest.raises(ValueError, match="missing client_id or client_secret"):
+        await handler._do_exchange("jwt", server)
+
+
+# ── resolve_mcp_auth Integration ──
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_auth_with_token_exchange():
+    """resolve_mcp_auth delegates to token exchange when server has OBO config and subject_token provided."""
+    server = _obo_server()
+    mock_handler = AsyncMock()
+    mock_handler.exchange_token.return_value = "obo-scoped-token"
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.oauth2_token_cache.mcp_token_exchange_handler",
+        mock_handler,
+    ):
+        result = await resolve_mcp_auth(server, subject_token="user-jwt")
+
+    assert result == "obo-scoped-token"
+    mock_handler.exchange_token.assert_called_once_with("user-jwt", server)
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_auth_obo_without_subject_token_falls_through():
+    """Without a subject_token, resolve_mcp_auth falls through to client_credentials."""
+    server = _obo_server(
+        token_url="https://auth.example.com/token",
+    )
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _exchange_response("cc-token")
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.oauth2_token_cache.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        result = await resolve_mcp_auth(server, subject_token=None)
+
+    # Falls through to client_credentials since subject_token is None
+    # The server has client_id/client_secret/token_url so has_client_credentials is True
+    assert result == "cc-token"
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_auth_header_beats_obo():
+    """An explicit mcp_auth_header takes priority over OBO token exchange."""
+    server = _obo_server()
+    result = await resolve_mcp_auth(
+        server, mcp_auth_header="Bearer override", subject_token="user-jwt"
+    )
+    assert result == "Bearer override"
+
+
+# ── Bearer Token Extraction ──
+
+
+def test_extract_bearer_token_from_oauth2_headers():
+    """Extracts token from oauth2_headers Authorization header."""
+    result = MCPServerManager._extract_bearer_token(
+        oauth2_headers={"Authorization": "Bearer my-jwt-token"},
+        raw_headers=None,
+    )
+    assert result == "my-jwt-token"
+
+
+def test_extract_bearer_token_from_raw_headers():
+    """Falls back to raw_headers when oauth2_headers missing."""
+    result = MCPServerManager._extract_bearer_token(
+        oauth2_headers=None,
+        raw_headers={"authorization": "Bearer raw-jwt"},
+    )
+    assert result == "raw-jwt"
+
+
+def test_extract_bearer_token_no_bearer_prefix():
+    """Returns token as-is when no Bearer prefix."""
+    result = MCPServerManager._extract_bearer_token(
+        oauth2_headers={"Authorization": "some-opaque-token"},
+        raw_headers=None,
+    )
+    assert result == "some-opaque-token"
+
+
+def test_extract_bearer_token_none():
+    """Returns None when no auth headers present."""
+    result = MCPServerManager._extract_bearer_token(
+        oauth2_headers=None,
+        raw_headers=None,
+    )
+    assert result is None
+
+
+# ── MCPServer Properties ──
+
+
+def test_has_token_exchange_config_true():
+    """has_token_exchange_config is True for a fully configured OBO server."""
+    server = _obo_server()
+    assert server.has_token_exchange_config is True
+
+
+def test_has_token_exchange_config_false_wrong_auth_type():
+    """has_token_exchange_config is False when auth_type is not oauth2_token_exchange."""
+    server = _obo_server(auth_type=MCPAuth.oauth2)
+    assert server.has_token_exchange_config is False
+
+
+def test_has_token_exchange_config_false_missing_creds():
+    """has_token_exchange_config is False when client_id/client_secret missing."""
+    server = _obo_server(client_id=None)
+    assert server.has_token_exchange_config is False
+
+
+def test_has_token_exchange_config_uses_token_url_fallback():
+    """has_token_exchange_config is True when token_url is set instead of token_exchange_endpoint."""
+    server = _obo_server(
+        token_exchange_endpoint=None,
+        token_url="https://idp.example.com/token",
+    )
+    assert server.has_token_exchange_config is True
+
+
+# ── Config Loading ──
+
+
+@pytest.mark.asyncio
+async def test_config_loading_token_exchange_fields():
+    """load_servers_from_config correctly maps OBO config fields to MCPServer."""
+    manager = MCPServerManager()
+    config = {
+        "my_obo_server": {
+            "url": "https://mcp.example.com/mcp",
+            "transport": "http",
+            "auth_type": "oauth2_token_exchange",
+            "client_id": "my-client",
+            "client_secret": "my-secret",
+            "token_exchange_endpoint": "https://idp.example.com/oauth2/token",
+            "audience": "api://my-mcp",
+            "scopes": ["read", "write"],
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        }
+    }
+    await manager.load_servers_from_config(config)
+
+    servers = list(manager.config_mcp_servers.values())
+    assert len(servers) == 1
+
+    server = servers[0]
+    assert server.auth_type == MCPAuth.oauth2_token_exchange
+    assert server.token_exchange_endpoint == "https://idp.example.com/oauth2/token"
+    assert server.audience == "api://my-mcp"
+    assert server.subject_token_type == "urn:ietf:params:oauth:token-type:jwt"
+    assert server.client_id == "my-client"
+    assert server.client_secret == "my-secret"
+    assert server.scopes == ["read", "write"]
+    assert server.has_token_exchange_config is True
+
+
+@pytest.mark.asyncio
+async def test_config_loading_default_subject_token_type():
+    """subject_token_type defaults to access_token when not specified in config."""
+    manager = MCPServerManager()
+    config = {
+        "obo_defaults": {
+            "url": "https://mcp.example.com/mcp",
+            "transport": "http",
+            "auth_type": "oauth2_token_exchange",
+            "client_id": "cid",
+            "client_secret": "csec",
+            "token_exchange_endpoint": "https://idp.example.com/token",
+        }
+    }
+    await manager.load_servers_from_config(config)
+
+    server = list(manager.config_mcp_servers.values())[0]
+    assert server.subject_token_type == "urn:ietf:params:oauth:token-type:access_token"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
 
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
 from litellm.proxy._types import UserAPIKeyAuth
@@ -549,7 +548,11 @@ class TestHookHeaderMergePriority:
         captured_extra_headers: Dict[str, Any] = {}
 
         async def fake_create_mcp_client(
-            server, mcp_auth_header=None, extra_headers=None, stdio_env=None
+            server,
+            mcp_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token=None,
         ):
             captured_extra_headers["value"] = extra_headers
             mock_client = MagicMock()
@@ -589,7 +592,11 @@ class TestHookHeaderMergePriority:
         captured_extra_headers: Dict[str, Any] = {}
 
         async def fake_create_mcp_client(
-            server, mcp_auth_header=None, extra_headers=None, stdio_env=None
+            server,
+            mcp_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token=None,
         ):
             captured_extra_headers["value"] = extra_headers
             mock_client = MagicMock()
@@ -635,7 +642,11 @@ class TestHookHeaderMergePriority:
         captured_extra_headers: Dict[str, Any] = {}
 
         async def fake_create_mcp_client(
-            server, mcp_auth_header=None, extra_headers=None, stdio_env=None
+            server,
+            mcp_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token=None,
         ):
             captured_extra_headers["value"] = extra_headers
             mock_client = MagicMock()
@@ -691,7 +702,11 @@ class TestHookHeaderMergePriority:
         captured_extra_headers: Dict[str, Any] = {}
 
         async def fake_create_mcp_client(
-            server, mcp_auth_header=None, extra_headers=None, stdio_env=None
+            server,
+            mcp_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token=None,
         ):
             captured_extra_headers["value"] = extra_headers
             mock_client = MagicMock()
@@ -739,7 +754,11 @@ class TestHookHeaderMergePriority:
         captured_extra_headers: Dict[str, Any] = {}
 
         async def fake_create_mcp_client(
-            server, mcp_auth_header=None, extra_headers=None, stdio_env=None
+            server,
+            mcp_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token=None,
         ):
             captured_extra_headers["value"] = extra_headers
             mock_client = MagicMock()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1296,6 +1296,71 @@ async def test_oauth2_headers_passed_to_mcp_client():
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
+async def test_obo_subject_token_passed_to_list_tools_fetch():
+    """OBO list_tools should exchange the caller token instead of routing with no auth."""
+    try:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+            set_auth_context,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+        from mcp.types import Tool as MCPTool
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    global_mcp_server_manager.registry.clear()
+    obo_server = MCPServer(
+        server_id="obo-server-id",
+        name="obo_server",
+        alias="obo_server",
+        transport=MCPTransport.http,
+        url="https://mcp.example.com/mcp",
+        auth_type=MCPAuth.oauth2_token_exchange,
+        client_id="client-id",
+        client_secret="client-secret",
+        token_exchange_endpoint="https://idp.example.com/token",
+    )
+    global_mcp_server_manager.registry[obo_server.server_id] = obo_server
+
+    user_api_key_auth = UserAPIKeyAuth(api_key="test_key", user_id="test_user")
+    oauth2_headers = {"Authorization": "Bearer caller-jwt"}
+    set_auth_context(user_api_key_auth=user_api_key_auth, oauth2_headers=oauth2_headers)
+
+    tool = MCPTool(name="obo_server-whoami", description="", inputSchema={})
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._get_allowed_mcp_servers",
+            AsyncMock(return_value=[obo_server]),
+        ),
+        patch.object(
+            global_mcp_server_manager,
+            "_get_tools_from_server",
+            new=AsyncMock(return_value=[tool]),
+        ) as mock_get_tools,
+    ):
+        tools = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=None,
+            mcp_servers=None,
+            oauth2_headers=oauth2_headers,
+        )
+
+    mock_get_tools.assert_awaited_once()
+    call_kwargs = mock_get_tools.await_args.kwargs
+    assert call_kwargs["subject_token"] == "caller-jwt"
+    assert call_kwargs["mcp_auth_header"] is None
+    assert call_kwargs["extra_headers"] is None
+    assert tools == [tool]
+
+
+@pytest.mark.asyncio
 async def test_list_tools_single_server_unprefixed_names():
     """When only one MCP server is allowed, list tools should return prefixed names (server prefix is always added)."""
     try:
@@ -2946,7 +3011,7 @@ async def test_list_tools_with_legacy_db_m2m_server_resolves_oauth2_flow():
     """
     P1 Regression: list_tools path must apply _resolve_oauth2_flow to legacy DB
     rows where oauth2_flow is NULL but M2M credentials are present.
-    
+
     Without this fix, has_client_credentials returns False and the caller's
     Authorization header is forwarded upstream instead of being blocked.
     """
@@ -3044,7 +3109,7 @@ async def test_call_tool_empty_extra_headers_returns_none():
     """
     P2 Regression: When all configured extra_headers are filtered out (e.g.
     Authorization for M2M), the resulting extra_headers should be None, not {}.
-    
+
     Downstream code that checks `if extra_headers is None` will behave
     differently if an empty dict is passed instead.
     """
@@ -3071,7 +3136,10 @@ async def test_call_tool_empty_extra_headers_returns_none():
         extra_headers=["Authorization"],  # Will be filtered out for M2M
     )
 
-    raw_headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
+    raw_headers = {
+        "Authorization": "Bearer sk-1234",
+        "Content-Type": "application/json",
+    }
 
     captured_extra_headers = None
 
@@ -3108,8 +3176,8 @@ async def test_call_tool_empty_extra_headers_returns_none():
             pass  # We only care about the captured headers
 
     # With P2 fix: extra_headers should be None (not {}) when all headers filtered
-    assert captured_extra_headers is None, (
-        "P2 API consistency issue: expected None for empty extra_headers, got: "
-        + str(captured_extra_headers)
+    assert (
+        captured_extra_headers is None
+    ), "P2 API consistency issue: expected None for empty extra_headers, got: " + str(
+        captured_extra_headers
     )
-

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1870,6 +1870,49 @@ class TestMCPServerManager:
         assert resolved_server_pref is not None
         assert resolved_server_pref.server_id == server.server_id
 
+    def test_get_mcp_server_from_prefixed_token_exchange_tool_without_mapping(self):
+        """OBO servers are not discovered at startup, but prefixed calls can still route."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="obo-server",
+            name="obo_server",
+            alias="obo_server",
+            server_name="obo_server",
+            url="https://mcp.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            client_id="client-id",
+            client_secret="client-secret",
+            token_exchange_endpoint="https://idp.example.com/token",
+        )
+        manager.config_mcp_servers = {server.server_id: server}
+
+        resolved_server = manager._get_mcp_server_from_tool_name("obo_server-whoami")
+
+        assert resolved_server is not None
+        assert resolved_server.server_id == server.server_id
+
+    @pytest.mark.asyncio
+    async def test_initialize_mapping_skips_token_exchange_servers(self):
+        """Startup discovery must not call OBO servers without a request subject token."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="obo-server",
+            name="obo_server",
+            url="https://mcp.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            client_id="client-id",
+            client_secret="client-secret",
+            token_exchange_endpoint="https://idp.example.com/token",
+        )
+        manager.config_mcp_servers = {server.server_id: server}
+        manager._get_tools_from_server = AsyncMock()
+
+        await manager._initialize_tool_name_to_mcp_server_name_mapping()
+
+        manager._get_tools_from_server.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_rest_endpoint_filters_by_allowed_tools(self):
         """Test that REST endpoint _get_tools_for_single_server respects allowed_tools configuration"""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -450,7 +450,7 @@ class TestMCPServerManager:
         captured_extra_headers = None
 
         async def capture_create_mcp_client(
-            server, mcp_auth_header, extra_headers, stdio_env
+            server, mcp_auth_header, extra_headers, stdio_env, subject_token=None
         ):  # pragma: no cover - helper
             nonlocal captured_extra_headers
             captured_extra_headers = extra_headers
@@ -1860,7 +1860,6 @@ class TestMCPServerManager:
 
         # Unprefixed resolution
         resolved_server_unpref = manager._get_mcp_server_from_tool_name("create_zap")
-        print(resolved_server_unpref)
         assert resolved_server_unpref is not None
         assert resolved_server_unpref.server_id == server.server_id
 


### PR DESCRIPTION
## Summary
Adds `oauth2_token_exchange` support for MCP servers using RFC 8693 token exchange. The proxy extracts the caller bearer token, exchanges it for a scoped MCP-server token, caches exchanged tokens per subject/server, and forwards the exchanged token to upstream MCP clients. Follow-up review fixes make OBO fail closed without a subject token, wrap token endpoint network errors, and keep token-exchange tool routing/listing functional without unauthenticated startup discovery.

## Repro
On `litellm_internal_staging`, this dependency-free repro fails because the auth type is missing:

```bash
python3 - <<'PY_REPRO'
import ast
from pathlib import Path

source = Path('litellm/types/mcp.py').read_text()
module = ast.parse(source)
values = []
for node in module.body:
    if isinstance(node, ast.ClassDef) and node.name == 'MCPAuth':
        for stmt in node.body:
            if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant):
                values.append(stmt.value.value)
assert 'oauth2_token_exchange' in values, 'oauth2_token_exchange auth type is missing'
PY_REPRO
```

## Evidence
Terminal evidence transcript: <a href="/opt/cursor/artifacts/mcp_token_exchange_test_evidence.txt">mcp_token_exchange_test_evidence.txt</a>

E2E OBO demo video: <video src="/opt/cursor/artifacts/mcp_obo_token_exchange_e2e_terminal_demo.mp4"></video>

## Tests
- `python3` AST baseline repro: failed before patch with `AssertionError: oauth2_token_exchange auth type is missing`; passes after patch.
- `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/test_token_exchange.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q` -> `232 passed in 60.63s`
- `uv run pytest tests/mcp_tests/test_mcp_server.py::test_mcp_http_transport_tool_not_found ...` affected routing tests -> passed.
- `uv run mypy proxy/_experimental/mcp_server/mcp_server_manager.py proxy/_experimental/mcp_server/server.py` -> `Success: no issues found in 2 source files`
- `uv run ruff check <changed files>` -> `All checks passed!`
- E2E mock IDP/MCP demo: PASS; IDP receives the caller JWT as `subject_token`, MCP receives only the exchanged token.
- Latest CI snapshot: 42 successful checks, 1 neutral review check, 0 failures.
- Greptile confidence score: 5/5.

## Relevant issues

Closes #21141. Refile of #26993 against `litellm_internal_staging`.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [x] Branch creation CI run  
       Link: https://github.com/BerriAI/litellm/pull/27306

- [x] CI run for the last commit  
       Link: https://github.com/BerriAI/litellm/pull/27306

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

See `## Evidence`.

## Type

New Feature
Test

## Changes

- Added MCP auth type/config fields for OAuth2 token exchange.
- Added `TokenExchangeHandler` with per-subject/server caching and RFC 8693 request construction.
- Threaded caller bearer-token extraction through MCP tool calls and MCP client auth headers.
- Fail closed for OBO servers when no subject token is available instead of falling back to shared client credentials.
- Wrapped token endpoint network/request errors as `ValueError`.
- Preserved token-exchange server routing/list-tools behavior when startup discovery cannot run without a request token.
- Added focused unit coverage for exchange success, caching, error handling, config loading, auth resolution, header extraction, fail-closed behavior, and OBO routing/listing.
