### PR TITLE
Fix MCP DB reload partial failures

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2916,46 +2916,66 @@ class MCPServerManager:
         # against the *full* set so dedup is deterministic regardless of
         # iteration order.
         for server in db_mcp_servers:
-            existing_server = previous_registry.get(server.server_id)
+            try:
+                existing_server = previous_registry.get(server.server_id)
 
-            if (
-                existing_server is not None
-                and existing_server.updated_at is not None
-                and server.updated_at is not None
-                and existing_server.updated_at == server.updated_at
-            ):
-                # Re-use existing server instance to avoid re-running build_mcp_server_from_table()
-                # which can perform network discovery for OAuth2 servers.
-                new_registry[server.server_id] = existing_server
-                continue
+                if (
+                    existing_server is not None
+                    and existing_server.updated_at is not None
+                    and server.updated_at is not None
+                    and existing_server.updated_at == server.updated_at
+                ):
+                    # Re-use existing server instance to avoid re-running build_mcp_server_from_table()
+                    # which can perform network discovery for OAuth2 servers.
+                    new_registry[server.server_id] = existing_server
+                    continue
 
-            _warn_on_server_name_fields(
-                server_id=server.server_id,
-                alias=getattr(server, "alias", None),
-                server_name=getattr(server, "server_name", None),
-            )
-            verbose_logger.debug(
-                f"Building server from DB: {server.server_id} ({server.server_name})"
-            )
-            new_server = await self.build_mcp_server_from_table(server)
-            # Carry the cached short_prefix from the previous registry entry
-            # (if any) so the prefix is stable across reloads.
-            if existing_server is not None and existing_server.short_prefix:
-                new_server.short_prefix = existing_server.short_prefix
-            new_registry[server.server_id] = new_server
+                _warn_on_server_name_fields(
+                    server_id=server.server_id,
+                    alias=getattr(server, "alias", None),
+                    server_name=getattr(server, "server_name", None),
+                )
+                verbose_logger.debug(
+                    f"Building server from DB: {server.server_id} ({server.server_name})"
+                )
+                new_server = await self.build_mcp_server_from_table(server)
+                # Carry the cached short_prefix from the previous registry entry
+                # (if any) so the prefix is stable across reloads.
+                if existing_server is not None and existing_server.short_prefix:
+                    new_server.short_prefix = existing_server.short_prefix
+                new_registry[server.server_id] = new_server
+            except Exception as e:
+                verbose_logger.exception(
+                    "Skipping MCP server %s (%s) during DB reload: %s",
+                    server.server_id,
+                    getattr(server, "alias", None),
+                    e,
+                )
 
         # Swap in the new registry first so _assign_unique_short_prefix
         # sees the complete set when checking for collisions.
         self.registry = new_registry
-        for new_server in new_registry.values():
-            self._assign_unique_short_prefix(new_server)
-            # Register OpenAPI tools *after* the final short prefix is assigned
-            # so the tools are stored in the global registry under the same
-            # prefix that lookups will use.
-            await self._maybe_register_openapi_tools(new_server)
+        registered_registry: Dict[str, MCPServer] = {}
+        for server_id, new_server in new_registry.items():
+            try:
+                self._assign_unique_short_prefix(new_server)
+                # Register OpenAPI tools *after* the final short prefix is assigned
+                # so the tools are stored in the global registry under the same
+                # prefix that lookups will use.
+                await self._maybe_register_openapi_tools(new_server)
+                registered_registry[server_id] = new_server
+            except Exception as e:
+                verbose_logger.exception(
+                    "Skipping MCP server %s (%s) during DB reload: %s",
+                    new_server.server_id,
+                    getattr(new_server, "alias", None),
+                    e,
+                )
+
+        self.registry = registered_registry
 
         verbose_logger.debug(
-            "MCP registry refreshed (%s servers in registry)", len(new_registry)
+            "MCP registry refreshed (%s servers in registry)", len(registered_registry)
         )
 
     def get_mcp_servers_from_ids(self, server_ids: List[str]) -> List[MCPServer]:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -768,7 +768,9 @@ class MCPServerManager:
         )
         return new_server
 
-    async def _maybe_register_openapi_tools(self, server: MCPServer):
+    async def _maybe_register_openapi_tools(
+        self, server: MCPServer, *, initialize_mapping: bool = True
+    ):
         """Register OpenAPI tools if the server has a spec_path configured."""
         if server.spec_path:
             verbose_logger.info(
@@ -779,7 +781,8 @@ class MCPServerManager:
                 server=server,
                 base_url=server.url or "",
             )
