### PR TITLE
fix(proxy): decode bytes and pass-through SSE for Google-native streamGenerateContent (#27444)

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6484,7 +6484,7 @@ def _restamp_streaming_chunk_model(
     return chunk, model_mismatch_logged
 
 
-async def async_data_generator(
+async def async_data_generator(  # noqa: PLR0915
     response, user_api_key_dict: UserAPIKeyAuth, request_data: dict
 ):
     verbose_proxy_logger.debug("inside generator")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6524,6 +6524,18 @@ async def async_data_generator(
 
             if isinstance(chunk, BaseModel):
                 chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+            elif isinstance(chunk, bytes):
+                # Some upstream streaming iterators (e.g. AsyncGoogleGenAIGenerateContentStreamingIterator
+                # for /v1beta/.../streamGenerateContent) yield raw SSE bytes from Gemini.
+                # Decode to str so the f-string below does not emit a Python b'...' literal,
+                # and pass already-formatted SSE through unchanged to avoid double "data:" prefix.
+                chunk = chunk.decode("utf-8", errors="replace")
+                if chunk.startswith(("data:", "event:", ":")):
+                    try:
+                        yield chunk if chunk.endswith("\n\n") else chunk + "\n\n"
+                    except Exception as e:
+                        yield f"data: {str(e)}\n\n"
+                    continue
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk
                 break


### PR DESCRIPTION
## Summary
Fixes #27444 — `/v1beta/models/{model}:streamGenerateContent?alt=sse` produced corrupted output that no JSON parser (and no `@google/genai` client) can read:

```
data: b'data: {"candidates": [...]}'
```

The bug is in `async_data_generator` in `litellm/proxy/proxy_server.py`. The Google-native streaming iterator (`AsyncGoogleGenAIGenerateContentStreamingIterator`) yields raw SSE bytes from `httpx.aiter_bytes()`. Those bytes flow into `async_data_generator`, where `yield f\"data: {chunk}\n\n\"` calls `str(bytes_obj)`, which renders the Python `b'...'` repr instead of the decoded string. The original payload is also already SSE-formatted (starts with `data:`), so wrapping it again would double-prefix.

OpenAI-format (`/v1/chat/completions`) is unaffected because chunks there are `BaseModel` instances and take the JSON-serializing branch.

## Fix
Add a `bytes` branch before the existing `str.startswith(\"data: \")` (error-detection) branch:

1. Decode UTF-8 (errors=\"replace\" so a malformed byte never tears the stream).
2. If the decoded payload already looks like an SSE event (`data:`, `event:`, or `:` comment line), pass it through unchanged — adding a trailing `\n\n` only if the upstream chunk didn't include one.
3. Otherwise fall through to the existing `data: {chunk}\n\n` wrapping path.

The existing OpenAI error-detection branch (`elif isinstance(chunk, str) and chunk.startswith(\"data: \")`) is preserved unchanged.

## Test plan
- [ ] Reproduction from #27444 (curl to `:streamGenerateContent?alt=sse`) now returns clean SSE; `@google/genai` SDK parses it without error.
- [ ] OpenAI-format streaming (`/v1/chat/completions`) still works (BaseModel branch unchanged).
- [ ] Existing proxy streaming tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)