### PR TITLE
feat(catalog): add zai/glm-5.1, zai/glm-4.7-flash, openrouter/z-ai/glm-5.1

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27403,6 +27403,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/z-ai/glm-5.1": {
+        "input_cost_per_token": 1.05e-06,
+        "output_cost_per_token": 3.5e-06,
+        "cache_read_input_token_cost": 5.25e-07,
+        "cache_creation_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "source": "https://openrouter.ai/z-ai/glm-5.1",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1.2e-06,
@@ -35130,6 +35146,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,
@@ -35150,6 +35181,21 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.7-flash": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 0,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
         "litellm_provider": "zai",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,


### PR DESCRIPTION
## Summary

Adds three pricing entries to `model_prices_and_context_window.json` for Z.AI GLM models that aren't yet in the catalog:

| Key | Provider | Input/1M | Cached/1M | Output/1M | Context (in / out) |
|---|---|---|---|---|---|
| `zai/glm-5.1` | zai | $1.40 | $0.26 | $4.40 | 200K / 128K |
| `zai/glm-4.7-flash` | zai | Free | Free | Free | 200K / 128K |
| `openrouter/z-ai/glm-5.1` | openrouter | $1.05 | $0.525 | $3.50 | 202752 / 65535 |

All three follow the conventions of the surrounding entries (`zai/glm-5`, `zai/glm-4.7`, `openrouter/z-ai/glm-5`).

## Why

Direct Z.AI users (`litellm_params.model` pointing at `api.z.ai`) and OpenRouter-route users on `z-ai/glm-5.1` currently get `response_cost: 0.0` in spend logs because the cost calculator falls back to the static catalog and finds nothing for these newer models. With these entries in the catalog the cost calculator picks them up by `router_model_id`, so spend tracking and budget enforcement work without per-deployment `input_cost_per_token` overrides.

## Sources

- `zai/*` entries — published Z.AI pay-as-you-go pricing on https://docs.z.ai/guides/overview/pricing (verified 2026-05-07). The page lists GLM-4.7-Flash with `Free / Free / Free / Free` across the four columns (input / cached input / cache storage / output).
- `openrouter/z-ai/glm-5.1` — `https://openrouter.ai/api/v1/models` JSON response (verified 2026-05-07). `max_output_tokens: 65535` is the value reported in `top_provider.max_completion_tokens` for that model on OpenRouter — the actual ceiling the OR endpoint will accept; this is the catalog-relevant value (not Z.AI direct's higher limit, which is captured by the `zai/glm-5.1` entry instead).

## Conventions matched

- `zai/*` entries copy the schema of the existing `zai/glm-5` and `zai/glm-4.7` blocks (cache_creation/cache_read fields, supports_* flags, `source` URL).
- `openrouter/z-ai/glm-5.1` copies the schema of the existing `openrouter/z-ai/glm-5` block, plus the cache fields that exist on the sibling `openrouter/z-ai/glm-4.7-flash` since OpenRouter publishes `input_cache_read` for glm-5.1 too.
- All three reference upstream pricing pages via the `source` field for future reproducibility.

## Relation to #26673

#26673 (open since 2026-04-28) proposed a single entry under the key `openrouter/zai/glm-5.1` (without dash). It received Greptile P1 feedback about (a) the missing dash conflicting with the rest of the `openrouter/z-ai/...` namespace, (b) a contested `max_output_tokens` value, (c) a missing `max_tokens` field. The author hasn't followed up in 10 days.

This PR addresses the same gap but:
- Uses the catalog-consistent `openrouter/z-ai/...` key.
- Sources `max_output_tokens: 65535` directly from the OpenRouter API response (`top_provider.max_completion_tokens`), making the value verifiable rather than asserted.
- Includes the `max_tokens` field per the existing convention.
- Also covers the direct `zai/...` namespace, which #26673 did not touch.

Happy to close #26673 in favour of this if a maintainer asks.

## Test plan

- [x] JSON parses (`python3 -c 'import json; json.load(open("model_prices_and_context_window.json"))'`).
- [x] All keys / values inspected against neighbour conventions, no duplicate fields.
- [ ] Maintainer review — happy to update if any field should be different.

## Pre-Submission checklist

- [ ] Tests in `tests/test_litellm/` — N/A for catalog-only data additions; no code path changes.
- [ ] `make test-unit` passes — N/A for the same reason.
- [x] Scope is isolated — single file, three additive entries, no removals or modifications of existing data.
- [ ] Greptile review with confidence ≥ 4/5 — will request below.

@greptileai please review