### PR TITLE
fix(opentelemetry): JSON-serialize dict metadata fields for OTEL span attributes (#27451)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -876,8 +876,13 @@ class OpenTelemetry(CustomLogger):
             "mcp_tool_call_metadata",
             "vector_store_request_metadata",
         ]:
-            if md.get(key) is not None:
-                common_attrs[f"metadata.{key}"] = str(md[key])
+            value = md.get(key)
+            if value is None:
+                continue
+            if isinstance(value, (dict, list)):
+                common_attrs[f"metadata.{key}"] = safe_dumps(value)
+            else:
+                common_attrs[f"metadata.{key}"] = str(value)
 
         # get hidden params
         hidden_params = getattr(std_log, "hidden_params", None) or (std_log or {}).get(


### PR DESCRIPTION
## Summary
Fixes #27451 — dict-valued metadata fields (notably `spend_logs_metadata`, `requester_metadata`, `prompt_management_metadata`, `applied_guardrails`, `mcp_tool_call_metadata`, `vector_store_request_metadata`) were being emitted to OTEL span attributes via `str(value)`, producing Python dict repr (`{'k': 'v'}`) instead of valid JSON (`{"k": "v"}`). This made the attributes unparseable downstream in Jaeger / Honeycomb / Grafana Tempo.

The fix routes dict and list values through `safe_dumps(...)` (already imported and used immediately below for `hidden_params`) while preserving `str(...)` for scalar values that are already string-friendly (string IDs, `requester_ip_address`, etc.).

## Root cause
`litellm/integrations/opentelemetry.py:880` unconditionally called `str(md[key])`. For dict-valued keys this produces single-quoted Python repr instead of double-quoted JSON.

## Fix
```python
value = md.get(key)
if value is None:
    continue
if isinstance(value, (dict, list)):
    common_attrs[f"metadata.{key}"] = safe_dumps(value)
else:
    common_attrs[f"metadata.{key}"] = str(value)
```

`safe_dumps` is already imported at the top of the file and is the same serializer used for `hidden_params` two blocks below — keeping the serialization consistent.

## Test plan
- [ ] Existing OTEL tests still pass
- [ ] Reproduction from #27451: `spend_logs_metadata` dict now appears as valid JSON in span attributes
- [ ] Scalar metadata fields (string IDs, IP) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)