### PR TITLE
fix(langfuse): introspect Langfuse.__init__ signature for sdk_integration kwarg

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -1,5 +1,6 @@
 #### What this does ####
 #    On success, logs events to Langfuse
+import inspect
 import os
 import traceback
 from datetime import datetime
@@ -113,6 +114,26 @@ def resolve_langfuse_credentials(
     return public_key, secret_key, resolved_host
 
 
+def _langfuse_init_supports_sdk_integration() -> bool:
+    """
+    Whether the installed Langfuse SDK's ``Langfuse.__init__`` accepts the
+    ``sdk_integration`` kwarg.
+
+    The kwarg was added in Langfuse 2.6.0 and removed in Langfuse 3.x. We
+    detect by signature introspection rather than version-string comparison
+    so the gate stays correct across past and future SDK releases.
+
+    See: https://github.com/BerriAI/litellm/issues/13137
+    """
+    from langfuse import Langfuse
+
+    try:
+        params = inspect.signature(Langfuse.__init__).parameters
+    except (TypeError, ValueError):
+        return False
+    return "sdk_integration" in params
+
+
 class LangFuseLogger:
     # Class variables or attributes
     def __init__(
@@ -169,7 +190,7 @@ class LangFuseLogger:
         }
         self.langfuse_sdk_version: str = langfuse.version.__version__
 
-        if Version(self.langfuse_sdk_version) >= Version("2.6.0"):
+        if _langfuse_init_supports_sdk_integration():
             parameters["sdk_integration"] = "litellm"
         self.Langfuse: Langfuse = self.safe_init_langfuse_client(parameters)
 

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -6,7 +6,6 @@ import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
-from packaging.version import Version
 from typing_extensions import TypeAlias
 
 from litellm.integrations.custom_logger import CustomLogger
@@ -20,7 +19,11 @@ from ...litellm_core_utils.specialty_caches.dynamic_logging_cache import (
     DynamicLoggingCache,
 )
 from ..prompt_management_base import PromptManagementBase
-from .langfuse import LangFuseLogger, resolve_langfuse_credentials
+from .langfuse import (
+    LangFuseLogger,
+    _langfuse_init_supports_sdk_integration,
+    resolve_langfuse_credentials,
+)
 from .langfuse_handler import LangFuseHandler
 
 if TYPE_CHECKING:
@@ -64,7 +67,6 @@ def langfuse_client_init(
         Exception: If langfuse package is not installed
     """
     try:
-        import langfuse
         from langfuse import Langfuse
     except Exception as e:
         raise Exception(
@@ -99,7 +101,7 @@ def langfuse_client_init(
         ),  # flush interval in seconds
     }
 
-    if Version(langfuse.version.__version__) >= Version("2.6.0"):
+    if _langfuse_init_supports_sdk_integration():
         parameters["sdk_integration"] = "litellm"
 
     client = Langfuse(**parameters)

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -19,6 +19,143 @@ from litellm.integrations.langfuse.langfuse import LangFuseLogger
 from litellm.types.integrations.langfuse import *
 
 
+def _make_fake_langfuse_module(langfuse_class):
+    """Build a stand-in for the langfuse package — only what LangFuseLogger / langfuse_client_init touch at init time."""
+    module = MagicMock()
+    module.Langfuse = langfuse_class
+    module.version = MagicMock()
+    module.version.__version__ = "3.14.0"
+    return module
+
+
+class _FakeLangfuseV3:
+    """Mimics Langfuse SDK v3.x: no ``sdk_integration`` kwarg, no ``**kwargs`` catchall."""
+
+    def __init__(
+        self,
+        public_key=None,
+        secret_key=None,
+        host=None,
+        release=None,
+        debug=None,
+        flush_interval=None,
+        httpx_client=None,
+        environment=None,
+    ):
+        self.public_key = public_key
+        self.client = MagicMock()
+        self.client.projects.get.side_effect = Exception("offline test")
+
+
+class _FakeLangfuseV2:
+    """Mimics Langfuse SDK v2.6+: ``sdk_integration`` is in the signature."""
+
+    def __init__(
+        self,
+        public_key=None,
+        secret_key=None,
+        host=None,
+        release=None,
+        debug=None,
+        flush_interval=None,
+        httpx_client=None,
+        sdk_integration=None,
+    ):
+        self.public_key = public_key
+        self.sdk_integration = sdk_integration
+        self.client = MagicMock()
+        self.client.projects.get.side_effect = Exception("offline test")
+
+
+def test_langfuse_init_supports_sdk_integration_true_on_v2_signature():
+    """Helper returns True when ``Langfuse.__init__`` accepts ``sdk_integration`` (v2.6+)."""
+    fake_module = _make_fake_langfuse_module(_FakeLangfuseV2)
+    with patch.dict(sys.modules, {"langfuse": fake_module}):
+        from litellm.integrations.langfuse.langfuse import (
+            _langfuse_init_supports_sdk_integration,
+        )
+
+        assert _langfuse_init_supports_sdk_integration() is True
+
+
+def test_langfuse_init_supports_sdk_integration_false_on_v3_signature():
+    """Helper returns False when ``Langfuse.__init__`` lacks ``sdk_integration`` (v3+).
+
+    Regression for #13137 / #11703 — passing the kwarg to v3 raises TypeError.
+    """
+    fake_module = _make_fake_langfuse_module(_FakeLangfuseV3)
+    with patch.dict(sys.modules, {"langfuse": fake_module}):
+        from litellm.integrations.langfuse.langfuse import (
+            _langfuse_init_supports_sdk_integration,
+        )
+
+        assert _langfuse_init_supports_sdk_integration() is False
+
+
+def test_lang_fuse_logger_does_not_pass_sdk_integration_on_v3():
+    """``LangFuseLogger`` constructs successfully against a v3-style ``Langfuse.__init__`` (no TypeError).
+
+    This is the customer-reported regression: with ``langfuse>=3.0.0`` installed,
+    LangFuseLogger init blew up because the kwarg was unconditionally injected.
+    """
+    fake_module = _make_fake_langfuse_module(_FakeLangfuseV3)
+    with patch.dict(sys.modules, {"langfuse": fake_module}):
+        from litellm.integrations.langfuse.langfuse import LangFuseLogger
+
+        logger = LangFuseLogger(
+            langfuse_public_key="pk-test",
+            langfuse_secret="sk-test",
+            langfuse_host="https://example.com",
+        )
+
+    assert isinstance(logger.Langfuse, _FakeLangfuseV3)
+    assert logger.Langfuse.public_key == "pk-test"
+
+
+def test_lang_fuse_logger_passes_sdk_integration_on_v2():
+    """``LangFuseLogger`` still tags ``sdk_integration="litellm"`` on a v2-style SDK.
+
+    Guards against silently dropping the litellm-origin tag for users on v2.6+.
+    """
+    fake_module = _make_fake_langfuse_module(_FakeLangfuseV2)
+    fake_module.version.__version__ = "2.60.0"
+    with patch.dict(sys.modules, {"langfuse": fake_module}):
+        from litellm.integrations.langfuse.langfuse import LangFuseLogger
+
+        logger = LangFuseLogger(
+            langfuse_public_key="pk-test",
+            langfuse_secret="sk-test",
+            langfuse_host="https://example.com",
+        )
+
+    assert isinstance(logger.Langfuse, _FakeLangfuseV2)
+    assert logger.Langfuse.sdk_integration == "litellm"
+
+
+def test_langfuse_client_init_does_not_pass_sdk_integration_on_v3():
+    """``langfuse_client_init`` (prompt management path) constructs against a v3-style SDK without TypeError.
+
+    Mirrors the LangFuseLogger test for the second crash site.
+    """
+    fake_module = _make_fake_langfuse_module(_FakeLangfuseV3)
+    with patch.dict(sys.modules, {"langfuse": fake_module}):
+        from litellm.integrations.langfuse.langfuse_prompt_management import (
+            langfuse_client_init,
+        )
+
+        # lru_cache on langfuse_client_init means the first call to a previously-cached
+        # arg tuple wins — clear to make this test independent of order.
+        langfuse_client_init.cache_clear()
+        client = langfuse_client_init(
+            langfuse_public_key="pk-test",
+            langfuse_secret="sk-test",
+            langfuse_host="https://example.com",
+        )
+
+    assert isinstance(client, _FakeLangfuseV3)
+    assert client.public_key == "pk-test"
+
+
 class TestLangfuseUsageDetails(unittest.TestCase):
     def setUp(self):
         # Save global Langfuse client counter to restore after test


### PR DESCRIPTION
## Relevant issues

Related to #13137, #11703

## Linear ticket

<!-- n/a -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

**Before** — `litellm.completion(...)` with `litellm.success_callback = ["langfuse"]` and `langfuse==3.14.0` installed crashes during callback init:

```
TypeError: Langfuse.__init__() got an unexpected keyword argument 'sdk_integration'
  File "litellm/integrations/langfuse/langfuse.py", line 174, in __init__
    self.Langfuse: Langfuse = self.safe_init_langfuse_client(parameters)
  File "...", in safe_init_langfuse_client
    langfuse_client = Langfuse(**parameters)
```

**After** — same setup, the constructor succeeds and the request returns normally:

```
litellm version: 1.84.0
langfuse version: 3.14.0

Request returned without crash:
<model output>
```

Targeted unit tests exercising both crash sites against fake v2 / v3 `Langfuse.__init__` signatures:

```
tests/test_litellm/integrations/test_langfuse.py::test_langfuse_init_supports_sdk_integration_true_on_v2_signature PASSED
tests/test_litellm/integrations/test_langfuse.py::test_langfuse_init_supports_sdk_integration_false_on_v3_signature PASSED
tests/test_litellm/integrations/test_langfuse.py::test_lang_fuse_logger_does_not_pass_sdk_integration_on_v3 PASSED
tests/test_litellm/integrations/test_langfuse.py::test_lang_fuse_logger_passes_sdk_integration_on_v2 PASSED
tests/test_litellm/integrations/test_langfuse.py::test_langfuse_client_init_does_not_pass_sdk_integration_on_v3 PASSED
```

## Type

🐛 Bug Fix

## Changes

### What was wrong

In `litellm/integrations/langfuse/langfuse.py` and `litellm/integrations/langfuse/langfuse_prompt_management.py`, the `sdk_integration="litellm"` kwarg was injected into the `Langfuse(...)` constructor whenever the installed SDK version was `>= 2.6.0`:

```python
if Version(langfuse.version.__version__) >= Version("2.6.0"):
    parameters["sdk_integration"] = "litellm"
```

The kwarg was added in Langfuse 2.6.0 but **removed** in Langfuse 3.0.0. The version-string gate has no upper bound, so any user on `langfuse>=3.0.0` who configures the `"langfuse"` callback hits a hard `TypeError` on the first request that initializes the logger — both in `LangFuseLogger.__init__` and in `langfuse_client_init` (the prompt-management path).

### What the fix does

Replaces the version-string check with **signature introspection** at both crash sites. A small helper in `litellm/integrations/langfuse/langfuse.py` answers the only question that actually matters: does the installed `Langfuse.__init__` accept `sdk_integration`?

```python
def _langfuse_init_supports_sdk_integration() -> bool:
    from langfuse import Langfuse
    try:
        params = inspect.signature(Langfuse.__init__).parameters
    except (TypeError, ValueError):
        return False
    return "sdk_integration" in params
```

Both call sites now do `if _langfuse_init_supports_sdk_integration(): parameters["sdk_integration"] = "litellm"`. This:

- Keeps existing behavior identical on Langfuse `2.6.0 ≤ v < 3.0.0` (signature still has the kwarg → tag is passed).
- Keeps existing behavior identical on Langfuse `< 2.6.0` (signature lacks the kwarg → tag is not passed).
- Fixes the crash on Langfuse `>= 3.0.0` (signature lacks the kwarg → tag is not passed; no `TypeError`).
- Stays correct across future SDK changes without requiring another version-string update.

`from packaging.version import Version` and the now-unused bare `import langfuse` are removed from `langfuse_prompt_management.py` to satisfy `ruff`.

### Scope / out of scope

This PR unblocks **Langfuse client construction** on v3 SDKs. It does **not** make the v2 logger code path (trace / generation creation, prompt management calls) work end-to-end against v3 — Langfuse v3 also removed the `.trace()` method that the v2 logger relies on. The maintainer's stated recommendation in #13137 for full v3 support is the separate `langfuse_otel` callback. Removing the startup crash is intentionally scoped to make that the user's *only* remaining decision (pin to `langfuse<3.0.0` for full v2 logging today, or migrate to `langfuse_otel` for v3) rather than a hard error at boot.

### Tests

5 unit tests added in `tests/test_litellm/integrations/test_langfuse.py`, using `_FakeLangfuseV2` / `_FakeLangfuseV3` stand-in classes injected via `patch.dict(sys.modules, ...)`:

1. Helper returns `True` against a v2-style signature.
2. Helper returns `False` against a v3-style signature.
3. `LangFuseLogger(...)` constructs successfully against a v3-style `Langfuse.__init__` (the regression this PR fixes).
4. `LangFuseLogger(...)` still passes `sdk_integration="litellm"` against a v2-style `Langfuse.__init__` (guards against the inverse regression).
5. `langfuse_client_init(...)` constructs successfully against a v3-style `Langfuse.__init__` (mirrors #3 for the prompt-management crash site).
