### PR TITLE
Deprecate legacy spend logs curl examples

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2200,6 +2200,8 @@ async def ui_view_request_response_for_request_id(
     "/spend/logs",
     tags=["Budget & Spend Tracking"],
     dependencies=[Depends(user_api_key_auth)],
+    deprecated=True,
+    summary="Deprecated: use /spend/logs/ui for paginated spend logs",
     responses={
         200: {"model": List[LiteLLM_SpendLogs]},
     },
@@ -2233,7 +2235,7 @@ async def view_spend_logs(  # noqa: PLR0915
 ):
     """
     [DEPRECATED] This endpoint is not paginated and can cause performance issues.
-    Please use `/spend/logs/v2` instead for paginated access to spend logs.
+    Please use `/spend/logs/ui` instead for paginated access to spend logs.
 
     View all spend logs, if request_id is provided, only logs for that request_id will be returned
 
@@ -2241,34 +2243,14 @@ async def view_spend_logs(  # noqa: PLR0915
     - summarize=true (default): Returns aggregated spend data grouped by date (maintains backward compatibility)
     - summarize=false: Returns filtered individual log entries within the date range
 
-    Example Request for all logs
+    Recommended paginated UI spend logs request:
     ```
-    curl -X GET "http://0.0.0.0:8000/spend/logs" \
--H "Authorization: Bearer sk-1234"
-    ```
-
-    Example Request for specific request_id
-    ```
-    curl -X GET "http://0.0.0.0:8000/spend/logs?request_id=chatcmpl-6dcb2540-d3d7-4e49-bb27-291f863f112e" \
--H "Authorization: Bearer sk-1234"
-    ```
-
-    Example Request for specific api_key
-    ```
-    curl -X GET "http://0.0.0.0:8000/spend/logs?api_key=sk-test-example-key-123" \
--H "Authorization: Bearer sk-1234"
-    ```
-
-    Example Request for specific user_id
-    ```
-    curl -X GET "http://0.0.0.0:8000/spend/logs?user_id=ishaan@berri.ai" \
--H "Authorization: Bearer sk-1234"
-    ```
-
-    Example Request for date range with individual logs (unsummarized)
-    ```
-    curl -X GET "http://0.0.0.0:8000/spend/logs?start_date=2024-01-01&end_date=2024-01-02&summarize=false" \
--H "Authorization: Bearer sk-1234"
+    curl -G "http://0.0.0.0:4000/spend/logs/ui" \
+      -H "Authorization: Bearer <proxy-api-key>" \
+      --data-urlencode "start_date=2024-01-01 00:00:00" \
+      --data-urlencode "end_date=2024-01-02 00:00:00" \
+      --data-urlencode "page=1" \
+      --data-urlencode "page_size=50"
     ```
     """
     from litellm.proxy.proxy_server import prisma_client

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -127,6 +127,20 @@ async def test_is_admin_view_safe_false():
     assert spend_management_endpoints._is_admin_view_safe(auth) is False
 
 
+def test_legacy_spend_logs_openapi_points_to_ui_endpoint(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    operation = response.json()["paths"]["/spend/logs"]["get"]
+    description = operation.get("description", "")
+
+    assert operation.get("deprecated") is True
+    assert "/spend/logs/ui" in description
+    assert "curl -G" in description
+    assert "page_size=50" in description
+    assert 'curl -X GET "http://0.0.0.0:8000/spend/logs"' not in description
+
+
 @pytest.mark.asyncio
 async def test_is_admin_view_safe_exception():
     # Ensure exceptions are swallowed and return False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Marked the legacy `/spend/logs` operation as deprecated in OpenAPI and replaced its old non-paginated curl examples with a paginated `/spend/logs/ui` curl using a credential placeholder.

## Repro
A caller consulting the generated API docs for spend logs would see the non-paginated legacy endpoint examples and no OpenAPI deprecation flag, making it easy to keep using the slower route.

## Evidence
<a href="/opt/cursor/artifacts/spend_logs_ui_curl_verification.txt">Verification transcript</a>

## Tests
- Added `test_legacy_spend_logs_openapi_points_to_ui_endpoint` in `tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py`.
- Confirmed the new test failed before the fix because the OpenAPI operation was not deprecated.
- `uv run pytest tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py::test_legacy_spend_logs_openapi_points_to_ui_endpoint -q` - passed.
- `uv run pytest tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py -q` - 65 passed.
- `cd litellm && uv run --no-sync black --check --exclude '/enterprise/' .` - passed.
- `cd litellm && uv run --no-sync ruff check .` - passed.
- `cd litellm && uv run --no-sync mypy .` - passed.
- `make test-unit` - stopped after unrelated live-provider authentication failures in interaction/compression tests after 4,582 passed; no spend-log tests failed.

## Relevant issues

Internal request to steer callers away from the legacy spend-log endpoint.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement.
- [ ] My PR passes all unit tests on `make test-unit`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review.

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

See verification transcript linked above.

## Type

📖 Documentation
✅ Test

## Changes

- Adds OpenAPI deprecation metadata to `/spend/logs`.
- Replaces legacy non-paginated curl examples with a paginated `/spend/logs/ui` curl.
- Adds regression coverage for the generated OpenAPI operation metadata and migration example.

## CI
- GitHub checks: 112 successful checks on the PR head.
- CircleCI `realtime_translation_testing`: pre-existing failure unrelated to this change. The same context is failing on `litellm_internal_staging` at `fee5900acc98b4034b1f3d02581d9a05401b9007` (https://circleci.com/gh/BerriAI/litellm/1627513); PR context: https://circleci.com/gh/BerriAI/litellm/1628198.

## Review
- No automated Greptile review was posted after CI reached steady state; no Greptile review threads were present to address.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e68113fb-1953-4b63-ad79-27f02079403e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e68113fb-1953-4b63-ad79-27f02079403e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

