### PR TITLE
feat(sso): show full IdP claims in /sso/debug/callback

### DIFF
--- a/litellm/proxy/common_utils/html_forms/jwt_display_template.py
+++ b/litellm/proxy/common_utils/html_forms/jwt_display_template.py
@@ -14,7 +14,7 @@ jwt_display_template = """
             padding: 20px;
             display: flex;
             justify-content: center;
-            align-items: center;
+            align-items: flex-start;
             min-height: 100vh;
             color: #333;
         }
@@ -27,18 +27,18 @@ jwt_display_template = """
             width: 800px;
             max-width: 100%;
         }
-        
+
         .logo-container {
             text-align: center;
             margin-bottom: 30px;
         }
-        
+
         .logo {
             font-size: 24px;
             font-weight: 600;
             color: #1e293b;
         }
-        
+
         h2 {
             margin: 0 0 10px;
             color: #1e293b;
@@ -46,7 +46,14 @@ jwt_display_template = """
             font-weight: 600;
             text-align: center;
         }
-        
+
+        h3 {
+            margin: 0 0 12px;
+            color: #1e293b;
+            font-size: 18px;
+            font-weight: 600;
+        }
+
         .subtitle {
             color: #64748b;
             margin: 0 0 20px;
@@ -58,15 +65,15 @@ jwt_display_template = """
             background-color: #f1f5f9;
             border-radius: 6px;
             padding: 20px;
-            margin-bottom: 30px;
+            margin-bottom: 20px;
             border-left: 4px solid #2563eb;
         }
-        
+
         .success-box {
             background-color: #f0fdf4;
             border-radius: 6px;
             padding: 20px;
-            margin-bottom: 30px;
+            margin-bottom: 20px;
             border-left: 4px solid #16a34a;
         }
 
@@ -78,7 +85,7 @@ jwt_display_template = """
             font-weight: 600;
             font-size: 16px;
         }
-        
+
         .success-header {
             display: flex;
             align-items: center;
@@ -87,46 +94,53 @@ jwt_display_template = """
             font-weight: 600;
             font-size: 16px;
         }
-        
+
         .info-header svg, .success-header svg {
             margin-right: 8px;
         }
-        
+
         .data-container {
             margin-top: 20px;
         }
-        
+
         .data-row {
             display: flex;
             border-bottom: 1px solid #e2e8f0;
             padding: 12px 0;
         }
-        
+
         .data-row:last-child {
             border-bottom: none;
         }
-        
+
         .data-label {
             font-weight: 500;
             color: #334155;
-            width: 180px;
+            width: 220px;
             flex-shrink: 0;
         }
-        
+
         .data-value {
             color: #475569;
             word-break: break-all;
         }
-        
+
+        .empty-note {
+            color: #64748b;
+            font-style: italic;
+            margin: 0;
+            font-size: 14px;
+        }
+
         .jwt-container {
             background-color: #f8fafc;
             border-radius: 6px;
             padding: 15px;
-            margin-top: 20px;
+            margin-top: 12px;
             overflow-x: auto;
             border: 1px solid #e2e8f0;
         }
-        
+
         .jwt-text {
             font-family: monospace;
             white-space: pre-wrap;
@@ -134,7 +148,7 @@ jwt_display_template = """
             margin: 0;
             color: #334155;
         }
-        
+
         .back-button {
             display: inline-block;
             background-color: #6466E9;
@@ -146,18 +160,18 @@ jwt_display_template = """
             margin-top: 20px;
             text-align: center;
         }
-        
+
         .back-button:hover {
             background-color: #4138C2;
             text-decoration: none;
         }
-        
+
         .buttons {
             display: flex;
             gap: 10px;
-            margin-top: 20px;
+            margin-top: 12px;
         }
