### PR TITLE
docs(cookbook): add Agent Threat Rules detection callback example

### DIFF
--- a/cookbook/atr_detection_callback/README.md
+++ b/cookbook/atr_detection_callback/README.md
@@ -20,6 +20,12 @@ common categories: instruction override, system prompt exfiltration,
 role-play jailbreak, base64-wrapped payloads, MCP tool override, and
 `file://` SSRF references. The full ruleset lives in the ATR repository.
 
+The hook scans both legacy string `content` and OpenAI structured
+content parts (`[{"type": "text", "text": "..."}]`), concatenating
+the text fields before pattern matching. This keeps the screen
+intact when an attacker splits a payload across multiple text parts.
+Non-text parts (image_url, input_audio, etc.) are ignored.
+
 ## Wire it up
 
 Add a guardrail entry to your proxy config:

--- a/cookbook/atr_detection_callback/README.md
+++ b/cookbook/atr_detection_callback/README.md
@@ -1,0 +1,44 @@
+# Agent Threat Rules detection callback
+
+A small cookbook example that screens user input against ATR-inspired
+threat patterns before the request reaches the model. ATR is an open
+detection standard for AI agent threats (prompt injection, tool
+poisoning, MCP attacks, skill compromise) published under Apache-2.0:
+
+https://github.com/Agent-Threat-Rule/agent-threat-rules
+
+## What it does
+
+`atr_detection_callback.py` defines `ATRDetectionGuardrail`, a
+`CustomGuardrail` whose `async_pre_call_hook` runs each user message
+through a handful of compiled regex patterns. On a match, it logs the
+rule id and raises a `ValueError`, which LiteLLM surfaces to the caller
+as a blocked request.
+
+The patterns embedded in the file are illustrative copies covering
+common categories: instruction override, system prompt exfiltration,
+role-play jailbreak, base64-wrapped payloads, MCP tool override, and
+`file://` SSRF references. The full ruleset lives in the ATR repository.
+
+## Wire it up
+
+Add a guardrail entry to your proxy config:
+
+```yaml
+guardrails:
+  - guardrail_name: "atr-input-screen"
+    litellm_params:
+      guardrail: cookbook.atr_detection_callback.atr_detection_callback.ATRDetectionGuardrail
+      mode: "pre_call"
+      default_on: true
+```
+
+Then start the proxy as usual. Requests containing matching patterns
+will be rejected before the LLM call, and the rule id will appear in
+the proxy logs.
+
+## Extending
+
+To run against the live ATR YAML ruleset instead of embedded patterns,
+load rule files at startup and compile their `detection.regex_patterns`
+fields into the same list shape.

