### PR TITLE
fix(proxy): Bedrock Knowledge Base pass-through: preserve SigV4 headers and signed request body

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -71,6 +71,11 @@ class BasePassthroughUtils:
             request_headers.pop("content-length", None)
             request_headers.pop("host", None)
 
+            custom_header_names = {header_name.lower() for header_name in headers}
+            for header_name in list(request_headers.keys()):
+                if header_name.lower() in custom_header_names:
+                    request_headers.pop(header_name, None)
+
             # Combine request headers with custom headers
             headers = {**request_headers, **headers}
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -44,6 +44,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 )
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
 )
 from litellm.proxy.utils import is_known_model
 from litellm.proxy.vector_store_endpoints.utils import (
@@ -1123,6 +1124,9 @@ async def bedrock_proxy_route(
         _forward_headers=True,
     )  # dynamically construct pass-through endpoint based on incoming path
     setattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY, data)
+    # SigV4 signs an exact payload; pass-through must send prepped.body, not json.dumps
+    # of a dict that hooks may mutate (logging_obj, metadata, etc.).
+    setattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, prepped.body)
     received_value = await endpoint_func(
         request,
         fastapi_response,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -739,9 +739,18 @@ async def pass_through_request(  # noqa: PLR0915
         # SigV4-signed callers (e.g. Bedrock) attach the exact bytes that were
         # signed via request.state; we must send those instead of re-encoding the
         # parsed dict (hooks mutate it, breaking the signature / Content-Length).
-        state_raw_body: Optional[Union[str, bytes]] = getattr(
-            request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, None
+        # Tolerate request objects without `state` (test fixtures) and only honor
+        # values httpx accepts for `content=`.
+        _request_state = getattr(request, "state", None)
+        state_raw_body: Optional[Union[str, bytes]] = (
+            getattr(_request_state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, None)
+            if _request_state is not None
+            else None
         )
+        if state_raw_body is not None and not isinstance(
+            state_raw_body, (str, bytes, bytearray)
+        ):
+            state_raw_body = None
 
         # Skip body parsing for multipart requests - make_multipart_http_request will handle it
         # But if custom_body is provided (e.g., JSON parsed despite multipart content-type), use it

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -6,7 +6,7 @@ import posixpath
 import traceback
 from base64 import b64encode
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 from urllib.parse import urlencode, urlparse
 
 import httpx
@@ -62,6 +62,7 @@ from litellm.types.llms.custom_http import httpxSpecialProvider
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     EndpointType,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
     PassthroughStandardLoggingPayload,
 )
 
@@ -375,6 +376,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         headers: dict,
         requested_query_params: Optional[dict] = None,
         custom_body: Optional[dict] = None,
+        custom_raw_body: Optional[Union[str, bytes]] = None,
     ) -> httpx.Response:
         """
         Make a non-streaming HTTP request
@@ -387,6 +389,14 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 url=url,
                 headers=headers,
                 params=requested_query_params,
+            )
+        elif custom_raw_body is not None:
+            response = await async_client.request(
+                method=request.method,
+                url=url,
+                headers=headers,
+                params=requested_query_params,
+                content=custom_raw_body,
             )
         else:
             response = await async_client.request(
@@ -406,6 +416,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         headers: dict,
         requested_query_params: Optional[dict] = None,
         _parsed_body: Optional[dict] = None,
+        custom_raw_body: Optional[Union[str, bytes]] = None,
         forward_multipart: bool = False,
     ) -> httpx.Response:
         """
@@ -419,6 +430,14 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 url=url,
                 headers=headers,
                 params=requested_query_params,
+            )
+        elif custom_raw_body is not None:
+            response = await async_client.request(
+                method=request.method,
+                url=url,
+                headers=headers,
+                params=requested_query_params,
+                content=custom_raw_body,
             )
         elif (
             HttpPassThroughEndpointHelpers.is_multipart(request) is True
@@ -659,6 +678,7 @@ async def pass_through_request(  # noqa: PLR0915
     custom_headers: dict,
     user_api_key_dict: UserAPIKeyAuth,
     custom_body: Optional[dict] = None,
+    custom_raw_body: Optional[Union[str, bytes]] = None,
     forward_headers: Optional[bool] = False,
     merge_query_params: Optional[bool] = False,
     query_params: Optional[dict] = None,
@@ -677,6 +697,9 @@ async def pass_through_request(  # noqa: PLR0915
         custom_headers: The custom headers
         user_api_key_dict: The user API key dictionary
         custom_body: The custom body
+        custom_raw_body: Exact request body bytes/str for upstream (e.g. SigV4-signed).
+            When set, this is sent as ``content=...`` instead of re-encoding ``custom_body``
+            as JSON, so signatures and Content-Length stay consistent.
         forward_headers: Whether to forward headers
         merge_query_params: Whether to merge query params
         query_params: The query params
@@ -738,10 +761,12 @@ async def pass_through_request(  # noqa: PLR0915
         # Skip body parsing for multipart requests - make_multipart_http_request will handle it
         # But if custom_body is provided (e.g., JSON parsed despite multipart content-type), use it
         is_multipart = (
-            HttpPassThroughEndpointHelpers.is_multipart(request) and not custom_body
+            HttpPassThroughEndpointHelpers.is_multipart(request)
+            and custom_body is None
+            and custom_raw_body is None
         )
 
-        if custom_body:
+        if custom_body is not None:
             _parsed_body = custom_body
         elif is_multipart:
             # Don't parse multipart body here - it will be handled by make_multipart_http_request
@@ -883,13 +908,22 @@ async def pass_through_request(  # noqa: PLR0915
                     )
                 )
             else:
-                req = async_client.build_request(
-                    "POST",
-                    url,
-                    json=_parsed_body,
-                    params=requested_query_params,
-                    headers=headers,
-                )
+                if custom_raw_body is not None:
+                    req = async_client.build_request(
+                        "POST",
+                        url,
+                        content=custom_raw_body,
+                        params=requested_query_params,
+                        headers=headers,
+                    )
+                else:
+                    req = async_client.build_request(
+                        "POST",
+                        url,
+                        json=_parsed_body,
+                        params=requested_query_params,
+                        headers=headers,
+                    )
 
                 response = await async_client.send(req, stream=stream)
 
@@ -925,6 +959,7 @@ async def pass_through_request(  # noqa: PLR0915
                 headers=headers,
                 requested_query_params=requested_query_params,
                 _parsed_body=_parsed_body,
+                custom_raw_body=custom_raw_body,
                 forward_multipart=is_multipart,
             )
         )
@@ -1225,7 +1260,7 @@ async def _parse_request_data_by_content_type(
 def create_pass_through_route(
     endpoint,
     target: str,
-    custom_headers: Optional[dict] = None,
+    custom_headers: Optional[Mapping[str, Any]] = None,
     _forward_headers: Optional[bool] = False,
     _merge_query_params: Optional[bool] = False,
     dependencies: Optional[List] = None,
@@ -1334,9 +1369,12 @@ def create_pass_through_route(
                 )
             )
 
-            # Ensure custom_headers is a dict
+            # Ensure custom_headers is a dict. Botocore returns a HeadersDict
+            # for SigV4-prepared requests, which is a Mapping but not a dict.
             headers_dict = (
-                param_custom_headers if isinstance(param_custom_headers, dict) else {}
+                dict(param_custom_headers)
+                if isinstance(param_custom_headers, Mapping)
+                else {}
             )
 
             # Ensure query_params and custom_body are dicts or None
@@ -1350,6 +1388,11 @@ def create_pass_through_route(
             state_custom_body: Optional[dict] = getattr(
                 request.state,
                 LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+                None,
+            )
+            state_raw_body: Optional[Union[str, bytes]] = getattr(
+                request.state,
+                LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
                 None,
             )
             final_custom_body: Optional[dict] = None
@@ -1372,6 +1415,7 @@ def create_pass_through_route(
                     ),
                     stream=is_streaming_request or stream,
                     custom_body=final_custom_body,
+                    custom_raw_body=state_raw_body,
                     cost_per_request=cast(Optional[float], param_cost_per_request),
                     custom_llm_provider=custom_llm_provider,
                     guardrails_config=cast(Optional[dict], param_guardrails),
@@ -1379,6 +1423,8 @@ def create_pass_through_route(
             finally:
                 if hasattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY):
                     delattr(request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY)
+                if hasattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY):
+                    delattr(request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY)
 
     return endpoint_func
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -376,7 +376,6 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         headers: dict,
         requested_query_params: Optional[dict] = None,
         custom_body: Optional[dict] = None,
-        custom_raw_body: Optional[Union[str, bytes]] = None,
     ) -> httpx.Response:
         """
         Make a non-streaming HTTP request
@@ -389,14 +388,6 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 url=url,
                 headers=headers,
                 params=requested_query_params,
-            )
-        elif custom_raw_body is not None:
-            response = await async_client.request(
-                method=request.method,
-                url=url,
-                headers=headers,
-                params=requested_query_params,
-                content=custom_raw_body,
             )
         else:
             response = await async_client.request(
@@ -416,7 +407,6 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         headers: dict,
         requested_query_params: Optional[dict] = None,
         _parsed_body: Optional[dict] = None,
-        custom_raw_body: Optional[Union[str, bytes]] = None,
         forward_multipart: bool = False,
     ) -> httpx.Response:
         """
@@ -430,14 +420,6 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 url=url,
                 headers=headers,
                 params=requested_query_params,
-            )
-        elif custom_raw_body is not None:
-            response = await async_client.request(
-                method=request.method,
-                url=url,
-                headers=headers,
-                params=requested_query_params,
-                content=custom_raw_body,
             )
         elif (
             HttpPassThroughEndpointHelpers.is_multipart(request) is True
@@ -678,7 +660,6 @@ async def pass_through_request(  # noqa: PLR0915
     custom_headers: dict,
     user_api_key_dict: UserAPIKeyAuth,
     custom_body: Optional[dict] = None,
-    custom_raw_body: Optional[Union[str, bytes]] = None,
     forward_headers: Optional[bool] = False,
     merge_query_params: Optional[bool] = False,
     query_params: Optional[dict] = None,
@@ -697,9 +678,6 @@ async def pass_through_request(  # noqa: PLR0915
         custom_headers: The custom headers
         user_api_key_dict: The user API key dictionary
         custom_body: The custom body
-        custom_raw_body: Exact request body bytes/str for upstream (e.g. SigV4-signed).
-            When set, this is sent as ``content=...`` instead of re-encoding ``custom_body``
-            as JSON, so signatures and Content-Length stay consistent.
         forward_headers: Whether to forward headers
         merge_query_params: Whether to merge query params
         query_params: The query params
@@ -758,15 +736,20 @@ async def pass_through_request(  # noqa: PLR0915
             str(url)
         )
 
+        # SigV4-signed callers (e.g. Bedrock) attach the exact bytes that were
+        # signed via request.state; we must send those instead of re-encoding the
+        # parsed dict (hooks mutate it, breaking the signature / Content-Length).
+        state_raw_body: Optional[Union[str, bytes]] = getattr(
+            request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, None
+        )
+
         # Skip body parsing for multipart requests - make_multipart_http_request will handle it
         # But if custom_body is provided (e.g., JSON parsed despite multipart content-type), use it
         is_multipart = (
-            HttpPassThroughEndpointHelpers.is_multipart(request)
-            and custom_body is None
-            and custom_raw_body is None
+            HttpPassThroughEndpointHelpers.is_multipart(request) and not custom_body
         )
 
-        if custom_body is not None:
+        if custom_body:
             _parsed_body = custom_body
         elif is_multipart:
             # Don't parse multipart body here - it will be handled by make_multipart_http_request
@@ -908,22 +891,20 @@ async def pass_through_request(  # noqa: PLR0915
                     )
                 )
             else:
-                if custom_raw_body is not None:
-                    req = async_client.build_request(
-                        "POST",
-                        url,
-                        content=custom_raw_body,
-                        params=requested_query_params,
-                        headers=headers,
-                    )
-                else:
-                    req = async_client.build_request(
-                        "POST",
-                        url,
-                        json=_parsed_body,
-                        params=requested_query_params,
-                        headers=headers,
-                    )
+                # SigV4-signed callers (Bedrock) supply the exact pre-signed bytes;
+                # otherwise httpx encodes the parsed JSON dict as before.
+                body_kwargs: Dict[str, Any] = (
+                    {"content": state_raw_body}
+                    if state_raw_body is not None
+                    else {"json": _parsed_body}
+                )
+                req = async_client.build_request(
+                    "POST",
+                    url,
+                    params=requested_query_params,
+                    headers=headers,
+                    **body_kwargs,
+                )
 
                 response = await async_client.send(req, stream=stream)
 
@@ -951,18 +932,28 @@ async def pass_through_request(  # noqa: PLR0915
                 status_code=response.status_code,
             )
 
-        response = (
-            await HttpPassThroughEndpointHelpers.non_streaming_http_request_handler(
-                request=request,
-                async_client=async_client,
+        if state_raw_body is not None:
+            # SigV4-signed callers (Bedrock) require the exact pre-signed bytes
+            # to be forwarded so the signature/Content-Length stay valid.
+            response = await async_client.request(
+                method=request.method,
                 url=url,
                 headers=headers,
-                requested_query_params=requested_query_params,
-                _parsed_body=_parsed_body,
-                custom_raw_body=custom_raw_body,
-                forward_multipart=is_multipart,
+                params=requested_query_params,
+                content=state_raw_body,
             )
-        )
+        else:
+            response = (
+                await HttpPassThroughEndpointHelpers.non_streaming_http_request_handler(
+                    request=request,
+                    async_client=async_client,
+                    url=url,
+                    headers=headers,
+                    requested_query_params=requested_query_params,
+                    _parsed_body=_parsed_body,
+                    forward_multipart=is_multipart,
+                )
+            )
         verbose_proxy_logger.debug("response.headers= %s", response.headers)
 
         if _is_streaming_response(response) is True:
@@ -1390,11 +1381,6 @@ def create_pass_through_route(
                 LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
                 None,
             )
-            state_raw_body: Optional[Union[str, bytes]] = getattr(
-                request.state,
-                LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
-                None,
-            )
             final_custom_body: Optional[dict] = None
             if isinstance(state_custom_body, dict):
                 final_custom_body = state_custom_body
@@ -1415,7 +1401,6 @@ def create_pass_through_route(
                     ),
                     stream=is_streaming_request or stream,
                     custom_body=final_custom_body,
-                    custom_raw_body=state_raw_body,
                     cost_per_request=cast(Optional[float], param_cost_per_request),
                     custom_llm_provider=custom_llm_provider,
                     guardrails_config=cast(Optional[dict], param_guardrails),

--- a/litellm/types/passthrough_endpoints/pass_through_endpoints.py
+++ b/litellm/types/passthrough_endpoints/pass_through_endpoints.py
@@ -7,6 +7,10 @@ from typing_extensions import TypedDict
 # JSON without a FastAPI `custom_body` parameter (which would consume the HTTP body).
 LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY = "litellm_pass_through_custom_body"
 
+# Request.state key for programmatic pass-through callers that must preserve an
+# exact byte/string body, such as AWS SigV4-signed requests.
+LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY = "litellm_pass_through_raw_body"
+
 
 class EndpointType(str, Enum):
     VERTEX_AI = "vertex-ai"

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -18,6 +18,7 @@ sys.path.insert(
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     HttpPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
     pass_through_request,
 )
 from litellm.proxy.pass_through_endpoints.success_handler import (
@@ -2153,7 +2154,12 @@ async def test_create_pass_through_route_custom_body_url_target():
     endpoint_func = create_pass_through_route(
         endpoint=unique_path,
         target="https://bedrock-agent-runtime.us-east-1.amazonaws.com",
-        custom_headers={"Content-Type": "application/json"},
+        custom_headers=Headers(
+            {
+                "Authorization": "AWS4-HMAC-SHA256 signed",
+                "Content-Type": "application/json",
+            }
+        ),
         _forward_headers=True,
     )
 
@@ -2200,6 +2206,8 @@ async def test_create_pass_through_route_custom_body_url_target():
         setattr(
             mock_request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY, bedrock_body
         )
+        signed_body = json.dumps(bedrock_body)
+        setattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, signed_body)
 
         await endpoint_func(
             request=mock_request,
@@ -2213,6 +2221,11 @@ async def test_create_pass_through_route_custom_body_url_target():
         # The critical assertion: custom_body takes precedence over
         # the body parsed from the raw request
         assert call_kwargs["custom_body"] == bedrock_body
+        assert call_kwargs["custom_raw_body"] == signed_body
+        assert call_kwargs["custom_headers"] == {
+            "authorization": "AWS4-HMAC-SHA256 signed",
+            "content-type": "application/json",
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -20,6 +20,9 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     pass_through_request,
 )
+from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+)
 from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
 )
@@ -2224,6 +2227,141 @@ async def test_create_pass_through_route_custom_body_url_target():
             "authorization": "AWS4-HMAC-SHA256 signed",
             "content-type": "application/json",
         }
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_non_streaming_uses_content_for_state_raw_body():
+    """
+    Bedrock SigV4 path: exact signed bytes live on request.state; upstream must receive
+    content=... even if pre_call_hook mutates the parsed dict (would change json=).
+    """
+    # Bytes that were signed (simulated); parsed body + hook will diverge on purpose.
+    raw_signed = b'{"retrievalQuery":{"text":"signed"},"sig":"intact"}'
+    parsed_from_wire = {"retrievalQuery": {"text": "signed"}, "sig": "intact"}
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.query_params = QueryParams({})
+    mock_request.headers = Headers({"Content-Type": "application/json"})
+    mock_request.state = SimpleNamespace()
+    setattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, raw_signed)
+    mock_request.body = AsyncMock(
+        return_value=json.dumps(parsed_from_wire).encode("utf-8")
+    )
+
+    mock_user = MagicMock()
+    mock_user.api_key = "sk-test"
+
+    upstream = httpx.Response(
+        status_code=200,
+        headers={"content-type": "application/json"},
+        content=b'{"ok": true}',
+        request=httpx.Request(
+            "POST",
+            "https://bedrock-agent-runtime.us-east-1.amazonaws.com/knowledgebases/KB/retrieve",
+        ),
+    )
+
+    mock_async_client = AsyncMock()
+    mock_async_client.request = AsyncMock(return_value=upstream)
+    mock_client_obj = MagicMock()
+    mock_client_obj.client = mock_async_client
+
+    async def _hook_mutates_body(**kwargs):
+        data = kwargs["data"]
+        if isinstance(data, dict):
+            data["hook_mutated"] = True
+        return data
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client",
+            return_value=mock_client_obj,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.pre_call_hook",
+            new=AsyncMock(side_effect=_hook_mutates_body),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler",
+            new=AsyncMock(),
+        ),
+    ):
+        await pass_through_request(
+            request=mock_request,
+            target="https://bedrock-agent-runtime.us-east-1.amazonaws.com/knowledgebases/KB/retrieve",
+            custom_headers={"content-type": "application/json"},
+            user_api_key_dict=mock_user,
+            stream=False,
+        )
+
+    mock_async_client.request.assert_called_once()
+    req_kw = mock_async_client.request.call_args[1]
+    assert req_kw.get("content") == raw_signed
+    assert "json" not in req_kw
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_streaming_uses_content_for_state_raw_body():
+    """Streaming pass-through with state raw body must use build_request(..., content=...)."""
+    raw_signed = b'{"model":"m","stream":true}'
+    parsed_from_wire = {"model": "m", "stream": True}
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.query_params = QueryParams({})
+    mock_request.headers = Headers({"Content-Type": "application/json"})
+    mock_request.state = SimpleNamespace()
+    setattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, raw_signed)
+    mock_request.body = AsyncMock(
+        return_value=json.dumps(parsed_from_wire).encode("utf-8")
+    )
+
+    mock_user = MagicMock()
+    mock_user.api_key = "sk-test"
+
+    mock_built = MagicMock()
+    mock_async_client = AsyncMock()
+    mock_async_client.build_request = MagicMock(return_value=mock_built)
+    stream_resp = httpx.Response(
+        status_code=200,
+        headers={"content-type": "text/event-stream"},
+        content=b"data: {}\n\n",
+        request=httpx.Request("POST", "https://example.com/v1/messages"),
+    )
+    mock_async_client.send = AsyncMock(return_value=stream_resp)
+    mock_client_obj = MagicMock()
+    mock_client_obj.client = mock_async_client
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client",
+            return_value=mock_client_obj,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.pre_call_hook",
+            new=AsyncMock(side_effect=lambda **kw: kw["data"]),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler",
+            new=AsyncMock(),
+        ),
+    ):
+        response = await pass_through_request(
+            request=mock_request,
+            target="https://example.com/v1/messages",
+            custom_headers={"Authorization": "Bearer x"},
+            user_api_key_dict=mock_user,
+            stream=None,
+        )
+
+    from fastapi.responses import StreamingResponse
+
+    assert isinstance(response, StreamingResponse)
+    mock_async_client.build_request.assert_called_once()
+    br_kw = mock_async_client.build_request.call_args[1]
+    assert br_kw.get("content") == raw_signed
+    assert "json" not in br_kw
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -18,7 +18,6 @@ sys.path.insert(
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     HttpPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
-    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
     pass_through_request,
 )
 from litellm.proxy.pass_through_endpoints.success_handler import (
@@ -2206,8 +2205,6 @@ async def test_create_pass_through_route_custom_body_url_target():
         setattr(
             mock_request.state, LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY, bedrock_body
         )
-        signed_body = json.dumps(bedrock_body)
-        setattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, signed_body)
 
         await endpoint_func(
             request=mock_request,
@@ -2221,7 +2218,8 @@ async def test_create_pass_through_route_custom_body_url_target():
         # The critical assertion: custom_body takes precedence over
         # the body parsed from the raw request
         assert call_kwargs["custom_body"] == bedrock_body
-        assert call_kwargs["custom_raw_body"] == signed_body
+        # HeadersDict-like custom_headers (e.g. botocore SigV4) must be coerced
+        # to a plain dict so signed headers actually reach the upstream.
         assert call_kwargs["custom_headers"] == {
             "authorization": "AWS4-HMAC-SHA256 signed",
             "content-type": "application/json",

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -538,6 +538,36 @@ def test_forward_headers_from_request_protected_headers_not_overwritten():
     assert "Anthropic-Beta" not in result
 
 
+def test_forward_headers_custom_wins_case_insensitive_over_request_authorization():
+    """
+    When forwarding request headers, provider-signed/custom headers must win
+    even if the incoming request uses a different case for the same header name.
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+
+    request_headers = {
+        "authorization": "Bearer sk-litellm-key",
+        "content-type": "application/json",
+        "x-request-id": "req-123",
+    }
+    signed_headers = {
+        "Authorization": "AWS4-HMAC-SHA256 signed",
+        "Content-Type": "application/json",
+    }
+
+    result = BasePassthroughUtils.forward_headers_from_request(
+        request_headers=request_headers,
+        headers=signed_headers.copy(),
+        forward_headers=True,
+    )
+
+    assert result["Authorization"] == "AWS4-HMAC-SHA256 signed"
+    assert "authorization" not in result
+    assert result["Content-Type"] == "application/json"
+    assert "content-type" not in result
+    assert result["x-request-id"] == "req-123"
+
+
 @pytest.mark.asyncio
 async def test_vertex_passthrough_custom_model_name_replaced_in_url():
     """


### PR DESCRIPTION
## Linear ticket

Resolves LIT-2966

**Bug:** Bedrock KB pass-through (`POST /bedrock/knowledgebases/…/retrieve`) dropped botocore SigV4 headers (`HeadersDict` was treated as non-`dict` → `{}`), could forward `Bearer` alongside `AWS4` auth, and re-`json=`’d a body hooks had mutated so it no longer matched the signed payload → **403** (“missing equal-sign” in `Authorization`) or hangs.

**Fix:** Coerce `Mapping` headers to `dict`; when `forward_headers=True`, strip request headers that case-insensitively collide with signed/custom headers; stash `prepped.body` on `request.state` and send it as `content=…` in `pass_through_request` so the wire matches SigV4.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(maintainer / author to confirm CI)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Problem**

- Bedrock KB retrieve via proxy (`POST /bedrock/knowledgebases/{id}/retrieve`) could drop botocore SigV4 headers because `prepped.headers` is a `HeadersDict` (`Mapping`, not `dict`), so pass-through coerced “custom headers” to `{}` and only the client’s `Authorization: Bearer …` reached AWS → malformed auth / hangs depending on transport.
- With `forward_headers=True`, request `authorization` (lowercase) could coexist with signed `Authorization`, duplicating auth semantics.
- After hooks inject fields into the parsed JSON dict, re-encoding with `json=` can diverge from the bytes SigV4 signed (`Content-Length` / body mismatch).

**After (runtime)**

- Proxy returns an AWS response quickly (no client hang). Example against a misconfigured KB: `HTTP 400` with AWS body  
  `{"message":"Invalid input or configuration provided. ..."}` — same class of response as a direct signed `POST` to `bedrock-agent-runtime`, proving SigV4 and body reach AWS.
- Debug log shows outbound URL `https://bedrock-agent-runtime.<region>.amazonaws.com/knowledgebases/.../retrieve`, `Authorization: AWS4-HMAC-SHA256…`, and `Content-Length` matching the signed payload.

**Important:** For the KB used in the capture below (`TIXO72HGCJ` in `eu-north-1`), **`HTTP 400` from the fixed proxy is expected and correct.** It means the request reached `bedrock-agent-runtime` with valid SigV4 and AWS returned a **ValidationException**-style message about KB input/configuration—not the previous **`403` “missing equal-sign” in `Authorization`** from malformed client auth reaching AWS.

### Live requests (same curl; RC vs fix)

Use `litellm-proxy` venv, `source .env`, and config `litellm_config/config_venv_1_83_3_minimal.yaml`. Knowledge base path: `/bedrock/knowledgebases/TIXO72HGCJ/retrieve`.

**Shared request**

```http
POST /bedrock/knowledgebases/TIXO72HGCJ/retrieve
Authorization: Bearer sk-123
Content-Type: application/json

{"retrievalQuery":{"text":"test"}}
```

**`curl` (add `-i` for response headers)**

```bash
curl -sS -i --max-time 35 -X POST 'http://127.0.0.1:<PORT>/bedrock/knowledgebases/TIXO72HGCJ/retrieve' \
  -H 'Authorization: Bearer sk-123' \
  -H 'Content-Type: application/json' \
  -d '{"retrievalQuery":{"text":"test"}}'
```

#### Before — `v1.84.0-rc.1` (no fix), proxy e.g. port **4036**

```http
HTTP/1.1 403 Forbidden
date: Sat, 09 May 2026 08:53:17 GMT
server: uvicorn
x-litellm-call-id: 6581523b-3a65-45ea-8bf5-02d78792a165
x-litellm-model-api-base: https://bedrock-agent-runtime.eu-north-1.amazonaws.com/knowledgebases/TIXO72HGCJ/retrieve
x-litellm-key-spend: 0.0
content-length: 246
content-type: application/json

{"error":{"message":"{\"message\":\"Invalid key=value pair (missing equal-sign) in Authorization header (hashed with SHA-256 and encoded with Base64): 'Gp8sbH4GYN+oHjYn0EUrSOuivOCwhx+sCUf3IkSFTi0='.\"}","type":"None","param":"None","code":"403"}}
```

#### After — branch `litellm_bedrock_kb_passthrough_sigv4_fix`, proxy e.g. port **4035**

**`HTTP 400` is expected** here: AWS accepted the transport/auth and responded with a KB validation/configuration error for this resource.

```http
HTTP/1.1 400 Bad Request
date: Sat, 09 May 2026 08:53:35 GMT
server: uvicorn
x-litellm-call-id: a6c44259-af96-48a8-8554-a46c22f2035b
x-litellm-model-api-base: https://bedrock-agent-runtime.eu-north-1.amazonaws.com/knowledgebases/TIXO72HGCJ/retrieve
x-litellm-key-spend: 0.0
content-length: 201
content-type: application/json

{"error":{"message":"{\"message\":\"Invalid input or configuration provided. Check the input and Knowledge Base configuration and try your request again.\"}","type":"None","param":"None","code":"400"}}
```

**Tests**

- `test_forward_headers_custom_wins_case_insensitive_over_request_authorization` — custom/signed headers win over forwarded request headers when names differ only by case.
- `test_create_pass_through_route_custom_body_url_target` — non-dict `custom_headers` (e.g. Starlette `Headers`) is coerced to a plain dict so values are not dropped.

## Type

🐛 Bug Fix

## Changes

- **`create_pass_through_route`**: Treat `custom_headers` as `Optional[Mapping[str, Any]]` and normalize with `dict(...)` when it is a `Mapping`, so botocore `HeadersDict` from SigV4-prepared requests is not replaced by `{}`.
- **`BasePassthroughUtils.forward_headers_from_request`**: When `forward_headers=True`, remove incoming request header names that collide **case-insensitively** with keys already in the custom/signed header dict before merging, so client `Bearer` does not sit beside `Authorization: AWS4-...`.
- **Bedrock KB pass-through** (`bedrock_proxy_route`): Store `prepped.body` on `request.state` under `LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY` (see `litellm/types/passthrough_endpoints/pass_through_endpoints.py`).
- **`pass_through_request`**: If that state key is set, send the exact bytes with `content=...` (streaming and non-streaming paths); otherwise keep the existing JSON path. Clear the raw-body state key in `create_pass_through_route`’s `finally` alongside the existing custom-body key.