-        
+
         .copy-button {
             background-color: #e2e8f0;
             color: #334155;
@@ -169,11 +183,11 @@ jwt_display_template = """
             display: flex;
             align-items: center;
         }
-        
+
         .copy-button:hover {
             background-color: #cbd5e1;
         }
-        
+
         .copy-button svg {
             margin-right: 6px;
         }
@@ -188,7 +202,7 @@ jwt_display_template = """
         </div>
         <h2>SSO Debug Information</h2>
         <p class="subtitle">Results from the SSO authentication process.</p>
-        
+
         <div class="success-box">
             <div class="success-header">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -199,11 +213,7 @@ jwt_display_template = """
             </div>
             <p>The SSO authentication completed successfully. Below is the information returned by the provider.</p>
         </div>
-        
-        <div class="data-container" id="userData">
-            <!-- Data will be inserted here by JavaScript -->
-        </div>
-        
+
         <div class="info-box">
             <div class="info-header">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -211,22 +221,62 @@ jwt_display_template = """
                     <line x1="12" y1="16" x2="12" y2="12"></line>
                     <line x1="12" y1="8" x2="12.01" y2="8"></line>
                 </svg>
-                JSON Representation
+                Parsed by Proxy
             </div>
+            <p class="empty-note">Fields the proxy extracted into its internal user model.</p>
+            <div class="data-container" id="parsedByProxy">
+                <!-- Populated by JavaScript -->
+            </div>
+        </div>
+
+        <div class="info-box">
+            <div class="info-header">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"></circle>
+                    <line x1="12" y1="16" x2="12" y2="12"></line>
+                    <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                </svg>
+                Raw Claims (userinfo)
+            </div>
+            <p class="empty-note">Complete set of claims returned by the IdP's userinfo endpoint.</p>
             <div class="jwt-container">
-                <pre class="jwt-text" id="jsonData">Loading...</pre>
+                <pre class="jwt-text" id="rawClaims">Loading...</pre>
             </div>
             <div class="buttons">
-                <button class="copy-button" onclick="copyToClipboard('jsonData')">
+                <button class="copy-button" onclick="copyToClipboard('rawClaims')">
                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
                     </svg>
-                    Copy to Clipboard
+                    Copy
                 </button>
             </div>
         </div>
-        
+
+        <div class="info-box">
+            <div class="info-header">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"></circle>
+                    <line x1="12" y1="16" x2="12" y2="12"></line>
+                    <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                </svg>
+                Access Token Claims
+            </div>
+            <p class="empty-note">Decoded payload of the access token JWT (when the IdP issues one).</p>
+            <div class="jwt-container">
+                <pre class="jwt-text" id="accessTokenClaims">Loading...</pre>
+            </div>
+            <div class="buttons">
+                <button class="copy-button" onclick="copyToClipboard('accessTokenClaims')">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                    </svg>
+                    Copy
+                </button>
+            </div>
+        </div>
+
         <a href="/sso/debug/login" class="back-button">
             Try Another SSO Login
         </a>
@@ -234,39 +284,58 @@ jwt_display_template = """
 
     <script>
         // This will be populated with the actual data from the server
-        const userData = SSO_DATA;
-        
-        function renderUserData() {
-            const container = document.getElementById('userData');
-            const jsonDisplay = document.getElementById('jsonData');
-            
-            // Format JSON with indentation for display
-            jsonDisplay.textContent = JSON.stringify(userData, null, 2);
-            
-            // Clear container
+        const ssoData = SSO_DATA;
+
+        function renderParsed(container, parsed) {
             container.innerHTML = '';
-            
-            // Add each key-value pair to the UI
-            for (const [key, value] of Object.entries(userData)) {
-                if (typeof value !== 'object' || value === null) {
-                    const row = document.createElement('div');
-                    row.className = 'data-row';
-                    
-                    const label = document.createElement('div');
-                    label.className = 'data-label';
-                    label.textContent = key;
-                    
-                    const dataValue = document.createElement('div');
-                    dataValue.className = 'data-value';
-                    dataValue.textContent = value !== null ? value : 'null';
-                    
-                    row.appendChild(label);
-                    row.appendChild(dataValue);
-                    container.appendChild(row);
+            const entries = Object.entries(parsed || {});
+            if (entries.length === 0) {
+                const note = document.createElement('p');
+                note.className = 'empty-note';
+                note.textContent = 'No fields available.';
+                container.appendChild(note);
+                return;
+            }
+            for (const [key, value] of entries) {
+                const row = document.createElement('div');
+                row.className = 'data-row';
+
+                const label = document.createElement('div');
+                label.className = 'data-label';
+                label.textContent = key;
+
+                const dataValue = document.createElement('div');
+                dataValue.className = 'data-value';
+                if (value === null || value === undefined) {
+                    dataValue.textContent = 'null';
+                } else if (typeof value === 'object') {
+                    dataValue.textContent = JSON.stringify(value);
+                } else {
+                    dataValue.textContent = String(value);
                 }
+
+                row.appendChild(label);
+                row.appendChild(dataValue);
+                container.appendChild(row);
             }
         }
-        
+
+        function renderJson(elementId, value) {
+            const el = document.getElementById(elementId);
+            const obj = value || {};
+            if (Object.keys(obj).length === 0) {
+                el.textContent = '(empty — provider returned no claims for this section)';
+            } else {
+                el.textContent = JSON.stringify(obj, null, 2);
+            }
+        }
+
+        function renderUserData() {
+            renderParsed(document.getElementById('parsedByProxy'), ssoData.parsed_by_proxy);
+            renderJson('rawClaims', ssoData.raw_claims);
+            renderJson('accessTokenClaims', ssoData.access_token_claims);
+        }
+
         function copyToClipboard(elementId) {
             const text = document.getElementById(elementId).textContent;
             navigator.clipboard.writeText(text).then(() => {
@@ -275,7 +344,7 @@ jwt_display_template = """
                 console.error('Could not copy text: ', err);
             });
         }
