### PR TITLE
test(interactions): align openapi compliance with upstream rename outputs->steps

### DIFF
--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -157,14 +157,15 @@ class TestResponseCompliance:
         # Check CreateModelInteractionParams which includes output fields
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
 
-        # Output fields (readOnly)
+        # Output fields (readOnly). Google renamed `outputs` → `steps` in the
+        # upstream spec; keep this list aligned with the live schema.
         output_fields = [
             "id",
             "status",
             "created",
             "updated",
             "role",
-            "outputs",
+            "steps",
             "usage",
         ]
 


### PR DESCRIPTION
## Summary

- `tests/test_litellm/interactions/test_openapi_compliance.py::TestResponseCompliance::test_interaction_response_fields` started failing on every CI run after Google updated their live Interactions OpenAPI spec at https://ai.google.dev/static/api/interactions.openapi.json.
- The spec removed the readOnly `outputs` property from `CreateModelInteractionParams` and replaced it with `steps` (a polymorphic transcript array, discriminated by `type` with 17 variants).
- The test fetches the live spec at runtime, so the change broke regardless of branch contents — most recently surfaced on https://github.com/BerriAI/litellm/actions/runs/25527782769/job/74927801303.
- Re-align the asserted output-field list: `outputs` → `steps`. No production code changes.

## Follow-ups (not in this PR)

- Our SDK response types in `litellm/types/interactions/generated.py` still expose `outputs: Optional[List[...]]` in 5 places and don't model `steps` / `Step`. Because `BaseLiteLLMOpenAIResponseObject` is `extra="allow"`, no exception is raised today, but `response.outputs` will silently be `None` if the wire follows the spec — a silent caller-visible break. A separate change should regenerate types from the new spec, add `steps`, and decide on a back-compat strategy for callers reading `.outputs` (e.g. derive it from `[s.content for s in steps if s.type == "model_output"]`).

## Test plan

- [x] `uv run pytest tests/test_litellm/interactions/test_openapi_compliance.py -v` — 13 passed