### PR TITLE
fix(router): set num_retries in aembedding for failover/retry parity

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4383,6 +4383,7 @@ class Router:
             kwargs["model"] = model
             kwargs["input"] = input
             kwargs["original_function"] = self._aembedding
+            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
             return response


### PR DESCRIPTION
## Summary

`Router.aembedding()` currently bypasses `Router.num_retries`. The path goes:

```
aembedding() → async_function_with_fallbacks(**kwargs)
```

`async_function_with_fallbacks` reads `kwargs.get('num_retries')` and falls back to `self.num_retries` only if certain conditions hold. For `acompletion`, `aresponses`, etc. (search the file), the wrapper sets `kwargs['num_retries'] = kwargs.get('num_retries', self.num_retries)` before calling the fallbacks helper. `aembedding` is the odd one out — so embedding requests do not honour `Router(num_retries=N)` the way completion requests do.

## Fix

One line, mirrors what every other `a*` wrapper in `Router` already does:

```python
kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
```

## Notes

- Targeting `litellm_agent_oss_staging_05_07_2026` per the new external-contributor flow (the guard-main-branch workflow now blocks fork PRs to `main`).
- This re-opens the same fix as #27378 (which targeted `main` and is blocked by the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)