-            self.initialize_tool_name_to_mcp_server_name_mapping()
+            if initialize_mapping:
+                self.initialize_tool_name_to_mcp_server_name_mapping()
 
     async def add_server(self, mcp_server: LiteLLM_MCPServerTable):
         try:
@@ -1978,7 +1981,11 @@ class MCPServerManager:
 
     _SHORT_PREFIX_MAX_REHASH_ATTEMPTS = 1024
 
-    def _assign_unique_short_prefix(self, server: MCPServer) -> None:
+    def _assign_unique_short_prefix(
+        self,
+        server: MCPServer,
+        registry: Optional[Dict[str, MCPServer]] = None,
+    ) -> None:
         """Resolve and cache a collision-free short tool prefix on ``server``.
 
         Called at registration time for every MCP server entering the
@@ -2002,7 +2009,8 @@ class MCPServerManager:
             return
 
         used: Dict[str, str] = {}
-        for other in self.get_registry().values():
+        registry_for_collision_check = registry or self.get_registry()
+        for other in registry_for_collision_check.values():
             if other.server_id == server.server_id:
                 continue
             if other.short_prefix:
@@ -2952,18 +2960,22 @@ class MCPServerManager:
                     e,
                 )
 
-        # Swap in the new registry first so _assign_unique_short_prefix
-        # sees the complete set when checking for collisions.
-        self.registry = new_registry
+        # Assign short prefixes against the full candidate set without
+        # publishing the staged registry to concurrent callers.
         registered_registry: Dict[str, MCPServer] = {}
+        registered_openapi_tools = False
         for server_id, new_server in new_registry.items():
             try:
-                self._assign_unique_short_prefix(new_server)
+                self._assign_unique_short_prefix(new_server, registry=new_registry)
                 # Register OpenAPI tools *after* the final short prefix is assigned
                 # so the tools are stored in the global registry under the same
                 # prefix that lookups will use.
-                await self._maybe_register_openapi_tools(new_server)
+                await self._maybe_register_openapi_tools(
+                    new_server, initialize_mapping=False
+                )
                 registered_registry[server_id] = new_server
+                if new_server.spec_path:
+                    registered_openapi_tools = True
             except Exception as e:
                 verbose_logger.exception(
                     "Skipping MCP server %s (%s) during DB reload: %s",
@@ -2973,6 +2985,8 @@ class MCPServerManager:
                 )
 
         self.registry = registered_registry
+        if registered_openapi_tools:
+            self.initialize_tool_name_to_mcp_server_name_mapping()
 
         verbose_logger.debug(
             "MCP registry refreshed (%s servers in registry)", len(registered_registry)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -2282,6 +2282,129 @@ class TestMCPServerManagerReload:
         mock_build.assert_awaited_once_with(db_row)
         assert manager.registry["server-1"] is rebuilt_server
 
+    @pytest.mark.asyncio
+    async def test_skips_server_when_build_from_database_fails(self, caplog):
+        try:
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                MCPServerManager,
+            )
+        except ImportError:
+            pytest.skip("MCP server not available")
+
+        manager = MCPServerManager()
+        timestamp = datetime.utcnow()
+        healthy_row = _make_db_mcp_server("healthy-server", timestamp)
+        bad_row = _make_db_mcp_server("bad-server", timestamp)
+        another_healthy_row = _make_db_mcp_server("another-healthy-server", timestamp)
+
+        healthy_server = MCPServer(
+            server_id="healthy-server",
+            name="healthy",
+            transport=MCPTransport.http,
+            updated_at=timestamp,
+        )
+        another_healthy_server = MCPServer(
+            server_id="another-healthy-server",
+            name="another-healthy",
+            transport=MCPTransport.http,
+            updated_at=timestamp,
+        )
+
+        async def build_server(db_row):
+            if db_row.server_id == "bad-server":
+                raise RuntimeError("transient build failure")
+            if db_row.server_id == "healthy-server":
+                return healthy_server
+            return another_healthy_server
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.find_many = AsyncMock(
+            return_value=[healthy_row, bad_row, another_healthy_row]
+        )
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_prisma,
+            ),
+            patch.object(
+                manager,
+                "build_mcp_server_from_table",
+                AsyncMock(side_effect=build_server),
+            ),
+            patch.object(manager, "_maybe_register_openapi_tools", AsyncMock()),
+            caplog.at_level("ERROR", logger="LiteLLM"),
+        ):
+            await manager.reload_servers_from_database()
+
+        assert set(manager.registry) == {"healthy-server", "another-healthy-server"}
+        assert manager.registry["healthy-server"] is healthy_server
+        assert manager.registry["another-healthy-server"] is another_healthy_server
+        assert "Skipping MCP server bad-server" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_skips_server_when_openapi_registration_fails(self, caplog):
+        try:
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                MCPServerManager,
+            )
+        except ImportError:
+            pytest.skip("MCP server not available")
+
+        manager = MCPServerManager()
+        timestamp = datetime.utcnow()
+        healthy_row = _make_db_mcp_server("healthy-server", timestamp)
+        bad_openapi_row = _make_db_mcp_server("bad-openapi-server", timestamp)
+
+        healthy_server = MCPServer(
+            server_id="healthy-server",
+            name="healthy",
+            transport=MCPTransport.http,
+            updated_at=timestamp,
+        )
+        bad_openapi_server = MCPServer(
+            server_id="bad-openapi-server",
+            name="bad-openapi",
+            transport=MCPTransport.http,
+            spec_path="https://example.invalid/openapi.json",
+            updated_at=timestamp,
+        )
+
+        async def build_server(db_row):
+            if db_row.server_id == "healthy-server":
+                return healthy_server
+            return bad_openapi_server
+
+        async def register_openapi_tools(server):
+            if server.server_id == "bad-openapi-server":
+                raise RuntimeError("blocked address")
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_mcpservertable.find_many = AsyncMock(
+            return_value=[healthy_row, bad_openapi_row]
+        )
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_prisma,
+            ),
+            patch.object(
+                manager,
+                "build_mcp_server_from_table",
+                AsyncMock(side_effect=build_server),
+            ),
+            patch.object(
+                manager,
+                "_maybe_register_openapi_tools",
+                AsyncMock(side_effect=register_openapi_tools),
+            ),
+            caplog.at_level("ERROR", logger="LiteLLM"),
+        ):
+            await manager.reload_servers_from_database()
+
+        assert set(manager.registry) == {"healthy-server"}
+        assert manager.registry["healthy-server"] is healthy_server
+        assert "Skipping MCP server bad-openapi-server" in caplog.text
+
 
 @pytest.mark.asyncio
 async def test_call_mcp_tool_logs_failure_via_post_call_failure_hook():
@@ -2946,7 +3069,7 @@ async def test_list_tools_with_legacy_db_m2m_server_resolves_oauth2_flow():
     """
     P1 Regression: list_tools path must apply _resolve_oauth2_flow to legacy DB
     rows where oauth2_flow is NULL but M2M credentials are present.
