### PR TITLE
fix(responses): preserve reasoning during tool continuations

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -56,7 +56,7 @@ from litellm.types.utils import (
 from litellm.utils import convert_to_model_response_object
 
 from ..common_utils import OpenAIError
-from ..common_utils import patch_deepseek_v4_reasoning_messages
+from ..deepseek_reasoning_utils import patch_deepseek_v4_reasoning_messages
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -56,6 +56,7 @@ from litellm.types.utils import (
 from litellm.utils import convert_to_model_response_object
 
 from ..common_utils import OpenAIError
+from ..common_utils import patch_deepseek_v4_reasoning_messages
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -169,6 +170,8 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         ]  # works across all models
 
         model_specific_params = []
+        if "deepseek" in model.lower():
+            model_specific_params.extend(["thinking", "reasoning_effort"])
         if (
             model != "gpt-3.5-turbo-16k" and model != "gpt-4"
         ):  # gpt-4 does not support 'response_format'
@@ -435,6 +438,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             dict: The transformed request. Sent as the body of the API call.
         """
         messages = self._transform_messages(messages=messages, model=model)
+        messages = patch_deepseek_v4_reasoning_messages(model=model, messages=messages)
         messages, tools = self.remove_cache_control_flag_from_messages_and_tools(
             model=model, messages=messages, tools=optional_params.get("tools", [])
         )
@@ -459,6 +463,9 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
     ) -> dict:
         transformed_messages = await self._transform_messages(
             messages=messages, model=model, is_async=True
+        )
+        transformed_messages = patch_deepseek_v4_reasoning_messages(
+            model=model, messages=transformed_messages
         )
         (
             transformed_messages,

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -258,6 +258,43 @@ class BaseOpenAILLM:
 class OpenAICredentials(NamedTuple):
     api_base: str
     api_key: Optional[str]
+
+
+def requires_deepseek_v4_reasoning_content(model: Optional[str]) -> bool:
+    """Return True when the model requires DeepSeek V4 thinking history."""
+    if not model:
+        return False
+
+    normalized_model = model.lower()
+    if normalized_model.startswith("responses/"):
+        normalized_model = normalized_model.split("responses/", 1)[1]
+
+    return "deepseek-v4" in normalized_model
+
+
+def patch_deepseek_v4_reasoning_messages(
+    model: Optional[str], messages: List[Any]
+) -> List[Any]:
+    """
+    Ensure assistant tool-call messages include reasoning_content for DeepSeek V4.
+
+    DeepSeek V4 rejects multi-turn requests when prior assistant tool-call messages
+    omit the reasoning_content field, even if the value is empty.
+    """
+    if not requires_deepseek_v4_reasoning_content(model):
+        return messages
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "assistant":
+            continue
+        if not (message.get("tool_calls") or message.get("tool_call_id")):
+            continue
+        if message.get("reasoning_content") is None:
+            message["reasoning_content"] = ""
+
+    return messages
     organization: Optional[str]
 
 

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -258,43 +258,6 @@ class BaseOpenAILLM:
 class OpenAICredentials(NamedTuple):
     api_base: str
     api_key: Optional[str]
-
-
-def requires_deepseek_v4_reasoning_content(model: Optional[str]) -> bool:
-    """Return True when the model requires DeepSeek V4 thinking history."""
-    if not model:
-        return False
-
-    normalized_model = model.lower()
-    if normalized_model.startswith("responses/"):
-        normalized_model = normalized_model.split("responses/", 1)[1]
-
-    return "deepseek-v4" in normalized_model
-
-
-def patch_deepseek_v4_reasoning_messages(
-    model: Optional[str], messages: List[Any]
-) -> List[Any]:
-    """
-    Ensure assistant tool-call messages include reasoning_content for DeepSeek V4.
-
-    DeepSeek V4 rejects multi-turn requests when prior assistant tool-call messages
-    omit the reasoning_content field, even if the value is empty.
-    """
-    if not requires_deepseek_v4_reasoning_content(model):
-        return messages
-
-    for message in messages:
-        if not isinstance(message, dict):
-            continue
-        if message.get("role") != "assistant":
-            continue
-        if not (message.get("tool_calls") or message.get("tool_call_id")):
-            continue
-        if message.get("reasoning_content") is None:
-            message["reasoning_content"] = ""
-
-    return messages
     organization: Optional[str]
 
 

--- a/litellm/llms/openai/deepseek_reasoning_utils.py
+++ b/litellm/llms/openai/deepseek_reasoning_utils.py
@@ -1,0 +1,38 @@
+from typing import Any, List, Optional
+
+
+def requires_deepseek_v4_reasoning_content(model: Optional[str]) -> bool:
+    """Return True when the model requires DeepSeek V4 thinking history."""
+    if not model:
+        return False
+
+    normalized_model = model.lower()
+    if normalized_model.startswith("responses/"):
+        normalized_model = normalized_model.split("responses/", 1)[1]
+
+    return "deepseek-v4" in normalized_model
+
+
+def patch_deepseek_v4_reasoning_messages(
+    model: Optional[str], messages: List[Any]
+) -> List[Any]:
+    """
+    Ensure assistant tool-call messages include reasoning_content for DeepSeek V4.
+
+    DeepSeek V4 rejects multi-turn requests when prior assistant tool-call messages
+    omit the reasoning_content field, even if the value is empty.
+    """
+    if not requires_deepseek_v4_reasoning_content(model):
+        return messages
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "assistant":
+            continue
+        if not (message.get("tool_calls") or message.get("tool_call_id")):
+            continue
+        if message.get("reasoning_content") is None:
+            message["reasoning_content"] = ""
+
+    return messages

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -58,6 +58,7 @@ from .chat.o_series_transformation import OpenAIOSeriesConfig
 from .common_utils import (
     BaseOpenAILLM,
     OpenAIError,
+    patch_deepseek_v4_reasoning_messages,
     drop_params_from_unprocessable_entity_error,
 )
 
@@ -267,6 +268,7 @@ class OpenAIConfig(BaseConfig):
         headers: dict,
     ) -> dict:
         messages = self._transform_messages(messages=messages, model=model)
+        messages = patch_deepseek_v4_reasoning_messages(model=model, messages=messages)
         return {"model": model, "messages": messages, **optional_params}
 
     def transform_response(
@@ -433,6 +435,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call chat.completions.create by default
         """
         start_time = time.time()
+        data["messages"] = patch_deepseek_v4_reasoning_messages(
+            model=data.get("model"), messages=data.get("messages", [])
+        )
         try:
             raw_response = (
                 await openai_aclient.chat.completions.with_raw_response.create(
@@ -474,6 +479,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call chat.completions.create by default
         """
         raw_response = None
+        data["messages"] = patch_deepseek_v4_reasoning_messages(
+            model=data.get("model"), messages=data.get("messages", [])
+        )
         try:
             raw_response = openai_client.chat.completions.with_raw_response.create(
                 **data, timeout=timeout

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -58,9 +58,9 @@ from .chat.o_series_transformation import OpenAIOSeriesConfig
 from .common_utils import (
     BaseOpenAILLM,
     OpenAIError,
-    patch_deepseek_v4_reasoning_messages,
     drop_params_from_unprocessable_entity_error,
 )
+from .deepseek_reasoning_utils import patch_deepseek_v4_reasoning_messages
 
 openaiOSeriesConfig = OpenAIOSeriesConfig()
 openAIGPT5Config = OpenAIGPT5Config()

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -152,9 +152,8 @@ class ResponsesSessionHandler:
             and _response_output
             and _response_output != {}
         ):
-            if (
-                _response_output.get("object") == "response"
-                or "output" in _response_output
+            if ResponsesSessionHandler._is_responses_api_output_response(
+                _response_output
             ):
                 chat_completion_message_history.extend(
                     LiteLLMCompletionResponsesConfig.transform_responses_api_output_to_chat_completion_messages(
@@ -169,6 +168,35 @@ class ResponsesSessionHandler:
                 if hasattr(choice, "message"):
                     chat_completion_message_history.append(getattr(choice, "message"))
         return chat_completion_message_history
+
+    @staticmethod
+    def _is_responses_api_output_response(response_output: dict) -> bool:
+        if response_output.get("object") == "response":
+            return True
+        if "choices" in response_output:
+            return False
+        output = response_output.get("output")
+        if not isinstance(output, list):
+            return False
+        responses_output_types = {
+            "reasoning",
+            "message",
+            "function_call",
+            "function_call_output",
+            "web_search_call",
+            "file_search_call",
+            "computer_call",
+            "image_generation_call",
+            "code_interpreter_call",
+            "mcp_call",
+            "custom_tool_call",
+        }
+        for output_item in output:
+            if not isinstance(output_item, dict):
+                continue
+            if output_item.get("type") in responses_output_types:
+                return True
+        return False
 
     @staticmethod
     async def get_proxy_server_request_from_spend_log(

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -142,11 +142,27 @@ class ResponsesSessionHandler:
         # Add Output messages for this Spend Log
         ############################################################
         _response_output = spend_log.get("response", "{}")
+        if isinstance(_response_output, str):
+            try:
+                _response_output = json.loads(_response_output)
+            except json.JSONDecodeError:
+                _response_output = {}
         if (
             isinstance(_response_output, dict)
             and _response_output
             and _response_output != {}
         ):
+            if (
+                _response_output.get("object") == "response"
+                or "output" in _response_output
+            ):
+                chat_completion_message_history.extend(
+                    LiteLLMCompletionResponsesConfig.transform_responses_api_output_to_chat_completion_messages(
+                        output=_response_output.get("output") or []
+                    )
+                )
+                return chat_completion_message_history
+
             # transform `ChatCompletion Response` to `ResponsesAPIResponse`
             model_response = ModelResponse(**_response_output)
             for choice in model_response.choices:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -17,6 +17,7 @@ from litellm.responses.litellm_completion_transformation.session_handler import 
 )
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionAssistantContentValue,
     ChatCompletionImageObject,
     ChatCompletionImageUrlObject,
     ChatCompletionResponseMessage,
@@ -357,6 +358,182 @@ class LiteLLMCompletionResponsesConfig:
         return litellm_completion_request
 
     @staticmethod
+    def _capture_pending_reasoning_item(
+        input_item: Any, pending_reasoning_parts: List[str]
+    ) -> bool:
+        if not isinstance(input_item, dict) or input_item.get("type") != "reasoning":
+            return False
+        reasoning_content = LiteLLMCompletionResponsesConfig._extract_reasoning_content_from_response_item(
+            input_item
+        )
+        if reasoning_content:
+            pending_reasoning_parts.append(reasoning_content)
+        return True
+
+    @staticmethod
+    def _apply_pending_reasoning_to_assistant_messages(
+        chat_completion_messages: List[Any],
+        pending_reasoning_parts: List[str],
+    ) -> None:
+        pending_reasoning = "\n".join(pending_reasoning_parts) or None
+        if not pending_reasoning:
+            return
+        for chat_completion_message in chat_completion_messages:
+            message_role = (
+                chat_completion_message.get("role")
+                if isinstance(chat_completion_message, dict)
+                else getattr(chat_completion_message, "role", None)
+            )
+            if message_role == "assistant":
+                LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+                    chat_completion_message,
+                    pending_reasoning,
+                )
+                pending_reasoning_parts.clear()
+                return
+
+    @staticmethod
+    def _merge_consecutive_function_call_messages(
+        messages: List[Any],
+        chat_completion_messages: List[Any],
+        input_item: Any,
+        existing_tool_call_ids: Set[str],
+    ) -> bool:
+        call_id_raw = input_item.get("call_id") or input_item.get("id") or ""
+        if call_id_raw:
+            existing_tool_call_ids.add(str(call_id_raw))
+        if not messages:
+            return False
+        last_msg = messages[-1]
+        last_role = (
+            last_msg.get("role")
+            if isinstance(last_msg, dict)
+            else getattr(last_msg, "role", None)
+        )
+        if last_role != "assistant":
+            return False
+        for new_msg in chat_completion_messages:
+            new_role = (
+                new_msg.get("role")
+                if isinstance(new_msg, dict)
+                else getattr(new_msg, "role", None)
+            )
+            if new_role != "assistant":
+                continue
+            for tool_call in LiteLLMCompletionResponsesConfig._get_tool_calls_list(
+                new_msg
+            ):
+                LiteLLMCompletionResponsesConfig._add_tool_call_to_assistant(
+                    last_msg, tool_call
+                )
+        return True
+
+    @staticmethod
+    def _tool_call_id_from_assistant_message(message: Any) -> str:
+        tool_calls: Any = (
+            message.get("tool_calls")
+            if isinstance(message, dict)
+            else getattr(message, "tool_calls", None)
+        )
+        if (
+            not isinstance(tool_calls, Sequence)
+            or isinstance(tool_calls, (str, bytes))
+            or not tool_calls
+        ):
+            return ""
+        first_call = tool_calls[0]
+        call_id_raw = (
+            first_call.get("id")
+            if isinstance(first_call, dict)
+            else getattr(first_call, "id", None)
+        )
+        return str(call_id_raw) if call_id_raw else ""
+
+    @staticmethod
+    def _dedupe_tool_call_output_messages(
+        chat_completion_messages: List[Any],
+        existing_tool_call_ids: Set[str],
+    ) -> List[Any]:
+        deduped_messages: List[Any] = []
+        for message in chat_completion_messages:
+            role = (
+                str(message.get("role") or "")
+                if isinstance(message, dict)
+                else str(getattr(message, "role", "") or "")
+            )
+            if role != "assistant":
+                deduped_messages.append(message)
+                continue
+            call_id = (
+                LiteLLMCompletionResponsesConfig._tool_call_id_from_assistant_message(
+                    message
+                )
+            )
+            if call_id and call_id in existing_tool_call_ids:
+                continue
+            if call_id:
+                existing_tool_call_ids.add(call_id)
+            deduped_messages.append(message)
+        return deduped_messages
+
+    @staticmethod
+    def _append_pending_reasoning_message(
+        messages: List[Any], pending_reasoning_parts: List[str]
+    ) -> None:
+        pending_reasoning = "\n".join(pending_reasoning_parts)
+        if pending_reasoning:
+            messages.append(
+                ChatCompletionResponseMessage(
+                    role="assistant",
+                    content=None,
+                    reasoning_content=pending_reasoning,
+                )
+            )
+
+    @staticmethod
+    def _transform_response_input_list_to_chat_completion_messages(
+        input_items: List[Any],
+    ) -> List[Any]:
+        messages: List[Any] = []
+        existing_tool_call_ids: Set[str] = set()
+        pending_reasoning_parts: List[str] = []
+        for input_item in input_items:
+            if LiteLLMCompletionResponsesConfig._capture_pending_reasoning_item(
+                input_item, pending_reasoning_parts
+            ):
+                continue
+            chat_completion_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+                input_item=input_item
+            )
+            LiteLLMCompletionResponsesConfig._apply_pending_reasoning_to_assistant_messages(
+                chat_completion_messages, pending_reasoning_parts
+            )
+            if LiteLLMCompletionResponsesConfig._is_input_item_function_call(
+                input_item=input_item
+            ) and LiteLLMCompletionResponsesConfig._merge_consecutive_function_call_messages(
+                messages,
+                chat_completion_messages,
+                input_item,
+                existing_tool_call_ids,
+            ):
+                continue
+            if LiteLLMCompletionResponsesConfig._is_input_item_tool_call_output(
+                input_item=input_item
+            ):
+                messages.extend(
+                    LiteLLMCompletionResponsesConfig._dedupe_tool_call_output_messages(
+                        chat_completion_messages,
+                        existing_tool_call_ids,
+                    )
+                )
+                continue
+            messages.extend(chat_completion_messages)
+        LiteLLMCompletionResponsesConfig._append_pending_reasoning_message(
+            messages, pending_reasoning_parts
+        )
+        return messages
+
+    @staticmethod
     def _transform_response_input_param_to_chat_completion_message(
         input: Union[str, ResponseInputParam],
     ) -> List[
@@ -382,108 +559,11 @@ class LiteLLMCompletionResponsesConfig:
         if isinstance(input, str):
             messages.append(ChatCompletionUserMessage(role="user", content=input))
         elif isinstance(input, list):
-            existing_tool_call_ids: Set[str] = set()
-            for _input in input:
-                chat_completion_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
-                    input_item=_input
+            messages.extend(
+                LiteLLMCompletionResponsesConfig._transform_response_input_list_to_chat_completion_messages(
+                    input
                 )
-
-                if LiteLLMCompletionResponsesConfig._is_input_item_function_call(
-                    input_item=_input
-                ):
-                    call_id_raw = _input.get("call_id") or _input.get("id") or ""
-                    if call_id_raw:
-                        existing_tool_call_ids.add(str(call_id_raw))
-
-                    #########################################################
-                    # Merge consecutive function_call items into a single assistant
-                    # message. Anthropic requires that all tool_use blocks appear in
-                    # ONE assistant message immediately followed by the tool_result
-                    # blocks. Without this merging, each function_call creates its own
-                    # assistant message, producing back-to-back assistant messages that
-                    # Anthropic rejects with "tool_use ids were found without
-                    # tool_result blocks immediately after".
-                    #########################################################
-                    if messages:
-                        last_msg = messages[-1]
-                        last_role = (
-                            last_msg.get("role")
-                            if isinstance(last_msg, dict)
-                            else getattr(last_msg, "role", None)
-                        )
-                        if last_role == "assistant":
-                            for new_msg in chat_completion_messages:
-                                new_role = (
-                                    new_msg.get("role")
-                                    if isinstance(new_msg, dict)
-                                    else getattr(new_msg, "role", None)
-                                )
-                                if new_role == "assistant":
-                                    _raw_tcs = (
-                                        new_msg.get("tool_calls")
-                                        if isinstance(new_msg, dict)
-                                        else getattr(new_msg, "tool_calls", None)
-                                    )
-                                    new_tcs: list = (
-                                        _raw_tcs if isinstance(_raw_tcs, list) else []
-                                    )
-                                    for tc in new_tcs:
-                                        LiteLLMCompletionResponsesConfig._add_tool_call_to_assistant(
-                                            last_msg, tc
-                                        )
-                            continue
-
-                #########################################################
-                # If Input Item is a Tool Call Output, add it to the tool_call_output_messages list
-                # preserving the ordering of tool call outputs. Some models require the tool
-                # result to immediately follow the assistant tool call.
-                #########################################################
-                if LiteLLMCompletionResponsesConfig._is_input_item_tool_call_output(
-                    input_item=_input
-                ):
-                    if not chat_completion_messages:
-                        continue
-
-                    deduped_in_place: List[Any] = []
-                    for m in chat_completion_messages:
-                        role = ""
-                        if isinstance(m, dict):
-                            role = str(m.get("role") or "")
-                        else:
-                            role = str(getattr(m, "role", "") or "")
-
-                        # Drop assistant tool_calls wrappers if we already have this call_id
-                        if role == "assistant":
-                            tool_calls: Any = (
-                                m.get("tool_calls")
-                                if isinstance(m, dict)
-                                else getattr(m, "tool_calls", None)
-                            )
-                            call_id = ""
-                            if (
-                                isinstance(tool_calls, Sequence)
-                                and not isinstance(tool_calls, (str, bytes))
-                                and len(tool_calls) > 0
-                            ):
-                                first_call = tool_calls[0]
-                                call_id_raw = (
-                                    first_call.get("id")
-                                    if isinstance(first_call, dict)
-                                    else getattr(first_call, "id", None)
-                                )
-                                if call_id_raw:
-                                    call_id = str(call_id_raw)
-                            if call_id and call_id in existing_tool_call_ids:
-                                continue
-                            if call_id:
-                                existing_tool_call_ids.add(call_id)
-
-                        deduped_in_place.append(m)
-
-                    messages.extend(deduped_in_place)
-                    continue
-
-                messages.extend(chat_completion_messages)
+            )
         return messages
 
     @staticmethod
@@ -799,6 +879,314 @@ class LiteLLMCompletionResponsesConfig:
                 assistant_message.tool_calls.append(tool_call_chunk)
 
     @staticmethod
+    def _get_chat_message_reasoning_content(message: Any) -> Optional[str]:
+        """Read reasoning_content from a chat message dict/object."""
+        reasoning_content = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            message, "reasoning_content"
+        )
+        if isinstance(reasoning_content, str) and reasoning_content:
+            return reasoning_content
+
+        provider_specific_fields = (
+            LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+                message, "provider_specific_fields"
+            )
+        )
+        if isinstance(provider_specific_fields, dict):
+            stored_reasoning = provider_specific_fields.get("reasoning_content")
+            if isinstance(stored_reasoning, str) and stored_reasoning:
+                return stored_reasoning
+        return None
+
+    @staticmethod
+    def _get_cached_tool_call_reasoning_content(
+        tool_use_definition: Any,
+    ) -> Optional[str]:
+        """Read reasoning_content stored with a cached tool call definition."""
+        reasoning_content = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            tool_use_definition, "reasoning_content"
+        )
+        if isinstance(reasoning_content, str) and reasoning_content:
+            return reasoning_content
+
+        provider_specific_fields = (
+            LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+                tool_use_definition, "provider_specific_fields"
+            )
+        )
+        if isinstance(provider_specific_fields, dict):
+            stored_reasoning = provider_specific_fields.get("reasoning_content")
+            if isinstance(stored_reasoning, str) and stored_reasoning:
+                return stored_reasoning
+        return None
+
+    @staticmethod
+    def _set_assistant_reasoning_content(
+        assistant_message: Any, reasoning_content: Optional[str]
+    ) -> None:
+        """Attach reasoning_content to an assistant message without overwriting it."""
+        if not reasoning_content:
+            return
+        existing = LiteLLMCompletionResponsesConfig._get_chat_message_reasoning_content(
+            assistant_message
+        )
+        if existing:
+            return
+        if isinstance(assistant_message, dict):
+            assistant_message["reasoning_content"] = reasoning_content
+        elif hasattr(assistant_message, "reasoning_content"):
+            setattr(assistant_message, "reasoning_content", reasoning_content)
+
+    @staticmethod
+    def _chat_tool_call_cache_value(
+        tool_call: Any, reasoning_content: Optional[str]
+    ) -> Dict[str, Any]:
+        """Serialize a chat tool call for cache/session reconstruction."""
+        function_raw = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            tool_call, "function"
+        )
+        function_name = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            function_raw, "name"
+        )
+        function_arguments = (
+            LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+                function_raw, "arguments"
+            )
+        )
+        tool_call_id = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            tool_call, "id"
+        )
+        tool_call_type = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            tool_call, "type", "function"
+        )
+        provider_specific_fields = (
+            LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+                tool_call, "provider_specific_fields"
+            )
+        )
+        cache_value: Dict[str, Any] = {
+            "id": tool_call_id or "",
+            "type": tool_call_type or "function",
+            "function": {
+                "name": function_name or "",
+                "arguments": function_arguments or "",
+            },
+        }
+        if provider_specific_fields:
+            cache_value["provider_specific_fields"] = provider_specific_fields
+        if reasoning_content:
+            cache_value["reasoning_content"] = reasoning_content
+        return cache_value
+
+    @staticmethod
+    def _response_item_to_dict(item: Any) -> Dict[str, Any]:
+        """Normalize a Responses output item object/dict to a plain dict."""
+        if isinstance(item, dict):
+            return dict(item)
+        model_dump = getattr(item, "model_dump", None)
+        if callable(model_dump):
+            return cast(Dict[str, Any], model_dump(exclude_none=True))
+        if hasattr(item, "dict") and callable(item.dict):
+            return cast(Dict[str, Any], item.dict(exclude_none=True))
+        if hasattr(item, "__dict__"):
+            return dict(item.__dict__)
+        return {}
+
+    @staticmethod
+    def _extract_text_from_responses_content(content: Any) -> str:
+        """Extract text from Responses content/summary arrays."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text_parts: List[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    text_parts.append(part)
+                    continue
+                part_dict = LiteLLMCompletionResponsesConfig._response_item_to_dict(
+                    part
+                )
+                text = part_dict.get("text") or part_dict.get("content")
+                if isinstance(text, str):
+                    text_parts.append(text)
+            return "".join(text_parts)
+        return ""
+
+    @staticmethod
+    def _extract_reasoning_content_from_response_item(item: Any) -> Optional[str]:
+        """Extract reasoning text from a Responses reasoning output item."""
+        item_dict = LiteLLMCompletionResponsesConfig._response_item_to_dict(item)
+        if item_dict.get("type") != "reasoning":
+            return None
+
+        reasoning_content = item_dict.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content:
+            return reasoning_content
+
+        content_text = (
+            LiteLLMCompletionResponsesConfig._extract_text_from_responses_content(
+                item_dict.get("content")
+            )
+        )
+        if content_text:
+            return content_text
+
+        summary_text = (
+            LiteLLMCompletionResponsesConfig._extract_text_from_responses_content(
+                item_dict.get("summary")
+            )
+        )
+        if summary_text:
+            return summary_text
+        return None
+
+    @staticmethod
+    def _merge_assistant_message(messages: List[Any], assistant_message: Any) -> None:
+        """Merge consecutive assistant tool-call messages where possible."""
+        if not messages:
+            messages.append(assistant_message)
+            return
+        last_message = messages[-1]
+        last_role = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            last_message, "role"
+        )
+        new_role = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value(
+            assistant_message, "role"
+        )
+        if last_role != "assistant" or new_role != "assistant":
+            messages.append(assistant_message)
+            return
+
+        new_tool_calls = LiteLLMCompletionResponsesConfig._get_tool_calls_list(
+            assistant_message
+        )
+        if not new_tool_calls:
+            messages.append(assistant_message)
+            return
+
+        reasoning_content = (
+            LiteLLMCompletionResponsesConfig._get_chat_message_reasoning_content(
+                assistant_message
+            )
+        )
+        LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+            last_message, reasoning_content
+        )
+        for tool_call in new_tool_calls:
+            LiteLLMCompletionResponsesConfig._add_tool_call_to_assistant(
+                last_message, tool_call
+            )
+
+    @staticmethod
+    def transform_responses_api_output_to_chat_completion_messages(
+        output: Any,
+    ) -> List[
+        Union[
+            AllMessageValues,
+            GenericChatCompletionMessage,
+            ChatCompletionResponseMessage,
+            ChatCompletionMessageToolCall,
+            Message,
+        ]
+    ]:
+        """Transform Responses API output history into chat completion messages.
+
+        This is used when reconstructing a /v1/responses session for providers
+        that are served through chat completions. Reasoning items must be
+        replayed as assistant reasoning_content, especially for thinking models
+        that reject tool continuations without the prior reasoning payload.
+        """
+        if not isinstance(output, list):
+            return []
+
+        messages: List[Any] = []
+        pending_reasoning_parts: List[str] = []
+
+        for item in output:
+            item_dict = LiteLLMCompletionResponsesConfig._response_item_to_dict(item)
+            item_type = item_dict.get("type")
+            if item_type == "reasoning":
+                reasoning_content = LiteLLMCompletionResponsesConfig._extract_reasoning_content_from_response_item(
+                    item_dict
+                )
+                if reasoning_content:
+                    pending_reasoning_parts.append(reasoning_content)
+                continue
+
+            pending_reasoning = "\n".join(pending_reasoning_parts) or None
+
+            if item_type == "function_call":
+                chat_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_function_call_to_chat_completion_message(
+                    function_call=item_dict
+                )
+                for chat_message in chat_messages:
+                    LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+                        chat_message, pending_reasoning
+                    )
+                    LiteLLMCompletionResponsesConfig._merge_assistant_message(
+                        messages, chat_message
+                    )
+                pending_reasoning_parts = []
+                continue
+
+            if item_type == "message":
+                content = item_dict.get("content")
+                if content is None:
+                    continue
+                role = item_dict.get("role") or "assistant"
+                if role == "assistant":
+                    chat_message = ChatCompletionResponseMessage(
+                        role="assistant",
+                        content=cast(
+                            Optional[ChatCompletionAssistantContentValue],
+                            LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+                                content
+                            ),
+                        ),
+                    )
+                    LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+                        chat_message, pending_reasoning
+                    )
+                    LiteLLMCompletionResponsesConfig._merge_assistant_message(
+                        messages, chat_message
+                    )
+                else:
+                    messages.append(
+                        GenericChatCompletionMessage(
+                            role=role,
+                            content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+                                content
+                            ),
+                        )
+                    )
+                pending_reasoning_parts = []
+
+        pending_reasoning = "\n".join(pending_reasoning_parts)
+        if pending_reasoning:
+            messages.append(
+                ChatCompletionResponseMessage(
+                    role="assistant",
+                    content=None,
+                    reasoning_content=pending_reasoning,
+                )
+            )
+
+        return cast(
+            List[
+                Union[
+                    AllMessageValues,
+                    GenericChatCompletionMessage,
+                    ChatCompletionResponseMessage,
+                    ChatCompletionMessageToolCall,
+                    Message,
+                ]
+            ],
+            messages,
+        )
+
+    @staticmethod
     def _ensure_tool_results_have_corresponding_tool_calls(
         messages: Sequence[
             Union[
@@ -939,6 +1327,12 @@ class LiteLLMCompletionResponsesConfig:
                         )
                         LiteLLMCompletionResponsesConfig._add_tool_call_to_assistant(
                             prev_assistant, tool_call_chunk
+                        )
+                        LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+                            prev_assistant,
+                            LiteLLMCompletionResponsesConfig._get_cached_tool_call_reasoning_content(
+                                normalized_tool_use_definition
+                            ),
                         )
 
         # Remove messages with empty tool_call_id that couldn't be fixed
@@ -1159,6 +1553,12 @@ class LiteLLMCompletionResponsesConfig:
             chat_completion_response_message = ChatCompletionResponseMessage(
                 tool_calls=[tool_call_chunk],
                 role="assistant",
+            )
+            LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+                chat_completion_response_message,
+                LiteLLMCompletionResponsesConfig._get_cached_tool_call_reasoning_content(
+                    _tool_use_definition
+                ),
             )
             return [chat_completion_response_message, tool_output_message]
 
