### PR TITLE
Fix: reset spend on tags linked to expiring budget tiers (#27481)

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -171,6 +171,57 @@ class ResetBudgetJob:
 
         return update_result
 
+    async def reset_budget_for_tags_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for tags linked to budget tiers that are being reset.
+
+        Tags (LiteLLM_TagTable) only carry a `budget_id` and rely entirely on
+        the linked LiteLLM_BudgetTable's reset schedule — there is no
+        per-tag `budget_duration` like keys have. Without this reset,
+        `LiteLLM_BudgetTable.budget_reset_at` advances correctly but
+        `LiteLLM_TagTable.spend` is never zeroed, so once a tag's accumulated
+        spend exceeds its `max_budget`, `_tag_max_budget_check` keeps reading
+        the stale (large) value from the tag row and rejects every subsequent
+        request with HTTP 400 budget_exceeded — across multiple reset cycles —
+        until someone manually clears the row.
+        """
+        budget_ids = [
+            budget.budget_id
+            for budget in budgets_to_reset
+            if budget.budget_id is not None
+        ]
+        if not budget_ids:
+            return
+
+        where_clause: dict = {
+            "budget_id": {"in": budget_ids},
+            "spend": {"gt": 0},  # only reset tags that have accumulated spend
+        }
+
+        try:
+            tags = await self.prisma_client.db.litellm_tagtable.find_many(
+                where=where_clause
+            )
+        except Exception as e:
+            tags = []
+            verbose_proxy_logger.warning(
+                "Failed to fetch tags for counter invalidation: %s", e
+            )
+
+        update_result = await self.prisma_client.db.litellm_tagtable.update_many(
+            where=where_clause,
+            data={
+                "spend": 0,
+            },
+        )
+
+        for t in tags:
+            await self._invalidate_spend_counter(f"spend:tag:{t.tag_name}")
+
+        return update_result
+
     async def reset_budget_for_litellm_budget_table(self):
         """
         Resets the budget for all LiteLLM End-Users (Customers), and Team Members if their budget has expired
@@ -234,6 +285,10 @@ class ResetBudgetJob:
                 )
 
                 await self.reset_budget_for_keys_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_tags_linked_to_budgets(
                     budgets_to_reset=budgets_to_reset
                 )
 

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -52,11 +52,32 @@ class MockLiteLLMEndUserTable:
         return self._find_many_results
 
 
+class MockLiteLLMTagTable:
+    def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": 1}
+
+
 class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
+        self.litellm_tagtable = MockLiteLLMTagTable()
 
 
 class MockPrismaClient:
@@ -1205,3 +1226,148 @@ def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monke
     counter_cache.in_memory_cache.set_cache.assert_any_call(
         key="spend:key:sk-linked", value=0.0, ttl=60
     )
