### PR TITLE
[Chore] CI: Assign test_request_size_limit_middleware To Proxy-Runtime Shard

### DIFF
--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -141,6 +141,7 @@ jobs:
               tests/proxy_unit_tests/test_server_root_path.py
               tests/proxy_unit_tests/test_proxy_pass_user_config.py
               tests/proxy_unit_tests/test_proxy_token_counter.py
+              tests/proxy_unit_tests/test_request_size_limit_middleware.py
             workers: 4
             dist: loadscope
             timeout: 15


### PR DESCRIPTION
## Summary

The `assert-shard-coverage` guard in `.github/workflows/test-unit-proxy-db.yml` is failing on `litellm_internal_staging` because `tests/proxy_unit_tests/test_request_size_limit_middleware.py` exists but isn't referenced by any matrix entry. Assigning it to the `proxy-runtime` shard, which already groups other server-runtime tests (`proxy_routes`, `proxy_gunicorn`, `server_root_path`).

## Test plan

- [x] Re-ran the inline `assert-shard-coverage` python script locally — `OK: all 58 files assigned to a shard.`
- [ ] CI `assert-shard-coverage` job passes
- [ ] CI `proxy-runtime` shard passes with the new file included