### PR TITLE
fix(logging): prevent AnthropicResponse ValidationError for Responses API events in anthropic_messages logging

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3446,6 +3446,33 @@ class Logging(LiteLLMLoggingBaseClass):
             )
         else:
             from litellm.types.llms.anthropic import AnthropicResponse
+            from litellm.types.llms.openai import (
+                ResponseCompletedEvent,
+                ResponseIncompleteEvent,
+            )
+
+            # When the experimental Anthropic pass-through adapter routes a request
+            # through the Responses API (e.g. to Azure/Foundry), the success handler
+            # may receive a ResponseIncompleteEvent or ResponseCompletedEvent rather
+            # than a plain dict or AnthropicResponse instance.
+            # AnthropicResponse.model_validate() rejects these types and raises a
+            # ValidationError in background logging (non-blocking but noisy).
+            # Guard against this before calling model_validate. (Fixes #27091)
+            if isinstance(result, (ResponseCompletedEvent, ResponseIncompleteEvent)):
+                verbose_logger.debug(
+                    "anthropic_messages logging: result is a Responses API event (%s), "
+                    "skipping AnthropicResponse transform",
+                    type(result).__name__,
+                )
+                return result  # type: ignore[return-value]
+
+            if not isinstance(result, (dict, AnthropicResponse)):
+                verbose_logger.debug(
+                    "anthropic_messages logging: unexpected result type %s, "
+                    "skipping AnthropicResponse transform",
+                    type(result).__name__,
+                )
+                return result  # type: ignore[return-value]
 
             pydantic_result = AnthropicResponse.model_validate(result)
             import httpx

--- a/tests/unit/litellm_core_utils/test_anthropic_messages_logging_responses_events.py
+++ b/tests/unit/litellm_core_utils/test_anthropic_messages_logging_responses_events.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for _handle_anthropic_messages_response_logging guard against
+ResponseIncompleteEvent / ResponseCompletedEvent (issue #27091).
+
+These cover the regression: when the experimental Anthropic pass-through routes
+through the Responses API backend the success handler receives a Responses API
+event object, not a plain dict or AnthropicResponse. Before the fix, Pydantic
+raised a ValidationError in background logging.
+"""
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+def _make_logging_obj(stream: bool = False):
+    """Build a minimal Logging instance without touching live infrastructure."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.utils import CallTypes
+
+    obj = Logging.__new__(Logging)
+    obj.stream = stream
+    obj.call_type = CallTypes.anthropic_messages.value
+    obj.model = "claude-sonnet-4-6"
+    obj.model_call_details = {}  # no httpx_response stored
+    return obj
+
+
+def _make_incomplete_event():
+    """Return a minimal ResponseIncompleteEvent with a stub .response."""
+    from litellm.types.llms.openai import ResponseIncompleteEvent
+
+    stub_response = MagicMock()
+    stub_response.status = "incomplete"
+    return ResponseIncompleteEvent(
+        type="response.incomplete",
+        response=stub_response,
+    )
+
+
+def _make_completed_event():
+    """Return a minimal ResponseCompletedEvent with a stub .response."""
+    from litellm.types.llms.openai import ResponseCompletedEvent
+
+    stub_response = MagicMock()
+    stub_response.status = "completed"
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=stub_response,
+    )
+
+
+class TestHandleAnthropicMessagesLoggingResponsesEvents:
+    """
+    _handle_anthropic_messages_response_logging must not raise a ValidationError
+    when it receives a Responses API event (ResponseIncompleteEvent,
+    ResponseCompletedEvent, or any unexpected type).
+    """
+
+    def test_incomplete_event_does_not_raise(self):
+        """ResponseIncompleteEvent must not trigger AnthropicResponse.model_validate."""
+        obj = _make_logging_obj()
+        event = _make_incomplete_event()
+        # Should return without raising ValidationError
+        result = obj._handle_anthropic_messages_response_logging(result=event)
+        # Result passes through unchanged
+        assert result is event
+
+    def test_completed_event_does_not_raise(self):
+        """ResponseCompletedEvent must not trigger AnthropicResponse.model_validate."""
+        obj = _make_logging_obj()
+        event = _make_completed_event()
+        result = obj._handle_anthropic_messages_response_logging(result=event)
+        assert result is event
+
+    def test_unknown_type_does_not_raise(self):
+        """Arbitrary non-dict, non-AnthropicResponse types must not crash."""
+        obj = _make_logging_obj()
+        random_obj = object()
+        # Should not raise
+        result = obj._handle_anthropic_messages_response_logging(result=random_obj)
+        assert result is random_obj
+
+    def test_model_response_still_returned_as_is(self):
+        """ModelResponse inputs should continue to pass through unchanged."""
+        from litellm import ModelResponse
+
+        obj = _make_logging_obj()
+        mr = ModelResponse(model="claude-sonnet-4-6")
+        result = obj._handle_anthropic_messages_response_logging(result=mr)
+        assert isinstance(result, ModelResponse)
+
+    def test_streaming_model_response_returned_as_is(self):
+        """Streaming ModelResponse should still short-circuit at the first guard."""
+        from litellm import ModelResponse
+
+        obj = _make_logging_obj(stream=True)
+        mr = ModelResponse(model="claude-sonnet-4-6")
+        result = obj._handle_anthropic_messages_response_logging(result=mr)
+        assert isinstance(result, ModelResponse)
+
+    def test_debug_log_emitted_for_incomplete_event(self, caplog):
+        """A debug message must be emitted when a Responses API event is encountered."""
+        import logging
+
+        obj = _make_logging_obj()
+        event = _make_incomplete_event()
+        with caplog.at_level(logging.DEBUG, logger="LiteLLM"):
+            obj._handle_anthropic_messages_response_logging(result=event)
+        assert any(
+            "ResponseIncompleteEvent" in rec.message for rec in caplog.records
+        ), "Expected debug log mentioning ResponseIncompleteEvent"


