### PR TITLE
fix(ui): key info view goes blank below the fold on small viewports

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -396,7 +396,7 @@ export default function KeyInfoView({
   };
 
   return (
-    <div className="w-full h-screen p-4">
+    <div className="w-full h-full overflow-y-auto p-4">
       <KeyInfoHeader
         data={{
           keyName: currentKeyData.key_alias || "Virtual Key",
@@ -614,7 +614,7 @@ export default function KeyInfoView({
 
           {/* Settings Panel */}
           <TabPanel>
-            <Card className="overflow-y-auto max-h-[65vh]">
+            <Card>
               <div className="flex justify-between items-center mb-4">
                 <Title>Key Settings</Title>
                 {!isEditing && canModifyKey && (


### PR DESCRIPTION
# PR: fix(ui): key info view goes blank below the fold on small viewports

> **Branch**: `Bytechoreographer:fix/key-info-view-layout-blank-on-small-screens`
> **Target**: `BerriAI:litellm_internal_staging`
> **PR link**: https://github.com/Bytechoreographer/litellm/pull/new/fix/key-info-view-layout-blank-on-small-screens

---

## Relevant issues

<!-- No open issue found; reproduced locally on a 13" MacBook Air (viewport ~750 px). -->

## Pre-Submission checklist

- [x] No test changes required — pure CSS/className edit, no test asserts on these classes
- [x] `npm run test` passes for affected files
- [x] Scope is isolated: one source file, two `className` lines
- [x] Comment `@greptileai` and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Root cause

On the **Virtual Keys** detail page (`KeyInfoView`), opening a key on a small
viewport (13" MacBook Air, ~750 px tall) showed the header and the first tab
correctly — but switching to the **Settings** tab (or scrolling down) left the
lower half of the page blank. No scrollbar appeared.

The layout chain locked the page into a fixed-height box with no scroll
fallback:

```
VirtualKeysTable.tsx:687
  <div className="w-full h-full overflow-hidden">      ← parent clips overflow
    KeyInfoView
      key_info_view.tsx:399
      <div className="w-full h-screen p-4">            ← 100vh, no overflow-y
        <KeyInfoHeader />                              ← ~110–140 px
        <TabGroup>
          <TabList />                                  ← ~40 px
          <TabPanel>  (Settings)
            key_info_view.tsx:617
            <Card className="overflow-y-auto max-h-[65vh]">  ← inner scroll, 65 vh
```

On a 750 px viewport the math is:

- Header + TabList ≈ 180 px
- Card wants `65vh` ≈ 487 px
- Plus padding/margins → total > 100vh

The outer `<div className="w-full h-screen p-4">` has no `overflow-y-auto`,
and its parent in `VirtualKeysTable` is `overflow-hidden`. So when content
exceeds the viewport height, the bottom is **clipped instead of scrolled** —
including the inner Card's own scroll region. The user sees blank space and
cannot reach the cut-off content.

The Overview tab fits because its Grid of summary Cards is short. Settings is
where it surfaces because the form is long.

**Reproduce:**
1. On a viewport ≤ ~800 px tall (13" MBA, half-height window, etc.), open the
   Virtual Keys page and click into any key.
2. The Overview tab renders fine.
3. Click **Settings** — the Card shows the top of the form, but everything
   below the viewport is blank, with no scrollbar.

### Fix

Replace the fixed `h-screen` with `h-full overflow-y-auto` on the
`KeyInfoView` root, and drop the inner Card's `max-h-[65vh] overflow-y-auto`.
Now the entire detail page scrolls as a single column inside whatever space
the parent gives it.

```diff
  return (
-   <div className="w-full h-screen p-4">
+   <div className="w-full h-full overflow-y-auto p-4">
      <KeyInfoHeader ... />
      ...
      <TabPanel>  {/* Settings */}
-       <Card className="overflow-y-auto max-h-[65vh]">
+       <Card>
          ...
        </Card>
      </TabPanel>
```

Why both edits:

- `h-full overflow-y-auto` makes `KeyInfoView` fill its parent (no longer
  hard-locked at `100vh`) and supplies its own scrollbar when content
  overflows.
- Removing `max-h-[65vh] overflow-y-auto` on the Settings Card eliminates a
  redundant nested scroll region. With one outer scroll, the Card naturally
  flows; nesting a second scroll inside a clipped parent is exactly what
  caused the blank-below-the-fold symptom.

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/templates/key_info_view.tsx` | Root: `h-screen` → `h-full overflow-y-auto`. Settings Card: remove `overflow-y-auto max-h-[65vh]`. |
