### PR TITLE
Add new chat model metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -28874,6 +28874,19 @@
         "mode": "chat",
         "output_cost_per_token": 0.0
     },
+    "sambanova/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "sambanova",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://cloud.sambanova.ai/plans/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "sambanova/DeepSeek-R1": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "sambanova",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28879,6 +28879,19 @@
         "mode": "chat",
         "output_cost_per_token": 0.0
     },
+    "sambanova/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "sambanova",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://cloud.sambanova.ai/plans/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "sambanova/DeepSeek-R1": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "sambanova",

--- a/tests/litellm/test_sambanova_model_metadata.py
+++ b/tests/litellm/test_sambanova_model_metadata.py
@@ -16,8 +16,8 @@ def test_sambanova_minimax_m27_model_info():
     ), f"{model} not found in model_prices_and_context_window.json"
     assert info["litellm_provider"] == "sambanova"
     assert info["mode"] == "chat"
-    assert info["input_cost_per_token"] == 3e-07
-    assert info["output_cost_per_token"] == 1.2e-06
+    assert info["input_cost_per_token"] > 0
+    assert info["output_cost_per_token"] > 0
     assert info["max_input_tokens"] == 204800
     assert info["max_output_tokens"] == 131072
     assert info["supports_function_calling"] is True

--- a/tests/litellm/test_sambanova_model_metadata.py
+++ b/tests/litellm/test_sambanova_model_metadata.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+
+def test_sambanova_minimax_m27_model_info():
+    model = "sambanova/MiniMax-M2.7"
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    info = model_cost.get(model)
+    assert (
+        info is not None
+    ), f"{model} not found in model_prices_and_context_window.json"
+    assert info["litellm_provider"] == "sambanova"
+    assert info["mode"] == "chat"
+    assert info["input_cost_per_token"] == 3e-07
+    assert info["output_cost_per_token"] == 1.2e-06
+    assert info["max_input_tokens"] == 204800
+    assert info["max_output_tokens"] == 131072
+    assert info["supports_function_calling"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_tool_choice"] is True
+
+    routed_model, provider, _, _ = get_llm_provider(model=model)
+    assert routed_model == "MiniMax-M2.7"
+    assert provider == "sambanova"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds metadata for the newly requested chat model to both model cost maps so provider-prefixed calls resolve and expose context, pricing, and capability information.

## Repro
A provider-prefixed model ID for a new chat model was absent from the model metadata map, so direct lookup returned no entry before the fix.

## Evidence
Terminal evidence from the regression test:

```text
Before fix: targeted metadata regression failed because the model map entry was missing.
After fix: 1 passed in 1.73s
```

## Tests
- Targeted metadata regression test: passed.
- JSON validation for both model metadata files: passed.
- CI formatting check scope: passed.
- CI Ruff lint scope: passed.
- CI mypy scope: passed.

## CI
- GitHub Actions `lint`: ✅ passed (https://github.com/BerriAI/litellm/actions/runs/25454822970/job/74681314416)
- GitHub Actions `validate-model-prices-json`: ✅ passed (https://github.com/BerriAI/litellm/actions/runs/25454823002/job/74681314291)
- GitHub Actions broad unit/test shards visible in the PR checks: ✅ passed.
- CircleCI: ⚠️ several jobs report failure on the final commit, but CircleCI logs were not accessible from this environment. The failed contexts include `audio_testing`, `batches_testing`, `build_and_test`, `image_gen_testing`, `langfuse_logging_unit_tests`, `litellm_assistants_api_testing`, `litellm_router_testing`, `litellm_router_unit_testing`, `litellm_utils_testing`, `local_testing_part1`, `local_testing_part2`, `logging_testing`, `proxy_logging_guardrails_model_info_tests`, `proxy_pass_through_endpoint_tests`, `proxy_store_model_in_db_tests`, `realtime_translation_testing`, and `llm_translation_testing`.
- CircleCI: `e2e_openai_endpoints` was still pending at the latest poll.

## Review
- Automated review check: ✅ passed.
- One automated review thread about hard-coded test prices was addressed in commit `614c7b8f71` by asserting positive pricing values instead of exact literals.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if applicable -->

## Pre-Submission checklist

- [x] I have added a focused regression test.
- [ ] Full unit suite was not run locally; targeted regression and CI lint/typecheck scope passed.
- [x] My PR's scope is isolated to one model metadata addition.
- [x] Automated review check passed; broader CI status is documented above.

## Screenshots / Proof of Fix

See the terminal evidence above.

## Type

🆕 New Feature
✅ Test

## Changes

- Added the new chat model entry to both model metadata maps.
- Added a regression test that verifies metadata lookup and provider routing for the new entry.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-527eaadb-9b0a-417d-b3e6-ac62d4398d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-527eaadb-9b0a-417d-b3e6-ac62d4398d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

