### PR TITLE
fix(anthropic-responses-adapter): respect drop_params for user field mapping

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -6,6 +6,8 @@ path used for OpenAI and Azure models.
 """
 
 import json
+
+import litellm
 from typing import Any, Dict, List, Optional, Union, cast
 
 from litellm.llms.anthropic.experimental_pass_through.utils import (
@@ -382,9 +384,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                 responses_kwargs["context_management"] = openai_cm
 
         # metadata user_id -> user
+        # When litellm.drop_params is set, omit optional fields that
+        # strict Responses API gateways may reject (resolves #26241).
         metadata = anthropic_request.get("metadata")
         if isinstance(metadata, dict) and "user_id" in metadata:
-            responses_kwargs["user"] = str(metadata["user_id"])[:64]
+            if not litellm.drop_params:
+                responses_kwargs["user"] = str(metadata["user_id"])[:64]
 
         return responses_kwargs
 

--- a/tests/pass_through_unit_tests/test_responses_adapter_drop_params.py
+++ b/tests/pass_through_unit_tests/test_responses_adapter_drop_params.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for litellm issue #26241:
+Anthropic -> Responses adapter must respect litellm.drop_params when
+mapping metadata.user_id to the Responses API `user` field.
+"""
+import pytest
+import litellm
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
+    LiteLLMAnthropicToResponsesAPIAdapter,
+)
+
+_ADAPTER = LiteLLMAnthropicToResponsesAPIAdapter()
+
+_BASE_REQUEST = {
+    "model": "gpt-4o",
+    "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+    "metadata": {"user_id": "test-user-123"},
+}
+
+
+def test_user_field_set_when_drop_params_false():
+    """user field IS forwarded when drop_params is False (default)."""
+    litellm.drop_params = False
+    try:
+        kwargs = _ADAPTER.translate_request(_BASE_REQUEST)
+        assert kwargs.get("user") == "test-user-123", (
+            "Expected user field to be set when drop_params=False"
+        )
+    finally:
+        litellm.drop_params = False
+
+
+def test_user_field_omitted_when_drop_params_true():
+    """user field is NOT forwarded when drop_params is True (fixes #26241)."""
+    litellm.drop_params = True
+    try:
+        kwargs = _ADAPTER.translate_request(_BASE_REQUEST)
+        assert "user" not in kwargs, (
+            f"Expected user field to be absent when drop_params=True, got {kwargs.get('user')}"
+        )
+    finally:
+        litellm.drop_params = False
+
+
+def test_user_field_absent_when_no_metadata():
+    """No user field if metadata is missing entirely."""
+    litellm.drop_params = False
+    req = {**_BASE_REQUEST, "metadata": None}
+    try:
+        kwargs = _ADAPTER.translate_request(req)
+        assert "user" not in kwargs
+    finally:
+        litellm.drop_params = False
+
+
+def test_user_field_absent_when_user_id_missing_from_metadata():
+    """No user field if metadata dict has no user_id key."""
+    litellm.drop_params = False
+    req = {**_BASE_REQUEST, "metadata": {"other_key": "value"}}
+    try:
+        kwargs = _ADAPTER.translate_request(req)
+        assert "user" not in kwargs
+    finally:
+        litellm.drop_params = False
+
+
+def test_user_field_truncated_to_64_chars():
+    """user_id longer than 64 chars is truncated (existing behavior, not regressed)."""
+    litellm.drop_params = False
+    long_id = "a" * 100
+    req = {**_BASE_REQUEST, "metadata": {"user_id": long_id}}
+    try:
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs.get("user") == "a" * 64
+    finally:
+        litellm.drop_params = False


### PR DESCRIPTION
## Problem

When `litellm.drop_params = True`, the Anthropic → Responses API adapter still unconditionally sets the `user` field from `metadata.user_id`. This breaks requests to strict Responses API gateways that reject unknown or optional parameters with a 400 error.

Fixes #26241.

## Root cause

`LiteLLMAnthropicToResponsesAPIAdapter.translate_request()` in
`litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py`
(lines 384-387) never checked `litellm.drop_params`:

```python
# before
metadata = anthropic_request.get("metadata")
if isinstance(metadata, dict) and "user_id" in metadata:
    responses_kwargs["user"] = str(metadata["user_id"])[:64]
```

## Fix

Added a guard so the `user` field is only forwarded when `drop_params` is `False`:

```python
# after
metadata = anthropic_request.get("metadata")
if isinstance(metadata, dict) and "user_id" in metadata:
    if not litellm.drop_params:
        responses_kwargs["user"] = str(metadata["user_id"])[:64]
```

Also added `import litellm` to the module-level imports (the file previously imported only from `litellm.*` sub-modules).

## Tests

Added `tests/pass_through_unit_tests/test_responses_adapter_drop_params.py` covering:

- `user` field IS set when `drop_params=False` (default behaviour preserved)
- `user` field is omitted when `drop_params=True` (the bug fix)
- `user` field absent when `metadata` is `None`
- `user` field absent when `metadata` dict lacks `user_id`
- `user_id` longer than 64 chars is still truncated (existing behaviour not regressed)