@@ -1469,11 +1869,17 @@ class LiteLLMCompletionResponsesConfig:
         for choice in chat_completion_response.choices:
             if isinstance(choice, Choices):
                 if choice.message.tool_calls:
+                    message_reasoning_content = LiteLLMCompletionResponsesConfig._get_chat_message_reasoning_content(
+                        choice.message
+                    )
                     all_chat_completion_tools.extend(choice.message.tool_calls)
                     for tool_call in choice.message.tool_calls:
                         TOOL_CALLS_CACHE.set_cache(
                             key=tool_call.id,
-                            value=tool_call,
+                            value=LiteLLMCompletionResponsesConfig._chat_tool_call_cache_value(
+                                tool_call=tool_call,
+                                reasoning_content=message_reasoning_content,
+                            ),
                         )
 
         responses_tools: List[ResponseFunctionToolCall] = []

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2,6 +2,7 @@
 Handles transforming from Responses API -> LiteLLM completion  (Chat Completion API)
 """
 
+import os
 from collections.abc import Sequence
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 
@@ -60,7 +61,26 @@ from litellm.types.utils import (
 )
 
 ########### Initialize Classes used for Responses API  ###########
-TOOL_CALLS_CACHE = InMemoryCache()
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+TOOL_CALLS_CACHE = InMemoryCache(
+    max_size_in_memory=_positive_int_env(
+        "LITELLM_RESPONSES_TOOL_CALL_CACHE_MAX_ITEMS", 128
+    ),
+    default_ttl=_positive_int_env("LITELLM_RESPONSES_TOOL_CALL_CACHE_TTL_SECONDS", 300),
+    max_size_per_item=_positive_int_env(
+        "LITELLM_RESPONSES_TOOL_CALL_CACHE_MAX_ITEM_KB", 256
+    ),
+)
 
 
 class ChatCompletionSession(TypedDict, total=False):

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -420,6 +420,15 @@ class LiteLLMCompletionResponsesConfig:
             )
             if new_role != "assistant":
                 continue
+            reasoning_content = (
+                LiteLLMCompletionResponsesConfig._get_chat_message_reasoning_content(
+                    new_msg
+                )
+            )
+            LiteLLMCompletionResponsesConfig._set_assistant_reasoning_content(
+                last_msg,
+                reasoning_content,
+            )
             for tool_call in LiteLLMCompletionResponsesConfig._get_tool_calls_list(
                 new_msg
             ):

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 import traceback
 from datetime import datetime
@@ -28,6 +29,31 @@ from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import ResponsesAPIStreamEvents
 from litellm.types.utils import CallTypes
 from litellm.utils import CustomStreamWrapper, async_post_call_success_deployment_hook
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+_MANAGED_WS_HISTORY_MAX_RESPONSES = _positive_int_env(
+    "LITELLM_RESPONSES_WS_HISTORY_MAX_RESPONSES", 16
+)
+_MANAGED_WS_HISTORY_MAX_MESSAGES = _positive_int_env(
+    "LITELLM_RESPONSES_WS_HISTORY_MAX_MESSAGES", 80
+)
+_MANAGED_WS_HISTORY_MAX_BYTES = _positive_int_env(
+    "LITELLM_RESPONSES_WS_HISTORY_MAX_BYTES", 524_288
+)
+_MANAGED_WS_HISTORY_TTL_SECONDS = _positive_int_env(
+    "LITELLM_RESPONSES_WS_HISTORY_TTL_SECONDS", 600
+)
 
 
 @lru_cache(maxsize=1)
@@ -1459,6 +1485,7 @@ class ManagedResponsesWebSocketHandler:
         # This avoids the async DB-write race condition where spend logs haven't
         # been committed yet when the next response.create arrives.
         self._session_history: Dict[str, List[Dict[str, Any]]] = {}
+        self._session_history_touched: Dict[str, float] = {}
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -1502,7 +1529,11 @@ class ManagedResponsesWebSocketHandler:
             previous_response_id
         )
         raw_id = decoded.get("response_id", previous_response_id)
-        return list(self._session_history.get(raw_id, []))
+        self._prune_session_history()
+        messages = self._session_history.get(raw_id, [])
+        if messages:
+            self._session_history_touched[raw_id] = time.time()
+        return list(messages)
 
     def _store_history(self, response_id: str, messages: List[Dict[str, Any]]) -> None:
         """
