### PR TITLE
fix(chatgpt): aggregate output items for non-streaming responses

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -134,6 +134,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
         completed_response = None
         error_message = None
+        collected_output_items: list = []
         for chunk in body_text.splitlines():
             stripped_chunk = CustomStreamWrapper._strip_sse_data_from_chunk(chunk)
             if not stripped_chunk:
@@ -150,10 +151,21 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             if not isinstance(parsed_chunk, dict):
                 continue
             event_type = parsed_chunk.get("type")
+            if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+                item = parsed_chunk.get("item")
+                if isinstance(item, dict):
+                    collected_output_items.append(item)
+                continue
             if event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
                 response_payload = parsed_chunk.get("response")
                 if isinstance(response_payload, dict):
                     response_payload = dict(response_payload)
+                    # ChatGPT backend leaves response.output empty on the final
+                    # `response.completed` event and emits items via earlier
+                    # `response.output_item.done` events; reassemble here so
+                    # non-streaming clients receive a populated output array.
+                    if not response_payload.get("output") and collected_output_items:
+                        response_payload["output"] = collected_output_items
                     if "created_at" in response_payload:
                         response_payload["created_at"] = _safe_convert_created_field(
                             response_payload["created_at"]


### PR DESCRIPTION
## Summary

For the `chatgpt/` provider (ChatGPT subscription via Codex CLI OAuth), non-streaming requests to `/v1/responses` — and `/v1/chat/completions` bridged through to responses — return HTTP 200 with status `completed` and populated `usage`, but an empty `output: []` array. Tokens are billed; clients see no content.

## Root cause

`ChatGPTResponsesAPIConfig.transform_response_api_response` aggregates the upstream SSE stream into a single `ResponsesAPIResponse`, but it builds the response only from the final `response.completed` event's `response` field. The ChatGPT backend at `chatgpt.com/backend-api/codex` leaves `response.output` empty on that final event and emits the actual items in earlier `response.output_item.done` events.

Reproduced trace:

```
event: response.output_item.done   item.type=message  content[0].text="pong"
event: response.completed          response.output=[]   usage.output_tokens=5
```

The aggregator reads `response.output` (empty) and discards the `output_item.done` items.

## Fix

Collect items from `response.output_item.done` events as the SSE stream is parsed. When the final `response.completed` payload's `output` is empty but items were collected, use the collected list. No-op when the backend populates `output` directly (forward-compatible).

12-line change in `litellm/llms/chatgpt/responses/transformation.py`.

## Test plan

- [x] `/v1/responses` non-streaming returns `output[0].content[0].text` for `chatgpt/gpt-5.4`
- [x] `/v1/responses` non-streaming returns `output[0].content[0].text` for `chatgpt/gpt-5.3-codex`
- [x] `/v1/chat/completions` (bridged) returns `choices[0].message.content` for both models
- [x] Streaming path (`stream: true`) unchanged — events pass through untouched
- [x] Concurrency test: 60 calls/min sustained, 30 concurrent peak — no regressions, no 429s from upstream
- [ ] Add unit test fixture for the SSE-aggregation path (happy to follow up if reviewers prefer)

## Reproduction

```bash
curl http://localhost:4000/v1/responses \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{"model":"chatgpt/gpt-5.4","input":[{"role":"user","content":[{"type":"input_text","text":"say pong"}]}]}'
```

Before: `{"output": [], "status": "completed", "usage": {...}}`
After:  `{"output": [{"type":"message","content":[{"type":"output_text","text":"pong"}]}], ...}`