### PR TITLE
Fix: reset tag spend on budget cycle (BerriAI/litellm#27481)

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -171,6 +171,60 @@ class ResetBudgetJob:
 
         return update_result
 
+    async def reset_budget_for_tags_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for tags linked to budget tiers that are being reset.
+
+        ``LiteLLM_TagTable.spend`` is the fallback value used by
+        ``_tag_max_budget_check`` when computing tag spend, so a stale value here
+        keeps a tag permanently over budget after its first overage. The reset
+        job has historically resets keys/users/teams/end-users on every cycle —
+        tags were missing the equivalent handler, so their ``spend`` column was
+        never zeroed even though ``budget_reset_at`` advanced. See
+        BerriAI/litellm#27481.
+
+        Only tags with accumulated spend (``spend > 0``) are touched, so a
+        ``find_many`` over an idle pool of tags is cheap.
+        """
+        budget_ids = [
+            budget.budget_id
+            for budget in budgets_to_reset
+            if budget.budget_id is not None
+        ]
+        if not budget_ids:
+            return
+
+        where_clause: dict = {
+            "budget_id": {"in": budget_ids},
+            "spend": {"gt": 0},
+        }
+
+        try:
+            tags = await self.prisma_client.db.litellm_tagtable.find_many(
+                where=where_clause
+            )
+        except Exception as e:
+            tags = []
+            verbose_proxy_logger.warning(
+                "Failed to fetch tags for counter invalidation: %s", e
+            )
+
+        update_result = await self.prisma_client.db.litellm_tagtable.update_many(
+            where=where_clause,
+            data={
+                "spend": 0,
+            },
+        )
+
+        for tag in tags:
+            tag_name = getattr(tag, "tag_name", None)
+            if tag_name:
+                await self._invalidate_spend_counter(f"spend:tag:{tag_name}")
+
+        return update_result
+
     async def reset_budget_for_litellm_budget_table(self):
         """
         Resets the budget for all LiteLLM End-Users (Customers), and Team Members if their budget has expired
@@ -234,6 +288,10 @@ class ResetBudgetJob:
                 )
 
                 await self.reset_budget_for_keys_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_tags_linked_to_budgets(
                     budgets_to_reset=budgets_to_reset
                 )
 

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -52,11 +52,32 @@ class MockLiteLLMEndUserTable:
         return self._find_many_results
 
 
+class MockLiteLLMTagTable:
+    def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": len(self._find_many_results)}
+
+
 class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
+        self.litellm_tagtable = MockLiteLLMTagTable()
 
 
 class MockPrismaClient:
@@ -1205,3 +1226,160 @@ def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monke
     counter_cache.in_memory_cache.set_cache.assert_any_call(
         key="spend:key:sk-linked", value=0.0, ttl=60
     )
