### PR TITLE
Fix Prometheus end-user metric cardinality tracking

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -414,6 +414,9 @@ custom_prometheus_metadata_labels: List[str] = []
 custom_prometheus_tags: List[str] = []
 prometheus_metrics_config: Optional[List] = None
 prometheus_emit_stream_label: bool = False
+prometheus_end_user_metrics_max_series_per_metric: Optional[int] = 10000
+prometheus_end_user_metrics_ttl_seconds: Optional[float] = 3600.0
+prometheus_end_user_metrics_cleanup_interval_seconds: Optional[float] = 60.0
 disable_add_prefix_to_prompt: bool = (
     False  # used by anthropic, to disable adding prefix to prompt
 )

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -995,7 +995,12 @@ class PrometheusLogger(CustomLogger):
         labels: Dict[str, Optional[str]],
         apply_metric_update: Callable[[Any], None],
     ) -> None:
-        with self._bounded_prometheus_series_tracker.lock:
+        tracker = getattr(self, "_bounded_prometheus_series_tracker", None)
+        if not isinstance(tracker, BoundedPrometheusSeriesTracker):
+            apply_metric_update(metric.labels(**labels))
+            return
+
+        with tracker.lock:
             labeled_metric = metric.labels(**labels)
             self._track_bounded_prometheus_metric_series(metric, metric_name, labels)
             apply_metric_update(labeled_metric)
@@ -1051,7 +1056,8 @@ class PrometheusLogger(CustomLogger):
             enum_values=enum_values,
             label_context=label_context,
         )
