### PR TITLE
fix(proxy): flush virtual-key model_max budget spend to Redis after success logging

### DIFF
--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -319,6 +319,9 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
                     response_cost=response_cost,
                 )
 
+        if self.dual_cache.redis_cache is not None:
+            await self._push_in_memory_increments_to_redis()
+
         verbose_proxy_logger.debug(
             "current state of in memory cache %s",
             json.dumps(

--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -413,3 +413,71 @@ async def test_async_log_success_event_uses_end_user_model_budget_duration(
             f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model}:{budget_duration}"
         )
         assert call_kwargs["response_cost"] == 0.05
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_pushes_redis_increments_when_redis_configured():
+    """
+    Virtual-key model max budget limiter does not run RouterBudgetLimiting.__init__,
+    so the periodic Redis flush task never starts. After logging spend we must call
+    _push_in_memory_increments_to_redis when Redis is wired so other workers see spend.
+    """
+    dual_cache = DualCache()
+    dual_cache.redis_cache = object()  # truthy placeholder; push only checks is not None
+    limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=dual_cache)
+    model = "gpt-4"
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 0.01,
+            "model": model,
+            "metadata": {"user_api_key_hash": "vk-hash"},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_model_max_budget": {
+                    model: {"budget_limit": 10.0, "time_period": "1d"},
+                },
+            },
+        },
+    }
+    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock):
+        with patch.object(
+            limiter,
+            "_push_in_memory_increments_to_redis",
+            new_callable=AsyncMock,
+        ) as mock_push:
+            await limiter.async_log_success_event(
+                kwargs, response_obj=None, start_time=None, end_time=None
+            )
+            mock_push.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_redis_push_without_redis(budget_limiter):
+    """When dual_cache has no Redis backend, do not await _push_in_memory_increments_to_redis."""
+    assert budget_limiter.dual_cache.redis_cache is None
+    model = "gpt-4"
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 0.01,
+            "model": model,
+            "metadata": {"user_api_key_hash": "vk-hash"},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_model_max_budget": {
+                    model: {"budget_limit": 10.0, "time_period": "1d"},
+                },
+            },
+        },
+    }
+    with patch.object(budget_limiter, "_increment_spend_for_key", new_callable=AsyncMock):
+        with patch.object(
+            budget_limiter,
+            "_push_in_memory_increments_to_redis",
+            new_callable=AsyncMock,
+        ) as mock_push:
+            await budget_limiter.async_log_success_event(
+                kwargs, response_obj=None, start_time=None, end_time=None
+            )
+            mock_push.assert_not_awaited()


### PR DESCRIPTION
## Linear ticket

Resolves LIT-2893

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added tests in `tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py` (same location as the existing model max budget limiter suite). **Note:** the repo template points at `tests/test_litellm/`; these tests follow the existing pattern for this hook in `proxy_unit_tests`. If maintainers want a mirror under `tests/test_litellm/`, I can add one.
- [x] My PR passes all unit tests on `make test-unit` (not run in this environment where `make`/`uv` is unavailable; locally: `pytest tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py` — **13 passed**.)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Manual repro (two proxy workers, one Redis):**

- Config used the usual pattern: `litellm_settings.cache` + Redis `cache_params`, and **`enable_redis_auth_cache: true`** so `user_api_key_cache` shares the same Redis-backed `DualCache` as `_PROXY_VirtualKeyModelMaxBudgetLimiter`.
- A virtual key with **`model_max_budget`** set to a very small cap for a model alias (e.g. model group name matching enforcement).
- **Proxy A** (e.g. port 4058): first chat completion → **HTTP 200** (spend recorded).
- **Proxy B** (e.g. port 4059), same Redis and same key: second completion → **HTTP 400** with **`budget_exceeded`**, proving spend visible across workers after the fix.

**Before the fix:** Redis could show budget window metadata (e.g. `virtual_key_budget_start_time:*`) while **`virtual_key_spend:*`** was missing or stale across workers, because increments stayed in the in-memory queue and were never flushed (subclass never runs `RouterBudgetLimiting.__init__`, so the periodic Redis sync task never starts).

**After the fix:** `async_log_success_event` calls `_push_in_memory_increments_to_redis()` when `dual_cache.redis_cache` is set, so the increment pipeline runs and multi-worker enforcement matches intent.

## Type

🐛 Bug Fix

## Changes

- **`litellm/proxy/hooks/model_max_budget_limiter.py`:** After virtual-key and end-user model budget increments in `async_log_success_event`, **`await self._push_in_memory_increments_to_redis()`** when Redis is attached to `dual_cache`, so queued increments are written with the same mechanism as `RouterBudgetLimiting`.
- **`tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py`:**  
  - `test_async_log_success_event_pushes_redis_increments_when_redis_configured` — asserts `_push_in_memory_increments_to_redis` is awaited once when `redis_cache` is set.  
  - `test_async_log_success_event_skips_redis_push_without_redis` — asserts it is not awaited when Redis is not configured.