### PR TITLE
[Fix] Guardrails: Reconcile In-Memory State Against DB On Each Polling Tick

### DIFF
--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -428,6 +428,10 @@ class InMemoryGuardrailHandler:
             verbose_proxy_logger.debug(
                 "guardrail_id already exists in IN_MEMORY_GUARDRAILS"
             )
+            # Honor the caller's source even on the early-return path so a
+            # racing polling tick or a hot-reload of config can correct an
+            # entry's provenance.
+            self._sources[guardrail_id] = source
             return self.IN_MEMORY_GUARDRAILS[guardrail_id]
 
         custom_guardrail_callback: Optional[CustomGuardrail] = None

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -165,6 +165,67 @@ async def test_list_guardrails_v2_with_db_and_config(
 
 
 @pytest.mark.asyncio
+async def test_list_guardrails_v2_skips_stale_db_backed_in_memory_entries(mocker):
+    """
+    A guardrail that's still in this pod's memory tagged source='db' but is no
+    longer in the DB result (deleted on another pod, awaiting reconcile) must
+    NOT surface in the list response — pre-fix it leaked as 'config'.
+    """
+    stale_guardrail = {
+        "guardrail_id": "stale-db-id",
+        "guardrail_name": "Stale DB Guardrail",
+        "litellm_params": {"guardrail": "bedrock", "mode": "pre_call"},
+        "guardrail_info": {},
+    }
+    mock_prisma_client = mocker.Mock()
+    mock_prisma_client.db = mocker.Mock()
+    mock_prisma_client.db.litellm_guardrailstable = mocker.Mock()
+    mock_prisma_client.db.litellm_guardrailstable.find_many = AsyncMock(return_value=[])
+
+    mock_in_memory_handler = mocker.Mock()
+    mock_in_memory_handler.list_in_memory_guardrails.return_value = [stale_guardrail]
+    mock_in_memory_handler.get_source.return_value = "db"
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    admin_auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN)
+    response = await list_guardrails_v2(user_api_key_dict=admin_auth)
+
+    assert response.guardrails == []
+    mock_in_memory_handler.get_source.assert_called_with("stale-db-id")
+
+
+@pytest.mark.asyncio
+async def test_get_guardrail_info_404s_stale_db_backed_entry(
+    mocker, mock_prisma_client, mock_in_memory_handler
+):
+    """
+    Stale DB-backed entry (in-memory but not in DB) must 404 instead of being
+    returned as if it were a config-loaded guardrail.
+    """
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+    mock_prisma_client.db.litellm_guardrailstable.find_unique = AsyncMock(
+        return_value=None
+    )
+    # In-memory still has it, but it's tagged as 'db' (stale, awaiting reconcile)
+    mock_in_memory_handler.get_source.return_value = "db"
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_guardrail_info("stale-db-id")
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_list_guardrails_v2_masks_sensitive_data_in_db_guardrails(mocker):
     """Test that sensitive litellm_params are masked for DB guardrails in list response"""
     db_guardrail_with_secrets = {

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -135,6 +135,37 @@ def test_delete_in_memory_guardrail_clears_source_marker():
     assert handler.get_source("a") is None
 
 
+def test_initialize_guardrail_early_return_updates_source_marker():
+    """
+    When initialize_guardrail is called for a guardrail that already exists
+    in memory, the early-return path must still honor the caller's source.
+    Otherwise a racing polling tick that placed a DB entry in memory first
+    would leave a later config-init call wrongly marked as 'db' (or vice
+    versa), and the entry would be reconciled with the wrong classification.
+    """
+    handler = InMemoryGuardrailHandler()
+    # Simulate a polling tick already placing the entry as DB-backed.
+    handler.IN_MEMORY_GUARDRAILS["collide"] = _make_guardrail("collide", name="bedrock")
+    handler._sources["collide"] = "db"
+
+    # Config init re-visits the same id (e.g., hot-reload, or UUID collision).
+    g = Guardrail(
+        guardrail_id="collide",
+        guardrail_name="bedrock",
+        litellm_params=LitellmParams(
+            guardrail="bedrock", mode="pre_call", default_on=False
+        ),
+    )
+    handler.initialize_guardrail(guardrail=g, source="config")
+
+    assert handler.get_source("collide") == "config"
+
+    # And the symmetric direction: db sync should override an entry left
+    # marked as 'config' from a stale init path.
+    handler.initialize_guardrail(guardrail=g, source="db")
+    assert handler.get_source("collide") == "db"
+
+
 def test_sync_guardrail_from_db_marks_source_db_when_unchanged():
     """
     sync_guardrail_from_db must enforce source='db' even when params are


### PR DESCRIPTION
## Summary

Fixes [LIT-2546](https://linear.app/berriai/issue/LIT-2546).

Multi-pod stale-state bug: deleting a DB-backed guardrail on one pod left other pods showing the deleted guardrail in `/v2/guardrails/list`, mislabeled as `guardrail_definition_location="config"`.

The 30s DB poll on `_init_guardrails_in_db` only added/updated entries — it never removed entries that had been deleted on another pod. Compounding this, the list endpoint inferred `guardrail_definition_location` by set-difference (in-memory minus current DB result), so stale DB-backed entries silently surfaced as if they came from `proxy_config.yaml`.

This PR makes provenance explicit:
- `InMemoryGuardrailHandler` now tracks `source: Literal["db", "config"]` per entry, set at insert time.
- New `reconcile_db_guardrails(db_ids)` drops in-memory entries whose `source == "db"` but whose ID is no longer in the latest DB result. Config-loaded entries are never touched.
- `_init_guardrails_in_db` calls `reconcile_db_guardrails` after each polling tick.
- `/v2/guardrails/list` and `/guardrails/{id}/info` read `source` directly instead of inferring it. Stale DB-backed entries are skipped (and 404'd, respectively) until the next reconcile pass.

The same additive-only sync pattern exists in `_init_vector_stores_in_db`, `_init_mcp_servers_in_db`, `_init_prompts_in_db`, `_init_agents_in_db`, `_init_pass_through_endpoints_in_db`, `_init_policies_in_db`, and `_init_tool_policy_in_db`. They likely have the same bug shape; out of scope here.

## Test plan

Verified with **two real proxy processes** on one Postgres (Pod A on :4001, Pod B on :4005, same config). Pre-fix: Pod A deletes a guardrail → Pod B's list still shows it as `'config'`, both immediately and after Pod B's next 30s polling tick. Post-fix: Pod B's list omits it immediately (source-marker skip) and reconcile fires on the next tick (log line: `Reconcile: removing stale DB-backed guardrail ... (deleted in DB by another pod)`).

- [x] `uv run pytest tests/test_litellm/proxy/guardrails/test_guardrail_registry.py tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py -v` → 71 passed
- [x] Two-pod harness: Pod A delete → immediate GET on Pod B (between polls) returns no stale entry
- [x] Two-pod harness: Pod A delete → 30s wait → reconcile fires on Pod B; entry removed from memory + callbacks
- [x] Adjacent: `static-config-bedrock` (config-loaded) survives polling on both pods
- [x] Adjacent: A guardrail created on Pod A is picked up by Pod B's polling tick as `guardrail_definition_location="db"`
- [x] Adjacent: Local create + DELETE via API on the same pod still removes from memory
- [x] `black --check` clean on touched files