### PR TITLE
fix(sso): honor singular team_id_jwt_field in SSO callback

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -224,6 +224,24 @@ class JWTHandler:
 
         return []
 
+    def get_all_jwt_team_ids(self, token: dict) -> List[str]:
+        """
+        Return team IDs from both the plural ``team_ids_jwt_field`` and the
+        singular ``team_id_jwt_field`` claim, as a deduplicated list preserving
+        plural-first order.
+
+        Membership-reconciliation paths (SSO callback, JWT-bearer sync) need
+        to consider both claim shapes. Reading only the plural field — as
+        callers historically did — silently dropped users whose IdP populates
+        the singular field, which is what Okta and Auth0 default to when a
+        user has a single primary team.
+        """
+        team_ids: List[str] = list(self.get_team_ids_from_jwt(token))
+        singular = self.get_team_id(token, default_value=None)
+        if singular and singular not in team_ids:
+            team_ids.append(singular)
+        return team_ids
+
     def get_end_user_id(
         self, token: dict, default_value: Optional[str]
     ) -> Optional[str]:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -740,7 +740,7 @@ def generic_response_convertor(
 
     all_teams = []
     if sso_jwt_handler is not None:
-        team_ids = sso_jwt_handler.get_team_ids_from_jwt(cast(dict, response))
+        team_ids = sso_jwt_handler.get_all_jwt_team_ids(cast(dict, response))
         all_teams.extend(team_ids)
 
     if team_mappings is not None and team_mappings.team_ids_jwt_field is not None:
@@ -755,7 +755,7 @@ def generic_response_convertor(
                 f"Loaded team_ids from DB team_mappings.team_ids_jwt_field='{team_mappings.team_ids_jwt_field}': {team_ids_from_db_mapping}"
             )
     else:
-        team_ids = jwt_handler.get_team_ids_from_jwt(cast(dict, response))
+        team_ids = jwt_handler.get_all_jwt_team_ids(cast(dict, response))
         all_teams.extend(team_ids)
 
     # Determine user role based on role_mappings if available

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -492,6 +492,41 @@ async def test_sync_user_role_and_teams_no_cache_write_when_nothing_changes():
     )
 
     mock_cache.async_set_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_all_jwt_team_ids_unions_singular_and_plural():
+    """get_all_jwt_team_ids must include the singular team_id_jwt_field claim
+    in addition to the plural team_ids_jwt_field, deduplicated."""
+    jwt_handler = JWTHandler()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=MagicMock(),
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_id_jwt_field="team_id",
+            team_ids_jwt_field="teams",
+        ),
+    )
+
+    # singular only — Okta/Auth0 default shape
+    assert jwt_handler.get_all_jwt_team_ids({"team_id": "team-low"}) == ["team-low"]
+
+    # plural only — pre-fix shape
+    assert jwt_handler.get_all_jwt_team_ids({"teams": ["a", "b"]}) == ["a", "b"]
+
+    # both populated, no overlap
+    assert jwt_handler.get_all_jwt_team_ids(
+        {"team_id": "primary", "teams": ["a", "b"]}
+    ) == ["a", "b", "primary"]
+
+    # both populated with overlap — singular dedup'd
+    assert jwt_handler.get_all_jwt_team_ids({"team_id": "a", "teams": ["a", "b"]}) == [
+        "a",
+        "b",
+    ]
+
+    # neither populated
+    assert jwt_handler.get_all_jwt_team_ids({}) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The SSO callback flow (`generic_response_convertor` → `add_missing_team_member`) was reading only the plural `team_ids_jwt_field` claim. IdPs that populate the singular `team_id_jwt_field` instead (Okta/Auth0 mapping a group → primary team) had their users created via SSO with `teams: []` — never assigned to the team named in the JWT, regardless of how the user's `user_metadata.team_id` changed across logins.

This adds `JWTHandler.get_all_jwt_team_ids()` returning the deduplicated union of both claim sources, and threads it through the two branches that build `all_teams` in `generic_response_convertor`. The result: SSO logins now read the singular claim the same way the JWT-bearer path's `find_and_validate_specific_team_id` always has.

**Scope intentionally narrow:**
- The JWT-bearer auth flow is unchanged in this PR. Its `sync_user_role_and_teams` already has add+remove reconciliation logic; expanding the input to include the singular claim would change runtime behavior for tenants who rely on its current "additive in practice" behavior. We're gathering customer signal before touching it. Tracked separately.
- The SSO path remains additive — users get added to the team named in their current JWT but are not removed from previous teams. Fixing the user-not-added symptom (the actual customer report) does not require removal logic. Strict "moved" semantics for SSO is parked as a follow-up pending customer input.
- `internal_user_viewer` role being assigned where `jwt_litellm_role_map` would produce `internal_user` was observed during the SSO repro but is unrelated to the team claim handling and is not addressed here.

## screenshots 
<img width="807" height="660" alt="Screenshot 2026-05-06 at 5 28 21 PM" src="https://github.com/user-attachments/assets/10c56355-1ae5-4984-b10a-4641687737c0" />

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/auth/test_handle_jwt.py tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` — 240 pass.
- [x] New test: `test_get_all_jwt_team_ids_unions_singular_and_plural` covering all four input combinations (singular only, plural only, both no-overlap, both with overlap, neither).
- [x] End-to-end SSO repro against a real Auth0 tenant with the Phil-shaped post-login Action — confirmed user is now added to the team in `user_metadata.team_id` (BEFORE: `teams: []`; AFTER: `teams: ["team-low"]` after first login, dual membership after re-login with changed metadata).
- [x] Black formatting applied (`uv run black` on the three changed files).
- [x] Existing 183 SSO tests untouched and still pass — no regression in the SSO suite.