+
+
+# ---------------------------------------------------------------------------
+# Tag budget reset (regression guard for the missing-tag-reset bug)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_budget_for_tags_linked_to_budgets(reset_budget_job, mock_prisma_client):
+    """When a budget tier is reset, tags linked to that budget (via budget_id)
+    must have their accumulated `spend` zeroed in the tag table.
+
+    Without this, `LiteLLM_BudgetTable.budget_reset_at` advances each cycle
+    but `LiteLLM_TagTable.spend` keeps the over-budget value forever, so
+    `_tag_max_budget_check` raises 400 budget_exceeded on every subsequent
+    request even after the reset window has passed.
+    """
+    now = datetime.now(timezone.utc)
+
+    expired_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "tag-budget-tier",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(
+            budgets_to_reset=[expired_budget]
+        )
+    )
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1, f"Expected 1 update_many call on tag table, got {len(calls)}"
+    call = calls[0]
+    assert call["where"]["budget_id"] == {"in": ["tag-budget-tier"]}
+    # only reset rows that have actually accumulated spend — avoids no-op writes
+    # against the (potentially large) full tag table on every reset tick.
+    assert call["where"]["spend"] == {"gt": 0}
+    assert call["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """No budgets to reset -> no work and no DB write on the tag table."""
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(budgets_to_reset=[])
+    )
+
+    assert mock_prisma_client.db.litellm_tagtable.update_many_calls == []
+    assert mock_prisma_client.db.litellm_tagtable.find_many_calls == []
+
+
+def test_budget_table_reset_also_resets_linked_tags(
+    reset_budget_job, mock_prisma_client
+):
+    """Integration-style: `reset_budget_for_litellm_budget_table` must drive
+    the tag-reset path so the bug fix is wired into the dispatcher, not just
+    available as a method nobody calls.
+    """
+    now = datetime.now(timezone.utc)
+
+    expired_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 0.05,
+            "budget_duration": "1d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "tag-budget-tier",
+            "created_at": now - timedelta(days=1),
+        },
+    )
+
+    mock_prisma_client.data["budget"] = [expired_budget]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1, (
+        "Expected reset_budget_for_litellm_budget_table to also reset tags "
+        f"linked to expiring budgets, but got {len(calls)} update_many calls"
+    )
+    assert calls[0]["where"]["budget_id"] == {"in": ["tag-budget-tier"]}
+    assert calls[0]["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter(monkeypatch):
+    """The spend counter (`spend:tag:{tag_name}`) must be cleared after the
+    DB write so `_tag_max_budget_check`'s next read does not block the user
+    on an in-memory/Redis counter that still holds the over-budget value.
+    """
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "tag-budget-tier"})
+    linked_tag = type("Tag", (), {"tag_name": "customer-co"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(
+        return_value={"count": 1}
+    )
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:customer-co", value=0.0, ttl=60
+    )
+    counter_cache.redis_cache.async_set_cache.assert_any_await(
+        key="spend:tag:customer-co", value=0.0, ttl=60
+    )
+
+
+def test_reset_budget_for_tags_linked_to_budgets_continues_when_find_many_fails(
+    monkeypatch,
+):
+    """If the find_many for cache invalidation fails, the DB reset still
+    happens — the counter is best-effort, but the row write is not.
+    """
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "tag-budget-tier"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(
+        side_effect=RuntimeError("transient db error")
+    )
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(
+        return_value={"count": 5}
+    )
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    # must not raise
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    prisma_client.db.litellm_tagtable.update_many.assert_awaited_once()
+    # No tags were returned from find_many, so no per-tag counter calls — but
+    # also no exception bubbled up.
+    counter_cache.in_memory_cache.set_cache.assert_not_called()


### PR DESCRIPTION
## Summary

Tag-based budgets in the proxy never reset their spend counters. `LiteLLM_BudgetTable.budget_reset_at` advanced normally each cycle, but `LiteLLM_TagTable.spend` was never zeroed, so once a tag's accumulated spend exceeded `max_budget`, `_tag_max_budget_check` kept reading the stale over-budget value and rejected every subsequent request with HTTP 400 `budget_exceeded` across multiple reset cycles — until someone manually cleared the row.

The fix adds `reset_budget_for_tags_linked_to_budgets()` to `litellm/proxy/common_utils/reset_budget_job.py`, mirroring the existing `reset_budget_for_keys_linked_to_budgets()` (without a `budget_duration` filter — tags rely entirely on the linked budget's schedule), and wires it into `reset_budget_for_litellm_budget_table()`. It also invalidates the `spend:tag:{name}` counter so the reset takes effect within the cross-pod TTL window. Fixes #27481.

## Repro

1. Create a `LiteLLM_BudgetTable` row with `max_budget=0.05`, `budget_duration="1m"`.
2. Bind it to a `LiteLLM_TagTable` row via `budget_id`.
3. Drive tagged traffic past the limit. `_tag_max_budget_check` raises `BudgetExceededError` (HTTP 400) — expected.
4. Wait through several reset cycles. `LiteLLM_BudgetTable.budget_reset_at` advances each cycle; `LiteLLM_TagTable.spend` does not.
5. Send another tagged request. **Before this PR:** still HTTP 400 forever, despite cycles having elapsed. **After this PR:** request succeeds because the tag's spend was zeroed at the cycle boundary.

## Evidence

Terminal transcript (gist hosting unavailable in this environment, falling back to inline transcript per the contract):

**Before fix — new tests fail on the starting ref**

```
$ git stash push -- litellm/proxy/common_utils/reset_budget_job.py
$ uv run --no-sync pytest \
    tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets \
    tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_empty \
    tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_budget_table_reset_also_resets_linked_tags \
    tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter \
    tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_continues_when_find_many_fails \
    --noconftest --no-cov -v

FAILED ::test_reset_budget_for_tags_linked_to_budgets
  AttributeError: 'ResetBudgetJob' object has no attribute 'reset_budget_for_tags_linked_to_budgets'
FAILED ::test_reset_budget_for_tags_linked_to_budgets_empty
  AttributeError: 'ResetBudgetJob' object has no attribute 'reset_budget_for_tags_linked_to_budgets'
FAILED ::test_budget_table_reset_also_resets_linked_tags
  AssertionError: Expected reset_budget_for_litellm_budget_table to also reset tags linked
                  to expiring budgets, but got 0 update_many calls
FAILED ::test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter
  AttributeError: 'ResetBudgetJob' object has no attribute 'reset_budget_for_tags_linked_to_budgets'
FAILED ::test_reset_budget_for_tags_linked_to_budgets_continues_when_find_many_fails
  AttributeError: 'ResetBudgetJob' object has no attribute 'reset_budget_for_tags_linked_to_budgets'
============================== 5 failed in 8.00s ===============================
```

**After fix — same five tests pass**

```
$ git stash pop
$ uv run --no-sync pytest <same five tests> --noconftest --no-cov -v

::test_reset_budget_for_tags_linked_to_budgets PASSED                              [ 20%]
::test_reset_budget_for_tags_linked_to_budgets_empty PASSED                        [ 40%]
::test_budget_table_reset_also_resets_linked_tags PASSED                           [ 60%]
::test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter PASSED    [ 80%]
::test_reset_budget_for_tags_linked_to_budgets_continues_when_find_many_fails PASSED [100%]
============================== 5 passed in 7.18s ===============================
```

## Tests

Five new tests in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py`, mirroring the existing keys-linked-to-budgets coverage:

- `test_reset_budget_for_tags_linked_to_budgets` — happy path: `update_many` is called with `{budget_id: {in: [...]}, spend: {gt: 0}}` and `{spend: 0}`.
- `test_reset_budget_for_tags_linked_to_budgets_empty` — no budgets to reset → no DB writes, no `find_many`, no exceptions.
- `test_budget_table_reset_also_resets_linked_tags` — integration-style: `reset_budget_for_litellm_budget_table()` drives the new tag path, so the fix is wired into the dispatcher and not just an orphan method.
- `test_reset_budget_for_tags_linked_to_budgets_invalidates_spend_counter` — confirms `spend:tag:{name}` is zeroed in both the in-memory cache and Redis after the DB write.
- `test_reset_budget_for_tags_linked_to_budgets_continues_when_find_many_fails` — defensive: if the cache-invalidation `find_many` raises, the DB `update_many` still happens (counter invalidation is best-effort, the row reset is not).

All five tests fail on the starting ref with `AttributeError: 'ResetBudgetJob' object has no attribute 'reset_budget_for_tags_linked_to_budgets'` and the integration test's `AssertionError: ... 0 update_many calls`. All five pass after the fix.

Lint runs clean at CI's scope:

```
$ cd litellm && uv run --no-sync black --check --exclude '/enterprise/' .
All done! ✨ 🍰 ✨ -- 1806 files would be left unchanged.
$ cd litellm && uv run --no-sync ruff check .
All checks passed!
$ cd litellm && uv run --no-sync mypy .
(clean exit, no errors)
```
