### PR TITLE
Fix tag spend reset for budget tiers

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -9,6 +9,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import (
     LiteLLM_BudgetTableFull,
     LiteLLM_EndUserTable,
+    LiteLLM_TagTable,
     LiteLLM_TeamTable,
     LiteLLM_UserTable,
     LiteLLM_VerificationToken,
@@ -81,6 +82,17 @@ class ResetBudgetJob:
         except Exception as e:
             verbose_proxy_logger.warning(
                 "Failed to reset spend counter %s: %s", counter_key, e
+            )
+
+    @staticmethod
+    async def _invalidate_tag_cache(tag_name: str) -> None:
+        try:
+            from litellm.proxy.proxy_server import user_api_key_cache
+
+            await user_api_key_cache.async_delete_cache(key=f"tag:{tag_name}")
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Failed to invalidate tag cache for %s: %s", tag_name, e
             )
 
     async def reset_budget_for_litellm_team_members(
@@ -171,6 +183,52 @@ class ResetBudgetJob:
 
         return update_result
 
+    async def reset_budget_for_tags_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for tags linked to budget tiers that are being reset.
+        """
+        budget_ids = [
+            budget.budget_id
+            for budget in budgets_to_reset
+            if budget.budget_id is not None
+        ]
+        if not budget_ids:
+            return
+
+        where_clause: dict = {
+            "budget_id": {"in": budget_ids},
+            "spend": {"gt": 0},
+        }
+
+        try:
+            tags: List[LiteLLM_TagTable] = (
+                await self.prisma_client.db.litellm_tagtable.find_many(
+                    where=where_clause
+                )
+            )
+        except Exception as e:
+            tags = []
+            verbose_proxy_logger.warning(
+                "Failed to fetch tags for counter invalidation: %s", e
+            )
+
+        update_result = await self.prisma_client.db.litellm_tagtable.update_many(
+            where=where_clause,
+            data={
+                "spend": 0,
+            },
+        )
+
+        for tag in tags:
+            tag_name = getattr(tag, "tag_name", None)
+            if tag_name:
+                await self._invalidate_spend_counter(f"spend:tag:{tag_name}")
+                await self._invalidate_tag_cache(tag_name=tag_name)
+
+        return update_result
+
     async def reset_budget_for_litellm_budget_table(self):
         """
         Resets the budget for all LiteLLM End-Users (Customers), and Team Members if their budget has expired
@@ -234,6 +292,10 @@ class ResetBudgetJob:
                 )
 
                 await self.reset_budget_for_keys_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_tags_linked_to_budgets(
                     budgets_to_reset=budgets_to_reset
                 )
 

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -39,6 +39,23 @@ class MockLiteLLMVerificationToken:
         return {"count": 1}
 
 
+class MockLiteLLMTagTable:
+    def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self.find_many_results: List[Any] = []
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self.find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": len(self.find_many_results)}
+
+
 class MockLiteLLMEndUserTable:
     def __init__(self):
         self.find_many_calls: List[Dict[str, Any]] = []
@@ -56,6 +73,7 @@ class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
+        self.litellm_tagtable = MockLiteLLMTagTable()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
 
 
@@ -615,6 +633,102 @@ def test_budget_table_reset_also_resets_linked_keys(
         f"linked to expiring budgets, but got {len(calls)} update_many calls"
     )
     assert calls[0]["where"]["budget_id"] == {"in": ["7d-budget-tier"]}
