### PR TITLE
fix(alerts): dedupe team soft-budget alerts by team_id (#27398)

### DIFF
--- a/litellm/integrations/SlackAlerting/budget_alert_types.py
+++ b/litellm/integrations/SlackAlerting/budget_alert_types.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Literal
 
-from litellm.proxy._types import CallInfo
+from litellm.proxy._types import CallInfo, Litellm_EntityType
 
 
 class BaseBudgetAlertType(ABC):
@@ -31,6 +31,11 @@ class SoftBudgetAlert(BaseBudgetAlertType):
         return "Soft Budget Crossed: "
 
     def get_id(self, user_info: CallInfo) -> str:
+        # For team-level soft-budget alerts, dedupe by team_id so a single team
+        # crossing the soft budget produces one alert per budget_alert_ttl
+        # (instead of one alert per active key/token under that team). See #27398.
+        if user_info.event_group == Litellm_EntityType.TEAM and user_info.team_id:
+            return user_info.team_id
         return user_info.token or "default_id"
 
 

--- a/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
@@ -39,3 +39,29 @@ class TestSoftBudgetAlert:
 
         result = alert.get_id(user_info)
         assert result == "default_id"
+
+    def test_get_id_team_event_group_returns_team_id(self):
+        """Team soft-budget alerts must dedupe by team_id, not token (issue #27398)."""
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=120.0,
+            token="some_active_key_token",
+            team_id="team_abc",
+            event_group=Litellm_EntityType.TEAM,
+        )
+
+        result = alert.get_id(user_info)
+        assert result == "team_abc"
+
+    def test_get_id_team_event_group_without_team_id_falls_back_to_token(self):
+        """If event_group is TEAM but team_id is missing, fall back to token."""
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=120.0,
+            token="key_token",
+            team_id=None,
+            event_group=Litellm_EntityType.TEAM,
+        )
+
+        result = alert.get_id(user_info)
+        assert result == "key_token"


### PR DESCRIPTION
## Summary

Closes #27398.

`SoftBudgetAlert.get_id()` always returned `user_info.token`, so for **team-level** soft-budget alerts, `SlackAlerting.budget_alerts()` built a per-token cache key:

```text
budget_alerts:soft_budget_crossed:{token}
```

Once a team crossed its soft budget, every active key/token under that team produced its own alert within `budget_alert_ttl` — flooding the notification channel.

This PR keys soft-budget dedup by `team_id` whenever `event_group == Litellm_EntityType.TEAM` and a `team_id` is present, matching how hard team-budget alerts already dedupe. All other paths (KEY-level, no team_id) keep the previous behavior.

## Change

- `litellm/integrations/SlackAlerting/budget_alert_types.py`
  - `SoftBudgetAlert.get_id()` returns `user_info.team_id` for team event-group alerts; falls back to `user_info.token or "default_id"` otherwise.
  - Adds `Litellm_EntityType` import.
- `tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py`
  - Adds `test_get_id_team_event_group_returns_team_id` and a fallback test for missing `team_id`.

## Test plan

- [x] `pytest tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py` (new + existing tests pass locally)
- [x] black formatting verified
- [ ] CI lint + unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
