### PR TITLE
fix(otel): serialize dict/list span attributes as JSON instead of Python repr

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1049,7 +1049,10 @@ class OpenTelemetry(CustomLogger):
             "vector_store_request_metadata",
         ]:
             if md.get(key) is not None:
-                common_attrs[f"metadata.{key}"] = str(md[key])
+                val = md[key]
+                common_attrs[f"metadata.{key}"] = (
+                    safe_dumps(val) if isinstance(val, (dict, list)) else str(val)
+                )
 
         # get hidden params
         hidden_params = getattr(std_log, "hidden_params", None) or (std_log or {}).get(
@@ -2065,6 +2068,8 @@ class OpenTelemetry(CustomLogger):
             return ""
         if isinstance(value, (str, bool, int, float)):
             return value
+        if isinstance(value, (dict, list)):
+            return safe_dumps(value)
         try:
             return str(value)
         except Exception:

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4279,3 +4279,37 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
             2,
             f"Two distinct guardrail invocations expected, got {len(guardrail_spans)}",
         )
+
+class TestCastAsPrimitiveValueType(unittest.TestCase):
+    """Tests for _cast_as_primitive_value_type JSON serialization.
+
+    Regression tests for https://github.com/BerriAI/litellm/issues/27451
+    """
+
+    def setUp(self):
+        self.otel = OpenTelemetry()
+
+    def test_dict_serialized_as_json(self):
+        result = self.otel._cast_as_primitive_value_type({"key": "value", "n": 1})
+        parsed = json.loads(result)
+        assert parsed == {"key": "value", "n": 1}
+
+    def test_list_serialized_as_json(self):
+        result = self.otel._cast_as_primitive_value_type(["a", "b"])
+        parsed = json.loads(result)
+        assert parsed == ["a", "b"]
+
+    def test_nested_dict_serialized_as_json(self):
+        value = {"outer": {"inner": [1, 2, 3]}}
+        result = self.otel._cast_as_primitive_value_type(value)
+        parsed = json.loads(result)
+        assert parsed == value
+
+    def test_primitives_unchanged(self):
+        assert self.otel._cast_as_primitive_value_type("hello") == "hello"
+        assert self.otel._cast_as_primitive_value_type(42) == 42
+        assert self.otel._cast_as_primitive_value_type(3.14) == 3.14
+        assert self.otel._cast_as_primitive_value_type(True) is True
+
+    def test_none_returns_empty_string(self):
+        assert self.otel._cast_as_primitive_value_type(None) == ""

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4313,3 +4313,41 @@ class TestCastAsPrimitiveValueType(unittest.TestCase):
 
     def test_none_returns_empty_string(self):
         assert self.otel._cast_as_primitive_value_type(None) == ""
+
+
+class TestRecordMetricsJsonSerialization(unittest.TestCase):
+    """Tests that _record_metrics serializes dict metadata as JSON.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/27451
+    """
+
+    def test_record_metrics_serializes_spend_logs_metadata_as_json(self):
+        otel = OpenTelemetry()
+        mock_histogram = MagicMock()
+        otel._operation_duration_histogram = mock_histogram
+        otel._token_usage_histogram = None
+
+        spend_metadata = {"user": "alice", "cost": 0.05}
+        kwargs = {
+            "model": "test-model",
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "standard_logging_object": {
+                "metadata": {
+                    "spend_logs_metadata": spend_metadata,
+                    "user_api_key_hash": "hash123",
+                }
+            },
+        }
+
+        otel._record_metrics(
+            kwargs=kwargs,
+            response_obj={},
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        )
+
+        recorded_attrs = mock_histogram.record.call_args[1]["attributes"]
+        raw = recorded_attrs["metadata.spend_logs_metadata"]
+        parsed = json.loads(raw)
+        assert parsed == spend_metadata
+        assert recorded_attrs["metadata.user_api_key_hash"] == "hash123"


### PR DESCRIPTION
## Relevant issues

Fixes #27451

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

- Bug Fix

## Changes

Dict and list values in OTEL span attributes (e.g. `spend_logs_metadata`, `requester_metadata`, `applied_guardrails`) are serialized with Python's `str()`, which produces `{'key': 'value'}` (single-quoted Python repr). Downstream OTEL tools (Jaeger, Honeycomb, Grafana Tempo) cannot parse this as valid JSON.

Two locations fixed:

1. `_cast_as_primitive_value_type()` -- the general attribute-setting path via `safe_set_attribute()`. Added a `dict`/`list` check before the `str()` fallback to use `safe_dumps()` instead.

2. `_record_metrics()` -- the metrics path that bypasses `safe_set_attribute()` entirely. Changed `str(md[key])` to use `safe_dumps()` for dict/list values.

`safe_dumps` is already imported and used elsewhere in the same file (for `hidden_params`, messages, etc.). It handles circular references, Pydantic models, and non-serializable objects gracefully via `json.dumps()`.

### Files changed

- `litellm/integrations/opentelemetry.py` -- use `safe_dumps()` for dict/list values in both attribute-setting paths
- `tests/test_litellm/integrations/test_opentelemetry.py` -- 5 regression tests for `_cast_as_primitive_value_type` JSON serialization