@@ -1511,7 +1542,62 @@ class ManagedResponsesWebSocketHandler:
         Replaces any prior value — callers are responsible for passing the full
         history (prior turns + current input + new output).
         """
-        self._session_history[response_id] = messages
+        self._prune_session_history()
+        normalized_messages = self._trim_history_messages(messages)
+        if not normalized_messages:
+            return
+        self._session_history[response_id] = normalized_messages
+        self._session_history_touched[response_id] = time.time()
+        self._prune_session_history()
+
+    def _delete_history(self, response_id: Optional[str]) -> None:
+        if not response_id:
+            return
+        decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(response_id)
+        raw_id = decoded.get("response_id", response_id)
+        self._session_history.pop(raw_id, None)
+        self._session_history_touched.pop(raw_id, None)
+
+    @staticmethod
+    def _history_size_bytes(messages: List[Dict[str, Any]]) -> int:
+        try:
+            return len(json.dumps(messages, default=str, separators=(",", ":")))
+        except Exception:
+            return sum(len(str(message)) for message in messages)
+
+    def _trim_history_messages(
+        self, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        normalized_messages = list(messages)
+        if len(normalized_messages) > _MANAGED_WS_HISTORY_MAX_MESSAGES:
+            normalized_messages = normalized_messages[-_MANAGED_WS_HISTORY_MAX_MESSAGES:]
+
+        while (
+            len(normalized_messages) > 1
+            and self._history_size_bytes(normalized_messages)
+            > _MANAGED_WS_HISTORY_MAX_BYTES
+        ):
+            normalized_messages.pop(0)
+        return normalized_messages
+
+    def _prune_session_history(self) -> None:
+        now = time.time()
+        expired_response_ids = [
+            response_id
+            for response_id, touched_at in self._session_history_touched.items()
+            if now - touched_at > _MANAGED_WS_HISTORY_TTL_SECONDS
+        ]
+        for response_id in expired_response_ids:
+            self._delete_history(response_id)
+
+        while len(self._session_history) > _MANAGED_WS_HISTORY_MAX_RESPONSES:
+            oldest_response_id = min(
+                self._session_history,
+                key=lambda response_id: self._session_history_touched.get(
+                    response_id, 0.0
+                ),
+            )
+            self._delete_history(oldest_response_id)
 
     @staticmethod
     def _extract_response_id(completed_event: Dict[str, Any]) -> Optional[str]:
@@ -1726,6 +1812,7 @@ class ManagedResponsesWebSocketHandler:
     def _save_turn_history(
         self,
         completed_event: Optional[Dict[str, Any]],
+        previous_response_id: Optional[str],
         prior_history: List[Dict[str, Any]],
         current_messages: List[Dict[str, Any]],
     ) -> None:
@@ -1738,6 +1825,15 @@ class ManagedResponsesWebSocketHandler:
         output_msgs = self._extract_output_messages(completed_event)
         all_messages = prior_history + current_messages + output_msgs
         self._store_history(new_response_id, all_messages)
+        decoded_previous = (
+            ResponsesAPIRequestUtils._decode_responses_api_response_id(
+                previous_response_id
+            ).get("response_id")
+            if previous_response_id
+            else None
+        )
+        if decoded_previous and decoded_previous != new_response_id:
+            self._delete_history(decoded_previous)
         verbose_logger.debug(
             "ManagedResponsesWS: stored %d messages for response_id=%s",
             len(all_messages),
@@ -1806,7 +1902,9 @@ class ManagedResponsesWebSocketHandler:
             await self._send_error(str(exc))
             return
 
-        self._save_turn_history(completed_event, prior_history, current_messages)
+        self._save_turn_history(
+            completed_event, previous_response_id, prior_history, current_messages
+        )
 
     # ------------------------------------------------------------------
     # Main entry point
@@ -1832,3 +1930,12 @@ class ManagedResponsesWebSocketHandler:
         except Exception as exc:
             verbose_logger.exception("ManagedResponsesWS: unexpected error: %s", exc)
             await self._send_error(f"Internal server error: {exc}")
+        finally:
+            cleared = len(self._session_history)
+            self._session_history.clear()
+            self._session_history_touched.clear()
+            if cleared:
+                verbose_logger.debug(
+                    "ManagedResponsesWS: cleared %d in-memory response histories",
+                    cleared,
+                )

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1222,7 +1222,7 @@ class Message(SafeAttributeModel, OpenAIObject):
             if hasattr(self, "annotations"):
                 del self.annotations
 
-        if reasoning_content is None:
+        if reasoning_content is None and not getattr(self, "tool_calls", None):
             # ensure default response matches OpenAI spec
             if hasattr(self, "reasoning_content"):
                 del self.reasoning_content

--- a/tests/llm_translation/test_deepseek_completion.py
+++ b/tests/llm_translation/test_deepseek_completion.py
@@ -176,3 +176,68 @@ def test_completion_cost_deepseek():
         pass
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+
+def test_deepseek_v4_supported_openai_params_include_thinking_controls():
+    from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+
+    supported_params = OpenAIGPTConfig().get_supported_openai_params(
+        "deepseek/deepseek-v4-pro"
+    )
+
+    assert "thinking" in supported_params
+    assert "reasoning_effort" in supported_params
+
+
+def test_deepseek_v4_transform_request_injects_reasoning_content_for_tool_calls():
+    from litellm.llms.openai.openai import OpenAIConfig
+
+    request = OpenAIConfig().transform_request(
+        model="deepseek/deepseek-v4-pro",
+        messages=[
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["messages"][1]["reasoning_content"] == ""
+
+
+def test_deepseek_reasoner_transform_request_does_not_inject_reasoning_content():
+    from litellm.llms.openai.openai import OpenAIConfig
+
+    request = OpenAIConfig().transform_request(
+        model="deepseek/deepseek-reasoner",
+        messages=[
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "reasoning_content" not in request["messages"][1]

--- a/tests/llm_translation/test_deepseek_completion.py
+++ b/tests/llm_translation/test_deepseek_completion.py
@@ -241,3 +241,15 @@ def test_deepseek_reasoner_transform_request_does_not_inject_reasoning_content()
     )
 
     assert "reasoning_content" not in request["messages"][1]
+
+
+def test_get_openai_credentials_preserves_organization_field():
+    from litellm.llms.openai.common_utils import get_openai_credentials
+
+    credentials = get_openai_credentials(
+        api_base="https://example.com/v1",
+        api_key="test-key",
+        organization="test-org",
+    )
+
+    assert credentials.organization == "test-org"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
@@ -263,6 +263,67 @@ class TestReasoningContentFinalResponse:
         assert len(reasoning_items) == 1, "Should have exactly one reasoning item"
         assert reasoning_items[0].content[0].text == "Reasoning for first answer"
 
+    def test_cached_tool_call_reconstruction_preserves_reasoning_content(self):
+        """Tool output reconstruction keeps reasoning_content from the tool-call turn."""
+        tool_call_id = "call_cached_reasoning"
+        response = ModelResponse(
+            id="test-id",
+            created=1234567890,
+            model="test-model",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        reasoning_content="I need to call get_weather first.",
+                        tool_calls=[
+                            {
+                                "id": tool_call_id,
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"location":"Boston"}',
+                                },
+                            }
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        try:
+            LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+                request_input="Weather in Boston?",
+                responses_api_request={},
+                chat_completion_response=response,
+            )
+            messages = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+                {
+                    "type": "function_call_output",
+                    "call_id": tool_call_id,
+                    "output": '{"temperature":"42F"}',
+                }
+            )
+        finally:
+            from litellm.responses.litellm_completion_transformation.transformation import (
+                TOOL_CALLS_CACHE,
+            )
+
+            TOOL_CALLS_CACHE.delete_cache(key=tool_call_id)
+
+        assistant_message = messages[0]
+        assert assistant_message.get("role") == "assistant"
+        assert (
+            assistant_message.get("reasoning_content")
+            == "I need to call get_weather first."
+        )
+        tool_calls = assistant_message.get("tool_calls") or []
+        assert len(tool_calls) == 1
+        assert tool_calls[0].get("id") == tool_call_id
+
 
 def test_streaming_chunk_id_raw():
     """Test that streaming chunk IDs are raw (not encoded) to match OpenAI format"""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
@@ -325,6 +325,58 @@ class TestReasoningContentFinalResponse:
         assert tool_calls[0].get("id") == tool_call_id
 
 
+def test_merge_consecutive_function_call_messages_preserves_reasoning_content():
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_first",
+                    "type": "function",
+                    "function": {
+                        "name": "first_tool",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+        }
+    ]
+    chat_completion_messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "Need a second tool before answering.",
+            "tool_calls": [
+                {
+                    "id": "call_second",
+                    "type": "function",
+                    "function": {
+                        "name": "second_tool",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+        }
+    ]
+
+    merged = LiteLLMCompletionResponsesConfig._merge_consecutive_function_call_messages(
+        messages=messages,
+        chat_completion_messages=chat_completion_messages,
+        input_item={"type": "function_call", "call_id": "call_second"},
+        existing_tool_call_ids={"call_first"},
+    )
+
+    assert merged is True
+    assert messages[0].get("reasoning_content") == (
+        "Need a second tool before answering."
+    )
+    assert [tool_call.get("id") for tool_call in messages[0].get("tool_calls", [])] == [
+        "call_first",
+        "call_second",
+    ]
+
+
 def test_streaming_chunk_id_raw():
     """Test that streaming chunk IDs are raw (not encoded) to match OpenAI format"""
     chunk = ModelResponseStream(

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -238,6 +238,52 @@ async def test_session_history_preserves_responses_reasoning_before_tool_call():
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_with_output_key_uses_choices_not_responses_output():
+    mock_spend_logs = [
+        {
+            "request_id": "chatcmpl-custom-output",
+            "call_type": "aresponses",
+            "session_id": "session-custom-output",
+            "proxy_server_request": {
+                "input": "Return a custom provider response.",
+                "model": "custom/provider-model",
+            },
+            "response": {
+                "id": "chatcmpl-custom-output",
+                "object": "chat.completion",
+                "model": "custom/provider-model",
+                "output": [{"custom_provider_payload": "not a Responses API item"}],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Provider answer from choices.",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            "status": "success",
+        }
+    ]
+
+    with patch.object(
+        ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = mock_spend_logs
+        result = await ResponsesSessionHandler.get_chat_completion_message_history_for_previous_response_id(
+            "chatcmpl-custom-output"
+        )
+
+    messages = result["messages"]
+    assert [message.get("role") for message in messages] == ["user", "assistant"]
+    assert messages[1].get("content") == "Provider answer from choices."
+
+
+@pytest.mark.asyncio
 async def test_previous_response_tool_output_continuation_replays_reasoning_content():
     """
     The continuation path should replay:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -1,11 +1,8 @@
