### PR TITLE
feat(provider): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ INFISICAL_TOKEN = ""
 NOVITA_API_KEY = ""
 # INFINITY
 INFINITY_API_KEY = ""
+# Eden AI
+EDENAI_API_KEY = ""
+EDENAI_API_BASE = "https://api.edenai.run/v3"
 
 # Development Configs
 LITELLM_MASTER_KEY = "sk-1234"

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 | [Deepgram (`deepgram`)](https://docs.litellm.ai/docs/providers/deepgram) | ✅ | ✅ | ✅ |  |  | ✅ |  |  |  |  |
 | [DeepInfra (`deepinfra`)](https://docs.litellm.ai/docs/providers/deepinfra) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Deepseek (`deepseek`)](https://docs.litellm.ai/docs/providers/deepseek) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Eden AI (`edenai`)](https://docs.litellm.ai/docs/providers/edenai) | ✅ | ✅ |  |  |  |  |  |  |  |  |
 | [ElevenLabs (`elevenlabs`)](https://docs.litellm.ai/docs/providers/elevenlabs) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ |  |  |  |
 | [Empower (`empower`)](https://docs.litellm.ai/docs/providers/empower) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Fal AI (`fal_ai`)](https://docs.litellm.ai/docs/providers/fal_ai) | ✅ | ✅ | ✅ |  | ✅ |  |  |  |  |  |

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -552,6 +552,7 @@ LITELLM_CHAT_PROVIDERS = [
     "huggingface",
     "together_ai",
     "datarobot",
+    "edenai",
     "helicone",
     "openrouter",
     "cometapi",
@@ -780,6 +781,7 @@ openai_compatible_endpoints: List = [
     "https://api.lambda.ai/v1",
     "https://api.hyperbolic.xyz/v1",
     "https://ai-gateway.helicone.ai/",
+    "https://api.edenai.run/v3",
     "https://ai-gateway.vercel.sh/v1",
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
@@ -819,6 +821,7 @@ openai_compatible_providers: List = [
     "novita",
     "meta_llama",
     "publicai",  # PublicAI - JSON-configured provider
+    "edenai",  # Eden AI - JSON-configured meta-gateway provider
     "synthetic",  # Synthetic - JSON-configured provider
     "apertis",  # Apertis - JSON-configured provider
     "nano-gpt",  # Nano-GPT - JSON-configured provider

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -114,5 +114,13 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "edenai": {
+    "base_url": "https://api.edenai.run/v3",
+    "api_key_env": "EDENAI_API_KEY",
+    "api_base_env": "EDENAI_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3333,6 +3333,7 @@ class LlmProviders(str, Enum):
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"
+    EDENAI = "edenai"
 
 
 # Create a set of all provider values for quick lookup

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -831,6 +831,22 @@
         "search": true
       }
     },
+    "edenai": {
+      "display_name": "Eden AI (`edenai`)",
+      "url": "https://docs.litellm.ai/docs/providers/edenai",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false
+      }
+    },
     "elevenlabs": {
       "display_name": "ElevenLabs (`elevenlabs`)",
       "url": "https://docs.litellm.ai/docs/providers/elevenlabs",

--- a/tests/test_litellm/llms/openai_like/test_edenai.py
+++ b/tests/test_litellm/llms/openai_like/test_edenai.py
@@ -1,0 +1,174 @@
+"""
+Tests for Eden AI provider configuration and integration.
+
+Eden AI (https://www.edenai.co/) is an OpenAI-compatible aggregator that
+exposes 100+ underlying models from OpenAI, Anthropic, Google, Mistral and
+others through a single chat-completions endpoint.
+"""
+
+import os
+
+import pytest
+
+import litellm
+
+
+class TestEdenAIProviderConfig:
+    """Test Eden AI provider configuration"""
+
+    def test_edenai_in_provider_list(self):
+        """Test that edenai is in the provider list"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "EDENAI")
+        assert LlmProviders.EDENAI.value == "edenai"
+        assert "edenai" in litellm.provider_list
+
+    def test_edenai_json_config_exists(self):
+        """Test that edenai is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("edenai")
+
+        edenai = JSONProviderRegistry.get("edenai")
+        assert edenai is not None
+        assert edenai.base_url == "https://api.edenai.run/v3"
+        assert edenai.api_key_env == "EDENAI_API_KEY"
+        assert edenai.api_base_env == "EDENAI_API_BASE"
+        assert edenai.param_mappings.get("max_completion_tokens") == "max_tokens"
+
+    def test_edenai_provider_resolution(self):
+        """Test that provider resolution finds edenai for prefixed model ids"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="edenai/openai/gpt-4o-mini",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        # Eden AI's model ids are themselves prefixed (e.g. openai/gpt-4o-mini),
+        # so the model returned is everything after the leading "edenai/".
+        assert model == "openai/gpt-4o-mini"
+        assert provider == "edenai"
+        assert api_base == "https://api.edenai.run/v3"
+
+    def test_edenai_api_base_env_override(self, monkeypatch):
+        """Test that EDENAI_API_BASE overrides the default base URL"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        monkeypatch.setenv("EDENAI_API_BASE", "https://custom-edenai.example.com/v3")
+        _, provider, _, api_base = get_llm_provider(
+            model="edenai/openai/gpt-4o-mini",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+        assert provider == "edenai"
+        assert api_base == "https://custom-edenai.example.com/v3"
+
+    def test_edenai_router_config(self):
+        """Test that edenai can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "edenai-gpt-4o-mini",
+                    "litellm_params": {
+                        "model": "edenai/openai/gpt-4o-mini",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "edenai-gpt-4o-mini"
+
+
+class TestEdenAICompletionMocked:
+    """Mocked completion tests — no real API calls."""
+
+    def test_edenai_completion_mocked(self):
+        """Test that a mocked completion through the edenai/ prefix routes
+        correctly and returns the stub content unchanged."""
+        response = litellm.completion(
+            model="edenai/openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "Say PING and nothing else"}],
+            api_key="test-key",
+            mock_response="PING",
+        )
+
+        assert response is not None
+        assert hasattr(response, "choices")
+        assert len(response.choices) > 0
+        assert response.choices[0].message.content == "PING"
+
+
+class TestEdenAILiveIntegration:
+    """Live integration tests against the real Eden AI API.
+
+    Skipped automatically when EDENAI_API_KEY is not set, so CI without the
+    secret stays green. When the key is present (local dev, or a dedicated
+    integration runner) these validate that each endpoint flagged `true` in
+    provider_endpoints_support.json actually routes a request through to
+    api.edenai.run/v3 end-to-end. Endpoints flagged `false` (`/responses`,
+    `/embeddings`, `/image/generations`, `/audio/*`, `/moderations`,
+    `/batches`, `/rerank`) intentionally have no live test here; their
+    handlers ship in follow-up PRs and the tests come with them.
+    """
+
+    @pytest.mark.skipif(
+        not os.environ.get("EDENAI_API_KEY"), reason="EDENAI_API_KEY not set"
+    )
+    def test_edenai_live_chat_completions(self):
+        """`/v1/chat/completions` via litellm.completion() — the openai_like
+        loader's primary surface."""
+        response = litellm.completion(
+            model="edenai/openai/gpt-4o-mini",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Reply with 'PING' and nothing else.",
+                }
+            ],
+            max_tokens=8,
+        )
+
+        assert response is not None
+        assert response.choices[0].message.content
+        assert response.usage is not None
+        assert response.usage.total_tokens > 0
+
+    @pytest.mark.skipif(
+        not os.environ.get("EDENAI_API_KEY"), reason="EDENAI_API_KEY not set"
+    )
+    @pytest.mark.asyncio
+    async def test_edenai_live_anthropic_messages(self):
+        """`/v1/messages` (Anthropic-format) via litellm.anthropic_messages().
+        LiteLLM translates the Anthropic-shape request to OpenAI shape
+        internally and routes through Eden AI's openai-compatible endpoint;
+        the response is translated back to Anthropic shape before being
+        returned to the caller."""
+        response = await litellm.anthropic_messages(
+            model="edenai/anthropic/claude-opus-4-6",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Reply with 'MSG' and nothing else.",
+                }
+            ],
+            max_tokens=8,
+        )
+
+        assert response is not None
+        # anthropic_messages returns a dict (Anthropic-shape response)
+        assert response.get("type") == "message"
+        assert response.get("role") == "assistant"
+        content = response.get("content", [])
+        assert content and content[0].get("type") == "text"
+        assert content[0].get("text")
+        usage = response.get("usage", {})
+        assert usage.get("total_tokens", 0) > 0


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" — none, this is a new-provider PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

<!-- to be added before requesting maintainer review:
     - `make lint` clean output
     - `uv run pytest tests/test_litellm/llms/openai_like/test_edenai.py -v` passing (8/8 including 2 live)
     - one mocked + one live completion call demonstrating routing -->

## Type

🆕 New Feature

## Changes

Adds **Eden AI** (<https://www.edenai.co/>) as a JSON-configured OpenAI-compatible provider via the existing `openai_like` loader. Eden AI is a meta-gateway that exposes 100+ underlying models from OpenAI, Anthropic, Google, Mistral, Cohere and others behind a single OpenAI-shape chat-completions endpoint at `https://api.edenai.run/v3`.

After this PR, users can call any of those models through LiteLLM with:

```python
import litellm
litellm.completion(
    model="edenai/openai/gpt-4o-mini",
    messages=[{"role": "user", "content": "Say hello"}],
)
```

once `EDENAI_API_KEY` is set. Pattern matches **Helicone** (PR #17663) and **AIHubMix** (PR #24294) — closest JSON-configured aggregator analogs.

### Files (7 files, +170 lines)

| File | Edit |
| --- | --- |
| `litellm/llms/openai_like/providers.json` | New `edenai` entry: base URL `https://api.edenai.run/v3`, env var `EDENAI_API_KEY`, optional `api_base_env=EDENAI_API_BASE`, `max_completion_tokens → max_tokens` param mapping. |
| `litellm/types/utils.py` | `LlmProviders.EDENAI = "edenai"` enum entry (hand-maintained, not auto-derived from JSON; without it `litellm.provider_list` doesn't surface the slug). |
| `litellm/constants.py` | Three lookup-list additions, mirroring Helicone (#17663): `LITELLM_CHAT_PROVIDERS`, `openai_compatible_endpoints` (the base URL), `openai_compatible_providers` (the slug). |
| `provider_endpoints_support.json` | `edenai` entry under `providers`. `chat_completions: true`, `messages: true` (verified live — Anthropic-format translation works through `openai_like`); all other endpoints `false` (their handlers ship in follow-up PRs). |
| `README.md` | Supported Providers table row. Only `/chat/completions` and `/messages` ticked, matching what's actually wired today. |
| `.env.example` | `# Eden AI` block with `EDENAI_API_KEY` and `EDENAI_API_BASE` lines, matching the surrounding `KEY = ""` style. |
| `tests/test_litellm/llms/openai_like/test_edenai.py` | Six mocked unit tests + two live integration tests guarded by `pytest.skipif(not os.environ.get("EDENAI_API_KEY"))`. |

### Endpoints wired through this PR

- `/v1/chat/completions` — primary surface via the `openai_like` loader. **Verified live.**
- `/v1/messages` — Anthropic-format calls translated to OpenAI shape internally and routed through Eden AI's chat-completions endpoint. **Verified live** (`litellm.anthropic_messages` returns proper Anthropic-shape responses).
- `/v1/responses` — **not enabled by default.** LiteLLM's `responses()` path injects an empty `tools=[]` array which the `openai_like` parameter validator rejects (`UnsupportedParamsError`). Eden AI's API itself supports `/v1/responses`, but enabling it through LiteLLM requires either (a) `drop_params=True` opt-in, or (b) a follow-up patch to either LiteLLM's responses path or the `openai_like` config. Tracked as a follow-up.
- `/embeddings`, `/image/generations`, `/audio/*`, `/moderations`, `/batches`, `/rerank` — out of scope. Provider-specific handlers under `litellm/llms/edenai/` ship in follow-up PRs and will flip those flags as they land.

### Tests

Eight tests in `tests/test_litellm/llms/openai_like/test_edenai.py`, all passing locally:

| Test | Type | What it checks |
| --- | --- | --- |
| `test_edenai_in_provider_list` | mocked | `LlmProviders.EDENAI` enum + presence in `litellm.provider_list`. |
| `test_edenai_json_config_exists` | mocked | JSON entry shape (`base_url`, `api_key_env`, `api_base_env`, param mappings). |
| `test_edenai_provider_resolution` | mocked | `get_llm_provider("edenai/openai/gpt-4o-mini")` returns `(model="openai/gpt-4o-mini", provider="edenai", api_base="https://api.edenai.run/v3")`. |
| `test_edenai_api_base_env_override` | mocked | `EDENAI_API_BASE` overrides the default URL. |
| `test_edenai_router_config` | mocked | `Router` instantiation with an Eden AI deployment. |
| `test_edenai_completion_mocked` | mocked | `litellm.completion(model="edenai/openai/gpt-4o-mini", mock_response="PING")` round-trips. |
| `test_edenai_live_chat_completions` | **live** | `/v1/chat/completions` against `api.edenai.run/v3`. Skipped when `EDENAI_API_KEY` is not set. |
| `test_edenai_live_anthropic_messages` | **live** | `/v1/messages` via `litellm.anthropic_messages()`. Skipped when `EDENAI_API_KEY` is not set. |

### Validation evidence (live, separate from CI)

| Test | Result |
| --- | --- |
| `litellm.completion("edenai/openai/gpt-4o-mini", ...)` | ✅ |
| `litellm.completion("edenai/anthropic/claude-opus-4-6", ...)` | ✅ |
| Streaming (SSE, token-by-token) | ✅ |
| Tool / function calling (single + multi-tool agent loop) | ✅ |
| `litellm.anthropic_messages("edenai/anthropic/claude-opus-4-6", ...)` | ✅ (returns Anthropic-shape response with content + usage) |
| `litellm.responses("edenai/...")` (default) | ❌ — `UnsupportedParamsError` for `tools=[]`; works with `drop_params=True` |
| `usage` field present and correct | ✅ |
| System-prompt passthrough | ✅ |
| Long context (~25k tokens, exact-recall needle) | ✅ |
| Error shape on bad request (`{"error":{"message":...}}`) | ✅ |
| JSON mode | ⚠️ output wrapped in markdown fence — see caveats |

### Known caveats (documented, not fixed)

- **JSON mode wraps output in a markdown code fence.** With `response_format={"type":"json_object"}`, Eden AI returns valid JSON inside a ` ```json … ``` ` fence rather than bare JSON. LiteLLM does not validate JSON-mode output, so `litellm.completion()` returns the fenced content unchanged. Tracked separately on Eden AI's side. Out of scope for this PR.
- **Additive non-OpenAI response fields** (`status`, `provider_time`, `edenai_time`, `provider_specific_fields`) — well-behaved OpenAI clients ignore unknown keys; LiteLLM does. No code change needed.
- **`/v1/responses` requires `drop_params=True`** (see "Endpoints wired" above). Eden AI itself accepts the request; LiteLLM's local param validation rejects the empty `tools=[]` array. Marked `responses: false` in `provider_endpoints_support.json` until that's resolved.

### Out of scope (follow-ups)

- **Provider docs page** in [`BerriAI/litellm-docs`](https://github.com/BerriAI/litellm-docs) — separate PR, already opened. Per `CLAUDE.md`: *"Do not create or edit documentation files in this repository — open doc PRs against `BerriAI/litellm-docs` instead."*
- **`/v1/responses`** — fix LiteLLM's responses path or the `openai_like` config so that empty `tools=[]` doesn't trigger `UnsupportedParamsError`. Then flip `responses: true`.
- **Per-model pricing** in `model_prices_and_context_window.json`. Recent JSON-configured providers (`xiaomi_mimo`, `charity_engine`, `helicone`, `aihubmix`) ship with zero pricing entries; defer until per-model cost tracking is requested.
- **Provider-specific handlers** under `litellm/llms/edenai/` for `/embeddings`, `/image/generations`, `/audio/*`, `/moderations` — Eden AI's API supports them all (some via `/v3/universal-ai`); each ships in its own follow-up PR.
- **Vision-input verification.** Several Eden AI models report `input_modalities: [file, image, text]`; not exercised in this PR's tests.
- **JSON-mode fence-stripping.** Tracked as a provider-side fix; not adding host-side post-processing.