--- a/cookbook/atr_detection_callback/atr_detection_callback.py
+++ b/cookbook/atr_detection_callback/atr_detection_callback.py
@@ -1,0 +1,113 @@
+"""
+ATR detection callback for LiteLLM.
+
+A minimal CustomGuardrail that screens user input against a small set of
+ATR-inspired regex patterns covering common AI agent threats: prompt
+injection overrides, role-play jailbreaks, base64-wrapped instructions,
+MCP tool override, and file:// SSRF. The patterns below are illustrative
+copies; the full open detection set lives in Agent Threat Rules:
+https://github.com/Agent-Threat-Rule/agent-threat-rules (Apache-2.0).
+
+Wire it up via proxy_config.yaml:
+
+    guardrails:
+      - guardrail_name: "atr-input-screen"
+        litellm_params:
+          guardrail: cookbook.atr_detection_callback.atr_detection_callback.ATRDetectionGuardrail
+          mode: "pre_call"
+          default_on: true
+"""
+
+import re
+from typing import Optional, Union
+
+from litellm._logging import verbose_proxy_logger
+from litellm.caching.caching import DualCache
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import CallTypesLiteral
+
+# (rule_id, label, compiled_pattern). rule_id mirrors the ATR namespace.
+ATR_INSPIRED_PATTERNS = [
+    (
+        "ATR-PI-001",
+        "instruction override",
+        re.compile(
+            r"\b(ignore|disregard|forget)\s+(all\s+)?(previous|prior|above)\s+"
+            r"(instructions?|prompts?|rules?)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "ATR-PI-002",
+        "system prompt exfiltration",
+        re.compile(
+            r"(reveal|print|repeat|show)\s+(your\s+)?"
+            r"(system\s+prompt|initial\s+instructions)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "ATR-PI-003",
+        "role-play jailbreak",
+        re.compile(
+            r"\b(you\s+are\s+now|act\s+as|pretend\s+to\s+be)\s+"
+            r"(DAN|developer\s+mode|jailbroken|an?\s+unrestricted)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "ATR-PI-004",
+        "base64-wrapped payload hint",
+        re.compile(
+            r"(decode|run|execute)\s+(this\s+)?base64[:\s]+[A-Za-z0-9+/=]{40,}",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "ATR-MCP-001",
+        "mcp tool override",
+        re.compile(r"<\s*(tool_override|mcp_override|new_tool_definition)\s*>", re.IGNORECASE),
+    ),
+    (
+        "ATR-SSRF-001",
+        "file:// scheme reference",
+        re.compile(r"file://[^\s\"'<>]+", re.IGNORECASE),
+    ),
+]
+
+
+class ATRDetectionGuardrail(CustomGuardrail):
+    """Block requests that hit any ATR-inspired threat pattern."""
+
+    def __init__(self, **kwargs):
+        self.optional_params = kwargs
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def _scan(text: str):
+        for rule_id, label, pattern in ATR_INSPIRED_PATTERNS:
+            if pattern.search(text):
+                return rule_id, label
+        return None
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: CallTypesLiteral,
+    ) -> Optional[Union[Exception, str, dict]]:
+        for message in data.get("messages") or []:
+            content = message.get("content")
+            if not isinstance(content, str):
+                continue
+            hit = self._scan(content)
+            if hit is None:
+                continue
+            rule_id, label = hit
+            verbose_proxy_logger.warning(
+                "ATR threat pattern matched: rule_id=%s label=%s", rule_id, label
+            )
+            raise ValueError(f"Request blocked by ATR guardrail: {rule_id} ({label}).")
+        return data

--- a/cookbook/atr_detection_callback/atr_detection_callback.py
+++ b/cookbook/atr_detection_callback/atr_detection_callback.py
@@ -78,11 +78,38 @@ ATR_INSPIRED_PATTERNS = [
 
 
 class ATRDetectionGuardrail(CustomGuardrail):
-    """Block requests that hit any ATR-inspired threat pattern."""
+    """Block requests that hit any ATR-inspired threat pattern.
+
+    Scans both legacy string content and OpenAI structured content parts
+    (list of {"type": "text", "text": "..."} entries), so a payload split
+    across multiple text parts is concatenated before pattern matching.
+    Non-text parts (image_url, input_audio, etc.) are ignored.
+    """
 
     def __init__(self, **kwargs):
         self.optional_params = kwargs
         super().__init__(**kwargs)
+
+    @staticmethod
+    def _extract_text(content) -> str:
+        """Return scannable text from any OpenAI-shaped message content.
+
+        Supports: string, list of strings, list of structured parts
+        (dicts with type == "text" and a "text" string field). Anything
+        else returns "".
+        """
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, str):
+                    parts.append(part)
+                elif isinstance(part, dict):
+                    if part.get("type") == "text" and isinstance(part.get("text"), str):
+                        parts.append(part["text"])
+            return "\n".join(parts)
+        return ""
 
     @staticmethod
     def _scan(text: str):
@@ -99,10 +126,10 @@ class ATRDetectionGuardrail(CustomGuardrail):
         call_type: CallTypesLiteral,
     ) -> Optional[Union[Exception, str, dict]]:
         for message in data.get("messages") or []:
-            content = message.get("content")
-            if not isinstance(content, str):
+            text = self._extract_text(message.get("content"))
+            if not text:
                 continue
-            hit = self._scan(content)
+            hit = self._scan(text)
             if hit is None:
                 continue
             rule_id, label = hit


### PR DESCRIPTION
This adds a small cookbook example showing how to plug Agent Threat Rules into LiteLLM as a CustomGuardrail. ATR is an open detection standard for AI agent threats (prompt injection, tool poisoning, MCP attacks, skill compromise) released under Apache-2.0 at https://github.com/Agent-Threat-Rule/agent-threat-rules.

The new file cookbook/atr_detection_callback/atr_detection_callback.py defines ATRDetectionGuardrail, a CustomGuardrail subclass whose async_pre_call_hook runs each user message through six ATR-inspired regex patterns covering instruction override, system prompt exfiltration, role-play jailbreak, base64-wrapped payloads, MCP tool override, and file:// SSRF. On match, the callback logs the rule id and raises ValueError, which LiteLLM surfaces as a blocked request.

The patterns embedded in the file are illustrative copies. The full ruleset and the YAML schema live in the ATR repository, and the README in the cookbook directory shows the proxy_config.yaml wiring snippet plus a one-paragraph note on extending the example to load live rule files at startup.

Both files are net-new and additive. No existing cookbook example or core module is modified.

Why this is useful: existing LiteLLM guardrail examples cover provider-specific moderation (OpenAI moderation, Bedrock guardrails, Lakera) but there is no minimal pattern-based example focused on agent-specific threat categories. This fills that gap with a self-contained, dependency-free starting point.