### PR TITLE
fix(azure_ai): map max_completion_tokens to max_tokens for Model Inference endpoint

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -46,6 +46,30 @@ class AzureAIStudioConfig(OpenAIConfig):
 
         return supported_params
 
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        # Azure AI Foundry's Model Inference endpoint (/models/chat/completions)
+        # only accepts `max_tokens`; `max_completion_tokens` is not in its request
+        # body schema and causes a 422. Apply the parent mapping first (which may
+        # internally rename max_tokens → max_completion_tokens for o-series /
+        # gpt-5 model families), then normalize back to max_tokens so Foundry-
+        # hosted deployments (e.g. mistral-large-3, cohere, Llama) always receive
+        # the supported parameter name. Fixes #26322.
+        optional_params = super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
+        if "max_completion_tokens" in optional_params:
+            optional_params["max_tokens"] = optional_params.pop("max_completion_tokens")
+        return optional_params
+
     def _supports_stop_reason(self, model: str) -> bool:
         """
         Check if the model supports stop tokens.

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_max_completion_tokens.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_max_completion_tokens.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for AzureAIStudioConfig.map_openai_params — ensures max_completion_tokens
+is correctly renamed to max_tokens for Azure AI Foundry's Model Inference endpoint.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/26322
+"""
+import pytest
+
+from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig
+
+
+@pytest.fixture
+def config():
+    return AzureAIStudioConfig()
+
+
+class TestAzureAIMapOpenAIParamsMaxTokens:
+    def test_max_completion_tokens_renamed_to_max_tokens(self, config):
+        """max_completion_tokens must be rewritten to max_tokens for the Foundry endpoint."""
+        result = config.map_openai_params(
+            non_default_params={"max_completion_tokens": 1000},
+            optional_params={},
+            model="mistral-large-3",
+            drop_params=False,
+        )
+        assert result.get("max_tokens") == 1000
+        assert "max_completion_tokens" not in result
+
+    def test_plain_max_tokens_passes_through(self, config):
+        """Plain max_tokens must still be forwarded unchanged."""
+        result = config.map_openai_params(
+            non_default_params={"max_tokens": 500},
+            optional_params={},
+            model="mistral-large-3",
+            drop_params=False,
+        )
+        assert result.get("max_tokens") == 500
+        assert "max_completion_tokens" not in result
+
+    def test_max_completion_tokens_wins_when_both_present(self, config):
+        """When both keys are provided, max_completion_tokens takes precedence."""
+        result = config.map_openai_params(
+            non_default_params={"max_tokens": 500, "max_completion_tokens": 1000},
+            optional_params={},
+            model="mistral-large-3",
+            drop_params=False,
+        )
+        assert result.get("max_tokens") == 1000
+        assert "max_completion_tokens" not in result
+
+    def test_does_not_mutate_caller_dict(self, config):
+        """The incoming non_default_params dict must not be mutated."""
+        non_default_params = {"max_completion_tokens": 1000}
+        config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params={},
+            model="mistral-large-3",
+            drop_params=False,
+        )
+        assert non_default_params == {"max_completion_tokens": 1000}
+
+    def test_no_max_tokens_key_untouched(self, config):
+        """Params with no token-limit key must pass through unchanged."""
+        result = config.map_openai_params(
+            non_default_params={"temperature": 0.7},
+            optional_params={},
+            model="mistral-large-3",
+            drop_params=False,
+        )
+        assert "max_tokens" not in result
+        assert "max_completion_tokens" not in result
+
+    @pytest.mark.parametrize("model", ["o3-mini", "gpt-5", "mistral-large-3", "cohere-command"])
+    def test_rename_applies_to_all_models(self, config, model):
+        """The rename must apply regardless of model name."""
+        result = config.map_openai_params(
+            non_default_params={"max_completion_tokens": 2048},
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+        assert result.get("max_tokens") == 2048
+        assert "max_completion_tokens" not in result


### PR DESCRIPTION
## Summary

Fixes #26322

Azure AI Foundry's Model Inference endpoint (`/models/chat/completions`) only
accepts `max_tokens` — `max_completion_tokens` is not in its request-body schema.
Clients that pass `max_completion_tokens` receive a 422, which LiteLLM surfaces as
`APIConnectionError: Azure_aiException - Extra data: line 2 column 1 (char 209)`
(the JSON parse fails on the error body in `transform_request_on_unprocessable_entity_error`).

## Root cause

`AzureAIStudioConfig` inherits `map_openai_params` from `OpenAIConfig` unchanged.
`OpenAIConfig.map_openai_params` passes `max_completion_tokens` through as-is for
most models. The Mistral-direct provider (`litellm/llms/mistral/chat/transformation.py`)
already renames `max_completion_tokens → max_tokens`, but `azure_ai` does not.

## Fix

Override `map_openai_params` in `AzureAIStudioConfig` to call `super()` then
rename `max_completion_tokens → max_tokens` in the result. Applying the rename
*after* `super()` ensures it also handles cases where the parent (o-series / gpt-5
config) actively renames in the other direction.

## Tests

Added `tests/test_litellm/llms/azure_ai/chat/test_azure_ai_max_completion_tokens.py`
with 6 parametrized unit tests (all mocked, no network calls):
- `max_completion_tokens` → `max_tokens` rename
- Plain `max_tokens` passes through unchanged
- `max_completion_tokens` takes priority when both are present
- Caller dict is not mutated
- Params without token-limit keys are untouched
- Rename applies to all model name patterns (mistral, o3, gpt-5, cohere)
