### PR TITLE
Fix Prometheus remaining rate limit metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1445,8 +1445,22 @@ class PrometheusLogger(CustomLogger):
 
         remaining_requests = metadata.get(remaining_requests_variable_name)
         if remaining_requests is None:
+            remaining_requests = (
+                self._get_model_per_key_remaining_value_from_additional_headers(
+                    kwargs=kwargs,
+                    rate_limit_type="requests",
+                )
+            )
+        if remaining_requests is None:
             remaining_requests = sys.maxsize
         remaining_tokens = metadata.get(remaining_tokens_variable_name)
+        if remaining_tokens is None:
+            remaining_tokens = (
+                self._get_model_per_key_remaining_value_from_additional_headers(
+                    kwargs=kwargs,
+                    rate_limit_type="tokens",
+                )
+            )
         if remaining_tokens is None:
             remaining_tokens = sys.maxsize
 
@@ -1483,6 +1497,28 @@ class PrometheusLogger(CustomLogger):
         self.litellm_remaining_api_key_tokens_for_model.labels(**tokens_labels).set(
             remaining_tokens
         )
+
+    @staticmethod
+    def _get_model_per_key_remaining_value_from_additional_headers(
+        kwargs: dict,
+        rate_limit_type: Literal["requests", "tokens"],
+    ) -> Optional[Any]:
+        standard_logging_payload = kwargs.get("standard_logging_object") or {}
+        hidden_params = standard_logging_payload.get("hidden_params") or {}
+        additional_headers = hidden_params.get("additional_headers") or {}
+        if not isinstance(additional_headers, dict):
+            return None
+
+        header_name = f"x-ratelimit-model_per_key-remaining-{rate_limit_type}"
+        if header_name in additional_headers:
+            return additional_headers[header_name]
+
+        normalized_header_name = header_name.lower()
+        for key, value in additional_headers.items():
+            if str(key).lower() == normalized_header_name:
+                return value
+
+        return None
 
     def _set_latency_metrics(
         self,

--- a/tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py
+++ b/tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py
@@ -157,3 +157,81 @@ def test_virtual_key_rate_limit_metrics_preserve_zero_remaining_values(
     assert any(sample.value == 0 for sample in token_samples)
     assert not any(sample.value == sys.maxsize for sample in request_samples)
     assert not any(sample.value == sys.maxsize for sample in token_samples)
+
+
+def test_virtual_key_rate_limit_metrics_read_remaining_values_from_hidden_headers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prometheus_logger = _create_prometheus_logger_with_custom_labels(monkeypatch)
+    metadata = {
+        "model_group": "gpt-4o-mini",
+    }
+    kwargs = {
+        "litellm_params": {
+            "metadata": metadata,
+        },
+        "standard_logging_object": {
+            **_standard_logging_payload_with_requester_metadata(),
+            "hidden_params": {
+                "additional_headers": {
+                    "x-ratelimit-model_per_key-remaining-requests": 7,
+                    "x-ratelimit-model_per_key-remaining-tokens": 321,
+                },
+            },
+        },
+    }
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="test-hash",
+        user_api_key_alias="test-alias",
+        kwargs=kwargs,
+        metadata=metadata,
+        model_id="model-123",
+    )
+
+    request_samples = _metric_samples("litellm_remaining_api_key_requests_for_model")
+    token_samples = _metric_samples("litellm_remaining_api_key_tokens_for_model")
+
+    assert any(sample.value == 7 for sample in request_samples)
+    assert any(sample.value == 321 for sample in token_samples)
+    assert not any(sample.value == sys.maxsize for sample in request_samples)
+    assert not any(sample.value == sys.maxsize for sample in token_samples)
+
+
+def test_virtual_key_rate_limit_metrics_preserve_zero_values_from_hidden_headers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prometheus_logger = _create_prometheus_logger_with_custom_labels(monkeypatch)
+    metadata = {
+        "model_group": "gpt-4o-mini",
+    }
+    kwargs = {
+        "litellm_params": {
+            "metadata": metadata,
+        },
+        "standard_logging_object": {
+            **_standard_logging_payload_with_requester_metadata(),
+            "hidden_params": {
+                "additional_headers": {
+                    "x-ratelimit-model_per_key-remaining-requests": 0,
+                    "x-ratelimit-model_per_key-remaining-tokens": 0,
+                },
+            },
+        },
+    }
+
+    prometheus_logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="test-hash",
+        user_api_key_alias="test-alias",
+        kwargs=kwargs,
+        metadata=metadata,
+        model_id="model-123",
+    )
+
+    request_samples = _metric_samples("litellm_remaining_api_key_requests_for_model")
+    token_samples = _metric_samples("litellm_remaining_api_key_tokens_for_model")
+
+    assert any(sample.value == 0 for sample in request_samples)
+    assert any(sample.value == 0 for sample in token_samples)
+    assert not any(sample.value == sys.maxsize for sample in request_samples)
+    assert not any(sample.value == sys.maxsize for sample in token_samples)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Prometheus virtual-key remaining request/token gauges only read metadata keys, while the proxy rate limiter writes the per-key model values into hidden response headers. This adds a fallback that reads `x-ratelimit-model_per_key-remaining-requests` and `x-ratelimit-model_per_key-remaining-tokens` from `hidden_params.additional_headers`, preserving existing metadata behavior and zero values.

## Repro
Call the Prometheus success logging path with a model group in metadata, no `litellm-key-remaining-*` metadata values, and hidden additional headers containing per-key remaining request/token counts. Before the fix, the gauges fall back to the sentinel value instead of the header values.

## Evidence
Terminal transcript:

```text
$ pytest tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py -vv
5 passed in 0.15s
```

## Tests
- Added regression tests in `tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py` for header-sourced remaining request/token values and zero-value preservation.
- Confirmed the new tests fail before the code change and pass after it.
- `pytest tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py -vv` - passed.
- `pytest tests/test_litellm/integrations --tb=short -vv -n 2 --durations=20` - 871 passed, 1 skipped, 1 unrelated live-provider authentication failure in `websearch_interception/test_websearch_chat_completion.py`.
- `uv lock --check` - passed.
- `black --check --exclude '/enterprise/' .` from `litellm/` - passed.
- `ruff check .` from `litellm/` - passed.
- `mypy .` from `litellm/` - passed.
- Circular import check - passed.
- Import safety check - passed.
- Hardcoded secret scan unit test - passed.

## CI
- Pull-request workflow runs: all registered PR-event checks passed, including linting, integrations, proxy/API groups, MCP, UI build, Semgrep, and code quality checks.
- Push workflow runs: security and proxy DB checks passed; caching workflow reported a startup failure before creating jobs and appears unrelated to this code path.

## Review
- No automated Greptile review was posted after polling the PR reviews/comments; no actionable review threads were available to address.

## Type
🐛 Bug Fix
✅ Test

## Changes
- Added a Prometheus helper to read per-key model remaining rate-limit values from hidden additional headers when metadata values are absent.
- Added regression coverage for non-zero and zero header values so gauges no longer report the sentinel when the proxy rate limiter already supplied real values.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca9f34a2-36bd-4584-ae3c-84ec1bbbe0f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca9f34a2-36bd-4584-ae3c-84ec1bbbe0f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