-import json
 import os
 import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import HTTPException
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -14,6 +11,9 @@ import litellm
 from litellm.responses.litellm_completion_transformation import session_handler
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
+)
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
 )
 
 
@@ -158,6 +158,168 @@ async def test_get_chat_completion_message_history_for_previous_response_id():
         content_3 = messages[3].get("content", "")
         if isinstance(content_3, str):
             assert "Here's more detailed information about Michael Jordan" in content_3
+
+
+@pytest.mark.asyncio
+async def test_session_history_preserves_responses_reasoning_before_tool_call():
+    """
+    A Responses API turn served by chat completions is stored with output items,
+    not choices. Reconstruct the assistant tool-call message with reasoning_content
+    so thinking providers can accept the following function_call_output turn.
+    """
+    mock_spend_logs = [
+        {
+            "request_id": "resp_previous",
+            "call_type": "aresponses",
+            "session_id": "session-responses-reasoning",
+            "proxy_server_request": {
+                "input": "Call get_weather for Boston.",
+                "model": "deepseek/deepseek-v4-pro",
+            },
+            "response": {
+                "id": "resp_previous",
+                "object": "response",
+                "created_at": 1760000000,
+                "model": "deepseek/deepseek-v4-pro",
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Need the weather tool before answering.",
+                                "annotations": [],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "fc_1",
+                        "call_id": "call_weather",
+                        "name": "get_weather",
+                        "arguments": '{"location":"Boston"}',
+                        "status": "completed",
+                    },
+                ],
+            },
+            "status": "success",
+        }
+    ]
+
+    with patch.object(
+        ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = mock_spend_logs
+
+        result = await ResponsesSessionHandler.get_chat_completion_message_history_for_previous_response_id(
+            "resp_previous"
+        )
+
+    messages = result["messages"]
+    assert messages[0].get("role") == "user"
+    assert messages[0].get("content") == "Call get_weather for Boston."
+
+    assistant_message = messages[1]
+    assert assistant_message.get("role") == "assistant"
+    assert (
+        assistant_message.get("reasoning_content")
+        == "Need the weather tool before answering."
+    )
+    tool_calls = assistant_message.get("tool_calls") or []
+    assert len(tool_calls) == 1
+    assert tool_calls[0].get("id") == "call_weather"
+    assert tool_calls[0].get("function", {}).get("name") == "get_weather"
+    assert tool_calls[0].get("function", {}).get("arguments") == '{"location":"Boston"}'
+
+
+@pytest.mark.asyncio
+async def test_previous_response_tool_output_continuation_replays_reasoning_content():
+    """
+    The continuation path should replay:
+    user -> assistant(reasoning_content + tool_calls) -> tool.
+    Thinking providers such as DeepSeek/Moonshot reject the continuation if
+    the assistant tool-call message loses reasoning_content.
+    """
+    mock_spend_logs = [
+        {
+            "request_id": "resp_previous",
+            "call_type": "aresponses",
+            "session_id": "session-tool-output-continuation",
+            "proxy_server_request": {
+                "input": "Call get_weather for Boston.",
+                "model": "deepseek/deepseek-v4-pro",
+            },
+            "response": {
+                "id": "resp_previous",
+                "object": "response",
+                "created_at": 1760000000,
+                "model": "deepseek/deepseek-v4-pro",
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "The user asked for weather, so I need the weather tool.",
+                                "annotations": [],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_weather",
+                        "name": "get_weather",
+                        "arguments": '{"location":"Boston"}',
+                    },
+                ],
+            },
+            "status": "success",
+        }
+    ]
+    current_request = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+        model="deepseek/deepseek-v4-pro",
+        input=[
+            {
+                "type": "function_call_output",
+                "call_id": "call_weather",
+                "output": '{"temperature":"42F"}',
+            }
+        ],
+        responses_api_request={"previous_response_id": "resp_previous"},
+    )
+
+    with patch.object(
+        ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = mock_spend_logs
+
+        result = (
+            await LiteLLMCompletionResponsesConfig.async_responses_api_session_handler(
+                previous_response_id="resp_previous",
+                litellm_completion_request=current_request,
+            )
+        )
+
+    messages = result["messages"]
+    assert [message.get("role") for message in messages] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert (
+        messages[1].get("reasoning_content")
+        == "The user asked for weather, so I need the weather tool."
+    )
+    assert messages[1].get("tool_calls")[0].get("id") == "call_weather"
+    assert messages[2].get("tool_call_id") == "call_weather"
+    assert messages[2].get("content") == '{"temperature":"42F"}'
 
 
 @pytest.mark.asyncio
@@ -355,7 +517,7 @@ async def test_should_check_cold_storage_for_full_payload():
             proxy_request_with_truncated_pdf
         )
         assert (
-            result1 == True
+            result1
         ), "Should return True for proxy request with truncated PDF content"
 
         # Test case 2: Should return False for regular content
