### PR TITLE
Fix team model test connection authorization

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -707,6 +707,8 @@ class LiteLLMRoutes(enum.Enum):
         # Project read routes - endpoint scopes results to caller's teams (non-admin)
         "/project/list",
         "/project/info",
+        # Endpoint enforces proxy-admin vs team-admin model access itself.
+        "/health/test_connection",
         # Invitation routes - org/team admins checked in endpoint via _user_has_admin_privileges
         "/invitation/new",
         "/invitation/delete",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -80,6 +80,28 @@ def test_compliance_routes_open_to_internal_user(route):
     )
 
 
+def test_health_test_connection_route_delegates_internal_user_auth_to_endpoint():
+    """Team model test-connection requests are authorized by the endpoint."""
+    role = LitellmUserRoles.INTERNAL_USER.value
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=role,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=role)
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=role,
+        route="/health/test_connection",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
 @pytest.mark.parametrize(
     "route",
     ["/compliance/eu-ai-act", "/compliance/gdpr"],


### PR DESCRIPTION
## Summary
Fixes: https://github.com/BerriAI/litellm/issues/27304

Allow the model test-connection route to reach its endpoint-specific authorization checks instead of being rejected by the generic proxy-admin route gate. This lets internal users who are team admins test team-scoped model connections while preserving the endpoint's proxy-admin/team-admin validation.

## Repro
A non-proxy-admin internal user opens the add-model flow for a team-scoped model and calls `POST /health/test_connection` with `model_info.team_id` before saving the model. Before this change, the route guard rejects the request before the team-admin check runs.

## Evidence
Terminal transcript from the focused regression proof:

```
.........                                                                [100%]
9 passed in 2.62s
```

## Tests
- Added `tests/test_litellm/proxy/auth/test_route_checks.py::test_health_test_connection_route_delegates_internal_user_auth_to_endpoint`.
- Confirmed the new regression test failed before the fix with the proxy-admin-only error.
- `uv run pytest tests/test_litellm/proxy/auth/test_route_checks.py tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py::TestModelManagementAuthChecks -q` -> 256 passed.
- `uv lock --check` -> passed.
- `cd litellm && uv run --no-sync black --check --exclude '/enterprise/' .` -> passed.
- `cd litellm && uv run --no-sync ruff check .` -> passed.
- `cd litellm && uv run --no-sync mypy .` -> passed.
- `cd litellm && uv run --no-sync python ../tests/documentation_tests/test_circular_imports.py` -> passed.
- `uv run --no-sync python -c "from litellm import *"` -> passed.

## Relevant issues
Fixes #27304

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

See Evidence and Tests above.

## Type

Bug Fix

## Changes

- Added `/health/test_connection` to self-managed routes so endpoint-specific model authorization runs.
- Added a regression test for internal-user route access to the test-connection endpoint.

## CI
- GitHub PR checks: all visible checks passed, including `lint`, `proxy-auth / Run tests`, `proxy-server`, and related coverage jobs (https://github.com/BerriAI/litellm/actions/runs/25575819747 and linked PR checks).
- CircleCI API verification: not available in this environment; public PR/check status was used instead.

## Review
- No Greptile review was posted after the wait window; no automated Greptile threads were available to address.
