### PR TITLE
fix(ui-tests): add Typography to antd mock in create_key_button test

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
@@ -155,6 +155,15 @@ vi.mock("antd", () => {
   const Button = ({ children, htmlType, ...props }: { children?: any; htmlType?: string }) =>
     React.createElement("button", { ...props, type: htmlType ?? props.type }, children);
 
+  const Typography = ({ children, ...props }: { children?: any }) =>
+    React.createElement("div", props, children);
+  Typography.Text = ({ children, ...props }: { children?: any }) =>
+    React.createElement("span", props, children);
+  Typography.Paragraph = ({ children, ...props }: { children?: any }) =>
+    React.createElement("p", props, children);
+  Typography.Title = ({ children, ...props }: { children?: any }) =>
+    React.createElement("h1", props, children);
+
   return {
     Button,
     Form,
@@ -171,6 +180,7 @@ vi.mock("antd", () => {
     Switch,
     Tag,
     Tooltip,
+    Typography,
   };
 });
 


### PR DESCRIPTION
## Summary

All 15 tests in `ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx` were failing deterministically in CI with:

```
Error: [vitest] No "Typography" export is defined on the "antd" mock.
```

PR #27218 switched the key-type dropdown labels in `create_key_button.tsx` to use `Typography.Text` / `Typography.Paragraph` from `antd`, but the local `vi.mock("antd", ...)` in the sibling test file does not export `Typography`. Adding `Typography` (with `.Text`, `.Paragraph`, `.Title` subcomponents) to the mock restores the test suite.

## Test plan

- [x] `npx vitest run src/components/organisms/create_key_button.test.tsx` passes locally — all 15 tests green
- [ ] CircleCI `litellm-dashboard-ui-tests` job passes on this branch