### PR TITLE
feat(model_prices): add ai21 jamba-mini-2 and dated jamba-large-1.7 aliases (#27094)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22040,6 +22040,16 @@
         "output_cost_per_token": 8e-06,
         "supports_tool_choice": true
     },
+    "jamba-large-1.7-2025-07": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "ai21",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "supports_tool_choice": true
+    },
     "jamba-mini-1.6": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
@@ -22051,6 +22061,26 @@
         "supports_tool_choice": true
     },
     "jamba-mini-1.7": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "ai21",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_tool_choice": true
+    },
+    "jamba-mini-2": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "ai21",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_tool_choice": true
+    },
+    "jamba-mini-2-2026-01": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22045,6 +22045,16 @@
         "output_cost_per_token": 8e-06,
         "supports_tool_choice": true
     },
+    "jamba-large-1.7-2025-07": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "ai21",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "supports_tool_choice": true
+    },
     "jamba-mini-1.6": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
@@ -22056,6 +22066,26 @@
         "supports_tool_choice": true
     },
     "jamba-mini-1.7": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "ai21",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_tool_choice": true
+    },
+    "jamba-mini-2": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "ai21",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_tool_choice": true
+    },
+    "jamba-mini-2-2026-01": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,


### PR DESCRIPTION
Re-opens #27112 against today's `litellm_agent_oss_staging_05_07_2026` branch (per the new external-contributor flow). Closes #27094.

## What

Adds three missing AI21 Jamba model entries to `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`:

- `jamba-large-1.7-2025-07` — dated alias for `jamba-large-1.7`
- `jamba-mini-2` — Jamba 2 mini
- `jamba-mini-2-2026-01` — dated alias for `jamba-mini-2`

Pricing / context window matches the existing un-dated 1.7 / 2 entries: 2e-06 / 8e-06 USD/token for large, 2e-07 / 4e-07 for mini; 256k context.

## Type

🐛 Bug Fix
🆕 New Feature

## Testing

JSON validity verified for both files (`json.load()` succeeds, all 3 new keys present).

## Notes

`#27112` was opened against the now-stale `litellm_oss_staging` branch and was failing the `Verify PR source branch` guard. Closing it in favor of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)