### PR TITLE
Fix router aspeech deployment metadata propagation

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3582,6 +3582,9 @@ class Router:
                 request_kwargs=kwargs,
             )
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
+            self._update_kwargs_with_deployment(
+                deployment=deployment, kwargs=kwargs, function_name="aspeech"
+            )
             data = deployment["litellm_params"].copy()
             data["model"]
             for k, v in self.default_litellm_params.items():

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2963,6 +2963,56 @@ def test_update_kwargs_with_deployment_model_info_in_metadata():
     assert model_info["output_cost_per_token"] == 0.0015
 
 
+@pytest.mark.asyncio
+async def test_aspeech_includes_deployment_model_info_in_metadata():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "tts",
+                "litellm_params": {
+                    "model": "openai/tts-1",
+                    "api_key": "fake-key",
+                },
+                "model_info": {
+                    "id": "custom-tts-pricing-id",
+                    "input_cost_per_character": 0.000015,
+                },
+            },
+        ],
+    )
+
+    deployment = {
+        "model_name": "tts",
+        "litellm_params": {
+            "model": "openai/tts-1",
+            "api_key": "fake-key",
+        },
+        "model_info": {
+            "id": "custom-tts-pricing-id",
+            "input_cost_per_character": 0.000015,
+        },
+    }
+
+    with patch.object(
+        router,
+        "async_get_available_deployment",
+        AsyncMock(return_value=deployment),
+    ), patch.object(router, "_get_client", return_value=None), patch(
+        "litellm.aspeech", AsyncMock(return_value=MagicMock())
+    ) as mock_aspeech:
+        await router.aspeech(
+            model="tts",
+            input="hello world",
+            voice="alloy",
+        )
+
+    called_kwargs = mock_aspeech.await_args.kwargs
+    assert "metadata" in called_kwargs
+    model_info = called_kwargs["metadata"]["model_info"]
+    assert model_info["id"] == "custom-tts-pricing-id"
+    assert model_info["input_cost_per_character"] == 0.000015
+
+
 def test_combine_fallback_usage():
     """Test that _combine_fallback_usage merges partial and fallback usage."""
     from litellm.router import Router


### PR DESCRIPTION
## Summary
- call `_update_kwargs_with_deployment()` from `Router.aspeech()` so deployment `model_info` is propagated into request metadata
- add a regression test covering `aspeech()` metadata propagation for custom-priced TTS deployments

Closes #27390.

## Testing
- `pytest tests/test_litellm/test_router.py -k "aspeech_includes_deployment_model_info_in_metadata or test_update_kwargs_with_deployment_model_info_in_metadata"`