@@ -363,20 +525,20 @@ async def test_should_check_cold_storage_for_full_payload():
             proxy_request_regular
         )
         assert (
-            result2 == False
+            not result2
         ), "Should return False for regular proxy request without truncation"
 
         # Test case 3: Should return True for empty request
         result3 = ResponsesSessionHandler._should_check_cold_storage_for_full_payload(
             proxy_request_empty
         )
-        assert result3 == True, "Should return True for empty proxy request"
+        assert result3, "Should return True for empty proxy request"
 
         # Test case 4: Should return True for None request
         result4 = ResponsesSessionHandler._should_check_cold_storage_for_full_payload(
             proxy_request_none
         )
-        assert result4 == True, "Should return True for None proxy request"
+        assert result4, "Should return True for None proxy request"
 
     # Test case 5: Should return False when cold storage is not configured
     with patch.object(litellm, "cold_storage_custom_logger", None):
@@ -384,7 +546,7 @@ async def test_should_check_cold_storage_for_full_payload():
             proxy_request_with_truncated_pdf
         )
         assert (
-            result5 == False
+            not result5
         ), "Should return False when cold storage is not configured, even with truncated content"
 
 
@@ -394,8 +556,6 @@ async def test_get_chat_completion_message_history_empty_response_dict():
     Test that empty response dict is handled correctly without processing.
     This tests the fix for response validation to check for empty dict responses.
     """
-    from unittest.mock import AsyncMock, patch
-
     # Mock spend logs with empty response dict
     mock_spend_logs = [
         {

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -165,6 +165,90 @@ class TestManagedWebSocketHandlerIntegration:
         assert handler.timeout == 30.0
         assert handler.custom_llm_provider == "test_provider"
 
+    def test_managed_handler_drops_superseded_turn_history(self):
+        """New response history supersedes the previous response key."""
+        from unittest.mock import MagicMock
+
+        from litellm.litellm_core_utils.litellm_logging import Logging
+        from litellm.responses.streaming_iterator import (
+            ManagedResponsesWebSocketHandler,
+        )
+
+        handler = ManagedResponsesWebSocketHandler(
+            websocket=MagicMock(),
+            model="test-model",
+            logging_obj=Logging(
+                model="test-model",
+                messages=[],
+                stream=True,
+                call_type="aresponses",
+                start_time=0,
+                litellm_call_id="test-id",
+                function_id="test-func",
+            ),
+        )
+        handler._store_history(
+            "first-response",
+            [{"type": "message", "role": "user", "content": "hello"}],
+        )
+
+        handler._save_turn_history(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "second-response",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "done"}],
+                        }
+                    ],
+                },
+            },
+            "first-response",
+            handler._get_history_messages("first-response"),
+            [{"type": "message", "role": "user", "content": "next"}],
+        )
+
+        assert "first-response" not in handler._session_history
+        assert "second-response" in handler._session_history
+
+    @pytest.mark.asyncio
+    async def test_managed_handler_clears_history_on_disconnect(self):
+        """Per-connection response history is released when the WS run ends."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.litellm_core_utils.litellm_logging import Logging
+        from litellm.responses.streaming_iterator import (
+            ManagedResponsesWebSocketHandler,
+        )
+
+        mock_websocket = MagicMock()
+        mock_websocket.receive_text = AsyncMock(side_effect=Exception("disconnect"))
+        handler = ManagedResponsesWebSocketHandler(
+            websocket=mock_websocket,
+            model="test-model",
+            logging_obj=Logging(
+                model="test-model",
+                messages=[],
+                stream=True,
+                call_type="aresponses",
+                start_time=0,
+                litellm_call_id="test-id",
+                function_id="test-func",
+            ),
+        )
+        handler._store_history(
+            "first-response",
+            [{"type": "message", "role": "user", "content": "hello"}],
+        )
+
+        await handler.run()
+
+        assert handler._session_history == {}
+        assert handler._session_history_touched == {}
+
 
 class TestChunkTransformation:
     """Test chunk serialization and transformation for WebSocket streaming"""

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -310,3 +310,27 @@ def test_delta_maps_reasoning_to_reasoning_content():
     # When neither is present, reasoning_content is not set (OpenAI spec)
     delta4 = Delta(content="hello")
     assert not hasattr(delta4, "reasoning_content")