-        self._apply_labeled_metric(
+        PrometheusLogger._apply_labeled_metric(
+            self,
             metric=counter,
             metric_name=metric_name,
             labels=_labels,

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -25,6 +25,9 @@ from typing import (
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.integrations.prometheus_helpers.bounded_prometheus_series_tracker import (
+    BoundedPrometheusSeriesTracker,
+)
 from litellm.integrations.prometheus_helpers import (
     PrometheusLabelFactoryContext,
     _get_cached_end_user_id_for_cost_tracking,
@@ -81,6 +84,7 @@ class PrometheusLogger(CustomLogger):
                 if _custom_buckets is not None
                 else LATENCY_BUCKETS
             )
+            self._bounded_prometheus_series_tracker = BoundedPrometheusSeriesTracker()
 
             # Create metric factory functions
             self._counter_factory = self._create_metric_factory(Counter)
@@ -984,6 +988,56 @@ class PrometheusLogger(CustomLogger):
 
         return filtered_labels
 
+    def _apply_labeled_metric(
+        self,
+        metric: Any,
+        metric_name: DEFINED_PROMETHEUS_METRICS,
+        labels: Dict[str, Optional[str]],
+        apply_metric_update: Callable[[Any], None],
+    ) -> None:
+        with self._bounded_prometheus_series_tracker.lock:
+            labeled_metric = metric.labels(**labels)
+            self._track_bounded_prometheus_metric_series(metric, metric_name, labels)
+            apply_metric_update(labeled_metric)
+
+    def _track_bounded_prometheus_metric_series(
+        self,
+        metric: Any,
+        metric_name: DEFINED_PROMETHEUS_METRICS,
+        labels: Dict[str, Optional[str]],
+    ) -> None:
+        labelnames = self.get_labels_for_metric(metric_name)
+        if UserAPIKeyLabelNames.END_USER.value not in labelnames:
+            return
+
+        end_user = labels.get(UserAPIKeyLabelNames.END_USER.value)
+        if end_user is None:
+            return
+
+        max_series = getattr(
+            litellm, "prometheus_end_user_metrics_max_series_per_metric", 10000
+        )
+        ttl_seconds = getattr(
+            litellm, "prometheus_end_user_metrics_ttl_seconds", 3600.0
+        )
+        ttl_cleanup_interval_seconds = getattr(
+            litellm,
+            "prometheus_end_user_metrics_cleanup_interval_seconds",
+            60.0,
+        )
+        if max_series is None and ttl_seconds is None:
+            return
+
+        label_values = tuple(labels.get(label) for label in labelnames)
+        self._bounded_prometheus_series_tracker.track_series(
+            metric=metric,
+            metric_name=metric_name,
+            label_values=label_values,
+            max_series=max_series,
+            ttl_seconds=ttl_seconds,
+            cleanup_interval_seconds=ttl_cleanup_interval_seconds,
+        )
+
     def _inc_labeled_counter(
         self,
         counter: Any,
@@ -997,7 +1051,12 @@ class PrometheusLogger(CustomLogger):
             enum_values=enum_values,
             label_context=label_context,
         )
-        counter.labels(**_labels).inc(amount)
+        self._apply_labeled_metric(
+            metric=counter,
+            metric_name=metric_name,
+            labels=_labels,
+            apply_metric_update=lambda labeled_metric: labeled_metric.inc(amount),
+        )
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         # Define prometheus client
@@ -1476,9 +1535,14 @@ class PrometheusLogger(CustomLogger):
                 enum_values=enum_values,
                 label_context=label_context,
             )
-            self.litellm_llm_api_time_to_first_token_metric.labels(
-                **_ttft_labels
-            ).observe(time_to_first_token_seconds)
+            self._apply_labeled_metric(
+                metric=self.litellm_llm_api_time_to_first_token_metric,
+                metric_name="litellm_llm_api_time_to_first_token_metric",
+                labels=_ttft_labels,
+                apply_metric_update=lambda labeled_metric: labeled_metric.observe(
+                    time_to_first_token_seconds
+                ),
+            )
         else:
             verbose_logger.debug(
                 "Time to first token metric not emitted, stream option in model_parameters is not True"
@@ -1496,8 +1560,13 @@ class PrometheusLogger(CustomLogger):
                 enum_values=enum_values,
                 label_context=label_context,
             )
-            self.litellm_llm_api_latency_metric.labels(**_labels).observe(
-                api_call_total_time_seconds
+            self._apply_labeled_metric(
+                metric=self.litellm_llm_api_latency_metric,
+                metric_name="litellm_llm_api_latency_metric",
+                labels=_labels,
+                apply_metric_update=lambda labeled_metric: labeled_metric.observe(
+                    api_call_total_time_seconds
+                ),
             )
 
         # total request latency
@@ -1513,8 +1582,13 @@ class PrometheusLogger(CustomLogger):
                 enum_values=enum_values,
                 label_context=label_context,
             )
-            self.litellm_request_total_latency_metric.labels(**_labels).observe(
-                total_time_seconds
+            self._apply_labeled_metric(
+                metric=self.litellm_request_total_latency_metric,
+                metric_name="litellm_request_total_latency_metric",
+                labels=_labels,
+                apply_metric_update=lambda labeled_metric: labeled_metric.observe(
+                    total_time_seconds
+                ),
             )
 
         # request queue time (time from arrival to processing start)
@@ -1530,8 +1604,13 @@ class PrometheusLogger(CustomLogger):
                 enum_values=enum_values,
                 label_context=label_context,
             )
-            self.litellm_request_queue_time_metric.labels(**_labels).observe(
-                queue_time_seconds
+            self._apply_labeled_metric(
+                metric=self.litellm_request_queue_time_metric,
+                metric_name="litellm_request_queue_time_seconds",
+                labels=_labels,
+                apply_metric_update=lambda labeled_metric: labeled_metric.observe(
+                    queue_time_seconds
+                ),
             )
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):

--- a/litellm/integrations/prometheus_helpers/bounded_prometheus_series_tracker.py
+++ b/litellm/integrations/prometheus_helpers/bounded_prometheus_series_tracker.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from threading import RLock
+from typing import Any, Dict, Optional
+
+
+class BoundedPrometheusSeriesTracker:
+    """
+    Tracks Prometheus child series and removes stale/excess labelsets.
+
+    The tracker is label-agnostic: callers decide which series should be tracked
+    and pass the full label tuple used by the Prometheus metric.
+    """
+
+    def __init__(self) -> None:
+        self._series: Dict[str, OrderedDict[tuple[Optional[str], ...], float]] = {}
+        self._last_ttl_cleanup: Dict[str, float] = {}
+        self.lock = RLock()
+
+    def track_series(
+        self,
+        metric: Any,
+        metric_name: str,
+        label_values: tuple[Optional[str], ...],
+        max_series: Optional[int],
+        ttl_seconds: Optional[float],
+        cleanup_interval_seconds: Optional[float],
+    ) -> None:
+        if max_series is None and ttl_seconds is None:
+            return
+
+        now = time.monotonic()
+
+        with self.lock:
+            series = self._series.setdefault(metric_name, OrderedDict())
+            series[label_values] = now
+            series.move_to_end(label_values)
+
+            if ttl_seconds is not None and self._should_run_ttl_cleanup(
+                metric_name=metric_name,
+                now=now,
+                cleanup_interval_seconds=cleanup_interval_seconds,
+            ):
+                expired_label_values = [
+                    tracked_label_values
+                    for tracked_label_values, last_seen in series.items()
+                    if now - last_seen > ttl_seconds
+                ]
+                for tracked_label_values in expired_label_values:
+                    self._remove_metric_series(metric, series, tracked_label_values)
+
+            if max_series is not None and max_series > 0:
+                while len(series) > max_series:
+                    tracked_label_values = next(iter(series))
+                    if not self._remove_metric_child(metric, tracked_label_values):
+                        break
+                    del series[tracked_label_values]
+            elif max_series is not None:
+                while series:
+                    tracked_label_values = next(iter(series))
+                    if not self._remove_metric_child(metric, tracked_label_values):
+                        break
+                    del series[tracked_label_values]
+
+    def _should_run_ttl_cleanup(
+        self,
+        metric_name: str,
+        now: float,
+        cleanup_interval_seconds: Optional[float],
+    ) -> bool:
+        if cleanup_interval_seconds is None or cleanup_interval_seconds <= 0:
+            self._last_ttl_cleanup[metric_name] = now
+            return True
+
+        last_cleanup = self._last_ttl_cleanup.get(metric_name)
+        if last_cleanup is None or now - last_cleanup >= cleanup_interval_seconds:
+            self._last_ttl_cleanup[metric_name] = now
+            return True
+        return False
+
+    def _remove_metric_series(
+        self,
+        metric: Any,
+        series: OrderedDict[tuple[Optional[str], ...], float],
+        label_values: tuple[Optional[str], ...],
+    ) -> None:
+        if self._remove_metric_child(metric, label_values):
+            series.pop(label_values, None)
+
+    @staticmethod
+    def _remove_metric_child(
+        metric: Any, label_values: tuple[Optional[str], ...]
+    ) -> bool:
+        """
+        Remove the Prometheus child for ``label_values`` and report whether the
+        tracker should commit the matching state change.
+
+        Returns ``True`` when the child is no longer present in Prometheus
+        (either it was just removed or it was already gone), and ``False`` when
+        ``metric.remove()`` raised an unexpected error and the child likely
+        still exists.
+        """
+        try:
+            metric.remove(*label_values)
+            return True
+        except KeyError:
+            return True
+        except (AttributeError, ValueError):
+            return False

--- a/tests/test_litellm/integrations/test_prometheus_end_user_cardinality.py
+++ b/tests/test_litellm/integrations/test_prometheus_end_user_cardinality.py
@@ -1,0 +1,236 @@
+from time import monotonic
+
+import pytest
+from prometheus_client import REGISTRY
+
+import litellm
+from litellm.integrations.prometheus import PrometheusLogger, prometheus_label_factory
+from litellm.integrations.prometheus_helpers import bounded_prometheus_series_tracker
+from litellm.integrations.prometheus_helpers.bounded_prometheus_series_tracker import (
+    BoundedPrometheusSeriesTracker,
+)
+from litellm.types.integrations.prometheus import UserAPIKeyLabelValues
+
+
+def _clear_prometheus_registry() -> None:
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    _clear_prometheus_registry()
+
+    old_enable_end_user = litellm.enable_end_user_cost_tracking_prometheus_only
+    old_metrics_config = litellm.prometheus_metrics_config
+    old_max_series = litellm.prometheus_end_user_metrics_max_series_per_metric
+    old_ttl_seconds = litellm.prometheus_end_user_metrics_ttl_seconds
+    old_cleanup_interval_seconds = (
+        litellm.prometheus_end_user_metrics_cleanup_interval_seconds
+    )
+
+    yield
+
+    litellm.enable_end_user_cost_tracking_prometheus_only = old_enable_end_user
+    litellm.prometheus_metrics_config = old_metrics_config
+    litellm.prometheus_end_user_metrics_max_series_per_metric = old_max_series
+    litellm.prometheus_end_user_metrics_ttl_seconds = old_ttl_seconds
+    litellm.prometheus_end_user_metrics_cleanup_interval_seconds = (
+        old_cleanup_interval_seconds
+    )
+
+    _clear_prometheus_registry()
+
+
+def test_prometheus_end_user_series_are_capped_per_metric():
+    litellm.enable_end_user_cost_tracking_prometheus_only = True
+    litellm.prometheus_metrics_config = [
+        {
+            "group": "end-user-spend",
+            "metrics": ["litellm_spend_metric"],
+            "include_labels": ["end_user"],
+        }
+    ]
+    litellm.prometheus_end_user_metrics_max_series_per_metric = 3
+    litellm.prometheus_end_user_metrics_ttl_seconds = None
+    logger = PrometheusLogger()
+
+    for index in range(6):
+        PrometheusLogger._inc_labeled_counter(
+            logger,
+            logger.litellm_spend_metric,
+            "litellm_spend_metric",
+            UserAPIKeyLabelValues(end_user=f"end-user-{index}"),
+            amount=0.01,
+        )
+
+    assert len(logger.litellm_spend_metric._metrics) == 3
+    assert set(logger.litellm_spend_metric._metrics) == {
+        ("end-user-3",),
+        ("end-user-4",),
+        ("end-user-5",),
+    }
+
+
+def test_bounded_prometheus_series_tracker_is_label_agnostic():
+    class FakeMetric:
+        def __init__(self):
+            self.removed_label_values = []
+
+        def remove(self, *label_values):
+            self.removed_label_values.append(label_values)
+
+    metric = FakeMetric()
+    tracker = BoundedPrometheusSeriesTracker()
+
+    for index in range(4):
+        tracker.track_series(
+            metric=metric,
+            metric_name="generic_metric",
+            label_values=(f"route-{index}", "200"),
+            max_series=2,
+            ttl_seconds=None,
+            cleanup_interval_seconds=60.0,
+        )
+
+    assert metric.removed_label_values == [
+        ("route-0", "200"),
+        ("route-1", "200"),
+    ]
+
+
+def test_bounded_prometheus_series_tracker_keeps_state_when_remove_fails():
+    class FakeMetric:
+        def __init__(self):
+            self.removed_label_values = []
+            self.failed_once = False
+
+        def remove(self, *label_values):
+            self.removed_label_values.append(label_values)
+            if label_values == ("route-0", "200") and not self.failed_once:
+                self.failed_once = True
+                raise ValueError("child still present")
+
+    metric = FakeMetric()
+    tracker = BoundedPrometheusSeriesTracker()
+
+    for index in range(3):
+        tracker.track_series(
+            metric=metric,
+            metric_name="generic_metric",
+            label_values=(f"route-{index}", "200"),
+            max_series=2,
+            ttl_seconds=None,
+            cleanup_interval_seconds=60.0,
+        )
+
+    assert metric.removed_label_values == [("route-0", "200")]
+    assert list(tracker._series["generic_metric"]) == [
+        ("route-0", "200"),
+        ("route-1", "200"),
+        ("route-2", "200"),
+    ]
+
+    tracker.track_series(
+        metric=metric,
+        metric_name="generic_metric",
+        label_values=("route-3", "200"),
+        max_series=2,
+        ttl_seconds=None,
+        cleanup_interval_seconds=60.0,
+    )
+
+    assert metric.removed_label_values == [
+        ("route-0", "200"),
+        ("route-0", "200"),
+        ("route-1", "200"),
+    ]
+    assert list(tracker._series["generic_metric"]) == [
+        ("route-2", "200"),
+        ("route-3", "200"),
+    ]
+
+
+def test_prometheus_end_user_series_expire_by_ttl(monkeypatch):
+    litellm.enable_end_user_cost_tracking_prometheus_only = True
+    litellm.prometheus_metrics_config = [
+        {
+            "group": "end-user-spend",
+            "metrics": ["litellm_spend_metric"],
+            "include_labels": ["end_user"],
+        }
+    ]
+    litellm.prometheus_end_user_metrics_max_series_per_metric = None
+    litellm.prometheus_end_user_metrics_ttl_seconds = 10.0
+    litellm.prometheus_end_user_metrics_cleanup_interval_seconds = 0.0
+    logger = PrometheusLogger()
+
+    current_time = [monotonic()]
+    monkeypatch.setattr(
+        bounded_prometheus_series_tracker.time,
+        "monotonic",
+        lambda: current_time[0],
+    )
+    PrometheusLogger._inc_labeled_counter(
+        logger,
+        logger.litellm_spend_metric,
+        "litellm_spend_metric",
+        UserAPIKeyLabelValues(end_user="stale-end-user"),
+        amount=0.01,
+    )
+
+    current_time[0] += 11.0
+    PrometheusLogger._inc_labeled_counter(
+        logger,
+        logger.litellm_spend_metric,
+        "litellm_spend_metric",
+        UserAPIKeyLabelValues(end_user="fresh-end-user"),
+        amount=0.01,
+    )
+
+    assert set(logger.litellm_spend_metric._metrics) == {("fresh-end-user",)}
+
+
+def test_prometheus_failure_metric_uses_filtered_labels_for_bounded_tracking():
+    litellm.enable_end_user_cost_tracking_prometheus_only = True
+    litellm.prometheus_metrics_config = [
+        {
+            "group": "failure-metrics",
+            "metrics": ["litellm_llm_api_failed_requests_metric"],
+            "include_labels": ["model"],
+        }
+    ]
+    litellm.prometheus_end_user_metrics_max_series_per_metric = 1
+    logger = PrometheusLogger()
+
+    for index in range(3):
+        PrometheusLogger._inc_labeled_counter(
+            logger,
+            logger.litellm_llm_api_failed_requests_metric,
+            "litellm_llm_api_failed_requests_metric",
+            UserAPIKeyLabelValues(
+                end_user=f"end-user-{index}",
+                model="gpt-4o-mini",
+            ),
+        )
+
+    assert set(logger.litellm_llm_api_failed_requests_metric._metrics) == {
+        ("gpt-4o-mini",)
+    }
+    assert "litellm_llm_api_failed_requests_metric" not in (
+        logger._bounded_prometheus_series_tracker._series
+    )
+
+
+def test_prometheus_end_user_not_tracked_by_default():
+    litellm.enable_end_user_cost_tracking_prometheus_only = None
+    labels = PrometheusLogger().get_labels_for_metric("litellm_spend_metric")
+    assert "end_user" in labels
+
+    label_values = UserAPIKeyLabelValues(end_user="not-exported")
+    prometheus_labels = prometheus_label_factory(labels, label_values)
+    assert prometheus_labels["end_user"] is None

--- a/tests/test_litellm/integrations/test_prometheus_end_user_cardinality.py
+++ b/tests/test_litellm/integrations/test_prometheus_end_user_cardinality.py
@@ -1,4 +1,5 @@
 from time import monotonic
+from unittest.mock import MagicMock
 
 import pytest
 from prometheus_client import REGISTRY
@@ -224,6 +225,22 @@ def test_prometheus_failure_metric_uses_filtered_labels_for_bounded_tracking():
     assert "litellm_llm_api_failed_requests_metric" not in (
         logger._bounded_prometheus_series_tracker._series
     )
+
+
+def test_inc_labeled_counter_supports_uninitialized_logger_test_doubles():
+    mock_logger = MagicMock()
+    mock_logger.get_labels_for_metric.return_value = ["model"]
+    counter = MagicMock()
+
+    PrometheusLogger._inc_labeled_counter(
+        mock_logger,
+        counter,
+        "litellm_cache_hits_metric",
+        UserAPIKeyLabelValues(model="gpt-4o-mini"),
+    )
+
+    counter.labels.assert_called_once_with(model="gpt-4o-mini")
+    counter.labels().inc.assert_called_once_with(1.0)
 
 
 def test_prometheus_end_user_not_tracked_by_default():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Prometheus metrics that include resolved `end_user` labels could grow one child series per distinct end user without a cleanup path. This rebuilds the cardinality cap fix on the current staging branch, keeps the existing custom-metadata label handling intact, and applies Bugbot feedback by sharing the bounded tracking path across counters/histograms with guarded tracker state updates.

## Repro
Emit `litellm_spend_metric` six times with `end_user` as the only enabled label and a configured cap of three series. Before the fix, the Prometheus child map retained all six label tuples; after the fix, it retains only the newest three.

## Evidence
Terminal transcript from the repro after the fix:

```text
children 3
series [('end-user-3',), ('end-user-4',), ('end-user-5',)]
```

Targeted regression suite after addressing the CI-reported test-double path:

```text
28 passed in 0.58s
```

## Tests
- Added `tests/test_litellm/integrations/test_prometheus_end_user_cardinality.py` covering max-series eviction, TTL expiry, label-agnostic cleanup, failed child removal state, filtered failure metrics, default end-user label behavior, and uninitialized logger test doubles.
- Ran `uv run --no-sync pytest tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py::test_async_log_failure_event tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py::test_async_log_failure_event_litellm_side_rate_limit tests/test_litellm/integrations/test_prometheus_end_user_cardinality.py tests/test_litellm/integrations/test_prometheus_labels.py tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py tests/test_litellm/integrations/test_prometheus_cache_metrics.py::TestPrometheusCacheMetrics::test_increment_cache_metrics_on_cache_hit tests/test_litellm/integrations/test_prometheus_cache_metrics.py::TestPrometheusCacheMetrics::test_increment_cache_metrics_on_cache_miss tests/test_litellm/integrations/test_prometheus_client_ip_user_agent.py::test_async_post_call_success_hook_includes_client_ip_user_agent -q` -> 28 passed.
- Ran CI lint gates locally: Black check, Ruff, MyPy, circular import check, and import safety -> passed.

## CI
- GitHub Actions lint, UI build, and integrations workflows are green on the latest head.
- CircleCI currently reports failures in provider/router/local contexts that are outside this Prometheus diff, and its public API/log pages were not accessible from this environment for deeper triage. The directly related GitHub integrations workflow passed after the follow-up fix.
- Some remote checks are still pending at the end of the bounded poll.

## Review
- Automated review has not posted a review on the latest pushed head during the bounded poll.

## Relevant issues

Addresses follow-up feedback on #27272.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack.

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

See `## Evidence`.

## Type

🐛 Bug Fix
✅ Test

## Changes
- Added a reusable bounded Prometheus series tracker with max-series and TTL cleanup.
- Applied bounded tracking to end-user-labeled counter and histogram updates while holding the tracker lock through the metric update.
- Preserved existing custom metadata label support on the current staging branch.
- Added regression tests for the merge-conflict and Bugbot feedback paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9925ecdb-de8a-4bae-846b-7b2ee3d01f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9925ecdb-de8a-4bae-846b-7b2ee3d01f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

