### PR TITLE
fix: add gpt-5.1-mini and gpt-5.1-nano registry entries with supports_none_reasoning_effort

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20746,6 +20746,89 @@
         "supports_xhigh_reasoning_effort": false,
         "supports_minimal_reasoning_effort": true
     },
+    "gpt-5.1-mini": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_flex": 1.25e-08,
+        "cache_read_input_token_cost_priority": 4.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_flex": 1.25e-07,
+        "input_cost_per_token_priority": 4.5e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_token_flex": 1e-06,
+        "output_cost_per_token_priority": 3.6e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true
+    },
+    "gpt-5.1-nano": {
+        "cache_read_input_token_cost": 5e-09,
+        "cache_read_input_token_cost_flex": 2.5e-09,
+        "input_cost_per_token": 5e-08,
+        "input_cost_per_token_flex": 2.5e-08,
+        "input_cost_per_token_priority": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_flex": 2e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true
+    },
     "gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20760,6 +20760,89 @@
         "supports_xhigh_reasoning_effort": false,
         "supports_minimal_reasoning_effort": true
     },
+    "gpt-5.1-mini": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_flex": 1.25e-08,
+        "cache_read_input_token_cost_priority": 4.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_flex": 1.25e-07,
+        "input_cost_per_token_priority": 4.5e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_token_flex": 1e-06,
+        "output_cost_per_token_priority": 3.6e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true
+    },
+    "gpt-5.1-nano": {
+        "cache_read_input_token_cost": 5e-09,
+        "cache_read_input_token_cost_flex": 2.5e-09,
+        "input_cost_per_token": 5e-08,
+        "input_cost_per_token_flex": 2.5e-08,
+        "input_cost_per_token_priority": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_flex": 2e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true
+    },
     "gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -276,6 +276,8 @@ def test_gpt5_1_model_detection(gpt5_config: OpenAIGPT5Config):
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.1", "none")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.1-2025-11-13", "none")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.1-chat-latest", "none")
+    assert gpt5_config._supports_reasoning_effort_level("gpt-5.1-mini", "none")
+    assert gpt5_config._supports_reasoning_effort_level("gpt-5.1-nano", "none")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.2", "none")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.2-2025-12-11", "none")
     # codex/pro/chat variants do not support none
@@ -302,6 +304,25 @@ def test_gpt5_1_temperature_with_reasoning_effort_none(config: OpenAIConfig):
         )
         assert params["temperature"] == temp
         assert params["reasoning_effort"] == "none"
+
+
+def test_gpt5_1_mini_nano_temperature_with_reasoning_effort_none(
+    config: OpenAIConfig,
+):
+    """Test that gpt-5.1-mini and gpt-5.1-nano support temperature when
+    reasoning_effort='none' (registry parity with bare gpt-5.1)."""
+    for model in ["gpt-5.1-mini", "gpt-5.1-nano"]:
+        for temp in [0.0, 0.7, 1.0, 1.5]:
+            params = config.map_openai_params(
+                non_default_params={"temperature": temp, "reasoning_effort": "none"},
+                optional_params={},
+                model=model,
+                drop_params=False,
+            )
+            assert params["temperature"] == temp, (
+                f"{model} should preserve temperature={temp} with effort='none'"
+            )
+            assert params["reasoning_effort"] == "none"
 
 
 def test_gpt5_2_temperature_with_reasoning_effort_none(config: OpenAIConfig):


### PR DESCRIPTION
## Relevant issues

Fixes #27351

## What this fixes

Per OpenAI's parameter compatibility guide, the **gpt-5.1 family** — including `gpt-5.1-mini` and `gpt-5.1-nano` — supports `temperature` when `reasoning_effort` is set to `'none'` (or omitted, since the API default is `'none'` for the 5.1 family). LiteLLM's pre-flight check in `OpenAIGPT5Config.map_openai_params` correctly applies this for the bare `gpt-5.1` slug because `gpt-5.1` has `supports_none_reasoning_effort: true` in `model_prices_and_context_window.json`.

But `gpt-5.1-mini` and `gpt-5.1-nano` are **absent from the registry entirely**, so the gate falls back to strict rejection — `litellm.UnsupportedParamsError` even when `reasoning_effort` is null/omitted.

## Reproduction (from #27351)

LiteLLM v1.83.10-stable, standard `/v1/chat/completions` (no Responses-API routing, no Azure):

