### PR TITLE
fix(guardrails): return HTTP 400 instead of 500 for blocked requests

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -918,9 +918,11 @@ class GuardrailRaisedException(Exception):
         guardrail_name: Optional[str] = None,
         message: str = "",
         should_wrap_with_default_message: bool = True,
+        status_code: int = 400,
     ):
         default_message = f"Guardrail raised an exception, Guardrail: {guardrail_name}, Message: {message}"
         self.guardrail_name = guardrail_name
+        self.status_code = status_code
         self.message = default_message if should_wrap_with_default_message else message
         super().__init__(self.message)
 
@@ -930,12 +932,14 @@ class BlockedPiiEntityError(Exception):
         self,
         entity_type: str,
         guardrail_name: Optional[str] = None,
+        status_code: int = 400,
     ):
         """
         Raised when a blocked entity is detected by a guardrail.
         """
         self.entity_type = entity_type
         self.guardrail_name = guardrail_name
+        self.status_code = status_code
         self.message = f"Blocked entity detected: {entity_type} by Guardrail: {guardrail_name}. This entity is not allowed to be used in this request."
         super().__init__(self.message)
 

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -737,11 +737,19 @@ class CustomGuardrail(CustomLogger):
         (this was logged previously as an API failure - guardrail_failed_to_respond).
 
         Guardrails signal intentional blocks by raising:
+        - GuardrailRaisedException (generic guardrail API, tool permission)
+        - BlockedPiiEntityError (Presidio PII detection)
         - HTTPException with status 400 (content policy violation)
         - ModifyResponseException (passthrough mode violation)
         """
+        from litellm.exceptions import (
+            BlockedPiiEntityError,
+            GuardrailRaisedException,
+        )
 
         if isinstance(e, ModifyResponseException):
+            return True
+        if isinstance(e, (GuardrailRaisedException, BlockedPiiEntityError)):
             return True
         if (
             HTTPException is not None

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -553,6 +553,7 @@ class TestGuardrailActions:
             # Verify the exception has the clean error message (no wrapper)
             assert str(exc_info.value) == "Content contains harmful instructions"
             assert exc_info.value.guardrail_name == "generic_guardrail_api"
+            assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_action_intervened_modifies_content(

--- a/tests/test_litellm/test_guardrail_exception_status_codes.py
+++ b/tests/test_litellm/test_guardrail_exception_status_codes.py
@@ -1,0 +1,66 @@
+"""
+Tests for guardrail exception status codes.
+
+GuardrailRaisedException and BlockedPiiEntityError must carry
+``status_code = 400`` so the proxy exception handler
+(``getattr(e, "status_code", 500)``) returns HTTP 400 instead of 500
+for intentional guardrail blocks.
+"""
+
+from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
+
+
+class TestGuardrailRaisedExceptionStatusCode:
+    """GuardrailRaisedException should default to status_code=400."""
+
+    def test_default_status_code(self):
+        exc = GuardrailRaisedException(
+            guardrail_name="test_guardrail",
+            message="blocked",
+        )
+        assert exc.status_code == 400
+
+    def test_custom_status_code(self):
+        exc = GuardrailRaisedException(
+            guardrail_name="test_guardrail",
+            message="rate limited",
+            status_code=429,
+        )
+        assert exc.status_code == 429
+
+    def test_getattr_fallback_resolves_to_400(self):
+        """The proxy uses ``getattr(e, 'status_code', 500)`` — verify it
+        resolves to 400, not the 500 default."""
+        exc = GuardrailRaisedException(
+            guardrail_name="test_guardrail",
+            message="blocked",
+        )
+        assert getattr(exc, "status_code", 500) == 400
+
+
+class TestBlockedPiiEntityErrorStatusCode:
+    """BlockedPiiEntityError should default to status_code=400."""
+
+    def test_default_status_code(self):
+        exc = BlockedPiiEntityError(
+            entity_type="CREDIT_CARD",
+            guardrail_name="presidio",
+        )
+        assert exc.status_code == 400
+
+    def test_custom_status_code(self):
+        exc = BlockedPiiEntityError(
+            entity_type="SSN",
+            guardrail_name="presidio",
+            status_code=403,
+        )
+        assert exc.status_code == 403
+
+    def test_getattr_fallback_resolves_to_400(self):
+        """The proxy uses ``getattr(e, 'status_code', 500)`` — verify it
+        resolves to 400, not the 500 default."""
+        exc = BlockedPiiEntityError(
+            entity_type="PHONE_NUMBER",
+            guardrail_name="presidio",
+        )
+        assert getattr(exc, "status_code", 500) == 400


### PR DESCRIPTION
## Summary

`GuardrailRaisedException` and `BlockedPiiEntityError` both lack a `status_code` attribute. When these exceptions reach the proxy exception handlers, `getattr(e, "status_code", 500)` defaults to HTTP 500 — making intentional guardrail blocks indistinguishable from server errors.

This affects:
- **All guardrails using the Generic Guardrail API** (raises `GuardrailRaisedException`)
- **Presidio PII detection** (raises `BlockedPiiEntityError`)
- **Tool permission guardrail** (raises `GuardrailRaisedException`)

Clients typically retry on 5xx but not 4xx. Returning 500 for guardrail blocks causes retry loops that repeatedly attempt to bypass content protections.

Additionally, `_is_guardrail_intervention()` did not recognize either exception, causing downstream observability tools (Langfuse, DataDog, etc.) to log intentional blocks as `guardrail_failed_to_respond` instead of `guardrail_intervened`.

## Relevant issues

Fixes #24348

## Changes

### `litellm/exceptions.py`
- Add `status_code: int = 400` (keyword-only) to `GuardrailRaisedException.__init__()`
- Add `status_code: int = 400` (keyword-only) to `BlockedPiiEntityError.__init__()`
- Both store `self.status_code` so `getattr(e, "status_code", 500)` resolves to 400

### `litellm/integrations/custom_guardrail.py`
- Update `_is_guardrail_intervention()` to recognize `GuardrailRaisedException` and `BlockedPiiEntityError`
- Blocks from these exceptions are now correctly logged as `guardrail_intervened`

### Tests
- **`tests/test_litellm/test_guardrail_exception_status_codes.py`**: 6 new unit tests covering default status code (400), custom override, and the `getattr` fallback pattern for both exceptions
- **`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py`**: Added `status_code == 400` assertion to existing `test_action_blocked_raises_exception`

## Why this works

PR #24693 already updated both code paths to propagate `status_code` via `getattr`:
- **Streaming**: `create_response()` at `common_request_processing.py`
- **Non-streaming**: `_handle_llm_api_exception()` at `common_request_processing.py`

Both default to 500 when the attribute is missing. Adding `self.status_code = 400` completes the fix with zero risk to other code paths. Existing callers are unaffected since the parameter uses a keyword-only default.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix