### PR TITLE
fix(sso): honor singular team_id_jwt_field in SSO callback

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -224,6 +224,36 @@ class JWTHandler:
 
         return []
 
+    def get_all_jwt_team_ids(self, token: dict) -> List[str]:
+        """
+        Return team IDs from both the plural ``team_ids_jwt_field`` and the
+        singular ``team_id_jwt_field`` claim, as a deduplicated list preserving
+        plural-first order.
+
+        Membership-reconciliation paths (SSO callback, JWT-bearer sync) need
+        to consider both claim shapes. Reading only the plural field — as
+        callers historically did — silently dropped users whose IdP populates
+        the singular field, which is what Okta and Auth0 default to when a
+        user has a single primary team.
+
+        This intentionally does NOT consult ``team_id_default``: that fallback
+        is a property of how the JWT-bearer auth flow resolves a single
+        request-bound team, not of the token's claims. Callers that want the
+        default-team behavior should still go through ``get_team_id``.
+        """
+        team_ids: List[str] = list(self.get_team_ids_from_jwt(token))
+        if self.litellm_jwtauth.team_id_jwt_field is not None:
+            singular = get_nested_value(
+                data=token,
+                key_path=self.litellm_jwtauth.team_id_jwt_field,
+                default=None,
+            )
+            if isinstance(singular, list):
+                singular = singular[0] if singular else None
+            if singular and singular not in team_ids:
+                team_ids.append(singular)
+        return team_ids
+
     def get_end_user_id(
         self, token: dict, default_value: Optional[str]
     ) -> Optional[str]:

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -249,6 +249,11 @@ class JWTHandler:
                 default=None,
             )
             if isinstance(singular, list):
+                if singular:
+                    verbose_proxy_logger.debug(
+                        f"JWT Auth: team_id_jwt_field '{self.litellm_jwtauth.team_id_jwt_field}' "
+                        f"returned a list {singular}; using first element '{singular[0]}' automatically."
+                    )
                 singular = singular[0] if singular else None
             if singular and singular not in team_ids:
                 team_ids.append(singular)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -740,7 +740,7 @@ def generic_response_convertor(
 
     all_teams = []
     if sso_jwt_handler is not None:
-        team_ids = sso_jwt_handler.get_team_ids_from_jwt(cast(dict, response))
+        team_ids = sso_jwt_handler.get_all_jwt_team_ids(cast(dict, response))
         all_teams.extend(team_ids)
 
     if team_mappings is not None and team_mappings.team_ids_jwt_field is not None:
@@ -755,7 +755,7 @@ def generic_response_convertor(
                 f"Loaded team_ids from DB team_mappings.team_ids_jwt_field='{team_mappings.team_ids_jwt_field}': {team_ids_from_db_mapping}"
             )
     else:
-        team_ids = jwt_handler.get_team_ids_from_jwt(cast(dict, response))
+        team_ids = jwt_handler.get_all_jwt_team_ids(cast(dict, response))
         all_teams.extend(team_ids)
 
     # Determine user role based on role_mappings if available

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -492,6 +492,75 @@ async def test_sync_user_role_and_teams_no_cache_write_when_nothing_changes():
     )
 
     mock_cache.async_set_cache.assert_not_called()
+
+
+def test_get_all_jwt_team_ids_unions_singular_and_plural():
+    """get_all_jwt_team_ids must include the singular team_id_jwt_field claim
+    in addition to the plural team_ids_jwt_field, deduplicated."""
+    jwt_handler = JWTHandler()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=MagicMock(),
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_id_jwt_field="team_id",
+            team_ids_jwt_field="teams",
+        ),
+    )
+
+    # singular only — Okta/Auth0 default shape
+    assert jwt_handler.get_all_jwt_team_ids({"team_id": "team-low"}) == ["team-low"]
+
+    # plural only — pre-fix shape
+    assert jwt_handler.get_all_jwt_team_ids({"teams": ["a", "b"]}) == ["a", "b"]
+
+    # both populated, no overlap
+    assert jwt_handler.get_all_jwt_team_ids(
+        {"team_id": "primary", "teams": ["a", "b"]}
+    ) == ["a", "b", "primary"]
+
+    # both populated with overlap — singular dedup'd
+    assert jwt_handler.get_all_jwt_team_ids({"team_id": "a", "teams": ["a", "b"]}) == [
+        "a",
+        "b",
+    ]
+
+    # neither populated
+    assert jwt_handler.get_all_jwt_team_ids({}) == []
+
+
+def test_get_all_jwt_team_ids_does_not_use_team_id_default():
+    """team_id_default is a JWT-bearer-flow auth-builder fallback, not a token
+    claim. It must NOT leak into get_all_jwt_team_ids — otherwise SSO logins
+    would silently start adding users to the default team for any tenant that
+    has team_id_default configured."""
+    jwt_handler = JWTHandler()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=MagicMock(),
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_id_jwt_field="team_id",
+            team_ids_jwt_field="teams",
+            team_id_default="default-team",
+        ),
+    )
+
+    # team_id claim missing — must not fall back to default-team
+    assert jwt_handler.get_all_jwt_team_ids({"teams": []}) == []
+    assert jwt_handler.get_all_jwt_team_ids({}) == []
+
+    # only the plural is populated — default still must not be added
+    assert jwt_handler.get_all_jwt_team_ids({"teams": ["a"]}) == ["a"]
+
+    # team_id_jwt_field unset entirely + only default configured: still no default
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=MagicMock(),
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_ids_jwt_field="teams",
+            team_id_default="default-team",
+        ),
+    )
+    assert jwt_handler.get_all_jwt_team_ids({"teams": []}) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The SSO callback flow (`generic_response_convertor` → `add_missing_team_member`) was reading only the plural `team_ids_jwt_field` claim. IdPs that populate the singular `team_id_jwt_field` instead (Okta/Auth0 mapping a group → primary team) had their users created via SSO with `teams: []` — never assigned to the team named in the JWT, regardless of how the user's `user_metadata.team_id` changed across logins.

This adds `JWTHandler.get_all_jwt_team_ids()` returning the deduplicated union of both claim sources, and threads it through the two branches that build `all_teams` in `generic_response_convertor`. The result: SSO logins now read the singular claim the same way the JWT-bearer path's `find_and_validate_specific_team_id` always has.

## screenshots 
<img width="807" height="660" alt="Screenshot 2026-05-06 at 5 28 21 PM" src="https://github.com/user-attachments/assets/10c56355-1ae5-4984-b10a-4641687737c0" />

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/auth/test_handle_jwt.py tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` — 240 pass.
- [x] New test: `test_get_all_jwt_team_ids_unions_singular_and_plural` covering all four input combinations (singular only, plural only, both no-overlap, both with overlap, neither).
- [x] End-to-end SSO repro against a real Auth0 tenant with the Phil-shaped post-login Action — confirmed user is now added to the team in `user_metadata.team_id` (BEFORE: `teams: []`; AFTER: `teams: ["team-low"]` after first login, dual membership after re-login with changed metadata).
- [x] Black formatting applied (`uv run black` on the three changed files).
- [x] Existing 183 SSO tests untouched and still pass — no regression in the SSO suite.