### PR TITLE
fix(router): call _update_kwargs_with_deployment in aspeech (#27390)

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3582,9 +3582,7 @@ class Router:
                 request_kwargs=kwargs,
             )
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
-            self._update_kwargs_with_deployment(
-                deployment=deployment, kwargs=kwargs
-            )
+            self._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs)
             data = deployment["litellm_params"].copy()
             data["model"]
             for k, v in self.default_litellm_params.items():

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3582,6 +3582,9 @@ class Router:
                 request_kwargs=kwargs,
             )
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
+            self._update_kwargs_with_deployment(
+                deployment=deployment, kwargs=kwargs
+            )
             data = deployment["litellm_params"].copy()
             data["model"]
             for k, v in self.default_litellm_params.items():


### PR DESCRIPTION
## What this PR does

Fixes #27390.

`Router.aspeech()` is the only async router method that does **not** call
`self._update_kwargs_with_deployment()` after `_update_kwargs_before_fallbacks()`.
TTS requests through the proxy therefore always record `spend = $0` whenever the
deployment uses custom pricing (`input_cost_per_character` in `model_info`).

### Root cause

`_update_kwargs_with_deployment()` writes the selected deployment's UUID into
`kwargs["metadata"]["model_info"]["id"]`. The cost callback later looks up that
UUID via `get_router_model_id()` to find the deployment's custom pricing.
Without this call:
- `kwargs["metadata"]["model_info"]["id"]` is never set,
- `get_router_model_id()` returns `None`,
- the cost calculator falls back to the bare model name which has no pricing
  entry, and
- spend is recorded as `0.0`.

### Fix

Add the call right after `_update_kwargs_before_fallbacks(...)` in `aspeech()`,
matching the existing pattern used in every other router async method:

| Method | calls `_update_kwargs_with_deployment` |
|---|---|
| `acompletion` | yes |
| `aembedding` | yes |
| `atranscription` (via `_atranscription`) | yes |
| `arerank` | yes |
| `aimage_generation` | yes |
| `aspeech` | yes (after this PR) |

The call uses the same signature as sibling methods (no `function_name=` kwarg)
for stylistic consistency — the metadata variable name resolution and clientside-
credential handling work the same way without it.

### Diff

3 lines added, 0 removed in `litellm/router.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
