### PR TITLE
fix(proxy): point /metrics 401 at the opt-out flag

### DIFF
--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -79,7 +79,10 @@ class PrometheusAuthMiddleware:
                 # Send 401 response directly via ASGI protocol
                 error_message = getattr(e, "message", str(e))
                 body = json.dumps(
-                    f"Unauthorized access to metrics endpoint: {error_message}"
+                    f"Unauthorized access to metrics endpoint: {error_message} "
+                    f"To allow unauthenticated access, set "
+                    f"`litellm_settings.require_auth_for_metrics_endpoint: false` "
+                    f"in your proxy_config.yaml."
                 ).encode("utf-8")
                 await send(
                     {

--- a/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py
@@ -121,6 +121,26 @@ def test_invalid_auth_metrics(app_with_middleware, monkeypatch):
     assert "Unauthorized access to metrics endpoint" in response.text
 
 
+def test_invalid_auth_metrics_includes_optout_hint(app_with_middleware, monkeypatch):
+    """
+    The 401 body must tell operators how to restore the previous unauthenticated
+    behavior, otherwise a Prometheus scraper that worked pre-upgrade just sees
+    "Malformed API Key" with no actionable migration path.
+    """
+    monkeypatch.setattr(litellm, "require_auth_for_metrics_endpoint", True)
+    monkeypatch.setattr(
+        "litellm.proxy.middleware.prometheus_auth_middleware.user_api_key_auth",
+        fake_invalid_auth,
+    )
+
+    client = TestClient(app_with_middleware)
+    response = client.get("/metrics")
+
+    assert response.status_code == 401, response.text
+    assert "require_auth_for_metrics_endpoint" in response.text
+    assert "false" in response.text
+
+
 def test_metrics_auth_uses_real_auth_when_route_is_public(
     app_with_middleware, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- Operators upgrading past `35bbca60b0` (which made `/metrics` auth default-on) hit `401 "Malformed API Key passed in. Ensure Key has 'Bearer ' prefix."` from any Prometheus scraper that doesn't send credentials, with no hint that the legacy public behavior is one YAML line away.
- Append `litellm_settings.require_auth_for_metrics_endpoint: false` discovery hint to the existing 401 body in `prometheus_auth_middleware.py`. No behavior change — auth still runs, still rejects bad/missing credentials, the legacy opt-out flag still bypasses cleanly. Just a clear migration path in the response operators actually see.

Post-fix body:
> `"Unauthorized access to metrics endpoint: <inner error>. To allow unauthenticated access, set 'litellm_settings.require_auth_for_metrics_endpoint: false' in your proxy_config.yaml."`

## Test plan
- [x] `uv run pytest tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware_asgi.py -v` — 11 passed (including new `test_invalid_auth_metrics_includes_optout_hint`)
- [x] Live proxy: `GET /metrics` with no auth → 401 body now contains the opt-out hint
- [x] Live proxy: `GET /metrics` with valid `Bearer sk-1234` → auth still passes
- [x] Live proxy: `GET /metrics` with invalid Bearer → 401 (auth still rejects), body now contains the opt-out hint
- [x] Live proxy: `GET /metrics` with `require_auth_for_metrics_endpoint: false` → auth bypass still works
- [x] Live proxy: `GET /health/liveliness` (unrelated public endpoint) → still 200