### PR TITLE
Fix tag budget reset cache invalidation

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -83,6 +83,18 @@ class ResetBudgetJob:
                 "Failed to reset spend counter %s: %s", counter_key, e
             )
 
+    @staticmethod
+    async def _invalidate_source_cache(cache_key: str) -> None:
+        """Remove a cached source row so future fallbacks do not reuse stale spend."""
+        try:
+            from litellm.proxy.proxy_server import user_api_key_cache
+
+            await user_api_key_cache.async_delete_cache(key=cache_key)
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Failed to invalidate source cache %s: %s", cache_key, e
+            )
+
     async def _cascade_reset_spend_for_budget_link(
         self,
         budgets_to_reset: List[LiteLLM_BudgetTableFull],
@@ -90,6 +102,7 @@ class ResetBudgetJob:
         counter_key_fn: Callable[[Any], str],
         log_subject: str,
         extra_where: Optional[dict] = None,
+        source_cache_key_fn: Optional[Callable[[Any], str]] = None,
     ):
         """
         Generic cascade: zero spend on rows whose budget_id is in the reset set.
@@ -114,6 +127,8 @@ class ResetBudgetJob:
 
         for row in rows:
             await self._invalidate_spend_counter(counter_key_fn(row))
+            if source_cache_key_fn is not None:
+                await self._invalidate_source_cache(source_cache_key_fn(row))
 
         return update_result
 
@@ -173,6 +188,7 @@ class ResetBudgetJob:
             counter_key_fn=lambda t: f"spend:tag:{t.tag_name}",
             log_subject="tags",
             extra_where={"spend": {"gt": 0}},
+            source_cache_key_fn=lambda t: f"tag:{t.tag_name}",
         )
 
     async def reset_budget_for_litellm_budget_table(self):

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -115,13 +115,23 @@ class ResetBudgetJob:
         if extra_where:
             where.update(extra_where)
 
+        rows: List[Any] = []
         try:
             rows = await table.find_many(where=where)
         except Exception as e:
-            rows = []
             verbose_proxy_logger.warning(
-                "Failed to fetch %s for counter invalidation: %s", log_subject, e
+                "Failed to fetch %s for counter invalidation, retrying once: %s",
+                log_subject,
+                e,
             )
+            try:
+                rows = await table.find_many(where=where)
+            except Exception as retry_err:
+                verbose_proxy_logger.warning(
+                    "Failed to fetch %s for counter invalidation after retry: %s",
+                    log_subject,
+                    retry_err,
+                )
 
         update_result = await table.update_many(where=where, data={"spend": 0})
 

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1268,16 +1268,20 @@ def _make_counter_invalidation_job(monkeypatch):
     spend_counter_cache.redis_cache = MagicMock()
     spend_counter_cache.redis_cache.async_set_cache = AsyncMock()
 
+    user_api_key_cache = MagicMock()
+    user_api_key_cache.async_delete_cache = AsyncMock()
+
     fake_module = types.ModuleType("litellm.proxy.proxy_server")
     fake_module.spend_counter_cache = spend_counter_cache
+    fake_module.user_api_key_cache = user_api_key_cache
     monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_module)
 
-    return spend_counter_cache
+    return spend_counter_cache, user_api_key_cache
 
 
 def test_reset_budget_for_team_members_invalidates_redis_counter(monkeypatch):
     """Team-member budget reset clears the Redis spend counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, _ = _make_counter_invalidation_job(monkeypatch)
 
     expired_budget = type("B", (), {"budget_id": "budget-1"})
     membership = type(
@@ -1309,7 +1313,7 @@ def test_reset_budget_for_keys_invalidates_redis_counter(
     reset_budget_job, mock_prisma_client, monkeypatch
 ):
     """Key budget reset must clear the Redis spend counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, _ = _make_counter_invalidation_job(monkeypatch)
 
     now = datetime.now(timezone.utc)
     mock_prisma_client.data["key"] = [
@@ -1337,7 +1341,7 @@ def test_reset_budget_for_users_invalidates_redis_counter(
     reset_budget_job, mock_prisma_client, monkeypatch
 ):
     """User budget reset must clear the Redis spend counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, _ = _make_counter_invalidation_job(monkeypatch)
 
     now = datetime.now(timezone.utc)
     mock_prisma_client.data["user"] = [
@@ -1365,7 +1369,7 @@ def test_reset_budget_for_teams_invalidates_redis_counter(
     reset_budget_job, mock_prisma_client, monkeypatch
 ):
     """Team budget reset must clear the Redis spend counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, _ = _make_counter_invalidation_job(monkeypatch)
 
     now = datetime.now(timezone.utc)
     mock_prisma_client.data["team"] = [
@@ -1391,7 +1395,7 @@ def test_reset_budget_for_teams_invalidates_redis_counter(
 
 def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monkeypatch):
     """Resetting keys via budget tier must clear each linked key's counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, _ = _make_counter_invalidation_job(monkeypatch)
 
     expired_budget = type("B", (), {"budget_id": "budget-1"})
     linked_key = type("Key", (), {"token": "sk-linked"})
@@ -1414,7 +1418,7 @@ def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monke
 
 def test_reset_budget_for_orgs_linked_to_budgets_invalidates_redis_counter(monkeypatch):
     """Resetting orgs via budget tier must clear each linked org's counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, _ = _make_counter_invalidation_job(monkeypatch)
 
     expired_budget = type("B", (), {"budget_id": "budget-1"})
     linked_org = type("Org", (), {"organization_id": "org-acme"})
@@ -1440,7 +1444,7 @@ def test_reset_budget_for_orgs_linked_to_budgets_invalidates_redis_counter(monke
 
 def test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter(monkeypatch):
     """Resetting tags via budget tier must clear each linked tag's counter."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    counter_cache, user_api_key_cache = _make_counter_invalidation_job(monkeypatch)
 
     expired_budget = type("B", (), {"budget_id": "budget-1"})
     linked_tag = type("Tag", (), {"tag_name": "tenant-42"})
@@ -1458,3 +1462,4 @@ def test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter(monke
     counter_cache.redis_cache.async_set_cache.assert_any_await(
         key="spend:tag:tenant-42", value=0.0, ttl=60
     )
+    user_api_key_cache.async_delete_cache.assert_any_await(key="tag:tenant-42")

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1463,3 +1463,26 @@ def test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter(monke
         key="spend:tag:tenant-42", value=0.0, ttl=60
     )
     user_api_key_cache.async_delete_cache.assert_any_await(key="tag:tenant-42")
+
+
+def test_reset_budget_for_tags_retries_fetch_before_cache_invalidation(monkeypatch):
+    """A transient read failure should not skip tag source-cache invalidation."""
+    counter_cache, user_api_key_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type("Tag", (), {"tag_name": "tenant-42"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(
+        side_effect=[RuntimeError("transient read failure"), [linked_tag]]
+    )
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    assert prisma_client.db.litellm_tagtable.find_many.await_count == 2
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:tenant-42", value=0.0, ttl=60
+    )
+    user_api_key_cache.async_delete_cache.assert_any_await(key="tag:tenant-42")


### PR DESCRIPTION
## Summary
Tag budget resets now clear stale cached tag rows after resetting linked tag spend. This prevents budget checks and fallback spend initialization from reusing pre-reset tag spend after the database row and spend counter have been reset.

## Repro
A tag linked to a recurring budget can exceed its max budget, then the budget reset job zeros the tag spend and spend counter while leaving the cached tag row with the old spend value. A later fallback path can reuse that stale cached spend.

## Evidence
External gist upload was unavailable in this environment, so here is the terminal transcript from the focused reset-budget suite:

```text
........................................                                 [100%]
=============================== warnings summary ===============================
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_all
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_key
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_keys_invalidates_redis_counter
  /workspace/litellm/proxy/common_utils/reset_budget_job.py:400: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_all
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_user
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_users_invalidates_redis_counter
  /workspace/litellm/proxy/common_utils/reset_budget_job.py:490: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_all
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_team
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_teams_invalidates_redis_counter
  /workspace/litellm/proxy/common_utils/reset_budget_job.py:587: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_all
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_handles_string_budget_limits
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_query_error_does_not_break_team_path
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_resets_expired_key_window
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_resets_expired_team_window
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_skips_row_with_empty_budget_limits
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_skips_unexpired_key_window
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_uses_is_not_null_filter
  /workspace/litellm/proxy/common_utils/reset_budget_job.py:721: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_handles_string_budget_limits
  /workspace/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py:1185: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_query_error_does_not_break_team_path
  /workspace/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py:1225: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_resets_expired_key_window
  /workspace/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py:1100: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_resets_expired_team_window
  /workspace/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py:1156: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_windows_skips_unexpired_key_window
  /workspace/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py:1136: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
40 passed, 22 warnings in 2.12s
```

## Tests
- Added regression coverage in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` for tag source-cache invalidation and transient tag lookup retry.
- `/home/ubuntu/.local/bin/uv run pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -q` -> 40 passed.
- CI lint commands run locally: `uv lock --check`, `uv sync --frozen`, `black --check --exclude '/enterprise/' .` from `litellm/`, `ruff check .` from `litellm/`, `mypy .` from `litellm/`, circular import check, and import safety check.

## CI
- GitHub Actions PR checks: all green on the latest commit, including lint, code-quality, proxy suites, coverage uploads, secret scan, and Codecov patch (https://github.com/BerriAI/litellm/pull/27564/checks).
- CircleCI API lookup for this branch returned `Project not found`; no CircleCI pipeline was available to poll for this repository/branch.

## Review
- Greptile score: 5/5 after 2 review rounds.
- 1 actionable comment addressed with a retry guard and regression test; no unresolved Greptile threads remain.
