### PR TITLE
Fix: tag budgets never reset (no tag handler in ResetBudgetJob)

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -119,6 +119,58 @@ class ResetBudgetJob:
 
         return update_result
 
+    async def reset_budget_for_tags_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for tags linked to budget tiers that are being reset.
+
+        The LiteLLM_TagTable schema has no `budget_duration` column of its own —
+        tags reference a budget tier via `budget_id` and rely entirely on the
+        linked budget's reset schedule. Without this handler, the
+        `LiteLLM_BudgetTable.budget_reset_at` advances on each tick of the reset
+        job but `LiteLLM_TagTable.spend` is never zeroed, so once a tag's
+        cumulative spend exceeds the linked budget's `max_budget` it stays over
+        the threshold forever and `_tag_max_budget_check` permanently blocks
+        every request that carries that tag.
+        """
+        budget_ids = [
+            budget.budget_id
+            for budget in budgets_to_reset
+            if budget.budget_id is not None
+        ]
+        if not budget_ids:
+            return
+
+        where_clause: dict = {
+            "budget_id": {"in": budget_ids},
+            "spend": {"gt": 0},  # only reset tags that have accumulated spend
+        }
+
+        try:
+            tags = await self.prisma_client.db.litellm_tagtable.find_many(
+                where=where_clause
+            )
+        except Exception as e:
+            tags = []
+            verbose_proxy_logger.warning(
+                "Failed to fetch tags for counter invalidation: %s", e
+            )
+
+        update_result = await self.prisma_client.db.litellm_tagtable.update_many(
+            where=where_clause,
+            data={
+                "spend": 0,
+            },
+        )
+
+        for tag in tags:
+            tag_name = getattr(tag, "tag_name", None)
+            if tag_name:
+                await self._invalidate_spend_counter(f"spend:tag:{tag_name}")
+
+        return update_result
+
     async def reset_budget_for_keys_linked_to_budgets(
         self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
     ):
@@ -234,6 +286,10 @@ class ResetBudgetJob:
                 )
 
                 await self.reset_budget_for_keys_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_tags_linked_to_budgets(
                     budgets_to_reset=budgets_to_reset
                 )
 

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -52,11 +52,32 @@ class MockLiteLLMEndUserTable:
         return self._find_many_results
 
 
+class MockLiteLLMTagTable:
+    def __init__(self):
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": 1}
+
+
 class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
+        self.litellm_tagtable = MockLiteLLMTagTable()
 
 
 class MockPrismaClient:
@@ -1205,3 +1226,154 @@ def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monke
     counter_cache.in_memory_cache.set_cache.assert_any_call(
         key="spend:key:sk-linked", value=0.0, ttl=60
     )
+
+
+# ---------------------------------------------------------------------------
+# reset_budget_for_tags_linked_to_budgets
+# Regression coverage for the bug where tags with attached budgets had their
+# spend frozen forever after the first overage — the reset job had no tag
+# handler so `LiteLLM_BudgetTable.budget_reset_at` advanced but
+# `LiteLLM_TagTable.spend` never returned to 0.
+# ---------------------------------------------------------------------------
+
+
+def test_reset_budget_for_tags_linked_to_budgets(reset_budget_job, mock_prisma_client):
+    """Tags linked to a budget tier being reset must have their spend zeroed.
+
+    Without this, the budget table's `budget_reset_at` ticks forward each cycle
+    but `LiteLLM_TagTable.spend` stays above `max_budget` permanently, so
+    `_tag_max_budget_check` keeps raising BudgetExceededError even after the
+    nominal reset time.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "tag-budget-tier",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    # Tag whose spend is over the linked budget threshold.
+    over_budget_tag = type(
+        "TagRow",
+        (),
+        {"tag_name": "premium-customer", "spend": 0.10, "budget_id": "tag-budget-tier"},
+    )
+    mock_prisma_client.db.litellm_tagtable.set_find_many_results([over_budget_tag])
+
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(
+            budgets_to_reset=[test_budget]
+        )
+    )
+
+    update_calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert (
+        len(update_calls) == 1
+    ), f"Expected 1 update_many call on tags, got {len(update_calls)}"
+
+    call = update_calls[0]
+    assert call["where"]["budget_id"] == {"in": ["tag-budget-tier"]}
+    # Only tags with accumulated spend should be touched (avoids no-op writes).
+    assert call["where"]["spend"] == {"gt": 0}
+    assert call["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """An empty budgets list must not issue any tag query or write."""
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(budgets_to_reset=[])
+    )
+
+    assert mock_prisma_client.db.litellm_tagtable.update_many_calls == []
+    assert mock_prisma_client.db.litellm_tagtable.find_many_calls == []
+
+
+def test_budget_table_reset_also_resets_linked_tags(
+    reset_budget_job, mock_prisma_client
+):
+    """Integration-style test: when `reset_budget_for_litellm_budget_table`
+    runs, it must drive the new tag handler so tags clear alongside keys,
+    end-users, and team memberships."""
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "tag-budget-tier",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    mock_prisma_client.data["budget"] = [test_budget]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    update_calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert (
+        len(update_calls) == 1
+    ), "reset_budget_for_litellm_budget_table must also reset linked tags"
+    assert update_calls[0]["where"]["budget_id"] == {"in": ["tag-budget-tier"]}
+    assert update_calls[0]["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_counter(monkeypatch):
+    """After zeroing tag spend in the DB, the per-tag spend counter must be
+    invalidated so `get_current_spend` doesn't keep reading the stale
+    pre-reset value from Redis/in-memory cache and re-blocking the tag."""
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "tag-budget-tier"})
+    linked_tag = type(
+        "Tag",
+        (),
+        {"tag_name": "premium-customer", "spend": 1.0, "budget_id": "tag-budget-tier"},
+    )
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:premium-customer", value=0.0, ttl=60
+    )
+    counter_cache.redis_cache.async_set_cache.assert_any_await(
+        key="spend:tag:premium-customer", value=0.0, ttl=60
+    )
+
+
+def test_reset_budget_for_tags_linked_to_budgets_swallows_find_many_failure(
+    monkeypatch,
+):
+    """If the find_many for counter invalidation fails (e.g. transient DB
+    blip), the update_many that actually zeroes spend in the DB must still
+    run — the same fail-open contract used for keys."""
+    _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "tag-budget-tier"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(
+        side_effect=RuntimeError("transient db error")
+    )
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    prisma_client.db.litellm_tagtable.update_many.assert_awaited_once()


### PR DESCRIPTION
## Summary

Tags with attached budgets had their spend permanently frozen after the first overage. The reset job's `reset_budget_for_litellm_budget_table()` advanced `LiteLLM_BudgetTable.budget_reset_at` on every tick but had no handler to zero `LiteLLM_TagTable.spend`. Once a tag exceeded its linked budget's `max_budget`, `_tag_max_budget_check` raised `BudgetExceededError` forever, blocking every request that carried the tag until ops manually patched the database.

The `LiteLLM_TagTable` schema has no `budget_duration` column of its own — tags only reference a budget tier via `budget_id` and rely entirely on the linked budget's reset schedule. So the fix mirrors the existing `reset_budget_for_keys_linked_to_budgets` pattern: zero `spend` for any tag whose `budget_id` is in the set of budgets being reset, and invalidate the `spend:tag:<name>` counter so the next request reads 0 instead of the stale Redis value.

## Repro

1. Create a budget with `max_budget: 0.05` and `budget_duration: "1m"`.
2. Attach it to a tag (e.g. `premium-customer`) via `LiteLLM_TagTable.budget_id`.
3. Run requests with that tag until cumulative spend exceeds `0.05` — proxy correctly returns `BudgetExceededError`.
4. Wait for one or more `budget_duration` cycles to pass. The budget table's `budget_reset_at` advances each cycle, but `LiteLLM_TagTable.spend` stays at the over-budget value.
5. Every subsequent request with that tag continues to fail with the same `BudgetExceededError`, even though the nominal reset time has long passed.

After the fix the reset job zeroes the tag's `spend` and invalidates the per-tag spend counter on the same cycle that advances the budget's `budget_reset_at`, so requests succeed again automatically.

## Evidence

Test transcript proving the new tests fail on the starting ref and pass after the fix.

Before fix (`reset_budget_for_tags_linked_to_budgets` does not exist):

```
FAILED tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_budget_table_reset_also_resets_linked_tags
FAILED tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets
FAILED tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_empty
FAILED tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_invalidates_counter
FAILED tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_swallows_find_many_failure
5 failed, 31 deselected in 7.40s
```

After fix:

```
$ uv run --no-sync pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -q
....................................                                     [100%]
36 passed in 7.22s
```

## Tests

Added five tests in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py`:

- `test_reset_budget_for_tags_linked_to_budgets` — happy path: tag with `budget_id` in the reset set has `spend` zeroed via `update_many` with the right `WHERE` clause.
- `test_reset_budget_for_tags_linked_to_budgets_empty` — no budgets to reset → no DB query, no write.
- `test_budget_table_reset_also_resets_linked_tags` — integration: the new handler is invoked from `reset_budget_for_litellm_budget_table()` end-to-end, alongside the existing keys/end-users/team-members handlers.
- `test_reset_budget_for_tags_linked_to_budgets_invalidates_counter` — after zeroing spend in the DB the per-tag spend counter is cleared in both the in-memory cache and Redis (so `get_current_spend` doesn't keep returning the stale value).
- `test_reset_budget_for_tags_linked_to_budgets_swallows_find_many_failure` — fail-open contract: a transient `find_many` error must not skip the `update_many` that zeroes `spend` (matches the keys-linked-to-budgets fail-open behavior).

Test runs:

- `pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` → 36/36 passing (31 existing + 5 new).
- `pytest tests/test_litellm/proxy/common_utils/` → 194/194 passing.
- `ruff check litellm/` → clean.
- `mypy litellm/proxy/common_utils/reset_budget_job.py --ignore-missing-imports` → clean.
- `black --check` on touched files → clean.