-    
+
     Without this fix, has_client_credentials returns False and the caller's
     Authorization header is forwarded upstream instead of being blocked.
     """
@@ -3044,7 +3167,7 @@ async def test_call_tool_empty_extra_headers_returns_none():
     """
     P2 Regression: When all configured extra_headers are filtered out (e.g.
     Authorization for M2M), the resulting extra_headers should be None, not {}.
-    
+
     Downstream code that checks `if extra_headers is None` will behave
     differently if an empty dict is passed instead.
     """
@@ -3071,7 +3194,10 @@ async def test_call_tool_empty_extra_headers_returns_none():
         extra_headers=["Authorization"],  # Will be filtered out for M2M
     )
 
-    raw_headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
+    raw_headers = {
+        "Authorization": "Bearer sk-1234",
+        "Content-Type": "application/json",
+    }
 
     captured_extra_headers = None
 
@@ -3108,8 +3234,8 @@ async def test_call_tool_empty_extra_headers_returns_none():
             pass  # We only care about the captured headers
 
     # With P2 fix: extra_headers should be None (not {}) when all headers filtered
-    assert captured_extra_headers is None, (
-        "P2 API consistency issue: expected None for empty extra_headers, got: "
-        + str(captured_extra_headers)
+    assert (
+        captured_extra_headers is None
+    ), "P2 API consistency issue: expected None for empty extra_headers, got: " + str(
+        captured_extra_headers
     )
-

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -2354,6 +2354,13 @@ class TestMCPServerManagerReload:
         timestamp = datetime.utcnow()
         healthy_row = _make_db_mcp_server("healthy-server", timestamp)
         bad_openapi_row = _make_db_mcp_server("bad-openapi-server", timestamp)
+        existing_server = MCPServer(
+            server_id="existing-server",
+            name="existing",
+            transport=MCPTransport.http,
+            updated_at=timestamp,
+        )
+        manager.registry = {existing_server.server_id: existing_server}
 
         healthy_server = MCPServer(
             server_id="healthy-server",
@@ -2374,7 +2381,11 @@ class TestMCPServerManagerReload:
                 return healthy_server
             return bad_openapi_server
 
-        async def register_openapi_tools(server):
+        observed_registries = []
+
+        async def register_openapi_tools(server, **kwargs):
+            observed_registries.append(set(manager.registry))
+            assert kwargs == {"initialize_mapping": False}
             if server.server_id == "bad-openapi-server":
                 raise RuntimeError("blocked address")
 
@@ -2403,6 +2414,10 @@ class TestMCPServerManagerReload:
 
         assert set(manager.registry) == {"healthy-server"}
         assert manager.registry["healthy-server"] is healthy_server
+        assert observed_registries == [
+            {"existing-server"},
+            {"existing-server"},
+        ]
         assert "Skipping MCP server bad-openapi-server" in caplog.text
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
MCP database reloads could abort when one row failed during server construction or OpenAPI tool registration. This change logs and skips the failing row while still publishing successfully loaded servers into the in-memory registry, and avoids exposing the staged registry before registration completes.

## Repro
1. Have multiple active rows in the MCP server table.
2. Make one row fail during DB reload, for example by using an OpenAPI spec URL that raises during validation or loading.
3. Trigger `reload_servers_from_database()`.
4. Before this fix, the exception escaped and healthy servers were not reliably available after reload; after this fix, healthy servers remain registered and the failed row is omitted.

## Evidence
<a href="/opt/cursor/artifacts/mcp_reload_evidence.txt">MCP reload regression evidence</a>

## Tests
- Added regression coverage in `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py` for build failures, OpenAPI registration failures, and avoiding intermediate staged-registry exposure during DB reload.
- Reproduced the new tests failing before the fix with propagated `RuntimeError` exceptions.
- `uv run --extra proxy pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::TestMCPServerManagerReload -q` (4 passed)
- `uv lock --check`
- `uv sync --frozen`
- `cd litellm && black --check --exclude '/enterprise/' .`
- `cd litellm && ruff check .`
- `cd litellm && mypy .`
- `cd litellm && python ../tests/documentation_tests/test_circular_imports.py`
- `python -c "from litellm import *"`

## CI
- GitHub Actions checks for the latest commit reached green for the lint, unit-test, UI-build, semgrep, secret-scan, model-prices, and related repository workflows visible via PR checks.
- CircleCI contexts still show unrelated failures in broad suites such as `audio_testing`, `batches_testing`, `image_gen_testing`, `langfuse_logging_unit_tests`, `litellm_assistants_api_testing`, `litellm_router_testing`, `litellm_router_unit_testing`, `litellm_utils_testing`, `local_testing_part1`, `local_testing_part2`, `logging_testing`, `proxy_logging_guardrails_model_info_tests`, `proxy_pass_through_endpoint_tests`, `proxy_store_model_in_db_tests`, and `realtime_translation_testing`.
- The current base branch also shows CircleCI failures/pending statuses in overlapping unrelated contexts including `audio_testing`, `batches_testing`, `image_gen_testing`, `langfuse_logging_unit_tests`, `litellm_assistants_api_testing`, `litellm_utils_testing`, `local_testing_part2`, and `realtime_translation_testing`; remaining failing contexts do not correspond to the touched MCP reload unit path.
- CircleCI contexts `e2e_openai_endpoints` and `llm_translation_testing` were still pending after the polling window on both the PR and base branch.

## Review
- Greptile posted one actionable P2 comment about publishing the staged registry before OpenAPI registration completed.
- Addressed in commit `7759c6708b` by assigning short prefixes against an isolated candidate registry and only swapping `self.registry` after successful registration; added a regression assertion that registration does not observe the staged registry.
- A refreshed Greptile score/body was not available yet; the original thread remains unresolved in GitHub because no write-capable review-thread tool is available in this environment.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR merging, see the repository PR review process.

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

See evidence link above.

## Type

🐛 Bug Fix
✅ Test

## Changes
- Wrap per-server reload work so failed DB rows are logged and skipped instead of aborting the refresh.
- Keep the final registry assignment scoped to successfully loaded servers.
- Avoid publishing the staged registry before OpenAPI registration completes.
- Add regression tests for build-time and OpenAPI-registration reload failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b644f3c-f7f0-439d-a173-04a017ad7428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b644f3c-f7f0-439d-a173-04a017ad7428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

