### PR TITLE
fix(text-completion): forward proxy x-* headers through OpenAI text-completion path

### DIFF
--- a/litellm/llms/openai/completion/handler.py
+++ b/litellm/llms/openai/completion/handler.py
@@ -49,6 +49,11 @@ class OpenAITextCompletion(BaseLLM):
         headers: Optional[dict] = None,
     ):
         try:
+            # Track caller-provided headers (e.g. proxy-forwarded x-* headers)
+            # separately so they can be merged into extra_headers for the SDK call
+            # without being conflated with the auto-generated auth dict from
+            # validate_environment().
+            extra_request_headers = headers
             if headers is None:
                 headers = self.validate_environment(api_key=api_key)
             if model is None or messages is None:
@@ -67,6 +72,11 @@ class OpenAITextCompletion(BaseLLM):
                 optional_params=optional_params,
                 headers=headers,
             )
+            if extra_request_headers:
+                data["extra_headers"] = {
+                    **(data.get("extra_headers") or {}),
+                    **extra_request_headers,
+                }
             max_retries = data.pop("max_retries", 2)
             ## LOGGING
             logging_obj.pre_call(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2095,6 +2095,7 @@ def completion(  # type: ignore # noqa: PLR0915
             _response = openai_text_completions.completion(
                 model=model,
                 messages=messages,
+                headers=headers,
                 model_response=model_response,
                 print_verbose=print_verbose,
                 api_key=api_key,


### PR DESCRIPTION
## Summary

Fixes #27410. `forward_client_headers_to_llm_api` correctly propagated client `x-*` headers to upstream providers for `/v1/chat/completions` and `/v1/embeddings`, but silently dropped them for `/v1/completions` (the OpenAI text-completion route).

## Root cause

Two co-located gaps in the text-completion path; either alone would cause the bug.

**1. `litellm/main.py` — text-completion dispatch did not pass `headers`.**

The chat-completion dispatch correctly forwards the merged `headers` dict:

```python
response = openai_chat_completions.completion(
    model=model,
    messages=messages,
    headers=headers,            # forwarded
    ...
)
```

The text-completion dispatch right above it did not — `headers=headers` was simply absent from the call site.

**2. `litellm/llms/openai/completion/handler.py` — handler did not propagate `headers` to the SDK call.**

The handler accepted a `headers` kwarg, but only used it for `validate_environment` fallback and `logging.pre_call`. It was never added to `data` before the SDK call, so even if `main.py` had passed it, it would not have reached the wire.

## Fix

- `litellm/main.py`: pass `headers=headers` to `openai_text_completions.completion(...)`, mirroring the chat-completion call site.
- `litellm/llms/openai/completion/handler.py`: track caller-supplied headers separately from the auto-generated auth dict produced by `validate_environment(api_key=...)`, and merge them into `data["extra_headers"]` before each SDK call. The merge propagates through to the streaming/async-streaming/acompletion sub-methods automatically since they receive `data`.

Behavior is unchanged for callers that do not pass `headers`: the existing `validate_environment` fallback still runs for logging, and the SDK's own auth via `api_key=` continues to handle the wire-level Authorization header.

## Test plan

- [ ] Existing chat/embedding header-forwarding tests still pass (no behavior change in those paths).
- [ ] With proxy `forward_client_headers_to_llm_api: true` and a `text-completion-openai/*` model in `model_list`, `POST /v1/completions` with custom `x-*` headers reaches upstream with those headers present (the bug repro from the linked issue).
- [ ] Calling `litellm.atext_completion(extra_headers={"x-test":"v"}, ...)` directly results in the OpenAI SDK `completions.create()` call receiving `extra_headers={"x-test":"v"}` (or merged superset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
