### PR TITLE
fix(proxy): coerce non-str x-litellm-* header values to avoid httpx TypeError (#27458)

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import json
 import re
 import time
 from collections import OrderedDict
@@ -794,8 +795,17 @@ class LiteLLMProxyRequestSetup:
                 )
             )
             for k, v in litellm_logging_metadata_headers.items():
-                if v is not None:
+                if v is None:
+                    continue
+                # httpx requires header values to be str or bytes; coerce numbers/bools
+                # to str and JSON-encode dict/list (e.g. user_api_key_spend is float,
+                # user_api_key_auth_metadata is dict). See #27458.
+                if isinstance(v, (dict, list)):
+                    returned_headers["x-litellm-{}".format(k)] = json.dumps(v)
+                elif isinstance(v, (str, bytes)):
                     returned_headers["x-litellm-{}".format(k)] = v
+                else:
+                    returned_headers["x-litellm-{}".format(k)] = str(v)
 
         return returned_headers
 

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -587,12 +587,21 @@ def test_foward_litellm_user_info_to_backend_llm_call():
         user_api_key_dict=user_api_key_dict,
     )
 
+    # All header values must be str/bytes so httpx won't reject them when the
+    # downstream client builds the request (regression: #27458).
+    for k, v in data.items():
+        assert isinstance(v, (str, bytes)), (
+            f"header {k!r} has non-str value {v!r} ({type(v).__name__}); "
+            "httpx will raise 'Header value must be str or bytes' when the LLM "
+            "request is built."
+        )
+
     expected_data = {
         "x-litellm-user_api_key_user_id": "test_user_id",
         "x-litellm-user_api_key_org_id": "test_org_id",
         "x-litellm-user_api_key_hash": "test_api_key",
-        "x-litellm-user_api_key_spend": 0.0,
-        "x-litellm-user_api_key_auth_metadata": {},
+        "x-litellm-user_api_key_spend": "0.0",
+        "x-litellm-user_api_key_auth_metadata": "{}",
     }
 
     assert json.dumps(data, sort_keys=True) == json.dumps(expected_data, sort_keys=True)


### PR DESCRIPTION
## Summary
Fixes [#27458](https://github.com/BerriAI/litellm/issues/27458) — when `add_user_information_to_llm_headers: true`, the proxy injects `x-litellm-*` headers from `get_sanitized_user_information_from_key()`, but several fields in `StandardLoggingUserAPIKeyMetadata` are non-string by definition:

| field | type |
|---|---|
| `user_api_key_spend` | `Optional[float]` |
| `user_api_key_max_budget` | `Optional[float]` |
| `user_api_key_auth_metadata` | `Optional[Dict[str, str]]` |

These got assigned directly into `returned_headers` and then passed to `httpx.AsyncClient.build_request()`, which raises:

```
TypeError: Header value must be str or bytes, not <class 'float'>
```

The reporter's traceback hits `httpx/_models.py:_normalize_header_value` exactly at the `float` branch, which matches `user_api_key_spend = 0.0` even on a fresh key.

## Fix
In `add_headers_to_llm_call`, coerce values before assigning into headers:
- `dict`/`list` → `json.dumps(v)`
- `str`/`bytes` → unchanged
- everything else (`float`, `int`, `bool`, …) → `str(v)`

## Test
`tests/proxy_unit_tests/test_proxy_utils.py::test_foward_litellm_user_info_to_backend_llm_call` previously *expected* a float and a dict in the output map (it never actually fed the result to httpx, so the regression slipped through). Updated to:
1. Assert every emitted header value is `str`/`bytes` — would have caught this regression.
2. Update the expected map to the coerced shape (`"0.0"`, `"{}"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
