### PR TITLE
[Feature] UI - Logs: Add 'Last Minute' to time-range quick select

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/constants.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/constants.ts
@@ -19,6 +19,7 @@ export const MCP_CALL_TYPES = ["call_mcp_tool", "list_mcp_tools"];
 export const AGENT_CALL_TYPES = ["asend_message"];
 
 export const QUICK_SELECT_OPTIONS: { label: string; value: number; unit: string }[] = [
+  { label: "Last Minute", value: 1, unit: "minutes" },
   { label: "Last 15 Minutes", value: 15, unit: "minutes" },
   { label: "Last Hour", value: 1, unit: "hours" },
   { label: "Last 4 Hours", value: 4, unit: "hours" },

--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import moment from "moment";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SpendLogsTable, { RequestViewer } from "./index";
 import type { LogEntry } from "./columns";
 import type { Row } from "@tanstack/react-table";
 import { renderWithProviders } from "../../../tests/test-utils";
+import { uiSpendLogsCall } from "../networking";
 
 const mockHandleFilterResetFromHook = vi.fn();
 vi.mock("./log_filter_logic", async (importOriginal) => {
@@ -236,6 +238,54 @@ describe("SpendLogsTable", () => {
     await waitFor(() => {
       const inputsAfterReset = document.querySelectorAll('input[type="datetime-local"]');
       expect(inputsAfterReset.length).toBe(0);
+    });
+  });
+
+  describe("Quick Select time range", () => {
+    const waitForWindowSeconds = async (minMinutes: number) => {
+      let diff = -1;
+      await waitFor(() => {
+        const lastCall = vi.mocked(uiSpendLogsCall).mock.calls.at(-1)?.[0];
+        if (!lastCall) throw new Error("uiSpendLogsCall was not called");
+        diff = moment
+          .utc(lastCall.end_date, "YYYY-MM-DD HH:mm:ss")
+          .diff(moment.utc(lastCall.start_date, "YYYY-MM-DD HH:mm:ss"), "seconds");
+        // start_date is rounded down to the minute boundary; end_date is current time
+        expect(diff).toBeGreaterThanOrEqual(minMinutes * 60);
+        expect(diff).toBeLessThan((minMinutes + 1) * 60);
+      });
+      return diff;
+    };
+
+    it("should pass a ~1-minute window to uiSpendLogsCall when 'Last Minute' is selected", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+      await user.click(screen.getByRole("button", { name: /Last 24 Hours/i }));
+      await user.click(await screen.findByRole("button", { name: "Last Minute" }));
+
+      await waitForWindowSeconds(1);
+    });
+
+    it("should pass a ~15-minute window to uiSpendLogsCall when 'Last 15 Minutes' is selected", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+      await user.click(screen.getByRole("button", { name: /Last 24 Hours/i }));
+      await user.click(await screen.findByRole("button", { name: "Last 15 Minutes" }));
+
+      await waitForWindowSeconds(15);
+    });
+
+    it("should update the time-range button label to 'Last Minute' after selecting it", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+      await user.click(screen.getByRole("button", { name: /Last 24 Hours/i }));
+      await user.click(await screen.findByRole("button", { name: "Last Minute" }));
+
+      expect(screen.getByRole("button", { name: "Last Minute" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Last 24 Hours/i })).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Relevant issues
Closes LIT-2829
## Summary

The logs page time-range quick-select dropdown currently jumps from "Last 15 Minutes" to no shorter preset, which makes it awkward to scope to a tight live window. Adds a "Last Minute" option as the first entry of `QUICK_SELECT_OPTIONS`.

### Change

- `QUICK_SELECT_OPTIONS` in `ui/litellm-dashboard/src/components/view_logs/constants.ts` gains `{ label: "Last Minute", value: 1, unit: "minutes" }` at the top of the array.

No backend, API, or component changes — the dropdown renders generically off the array, and `formatTimeUnit` already handles singular "minute".

## Testing

Three integration tests added in `ui/litellm-dashboard/src/components/view_logs/index.test.tsx`:

- Selecting "Last Minute" causes `uiSpendLogsCall` to receive `start_date` / `end_date` whose diff is in `[60s, 120s)`.
- Selecting "Last 15 Minutes" passes a `[900s, 960s)` window (regression coverage on the same flow).
- The trigger button label updates to "Last Minute" after selection.

The window upper bound is `(N+1)*60` rather than `N*60` because `startTime` state is rounded down to the minute boundary while `end_date` is the exact current time at fetch.

`npx vitest run src/components/view_logs/` — 221 tests pass.

## Type

🆕 New Feature
✅ Test

## Screenshots
<img width="1664" height="290" alt="image" src="https://github.com/user-attachments/assets/1fa6c3a0-8ea3-44f3-8a82-4a73218b709c" />
<img width="1670" height="322" alt="image" src="https://github.com/user-attachments/assets/955b0f4d-a6c7-4f1d-b818-3a6defc7a010" />