-        
+
         // Render the data when the page loads
         document.addEventListener('DOMContentLoaded', renderUserData);
     </script>

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -4154,7 +4154,7 @@ async def debug_sso_callback(request: Request):
     # Replace the placeholder in the template with the actual data
     html_content = jwt_display_template.replace(
         "const ssoData = SSO_DATA;",
-        f"const ssoData = {json.dumps(sso_payload, indent=2, default=str)};",
+        f"const ssoData = {json.dumps(sso_payload, indent=2, default=str).replace('</', '<\\/')};",
     )
 
     return HTMLResponse(content=html_content)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -4078,6 +4078,8 @@ async def debug_sso_callback(request: Request):
         redirect_url += "/sso/debug/callback"
 
     result = None
+    received_response: Optional[dict] = None
+    access_token_payload: Optional[dict] = None
     if google_client_id is not None:
         result = await GoogleSSOHandler.get_google_callback_response(
             request=request,
@@ -4094,12 +4096,14 @@ async def debug_sso_callback(request: Request):
         )
 
     elif generic_client_id is not None:
-        result, _, _ = await get_generic_sso_response(
-            request=request,
-            jwt_handler=jwt_handler,
-            generic_client_id=generic_client_id,
-            redirect_url=redirect_url,
-            sso_jwt_handler=sso_jwt_handler,
+        result, received_response, access_token_payload = (
+            await get_generic_sso_response(
+                request=request,
+                jwt_handler=jwt_handler,
+                generic_client_id=generic_client_id,
+                redirect_url=redirect_url,
+                sso_jwt_handler=sso_jwt_handler,
+            )
         )
 
     # If result is None, return a basic error message
@@ -4128,10 +4132,29 @@ async def debug_sso_callback(request: Request):
                 except Exception as e:
                     filtered_result[key] = f"Complex value (not displayable): {str(e)}"
 
+    # Defense-in-depth: ensure no bearer tokens leak into the rendered HTML even if
+    # a non-conforming IdP places them in its userinfo response.
+    safe_raw_claims = {
+        k: v
+        for k, v in (received_response or {}).items()
+        if k not in _OAUTH_TOKEN_FIELDS
+    }
+    safe_access_token_claims = {
+        k: v
+        for k, v in (access_token_payload or {}).items()
+        if k not in _OAUTH_TOKEN_FIELDS
+    }
+
+    sso_payload = {
+        "parsed_by_proxy": filtered_result,
+        "raw_claims": safe_raw_claims,
+        "access_token_claims": safe_access_token_claims,
+    }
+
     # Replace the placeholder in the template with the actual data
     html_content = jwt_display_template.replace(
-        "const userData = SSO_DATA;",
-        f"const userData = {json.dumps(filtered_result, indent=2)};",
+        "const ssoData = SSO_DATA;",
+        f"const ssoData = {json.dumps(sso_payload, indent=2, default=str)};",
     )
 
     return HTMLResponse(content=html_content)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -4152,9 +4152,12 @@ async def debug_sso_callback(request: Request):
     }
 
     # Replace the placeholder in the template with the actual data
