### PR TITLE
[Fix] Team-based model name corruption on PATCH

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -446,9 +446,28 @@ def _get_public_model_name(
     patch_data: updateDeployment,
     db_model: Deployment,
 ) -> str:
-    """Determine the public model name from patch or existing model."""
-    if patch_data.model_name:
-        return patch_data.model_name
+    """Determine the public model name from patch or existing model.
+
+    Defends against a stale client round-tripping the internal mangled
+    `model_name` (the routing key `model_name_{team_id}_{uuid}`) instead
+    of the actual public name. A no-op (incoming equals current DB column)
+    or an internal-shape match is treated as "no rename intent" and falls
+    through to the existing public name.
+    """
+    incoming = patch_data.model_name
+    if incoming:
+        team_id = (
+            patch_data.model_info.team_id if patch_data.model_info else None
+        ) or (
+            db_model.model_info.team_id if db_model.model_info else None
+        )
+        is_internal_shape = (
+            team_id is not None
+            and incoming.startswith(f"model_name_{team_id}_")
+        )
+        is_no_op = incoming == db_model.model_name
+        if not (is_internal_shape or is_no_op):
+            return incoming
 
     if db_model.model_info and db_model.model_info.team_public_model_name:
         return db_model.model_info.team_public_model_name

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -458,12 +458,9 @@ def _get_public_model_name(
     if incoming:
         team_id = (
             patch_data.model_info.team_id if patch_data.model_info else None
-        ) or (
-            db_model.model_info.team_id if db_model.model_info else None
-        )
-        is_internal_shape = (
-            team_id is not None
-            and incoming.startswith(f"model_name_{team_id}_")
+        ) or (db_model.model_info.team_id if db_model.model_info else None)
+        is_internal_shape = team_id is not None and incoming.startswith(
+            f"model_name_{team_id}_"
         )
         is_no_op = incoming == db_model.model_name
         if not (is_internal_shape or is_no_op):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11081,6 +11081,9 @@ async def model_info_v2(
     # Update total count to include agents
     search_total_count = len(all_models)
 
+    # Translate `model_name` to the public name for team-scoped rows.
+    all_models = [_translate_model_name_for_response(m) for m in all_models]
+
     return _paginate_models_response(
         all_models=all_models,
         page=page,
@@ -11515,6 +11518,28 @@ async def model_metrics_exceptions(
     return {"data": response, "exception_types": list(exception_types)}
 
 
+def _translate_model_name_for_response(model: dict) -> dict:
+    """For team-scoped DB rows, replace `model_name` with the public name
+    in `model_info.team_public_model_name` before returning. The DB column
+    and the in-memory router index keep the internal mangled name
+    (`model_name_{team_id}_{uuid}`) as the routing key — this swap is a
+    presentation-layer concern. Returns a shallow copy; never mutates.
+    """
+    if not isinstance(model, dict):
+        return model
+    model_info = model.get("model_info") or {}
+    if not isinstance(model_info, dict):
+        return model
+    team_public = model_info.get("team_public_model_name")
+    team_id = model_info.get("team_id")
+    if not team_public or not team_id:
+        return model
+    current = model.get("model_name") or ""
+    if not current.startswith(f"model_name_{team_id}_"):
+        return model
+    return {**model, "model_name": team_public}
+
+
 def _get_proxy_model_info(model: dict) -> dict:
     # provided model_info in config.yaml
     model_info = model.get("model_info", {})
@@ -11555,7 +11580,7 @@ def _get_proxy_model_info(model: dict) -> dict:
         deployment_dict=model, excluded_keys={"litellm_credential_name"}
     )
 
-    return model
+    return _translate_model_name_for_response(model)
 
 
 @router.get(

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
@@ -127,6 +127,14 @@ function getAgentModelId(agent: AgentModel): string | null {
   return info?.id ?? null;
 }
 
+// Selection key that always resolves to a non-null string. Prefers the DB
+// id (stable across renames and unique across teams) but falls back to
+// `model_name` so config-file-defined agents — which have no `model_info.id`
+// — remain selectable.
+function getAgentSelectionKey(agent: AgentModel): string {
+  return getAgentModelId(agent) ?? agent.model_name;
+}
+
 function parseUnderlyingModel(litellmModel: string | undefined): string | undefined {
   if (!litellmModel || !litellmModel.startsWith("litellm_agent/")) return undefined;
   return litellmModel.slice("litellm_agent/".length) || undefined;
@@ -194,7 +202,7 @@ export default function AgentBuilderView({
   const selectedAgent =
     selectedId === NEW_AGENT_ID
       ? null
-      : agentModels.find((a) => getAgentModelId(a) === selectedId) ?? null;
+      : agentModels.find((a) => getAgentSelectionKey(a) === selectedId) ?? null;
   const isNewAgent = selectedId === NEW_AGENT_ID;
   const selectedAgentModelId = selectedAgent ? getAgentModelId(selectedAgent) : null;
 
@@ -207,9 +215,9 @@ export default function AgentBuilderView({
       if (
         !selectedId ||
         (selectedId !== NEW_AGENT_ID &&
-          !list.some((a) => getAgentModelId(a) === selectedId))
+          !list.some((a) => getAgentSelectionKey(a) === selectedId))
       ) {
-        setSelectedId(list.length > 0 ? getAgentModelId(list[0]) : null);
+        setSelectedId(list.length > 0 ? getAgentSelectionKey(list[0]) : null);
       }
       return list;
     } catch (e) {
@@ -306,7 +314,7 @@ export default function AgentBuilderView({
     }
     setSaving(true);
     try {
-      await modelCreateCall(accessToken, {
+      const response = await modelCreateCall(accessToken, {
         model_name: draftName.trim(),
         litellm_params: {
           model: `litellm_agent/${draftUnderlyingModel}`,
@@ -317,10 +325,18 @@ export default function AgentBuilderView({
         },
         model_info: {},
       });
-      const newName = draftName.trim();
+      // /model/new returns the row with `model_id` at the top level.
+      // Prefer that id over name-matching so we land on the just-created
+      // agent even when its public name collides with another team's.
+      const createdId: string | null =
+        response?.model_id ?? response?.model_info?.id ?? null;
       const list = await loadAgents();
-      const created = list.find((a) => a.model_name === newName);
-      setSelectedId(getAgentModelId(created ?? list[0]) ?? null);
+      const created = createdId
+        ? list.find((a) => getAgentModelId(a) === createdId)
+        : list.find((a) => a.model_name === draftName.trim());
+      setSelectedId(
+        created ? getAgentSelectionKey(created) : list[0] ? getAgentSelectionKey(list[0]) : null,
+      );
       setActiveTab("chat");
     } catch (e) {
       NotificationsManager.fromBackend("Failed to save agent");
@@ -356,7 +372,8 @@ export default function AgentBuilderView({
       const stillSelected = list.find(
         (a) => getAgentModelId(a) === selectedAgentModelId,
       );
-      setSelectedId(getAgentModelId(stillSelected ?? list[0]) ?? null);
+      const target = stillSelected ?? list[0];
+      setSelectedId(target ? getAgentSelectionKey(target) : null);
     } catch (e) {
       NotificationsManager.fromBackend("Failed to update agent");
     } finally {
@@ -405,7 +422,7 @@ export default function AgentBuilderView({
             (a) => getAgentModelId(a) !== selectedAgentModelId,
           );
           setSelectedId(
-            remaining.length > 0 ? getAgentModelId(remaining[0]) : null,
+            remaining.length > 0 ? getAgentSelectionKey(remaining[0]) : null,
           );
         } catch (e) {
           NotificationsManager.fromBackend("Failed to delete agent");
@@ -470,14 +487,14 @@ export default function AgentBuilderView({
             ) : (
               <>
                 {agentModels.map((agent) => {
-                  const id = getAgentModelId(agent);
+                  const key = getAgentSelectionKey(agent);
                   return (
                     <button
-                      key={id ?? agent.model_name}
+                      key={key}
                       type="button"
-                      onClick={() => id && setSelectedId(id)}
+                      onClick={() => setSelectedId(key)}
                       className={`mb-1 w-full rounded-md border-l-2 px-3 py-2 text-left text-sm transition-colors ${
-                        selectedId === id
+                        selectedId === key
                           ? "border-blue-500 bg-blue-50 text-blue-800"
                           : "border-transparent hover:bg-gray-50"
                       }`}

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AgentBuilderView.tsx
@@ -191,22 +191,31 @@ export default function AgentBuilderView({
   const [deleting, setDeleting] = useState(false);
 
   const effectiveApiKey = apiKey || accessToken || "";
-  const selectedAgent = selectedId === NEW_AGENT_ID ? null : agentModels.find((a) => a.model_name === selectedId) ?? null;
+  const selectedAgent =
+    selectedId === NEW_AGENT_ID
+      ? null
+      : agentModels.find((a) => getAgentModelId(a) === selectedId) ?? null;
   const isNewAgent = selectedId === NEW_AGENT_ID;
   const selectedAgentModelId = selectedAgent ? getAgentModelId(selectedAgent) : null;
 
-  const loadAgents = useCallback(async () => {
-    if (!accessToken || !userID || !userRole) return;
+  const loadAgents = useCallback(async (): Promise<AgentModel[]> => {
+    if (!accessToken || !userID || !userRole) return [];
     setLoadingAgents(true);
     try {
       const list = await fetchAvailableAgentModels(accessToken, userID, userRole);
       setAgentModels(list);
-      if (!selectedId || (selectedId !== NEW_AGENT_ID && !list.some((a) => a.model_name === selectedId))) {
-        setSelectedId(list.length > 0 ? list[0].model_name : null);
+      if (
+        !selectedId ||
+        (selectedId !== NEW_AGENT_ID &&
+          !list.some((a) => getAgentModelId(a) === selectedId))
+      ) {
+        setSelectedId(list.length > 0 ? getAgentModelId(list[0]) : null);
       }
+      return list;
     } catch (e) {
       console.error(e);
       NotificationsManager.fromBackend("Failed to load agents");
+      return [];
     } finally {
       setLoadingAgents(false);
     }
@@ -309,8 +318,9 @@ export default function AgentBuilderView({
         model_info: {},
       });
       const newName = draftName.trim();
-      await loadAgents();
-      setSelectedId(newName);
+      const list = await loadAgents();
+      const created = list.find((a) => a.model_name === newName);
+      setSelectedId(getAgentModelId(created ?? list[0]) ?? null);
       setActiveTab("chat");
     } catch (e) {
       NotificationsManager.fromBackend("Failed to save agent");
@@ -342,8 +352,11 @@ export default function AgentBuilderView({
         selectedAgentModelId,
       );
       NotificationsManager.success("Agent updated successfully");
-      await loadAgents();
-      setSelectedId(draftName.trim());
+      const list = await loadAgents();
+      const stillSelected = list.find(
+        (a) => getAgentModelId(a) === selectedAgentModelId,
+      );
+      setSelectedId(getAgentModelId(stillSelected ?? list[0]) ?? null);
     } catch (e) {
       NotificationsManager.fromBackend("Failed to update agent");
     } finally {
@@ -387,9 +400,13 @@ export default function AgentBuilderView({
         try {
           await modelDeleteCall(accessToken, selectedAgentModelId);
           NotificationsManager.success("Agent deleted");
-          await loadAgents();
-          const remaining = agentModels.filter((a) => a.model_name !== selectedAgent.model_name);
-          setSelectedId(remaining.length > 0 ? remaining[0].model_name : null);
+          const list = await loadAgents();
+          const remaining = list.filter(
+            (a) => getAgentModelId(a) !== selectedAgentModelId,
+          );
+          setSelectedId(
+            remaining.length > 0 ? getAgentModelId(remaining[0]) : null,
+          );
         } catch (e) {
           NotificationsManager.fromBackend("Failed to delete agent");
         } finally {
@@ -452,21 +469,24 @@ export default function AgentBuilderView({
               </div>
             ) : (
               <>
-                {agentModels.map((agent) => (
-                  <button
-                    key={agent.model_name}
-                    type="button"
-                    onClick={() => setSelectedId(agent.model_name)}
-                    className={`mb-1 w-full rounded-md border-l-2 px-3 py-2 text-left text-sm transition-colors ${
-                      selectedId === agent.model_name
-                        ? "border-blue-500 bg-blue-50 text-blue-800"
-                        : "border-transparent hover:bg-gray-50"
-                    }`}
-                  >
-                    <div className="font-medium truncate">{agent.model_name}</div>
-                    <div className="text-[10px] text-gray-500 truncate">litellm_agent</div>
-                  </button>
-                ))}
+                {agentModels.map((agent) => {
+                  const id = getAgentModelId(agent);
+                  return (
+                    <button
+                      key={id ?? agent.model_name}
+                      type="button"
+                      onClick={() => id && setSelectedId(id)}
+                      className={`mb-1 w-full rounded-md border-l-2 px-3 py-2 text-left text-sm transition-colors ${
+                        selectedId === id
+                          ? "border-blue-500 bg-blue-50 text-blue-800"
+                          : "border-transparent hover:bg-gray-50"
+                      }`}
+                    >
+                      <div className="font-medium truncate">{agent.model_name}</div>
+                      <div className="text-[10px] text-gray-500 truncate">litellm_agent</div>
+                    </button>
+                  );
+                })}
                 <button
                   type="button"
                   onClick={handleAddAgent}


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

For team-scoped ("Team-BYOK") models, the backend stores two names:

- `model_name` (DB column): an internal routing key `model_name_{team_id}_{uuid}`, used by the in-memory router's primary `model_name → deployment` index. Two teams with the same public name need distinct routing keys here.
- `model_info.team_public_model_name`: the user-facing public name (e.g. `gpt-4o`).

The internal name was leaking into `/v1/model/info` and `/v2/model/info` API responses. The UI bound the model edit form to that field, so any non-rename edit (e.g. changing TPM) PATCHed the model with the internal name as `model_name`. The PATCH endpoint then treated it as a new public name, overwrote `team_public_model_name`, and rewrote the team's `models[]` list with the mangled string — breaking team-based routing for that model.

### Fix

1. Add `_translate_model_name_for_response` in `proxy_server.py`. For team-scoped rows, swap `model_name` to the public name held in `model_info.team_public_model_name` before returning. Apply at `_get_proxy_model_info` (covers `/v1/model/info`, `/model/info`) and in `/v2/model/info` before pagination. The DB column and router index keep the internal name as the routing key — the swap is presentation-layer only.

2. Harden `_get_public_model_name` in `model_management_endpoints.py`. When `patch_data.model_name` matches the internal mangled shape `model_name_{team_id}_{uuid}` or equals the existing DB column, treat it as "no rename intent" and fall through to the existing `team_public_model_name`. This protects against any client (UI, scripts, future code) that round-trips the leaked internal name.

3. Standardize `AgentBuilderView` selection on `model_info.id` instead of `model_name`. Once response translation lands, two team-scoped agents can share a public name; the lookup needs a stable id to avoid collisions.

## Testing

Verified end-to-end against a local proxy with a regression harness exercising three PATCH scenarios on fixtures including a deliberate cross-team public-name collision:

- TPM-only edit on a team model — `team_public_model_name` and the team's `models[]` list are unchanged after the PATCH; only `litellm_params.tpm` updates.
- Genuine rename on a team model — still works; team's `models[]` list updates correctly.
- Defensive case: client PATCHes with a fabricated `model_name_{team_id}_{uuid}` payload — treated as a no-op for the public name; no corruption.

Across all scenarios, the DB `model_name` column for team rows is unchanged (router invariant preserved). Two fresh captures on the fixed backend produce zero diffs against each other (determinism).

## Type

🐛 Bug Fix

## Screenshots