### PR TITLE
fix(router): set num_retries in aembedding for failover/retry parity

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4383,6 +4383,7 @@ class Router:
             kwargs["model"] = model
             kwargs["input"] = input
             kwargs["original_function"] = self._aembedding
+            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
             return response


### PR DESCRIPTION
Fixes #27363.

## Problem

`Router.aembedding()` did not propagate `num_retries` into `kwargs` before calling `async_function_with_fallbacks`, unlike every other async router method (`acompletion`, `acreate_file`, `atext_completion`, etc.). As a consequence, embedding routing retried zero times and never failed over to other deployments in the model group when one deployment was unreachable.

The reporter (@dredwilliams) confirmed via debug logs that `get_available_deployment` kept returning the same dead host on every retry attempt.

## Fix

Add the one missing line in `aembedding()`, matching the pattern used by every other async router method:

```python
kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
```

Compare:
- `aembedding` (line 4375) — was missing this line
- `acreate_file` (line 4470) — has it ✓
- `atext_completion` (line 3705) — has it ✓
- `acompletion` (line 2543) — has it ✓
- ...and the other 5+ async methods that route through `async_function_with_fallbacks` all have it.

## Test plan
- Embedding model group with two deployments where one host is unreachable → request now retries `self.num_retries` times and fails over to the healthy deployment.
- Behavior with explicit `num_retries=N` kwarg is preserved (the `kwargs.get` honors the caller's override).
- Single-deployment embedding requests behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
