### PR TITLE
[Chore] CI: Block PRs that drop overall code coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -28,7 +28,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1% # at maximum allow project coverage to drop by 1%
+        threshold: 0% # do not allow project coverage to drop
     patch:
       default:
         target: auto

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,3 +1,8 @@
+codecov:
+  require_ci_to_pass: false # post coverage status even if CI has unrelated failures
+  notify:
+    wait_for_ci: false # post as soon as expected uploads arrive, don't wait on CI
+
 component_management:
   individual_components:
     - component_id: "Router"


### PR DESCRIPTION
## Summary

- Tighten Codecov project status threshold from `1%` → `0%` in [codecov.yaml](codecov.yaml).
- With `target: auto` + `threshold: 0%`, the `codecov/project` check fails on any drop in overall project coverage relative to the base commit. The bar floats with the codebase — no manual updates as coverage moves.
- This PR is the config side. To actually block merges, `codecov/project` still needs to be added as a required status check in branch protection for `main` / `litellm_internal_staging` (GitHub UI step, done after this lands so the check name registers).

## Test plan

- [ ] Confirm Codecov uploads run on this PR's CI build and the `codecov/project` status posts back.
- [ ] After merge, add `codecov/project` as a required status check in branch protection for `litellm_internal_staging` and `main`.
- [ ] Verify on a follow-up PR: a change that lowers overall coverage gets a red `codecov/project` and is blocked from merging.