### PR DESCRIPTION
## Summary

Fixes #27091 (Part 2 — non-blocking Pydantic ValidationError in background logging)

When the experimental Anthropic pass-through adapter routes a request through the
Responses API backend (e.g. Azure/Microsoft Foundry), the success handler in
`_handle_anthropic_messages_response_logging()` receives a `ResponseIncompleteEvent`
or `ResponseCompletedEvent` object from the Responses API stream. These types are
not dict-serialisable as `AnthropicResponse`, so `AnthropicResponse.model_validate()`
raises a `ValidationError` in background logging:

```
Exception: [Non-Blocking] LiteLLM.Success_Call Error:
  1 validation error for AnthropicResponse
  Input should be a valid dictionary or instance of AnthropicResponse
  [type=model_type, input_value=ResponseIncompleteEvent(...)]
```

## Root cause

`_handle_anthropic_messages_response_logging` (litellm_logging.py) guards for
`ModelResponse` and `httpx.Response` but falls through to a bare
`AnthropicResponse.model_validate(result)` for all other types. When the result
is a Responses API event object the call explodes.

## Fix

Add `isinstance` guards before `model_validate`:

1. If `result` is a `ResponseCompletedEvent` or `ResponseIncompleteEvent`, emit a
   debug-level log and return the event as-is (logging continues without crashing).
2. If `result` is any other non-dict / non-`AnthropicResponse` type, same guard.

## Tests

Added `tests/unit/litellm_core_utils/test_anthropic_messages_logging_responses_events.py`
with 6 unit tests covering:
- `ResponseIncompleteEvent` does not raise
- `ResponseCompletedEvent` does not raise
- Arbitrary unknown type does not raise
- `ModelResponse` still passes through unchanged
- Streaming `ModelResponse` still passes through
- Debug log is emitted when a Responses API event is encountered
