### PR TITLE
Fix Bedrock passthrough call ID headers

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1512,7 +1512,7 @@ class ProxyBaseLLMRequestProcessing:
             status_code=result.status_code,
             headers=HttpPassThroughEndpointHelpers.get_response_headers(
                 headers=result.headers,
-                custom_headers=None,
+                custom_headers=dict(fastapi_response.headers),
             ),
         )
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -3,8 +3,9 @@ import datetime
 from typing import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse, StreamingResponse
 
 import litellm
@@ -26,6 +27,48 @@ from litellm.proxy.utils import ProxyLogging
 
 
 class TestProxyBaseLLMRequestProcessing:
+    @pytest.mark.asyncio
+    async def test_base_passthrough_process_llm_request_preserves_litellm_headers_for_non_streaming_response(
+        self, monkeypatch
+    ):
+        processing_obj = ProxyBaseLLMRequestProcessing(data={})
+
+        async def fake_base_process_llm_request(**kwargs):
+            passthrough_response = kwargs["fastapi_response"]
+            passthrough_response.headers["x-litellm-call-id"] = "test-call-id"
+            passthrough_response.headers["x-litellm-version"] = "test-version"
+            return httpx.Response(
+                status_code=200,
+                content=b'{"ok":true}',
+                headers={
+                    "content-type": "application/json",
+                    "x-amzn-requestid": "bedrock-request-id",
+                },
+            )
+
+        monkeypatch.setattr(
+            processing_obj,
+            "base_process_llm_request",
+            fake_base_process_llm_request,
+        )
+
+        result = await processing_obj.base_passthrough_process_llm_request(
+            request=MagicMock(spec=Request),
+            fastapi_response=Response(),
+            user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+            proxy_logging_obj=MagicMock(spec=ProxyLogging),
+            general_settings={},
+            proxy_config=MagicMock(spec=ProxyConfig),
+            select_data_generator=MagicMock(),
+            model="bedrock-test-model",
+        )
+
+        assert result.status_code == 200
+        assert result.body == b'{"ok":true}'
+        assert result.headers["x-amzn-requestid"] == "bedrock-request-id"
+        assert result.headers["x-litellm-call-id"] == "test-call-id"
+        assert result.headers["x-litellm-version"] == "test-version"
+
     @pytest.mark.asyncio
     async def test_common_processing_pre_call_logic_pre_call_hook_receives_litellm_call_id(
         self, monkeypatch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Non-streaming ALLM passthrough responses were rebuilding a FastAPI response from the upstream provider response after common request processing had already attached LiteLLM metadata headers to the injected response object. The fix merges those accumulated LiteLLM headers into the final passthrough response so Bedrock Invoke responses include the call ID while preserving provider headers.

## Repro
Call a non-streaming Bedrock passthrough route such as `/bedrock/model/<bedrock-model-id>/invoke`. Before the fix, provider headers like `x-amzn-requestid` were returned, but `x-litellm-call-id` was missing from the client response.

## Evidence
Goal: the final passthrough response should include the upstream Bedrock-style headers and LiteLLM metadata headers, including `x-litellm-call-id`.

Focused proof run after the fix:

```text
status: 200
provider header x-amzn-requestid: bedrock-request-id
litellm header x-litellm-call-id: test-call-id
litellm header x-litellm-version: test-version
.                                                                        [100%]
1 passed in 1.80s
```

Regression observed before the fix:

```text
FAILED tests/test_litellm/proxy/test_common_request_processing.py::TestProxyBaseLLMRequestProcessing::test_base_passthrough_process_llm_request_preserves_litellm_headers_for_non_streaming_response
KeyError: 'x-litellm-call-id'
```

## Tests
- Added `tests/test_litellm/proxy/test_common_request_processing.py::TestProxyBaseLLMRequestProcessing::test_base_passthrough_process_llm_request_preserves_litellm_headers_for_non_streaming_response`.
- Confirmed the new regression test failed before the fix with `KeyError: x-litellm-call-id`.
- `uv run pytest tests/test_litellm/proxy/test_common_request_processing.py -q` -> 87 passed.
- CI-scope lint/type/import checks from `.github/workflows/test-linting.yml` passed locally: lock check, frozen sync, Black check, Ruff, MyPy, circular import check, and import safety.

## CI
- GitHub Actions checks on the PR head: green, including `LiteLLM Linting`, unit-test workflows, UI build, code quality, Semgrep, and MCP tests.
- CircleCI: most contexts green. `realtime_translation_testing` is failing on the PR and also failing on `litellm_internal_staging`, so it appears pre-existing. `litellm_utils_testing` is failing on the PR while the latest base-branch status is green; CircleCI job logs were not accessible from this environment, and the code change is limited to proxy passthrough response headers plus a proxy unit test.

## Review
- Greptile check completed successfully: 2 files reviewed, 0 comments added. No review score was exposed in the available check output.

## Relevant issues

Internal bug report.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

See Evidence above.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Preserve LiteLLM custom headers when finalizing non-streaming passthrough responses.
- Add a regression test covering Bedrock-like provider headers plus LiteLLM call metadata.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e01115b2-14e2-402d-b8ff-66d9703d2691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e01115b2-14e2-402d-b8ff-66d9703d2691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

