### PR TITLE
Fix bulk invite template download button

### DIFF
--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import BulkCreateUsersButton from "./bulk_create_users_button";
 
@@ -24,5 +24,51 @@ describe("BulkCreateUsersButton", () => {
   it("should render", () => {
     const { getByText } = render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
     expect(getByText("+ Bulk Invite Users")).toBeInTheDocument();
+  });
+
+  it("downloads the CSV template when clicked", async () => {
+    const originalCreateObjectURL = window.URL.createObjectURL;
+    const originalRevokeObjectURL = window.URL.revokeObjectURL;
+    const createObjectURLSpy = vi.fn(() => "blob:test");
+    const revokeObjectURLSpy = vi.fn();
+    const appendChildSpy = vi.spyOn(document.body, "appendChild");
+    const removeChildSpy = vi.spyOn(document.body, "removeChild");
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    let createdAnchor: HTMLAnchorElement | null = null;
+
+    window.URL.createObjectURL = createObjectURLSpy;
+    window.URL.revokeObjectURL = revokeObjectURLSpy;
+
+    const createElementSpy = vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "a") {
+        const anchor = originalCreateElement("a");
+        anchor.click = clickSpy;
+        createdAnchor = anchor;
+        return anchor;
+      }
+
+      return originalCreateElement(tagName);
+    });
+
+    const { getByText, findByText } = render(
+      <BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />
+    );
+
+    fireEvent.click(getByText("+ Bulk Invite Users"));
+    fireEvent.click(await findByText("Download CSV Template"));
+
+    expect(createObjectURLSpy).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(createdAnchor).not.toBeNull();
+    expect(appendChildSpy).toHaveBeenCalledWith(createdAnchor);
+    expect(removeChildSpy).toHaveBeenCalledWith(createdAnchor);
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:test");
+
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+    createElementSpy.mockRestore();
+    window.URL.createObjectURL = originalCreateObjectURL;
+    window.URL.revokeObjectURL = originalRevokeObjectURL;
   });
 });

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
@@ -629,7 +629,13 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                   </div>
                 </div>
 
-                <Button type="primary" size="large" className="w-full md:w-auto" icon={<DownloadOutlined />}>
+                <Button
+                  type="primary"
+                  size="large"
+                  className="w-full md:w-auto"
+                  icon={<DownloadOutlined />}
+                  onClick={downloadTemplate}
+                >
                   Download CSV Template
                 </Button>
               </div>


### PR DESCRIPTION
## Summary
- wire the bulk invite template button to `downloadTemplate`
- add a regression test that opens the modal and verifies the CSV template download flow

Closes #27197.

## Testing
- `npm test -- bulk_create_users_button.test.tsx`