+
+
+def test_message_keeps_reasoning_content_slot_for_tool_calls():
+    """
+    DeepSeek V4 requires reasoning_content to remain available on assistant
+    tool-call messages so later request transforms can re-inject it.
+    """
+    from litellm.types.utils import Message
+
+    message = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+        reasoning_content=None,
+    )
+
+    assert hasattr(message, "reasoning_content")
+    assert message.reasoning_content is None


### PR DESCRIPTION
## Relevant issues

No upstream issue found for this exact failure class.

Related open PRs, but not duplicates:

- #26660 fixes DeepSeek V4 chat-mode thinking replay and model routing.
- #26678 fixes DeepSeek V4 multi-turn chat reasoning handling.
- #26087 handles incomplete reasoning-only Responses output.
- #26614 preserves Anthropic reasoning in a provider-specific pass-through path.

This PR fixes the generic `/v1/responses` session-reconstruction path for chat-completion-backed providers using `previous_response_id` plus tool continuations.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Problem

When `/v1/responses` is backed by chat completions, LiteLLM reconstructs a follow-up `previous_response_id` conversation from stored spend-log rows.

For thinking models that call tools, the prior Responses output can look like:

1. `reasoning` output item
2. `function_call` output item

The next turn then supplies:

1. `function_call_output`

