### PR TITLE
fix(mcp): public-client PKCE support in OAuth metadata + token endpoints

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -382,41 +382,48 @@ async def authorize_with_server(
 async def _post_to_upstream_token_endpoint(token_url: str, token_data: Dict[str, Any]):
     """POST to the upstream IdP /token endpoint.
 
-    Uses a raw httpx client (instead of get_async_httpx_client) so we can inspect
-    4xx/5xx responses and surface them as proper OAuth2 error JSON per RFC 6749
-    §5.2. The wrapped client raises MaskedHTTPStatusError on raise_for_status()
-    before downstream code can read the response body, so the actual
-    AADSTS<code> / error_description from Entra/Okta is lost and the client sees
-    a generic 500.
+    Uses the pooled get_async_httpx_client and catches the wrapped
+    HTTPStatusError so the upstream `error` / `error_description` payload
+    (RFC 6749 §5.2) reaches the client. The wrapper turns any 4xx/5xx into
+    a MaskedHTTPStatusError before downstream code can read the response
+    body, which would otherwise surface as a generic 500 and hide the
+    actual AADSTS<code> / error_description from Entra/Okta.
 
-    Returns the parsed JSON dict on success, or a JSONResponse with the upstream
-    error body on 4xx/5xx (or a transport failure).
+    Returns the parsed JSON dict on success, or a JSONResponse with the
+    upstream error body on 4xx/5xx (or a transport failure).
     """
+    async_client = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
     try:
-        async with httpx.AsyncClient(timeout=30.0) as raw_client:
-            response = await raw_client.post(
-                token_url,
-                headers={"Accept": "application/json"},
-                data=token_data,
+        response = await async_client.post(
+            token_url,
+            headers={"Accept": "application/json"},
+            data=token_data,
+        )
+    except httpx.HTTPStatusError as exc:
+        upstream_response = exc.response
+        try:
+            err_body = upstream_response.json()
+        except ValueError:
+            # MaskedHTTPStatusError (the wrapped form) carries a sanitized body
+            # on `.text`; fall back to the raw response text otherwise.
+            description = (
+                getattr(exc, "text", None)
+                or upstream_response.text
+                or "upstream token endpoint error"
             )
+            err_body = {
+                "error": "invalid_request",
+                "error_description": description,
+            }
+        return JSONResponse(
+            err_body,
+            status_code=upstream_response.status_code,
+            headers=TOKEN_NO_CACHE_HEADERS,
+        )
     except httpx.HTTPError as exc:
         return JSONResponse(
             {"error": "server_error", "error_description": str(exc)},
             status_code=502,
-            headers=TOKEN_NO_CACHE_HEADERS,
-        )
-
-    if response.status_code >= 400:
-        try:
-            err_body = response.json()
-        except ValueError:
-            err_body = {
-                "error": "invalid_request",
-                "error_description": response.text or "upstream token endpoint error",
-            }
-        return JSONResponse(
-            err_body,
-            status_code=response.status_code,
             headers=TOKEN_NO_CACHE_HEADERS,
         )
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+import httpx
 from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
@@ -378,6 +379,50 @@ async def authorize_with_server(
     return RedirectResponse(final_url)
 
 
+async def _post_to_upstream_token_endpoint(token_url: str, token_data: Dict[str, Any]):
+    """POST to the upstream IdP /token endpoint.
+
+    Uses a raw httpx client (instead of get_async_httpx_client) so we can inspect
+    4xx/5xx responses and surface them as proper OAuth2 error JSON per RFC 6749
+    §5.2. The wrapped client raises MaskedHTTPStatusError on raise_for_status()
+    before downstream code can read the response body, so the actual
+    AADSTS<code> / error_description from Entra/Okta is lost and the client sees
+    a generic 500.
+
+    Returns the parsed JSON dict on success, or a JSONResponse with the upstream
+    error body on 4xx/5xx (or a transport failure).
+    """
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as raw_client:
+            response = await raw_client.post(
+                token_url,
+                headers={"Accept": "application/json"},
+                data=token_data,
+            )
+    except httpx.HTTPError as exc:
+        return JSONResponse(
+            {"error": "server_error", "error_description": str(exc)},
+            status_code=502,
+            headers=TOKEN_NO_CACHE_HEADERS,
+        )
+
+    if response.status_code >= 400:
+        try:
+            err_body = response.json()
+        except ValueError:
+            err_body = {
+                "error": "invalid_request",
+                "error_description": response.text or "upstream token endpoint error",
+            }
+        return JSONResponse(
+            err_body,
+            status_code=response.status_code,
+            headers=TOKEN_NO_CACHE_HEADERS,
+        )
+
+    return response.json()
+
+
 async def exchange_token_with_server(
     request: Request,
     mcp_server: MCPServer,
@@ -400,6 +445,12 @@ async def exchange_token_with_server(
     resolved_client_secret = (
         mcp_server.client_secret if mcp_server.client_secret else client_secret
     )
+    # Drop placeholder / empty secrets that come from LiteLLM's dummy /register
+    # response (or from in-flight clients that already cached "dummy" before
+    # the public-client branch deployed). Forwarding these to a real IdP yields
+    # a 401.
+    if resolved_client_secret in (None, "", "dummy"):
+        resolved_client_secret = None
 
     if grant_type == "refresh_token":
         if not refresh_token:
@@ -434,15 +485,13 @@ async def exchange_token_with_server(
         if code_verifier:
             token_data["code_verifier"] = code_verifier
 
-    async_client = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
-    response = await async_client.post(
-        mcp_server.token_url,
-        headers={"Accept": "application/json"},
-        data=token_data,
+    upstream_result = await _post_to_upstream_token_endpoint(
+        mcp_server.token_url, token_data
     )
+    if isinstance(upstream_result, JSONResponse):
+        return upstream_result
 
-    response.raise_for_status()
-    token_response = response.json()
+    token_response = upstream_result
     access_token = token_response["access_token"]
 
     # Validate token response against server-configured rules before any storage.
@@ -513,6 +562,16 @@ async def register_client_with_server(
         "client_secret": "dummy",
         "redirect_uris": [f"{request_base_url}/callback"],
     }
+
+    # Public-client / PKCE-broker mode: configured client_id but no client_secret.
+    # Return the real client_id and OMIT client_secret so the downstream MCP
+    # client doesn't cache a placeholder and forward it to the upstream IdP.
+    if mcp_server.client_id and not mcp_server.client_secret:
+        return {
+            "client_id": mcp_server.client_id,
+            "redirect_uris": [f"{request_base_url}/callback"],
+            "token_endpoint_auth_method": "none",
+        }
 
     if mcp_server.client_id and mcp_server.client_secret:
         return dummy_return
@@ -871,6 +930,17 @@ def _build_oauth_authorization_server_response(
             mcp_server_name, client_ip=client_ip
         )
 
+    # Per RFC 8414 §2: token_endpoint_auth_methods_supported declares which
+    # client-authentication methods this auth server accepts at /token.
+    # Public clients (PKCE-broker, no client_secret stored) must advertise
+    # "none". Fall back to "client_secret_post" when the server can't be
+    # resolved (root /.well-known or unknown server name) — preserves legacy
+    # behavior for that case.
+    if mcp_server and mcp_server.client_id and not mcp_server.client_secret:
+        token_endpoint_auth_methods_supported = ["none"]
+    else:
+        token_endpoint_auth_methods_supported = ["client_secret_post"]
+
     return {
         "issuer": request_base_url,  # point to your proxy
         "authorization_endpoint": authorization_endpoint,
@@ -881,7 +951,7 @@ def _build_oauth_authorization_server_response(
         ),
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
-        "token_endpoint_auth_methods_supported": ["client_secret_post"],
+        "token_endpoint_auth_methods_supported": token_endpoint_auth_methods_supported,
         # Claude expects a registration endpoint, even if we just fake it
         "registration_endpoint": (
             f"{request_base_url}/{mcp_server_name}/register"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
@@ -296,13 +297,10 @@ async def test_token_endpoint_forwards_code_verifier():
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         # Call token endpoint with code_verifier
         response = await token_endpoint(
@@ -641,13 +639,10 @@ async def test_token_endpoint_respects_x_forwarded_proto():
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         await token_endpoint(
             request=mock_request,
@@ -947,13 +942,10 @@ async def test_token_endpoint_respects_x_forwarded_host():
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         await token_endpoint(
             request=mock_request,
@@ -1578,14 +1570,11 @@ async def test_token_root_resolves_single_oauth2_server():
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     try:
         with patch(
-            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-            return_value=fake_cm,
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
         ):
             # Call /token WITHOUT mcp_server_name
             response = await token_endpoint(
@@ -2101,13 +2090,10 @@ async def test_token_endpoint_refresh_token_grant():
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         response = await token_endpoint(
             request=mock_request,
@@ -2398,13 +2384,10 @@ async def test_token_endpoint_sets_no_store_cache_control():
     }
     fake_http_client = MagicMock()
     fake_http_client.post = AsyncMock(return_value=fake_http_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=fake_http_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=fake_http_client,
     ):
         response = await exchange_token_with_server(
             request=mock_request,
@@ -2646,13 +2629,10 @@ async def test_exchange_token_omits_placeholder_client_secret(placeholder):
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         await exchange_token_with_server(
             request=mock_request,
@@ -2706,19 +2686,18 @@ async def test_exchange_token_surfaces_upstream_4xx_as_oauth_error_json():
         "error": "invalid_grant",
         "error_description": "AADSTS70008: The provided authorization code or refresh token has expired",
     }
-    mock_response = MagicMock()
-    mock_response.status_code = 400
-    mock_response.json.return_value = upstream_body
+    fake_request = httpx.Request("POST", server.token_url)
+    fake_response = httpx.Response(400, json=upstream_body, request=fake_request)
+    raised = httpx.HTTPStatusError(
+        "400 Bad Request", request=fake_request, response=fake_response
+    )
 
     mock_async_client = MagicMock()
-    mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_async_client.post = AsyncMock(side_effect=raised)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         response = await exchange_token_with_server(
             request=mock_request,
@@ -2769,20 +2748,22 @@ async def test_exchange_token_handles_upstream_non_json_4xx():
     mock_request.base_url = "https://proxy.litellm.example/"
     mock_request.headers = {}
 
-    mock_response = MagicMock()
-    mock_response.status_code = 502
-    mock_response.json.side_effect = ValueError("not json")
-    mock_response.text = "<html>upstream gateway error</html>"
+    fake_request = httpx.Request("POST", server.token_url)
+    fake_response = httpx.Response(
+        502,
+        content=b"<html>upstream gateway error</html>",
+        request=fake_request,
+    )
+    raised = httpx.HTTPStatusError(
+        "502 Bad Gateway", request=fake_request, response=fake_response
+    )
 
     mock_async_client = MagicMock()
-    mock_async_client.post = AsyncMock(return_value=mock_response)
-    fake_cm = MagicMock()
-    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
-    fake_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_async_client.post = AsyncMock(side_effect=raised)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
-        return_value=fake_cm,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
     ):
         response = await exchange_token_with_server(
             request=mock_request,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for MCP OAuth discoverable endpoints"""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -285,25 +286,24 @@ async def test_token_endpoint_forwards_code_verifier():
 
     # Mock httpx client response
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {
         "access_token": "ya29.test_access_token",
         "token_type": "Bearer",
         "expires_in": 3599,
         "scope": "openid email https://www.googleapis.com/auth/drive",
     }
-    mock_response.raise_for_status = MagicMock()
 
-    # Mock the async httpx client with AsyncMock for async methods
-    from unittest.mock import AsyncMock
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
-    ) as mock_get_client:
-        mock_async_client = MagicMock()
-        # Use AsyncMock for the async post method
-        mock_async_client.post = AsyncMock(return_value=mock_response)
-        mock_get_client.return_value = mock_async_client
-
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
         # Call token endpoint with code_verifier
         response = await token_endpoint(
             request=mock_request,
@@ -632,22 +632,23 @@ async def test_token_endpoint_respects_x_forwarded_proto():
 
     # Mock httpx client response
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {
         "access_token": "test_token",
         "token_type": "Bearer",
         "expires_in": 3599,
     }
-    mock_response.raise_for_status = MagicMock()
 
-    # Mock the async httpx client
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
-    ) as mock_get_client:
-        mock_get_client.return_value = mock_async_client
-
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
         await token_endpoint(
             request=mock_request,
             grant_type="authorization_code",
@@ -937,22 +938,23 @@ async def test_token_endpoint_respects_x_forwarded_host():
 
     # Mock httpx client response
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {
         "access_token": "test_token",
         "token_type": "Bearer",
         "expires_in": 3599,
     }
-    mock_response.raise_for_status = MagicMock()
 
-    # Mock the async httpx client
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
-    ) as mock_get_client:
-        mock_get_client.return_value = mock_async_client
-
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
         await token_endpoint(
             request=mock_request,
             grant_type="authorization_code",
@@ -1567,22 +1569,24 @@ async def test_token_root_resolves_single_oauth2_server():
     mock_request.headers = {}
 
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {
         "access_token": "ya29.test_token",
         "token_type": "Bearer",
         "expires_in": 3599,
     }
-    mock_response.raise_for_status = MagicMock()
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     try:
         with patch(
-            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
-        ) as mock_get_client:
-            mock_get_client.return_value = mock_async_client
-
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+            return_value=fake_cm,
+        ):
             # Call /token WITHOUT mcp_server_name
             response = await token_endpoint(
                 request=mock_request,
@@ -2087,22 +2091,24 @@ async def test_token_endpoint_refresh_token_grant():
 
     # Mock httpx client response with new tokens
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {
         "access_token": "new_access_token",
         "token_type": "Bearer",
         "expires_in": 3599,
         "refresh_token": "new_refresh_token",
     }
-    mock_response.raise_for_status = MagicMock()
 
     mock_async_client = MagicMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
-    ) as mock_get_client:
-        mock_get_client.return_value = mock_async_client
-
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
         response = await token_endpoint(
             request=mock_request,
             grant_type="refresh_token",
@@ -2384,18 +2390,21 @@ async def test_token_endpoint_sets_no_store_cache_control():
     mock_request.headers = {}
 
     fake_http_response = MagicMock()
+    fake_http_response.status_code = 200
     fake_http_response.json.return_value = {
         "access_token": "tok",
         "token_type": "Bearer",
         "expires_in": 3600,
     }
-    fake_http_response.raise_for_status = MagicMock()
     fake_http_client = MagicMock()
     fake_http_client.post = AsyncMock(return_value=fake_http_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=fake_http_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
-        return_value=fake_http_client,
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
     ):
         response = await exchange_token_with_server(
             request=mock_request,
@@ -2410,3 +2419,383 @@ async def test_token_endpoint_sets_no_store_cache_control():
 
     assert response.headers["cache-control"] == "no-store"
     assert response.headers["pragma"] == "no-cache"
+
+
+@pytest.mark.asyncio
+async def test_register_client_public_client_returns_real_client_id_and_no_secret():
+    """Bug 1 fix: when client_id is set without client_secret, /register returns
+    the real client_id, no client_secret, and token_endpoint_auth_method=none."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            register_client,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+    public_server = MCPServer(
+        server_id="public_server",
+        name="public_server",
+        server_name="public_server",
+        alias="public_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="real-entra-client-id",
+        client_secret=None,
+        authorization_url="https://login.microsoftonline.com/tid/oauth2/v2.0/authorize",
+        token_url="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+    )
+    global_mcp_server_manager.registry[public_server.server_id] = public_server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    try:
+        with patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._read_request_body",
+            new=AsyncMock(return_value={}),
+        ):
+            result = await register_client(
+                request=mock_request, mcp_server_name="public_server"
+            )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert result == {
+        "client_id": "real-entra-client-id",
+        "redirect_uris": ["https://proxy.litellm.example/callback"],
+        "token_endpoint_auth_method": "none",
+    }
+    assert "client_secret" not in result
+
+
+def test_oauth_authorization_server_metadata_advertises_none_for_public_client():
+    """Bug 2 fix: token_endpoint_auth_methods_supported includes 'none' when the
+    server has client_id but no client_secret."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            _build_oauth_authorization_server_response,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+    public_server = MCPServer(
+        server_id="public_server",
+        name="public_server",
+        server_name="public_server",
+        alias="public_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="real-entra-client-id",
+        client_secret=None,
+        authorization_url="https://login.microsoftonline.com/tid/oauth2/v2.0/authorize",
+        token_url="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+    )
+    global_mcp_server_manager.registry[public_server.server_id] = public_server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    try:
+        result = _build_oauth_authorization_server_response(
+            request=mock_request, mcp_server_name="public_server"
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert result["token_endpoint_auth_methods_supported"] == ["none"]
+
+
+def test_oauth_authorization_server_metadata_keeps_client_secret_post_for_confidential_client():
+    """Bug 2 fix regression guard: confidential client (both client_id +
+    client_secret stored) keeps advertising client_secret_post."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            _build_oauth_authorization_server_response,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+    confidential_server = MCPServer(
+        server_id="confidential_server",
+        name="confidential_server",
+        server_name="confidential_server",
+        alias="confidential_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="real-client-id",
+        client_secret="real-client-secret",
+        authorization_url="https://provider.example/authorize",
+        token_url="https://provider.example/token",
+    )
+    global_mcp_server_manager.registry[confidential_server.server_id] = (
+        confidential_server
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    try:
+        result = _build_oauth_authorization_server_response(
+            request=mock_request, mcp_server_name="confidential_server"
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert result["token_endpoint_auth_methods_supported"] == ["client_secret_post"]
+
+
+def test_oauth_authorization_server_metadata_default_for_unresolved_server():
+    """Bug 2 fix regression guard: unknown server name and empty registry fall
+    back to legacy ['client_secret_post']."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            _build_oauth_authorization_server_response,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    result = _build_oauth_authorization_server_response(
+        request=mock_request, mcp_server_name=None
+    )
+
+    assert result["token_endpoint_auth_methods_supported"] == ["client_secret_post"]
+
+
+@pytest.mark.parametrize("placeholder", [None, "", "dummy"])
+@pytest.mark.asyncio
+async def test_exchange_token_omits_placeholder_client_secret(placeholder):
+    """Cyrus Patch 2: client_secret in (None, '', 'dummy') is dropped from the
+    upstream /token form body."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            exchange_token_with_server,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    server = MCPServer(
+        server_id="public_server",
+        name="public_server",
+        server_name="public_server",
+        alias="public_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="real-client-id",
+        client_secret=None,
+        authorization_url="https://provider.example/authorize",
+        token_url="https://provider.example/token",
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "access_token": "tok",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
+        await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="c",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="real-client-id",
+            client_secret=placeholder,
+            code_verifier="cv",
+        )
+
+    call_args = mock_async_client.post.call_args
+    assert "client_secret" not in call_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_surfaces_upstream_4xx_as_oauth_error_json():
+    """Cyrus Patch 3: when upstream /token returns 400 with AADSTS body, we
+    return that body verbatim with the same status — not a generic 500."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            exchange_token_with_server,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    server = MCPServer(
+        server_id="entra_server",
+        name="entra_server",
+        server_name="entra_server",
+        alias="entra_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="real-client-id",
+        client_secret=None,
+        authorization_url="https://login.microsoftonline.com/tid/oauth2/v2.0/authorize",
+        token_url="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    upstream_body = {
+        "error": "invalid_grant",
+        "error_description": "AADSTS70008: The provided authorization code or refresh token has expired",
+    }
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json.return_value = upstream_body
+
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
+        response = await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="bad-code",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="real-client-id",
+            client_secret=None,
+            code_verifier="cv",
+        )
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == upstream_body
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_exchange_token_handles_upstream_non_json_4xx():
+    """Cyrus Patch 3 edge: upstream returns 4xx with non-JSON body — we wrap it
+    as RFC 6749 invalid_request with the raw text in error_description."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            exchange_token_with_server,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    server = MCPServer(
+        server_id="entra_server",
+        name="entra_server",
+        server_name="entra_server",
+        alias="entra_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="real-client-id",
+        client_secret=None,
+        authorization_url="https://login.microsoftonline.com/tid/oauth2/v2.0/authorize",
+        token_url="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 502
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = "<html>upstream gateway error</html>"
+
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=mock_async_client)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.httpx.AsyncClient",
+        return_value=fake_cm,
+    ):
+        response = await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="c",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="real-client-id",
+            client_secret=None,
+            code_verifier="cv",
+        )
+
+    assert response.status_code == 502
+    body = json.loads(response.body)
+    assert body["error"] == "invalid_request"
+    assert "<html>upstream gateway error</html>" in body["error_description"]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### Behavior contracts (before → after)

**1. `POST /{server}/register` for a public client (`client_id` set, no `client_secret`):**

```diff
- {"client_id": "<server_alias>", "client_secret": "dummy", "redirect_uris": [...]}
+ {"client_id": "<configured_client_id>", "redirect_uris": [...], "token_endpoint_auth_method": "none"}
```

**2. `GET /.well-known/oauth-authorization-server/{server}/mcp` for a public client:**

```diff
-   "token_endpoint_auth_methods_supported": ["client_secret_post"]
+   "token_endpoint_auth_methods_supported": ["none"]
```

Confidential clients and unresolved-server fallback continue to advertise `["client_secret_post"]`.

**3. `POST /{server}/token` form body when an in-flight client replays a cached `"dummy"` (or empty) `client_secret`:**

```diff
  grant_type=authorization_code
  client_id=<configured_client_id>
  code=...
- client_secret=dummy        # rejected by upstream IdP (e.g. AADSTS7000218)
+ # field omitted entirely → upstream IdP accepts as public-client + PKCE
```

**4. `POST /{server}/token` when the upstream IdP returns 4xx (e.g. `AADSTS70008` from Entra):**

```diff
- HTTP/1.1 500 Internal Server Error
- {"error": "MCP request failed", "details": ""}
+ HTTP/1.1 400 Bad Request
+ Cache-Control: no-store
+ {"error": "invalid_grant", "error_description": "AADSTS70008: ..."}
```

The original status code is preserved (4xx stays 4xx). Non-JSON upstream bodies are wrapped as `{"error": "invalid_request", "error_description": "<raw text>"}`. Transport failures surface as 502 `server_error`.

### Test output

```
$ uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py -v -k "public_client or advertises_none or keeps_client_secret_post or default_for_unresolved or omits_placeholder or surfaces_upstream or non_json_4xx"

tests/.../test_discoverable_endpoints.py::test_exchange_token_handles_upstream_non_json_4xx PASSED                       [ 11%]
tests/.../test_discoverable_endpoints.py::test_exchange_token_omits_placeholder_client_secret[None] PASSED               [ 22%]
tests/.../test_discoverable_endpoints.py::test_exchange_token_omits_placeholder_client_secret[] PASSED                   [ 33%]
tests/.../test_discoverable_endpoints.py::test_exchange_token_omits_placeholder_client_secret[dummy] PASSED              [ 44%]
tests/.../test_discoverable_endpoints.py::test_exchange_token_surfaces_upstream_4xx_as_oauth_error_json PASSED           [ 55%]
tests/.../test_discoverable_endpoints.py::test_oauth_authorization_server_metadata_advertises_none_for_public_client PASSED                          [ 66%]
tests/.../test_discoverable_endpoints.py::test_oauth_authorization_server_metadata_default_for_unresolved_server PASSED  [ 77%]
tests/.../test_discoverable_endpoints.py::test_oauth_authorization_server_metadata_keeps_client_secret_post_for_confidential_client PASSED           [ 88%]
tests/.../test_discoverable_endpoints.py::test_register_client_public_client_returns_real_client_id_and_no_secret PASSED [100%]

======================= 9 passed, 58 deselected in 1.87s =======================
```

Full file (60 existing + 7 new = 67 tests): all passing.

```
======================= 67 passed in 3.33s =======================
```

## Type

🐛 Bug Fix

## Changes

Adds public-client (PKCE-broker) support across the MCP OAuth surface in `litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py`. A "public client" here is an MCP server configured with `client_id` but no `client_secret` — common when the upstream IdP (Microsoft Entra, Okta non-DCR) does not issue a client secret to the proxy.

Four changes, all in the same file.

### 1. `register_client_with_server` — public-client branch

When `client_id` is set without `client_secret`, return the configured `client_id` (instead of the server alias), omit `client_secret` from the response, and advertise `token_endpoint_auth_method: "none"`. Previously this path fell through to the confidential-client branch and returned `client_secret: "dummy"` plus the server alias as `client_id`, which downstream MCP clients then cached and forwarded back to the upstream IdP on every `/token` call.

### 2. `_build_oauth_authorization_server_response` — advertise `"none"` for public clients

Per RFC 8414 §2, `token_endpoint_auth_methods_supported` declares which client-authentication methods the authorization server accepts at `/token`. Public clients must advertise `"none"`. The builder now derives the value from the resolved server's posture: `["none"]` for public clients, `["client_secret_post"]` for confidential clients and the unresolved-server fallback (root `/.well-known` or unknown server name). The legacy fallback is preserved so existing flows are unaffected.

This builder is the single source of truth for four `.well-known` route handlers, so all four inherit the fix.

### 3. `exchange_token_with_server` — drop placeholder secrets

Normalize `resolved_client_secret` in `(None, "", "dummy")` to `None` before forwarding the form body to the upstream IdP. This handles in-flight clients that cached the previous `"dummy"` placeholder before change 1 deployed; otherwise the upstream IdP rejects the request (e.g. `AADSTS7000218` from Entra). The two existing `if resolved_client_secret is not None` guards already drop the field correctly once the value is normalized.

### 4. New helper `_post_to_upstream_token_endpoint` — surface upstream `/token` errors as RFC 6749 §5.2 JSON

Wraps the existing pooled `get_async_httpx_client(httpxSpecialProvider.Oauth2Check)` POST and catches the `MaskedHTTPStatusError` (a subclass of `httpx.HTTPStatusError`) raised by the wrapper on 4xx/5xx. Without this catch, the upstream `error` / `error_description` payload (RFC 6749 §5.2) is dropped and the client sees a generic 500.

The helper returns the upstream JSON with the original status code preserved (4xx stays 4xx, not 500), wraps non-JSON bodies as `invalid_request` with the masked text in `error_description`, and surfaces transport failures as 502 `server_error`.

### Backwards compatibility

- Confidential-client behavior (both `client_id` and `client_secret` configured) is unchanged.
- DCR registration via `registration_url` is unchanged.
- The `/.well-known` fallback for unresolved server names continues to advertise `["client_secret_post"]`.
- The pooled httpx client (`get_async_httpx_client`) is preserved — no per-request `httpx.AsyncClient` instances are created.

### Tests

7 new tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py`:

- `test_register_client_public_client_returns_real_client_id_and_no_secret`
- `test_oauth_authorization_server_metadata_advertises_none_for_public_client`
- `test_oauth_authorization_server_metadata_keeps_client_secret_post_for_confidential_client` (regression guard)
- `test_oauth_authorization_server_metadata_default_for_unresolved_server` (regression guard)
- `test_exchange_token_omits_placeholder_client_secret` parametrized over `[None, "", "dummy"]`
- `test_exchange_token_surfaces_upstream_4xx_as_oauth_error_json`
- `test_exchange_token_handles_upstream_non_json_4xx`

All 67 tests in the file pass; `ruff` and `black` clean on changed files; `tests/code_coverage_tests/ensure_async_clients_test.py` clean.