### PR TITLE
fix(anthropic): report reasoning_tokens in streaming usage

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -585,6 +585,14 @@ class ModelResponseIterator:
         self._current_server_tool_id: Optional[str] = None
         self._container_id: Optional[str] = None
 
+        # Accumulate streamed reasoning ("thinking") text so we can estimate
+        # reasoning_tokens in the final usage object. Anthropic's streaming
+        # message_delta only reports total output_tokens, so without this
+        # accumulator completion_tokens_details.reasoning_tokens is always 0
+        # for streaming responses even when extended thinking is enabled.
+        # See: https://github.com/BerriAI/litellm/issues/<TBD>
+        self.accumulated_reasoning_content: str = ""
+
     def check_empty_tool_call_args(self) -> bool:
         """
         Check if the tool call block so far has been an empty string
@@ -609,9 +617,13 @@ class ModelResponseIterator:
         return False
 
     def _handle_usage(self, anthropic_usage_chunk: Union[dict, UsageDelta]) -> Usage:
+        # Pass the accumulated thinking text (if any) so calculate_usage can
+        # estimate reasoning_tokens for streaming responses. Falsy when no
+        # thinking deltas were observed, which preserves the previous behavior
+        # for non-thinking streams.
         return AnthropicConfig().calculate_usage(
             usage_object=cast(dict, anthropic_usage_chunk),
-            reasoning_content=None,
+            reasoning_content=self.accumulated_reasoning_content or None,
             speed=self.speed,
         )
 
@@ -658,14 +670,21 @@ class ModelResponseIterator:
             "thinking" in content_block["delta"]
             or "signature" in content_block["delta"]
         ):
+            thinking_text = content_block["delta"].get("thinking") or ""
             thinking_blocks = [
                 ChatCompletionThinkingBlock(
                     type="thinking",
-                    thinking=content_block["delta"].get("thinking") or "",
+                    thinking=thinking_text,
                     signature=str(content_block["delta"].get("signature") or ""),
                 )
             ]
             provider_specific_fields["thinking_blocks"] = thinking_blocks
+            # Accumulate so the final usage chunk can report reasoning_tokens.
+            # Anthropic's streaming message_delta only carries total
+            # output_tokens; without this accumulator, _handle_usage() would
+            # always pass reasoning_content=None and yield reasoning_tokens=0.
+            if thinking_text:
+                self.accumulated_reasoning_content += thinking_text
         elif (
             "content" in content_block["delta"]
             and content_block["delta"].get("type") == "compaction_delta"

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -1614,3 +1614,148 @@ def test_non_bash_tool_result_skipped():
     assert (
         len(code_results) == 0
     ), f"Expected 0 code_interpreter_results for text_editor result, got {len(code_results)}"
+
+
+def test_streaming_accumulates_reasoning_tokens_in_usage():
+    """Reasoning tokens should be reported in the final usage chunk for streaming
+    responses with extended thinking.
+
+    Regression test for the bug where streaming Anthropic responses always
+    returned reasoning_tokens=0 because thinking deltas were forwarded but never
+    accumulated, so the message_delta -> calculate_usage path passed
+    reasoning_content=None.
+    """
+    chunks = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "thinking_delta",
+                "thinking": "Let me think carefully about this problem. ",
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "thinking_delta",
+                "thinking": "I need to consider every possibility before answering.",
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "sig_abc"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "The answer is 42."},
+        },
+        {"type": "content_block_stop", "index": 1},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 50},
+        },
+    ]
+
+    iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+
+    final_usage = None
+    for chunk in chunks:
+        parsed = iterator.chunk_parser(chunk)
+        if parsed.usage is not None:
+            final_usage = parsed.usage
+
+    expected_thinking = (
+        "Let me think carefully about this problem. "
+        "I need to consider every possibility before answering."
+    )
+    assert iterator.accumulated_reasoning_content == expected_thinking
+
+    assert final_usage is not None
+    assert final_usage.completion_tokens == 50
+
+    completion_details = final_usage.completion_tokens_details
+    assert completion_details is not None
+    assert completion_details.reasoning_tokens > 0, (
+        "Expected reasoning_tokens > 0 in streaming usage when thinking deltas "
+        f"were observed; got {completion_details.reasoning_tokens}. This is the "
+        "Anthropic streaming reasoning_tokens=0 regression."
+    )
+    # text_tokens is the remainder; it should not absorb the reasoning tokens.
+    assert completion_details.text_tokens == (50 - completion_details.reasoning_tokens)
+
+
+def test_streaming_no_thinking_leaves_reasoning_tokens_zero():
+    """Streams without any thinking deltas should still report
+    reasoning_tokens=0 (no false positives from the new accumulator)."""
+    chunks = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_456",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "usage": {"input_tokens": 5, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello world"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 12},
+        },
+    ]
+
+    iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+
+    final_usage = None
+    for chunk in chunks:
+        parsed = iterator.chunk_parser(chunk)
+        if parsed.usage is not None:
+            final_usage = parsed.usage
+
+    assert iterator.accumulated_reasoning_content == ""
+    assert final_usage is not None
+    completion_details = final_usage.completion_tokens_details
+    assert completion_details is not None
+    assert completion_details.reasoning_tokens == 0
+    assert completion_details.text_tokens == 12


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Fixes a bug where streaming Anthropic chat completions with extended thinking always returned `completion_tokens_details.reasoning_tokens = 0`, while non-streaming requests for the exact same prompt correctly reported the reasoning token count. All thinking tokens were silently absorbed into `text_tokens`.

## Linear ticket

<!-- internal -->

## Root cause

`ModelResponseIterator` (in `litellm/llms/anthropic/chat/handler.py`, also referred to as `AnthropicStreamResponse` in some bug reports) forwards thinking deltas to the client as streaming chunks but **never accumulates the thinking text internally**. By the time the stream's `message_delta` arrives and `_handle_usage()` builds the final `Usage`, the thinking text is gone — so it calls `AnthropicConfig().calculate_usage(..., reasoning_content=None, ...)`.

In `transformation.py`, `calculate_usage` estimates reasoning tokens by running `token_counter()` over `reasoning_content`. With `None` it short-circuits to `0`:

```python
reasoning_tokens = (
    token_counter(text=reasoning_content, count_response_tokens=True)
    if reasoning_content
    else 0
)
```

The non-streaming path works because the full response (including thinking blocks) is materialized before `calculate_usage` runs.

Reported numbers from the same prompt ("probability of getting exactly 2 red balls from 3 boxes") with `thinking: {"type": "adaptive"}`:

| Mode | reasoning_tokens | text_tokens |
| --- | --- | --- |
| `stream: false` | 169 | 332 |
| `stream: true` (before fix) | **0** | 732 |

## Fix

- Add `self.accumulated_reasoning_content: str = ""` to `ModelResponseIterator.__init__`.
- In `_content_block_delta_helper`, append the thinking text from each `thinking_delta` event to that buffer (no-op for non-thinking deltas, including signature-only deltas).
- In `_handle_usage`, pass `reasoning_content=self.accumulated_reasoning_content or None` so `calculate_usage` can estimate `reasoning_tokens` for streams that contain thinking, while preserving the existing `None` path for non-thinking streams.

The buffer is purely additive and stays empty for any stream that doesn't carry thinking deltas, so non-thinking streaming responses are unaffected. Same pattern used by the existing `web_search_results`, `compaction_blocks`, and `tool_results` accumulators in the same class.

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/` (two new regression tests in `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py`):
  - `test_streaming_accumulates_reasoning_tokens_in_usage` — drives a synthetic Anthropic SSE stream containing `thinking_delta` chunks and asserts the final `Usage` reports `reasoning_tokens > 0` and `text_tokens = output_tokens - reasoning_tokens`. Without the fix this asserts on `reasoning_tokens=0` and fails.
  - `test_streaming_no_thinking_leaves_reasoning_tokens_zero` — drives a text-only stream and asserts `reasoning_tokens` stays `0` and `text_tokens` equals the full `output_tokens`. Guards against false positives from the new accumulator.
- [x] All anthropic chat tests pass: `uv run pytest tests/test_litellm/llms/anthropic/chat/ -x -q` → **258 passed**.
- [x] Bedrock anthropic-message tests pass: `uv run pytest tests/test_litellm/llms/bedrock/messages/ -q` → **36 passed**.
- [x] PR's scope is isolated to one specific problem (Anthropic streaming reasoning_tokens accounting).

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/anthropic/chat/handler.py`:
  - Added `accumulated_reasoning_content` buffer to `ModelResponseIterator`.
  - Append `thinking_delta` text to the buffer in `_content_block_delta_helper`.
  - Passed the buffered text into `calculate_usage` from `_handle_usage`.
- `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py`:
  - Added two regression tests covering the streaming reasoning token accumulation.

## Proof of fix

Output from running the new tests against this branch:

```
$ uv run pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py -k "reasoning_tokens" -vv
...
collected 30 items / 28 deselected / 2 selected

tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py::test_streaming_accumulates_reasoning_tokens_in_usage PASSED [ 50%]
tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py::test_streaming_no_thinking_leaves_reasoning_tokens_zero PASSED [100%]

======================= 2 passed, 28 deselected in 0.58s =======================
```

Both new tests pass with the fix. The first test fails (`reasoning_tokens == 0`) on `main` without the change, reproducing the bug.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778094890491749?thread_ts=1778094890.491749&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-3f9827a7-2edd-5a21-a11e-67a30207ccc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f9827a7-2edd-5a21-a11e-67a30207ccc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