Before this PR, the session handler reconstructed the prior turn as a chat assistant tool-call message without the original `reasoning_content`. Thinking providers such as DeepSeek and other OpenAI-compatible reasoning models can require that reasoning payload to be replayed on the assistant tool-call message before they accept the tool result. The failure mode is generic: the model can emit a tool call on the first Responses turn, but the continuation can fail because the reconstructed chat history loses the reasoning payload.

This is not InfoHound-specific and not DeepSeek-only. Any chat-completion-backed `/v1/responses` provider with a reasoning payload tied to an assistant tool call can hit the same continuation bug.

### Fix

This PR preserves `reasoning_content` across the Responses-to-chat bridge:

- extracts reasoning text from Responses `reasoning` output items
- reconstructs stored Responses `output` history into chat messages for `previous_response_id`
- attaches pending reasoning to the assistant message that carries the following `function_call`
- preserves reasoning when cached tool-call definitions are replayed for `function_call_output`
- keeps provider-specific reasoning fields intact when available
- leaves normal text/tool/message conversion behavior unchanged

### Regression coverage

Added mocked tests under `tests/test_litellm/` for:

- spend-log session reconstruction preserving Responses reasoning before a tool call
- `previous_response_id` plus `function_call_output` continuation replaying `reasoning_content`
- cached tool-call reconstruction preserving `reasoning_content`