+    sso_payload_json = json.dumps(sso_payload, indent=2, default=str).replace(
+        "</", "<\\/"
+    )
     html_content = jwt_display_template.replace(
         "const ssoData = SSO_DATA;",
-        f"const ssoData = {json.dumps(sso_payload, indent=2, default=str).replace('</', '<\\/')};",
+        f"const ssoData = {sso_payload_json};",
     )
 
     return HTMLResponse(content=html_content)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -6129,3 +6129,163 @@ class TestPKCEStateCookieBinding:
         # State-cookie check passed, so the function got past the early
         # ProxyException raise and produced an SSO result object.
         assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_debug_sso_callback_renders_full_jwt_claims():
+    """
+    /sso/debug/callback should render the complete set of claims returned by the
+    IdP — both the raw userinfo response and the decoded access-token JWT — in
+    addition to the proxy-parsed OpenID fields. Bearer tokens must be stripped
+    even if a non-conforming IdP places them in its userinfo response.
+    """
+    from litellm.proxy.management_endpoints.ui_sso import debug_sso_callback
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://proxy.example.com/"
+    mock_request.cookies = {}
+    mock_request.query_params = {}
+
+    parsed_openid = CustomOpenID(
+        id="user_123",
+        email="philip@example.com",
+        first_name="Philip",
+        last_name="Schwartz",
+        display_name="Philip Schwartz",
+        provider="generic",
+        team_ids=["ord-engineering-high"],
+        user_role=None,
+    )
+
+    raw_userinfo_with_leaked_token = {
+        "sub": "user_123",
+        "email": "philip@example.com",
+        "team_id": "ord-engineering-high",
+        "team_alias": "ord-engineering-high",
+        "teams": ["ord-engineering-high"],
+        "roles": ["litellm.api.user"],
+        # Defense-in-depth: a non-conforming IdP could shove a bearer token
+        # into userinfo. The debug endpoint must strip it before rendering.
+        "access_token": "should-not-render",
+        "id_token": "should-not-render-either",
+    }
+
+    access_token_payload = {
+        "sub": "user_123",
+        "scope": "openid profile email",
+        "groups": ["litellm-users"],
+    }
+
+    async def fake_get_generic_sso_response(**kwargs):
+        return parsed_openid, raw_userinfo_with_leaked_token, access_token_payload
+
+    with (
+        patch.dict(
+            os.environ,
+            {"GENERIC_CLIENT_ID": "test_client_id"},
+            clear=False,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.get_generic_sso_response",
+            side_effect=fake_get_generic_sso_response,
+        ),
+        patch("litellm.proxy.proxy_server.general_settings", {}),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.jwt_handler", MagicMock(spec=JWTHandler)),
+    ):
+        # Microsoft / Google envs may leak in from other tests — ensure only
+        # the generic path runs.
+        for var in ("MICROSOFT_CLIENT_ID", "GOOGLE_CLIENT_ID"):
+            os.environ.pop(var, None)
+        response = await debug_sso_callback(mock_request)
+
+    body = response.body.decode()
+
+    # The embedded JSON payload drives the rendered page. Extract and parse it
+    # so we can assert on shape, not on cosmetic HTML details.
+    marker = "const ssoData = "
+    start = body.index(marker) + len(marker)
+    end = body.index(";", start)
+    while body[end - 1] not in "}]":  # handle ';' inside string values
+        end = body.index(";", end + 1)
+    payload = json.loads(body[start:end])
+
+    assert set(payload.keys()) == {
+        "parsed_by_proxy",
+        "raw_claims",
+        "access_token_claims",
+    }
+
+    # Parsed OpenID fields are shown
+    assert payload["parsed_by_proxy"]["email"] == "philip@example.com"
+    assert payload["parsed_by_proxy"]["id"] == "user_123"
+
+    # Raw IdP claims surface fields the OpenID model drops (the original LIT-2838 ask)
+    assert payload["raw_claims"]["team_id"] == "ord-engineering-high"
+    assert payload["raw_claims"]["team_alias"] == "ord-engineering-high"
+    assert payload["raw_claims"]["teams"] == ["ord-engineering-high"]
+    assert payload["raw_claims"]["roles"] == ["litellm.api.user"]
+
+    # Defense-in-depth: bearer tokens must never appear in the rendered HTML
+    assert "access_token" not in payload["raw_claims"]
+    assert "id_token" not in payload["raw_claims"]
+    assert "should-not-render" not in body
+
+    # Decoded access-token JWT claims are surfaced
+    assert payload["access_token_claims"]["groups"] == ["litellm-users"]
+
+
+@pytest.mark.asyncio
+async def test_debug_sso_callback_handles_missing_raw_response():
+    """
+    Microsoft and Google paths don't return a raw response or access-token
+    payload. The debug endpoint must still render successfully with empty
+    sections instead of crashing.
+    """
+    from litellm.proxy.management_endpoints.ui_sso import debug_sso_callback
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://proxy.example.com/"
+    mock_request.cookies = {}
+    mock_request.query_params = {}
+
+    parsed_openid = CustomOpenID(
+        id="user_456",
+        email="user@example.com",
+        first_name="Some",
+        last_name="User",
+        display_name="Some User",
+        provider="microsoft",
+        team_ids=[],
+        user_role=None,
+    )
+
+    async def fake_microsoft_callback(**kwargs):
+        return parsed_openid
+
+    with (
+        patch.dict(
+            os.environ,
+            {"MICROSOFT_CLIENT_ID": "test_microsoft_id"},
+            clear=False,
+        ),
+        patch.object(
+            MicrosoftSSOHandler,
+            "get_microsoft_callback_response",
+            side_effect=fake_microsoft_callback,
+        ),
+        patch("litellm.proxy.proxy_server.general_settings", {}),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.jwt_handler", MagicMock(spec=JWTHandler)),
+    ):
+        for var in ("GENERIC_CLIENT_ID", "GOOGLE_CLIENT_ID"):
+            os.environ.pop(var, None)
+        response = await debug_sso_callback(mock_request)
+
+    assert response.status_code == 200
+    body = response.body.decode()
+    assert '"raw_claims": {}' in body
+    assert '"access_token_claims": {}' in body
+    assert "user@example.com" in body


