### PR TITLE
Fix Vertex Anthropic streaming status error hangs

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -135,6 +135,10 @@ _DEFAULT_TIMEOUT = httpx.Timeout(
     connect=HTTP_HANDLER_CONNECT_TIMEOUT_SECONDS,
 )
 _STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS = 5.0
+_STREAMING_ERROR_BODY_READ_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=50,
+    thread_name_prefix="litellm-streaming-error-body-read",
+)
 
 
 def _prepare_request_data_and_content(
@@ -406,15 +410,12 @@ def _safe_read_response(
     """Safely read sync response body, falling back to empty bytes on errors."""
     try:
         if timeout is not None:
-            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            future = executor.submit(response.read)
+            future = _STREAMING_ERROR_BODY_READ_EXECUTOR.submit(response.read)
             try:
                 return future.result(timeout=timeout)
             except Exception:
                 response.close()
                 return b""
-            finally:
-                executor.shutdown(wait=False, cancel_futures=True)
         return response.read()
     except Exception:
         return b""

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import inspect
 import os
 import socket
@@ -399,9 +400,21 @@ async def _safe_aread_response(
         return b""
 
 
-def _safe_read_response(response: httpx.Response) -> bytes:
+def _safe_read_response(
+    response: httpx.Response, timeout: Optional[float] = None
+) -> bytes:
     """Safely read sync response body, falling back to empty bytes on errors."""
     try:
+        if timeout is not None:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(response.read)
+            try:
+                return future.result(timeout=timeout)
+            except Exception:
+                response.close()
+                return b""
+            finally:
+                executor.shutdown(wait=False, cancel_futures=True)
         return response.read()
     except Exception:
         return b""
@@ -410,8 +423,19 @@ def _safe_read_response(response: httpx.Response) -> bytes:
 def _raise_masked_sync_error(e: httpx.HTTPStatusError, stream: bool) -> None:
     """Raise a MaskedHTTPStatusError for sync HTTP handlers."""
     if stream:
-        _body = mask_sensitive_info(_safe_read_response(e.response))
-        raise MaskedHTTPStatusError(e, message=_body, text=_body) from None
+        try:
+            _body = mask_sensitive_info(
+                _safe_read_response(
+                    e.response,
+                    timeout=_STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS,
+                )
+            )
+            raise MaskedHTTPStatusError(e, message=_body, text=_body) from None
+        finally:
+            try:
+                e.response.close()
+            except Exception:
+                pass
     _text = mask_sensitive_info(_safe_get_response_text(e.response))
     raise MaskedHTTPStatusError(e, message=_text, text=_text) from None
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -133,6 +133,7 @@ _DEFAULT_TIMEOUT = httpx.Timeout(
     timeout=COMPLETION_HTTP_FALLBACK_SECONDS,
     connect=HTTP_HANDLER_CONNECT_TIMEOUT_SECONDS,
 )
+_STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS = 5.0
 
 
 def _prepare_request_data_and_content(
@@ -386,9 +387,13 @@ def _safe_get_response_text(response: httpx.Response) -> str:
         return ""
 
 
-async def _safe_aread_response(response: httpx.Response) -> bytes:
+async def _safe_aread_response(
+    response: httpx.Response, timeout: Optional[float] = None
+) -> bytes:
     """Safely read async response body, falling back to empty bytes on errors."""
     try:
+        if timeout is not None:
+            return await asyncio.wait_for(response.aread(), timeout=timeout)
         return await response.aread()
     except Exception:
         return b""
@@ -414,8 +419,19 @@ def _raise_masked_sync_error(e: httpx.HTTPStatusError, stream: bool) -> None:
 async def _raise_masked_async_error(e: httpx.HTTPStatusError, stream: bool) -> None:
     """Raise a MaskedHTTPStatusError for async HTTP handlers."""
     if stream:
-        _body = mask_sensitive_info(await _safe_aread_response(e.response))
-        raise MaskedHTTPStatusError(e, message=_body, text=_body) from None
+        try:
+            _body = mask_sensitive_info(
+                await _safe_aread_response(
+                    e.response,
+                    timeout=_STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS,
+                )
+            )
+            raise MaskedHTTPStatusError(e, message=_body, text=_body) from None
+        finally:
+            try:
+                await e.response.aclose()
+            except Exception:
+                pass
     _text = mask_sensitive_info(_safe_get_response_text(e.response))
     raise MaskedHTTPStatusError(e, message=_text, text=_text) from None
 

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import os
 import pathlib
@@ -18,9 +19,60 @@ from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
+    MaskedHTTPStatusError,
     _get_httpx_client,
     get_ssl_configuration,
 )
+
+
+@pytest.mark.asyncio
+async def test_async_post_streaming_status_error_should_not_wait_forever_for_body(
+    monkeypatch,
+):
+    """
+    Vertex Anthropic streamRawPredict can return a pre-stream 4xx where the
+    streamed error body never terminates. The handler must still surface the
+    status promptly instead of blocking the downstream client.
+    """
+
+    class HangingErrorStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            await asyncio.Event().wait()
+            if False:
+                yield b""
+
+    async def mock_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            request=request,
+            headers={"content-type": "application/json"},
+            stream=HangingErrorStream(),
+        )
+
+    monkeypatch.setattr(
+        "litellm.llms.custom_httpx.http_handler._STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    litellm_handler = AsyncHTTPHandler()
+    await litellm_handler.client.aclose()
+    litellm_handler.client = httpx.AsyncClient(
+        transport=httpx.MockTransport(mock_handler)
+    )
+    try:
+        with pytest.raises(MaskedHTTPStatusError) as exc_info:
+            await asyncio.wait_for(
+                litellm_handler.post(
+                    "https://vertex.example/streamRawPredict",
+                    stream=True,
+                ),
+                timeout=0.2,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.response.status_code == 400
+    finally:
+        await litellm_handler.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import ssl
 import sys
+import threading
 from unittest.mock import MagicMock, patch
 
 import certifi
@@ -73,6 +74,55 @@ async def test_async_post_streaming_status_error_should_not_wait_forever_for_bod
         assert exc_info.value.response.status_code == 400
     finally:
         await litellm_handler.close()
+
+
+def test_sync_post_streaming_status_error_should_not_wait_forever_for_body(
+    monkeypatch,
+):
+    """
+    Keep the sync streaming error path aligned with the async path so a
+    non-terminating streamed error body cannot block a worker thread forever.
+    """
+
+    class HangingSyncErrorStream(httpx.SyncByteStream):
+        def __init__(self):
+            self.closed_event = threading.Event()
+
+        def __iter__(self):
+            self.closed_event.wait()
+            if False:
+                yield b""
+
+        def close(self):
+            self.closed_event.set()
+
+    def mock_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            request=request,
+            headers={"content-type": "application/json"},
+            stream=HangingSyncErrorStream(),
+        )
+
+    monkeypatch.setattr(
+        "litellm.llms.custom_httpx.http_handler._STREAMING_ERROR_BODY_READ_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    litellm_handler = HTTPHandler()
+    litellm_handler.client.close()
+    litellm_handler.client = httpx.Client(transport=httpx.MockTransport(mock_handler))
+    try:
+        with pytest.raises(MaskedHTTPStatusError) as exc_info:
+            litellm_handler.post(
+                "https://vertex.example/streamRawPredict",
+                stream=True,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.response.status_code == 400
+    finally:
+        litellm_handler.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Streaming HTTP status errors from upstream providers were trying to fully read the streamed error body before raising. If Vertex Anthropic returned a pre-stream 400 whose response body did not terminate, that read could block the proxy request handler and leave downstream clients hanging. This caps streamed error-body reads for both async and sync handlers, closes the upstream error response, and still raises a status-bearing `MaskedHTTPStatusError` promptly. The sync fallback uses a shared capped executor so stuck sync body reads cannot create unbounded worker threads.

## Repro
On the starting ref, run this focused repro after installing test dependencies:

```bash
. .venv/bin/activate && python - <<'PY'
import asyncio
import httpx
from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler

class HangingErrorStream(httpx.AsyncByteStream):
    async def __aiter__(self):
        await asyncio.Event().wait()
        if False:
            yield b''

async def main():
    async def handler(request: httpx.Request) -> httpx.Response:
        return httpx.Response(400, request=request, stream=HangingErrorStream())

    litellm_handler = AsyncHTTPHandler()
    await litellm_handler.client.aclose()
    litellm_handler.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
    try:
        await asyncio.wait_for(
            litellm_handler.post("https://vertex.example/streamRawPredict", stream=True),
            timeout=0.25,
        )
    except asyncio.TimeoutError:
        print("REPRODUCED: streaming 400 body read does not return promptly")
    finally:
        await litellm_handler.close()

asyncio.run(main())
PY
```

## Evidence
This is a terminal/library fix, so there is no meaningful UI screenshot/GIF. I ran the same synthetic Vertex-style pre-stream 400 with a non-terminating streamed body against the base ref and this PR branch:

```text
BEFORE base origin/litellm_internal_staging
module=/tmp/litellm-repro-base/litellm/llms/custom_httpx/http_handler.py
REPRODUCED: timed out after 0.258s waiting for status error

AFTER PR branch litellm_vertex-anthropic-stream-error-8aa7
module=/workspace/litellm/llms/custom_httpx/http_handler.py
FIXED: raised status=400 in 0.014s
```

Additional post-fix test transcript after addressing Greptile and Mateo comments:

```text
$ . .venv/bin/activate && pytest tests/test_litellm/llms/custom_httpx/test_http_handler.py::test_async_post_streaming_status_error_should_not_wait_forever_for_body tests/test_litellm/llms/custom_httpx/test_http_handler.py::test_sync_post_streaming_status_error_should_not_wait_forever_for_body -q
..                                                                       [100%]
2 passed in 0.24s

$ . .venv/bin/activate && pytest tests/test_litellm/llms/custom_httpx tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py -q
........................................................................ [ 52%]
.................................................................        [100%]
137 passed in 43.25s
```

## Tests
- Added `test_async_post_streaming_status_error_should_not_wait_forever_for_body` in `tests/test_litellm/llms/custom_httpx/test_http_handler.py`.
- Added `test_sync_post_streaming_status_error_should_not_wait_forever_for_body` for Greptile's sync-path comment.
- `pytest tests/test_litellm/llms/custom_httpx/test_http_handler.py::test_async_post_streaming_status_error_should_not_wait_forever_for_body tests/test_litellm/llms/custom_httpx/test_http_handler.py::test_sync_post_streaming_status_error_should_not_wait_forever_for_body -q` -> `2 passed`.
- `pytest tests/test_litellm/llms/custom_httpx tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py -q` -> `137 passed`.
- Attempted broader `pytest tests/test_litellm/ -x -q`; it stops during collection at `tests/test_litellm/a2a_protocol/test_card_resolver.py` with `TypeError: NoneType takes no arguments`, caused by the local environment missing the A2A resolver dependency path, before reaching this change.

## Relevant issues

Fixes streaming pre-response Vertex Anthropic 400 hangs.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, **Adding at least 1 test is a hard requirement**
- [ ] My PR passes all unit tests on `make test-unit` (see collection failure noted above)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
✅ Test

## Changes

- Bound streamed error body reads when masking async HTTP status errors.
- Bound streamed error body reads when masking sync HTTP status errors, addressing Greptile's review comment.
- Use a shared capped executor for sync error body reads, addressing Mateo's review comment about unbounded stuck worker threads.
- Close upstream streamed error responses on the error path.
- Added regression tests for non-terminating pre-stream 400 response bodies in both async and sync handlers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5700bab-7a24-4bee-af54-381131518aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5700bab-7a24-4bee-af54-381131518aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