### Local validation

Passing:

```bash
uv run --python 3.13 --extra proxy --group dev pytest tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py -q
```

Result: `16 passed in 1.24s`

```bash
uv run --python 3.13 --extra proxy --group dev pytest tests/test_litellm/responses/litellm_completion_transformation -q
```

Result: `102 passed, 1 warning in 9.76s`

Warning observed: `RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited`.

```bash
uv run --python 3.13 --extra proxy --group dev black --check litellm/responses/litellm_completion_transformation/transformation.py litellm/responses/litellm_completion_transformation/session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
```

Result: `4 files would be left unchanged`

```bash
uv run --python 3.13 --extra proxy --group dev ruff check litellm/responses/litellm_completion_transformation/transformation.py litellm/responses/litellm_completion_transformation/session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
```

Result: `All checks passed`

```bash
git diff --check -- litellm/responses/litellm_completion_transformation/transformation.py litellm/responses/litellm_completion_transformation/session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
```

Result: passed

Attempted broader local repo checks:

- `make lint` failed locally before this PR's files due to pre-existing Black formatting failures in unrelated enterprise files, including `litellm/proxy/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/smtp_email.py`, `sendgrid_email.py`, and `audit_logging_endpoints.py`.
- `make lint-dev` completed successfully, but emitted a Makefile range warning: `invalid value '0:1-0:999' for '--range <RANGE>': the start line is 0`.
- `make test-unit` was attempted locally and failed early with suite/environment-level runtime issues before reaching this related suite, including `Cannot call collect on a MetricReader until it is registered on a MeterProvider`, unawaited coroutine warnings, and unclosed aiohttp sessions/connectors.

### GitHub PR validation

All GitHub checks on this PR passed after opening, including:

- `lint`
- `code-quality`
- `codecov/patch`
- `Greptile Review`
- `Unit Tests: Core Utilities`
- `Unit Tests: LLM Provider Transformations`
- `Unit Tests: Proxy Auth & Key Management`
- `Unit Tests: Proxy API Endpoints`
- `Unit Tests: Proxy Infrastructure`
- `Unit Tests: MCP, Secrets, Containers & Misc`
- `Unit Tests: Enterprise, Google GenAI & Routing`
- `Test Proxy SERVER_ROOT_PATH Routing`
- `secret-scan`
- `semgrep`
- `build-ui`

## Type

🐛 Bug Fix
✅ Test