**Case A — `openai/gpt-5.1` (control, in registry):**
```
$ curl -sw "\n%{http_code}\n" -X POST $LITELLM_URL/v1/chat/completions \
    -H "Authorization: Bearer $VKEY" -H "Content-Type: application/json" \
    -d '{"model":"openai/gpt-5.1","messages":[{"role":"user","content":"reply ok"}],"temperature":0.7,"max_tokens":50}'
{"id":"chatcmpl-...","model":"openai/gpt-5.1","object":"chat.completion","choices":[...],...}
200
```

**Case B — `openai/gpt-5.1-mini` (not in registry):**
```
{"error":{"message":"litellm.UnsupportedParamsError: gpt-5 models (including gpt-5-codex) don't support temperature=0.7. Only temperature=1 is supported. For gpt-5.1, temperature is supported when reasoning_effort='none' (or not specified, as it defaults to 'none')...","type":"None","param":null,"code":"400"}}
400
```

**Case C — `openai/gpt-5.1-nano` (not in registry):** identical 400.

After this PR: B and C return 200, matching A.

## Changes

Adds two new entries to `model_prices_and_context_window.json` — `gpt-5.1-mini` and `gpt-5.1-nano` — placed alphabetically right after `gpt-5.1-codex-mini`. The flag matrix mirrors the existing `gpt-5.1` entry, in particular:

- `supports_none_reasoning_effort: true` — the load-bearing flag that gates the temperature pass-through
- `supports_minimal_reasoning_effort: true`
- `supports_xhigh_reasoning_effort: false`
- All `supports_*` capability flags (function_calling, parallel_function_calling, prompt_caching, reasoning, response_schema, system_messages, tool_choice, vision, web_search, pdf_input, native_streaming) align with the bare `gpt-5.1` row.
- `mode: "chat"`, `supported_endpoints: ["/v1/chat/completions", "/v1/batch", "/v1/responses"]`.

### Pricing rationale

OpenAI has not (to my knowledge) yet published distinct pricing for `gpt-5.1-mini` / `gpt-5.1-nano`. Rather than invent numbers, this PR anchors pricing to the `gpt-5-mini` / `gpt-5-nano` registry entries (the 5.0-generation siblings on the same scale tier from the same provider). When OpenAI publishes explicit 5.1-mini/-nano pricing, those rows can be tightened in a follow-up — and meanwhile cost tracking won't fall through to `$0`.

Specifically:
- `gpt-5.1-mini` pricing matches `gpt-5-mini` (input `2.5e-07`, output `2e-06`, with flex / priority tiers populated per the sibling).
- `gpt-5.1-nano` pricing matches `gpt-5-nano` (input `5e-08`, output `4e-07`, with flex tiers populated).
- Context window: `max_input_tokens: 272000`, `max_output_tokens: 128000` — same as the rest of the gpt-5.1 family and the gpt-5-mini/-nano siblings.

## Overlap with #22621

There is an open PR #22621 that adds **pricing** for `gpt-5.1-mini` (using the OpenAI mini pricing tier with `400K` context / `128K` max output) but does **not** address the missing reasoning-effort flags and so does not actually fix the `UnsupportedParamsError` users see today. This PR is filed independently with a tighter, JSON-only scope so maintainers can decide merge order; if #22621 lands first, the conflict will be a single key and easy to resolve (and our mini context window can adopt the 400K value if maintainers prefer it). If this PR lands first, #22621 reduces to a clean pricing tightening on top.

## Sibling note (NOT changed in this PR)

`gpt-5.1-codex` is in the registry with `supports_none_reasoning_effort: false`. If Codex variants follow the same OpenAI contract as the rest of the 5.1 family, that's likely also wrong — but it's a behavior change to an existing row rather than an unambiguous gap, so it's deliberately out of scope here. Same for `gpt-5.1-codex-mini` and `gpt-5.1-codex-max`. Filing this PR for the absent rows only.

## Tests

Extends `tests/test_litellm/llms/openai/test_gpt5_transformation.py`:
- `test_gpt5_1_model_detection`: adds two assertions that `_supports_reasoning_effort_level("gpt-5.1-mini", "none")` and `_supports_reasoning_effort_level("gpt-5.1-nano", "none")` both resolve to `True` via the registry.
- `test_gpt5_1_mini_nano_temperature_with_reasoning_effort_none`: new test mirroring the existing `test_gpt5_1_temperature_with_reasoning_effort_none`, asserting `temperature` pass-through for the two new slugs across `[0.0, 0.7, 1.0, 1.5]` with `reasoning_effort='none'`.

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/` directory
- [x] My PR's scope is as isolated as possible — JSON registry + a targeted test extension only
- [x] No code logic changed; pure data/registry update plus matching test
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review (will request right after this PR opens)

## Type
Bug Fix