### PR TITLE
Fix Prometheus remaining metric zero values

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1443,12 +1443,12 @@ class PrometheusLogger(CustomLogger):
         )
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
-        remaining_requests = (
-            metadata.get(remaining_requests_variable_name, sys.maxsize) or sys.maxsize
-        )
-        remaining_tokens = (
-            metadata.get(remaining_tokens_variable_name, sys.maxsize) or sys.maxsize
-        )
+        remaining_requests = metadata.get(remaining_requests_variable_name)
+        if remaining_requests is None:
+            remaining_requests = sys.maxsize
+        remaining_tokens = metadata.get(remaining_tokens_variable_name)
+        if remaining_tokens is None:
+            remaining_tokens = sys.maxsize
 
         enum_values = UserAPIKeyLabelValues(
             hashed_api_key=user_api_key,

--- a/tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py
+++ b/tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 from prometheus_client import REGISTRY
@@ -123,3 +124,36 @@ def test_virtual_key_rate_limit_metrics_accept_custom_metadata_labels(
         and sample.value == 3
         for sample in samples
     )
+
+
+def test_virtual_key_rate_limit_metrics_preserve_zero_remaining_values(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prometheus_logger = _create_prometheus_logger_with_custom_labels(monkeypatch)
+    metadata = {
+        "model_group": "gpt-4o-mini",
+        "litellm-key-remaining-requests-gpt-4o-mini": 0,
+        "litellm-key-remaining-tokens-gpt-4o-mini": 0,
+    }
+    kwargs = {
+        "litellm_params": {
+            "metadata": metadata,
+        },
+        "standard_logging_object": _standard_logging_payload_with_requester_metadata(),
+    }
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="test-hash",
+        user_api_key_alias="test-alias",
+        kwargs=kwargs,
+        metadata=metadata,
+        model_id="model-123",
+    )
+
+    request_samples = _metric_samples("litellm_remaining_api_key_requests_for_model")
+    token_samples = _metric_samples("litellm_remaining_api_key_tokens_for_model")
+
+    assert any(sample.value == 0 for sample in request_samples)
+    assert any(sample.value == 0 for sample in token_samples)
+    assert not any(sample.value == sys.maxsize for sample in request_samples)
+    assert not any(sample.value == sys.maxsize for sample in token_samples)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Addresses an internal bug report for Prometheus API key remaining request/token gauges.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [x] **Branch creation CI run**  
       Link: checks attached to this PR branch are green

- [x] **CI run for the last commit**  
       Link: all visible GitHub Actions and CircleCI checks passed for commit `51ecb50a9d`

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Terminal evidence saved as `/opt/cursor/artifacts/prometheus_zero_metrics_test_evidence.txt`.

## Type

🐛 Bug Fix
✅ Test

## Changes

## Summary

Prometheus remaining request/token gauges for API keys treated `0` as false and replaced it with the sentinel maximum value. The fix now falls back only when the metadata value is `None` or missing, preserving real zero values.

## Repro

Call `_set_virtual_key_rate_limit_metrics` with metadata containing `litellm-key-remaining-requests-<model_group>: 0` and `litellm-key-remaining-tokens-<model_group>: 0`; before this change, both gauge samples were emitted as the sentinel maximum instead of `0`.

## Evidence

- Regression test failed before the fix: `assert any(sample.value == 0 for sample in request_samples)` was false.
- After the fix: `tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py` passed (`3 passed in 0.10s`).

## Tests

- `uv lock --check`
- `python -m pytest tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py::test_virtual_key_rate_limit_metrics_preserve_zero_remaining_values -q` (before fix: failed; after fix: passed)
- `python -m pytest tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py -q` (passed)
- `black --check --exclude '/enterprise/' .` from `litellm/` (passed)
- `ruff check .` from `litellm/` (passed)
- `mypy .` from `litellm/` (passed)
- `python ../tests/documentation_tests/test_circular_imports.py` from `litellm/` (passed)
- `python -c "from litellm import *"` from repo root (passed)

## CI

- GitHub Actions: all visible PR checks passed, including `lint`, `integrations / Run tests`, and `unit-test`.
- CircleCI: all visible CircleCI checks passed, including `build_and_test`, `logging_testing`, and `proxy_logging_guardrails_model_info_tests`.

## Review

- Greptile score: 5/5.
- Unresolved Greptile threads: 0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95060c97-26dd-43a3-a2d7-ee7740d4a410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95060c97-26dd-43a3-a2d7-ee7740d4a410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

