### PR TITLE
Add OpenAI chat-latest model metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8973,6 +8973,43 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "chat-latest": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "gpt-4o-transcribe-diarize": {
         "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8973,6 +8973,43 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "chat-latest": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "gpt-4o-transcribe-diarize": {
         "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,

--- a/tests/test_litellm/test_openai_chat_latest_model_metadata.py
+++ b/tests/test_litellm/test_openai_chat_latest_model_metadata.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+
+def test_openai_chat_latest_model_info():
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+    litellm.add_known_models(model_cost)
+
+    info = model_cost.get("chat-latest")
+    assert (
+        info is not None
+    ), "chat-latest not found in model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "openai"
+    assert info["mode"] == "chat"
+
+    assert info["input_cost_per_token"] == 5e-06
+    assert info["output_cost_per_token"] == 3e-05
+    assert info["cache_read_input_token_cost"] == 5e-07
+
+    assert info["max_input_tokens"] == 272000
+    assert info["max_output_tokens"] == 128000
+    assert info["max_tokens"] == 128000
+
+    assert info["supported_endpoints"] == [
+        "/v1/chat/completions",
+        "/v1/responses",
+    ]
+    assert info["supports_function_calling"] is True
+    assert info["supports_parallel_function_calling"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_system_messages"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_vision"] is True
+    assert info["supports_web_search"] is True
+
+    routed_model, provider, _, _ = get_llm_provider(model="chat-latest")
+    assert routed_model == "chat-latest"
+    assert provider == "openai"
+
+
+def test_openai_chat_latest_backup_matches_main():
+    repo_root = Path(__file__).parents[2]
+    main_path = repo_root / "model_prices_and_context_window.json"
+    backup_path = repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+
+    with open(main_path) as f:
+        main_cost = json.load(f)
+    with open(backup_path) as f:
+        backup_cost = json.load(f)
+
+    assert "chat-latest" in main_cost
+    assert "chat-latest" in backup_cost
+    assert backup_cost.get("chat-latest") == main_cost.get("chat-latest")


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

N/A

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Tested locally:

```bash
uv run pytest tests/test_litellm/test_openai_chat_latest_model_metadata.py -vv
uv run pytest tests/test_litellm/test_utils.py -k "model_prices" -vv
uv run pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py -k "web_search or file_search" -vv
```

Automated review:

```text
cr --agent
findings: 0
```

Reference docs:

- https://developers.openai.com/api/docs/models/chat-latest
- https://developers.openai.com/api/docs/pricing#tools

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes

Adds OpenAI `chat-latest` metadata to the root model pricing map and the
packaged backup map.

The new entry includes token limits, pricing, endpoint support, modal
support, and hosted tool capability metadata, including file search and
web search cost tracking.

Adds a focused test covering:

- `chat-latest` model metadata and routing through the OpenAI provider
- root model map and packaged backup map parity
