### PR TITLE
fix(docker): use /usr/bin/python3 in process_monitor eventlistener

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -40,7 +40,7 @@ stderr_logfile_maxbytes = 0
 environment=PYTHONUNBUFFERED=true
 
 [eventlistener:process_monitor]
-command=python -c "from supervisor import childutils; import os, signal; [os.kill(os.getppid(), signal.SIGTERM) for h,p in iter(lambda: childutils.listener.wait(), None) if h['eventname'] in ['PROCESS_STATE_FATAL', 'PROCESS_STATE_EXITED'] and dict([x.split(':') for x in p.split(' ')])['processname'] in ['main', 'health'] or childutils.listener.ok()]"
+command=/usr/bin/python3 -c "from supervisor import childutils; import os, signal; [os.kill(os.getppid(), signal.SIGTERM) for h,p in iter(lambda: childutils.listener.wait(), None) if h['eventname'] in ['PROCESS_STATE_FATAL', 'PROCESS_STATE_EXITED'] and dict([x.split(':') for x in p.split(' ')])['processname'] in ['main', 'health'] or childutils.listener.ok()]"
 events=PROCESS_STATE_EXITED,PROCESS_STATE_FATAL
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary

Fixes #27393 — `process_monitor` eventlistener crashes to FATAL when `SEPARATE_HEALTH_APP=1` on `v1.83.10-stable`+.

## Root cause

The eventlistener command in `docker/supervisord.conf` runs:
```
command=python -c "from supervisor import childutils; ..."
```

Since the migration to **uv** in [#25007](https://github.com/BerriAI/litellm/pull/25007) (released in `v1.83.10-stable`), the runtime image sets `PATH=\"/app/.venv/bin:\${PATH}\"`, so bare `python` resolves to the project venv at `/app/.venv/bin/python`.

The `supervisor` Python package is installed by `apk add supervisor` into the **system** Python's site-packages (`/usr/lib/pythonX.Y/site-packages/`), not into the venv. The venv has no `--system-site-packages`, so:

```
ModuleNotFoundError: No module named 'supervisor'
```

Python exits with status 1, supervisord retries 3 times per `startretries=3`, then marks the listener `FATAL` — exactly matching the symptom in the issue. Pre-uv builds installed everything into system Python, so `python` was the system interpreter and the import worked.

## Fix

Pin the eventlistener to `/usr/bin/python3`, the system interpreter where apk's `supervisor` package is importable. One-line change in `docker/supervisord.conf`. The other `python` references in the file (the `program:main` command) already invoke project code that lives in the venv, so they correctly resolve to `/app/.venv/bin/python` — only the eventlistener needs the system interpreter.

## Test plan

- [x] Diff is one character change on the `[eventlistener:process_monitor]` `command=` line.
- [ ] CI: existing test suite covers the proxy entry point; no test specifically exercises supervisord boot, but a maintainer can verify locally with:
  ```
  docker build -t litellm-test -f Dockerfile .
  docker run --rm -e SEPARATE_HEALTH_APP=1 litellm-test
  ```
  Before the fix: `process_monitor entered FATAL state`. After: `process_monitor entered RUNNING state` and stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)