+    assert calls[0]["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_caches(monkeypatch):
+    """Resetting tags via budget tier must clear DB spend and stale caches."""
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    user_api_key_cache = MagicMock()
+    user_api_key_cache.async_delete_cache = AsyncMock()
+    fake_module = sys.modules["litellm.proxy.proxy_server"]
+    fake_module.user_api_key_cache = user_api_key_cache
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type("Tag", (), {"tag_name": "tenant:example"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    prisma_client.db.litellm_tagtable.find_many.assert_awaited_once_with(
+        where={"budget_id": {"in": ["budget-1"]}, "spend": {"gt": 0}}
+    )
+    prisma_client.db.litellm_tagtable.update_many.assert_awaited_once_with(
+        where={"budget_id": {"in": ["budget-1"]}, "spend": {"gt": 0}},
+        data={"spend": 0},
+    )
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:tenant:example", value=0.0, ttl=60
+    )
+    user_api_key_cache.async_delete_cache.assert_awaited_once_with(
+        key="tag:tenant:example"
+    )
+
+
+def test_reset_budget_for_tags_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """No tag-table query should run when no expiring budget has an ID."""
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(
+            budgets_to_reset=[type("B", (), {"budget_id": None})]
+        )
+    )
+
+    assert mock_prisma_client.db.litellm_tagtable.find_many_calls == []
+    assert mock_prisma_client.db.litellm_tagtable.update_many_calls == []
+
+
+def test_budget_table_reset_also_resets_linked_tags(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Integration-style test: when a budget tier resets, tags linked to that
+    budget must have spend reset so future tagged requests are not blocked.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 10.0,
+            "budget_duration": "7d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "7d-budget-tier",
+            "created_at": now - timedelta(days=7),
+        },
+    )
+
+    mock_prisma_client.data["budget"] = [test_budget]
+    mock_prisma_client.db.litellm_tagtable.find_many_results = [
+        type(
+            "LiteLLM_TagTable",
+            (),
+            {
+                "tag_name": "tenant:example",
+                "spend": 11.0,
+                "budget_id": "7d-budget-tier",
+            },
+        )
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1, (
+        "Expected reset_budget_for_litellm_budget_table to also reset tags "
+        f"linked to expiring budgets, but got {len(calls)} update_many calls"
+    )
+    assert calls[0]["where"] == {
+        "budget_id": {"in": ["7d-budget-tier"]},
+        "spend": {"gt": 0},
+    }
     assert calls[0]["data"]["spend"] == 0
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes #27481. Tags linked to a budget tier were not reset when that budget tier advanced to its next reset window, leaving stale tag spend over the cap. This adds a tag reset path alongside existing budget-linked key resets and clears stale tag enforcement caches after the DB write.

## Repro
Create a budget tier with a recurring duration, attach a tag to it, send tagged traffic until the tag spend exceeds the tier budget, then wait until the budget tier reset time passes. Before this fix, the budget tier reset time advanced but the tag row spend stayed over budget, so later tagged requests were still rejected.

## Evidence
Terminal evidence artifact: <a href="/opt/cursor/artifacts/tag_budget_reset_test_evidence.txt">tag_budget_reset_test_evidence.txt</a>

Key transcript:
```text
Before production fix:
- tag reset regression tests failed because ResetBudgetJob had no tag reset handler and full budget-table reset made 0 tag update calls.

After fix:
- 3 passed, 31 deselected for the new tag reset regression tests.
- 34 passed, 22 warnings for tests/test_litellm/proxy/common_utils/test_reset_budget_job.py.
- CI-scope lint commands passed: lock check, Black check, Ruff, MyPy, circular-import check, and import-safety check.
```

## Tests
- Added regression coverage in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` for budget-linked tag resets, empty budget-ID input, full budget-table dispatch, spend counter invalidation, and tag object cache invalidation.
- `uv run pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -k "tags_linked_to_budgets or budget_table_reset_also_resets_linked_tags" -vv` ✅
- `uv run pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -vv` ✅
- CI lint workflow commands at repo scope ✅
- `uv run pytest tests/test_litellm/proxy/test_proxy_server.py::test_login_v3_exchange_happy_path tests/test_litellm/proxy/test_proxy_server.py::test_login_v3_exchange_invalid_code tests/test_litellm/proxy/test_proxy_server.py::test_login_v3_exchange_single_use -vv` ✅
- Local CircleCI-equivalent utility job (`tests/litellm_utils_tests`) ⚠️ failed on unrelated existing/provider-dependent utility tests: audio speech health check reported an invalid provider credential, and a provider model-list mock assertion failed.
- `make test-unit-proxy-misc` ⚠️ returned nonzero: 2461 passed, 2 skipped, 3 failed, 3 errors. The health endpoint connection errors reproduced with this PR's changes stashed (`httpx.ConnectError: All connection attempts failed`). The login-v3 failures from the full matrix passed when run in isolation on both the base code and this branch, indicating matrix/environment interaction rather than this change.

## CI
- GitHub Actions: ✅ PR checks are green, including lint, code-quality, proxy-utils, proxy-server, proxy-auth, proxy-infra, proxy-endpoints, unit-test, and related unit shards.
- CircleCI: ⚠️ most status contexts are green. Two status contexts are currently failing: `litellm_utils_testing` (https://circleci.com/gh/BerriAI/litellm/1632991) and `llm_translation_testing` (https://circleci.com/gh/BerriAI/litellm/1632975). CircleCI log API access was unavailable from this environment and the public pages do not expose logs, so I could not fully triage those remote failures. The local equivalent of `litellm_utils_testing` fails on unrelated utility/provider-dependent tests, not the reset-budget code touched here.

## Review
- No Greptile review, comment, or review thread was present after the post-PR wait. I could not run a review loop because there was no Greptile output to act on.

## Relevant issues

Fixes #27481

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack.

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

See `## Evidence` above for the terminal evidence artifact and transcript.

## Type

🐛 Bug Fix
✅ Test

## Changes
- Added `reset_budget_for_tags_linked_to_budgets()` to reset tag spend for expiring budget tiers.
- Invalidated `spend:tag:<tag>` counters and `tag:<tag>` cached tag objects after tag reset writes.
- Wired tag reset into `reset_budget_for_litellm_budget_table()`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7dc0575-8094-4819-9535-bd30c71cbf71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7dc0575-8094-4819-9535-bd30c71cbf71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

