### PR TITLE
Fix proxy metadata headers with non-string values

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import json
 import re
 import time
 from collections import OrderedDict
@@ -54,6 +55,20 @@ def _sanitize_for_log(value: Any) -> str:
         text = repr(value)
     # Strip CR/LF characters commonly used for log injection
     return text.replace("\r", "").replace("\n", "")
+
+
+def _coerce_header_value(value: Any) -> Union[str, bytes]:
+    """
+    Convert header values to httpx-compatible types (str/bytes).
+    """
+    if isinstance(value, (str, bytes)):
+        return value
+    if isinstance(value, (dict, list, tuple, bool, int, float)):
+        try:
+            return json.dumps(value, default=str)
+        except (TypeError, ValueError):
+            return str(value)
+    return str(value)
 
 
 from litellm.router import Router
@@ -796,6 +811,12 @@ class LiteLLMProxyRequestSetup:
             for k, v in litellm_logging_metadata_headers.items():
                 if v is not None:
                     returned_headers["x-litellm-{}".format(k)] = v
+
+        returned_headers = {
+            header_name: _coerce_header_value(header_value)
+            for header_name, header_value in returned_headers.items()
+            if header_value is not None
+        }
 
         return returned_headers
 

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -573,6 +573,8 @@ def test_add_litellm_data_for_backend_llm_call(
 def test_foward_litellm_user_info_to_backend_llm_call():
     import json
 
+    import httpx
+
     litellm.add_user_information_to_llm_headers = True
 
     from litellm.proxy._types import UserAPIKeyAuth
@@ -587,12 +589,16 @@ def test_foward_litellm_user_info_to_backend_llm_call():
         user_api_key_dict=user_api_key_dict,
     )
 
+    # Regression for #27458: if any value is non-string/bytes, httpx will throw
+    # `TypeError: Header value must be str or bytes`.
+    httpx.Headers(data)
+
     expected_data = {
         "x-litellm-user_api_key_user_id": "test_user_id",
         "x-litellm-user_api_key_org_id": "test_org_id",
         "x-litellm-user_api_key_hash": "test_api_key",
-        "x-litellm-user_api_key_spend": 0.0,
-        "x-litellm-user_api_key_auth_metadata": {},
+        "x-litellm-user_api_key_spend": "0.0",
+        "x-litellm-user_api_key_auth_metadata": "{}",
     }
 
     assert json.dumps(data, sort_keys=True) == json.dumps(expected_data, sort_keys=True)

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2159,6 +2159,44 @@ def test_add_headers_to_llm_call_by_model_group_existing_headers_in_data():
         litellm.model_group_settings = original_model_group_settings
 
 
+def test_add_headers_to_llm_call_coerces_non_string_header_values():
+    """
+    Regression test for #27458: proxy-added metadata headers can include floats/dicts.
+    Ensure returned headers are valid for httpx request construction.
+    """
+    import httpx
+    import litellm
+
+    original_add_user_information_to_llm_headers = (
+        litellm.add_user_information_to_llm_headers
+    )
+    litellm.add_user_information_to_llm_headers = True
+
+    try:
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test_api_key",
+            spend=0.25,
+            metadata={"service_account_id": "svc-123"},
+        )
+
+        headers = LiteLLMProxyRequestSetup.add_headers_to_llm_call(
+            headers={},
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        # Raises TypeError if any header value is non-string/bytes.
+        httpx.Headers(headers)
+
+        assert headers["x-litellm-user_api_key_spend"] == "0.25"
+        assert json.loads(headers["x-litellm-user_api_key_auth_metadata"]) == {
+            "service_account_id": "svc-123"
+        }
+    finally:
+        litellm.add_user_information_to_llm_headers = (
+            original_add_user_information_to_llm_headers
+        )
+
+
 import json
 import time
 from typing import Optional


### PR DESCRIPTION
## Relevant issues

Fixes #27458

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review).

## CI (LiteLLM team)

- [ ] Branch creation CI run
- [ ] CI run for the last commit
- [ ] Merge / cherry-pick CI run

## Screenshots / Proof of Fix

Before the fix, `LiteLLMProxyRequestSetup.add_headers_to_llm_call()` could return proxy metadata headers with native `float` and `dict` values. Passing those headers into `httpx.Headers(...)` reproduced:

```text
TypeError: Header value must be str or bytes, not <class 'float'>
```

Targeted verification:

```text
.venv/bin/pytest tests/proxy_unit_tests/test_proxy_utils.py -k foward_litellm_user_info_to_backend_llm_call -x -vv
.venv/bin/pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py -k "add_headers_to_llm_call_by_model_group or coerces_non_string_header_values" -x -vv
```

Both targeted test commands pass.

## Type

Bug Fix
Test

## Changes

- Coerce returned proxy LLM headers to `str` or `bytes` before request construction.
- Preserve existing string and bytes header values.
- Serialize metadata containers and primitive values deterministically for generated `x-litellm-*` headers.
- Add regression coverage that validates the returned headers can be consumed by `httpx.Headers`.