### PR TITLE
Fix bedrock invoke xhigh

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -204,15 +204,24 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         Mirrors the pattern used in ``openai/chat/gpt_5_transformation.py`` so
         that adding support for a new effort level is a pure model-map change.
+        Bedrock Claude invoke still uses AnthropicConfig for request shaping, so
+        explicit Bedrock route prefixes must check Bedrock model-map entries.
         """
-        try:
-            return _supports_factory(
-                model=model,
-                custom_llm_provider="anthropic",
-                key=f"supports_{level}_reasoning_effort",
-            )
-        except Exception:
-            return False
+        providers_to_check: List[Optional[str]] = [None, "anthropic"]
+        if model.startswith(("bedrock/", "converse/", "invoke/")):
+            providers_to_check.insert(0, "bedrock")
+
+        for custom_llm_provider in providers_to_check:
+            try:
+                if _supports_factory(
+                    model=model,
+                    custom_llm_provider=custom_llm_provider,
+                    key=f"supports_{level}_reasoning_effort",
+                ):
+                    return True
+            except Exception:
+                continue
+        return False
 
     def get_supported_openai_params(self, model: str):
         params = [

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1185,6 +1185,36 @@
         "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
+    "invoke/global.anthropic.claude-opus-4-7": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
+    },
     "us.anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1199,6 +1199,36 @@
         "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
+    "invoke/global.anthropic.claude-opus-4-7": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
+    },
     "us.anthropic.claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_read_input_token_cost": 5.5e-07,

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1609,6 +1609,21 @@ def test_effort_validation():
         )
 
 
+def test_xhigh_effort_accepted_for_bedrock_invoke_opus_47():
+    """Test xhigh effort uses Bedrock model-map capabilities for invoke models."""
+    config = AnthropicConfig()
+
+    result = config.transform_request(
+        model="invoke/global.anthropic.claude-opus-4-7",
+        messages=[{"role": "user", "content": "Test"}],
+        optional_params={"output_config": {"effort": "xhigh"}},
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["output_config"]["effort"] == "xhigh"
+
+
 def test_effort_with_claude_opus_45():
     """Test effort parameter works with Claude Opus 4.5 model."""
     config = AnthropicConfig()


### PR DESCRIPTION
```markdown
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, Bedrock invoke requests for Claude Opus 4.7 with `output_config.effort="xhigh"` failed capability validation:

```text
ValueError: effort='xhigh' is not supported by this model. Got model: invoke/global.anthropic.claude-opus-4-7
```

Local validation:

```bash
python3 -m py_compile litellm/llms/anthropic/chat/transformation.py
python3 -m py_compile tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
python3 -m json.tool model_prices_and_context_window.json >/dev/null
python3 -m json.tool litellm/model_prices_and_context_window_backup.json >/dev/null
git diff --check
```

Verified the local proxy container loaded the local model cost map and included the Bedrock invoke entry:

```text
source: {'source': 'local', 'url': None, 'is_env_forced': True, 'fallback_reason': None}
model entry: {'litellm_provider': 'bedrock', 'supports_xhigh_reasoning_effort': True, ...}
```

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Added `invoke/global.anthropic.claude-opus-4-7` to the model cost maps with `litellm_provider="bedrock"`.
- Marked the Bedrock invoke Claude Opus 4.7 entry as supporting `xhigh`, `max`, and `minimal` reasoning effort.
- Updated Anthropic effort capability lookup so explicit Bedrock route prefixes (`bedrock/`, `converse/`, `invoke/`) check Bedrock model-map entries before falling back to Anthropic lookup.
- Added a regression test for `output_config.effort="xhigh"` on `invoke/global.anthropic.claude-opus-4-7`.
```