### PR TITLE
Fix always_include_stream_usage missing in UI

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2452,6 +2452,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="If True, forwards client headers (e.g. Authorization) to the LLM API. Required for Claude Code with Max subscription.",
     )
+    always_include_stream_usage: Optional[bool] = Field(
+        None,
+        description="If True, automatically includes usage information in all streaming responses.",
+    )
     mcp_required_fields: Optional[List[str]] = Field(
         None,
         description="List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).",

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
@@ -41,12 +41,16 @@ const buildSettingsResponse = (overrides?: Partial<Record<string, unknown>>) => 
         require_auth_for_public_ai_hub: {
           description: "Require authentication for public AI Hub",
         },
+        always_include_stream_usage: {
+          description: "Always include stream usage",
+        },
       },
     },
     values: {
       disable_model_add_for_internal_users: false,
       disable_team_admin_delete_team_user: false,
       require_auth_for_public_ai_hub: false,
+      always_include_stream_usage: false,
     },
   },
   isLoading: false,
@@ -74,6 +78,7 @@ describe("UISettings", () => {
     expect(screen.getByRole("switch", { name: "Disable model add for internal users" })).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Disable team admin delete team user" })).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Require authentication for public AI Hub" })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Always include stream usage" })).toBeInTheDocument();
   });
 
   it("should toggle setting and call update", () => {
@@ -155,6 +160,35 @@ describe("UISettings", () => {
 
     expect(mutateMock).toHaveBeenCalledWith(
       { require_auth_for_public_ai_hub: true },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+    expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully");
+  });
+
+  it("should toggle always include stream usage setting and call update", () => {
+    const mutateMock = vi.fn((_settings, options) => {
+      options?.onSuccess?.();
+    });
+
+    mockUseUpdateUISettings.mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      error: null,
+    });
+
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Always include stream usage" });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { always_include_stream_usage: true },
       expect.objectContaining({
         onSuccess: expect.any(Function),
         onError: expect.any(Function),

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
@@ -17,6 +17,7 @@ export default function UISettings() {
   const disableTeamAdminDeleteProperty = schema?.properties?.disable_team_admin_delete_team_user;
   const requireAuthForPublicAIHubProperty = schema?.properties?.require_auth_for_public_ai_hub;
   const forwardClientHeadersProperty = schema?.properties?.forward_client_headers_to_llm_api;
+  const alwaysIncludeStreamUsageProperty = schema?.properties?.always_include_stream_usage;
   const forwardLLMProviderAuthHeadersProperty =
     schema?.properties?.forward_llm_provider_auth_headers;
   const enableProjectsUIProperty = schema?.properties?.enable_projects_ui;
@@ -28,6 +29,7 @@ export default function UISettings() {
   const scopeUserSearchProperty = schema?.properties?.scope_user_search_to_org;
   const disableCustomApiKeysProperty = schema?.properties?.disable_custom_api_keys;
   const values = data?.values ?? {};
+  const isAlwaysIncludeStreamUsage = Boolean(values.always_include_stream_usage);
   const isDisabledForInternalUsers = Boolean(values.disable_model_add_for_internal_users);
   const isDisabledTeamAdminDeleteTeamUser = Boolean(values.disable_team_admin_delete_team_user);
   const isAgentsDisabled = Boolean(values.disable_agents_for_internal_users);
@@ -75,6 +77,20 @@ export default function UISettings() {
   const handleToggleForwardClientHeaders = (checked: boolean) => {
     updateSettings(
       { forward_client_headers_to_llm_api: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleAlwaysIncludeStreamUsage = (checked: boolean) => {
+    updateSettings(
+      { always_include_stream_usage: checked },
       {
         onSuccess: () => {
           NotificationManager.success("UI settings updated successfully");
@@ -283,22 +299,39 @@ export default function UISettings() {
             </Space>
           </Space>
 
-          <Space align="start" size="middle">
-            <Switch
-              checked={Boolean(values.forward_client_headers_to_llm_api)}
-              disabled={isUpdating}
-              loading={isUpdating}
-              onChange={handleToggleForwardClientHeaders}
-              aria-label={forwardClientHeadersProperty?.description ?? "Forward client headers to LLM API"}
-            />
-            <Space direction="vertical" size={4}>
-              <Typography.Text strong>Forward client headers to LLM API</Typography.Text>
-              <Typography.Text type="secondary">
-                {forwardClientHeadersProperty?.description ??
-                  "Forwards client headers (Authorization, anthropic-beta, and x-* custom headers) to the upstream LLM. Enable for Claude Code with a Max subscription (forwards the OAuth token) or to pass custom/tracing headers through to the provider. Independent of the BYOK toggle — enable only the one(s) you need."}
-              </Typography.Text>
+<Space align="start" size="middle">
+              <Switch
+                checked={Boolean(values.forward_client_headers_to_llm_api)}
+                disabled={isUpdating}
+                loading={isUpdating}
+                onChange={handleToggleForwardClientHeaders}
+                aria-label={forwardClientHeadersProperty?.description ?? "Forward client headers to LLM API"}
+              />
+              <Space direction="vertical" size={4}>
+                <Typography.Text strong>Forward client headers to LLM API</Typography.Text>
+                <Typography.Text type="secondary">
+                  {forwardClientHeadersProperty?.description ??
+                    "Forwards client headers (Authorization, anthropic-beta, and x-* custom headers) to the upstream LLM. Enable for Claude Code with a Max subscription (forwards the OAuth token) or to pass custom/tracing headers through to the provider. Independent of the BYOK toggle — enable only the one(s) you need."}
+                </Typography.Text>
+              </Space>
             </Space>
-          </Space>
+
+            <Space align="start" size="middle">
+              <Switch
+                checked={isAlwaysIncludeStreamUsage}
+                disabled={isUpdating}
+                loading={isUpdating}
+                onChange={handleToggleAlwaysIncludeStreamUsage}
+                aria-label={alwaysIncludeStreamUsageProperty?.description ?? "Always include stream usage"}
+              />
+              <Space direction="vertical" size={4}>
+                <Typography.Text strong>Always include stream usage</Typography.Text>
+                <Typography.Text type="secondary">
+                  {alwaysIncludeStreamUsageProperty?.description ??
+                    "If enabled, usage is included in stream responses."}
+                </Typography.Text>
+              </Space>
+            </Space>
 
           <Space align="start" size="middle">
             <Switch

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
@@ -299,7 +299,7 @@ export default function UISettings() {
             </Space>
           </Space>
 
-<Space align="start" size="middle">
+          <Space align="start" size="middle">
               <Switch
                 checked={Boolean(values.forward_client_headers_to_llm_api)}
                 disabled={isUpdating}


### PR DESCRIPTION
## Relevant issues

Fixes #23343 always_include_stream_usage flag missing in UI settings for proxy



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).



## Screenshots / Proof of Fix

<img width="1012" height="120" alt="Screenshot 2026-05-07 at 5 44 36 pm" src="https://github.com/user-attachments/assets/2408423e-ead6-4863-893b-c9dac9b4a9f2" />



## Type

🐛 Bug Fix, its already in the documentation however isnt actually in the UI as described.  

<img width="1081" height="577" alt="Screenshot 2026-05-14 at 12 48 05 pm" src="https://github.com/user-attachments/assets/dff9a88b-66f6-4d09-a9b1-699c5e12d279" />



## Changes

Adds a UI boolean switch which enables always_include_stream_usage setting in the proxy UI. 