### PR TITLE
Fix hosted vllm provider label

### DIFF
--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -95,6 +95,12 @@ describe("provider_info_helpers", () => {
         }
       });
     });
+
+    it("should use distinct display names for hosted and deprecated vllm providers", () => {
+      expect(Providers.Hosted_Vllm).toBe("Hosted Vllm");
+      expect(Providers.VLLM).toBe("Vllm");
+      expect(Providers.Hosted_Vllm).not.toBe(Providers.VLLM);
+    });
   });
 
   describe("getPlaceholder", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -45,7 +45,7 @@ export enum Providers {
   GradientAI = "GradientAI",
   Groq = "Groq",
   HEROKU = "Heroku",
-  Hosted_Vllm = "vllm",
+  Hosted_Vllm = "Hosted Vllm",
   HUGGINGFACE = "Huggingface",
   HYPERBOLIC = "Hyperbolic",
   Infinity = "Infinity",


### PR DESCRIPTION
## Summary
- rename the hosted vLLM provider display label so the Add Model menu no longer shows two near-identical `vllm` entries
- add a regression test covering the hosted vs deprecated vLLM display names

Closes #27384.

## Testing
- `npm test -- provider_info_helpers.test.tsx`
