### PR TITLE
Fix Anthropic streaming web search cost usage

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1553,7 +1553,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
         completion_tokens_details: Optional[
             Union[CompletionTokensDetailsWrapper, dict]
         ] = None,
-        server_tool_use: Optional[ServerToolUse] = None,
+        server_tool_use: Optional[Union[ServerToolUse, Dict[str, Any]]] = None,
         cost: Optional[float] = None,
         **params,
     ):
@@ -1655,6 +1655,8 @@ class Usage(SafeAttributeModel, CompletionUsage):
         )
 
         if server_tool_use is not None:
+            if isinstance(server_tool_use, dict):
+                server_tool_use = ServerToolUse(**server_tool_use)
             self.server_tool_use = server_tool_use
         else:  # maintain openai compatibility in usage object if possible
             del self.server_tool_use

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -8,7 +8,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm import stream_chunk_builder
+from litellm import completion_cost, stream_chunk_builder
 from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
 from litellm.types.utils import (
     ChatCompletionDeltaToolCall,
@@ -520,7 +520,66 @@ def test_stream_chunk_builder_anthropic_web_search():
     assert usage.prompt_tokens == 50
     assert usage.completion_tokens == 27
     assert usage.total_tokens == 77
-    assert usage.server_tool_use["web_search_requests"] == 2
+    assert usage.server_tool_use.web_search_requests == 2
+
+
+def test_stream_chunk_builder_anthropic_web_search_cost_calculation():
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-mocked-usage-1",
+        created=1745513206,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="", role="assistant"),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=0,
+            prompt_tokens=50,
+            total_tokens=50,
+            completion_tokens_details=None,
+            server_tool_use=ServerToolUse(web_search_requests=2),
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-mocked-usage-1",
+        created=1745513207,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="done", role=None),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=27,
+            prompt_tokens=0,
+            total_tokens=27,
+            completion_tokens_details=None,
+            prompt_tokens_details=None,
+        ),
+    )
+
+    response = stream_chunk_builder(chunks=[chunk1, chunk2])
+
+    assert response is not None
+    assert isinstance(response.usage.server_tool_use, ServerToolUse)
+    assert completion_cost(completion_response=response) > 0
 
 
 def test_sort_chunks_handles_dict_hidden_params_created_at():

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -45,6 +45,7 @@ def test_usage_dump():
     from litellm.types.utils import (
         CompletionTokensDetailsWrapper,
         PromptTokensDetailsWrapper,
+        ServerToolUse,
         Usage,
     )
 
@@ -73,6 +74,16 @@ def test_usage_dump():
 
     new_usage = Usage(**current_usage.model_dump())
     assert new_usage.prompt_tokens_details.web_search_requests == 1
+
+    server_tool_usage = Usage(
+        completion_tokens=10,
+        prompt_tokens=5,
+        total_tokens=15,
+        server_tool_use=ServerToolUse(web_search_requests=2),
+    )
+    new_server_tool_usage = Usage(**server_tool_usage.model_dump())
+    assert isinstance(new_server_tool_usage.server_tool_use, ServerToolUse)
+    assert new_server_tool_usage.server_tool_use.web_search_requests == 2
 
 
 def test_usage_completion_tokens_details_text_tokens():


### PR DESCRIPTION
## Summary
`Usage` now normalizes dict-shaped `server_tool_use` payloads back into `ServerToolUse` objects. This preserves typed usage after streaming responses are rebuilt and prevents web-search cost calculation from raising on Anthropic streaming responses.

## Repro
A streaming Anthropic chat completion with web search usage emits chunks whose aggregated usage is round-tripped through `model_dump()`. Before this fix, the rebuilt response had `usage.server_tool_use` as a dict, and calling cost calculation on the response raised an attribute error.

## Evidence
Terminal transcript from the local repro after the fix:

```text
ServerToolUse
2
0.020555
```

## Tests
- Added regression coverage in `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py` for streaming Anthropic web-search cost calculation.
- Added round-trip coverage in `tests/test_litellm/types/test_types_utils.py` for `Usage(**usage.model_dump())` preserving `ServerToolUse`.
- `uv run --no-sync pytest tests/test_litellm/types/test_types_utils.py tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py -vv` -> 26 passed.
- `uv lock --check` -> passed.
- `uv sync --frozen` -> passed.
- `cd litellm && uv run --no-sync black --check --exclude '/enterprise/' .` -> passed.
- `cd litellm && uv run --no-sync ruff check .` -> passed.
- `cd litellm && uv run --no-sync mypy .` -> passed.
- `cd litellm && uv run --no-sync python ../tests/documentation_tests/test_circular_imports.py` -> passed.
- `uv run --no-sync python -c "from litellm import *"` -> passed.

## CI
- GitHub PR checks: all visible jobs green, including lint, core-utils, responses-caching-types, provider tests, proxy tests, code-quality, secret scan, and UI build.
- CircleCI: no pipeline was visible for this fork branch through the available public API; GitHub checks were used as the observable PR CI signal.

## Review
- Greptile review: no review was posted after the wait window, so there were no automated review threads to address.

## Relevant issues
Fixes #26153

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [x] Branch creation CI run
       Link: https://github.com/BerriAI/litellm/actions/runs/25468084127

- [x] CI run for the last commit
       Link: https://github.com/BerriAI/litellm/actions/runs/25468084104

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

See the terminal transcript in `## Evidence`.

## Type

🐛 Bug Fix
✅ Test

## Changes
- Normalize dict `server_tool_use` inputs in `Usage`.
- Assert streaming Anthropic web-search usage remains typed after aggregation.
- Assert completion cost calculation succeeds for the rebuilt streaming response.
