### PR TITLE
Fix Jina embedding credential fallback

### DIFF
--- a/litellm/llms/jina_ai/embedding/transformation.py
+++ b/litellm/llms/jina_ai/embedding/transformation.py
@@ -85,8 +85,7 @@ class JinaAIEmbeddingConfig(BaseEmbeddingConfig):
         )  # type: ignore
         dynamic_api_key = api_key or (
             get_secret_str("JINA_AI_API_KEY")
-            or get_secret_str("JINA_AI_API_KEY")
-            or get_secret_str("JINA_AI_API_KEY")
+            or get_secret_str("JINA_API_KEY")
             or get_secret_str("JINA_AI_TOKEN")
         )
         return LlmProviders.JINA_AI.value, api_base, dynamic_api_key

--- a/tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py
+++ b/tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py
@@ -6,6 +6,7 @@ sys.path.insert(
     0, os.path.abspath("../../../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm.llms.jina_ai.embedding.transformation as jina_embedding_transformation
 from litellm.llms.jina_ai.embedding.transformation import JinaAIEmbeddingConfig
 
 
@@ -25,6 +26,29 @@ class TestJinaAIEmbeddingTransform:
             drop_params=False,
         )
         assert result == {"dimensions": 1024}
+
+    def test_provider_info_uses_jina_api_key_alias(self, monkeypatch):
+        """Test provider info resolves the shared Jina credential alias"""
+
+        def fake_get_secret_str(secret_name):
+            if secret_name == "JINA_API_KEY":
+                return "test-jina-key"
+            return None
+
+        monkeypatch.setattr(
+            jina_embedding_transformation, "get_secret_str", fake_get_secret_str
+        )
+
+        custom_llm_provider, api_base, dynamic_api_key = (
+            self.config._get_openai_compatible_provider_info(
+                api_base=None,
+                api_key=None,
+            )
+        )
+
+        assert custom_llm_provider == "jina_ai"
+        assert api_base == "https://api.jina.ai/v1"
+        assert dynamic_api_key == "test-jina-key"
 
     def test_transform_embedding_request_text_input(self):
         """Test transformation of a standard text embedding request"""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Jina embedding provider credential resolution had a duplicated fallback lookup, so one supported Jina credential alias was never consulted. This replaces the duplicate lookup with the shared alias and adds a regression test for the provider-info resolution path.

## Repro
Configure only the shared Jina credential alias, then resolve provider info for a Jina embedding model without passing an explicit key. Before the fix, the resolved dynamic credential is empty; after the fix, the configured alias is returned.

## Evidence
<a href="/opt/cursor/artifacts/jina_credential_fallback_evidence.txt">Terminal evidence for failing repro and passing verification</a>

## Tests
- Confirmed the new regression test fails against the previous fallback logic with `None` returned for the dynamic credential.
- `uv run pytest tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py tests/local_testing/test_get_llm_provider.py::test_get_llm_provider_jina_ai -q` - 6 passed.
- CI lint scope after frozen dependency reset: `black --check --exclude '/enterprise/' .`, `ruff check .`, and `mypy .` all passed from `litellm/`.
- Attempted `uv run pytest tests/test_litellm/ -x -vv -n 4`; after installing optional test extras, it progressed to unrelated environment/provider-authentication failures outside this diff.

## CI
- GitHub Actions check rollup reached terminal state with no failing GitHub Actions jobs observed.
- CircleCI contexts `batches_testing` and `realtime_translation_testing` reported failure: https://circleci.com/gh/BerriAI/litellm/1629678 and https://circleci.com/gh/BerriAI/litellm/1629681. Public CircleCI pages/API did not expose job logs from this environment, so I could not inspect failed steps. These contexts are unrelated to the Jina embedding credential-resolution code path changed here.

## Review
- No Greptile review was present after the review wait window, so there were no review threads or score to address.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7913f4c8-b770-4a36-93eb-e2c6c80f77d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7913f4c8-b770-4a36-93eb-e2c6c80f77d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

