### PR TITLE
fix(ui): remove blank leading entry from access group model dropdown

### DIFF
--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx
@@ -535,6 +535,21 @@ describe("ModelSelect", () => {
     });
   });
 
+  it("should not render an empty optgroup when includeSpecialOptions is omitted", async () => {
+    renderWithProviders(<ModelSelect onChange={mockOnChange} context="global" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-select")).toBeInTheDocument();
+    });
+
+    const optgroups = document.querySelectorAll("optgroup");
+    // Wildcard Options + Models — no blank leading group
+    expect(optgroups.length).toBe(2);
+    optgroups.forEach((g) => {
+      expect(g.getAttribute("label")).toBeTruthy();
+    });
+  });
+
   it("should render maxTagPlaceholder when many items are selected", async () => {
     // Create many models to trigger maxTagCount responsive behavior
     const manyModels: ProxyModel[] = Array.from({ length: 20 }, (_, i) => ({

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
@@ -141,36 +141,38 @@ export const ModelSelect = (props: ModelSelectProps) => {
       onChange={handleChange}
       style={style}
       options={[
-        includeSpecialOptions
-          ? {
-            label: <span>Special Options</span>,
-            title: "Special Options",
-            options: [
-              ...(shouldShowAllProxyModels
-                ? [
-                  {
-                    label: <span>All Proxy Models</span>,
-                    value: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                    disabled:
-                      value.length > 0 &&
-                      value.some(
-                        (v) => isSpecialOption(v) && v !== MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                      ),
-                    key: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                  },
-                ]
-                : []),
-              {
-                label: <span>No Default Models</span>,
-                value: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
-                disabled:
-                  value.length > 0 &&
-                  value.some((v) => isSpecialOption(v) && v !== MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value),
-                key: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
-              },
-            ],
-          }
-          : [],
+        ...(includeSpecialOptions
+          ? [
+            {
+              label: <span>Special Options</span>,
+              title: "Special Options",
+              options: [
+                ...(shouldShowAllProxyModels
+                  ? [
+                    {
+                      label: <span>All Proxy Models</span>,
+                      value: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                      disabled:
+                        value.length > 0 &&
+                        value.some(
+                          (v) => isSpecialOption(v) && v !== MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                        ),
+                      key: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                    },
+                  ]
+                  : []),
+                {
+                  label: <span>No Default Models</span>,
+                  value: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
+                  disabled:
+                    value.length > 0 &&
+                    value.some((v) => isSpecialOption(v) && v !== MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value),
+                  key: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
+                },
+              ],
+            },
+          ]
+          : []),
         ...(wildcard.length > 0
           ? [
             {


### PR DESCRIPTION
# PR: fix(ui): blank leading entry in Models dropdown when creating an access group

> **Branch**: `Bytechoreographer:fix/empty_model`
> **Target**: `BerriAI:litellm_internal_staging`
> **PR link**: https://github.com/Bytechoreographer/litellm/pull/new/fix/empty_model

---

## Relevant issues

<!-- No open issue found; reproduced locally on the Access Groups → Create modal. -->

## Pre-Submission checklist

- [x] `npx vitest run src/components/ModelSelect/ModelSelect.test.tsx` passes (13/13, including a new regression test)
- [x] Scope is isolated: 2 files changed, no new dependencies, no behavior change for callers that already pass `includeSpecialOptions`
- [x] Comment `@greptileai` and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Root cause
<img width="1474" height="868" alt="img_v3_0211h_1b14bc5d-19ad-494d-b649-e3a6b2f6128g" src="https://github.com/user-attachments/assets/2f188a3a-2ec4-486e-a0b7-ce10e8e850db" />

On the **Access Groups → Create** modal, opening the **Allowed Models** dropdown
shows a blank/empty entry as the first item, above the actual model list.

`AccessGroupBaseForm.tsx:81` renders the model picker as
`<ModelSelect context="global" ... />` — without `includeSpecialOptions`. Inside
`ModelSelect.tsx`, the `options` array passed to antd's `Select` is built like
this:

```jsx
options={[
  includeSpecialOptions ? { label: ..., options: [...] } : [],   // ← not spread
  ...(wildcard.length > 0 ? [{...}] : []),
  { label: <span>Models</span>, ... },
]}
```

The first element uses a ternary that **returns `[]`** when
`includeSpecialOptions` is falsy — but it is placed as a single element of the
outer array, not spread. So antd receives:

```
[ [], {Wildcard Options}, {Models} ]
```

antd `Select` walks each top-level element as an option group. The bare `[]`
has no `label` / `value`, so it renders as an empty/blank leading row in the
popup. The two siblings below (`Wildcard Options`, `Models`) already use the
correct `...(cond ? [{...}] : [])` spread pattern; only the Special Options
branch was inconsistent.

**Reproduce:**
1. Navigate to **Access Groups** → click **Create Access Group**.
2. Expand the **Models** section and click the **Allowed Models** dropdown.
3. The first row in the popup is blank ✗; the model list begins on row 2.

### Fix

Change the first branch to match the spread pattern already used by the other
two branches:

```diff
  options={[
-   includeSpecialOptions
-     ? { label: ..., title: "Special Options", options: [ ... ] }
-     : [],
+   ...(includeSpecialOptions
+     ? [
+       { label: ..., title: "Special Options", options: [ ... ] },
+     ]
+     : []),
    ...(wildcard.length > 0 ? [{ ... }] : []),
    { label: <span>Models</span>, title: "Models", options: regular.map(...) },
  ]}
```

Now the array contains only real groups. Empty branches contribute zero
elements instead of an empty array, so the leading blank row disappears.

**No behavior change for callers that pass `includeSpecialOptions={true}`**
(team / organization / user model pickers): before the fix the array was
`[ {special}, {wildcard?}, {models} ]`, after the fix it is still
`[ {special}, {wildcard?}, {models} ]`. The bug only ever manifested when
`includeSpecialOptions` was falsy — which today is just the access-group
create/edit form (`context="global"` without the flag).

### Tests

Added a regression test in `ModelSelect.test.tsx` that renders
`<ModelSelect context="global" />` (the same way `AccessGroupBaseForm` calls
it) and asserts the rendered popup contains exactly two `<optgroup>`s
(`Wildcard Options` + `Models`), each with a non-empty `label`. Before the fix
this test produces three optgroups, the first with `label=undefined` —
matching the visual blank-row symptom.

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx` | Switch the `Special Options` branch to the same `...(cond ? [{...}] : [])` spread pattern used by `Wildcard Options` / `Models`, so a falsy `includeSpecialOptions` contributes zero elements instead of an empty array |
| `ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.test.tsx` | Add regression test asserting no blank leading optgroup is rendered when `includeSpecialOptions` is omitted |
