### PR TITLE
fix(ui): label deprecated vLLM provider entry distinctly (#27384)

### DIFF
--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -95,7 +95,7 @@ export enum Providers {
   VERCEL_AI_GATEWAY = "Vercel Ai Gateway",
   Vertex_AI = "Vertex AI (Anthropic, Gemini, etc.)",
   VERTEX_AI_BETA = "Vertex Ai Beta",
-  VLLM = "Vllm",
+  VLLM = "vLLM (deprecated, packaged installs)",
   VolcEngine = "VolcEngine",
   Voyage = "Voyage AI",
   WANDB = "Wandb",


### PR DESCRIPTION
Closes #27384.

## What

The Add Model dropdown showed two entries that looked like a duplicate for vLLM:

- `Hosted_Vllm` rendered as `"vllm"` (the recommended hosted provider — backend `hosted_vllm`)
- `VLLM` rendered as `"Vllm"` (the deprecated packaged-installs path — backend `vllm`)

Casing alone is not a clear visual cue, so users perceive a duplicate. The reporter ran into exactly this confusion and pointed at `provider_info_helpers.tsx:48` and `:98`.

## Fix

One-line label change in `provider_info_helpers.tsx`:

```diff
-  VLLM = "Vllm",
+  VLLM = "vLLM (deprecated, packaged installs)",
```

The wording matches how the [vllm provider docs](https://docs.litellm.ai/docs/providers/vllm#deprecated-for-packaged-vllm-installs) describe this path.

## Out of scope (intentionally)

- The deeper code duplication between `Hosted_Vllm` and `VLLM` (two enum entries, two `provider_map` keys, two logo entries pointing at the same `vllm.png`) is left as-is. The reporter explicitly noted that and didn't want to question it; this PR is a minimal user-visible label fix.
- Backend strings (`provider_map`, asset paths, enum identifiers) are unchanged, so no test or downstream consumer should break. The existing `provider_specific_fields.test.tsx` references `Providers.Hosted_Vllm` (the enum), not the literal display string.

## Type

🐛 Bug Fix

## Testing

UI-only label change; static type-check + existing tests should be sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)