### PR TITLE
fix(ui): omit allowed_routes from key edit save when unchanged

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -467,10 +467,6 @@ describe("KeyEditView", () => {
     });
   });
 
-  // LIT-2681: re-sending the original allowed_routes value on a no-op save
-  // trips the proxy-admin gate for non-admins. Verify a no-op save on an
-  // AI APIs key (allowed_routes = ["llm_api_routes"]) does not include
-  // allowed_routes in the patch.
   it("should omit allowed_routes from submit when value is unchanged", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
     const aiApisKeyData = {
@@ -503,9 +499,6 @@ describe("KeyEditView", () => {
     });
   });
 
-  // LIT-2681: when the key never had allowed_routes set (null / undefined), an
-  // untouched submit must also strip the field — not coast through with `[]`,
-  // which would still bypass the gate but adds noise the patch doesn't need.
   it("should omit allowed_routes from submit when keyData.allowed_routes is null and form is untouched", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
     const keyDataNullRoutes = {
@@ -538,8 +531,6 @@ describe("KeyEditView", () => {
     });
   });
 
-  // LIT-2681: server-side reorder of allowed_routes shouldn't register as a
-  // user edit. Use a Set-based comparison so the patch still strips correctly.
   it("should omit allowed_routes from submit when server returned routes in a different order", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
     const keyDataReordered = {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -503,6 +503,75 @@ describe("KeyEditView", () => {
     });
   });
 
