### PR TITLE
Reset tag spend when linked budget cycle expires (fixes #27481)

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -119,6 +119,56 @@ class ResetBudgetJob:
 
         return update_result
 
+    async def reset_budget_for_tags_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for tags linked to budget tiers that are being reset.
+
+        Tags carry their accumulated spend on `LiteLLM_TagTable.spend` and inherit
+        their reset schedule from the linked `LiteLLM_BudgetTable` (via `budget_id`).
+        Without this handler, `budget_reset_at` advances on the budget row but the
+        tag's `spend` is never zeroed — once a tag accumulates beyond its
+        `max_budget`, every subsequent request bearing that tag is rejected with
+        HTTP 400 forever, requiring a manual DB write to recover.
+        """
+        budget_ids = [
+            budget.budget_id
+            for budget in budgets_to_reset
+            if budget.budget_id is not None
+        ]
+        if not budget_ids:
+            return
+
+        where_clause: dict = {
+            "budget_id": {"in": budget_ids},
+            "spend": {"gt": 0},  # only reset tags that have accumulated spend
+        }
+
+        try:
+            tags = await self.prisma_client.db.litellm_tagtable.find_many(
+                where=where_clause
+            )
+        except Exception as e:
+            tags = []
+            verbose_proxy_logger.warning(
+                "Failed to fetch tags for counter invalidation: %s", e
+            )
+
+        update_result = await self.prisma_client.db.litellm_tagtable.update_many(
+            where=where_clause,
+            data={
+                "spend": 0,
+            },
+        )
+
+        for t in tags:
+            tag_name = getattr(t, "tag_name", None)
+            if tag_name:
+                await self._invalidate_spend_counter(f"spend:tag:{tag_name}")
+
+        return update_result
+
     async def reset_budget_for_keys_linked_to_budgets(
         self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
     ):
@@ -234,6 +284,10 @@ class ResetBudgetJob:
                 )
 
                 await self.reset_budget_for_keys_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_tags_linked_to_budgets(
                     budgets_to_reset=budgets_to_reset
                 )
 

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -52,11 +52,32 @@ class MockLiteLLMEndUserTable:
         return self._find_many_results
 
 
+class MockLiteLLMTagTable:
+    def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": len(self._find_many_results) or 1}
+
+
 class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
+        self.litellm_tagtable = MockLiteLLMTagTable()
 
 
 class MockPrismaClient:
@@ -1204,4 +1225,118 @@ def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monke
 
     counter_cache.in_memory_cache.set_cache.assert_any_call(
         key="spend:key:sk-linked", value=0.0, ttl=60
+    )
+
+
+# ---------------------------------------------------------------------------
+# reset_budget_for_tags_linked_to_budgets — tag spend never reset bug
+# ---------------------------------------------------------------------------
+
+
+def test_reset_budget_for_tags_linked_to_budgets(reset_budget_job, mock_prisma_client):
+    """
+    Tags carry their accumulated spend on `LiteLLM_TagTable.spend` and inherit
+    their reset schedule from the linked `LiteLLM_BudgetTable`. When a budget
+    tier is reset, every tag pointing at it must have its `spend` zeroed too.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "tenant-budget-1d",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(
+            budgets_to_reset=[test_budget]
+        )
+    )
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1, f"Expected 1 update_many call, got {len(calls)}"
+    call = calls[0]
+    assert call["where"]["budget_id"] == {"in": ["tenant-budget-1d"]}
+    assert call["where"]["spend"] == {"gt": 0}
+    assert call["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """No-op when there are no expiring budgets — must not touch the tag table."""
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(budgets_to_reset=[])
+    )
+
+    assert mock_prisma_client.db.litellm_tagtable.update_many_calls == []
+    assert mock_prisma_client.db.litellm_tagtable.find_many_calls == []
+
+
+def test_budget_table_reset_also_resets_linked_tags(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Integration-style guard for issue #27481: when
+    reset_budget_for_litellm_budget_table runs against an expired tag budget,
+    it must also zero the tag's spend column. Without this wiring, a tag whose
+    accumulated cost has crossed `max_budget` stays blocked forever — even
+    after `budget_reset_at` advances on subsequent cycles — and only a manual
+    DB update unblocks it.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "tag-tenant-budget",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    mock_prisma_client.data["budget"] = [test_budget]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1, (
+        "Expected reset_budget_for_litellm_budget_table to also reset tags "
+        f"linked to expiring budgets, but got {len(calls)} update_many calls. "
+        "See issue #27481."
+    )
+    assert calls[0]["where"]["budget_id"] == {"in": ["tag-tenant-budget"]}
+    assert calls[0]["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter(monkeypatch):
+    """Resetting tags via budget tier must clear each tag's `spend:tag:{name}`
+    counter. Without this, get_current_spend reads the stale Redis counter
+    and the tag remains blocked even after the DB row is zeroed."""
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type("Tag", (), {"tag_name": "tenant:demo"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:tenant:demo", value=0.0, ttl=60
+    )
+    counter_cache.redis_cache.async_set_cache.assert_any_await(
+        key="spend:tag:tenant:demo", value=0.0, ttl=60
     )


### PR DESCRIPTION
## Summary

Tag-based budgets (`LiteLLM_TagTable`) inherit their reset schedule from the linked `LiteLLM_BudgetTable` via `budget_id`, but `ResetBudgetJob` had no tag handler — `budget_reset_at` advanced each cycle while `TagTable.spend` kept growing, so once a tag crossed `max_budget` every subsequent request bearing that tag was rejected with HTTP 400 forever and only a manual DB write restored access.

This adds `reset_budget_for_tags_linked_to_budgets()` and wires it into `reset_budget_for_litellm_budget_table()`, modeled on the existing keys-linked-to-budgets handler. It also invalidates the `spend:tag:{name}` counter through the same `_invalidate_spend_counter` path the per-tag enforcement check reads, so the reset propagates across pods immediately.

Fixes #27481.

## Repro

1. Create a budget tier with `max_budget: 0.05` and `budget_duration: "1d"`.
2. Create a tag whose `budget_id` points at that budget.
3. Send tagged requests until accumulated `spend > 0.05`. Subsequent requests fail with `Budget has been exceeded! Tag=<name>...`.
4. Wait past `budget_reset_at` (or fast-forward by manually setting it). Inspect the DB:
   - `LiteLLM_BudgetTable.budget_reset_at` advances correctly.
   - `LiteLLM_TagTable.spend` is unchanged.
5. New tagged requests still fail with the same error — the tag is permanently blocked until someone runs `UPDATE "LiteLLM_TagTable" SET spend = 0 WHERE tag_name = ...`.

After this fix, step 5 works as expected: the next reset job tick zeros `TagTable.spend` for every tag whose linked budget is rolling over and clears the matching `spend:tag:{name}` counter in DualCache.

## Evidence

Test transcript demonstrating the four new tests fail on the starting ref (no `reset_budget_for_tags_linked_to_budgets` attribute) and pass after the fix:

```
# On starting ref (no fix)
$ pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -k "tag" -v
FAILED tests/.../test_reset_budget_for_tags_linked_to_budgets
   AttributeError: 'ResetBudgetJob' object has no attribute 'reset_budget_for_tags_linked_to_budgets'
FAILED tests/.../test_reset_budget_for_tags_linked_to_budgets_empty
FAILED tests/.../test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter
FAILED tests/.../test_budget_table_reset_also_resets_linked_tags
   AssertionError: Expected reset_budget_for_litellm_budget_table to also reset tags
   linked to expiring budgets, but got 0 update_many calls. See issue #27481.
4 failed, 31 deselected

# With fix applied
$ pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -v
35 passed in 7.94s
```

I could not produce a screenshot/GIF — the bug surface is a background reset job, not a UI flow. The transcript above and the unit tests are the proof.

## Tests

Added four tests to `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py`:

- `test_reset_budget_for_tags_linked_to_budgets` — happy path: zeroes tag spend filtered by `budget_id` and `spend > 0`.
- `test_reset_budget_for_tags_linked_to_budgets_empty` — no-op when `budgets_to_reset` is empty.
- `test_budget_table_reset_also_resets_linked_tags` — integration guard for the wiring inside `reset_budget_for_litellm_budget_table`. Includes a regression message explicitly citing the issue number so a future revert is obvious.
- `test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter` — verifies the `spend:tag:{name}` counter is cleared in both the in-memory cache and Redis, mirroring the existing key/team/user invalidation tests.

All four fail on the starting ref with `AttributeError`/missing-call assertions and pass after the fix. Full file (35 tests) was re-run green; the wider `tests/test_litellm/proxy/common_utils/` suite (193 tests) also passes.

Lint scope (matches CI):
- `black --check litellm/proxy/common_utils/reset_budget_job.py tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` — clean.
- `ruff check litellm/proxy/common_utils/reset_budget_job.py` — clean. The test file has 4 pre-existing `F401` unused-import warnings on lines unrelated to this change (verified by re-running ruff against the starting ref); not touched here.
- `mypy litellm/proxy/common_utils/reset_budget_job.py --ignore-missing-imports` — clean.
