### PR TITLE
fix(chat-completions): decode unified file_id when model_file_id_mapping is unavailable

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -459,7 +459,13 @@ def update_messages_with_model_file_ids(
                 if isinstance(content, str):
                     continue
                 for c in content:
-                    if c["type"] == "file":
+                    if not isinstance(c, dict):
+                        # Content list items aren't always dicts. e.g.
+                        # text_completion forwards a token-ids list/list-of-
+                        # lists through this path. Skip non-dict items
+                        # instead of indexing into them.
+                        continue
+                    if c.get("type") == "file":
                         file_object = cast(ChatCompletionFileObject, c)
                         file_object_file_field = file_object.get("file")
                         if not isinstance(file_object_file_field, dict):

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -436,12 +436,21 @@ def update_messages_with_model_file_ids(
     """
     Updates messages with model file ids.
 
+    For managed files (unified file IDs), uses model_file_id_mapping if it
+    resolves the id, otherwise decodes the base64-encoded unified file ID
+    and extracts the llm_output_file_id directly. Mirrors the Responses-API
+    sibling `update_responses_input_with_model_file_ids`.
+
     model_file_id_mapping: Dict[str, Dict[str, str]] = {
         "litellm_proxy/file_id": {
             "model_id": "provider_file_id"
         }
     }
     """
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        _is_base64_encoded_unified_file_id,
+        convert_b64_uid_to_unified_uid,
+    )
 
     for message in messages:
         if message.get("role") == "user":
@@ -468,9 +477,23 @@ def update_messages_with_model_file_ids(
                         if file_id:
                             provider_file_id = (
                                 model_file_id_mapping.get(file_id, {}).get(model_id)
-                                or file_id
+                                if model_file_id_mapping
+                                else None
                             )
-                            file_object_file_field["file_id"] = provider_file_id
+                            if (
+                                not provider_file_id
+                                and _is_base64_encoded_unified_file_id(file_id)
+                            ):
+                                unified_file_id = convert_b64_uid_to_unified_uid(
+                                    file_id
+                                )
+                                if "llm_output_file_id," in unified_file_id:
+                                    provider_file_id = unified_file_id.split(
+                                        "llm_output_file_id,"
+                                    )[1].split(";")[0]
+                            file_object_file_field["file_id"] = (
+                                provider_file_id or file_id
+                            )
                         if format:
                             file_object_file_field["format"] = format
     return messages

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1459,14 +1459,14 @@ def completion(  # type: ignore # noqa: PLR0915
             if eos_token:
                 custom_prompt_dict[model]["eos_token"] = eos_token
 
-        if kwargs.get("model_file_id_mapping"):
-            messages = update_messages_with_model_file_ids(
-                messages=messages,
-                model_id=kwargs.get("model_info", {}).get("id", None),
-                model_file_id_mapping=cast(
-                    Dict[str, Dict[str, str]], kwargs.get("model_file_id_mapping")
-                ),
-            )
+        messages = update_messages_with_model_file_ids(
+            messages=messages,
+            model_id=kwargs.get("model_info", {}).get("id", None),
+            model_file_id_mapping=cast(
+                Dict[str, Dict[str, str]],
+                kwargs.get("model_file_id_mapping") or {},
+            ),
+        )
 
         provider_config: Optional[BaseConfig] = None
         if custom_llm_provider is not None and custom_llm_provider in [

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -473,3 +473,22 @@ def test_update_messages_with_model_file_ids_mapping_miss_falls_back_to_decode()
     updated = update_messages_with_model_file_ids(messages, "model-A", mapping)
 
     assert updated[0]["content"][0]["file"]["file_id"] == "file-ECBPW7ML9g7XHdwGgUPZaM"
+
+
+def test_update_messages_with_model_file_ids_tolerates_non_dict_content_items():
+    """Content list items aren't always dicts. text_completion forwards
+    token-ids (list of ints, or list of list of ints for batch) through
+    this path. The function must skip non-dict items instead of indexing
+    into them."""
+    messages_token_ids = [{"role": "user", "content": [15496, 995]}]
+    messages_token_ids_batch = [{"role": "user", "content": [[15496, 995], [9906, 0]]}]
+
+    # Both should pass through unchanged without raising.
+    assert (
+        update_messages_with_model_file_ids(messages_token_ids, "model-A", {})
+        == messages_token_ids
+    )
+    assert (
+        update_messages_with_model_file_ids(messages_token_ids_batch, "model-A", {})
+        == messages_token_ids_batch
+    )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -367,3 +367,109 @@ def test_update_messages_with_model_file_ids_skips_non_openai_file_blocks():
 
     # Messages pass through unchanged when there is no `file` sub-dict to remap.
     assert updated == messages
+
+
+# Reusable fixture (decodes to: litellm_proxy:application/pdf;unified_id,...;
+# target_model_names,gpt-4o;llm_output_file_id,file-ECBPW7ML9g7XHdwGgUPZaM;
+# llm_output_file_model_id,...)
+UNIFIED_FILE_ID_B64 = (
+    "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0"
+    "LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1f"
+    "b3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRf"
+    "ZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFk"
+    "MDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
+)
+
+
+def test_update_messages_with_model_file_ids_decodes_unified_id_when_mapping_empty():
+    """When the mapping is empty (e.g. multi-replica cache miss), the function
+    must decode the base64-encoded unified file id and substitute the embedded
+    llm_output_file_id — mirroring the Responses-API sibling."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this recording?"},
+                {
+                    "type": "file",
+                    "file": {
+                        "file_id": UNIFIED_FILE_ID_B64,
+                        "format": "audio/wav",
+                    },
+                },
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "any-model-id", {})
+
+    assert updated[0]["content"][1]["file"]["file_id"] == "file-ECBPW7ML9g7XHdwGgUPZaM"
+    # Customer-supplied format is preserved (this is the field whose absence
+    # the misleading error message used to complain about).
+    assert updated[0]["content"][1]["file"]["format"] == "audio/wav"
+
+
+def test_update_messages_with_model_file_ids_mapping_takes_precedence_over_decode():
+    """When both mapping and decode would resolve, the mapping must win
+    (preserves per-deployment routing precision)."""
+    mapping = {UNIFIED_FILE_ID_B64: {"model-A": "mapped-provider-file-id"}}
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "file",
+                    "file": {
+                        "file_id": UNIFIED_FILE_ID_B64,
+                        "format": "application/pdf",
+                    },
+                },
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", mapping)
+
+    assert updated[0]["content"][0]["file"]["file_id"] == "mapped-provider-file-id"
+
+
+def test_update_messages_with_model_file_ids_non_unified_passes_through():
+    """A raw provider id (e.g. gs:// URI or a random string) must be left
+    untouched when the mapping doesn't resolve it. The decode fallback must
+    not corrupt non-unified ids."""
+    raw_id = "gs://my-bucket/uploads/abc-123.wav"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file": {"file_id": raw_id, "format": "audio/wav"}},
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", {})
+
+    assert updated[0]["content"][0]["file"]["file_id"] == raw_id
+
+
+def test_update_messages_with_model_file_ids_mapping_miss_falls_back_to_decode():
+    """A mapping that exists but doesn't contain this file_id should still
+    trigger the decode fallback — covers the case where the hook resolved
+    *some* ids but not this one."""
+    other_id = "some-other-file-id"
+    mapping = {other_id: {"model-A": "other-provider-id"}}
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "file",
+                    "file": {"file_id": UNIFIED_FILE_ID_B64, "format": "audio/wav"},
+                },
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-A", mapping)
+
+    assert updated[0]["content"][0]["file"]["file_id"] == "file-ECBPW7ML9g7XHdwGgUPZaM"


### PR DESCRIPTION
## Relevant issues

N/A — no open issue. Related precedent: PRs #24776 and #24907 fixed the analogous Responses-API path; this brings the chat-completions path to parity.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

The patched chat-completions branch mirrors the Responses-API sibling already in production (`common_utils.py:541-561`, shipped in PR #16733 follow-ups).

Walking the patched function through a representative encoded unified ID (mapping empty):

```
file_id (base64)        → "<base64-encoded-unified-id>"
mapping lookup          → miss (None)
_is_base64_…unified(…)   → True
convert_b64_uid_to_…    → "litellm_proxy:<mime-type>;unified_id,<uuid>;
                           target_model_names,<model>;
                           llm_output_file_id,<provider-file-id>;
                           llm_output_file_model_id,<hash>"
split(\"llm_output_file_id,\")[1].split(\";\")[0]
                        → "<provider-file-id>"
file.file_id            → "<provider-file-id>"   (decoded)
file.format             → "<caller-supplied-mime>"   (preserved)
```

The substituted provider ID flows through the existing `gs://` / `https://generativelanguage…` handlers in `_process_gemini_media` (`vertex_ai/gemini/transformation.py:195-208`), which already honour caller-supplied `file.format`.

## Type

🐛 Bug Fix

## Changes

### Problem

`update_messages_with_model_file_ids` (chat-completions path) translates unified file IDs only via the DB/cache-backed `model_file_id_mapping`. When that lookup misses — or when the mapping is empty — the base64-encoded unified file ID leaks unchanged into the provider transformation. For Gemini this surfaces as a misleading error from `_process_gemini_media`:

```
Unable to determine mime type for file_id: <encoded id>, set this explicitly using message[0].content[1].file.format
```

The error is misleading because `file.format` is honoured on the `gs://` branch of `_process_gemini_media` — the actual problem is the un-translated encoded id reaching that function at all.

The Responses-API sibling `update_responses_input_with_model_file_ids` already has a decode fallback (added in PR #16733 follow-ups) that handles this case by decoding the unified ID and extracting the embedded `llm_output_file_id` directly. The chat-completions path has the same surface but no equivalent fallback — a long-standing asymmetry.

There is also a guard at `litellm/main.py:1462`:

```python
if kwargs.get("model_file_id_mapping"):
    messages = update_messages_with_model_file_ids(...)
```

An empty dict `{}` is falsy in Python, so when the pre-call hook produces an empty mapping (e.g. multi-replica cache misses, missing `model_info.id`, hook-disabled deployments), the translation function isn't called at all and the encoded id passes through verbatim.

### Fix

1. **`litellm/litellm_core_utils/prompt_templates/common_utils.py`** — add the same decode fallback the Responses-API sibling uses to `update_messages_with_model_file_ids`:
   - Mapping still wins when present (preserves per-deployment routing precision).
   - On mapping miss, check `_is_base64_encoded_unified_file_id(file_id)` and, if true, decode the unified id via `convert_b64_uid_to_unified_uid` and extract the embedded `llm_output_file_id`.
   - Final `provider_file_id or file_id` keeps the existing pass-through behaviour for non-unified ids and for unified ids that don't carry an `llm_output_file_id` (defensive).
   - Inline import of `_is_base64_encoded_unified_file_id` / `convert_b64_uid_to_unified_uid` mirrors the import pattern the Responses sibling already uses (avoids circular import at module load).

2. **`litellm/main.py`** — relax the `if kwargs.get(\"model_file_id_mapping\"):` guard so the translation is invoked even when the mapping is empty/absent. The function early-returns on string content and no-ops on messages without `type:\"file\"` blocks, so unconditional invocation is cheap. `kwargs.get(\"model_file_id_mapping\") or {}` keeps the function signature satisfied (`Dict[str, Dict[str, str]]`).

### Tests

Added four tests in `tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py`:

- `test_update_messages_with_model_file_ids_decodes_unified_id_when_mapping_empty` — empty mapping triggers decode fallback.
- `test_update_messages_with_model_file_ids_mapping_takes_precedence_over_decode` — when both could resolve, mapping wins.
- `test_update_messages_with_model_file_ids_non_unified_passes_through` — raw provider ids (e.g. `gs://...` URIs) are left untouched when the mapping doesn't resolve them.
- `test_update_messages_with_model_file_ids_mapping_miss_falls_back_to_decode` — mapping that exists but doesn't contain this `file_id` still triggers the decode fallback.

All four new tests use the same base64 fixture format as the Responses-API tests for consistency, and the existing `test_update_messages_with_model_file_ids` regression test continues to pass.

### Backwards compatibility / risk

- Function signature is unchanged. Behaviour is strictly additive: when the mapping resolves an id, behaviour is identical; when it doesn't, decode is attempted before falling through to the original pass-through.
- Responses-API path is untouched. Provider transformations are untouched.
- Single-commit revert if needed; no schema, migration, or dependency changes.