+  // LIT-2681: when the key never had allowed_routes set (null / undefined), an
+  // untouched submit must also strip the field — not coast through with `[]`,
+  // which would still bypass the gate but adds noise the patch doesn't need.
+  it("should omit allowed_routes from submit when keyData.allowed_routes is null and form is untouched", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataNullRoutes = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: null as unknown as string[],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataNullRoutes}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("allowed_routes" in callArgs).toBe(false);
+    });
+  });
+
+  // LIT-2681: server-side reorder of allowed_routes shouldn't register as a
+  // user edit. Use a Set-based comparison so the patch still strips correctly.
+  it("should omit allowed_routes from submit when server returned routes in a different order", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataReordered = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: ["beta_routes", "alpha_routes"],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataReordered}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("allowed_routes" in callArgs).toBe(false);
+    });
+  });
+
   it("should pass access_group_ids to onSubmit when saving key with access groups", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
     const keyDataWithAccessGroups = {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -158,8 +158,8 @@ describe("KeyEditView", () => {
     const { getByText } = renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -176,8 +176,8 @@ describe("KeyEditView", () => {
     const { getByText } = renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -194,8 +194,8 @@ describe("KeyEditView", () => {
     const { getByLabelText } = renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -219,7 +219,7 @@ describe("KeyEditView", () => {
       <KeyEditView
         keyData={MOCK_KEY_DATA}
         onCancel={onCancelMock}
-        onSubmit={async () => { }}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -241,8 +241,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -259,8 +259,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -277,8 +277,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -295,8 +295,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -314,7 +314,7 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -344,8 +344,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={keyDataWithManagementRoutes}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -367,8 +367,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={keyDataWithInfoRoutes}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -385,8 +385,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={"test-token"}
         userID={""}
         userRole={""}
@@ -404,7 +404,7 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -434,10 +434,14 @@ describe("KeyEditView", () => {
 
   it("should handle empty allowed routes string on submit", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithRoutes = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: ["llm_api_routes"],
+    };
     renderWithProviders(
       <KeyEditView
-        keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        keyData={keyDataWithRoutes}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -463,6 +467,41 @@ describe("KeyEditView", () => {
     });
   });
 
+  // LIT-2681: re-sending the original allowed_routes value on a no-op save
+  // trips the proxy-admin gate for non-admins. Verify a no-op save on an
+  // AI APIs key (allowed_routes = ["llm_api_routes"]) does not include
+  // allowed_routes in the patch.
+  it("should omit allowed_routes from submit when value is unchanged", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const aiApisKeyData = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: ["llm_api_routes"],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={aiApisKeyData}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("allowed_routes" in callArgs).toBe(false);
+    });
+  });
 
   it("should pass access_group_ids to onSubmit when saving key with access groups", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
@@ -554,7 +593,7 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -576,10 +615,13 @@ describe("KeyEditView", () => {
     });
 
     // Wait for the cancel button to actually be disabled (state update may take a moment)
-    await waitFor(() => {
-      const cancelButton = screen.getByRole("button", { name: /cancel/i });
-      expect(cancelButton).toBeDisabled();
-    }, { timeout: 3000 });
+    await waitFor(
+      () => {
+        const cancelButton = screen.getByRole("button", { name: /cancel/i });
+        expect(cancelButton).toBeDisabled();
+      },
+      { timeout: 3000 },
+    );
 
     // Clean up: resolve the promise to allow the form to complete
     if (resolveSubmit) {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -78,7 +78,6 @@ const getKeyTypeFromRoutes = (allowedRoutes: string[] | null | undefined): strin
   return "default";
 };
 
-
 export function KeyEditView({
   keyData,
   onCancel,
@@ -106,7 +105,7 @@ export function KeyEditView({
   const [neverExpire, setNeverExpire] = useState<boolean>(!keyData.expires);
   const [isKeySaving, setIsKeySaving] = useState(false);
   const [budgetLimits, setBudgetLimits] = useState<BudgetWindowEntry[]>(
-    Array.isArray(keyData.budget_limits) ? keyData.budget_limits : []
+    Array.isArray(keyData.budget_limits) ? keyData.budget_limits : [],
   );
   const { data: organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const { data: projects } = useProjects();
@@ -116,9 +115,7 @@ export function KeyEditView({
   const projectDisplay = (() => {
     if (!keyData.project_id) return null;
     const project = projects?.find((p) => p.project_id === keyData.project_id);
-    return project?.project_alias
-      ? `${project.project_alias} (${keyData.project_id})`
-      : keyData.project_id;
+    return project?.project_alias ? `${project.project_alias} (${keyData.project_id})` : keyData.project_id;
   })();
 
   useEffect(() => {
@@ -198,9 +195,10 @@ export function KeyEditView({
     access_group_ids: keyData.access_group_ids || [],
     auto_rotate: keyData.auto_rotate || false,
     ...(keyData.rotation_interval && { rotation_interval: keyData.rotation_interval }),
-    allowed_routes: Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
-      ? keyData.allowed_routes.join(", ")
-      : "",
+    allowed_routes:
+      Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
+        ? keyData.allowed_routes.join(", ")
+        : "",
   };
 
   useEffect(() => {
@@ -226,9 +224,10 @@ export function KeyEditView({
       access_group_ids: keyData.access_group_ids || [],
       auto_rotate: keyData.auto_rotate || false,
       ...(keyData.rotation_interval && { rotation_interval: keyData.rotation_interval }),
-      allowed_routes: Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
-        ? keyData.allowed_routes.join(", ")
-        : "",
+      allowed_routes:
+        Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
+          ? keyData.allowed_routes.join(", ")
+          : "",
     });
   }, [keyData, form]);
 
@@ -275,12 +274,27 @@ export function KeyEditView({
       }
       // If it's already an array (shouldn't happen, but handle it), keep as is
 
+      // Drop allowed_routes from the patch when unchanged. Backend rejects any
+      // non-empty allowed_routes from non-proxy-admins (LIT-2681), so re-sending
+      // the existing value on a no-op save would 403. Stripping it lets the
+      // backend treat absence as "leave alone."
+      const originalAllowedRoutes = Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : [];
+      const allowedRoutesUnchanged =
+        Array.isArray(values.allowed_routes) &&
+        values.allowed_routes.length === originalAllowedRoutes.length &&
+        values.allowed_routes.every((r: string, i: number) => r === originalAllowedRoutes[i]);
+      if (allowedRoutesUnchanged) {
+        delete values.allowed_routes;
+      }
+
       if (neverExpire) {
         values.duration = null;
       }
 
       // Include multi-window budget limits (filter out incomplete entries)
-      const validWindows = budgetLimits.filter((w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined);
+      const validWindows = budgetLimits.filter(
+        (w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined,
+      );
       values.budget_limits = validWindows.length > 0 ? validWindows : undefined;
 
       await onSubmit(values);
@@ -305,9 +319,13 @@ export function KeyEditView({
           {({ getFieldValue, setFieldValue }) => {
             const allowedRoutesValue = getFieldValue("allowed_routes") || "";
             // Convert string to array for checking
-            const allowedRoutes = typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
-              ? allowedRoutesValue.split(",").map((r: string) => r.trim()).filter((r: string) => r.length > 0)
-              : [];
+            const allowedRoutes =
+              typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
+                ? allowedRoutesValue
+                    .split(",")
+                    .map((r: string) => r.trim())
+                    .filter((r: string) => r.length > 0)
+                : [];
             const isDisabled = allowedRoutes.includes("management_routes") || allowedRoutes.includes("info_routes");
             const models = getFieldValue("models") || [];
 
@@ -348,9 +366,13 @@ export function KeyEditView({
           {({ getFieldValue, setFieldValue }) => {
             const allowedRoutesValue = getFieldValue("allowed_routes") || "";
             // Convert string to array for getKeyTypeFromRoutes
-            const allowedRoutes = typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
-              ? allowedRoutesValue.split(",").map((r: string) => r.trim()).filter((r: string) => r.length > 0)
-              : [];
+            const allowedRoutes =
+              typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
+                ? allowedRoutesValue
+                    .split(",")
+                    .map((r: string) => r.trim())
+                    .filter((r: string) => r.length > 0)
+                : [];
             const keyTypeValue = getKeyTypeFromRoutes(allowedRoutes);
 
             return (
@@ -415,9 +437,7 @@ export function KeyEditView({
         }
         name="allowed_routes"
       >
-        <Input
-          placeholder="Enter allowed routes (comma-separated). Special values: llm_api_routes, management_routes. Examples: llm_api_routes, /chat/completions, /keys/*. Leave empty to allow all routes"
-        />
+        <Input placeholder="Enter allowed routes (comma-separated). Special values: llm_api_routes, management_routes. Examples: llm_api_routes, /chat/completions, /keys/*. Leave empty to allow all routes" />
       </Form.Item>
 
       <Form.Item label="Max Budget (USD)" name="max_budget">
@@ -442,10 +462,7 @@ export function KeyEditView({
           </span>
         }
       >
-        <BudgetWindowsEditor
-          value={budgetLimits}
-          onChange={setBudgetLimits}
-        />
+        <BudgetWindowsEditor value={budgetLimits} onChange={setBudgetLimits} />
       </Form.Item>
 
       <Form.Item label="TPM Limit" name="tpm_limit">
@@ -579,7 +596,7 @@ export function KeyEditView({
               !premiumUser
                 ? "Premium feature - Upgrade to set allowed pass through routes by key"
                 : Array.isArray(keyData.metadata?.allowed_passthrough_routes) &&
-                  keyData.metadata.allowed_passthrough_routes.length > 0
+                    keyData.metadata.allowed_passthrough_routes.length > 0
                   ? `Current: ${keyData.metadata.allowed_passthrough_routes.join(", ")}`
                   : "Select or enter allowed pass through routes"
             }
@@ -690,14 +707,13 @@ export function KeyEditView({
             return team.team_alias?.toLowerCase().includes(input.toLowerCase()) ?? false;
           }}
         >
-          {(selectedOrganizationId
-            ? teams?.filter((t) => t.organization_id === selectedOrganizationId)
-            : teams
-          )?.map((team) => (
-            <Select.Option key={team.team_id} value={team.team_id}>
-              {`${team.team_alias} (${team.team_id})`}
-            </Select.Option>
-          ))}
+          {(selectedOrganizationId ? teams?.filter((t) => t.organization_id === selectedOrganizationId) : teams)?.map(
+            (team) => (
+              <Select.Option key={team.team_id} value={team.team_id}>
+                {`${team.team_alias} (${team.team_id})`}
+              </Select.Option>
+            ),
+          )}
         </Select>
       </Form.Item>
       {enableProjectsUI && hasProject && (

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -276,8 +276,8 @@ export function KeyEditView({
 
       // Backend rejects non-empty allowed_routes from non-admins, so re-sending
       // an unchanged value 403s a team admin. Set compare tolerates reorder.
-      const originalRoutesSet = new Set(Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : []);
-      const submittedRoutesSet = new Set(Array.isArray(values.allowed_routes) ? values.allowed_routes : []);
+      const originalRoutesSet = new Set<string>(Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : []);
+      const submittedRoutesSet = new Set<string>(Array.isArray(values.allowed_routes) ? values.allowed_routes : []);
       const allowedRoutesUnchanged =
         originalRoutesSet.size === submittedRoutesSet.size &&
         [...submittedRoutesSet].every((r) => originalRoutesSet.has(r));

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -274,11 +274,8 @@ export function KeyEditView({
       }
       // If it's already an array (shouldn't happen, but handle it), keep as is
 
-      // Drop allowed_routes from the patch when unchanged. Backend rejects any
-      // non-empty allowed_routes from non-proxy-admins (LIT-2681), so re-sending
-      // the existing value on a no-op save would 403. Stripping it lets the
-      // backend treat absence as "leave alone." Compare as sets so a server-side
-      // reorder of the array doesn't register as a user edit.
+      // Backend rejects non-empty allowed_routes from non-admins, so re-sending
+      // an unchanged value 403s a team admin. Set compare tolerates reorder.
       const originalRoutesSet = new Set(Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : []);
       const submittedRoutesSet = new Set(Array.isArray(values.allowed_routes) ? values.allowed_routes : []);
       const allowedRoutesUnchanged =

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -277,12 +277,13 @@ export function KeyEditView({
       // Drop allowed_routes from the patch when unchanged. Backend rejects any
       // non-empty allowed_routes from non-proxy-admins (LIT-2681), so re-sending
       // the existing value on a no-op save would 403. Stripping it lets the
-      // backend treat absence as "leave alone."
-      const originalAllowedRoutes = Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : [];
+      // backend treat absence as "leave alone." Compare as sets so a server-side
+      // reorder of the array doesn't register as a user edit.
+      const originalRoutesSet = new Set(Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : []);
+      const submittedRoutesSet = new Set(Array.isArray(values.allowed_routes) ? values.allowed_routes : []);
       const allowedRoutesUnchanged =
-        Array.isArray(values.allowed_routes) &&
-        values.allowed_routes.length === originalAllowedRoutes.length &&
-        values.allowed_routes.every((r: string, i: number) => r === originalAllowedRoutes[i]);
+        originalRoutesSet.size === submittedRoutesSet.size &&
+        [...submittedRoutesSet].every((r) => originalRoutesSet.has(r));
       if (allowedRoutesUnchanged) {
         delete values.allowed_routes;
       }


### PR DESCRIPTION
## Summary

Resolves LIT-2681. When a team admin opens **Edit Settings** on a key with `key_type = AI APIs` and clicks Save without changing anything, the UI re-sends the existing `allowed_routes` value. The backend's `_check_allowed_routes_caller_permission` gate (`litellm/proxy/management_endpoints/key_management_endpoints.py:467-501`) rejects any non-empty `allowed_routes` from non-proxy-admins, so the no-op save 403s.

This patch strips `allowed_routes` from the submitted payload when it deep-equals the original `keyData.allowed_routes`. The backend treats absence as "leave alone," so no-op saves now succeed for team admins. Admins explicitly editing the field still send the new value.

- Targeted, ~13 lines in `handleSubmit` of `key_edit_view.tsx`
- One regression test added; one existing test updated to reflect the new behavior (clearing an already-empty field is no longer a "change")

## screenshots 

before 

<img width="1068" height="424" alt="Screenshot 2026-05-09 at 10 56 11 AM" src="https://github.com/user-attachments/assets/cb745499-e859-4e09-9834-9f54a6c019e5" />


after 

<img width="1197" height="736" alt="Screenshot 2026-05-09 at 1 50 20 PM" src="https://github.com/user-attachments/assets/f301a243-53bd-4ebf-8cac-0251a21dc7da" />


## Test plan

- [x] `cd ui/litellm-dashboard && npx vitest run src/components/templates/key_edit_view.test.tsx` — 22/22 pass
- [x] Manual: as a team admin, open Edit Settings on an `AI APIs` key, click Save with no changes → success (was 403 before fix)
- [x] Manual: as a team admin, edit `key_alias` on an AI APIs key → success