### PR TITLE
[Fix] /health/test_connection: disambiguate by model_info.id when deployments share a model_name

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1742,29 +1742,54 @@ async def test_model_connection(
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
         config_litellm_params: dict = {}
-        if model_name and llm_router is not None:
+        if llm_router is not None:
+            # Prefer disambiguation by deployment id (`model_info.id`) when
+            # the caller supplies it. This is required when multiple
+            # deployments share a `model_name` (e.g. wildcard `openai/*`
+            # with multiple `api_base` values for failover): the UI's
+            # "Test Connection" button targets a specific row, and that
+            # row's id is the only thing that uniquely identifies which
+            # deployment to probe. Without this, all duplicates collapse
+            # onto `deployments[0]`.
+            request_model_info = model_info or {}
+            request_model_id = request_model_info.get("id")
             try:
-                # First try to find by proxy model_name (e.g., "gpt-4o")
-                deployments = llm_router.get_model_list(model_name=model_name)
-
-                # If not found, try to find by litellm model name (e.g., "azure/gpt-4o")
-                if not deployments or len(deployments) == 0:
-                    all_deployments = llm_router.get_model_list(model_name=None)
-                    if all_deployments:
-                        for deployment in all_deployments:
-                            if (
-                                deployment.get("litellm_params", {}).get("model")
-                                == model_name
-                            ):
-                                deployments = [deployment]
-                                break
-
-                if deployments and len(deployments) > 0:
-                    # Use the first deployment's litellm_params as base config
-                    # These already have resolved environment variables from proxy config
-                    config_litellm_params = dict(
-                        deployments[0].get("litellm_params", {})
+                deployment_by_id = None
+                if request_model_id:
+                    deployment_by_id = llm_router.get_deployment(
+                        model_id=request_model_id
                     )
+
+                if deployment_by_id is not None:
+                    config_litellm_params = deployment_by_id.litellm_params.model_dump(
+                        exclude_none=True
+                    )
+                elif model_name:
+                    # Fall back to model_name lookup for callers (e.g. the
+                    # "Add Model" wizard, or curl) that don't supply an id.
+                    # First try to find by proxy model_name (e.g., "gpt-4o")
+                    deployments = llm_router.get_model_list(model_name=model_name)
+
+                    # If not found, try to find by litellm model name
+                    # (e.g., "azure/gpt-4o")
+                    if not deployments or len(deployments) == 0:
+                        all_deployments = llm_router.get_model_list(model_name=None)
+                        if all_deployments:
+                            for deployment in all_deployments:
+                                if (
+                                    deployment.get("litellm_params", {}).get("model")
+                                    == model_name
+                                ):
+                                    deployments = [deployment]
+                                    break
+
+                    if deployments and len(deployments) > 0:
+                        # Use the first deployment's litellm_params as base
+                        # config. These already have resolved environment
+                        # variables from proxy config.
+                        config_litellm_params = dict(
+                            deployments[0].get("litellm_params", {})
+                        )
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. "

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -467,6 +467,236 @@ async def test_test_model_connection_loads_config_from_router():
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_uses_model_info_id_to_disambiguate_duplicate_model_names():
+    """
+    When two deployments share the same `model_name` (e.g. wildcard
+    `openai/*`) but have different `api_base` values, clicking "Test
+    Connection" on a specific row in the UI must probe THAT row's
+    `api_base` — not whichever happens to be `deployments[0]`.
+
+    The UI passes `model_info.id` to identify the deployment the user
+    actually clicked on. The backend must use that id to look up the
+    specific deployment rather than always grabbing the first match.
+
+    Regression test for: silent fallback to deployments[0] when
+    multiple deployments share a wildcard model_name.
+    """
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    mock_request = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+    mock_user_api_key_dict.user_id = "test-user"
+    mock_user_api_key_dict.token = "test-token"
+
+    mock_prisma_client = MagicMock()
+
+    deployment_a = {
+        "model_name": "openai/*",
+        "litellm_params": {
+            "model": "openai/*",
+            "api_base": "https://deployment-A-base.invalid/v1",
+            "api_key": "fake-key-A",
+        },
+        "model_info": {"id": "deployment-A-id"},
+    }
+    deployment_b = {
+        "model_name": "openai/*",
+        "litellm_params": {
+            "model": "openai/*",
+            "api_base": "https://deployment-B-base.invalid/v1",
+            "api_key": "fake-key-B",
+        },
+        "model_info": {"id": "deployment-B-id"},
+    }
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [deployment_a, deployment_b]
+
+    # Backend uses get_deployment(model_id=...) for O(1) lookup by id.
+    def _get_deployment_by_id(model_id):
+        if model_id == "deployment-A-id":
+            return Deployment(
+                model_name="openai/*",
+                litellm_params=LiteLLM_Params(**deployment_a["litellm_params"]),
+                model_info=deployment_a["model_info"],
+            )
+        if model_id == "deployment-B-id":
+            return Deployment(
+                model_name="openai/*",
+                litellm_params=LiteLLM_Params(**deployment_b["litellm_params"]),
+                model_info=deployment_b["model_info"],
+            )
+        return None
+
+    mock_router.get_deployment.side_effect = _get_deployment_by_id
+
+    mock_can_user_make_model_call = AsyncMock()
+
+    mock_health_check_result = {"status": "healthy", "response_time_ms": 50}
+    mock_ahealth_check = AsyncMock(return_value=mock_health_check_result)
+    mock_run_with_timeout = AsyncMock(return_value=mock_health_check_result)
+
+    def mock_update_params(model_info, litellm_params):
+        params = litellm_params.copy()
+        params["messages"] = [{"role": "user", "content": "test"}]
+        return params
+
+    def mock_reject_os_environ(params):
+        return None
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.prisma_client",
+            mock_prisma_client,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.llm_router",
+            mock_router,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.premium_user",
+            False,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            mock_update_params,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        # Click "Test Connection" on deployment B (NOT the first one).
+        # The UI sends only `model` + `model_info.id` — it does NOT
+        # send `api_base`/`api_key`, so the backend must resolve them
+        # from the right deployment.
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "openai/*"},
+            model_info={"id": "deployment-B-id"},
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        # The outbound health check must hit deployment B's api_base.
+        ahealth_check_call_args = mock_ahealth_check.call_args
+        assert ahealth_check_call_args is not None
+        model_params = ahealth_check_call_args.kwargs.get("model_params", {})
+
+        assert model_params.get("api_base") == (
+            "https://deployment-B-base.invalid/v1"
+        ), (
+            "Expected /health/test_connection to probe deployment B's "
+            "api_base when model_info.id='deployment-B-id' was provided. "
+            f"Got: {model_params.get('api_base')!r}. This means the "
+            "backend silently fell back to deployments[0] (A) instead "
+            "of disambiguating by model_info.id."
+        )
+        assert model_params.get("api_key") == "fake-key-B"
+
+
+@pytest.mark.asyncio
+async def test_test_model_connection_falls_back_to_deployments_zero_without_id():
+    """
+    Backwards-compat: when the request body does NOT include
+    `model_info.id`, the legacy behavior of using `deployments[0]`
+    is preserved (single-deployment case, or callers that haven't
+    been updated to pass an id).
+    """
+    mock_request = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+    mock_user_api_key_dict.user_id = "test-user"
+    mock_user_api_key_dict.token = "test-token"
+
+    mock_prisma_client = MagicMock()
+
+    deployment_a = {
+        "model_name": "openai/*",
+        "litellm_params": {
+            "model": "openai/*",
+            "api_base": "https://deployment-A-base.invalid/v1",
+            "api_key": "fake-key-A",
+        },
+        "model_info": {"id": "deployment-A-id"},
+    }
+    deployment_b = {
+        "model_name": "openai/*",
+        "litellm_params": {
+            "model": "openai/*",
+            "api_base": "https://deployment-B-base.invalid/v1",
+            "api_key": "fake-key-B",
+        },
+        "model_info": {"id": "deployment-B-id"},
+    }
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [deployment_a, deployment_b]
+
+    mock_can_user_make_model_call = AsyncMock()
+    mock_health_check_result = {"status": "healthy"}
+    mock_ahealth_check = AsyncMock(return_value=mock_health_check_result)
+    mock_run_with_timeout = AsyncMock(return_value=mock_health_check_result)
+
+    def mock_update_params(model_info, litellm_params):
+        params = litellm_params.copy()
+        params["messages"] = [{"role": "user", "content": "test"}]
+        return params
+
+    def mock_reject_os_environ(params):
+        return None
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            mock_can_user_make_model_call,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            mock_ahealth_check,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            mock_run_with_timeout,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._update_litellm_params_for_health_check",
+            mock_update_params,
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints._reject_os_environ_references",
+            mock_reject_os_environ,
+        ),
+    ):
+        await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "openai/*"},
+            model_info={},  # no id provided
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        # Without id, deployments[0] (A) should be used (legacy behavior).
+        model_params = mock_ahealth_check.call_args.kwargs.get("model_params", {})
+        assert model_params.get("api_base") == "https://deployment-A-base.invalid/v1"
+        assert model_params.get("api_key") == "fake-key-A"
+
+
+@pytest.mark.asyncio
 async def test_health_services_endpoint_datadog_llm_observability():
     """
     Verify that 'datadog_llm_observability' is accepted as a valid service

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -250,6 +250,33 @@ describe("ModelInfoView", () => {
     });
   });
 
+  it("should pass model_info.id to disambiguate duplicate model_name deployments", async () => {
+    // Regression test: when two deployments share `model_name` (e.g.
+    // wildcard `openai/*` with different `api_base` values), the UI
+    // must forward the clicked row's `model_info.id` to the backend.
+    // Otherwise /health/test_connection silently probes deployments[0]
+    // instead of the deployment the user actually selected.
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Model Settings")).toBeInTheDocument();
+    });
+
+    const testButton = screen.getByRole("button", { name: /test connection/i });
+    await user.click(testButton);
+
+    await waitFor(() => {
+      expect(mockTestConnectionRequest).toHaveBeenCalled();
+    });
+
+    const callArgs = mockTestConnectionRequest.mock.calls[0];
+    // Signature: (accessToken, litellm_params, model_info, mode)
+    const modelInfoArg = callArgs[2] as Record<string, unknown>;
+    expect(modelInfoArg).toBeDefined();
+    expect(modelInfoArg.id).toBe("123");
+  });
+
   it("should display error notification when connection test fails", async () => {
     const user = userEvent.setup();
     mockTestConnectionRequest.mockRejectedValue(new Error("Connection failed"));

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -379,6 +379,12 @@ export default function ModelInfoView({
           model: localModelData.litellm_model_name,
         },
         {
+          // `id` is required to disambiguate when multiple deployments
+          // share the same model_name (e.g. wildcard `openai/*` with two
+          // different `api_base` values for failover). Without it the
+          // backend silently falls back to deployments[0] and probes
+          // the wrong endpoint.
+          id: localModelData.model_info?.id,
           mode: localModelData.model_info?.mode,
         },
         localModelData.model_info?.mode,


### PR DESCRIPTION
## Summary

When two or more deployments in `proxy_config.yaml` share the same `model_name` (e.g. wildcard `openai/*` with multiple `api_base` values for failover), clicking **Test Connection** on a specific row in the dashboard silently probed `deployments[0]` instead of the row the user actually selected.

## Root cause

- **Backend** (`litellm/proxy/health_endpoints/_health_endpoints.py`): the `/health/test_connection` handler resolved `litellm_params` via `get_model_list(model_name=...)` and unconditionally used the first match (`deployments[0]`). The incoming `model_info` field was passed to auth checks but never used to pick which deployment to actually probe.
- **UI** (`ui/litellm-dashboard/src/components/model_info_view.tsx`): the Test Connection click handler didn't forward the clicked row's `model_info.id` at all, leaving the backend with no way to disambiguate.

## Fix

- **Backend**: when `model_info.id` is on the request body, resolve the deployment via the router's existing O(1) `Router.get_deployment(model_id=...)` helper. Falls back to the legacy `model_name` lookup when no id is supplied, preserving behavior for callers that don't pass one (e.g. the "Add Model" wizard, raw curl).
- **UI**: forward `localModelData.model_info?.id` in the `model_info` payload of `testConnectionRequest`.

## Test plan

### New automated tests

- `tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py`
  - `test_test_model_connection_uses_model_info_id_to_disambiguate_duplicate_model_names` — sets up two deployments sharing `model_name: openai/*` with different `api_base` values, calls the endpoint with `model_info.id` pointing at the second one, asserts the outbound `api_base` matches that specific deployment.
  - `test_test_model_connection_falls_back_to_deployments_zero_without_id` — no `id` provided, legacy first-match behavior preserved.
- `ui/litellm-dashboard/src/components/model_info_view.test.tsx`
  - `should pass model_info.id to disambiguate duplicate model_name deployments` — asserts the `testConnectionRequest` payload from the click handler contains `id`.

### Live end-to-end verification

Started a real proxy on `localhost:4747` (random port to avoid colliding with other local proxies) backed by this minimal `dev_config.yaml`:

```yaml
model_list:
  - model_name: "openai/*"
    litellm_params:
      model: "openai/*"
      api_base: "https://deployment-A-base.invalid/v1"
      api_key: "fake-key-A"
  - model_name: "openai/*"
    litellm_params:
      model: "openai/*"
      api_base: "https://deployment-B-base.invalid/v1"
      api_key: "fake-key-B"

general_settings:
  master_key: sk-1234
```

Pulled the two deployment ids from `/model/info`:

```bash
A_ID="a30bd4954c475e58880801eb8bded67419dcdf92eec0d78a2f4a8cf582a2e679"  # api_base = deployment-A-base.invalid
B_ID="4ce4a636d2bd5513ee98766a83082a07ebf2b2835b028468a0b7131e8931441a"  # api_base = deployment-B-base.invalid
```

Ran the same three curl scenarios against the same proxy run, both **before** the fix (`git checkout HEAD~1 -- litellm/proxy/health_endpoints/_health_endpoints.py`, restart proxy) and **after** the fix (committed code):

```bash
# Scenario 1: no id (legacy)
curl -s -X POST http://localhost:4747/health/test_connection \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"litellm_params":{"model":"openai/*"},"model_info":{},"mode":"chat"}'

# Scenario 2: id = deployment B
curl -s -X POST http://localhost:4747/health/test_connection \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"litellm_params\":{\"model\":\"openai/*\"},\"model_info\":{\"id\":\"$B_ID\"},\"mode\":\"chat\"}"

# Scenario 3: id = deployment A
curl -s -X POST http://localhost:4747/health/test_connection \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"litellm_params\":{\"model\":\"openai/*\"},\"model_info\":{\"id\":\"$A_ID\"},\"mode\":\"chat\"}"
```

For each scenario I read two fields from the response body to determine which deployment was actually probed: `result.api_base` and `result.raw_request_typed_dict.raw_request_api_base`.

**BEFORE fix** (pre-fix code on staging):

| Scenario     | `result.api_base`                       | `raw_request_api_base`                  | Expected | Actual    |
| ------------ | --------------------------------------- | --------------------------------------- | -------- | --------- |
| No id        | `https://deployment-A-base.invalid/v1`  | `https://deployment-a-base.invalid/v1/` | A        | A         |
| **id = B**   | `https://deployment-A-base.invalid/v1`  | `https://deployment-a-base.invalid/v1/` | **B**    | **A**     |
| id = A       | `https://deployment-A-base.invalid/v1`  | `https://deployment-a-base.invalid/v1/` | A        | A         |

**AFTER fix** (committed code, same proxy + same curls):

| Scenario     | `result.api_base`                       | `raw_request_api_base`                  | Expected | Actual    |
| ------------ | --------------------------------------- | --------------------------------------- | -------- | --------- |
| No id        | `https://deployment-A-base.invalid/v1`  | `https://deployment-a-base.invalid/v1/` | A        | A         |
| **id = B**   | `https://deployment-B-base.invalid/v1`  | `https://deployment-b-base.invalid/v1/` | **B**    | **B**     |
| id = A       | `https://deployment-A-base.invalid/v1`  | `https://deployment-a-base.invalid/v1/` | A        | A         |

Scenario 2 is the regression case. Pre-fix, supplying `model_info.id = B_ID` was silently ignored and the proxy probed deployment A; post-fix it correctly probes deployment B. The `no id` and `id = A` cases continue to hit A, so the legacy fallback path used by raw curl / the Add Model wizard is preserved.