### PR TITLE
Fix: add OpenRouter Qwen 3.6 Plus metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27187,6 +27187,20 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/qwen/qwen3.6-plus": {
+        "input_cost_per_token": 3.25e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.95e-06,
+        "source": "https://openrouter.ai/qwen/qwen3.6-plus",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/qwen/qwen3.5-35b-a3b": {
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "openrouter",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27192,6 +27192,20 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/qwen/qwen3.6-plus": {
+        "input_cost_per_token": 3.25e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.95e-06,
+        "source": "https://openrouter.ai/qwen/qwen3.6-plus",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/qwen/qwen3.5-35b-a3b": {
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "openrouter",

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -110,6 +110,25 @@ def test_wandb_model_api_pricing_entries():
         assert model_info["output_cost_per_token"] == output_cost
 
 
+def test_openrouter_qwen36_plus_model_info():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get("openrouter/qwen/qwen3.6-plus")
+
+    assert model_info is not None
+    assert model_info["litellm_provider"] == "openrouter"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 1000000
+    assert model_info["max_output_tokens"] == 65536
+    assert model_info["input_cost_per_token"] == 3.25e-07
+    assert model_info["output_cost_per_token"] == 1.95e-06
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_tool_choice"] is True
+    assert model_info["supports_reasoning"] is True
+    assert model_info["supports_vision"] is True
+
+
 def test_cost_calculator_with_usage(monkeypatch):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")


### PR DESCRIPTION
## Summary
Adds the missing OpenRouter `qwen/qwen3.6-plus` model metadata to both LiteLLM cost-map files, including context length, output limit, pricing, source URL, and supported capability flags. This fixes local cost-map lookups returning no model info for the new OpenRouter Qwen 3.6 Plus model.

## Repro
A local cost-map lookup for `openrouter/qwen/qwen3.6-plus` previously returned `None`, so cost/context information was unavailable for that OpenRouter model.

## Evidence
Terminal evidence: <a href="/opt/cursor/artifacts/qwen36_model_metadata_test_evidence.txt">qwen36_model_metadata_test_evidence.txt</a>

## Tests
- Reproduced before fix: `pytest tests/test_litellm/test_cost_calculator.py::test_openrouter_qwen36_plus_model_info -q` failed with `assert None is not None`.
- Added `tests/test_litellm/test_cost_calculator.py::test_openrouter_qwen36_plus_model_info`.
- Passed: `pytest tests/test_litellm/test_cost_calculator.py::test_openrouter_qwen36_plus_model_info -q`.
- Passed: `pytest tests/test_litellm/test_cost_calculator.py -q` (`39 passed, 12 warnings`).
- Passed CI lint scope locally: lock check, frozen sync, Black check, Ruff, MyPy, circular import check, import safety check.

## CI
- Available PR checks: all jobs green, including lint, code-quality, validate-model-prices-json, unit-test, provider test groups, proxy test groups, secret-scan, semgrep, and Codecov patch.
- CircleCI pipeline lookup for the fork branch returned no pipeline from the public project API, so there was no CircleCI workflow to triage for this PR.

## Review
- No Greptile review or comment was available after the initial CI wait and polling window, so there were no AI-review threads to address.

## Relevant issues

Fixes #27424

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [x] **CI run for the last commit**  
       Link: Available PR checks are green on the latest commit.

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

See the terminal evidence and tests above.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Added `openrouter/qwen/qwen3.6-plus` to `model_prices_and_context_window.json`.
- Added the same entry to `litellm/model_prices_and_context_window_backup.json`.
- Added a regression test for the local cost-map entry.
