### PR TITLE
fix(bedrock/messages): preserve compact_20260112 context_management on /v1/messages

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -408,6 +408,47 @@ class AmazonAnthropicClaudeMessagesConfig(
             if self._supports_tool_search_on_bedrock(model):
                 beta_set.add("tool-search-tool-2025-10-19")
 
+    @staticmethod
+    def _filter_context_management_for_bedrock_invoke(
+        anthropic_messages_request: Dict,
+        beta_set: set,
+    ) -> None:
+        """
+        Bedrock InvokeModel accepts ``context_management`` only when it carries
+        ``compact_20260112`` edits paired with the ``compact-2026-01-12``
+        anthropic-beta header. Other edit types (notably ``clear_thinking_20251015``,
+        which Claude Code sends on every request) are LiteLLM-internal and would
+        cause Bedrock to 400 with ``"context_management: Extra inputs are not
+        permitted"``.
+
+        Filter the edits list to the supported subset, add the beta header when
+        compact edits remain, and drop ``context_management`` entirely when no
+        supported edits are left so the safety-net allowlist can pass it through.
+
+        Ref: https://github.com/BerriAI/litellm/issues/27532
+        """
+        cm = anthropic_messages_request.get("context_management")
+        if not isinstance(cm, dict):
+            return
+        edits = cm.get("edits")
+        if not isinstance(edits, list):
+            anthropic_messages_request.pop("context_management", None)
+            return
+
+        compact_edits = [
+            e
+            for e in edits
+            if isinstance(e, dict) and e.get("type") == "compact_20260112"
+        ]
+        if compact_edits:
+            beta_set.add("compact-2026-01-12")
+            anthropic_messages_request["context_management"] = {
+                **cm,
+                "edits": compact_edits,
+            }
+        else:
+            anthropic_messages_request.pop("context_management", None)
+
     def _convert_output_format_to_inline_schema(
         self,
         output_format: Dict,
@@ -551,6 +592,11 @@ class AmazonAnthropicClaudeMessagesConfig(
         if injected_thinking_for_clear_thinking:
             beta_set.add("interleaved-thinking-2025-05-14")
 
+        self._filter_context_management_for_bedrock_invoke(
+            anthropic_messages_request=anthropic_messages_request,
+            beta_set=beta_set,
+        )
+
         self._get_tool_search_beta_header_for_bedrock(
             model=model,
             tool_search_used=tool_search_used,
@@ -597,8 +643,9 @@ class AmazonAnthropicClaudeMessagesConfig(
             anthropic_messages_request.pop("output_config", None)
 
         # 7. Final safety net: filter top-level fields to the Bedrock Invoke allowlist.
-        # Catches Anthropic-only extensions (context_management, output_config, speed,
-        # mcp_servers, ...) and any future additions Claude Code may start sending.
+        # Catches Anthropic-only extensions (output_config, speed, mcp_servers, ...)
+        # and any future additions Claude Code may start sending. ``context_management``
+        # has already been pre-filtered to its Bedrock-supported subset above.
         allowed = self.BEDROCK_INVOKE_ALLOWED_TOP_LEVEL_FIELDS
         stripped = sorted(k for k in anthropic_messages_request if k not in allowed)
         if stripped:

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -1042,3 +1042,10 @@ class BedrockInvokeAnthropicMessagesRequest(TypedDict, total=False):
     thinking: dict
     metadata: dict
     output_config: dict
+
+    # `context_management` is allowed for Bedrock InvokeModel only when it
+    # carries `compact_20260112` edits paired with the `compact-2026-01-12`
+    # anthropic-beta header. The Invoke transformation filters edits to the
+    # supported subset and strips the field entirely when nothing remains, so
+    # other edit types (e.g. `clear_thinking_20251015`) never reach Bedrock.
+    context_management: dict

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -867,10 +867,12 @@ def test_bedrock_messages_explicit_output_config_wins_over_reasoning_effort():
 def test_bedrock_messages_strips_context_management():
     """
     Ensure context_management is stripped from the request before sending to
-    Bedrock Invoke, which doesn't support this Anthropic-specific parameter.
+    Bedrock Invoke when it carries only LiteLLM-internal edits (e.g.
+    clear_thinking_20251015, which is consumed via thinking injection).
 
-    Claude Code sends context_management on every request; leaving it in the body
-    causes a 400 "context_management: Extra inputs are not permitted" from Bedrock.
+    Claude Code sends context_management on every request; leaving such edits
+    in the body causes a 400 "context_management: Extra inputs are not
+    permitted" from Bedrock.
     """
     from litellm.types.router import GenericLiteLLMParams
 
@@ -895,6 +897,77 @@ def test_bedrock_messages_strips_context_management():
         "context_management" not in result
     ), "context_management should be stripped — Bedrock Invoke rejects it"
     assert result.get("max_tokens") == 4096
+
+
+def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
+    """
+    Bedrock InvokeModel supports compaction when paired with the
+    ``compact-2026-01-12`` anthropic-beta header, even though the Converse API
+    does not. The transformation should:
+      1. Keep ``context_management`` with compact_20260112 edits in the body
+         (Bedrock rejects unknown top-level fields, but accepts this one with
+         the right beta).
+      2. Auto-inject ``compact-2026-01-12`` into ``anthropic_beta``.
+
+    Ref: https://github.com/BerriAI/litellm/issues/27532
+    """
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [{"type": "compact_20260112"}]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-sonnet-4-6-20250929-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("context_management") == {
+        "edits": [{"type": "compact_20260112"}]
+    }
+    assert "compact-2026-01-12" in result.get("anthropic_beta", [])
+    assert result["max_tokens"] == 4096
+
+
+def test_bedrock_messages_filters_unsupported_context_management_edits():
+    """
+    Mixed edit lists must drop the LiteLLM-internal ``clear_thinking_20251015``
+    entries while keeping ``compact_20260112`` and adding the compact beta.
+    """
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "clear_thinking_20251015", "keep": "all"},
+                {"type": "compact_20260112"},
+            ]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-sonnet-4-6-20250929-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("context_management") == {
+        "edits": [{"type": "compact_20260112"}]
+    }
+    assert "compact-2026-01-12" in result.get("anthropic_beta", [])
 
 
 def test_bedrock_messages_allowlist_filters_anthropic_only_fields():


### PR DESCRIPTION
## Summary

Fixes #27532

Bedrock **InvokeModel** supports Anthropic compaction (`compact-2026-01-12` beta) when `context_management` is sent with the matching `anthropic-beta` header. Only the **Converse** API rejects it. The current `/v1/messages` → Bedrock Invoke transformation in `anthropic_claude3_transformation.py` strips `context_management` unconditionally via the allowlist safety net, so:

- Claude Code clients that send `context_management.edits=[{type: compact_20260112}]` lose compaction silently, **or**
- on older LiteLLM versions Bedrock 400s with `"context_management: Extra inputs are not permitted"` because the beta header isn't auto-injected.

## Fix

Pre-filter `context_management` before the existing safety-net strip in `transform_anthropic_messages_request`:

1. Keep edits with `type=compact_20260112` (the only Bedrock-supported edit type).
2. Auto-inject `compact-2026-01-12` into `anthropic_beta` when any compact edits survive — same pattern as Vertex AI's `_add_context_management_beta_headers`.
3. Drop the field entirely when nothing supported remains, so LiteLLM-internal edits like `clear_thinking_20251015` (which are consumed via thinking injection elsewhere) stay out of the outgoing body.
4. Add `context_management: dict` to `BedrockInvokeAnthropicMessagesRequest` so the filtered field passes the allowlist.

`anthropic_beta_headers_config.json` already maps `compact-2026-01-12 → compact-2026-01-12` for the `bedrock` provider, so no further header config change is needed.

## Test plan

- [x] `test_bedrock_messages_strips_context_management` (existing, clear_thinking-only) — still strips, since no compact edits survive the filter.
- [x] `test_bedrock_messages_allowlist_filters_anthropic_only_fields` (existing, empty edits list) — still strips.
- [x] `test_bedrock_messages_preserves_compact_context_management_and_adds_beta` (new) — compact edits stay in body and `compact-2026-01-12` is added to `anthropic_beta`.
- [x] `test_bedrock_messages_filters_unsupported_context_management_edits` (new) — mixed list keeps only compact edits and adds the beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)