### PR TITLE
fix(ui): don't overwrite guardrails with empty array on model edit

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -579,6 +579,34 @@ describe("ModelInfoView", () => {
     expect(updatePayload.litellm_params).not.toHaveProperty("vector_store_ids");
   });
 
+  it("should not include guardrails in update payload when model has none and user does not touch the field", async () => {
+    // Regression: editing a model without guardrails used to inject
+    // guardrails: [] into litellm_params on every save, because the
+    // submit handler used `if (values.guardrails)` and an empty array
+    // is truthy in JavaScript.
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.litellm_params).not.toHaveProperty("guardrails");
+  });
+
   it("should not include input_cost_per_token or output_cost_per_token in update payload when user does not touch cost fields", async () => {
     // Regression: editing a model without touching cost fields used to inject
     // input_cost_per_token: 0 and output_cost_per_token: 0 into litellm_params,

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -268,8 +268,13 @@ export default function ModelInfoView({
       } else {
         delete updatedLitellmParams.litellm_credential_name;
       }
-      if (values.guardrails) {
+      if (values.guardrails?.length > 0) {
         updatedLitellmParams.guardrails = values.guardrails;
+      } else if (values.guardrails !== undefined) {
+        // User explicitly cleared previously-set guardrails — send [] to clear on backend
+        updatedLitellmParams.guardrails = [];
+      } else {
+        delete updatedLitellmParams.guardrails;
       }
       if (values.vector_store_ids?.length > 0) {
         updatedLitellmParams.vector_store_ids = values.vector_store_ids;
@@ -637,9 +642,11 @@ export default function ModelInfoView({
                     model_access_group: Array.isArray(localModelData.model_info?.access_groups)
                       ? localModelData.model_info.access_groups
                       : [],
-                    guardrails: Array.isArray(localModelData.litellm_params?.guardrails)
-                      ? localModelData.litellm_params.guardrails
-                      : [],
+                    guardrails:
+                      Array.isArray(localModelData.litellm_params?.guardrails) &&
+                      localModelData.litellm_params.guardrails.length > 0
+                        ? localModelData.litellm_params.guardrails
+                        : undefined,
                     vector_store_ids:
                       Array.isArray(localModelData.litellm_params?.vector_store_ids) &&
                       localModelData.litellm_params.vector_store_ids.length > 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Reported via Slack (#ui-engineering): user edited litellm params for an Anthropic model in the Admin UI and noticed an empty `"guardrails": []` was persisted into the model's `litellm_params`, even though they hadn't touched the guardrails field. They also hit `prompt_id is required for Prompt Management Base class` on inference, and recalled "i thought this was fixed somewhere" — referring to the analogous `vector_store_ids` fix from #91d88737b4.

## Root cause

In `ui/litellm-dashboard/src/components/model_info_view.tsx`, the edit-model form initialized `guardrails` to `[]` and then included it in the update payload via:

```ts
if (values.guardrails) {
  updatedLitellmParams.guardrails = values.guardrails;
}
```

Empty arrays are truthy in JavaScript, so `if ([])` is `true`. Editing any unrelated field (e.g. `temperature`) on a model without guardrails would inject `guardrails: []` into the model's `litellm_params` via the PATCH-merge backend, polluting the saved config.

## Fix

Mirror the `vector_store_ids` pattern directly above:

- Initialize the form value to `undefined` when there are no stored guardrails, so the submit handler can distinguish *untouched* from *cleared*.
- Only include the field when `length > 0`; if the user explicitly cleared previously-set guardrails, send `[]` to clear on the backend; otherwise `delete` the key from the payload so PATCH leaves the stored value untouched.

```ts
if (values.guardrails?.length > 0) {
  updatedLitellmParams.guardrails = values.guardrails;
} else if (values.guardrails !== undefined) {
  // User explicitly cleared previously-set guardrails — send [] to clear on backend
  updatedLitellmParams.guardrails = [];
} else {
  delete updatedLitellmParams.guardrails;
}
```

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** — added a regression test in `ui/litellm-dashboard/src/components/model_info_view.test.tsx` that asserts `guardrails` is not in the update payload when the model has none and the user does not touch the field. The existing `vector_store_ids` regression test lives next to it.
- [x] My PR passes all unit tests — `npx vitest run src/components/model_info_view.test.tsx` → 36/36 passing.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.

## Type

🐛 Bug Fix

## Changes

- `ui/litellm-dashboard/src/components/model_info_view.tsx`
  - Initialize `guardrails` form value to `undefined` (not `[]`) when the model has no guardrails configured.
  - Replace the truthy-array check in the submit handler with a length-aware branch that mirrors `vector_store_ids` semantics.
- `ui/litellm-dashboard/src/components/model_info_view.test.tsx`
  - New regression test: `should not include guardrails in update payload when model has none and user does not touch the field`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C09JWQ7PZ29/p1778203593355109?thread_ts=1778203593.355109&cid=C09JWQ7PZ29)

<div><a href="https://cursor.com/agents/bc-9ca47644-0d4c-5f5f-937b-380f8e888da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ca47644-0d4c-5f5f-937b-380f8e888da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