+
+
+# ---------------------------------------------------------------------------
+# Tag budget resets — regression coverage for BerriAI/litellm#27481
+# ---------------------------------------------------------------------------
+
+
+def test_reset_budget_for_tags_linked_to_budgets(reset_budget_job, mock_prisma_client):
+    """
+    Tags linked to a budget tier whose ``budget_reset_at`` has elapsed must
+    have ``LiteLLM_TagTable.spend`` reset to 0 — otherwise the tag stays
+    permanently over budget after its first overage (the bug from
+    BerriAI/litellm#27481).
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "1d-tag-budget",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    over_cap_tag = type(
+        "Tag",
+        (),
+        {"tag_name": "tenant:over-cap", "spend": 0.063, "budget_id": "1d-tag-budget"},
+    )
+    mock_prisma_client.db.litellm_tagtable.set_find_many_results([over_cap_tag])
+
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(
+            budgets_to_reset=[test_budget]
+        )
+    )
+
+    update_calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert (
+        len(update_calls) == 1
+    ), f"Expected 1 update_many call, got {len(update_calls)}"
+
+    call = update_calls[0]
+    assert call["where"]["budget_id"] == {"in": ["1d-tag-budget"]}
+    # Only tags with accumulated spend should be touched.
+    assert call["where"]["spend"] == {"gt": 0}
+    # Reset must zero `spend` and only `spend` (not e.g. `max_budget`).
+    assert call["data"] == {"spend": 0}
+
+
+def test_reset_budget_for_tags_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """No budgets to reset → no DB write on ``litellm_tagtable``."""
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(budgets_to_reset=[])
+    )
+
+    assert mock_prisma_client.db.litellm_tagtable.update_many_calls == []
+    assert mock_prisma_client.db.litellm_tagtable.find_many_calls == []
+
+
+def test_budget_table_reset_also_resets_linked_tags(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Integration-style guard: ``reset_budget_for_litellm_budget_table`` must
+    invoke the tag reset alongside the existing key/team-member/end-user
+    resets. Without this wiring, the tag handler exists but is unreachable
+    from the periodic reset job — which is exactly the failure mode in
+    BerriAI/litellm#27481.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "1d-tag-budget",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    over_cap_tag = type(
+        "Tag",
+        (),
+        {"tag_name": "tenant:over-cap", "spend": 0.063, "budget_id": "1d-tag-budget"},
+    )
+
+    mock_prisma_client.data["budget"] = [test_budget]
+    mock_prisma_client.db.litellm_tagtable.set_find_many_results([over_cap_tag])
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    update_calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(update_calls) == 1, (
+        "Expected reset_budget_for_litellm_budget_table to also reset tag "
+        f"spend, but got {len(update_calls)} update_many calls on tags"
+    )
+    assert update_calls[0]["where"]["budget_id"] == {"in": ["1d-tag-budget"]}
+    assert update_calls[0]["data"] == {"spend": 0}
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter(
+    monkeypatch,
+):
+    """Resetting a tag's row must also clear the cross-pod
+    ``spend:tag:<name>`` counter — otherwise ``_tag_max_budget_check`` keeps
+    reading the over-cap value out of cache and the tag stays blocked.
+    """
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type(
+        "Tag",
+        (),
+        {"tag_name": "tenant:over-cap", "spend": 0.063, "budget_id": "budget-1"},
+    )
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:tenant:over-cap", value=0.0, ttl=60
+    )
+    counter_cache.redis_cache.async_set_cache.assert_any_await(
+        key="spend:tag:tenant:over-cap", value=0.0, ttl=60
+    )
+
+
+def test_reset_budget_for_tags_skips_tags_without_spend(monkeypatch):
+    """Tags with ``spend == 0`` should be skipped server-side via the
+    ``spend > 0`` filter — confirms we don't churn the table for idle pools.
+    """
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    update_call = prisma_client.db.litellm_tagtable.update_many.await_args
+    assert update_call.kwargs["where"]["spend"] == {"gt": 0}
+    assert update_call.kwargs["where"]["budget_id"] == {"in": ["budget-1"]}


### PR DESCRIPTION
## Summary

Closes BerriAI/litellm#27481.

Tags linked to a budget tier with `budget_duration` set were never having
their `LiteLLM_TagTable.spend` zeroed when the budget reset cycle elapsed.
The budget's `budget_reset_at` advanced correctly each cycle, but the tag's
`spend` column was untouched — so any tag that crossed `max_budget` once
returned HTTP 400 `budget_exceeded` indefinitely, recoverable only by a
manual `UPDATE LiteLLM_TagTable SET spend=0`. `_tag_max_budget_check`
reads `tag_object.spend` as the fallback when the cross-pod
`spend:tag:<name>` counter is missing, which keeps the gate stuck on the
stale over-cap value forever.

`reset_budget_job.py` had handlers for keys, users, teams, end-users, and
team-members — but not tags. This PR adds
`reset_budget_for_tags_linked_to_budgets` analogous to
`reset_budget_for_keys_linked_to_budgets`, and wires it into
`reset_budget_for_litellm_budget_table` next to the existing dispatches.
The handler also invalidates `spend:tag:<name>` via the existing
`_invalidate_spend_counter` helper so the reset takes effect across pods
immediately.

## Repro

1. Create a budget `{"max_budget": 0.05, "budget_duration": "1m"}` →
   returns `budget_id=B`, `budget_reset_at=T0+60s`.
2. Create a tag bound to `B`.
3. Drive body-tagged traffic to push tag spend past `$0.05`; observe HTTP
   400 firing as expected.
4. Wait through three full reset cycles (3+ minutes) — each cycle,
   `LiteLLM_BudgetTable.budget_reset_at` advances but
   `LiteLLM_TagTable.spend` stays at the over-cap value.
5. Send another body-tagged request → still HTTP 400 with the same
   `Current cost: 0.063, Max budget: 0.05` body.

After the fix, step 5 succeeds — `spend` is zeroed at the boundary and
the cross-pod counter is cleared in lockstep.

## Evidence

```
$ uv run --no-project pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -v -k tag
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_budget_table_reset_also_resets_linked_tags PASSED
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets PASSED
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_empty PASSED
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter PASSED
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_skips_tags_without_spend PASSED
======================= 5 passed, 31 deselected =======================
```

Each of these 5 tests fails on the starting ref (the function doesn't exist
yet) and passes after the patch — confirming they pin the new behavior.

## Tests

Added 5 tests in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py`:

- `test_reset_budget_for_tags_linked_to_budgets` — happy path: an over-cap
  tag bound to an expiring budget tier gets `spend` zeroed via
  `update_many` with the correct `where` clause.
- `test_reset_budget_for_tags_linked_to_budgets_empty` — empty input: no
  budget IDs → no DB write, no `find_many`.
- `test_budget_table_reset_also_resets_linked_tags` — integration guard
  that `reset_budget_for_litellm_budget_table` actually invokes the tag
  handler (the failure mode in the issue is that the handler exists but
  is unreachable).
- `test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter`
  — confirms `spend:tag:<name>` is cleared in both the in-memory cache
  and Redis after the row is reset, mirroring the key/team handlers.
- `test_reset_budget_for_tags_skips_tags_without_spend` — confirms the
  `spend > 0` filter so we don't churn idle tag pools every cycle.

The full file (36 tests, including the existing key/user/team/end-user
coverage) passes.

Lint:
- `uv run black --check litellm/proxy/common_utils/reset_budget_job.py
  tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` —
  clean.
- `cd litellm && uv run ruff check .` — clean (CI scope).
- `cd litellm && uv run mypy . --ignore-missing-imports` — clean
  (CI scope).

There are 4 pre-existing `F401` ruff warnings in
`tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` from
before this PR (unused imports in test code), but they are outside the
CI lint scope (which is `litellm/`) and unrelated to this change.