### PR DESCRIPTION
## Summary

`/sso/debug/callback` only showed the proxy-parsed OpenID summary (`id`, `email`, `display_name`, `team_ids`, `user_role`). Customers using custom JWT claim mappings (`team_id_jwt_field`, `team_alias_jwt_field`, etc.) had no way to confirm what their IdP was actually returning — the very fields they configured were invisible in the debug page.

This PR renders two additional sections on the callback HTML:

- **Raw Claims (userinfo)** — full IdP userinfo response.
- **Access Token Claims** — decoded access-token JWT payload (when the IdP issues a JWT, not opaque).

Plus the existing OpenID summary, now labeled **Parsed by Proxy**.

## Screenshots

before 
<img width="2400" height="1858" alt="before" src="https://github.com/user-attachments/assets/33923979-66dc-42a3-8b33-30cb38d9264b" />


after

<img width="2400" height="2944" alt="after" src="https://github.com/user-attachments/assets/16fa32fd-09c3-4fd9-ab3c-072a46565cb1" />


## Test plan
- [x] `make test-unit` for the SSO test module passes locally.
- [x] New: `test_debug_sso_callback_renders_full_jwt_claims` — asserts custom claims (`team_id`, `team_alias`, `teams`, `roles`) reach the rendered HTML, and a planted `access_token` / `id_token` in userinfo is stripped from the response body.
- [x] New: `test_debug_sso_callback_handles_missing_raw_response` — asserts Microsoft / Google paths (which don't return raw responses or access-token payloads today) still render successfully with empty raw-claims and access-token-claims sections.
- [x] End-to-end: ran `/sso/debug/login` -> Auth0 -> `/sso/debug/callback` against an Auth0 tenant with a Post-Login Action emitting custom claims; verified before/after rendering and bearer-token strip on a real flow.

Resolves LIT-2838