### PR TITLE
chore(mcp): tighten stdio server registration paths

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -806,6 +806,13 @@ class MCPServerManager:
                 self.initialize_tool_name_to_mcp_server_name_mapping()
 
     async def add_server(self, mcp_server: LiteLLM_MCPServerTable):
+        # The runtime registry is the allowlist for tool calls and health
+        # probes (which spawn the underlying transport, including stdio
+        # subprocesses). Match the eligibility set used by the bulk DB
+        # filter in reload_servers_from_database() — NULL is legacy and
+        # "approved" is a legacy alias for "active".
+        if mcp_server.approval_status not in (None, "active", "approved"):
+            return
         try:
             if mcp_server.server_id not in self.registry:
                 new_server = await self.build_mcp_server_from_table(mcp_server)
@@ -819,6 +826,13 @@ class MCPServerManager:
             raise e
 
     async def update_server(self, mcp_server: LiteLLM_MCPServerTable):
+        # If a previously-active server has been moved out of the active
+        # state, evict any stale registry entry so subsequent tool calls and
+        # health probes can't reach it.
+        if mcp_server.approval_status not in (None, "active", "approved"):
+            if mcp_server.server_id in self.registry:
+                del self.registry[mcp_server.server_id]
+            return
         try:
             if mcp_server.server_id in self.registry:
                 new_server = await self.build_mcp_server_from_table(mcp_server)

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -142,6 +142,7 @@ if MCP_AVAILABLE:
         MCPOAuthUserCredentialRequest,
         MCPOAuthUserCredentialStatus,
         MCPSubmissionsSummary,
+        MCPTransport,
         MCPUserCredentialListItem,
         MCPUserCredentialRequest,
         MCPUserCredentialResponse,
@@ -1067,6 +1068,24 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={
                     "error": "Registration requires an API key associated with a team. Use a team-scoped key."
+                },
+            )
+
+        # stdio servers spawn a local subprocess on the proxy host with the
+        # configured command + args, so accepting them from non-admin callers
+        # would let a team member propose a server config that an admin could
+        # rubber-stamp into local code execution. Restrict stdio submission to
+        # the admin POST /v1/mcp/server path or to config.yaml.
+        if payload.transport == MCPTransport.stdio:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": (
+                        "stdio MCP servers cannot be submitted via the user "
+                        "registration workflow. Ask a proxy admin to add this "
+                        "server via POST /v1/mcp/server or to declare it in "
+                        "config.yaml."
+                    )
                 },
             )
 

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1494,6 +1494,7 @@ async def test_add_update_server_with_alias():
     mock_mcp_server.created_at = None
     mock_mcp_server.updated_at = None
     mock_mcp_server.instructions = None
+    mock_mcp_server.approval_status = "active"
 
     # Add server to manager
     await test_manager.add_server(mock_mcp_server)
@@ -1551,6 +1552,7 @@ async def test_add_update_server_without_alias():
     mock_mcp_server.created_at = None
     mock_mcp_server.updated_at = None
     mock_mcp_server.instructions = None
+    mock_mcp_server.approval_status = "active"
 
     # Add server to manager
     await test_manager.add_server(mock_mcp_server)
@@ -1609,6 +1611,7 @@ async def test_add_update_server_fallback_to_server_id():
     mock_mcp_server.created_at = None
     mock_mcp_server.updated_at = None
     mock_mcp_server.instructions = None
+    mock_mcp_server.approval_status = "active"
     # Add server to manager
     await test_manager.add_server(mock_mcp_server)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -29,7 +29,11 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
     _deserialize_json_dict,
 )
-from litellm.proxy._types import LiteLLM_MCPServerTable, MCPTransport
+from litellm.proxy._types import (
+    LiteLLM_MCPServerTable,
+    MCPApprovalStatus,
+    MCPTransport,
+)
 from litellm.types.mcp import MCPAuth
 from litellm.types.mcp_server.mcp_server_manager import MCPOAuthMetadata, MCPServer
 
@@ -3309,6 +3313,83 @@ class TestOAuthDiscoverySSRFGuard:
 
         assert result is None
         mock_client.get.assert_not_called()
+
+
+class TestApprovalStatusGate:
+    """
+    Regression tests for GHSA-gm4g-h72v-jhc3.
+
+    The runtime registry must only contain servers an admin has approved.
+    A non-admin can submit a pending stdio MCP server with an attacker-chosen
+    command/args; before this gate, an admin opening the per-row endpoint
+    triggered ``add_server`` + ``health_check_server``, which spawned the
+    attacker's process under the proxy. The data-layer gate in
+    ``add_server`` / ``update_server`` blocks pending and rejected rows
+    from entering the registry regardless of which caller passes them in.
+    """
+
+    def _make_server(self, server_id: str, approval_status):
+        return LiteLLM_MCPServerTable(
+            server_id=server_id,
+            alias=f"server_{server_id}",
+            description="test",
+            url=None,
+            transport=MCPTransport.stdio,
+            command="python",
+            args=["-c", "print('attacker payload')"],
+            env={},
+            approval_status=approval_status,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+    @pytest.mark.parametrize(
+        "approval_status,expect_in_registry",
+        [
+            (MCPApprovalStatus.pending_review, False),
+            (MCPApprovalStatus.rejected, False),
+            (MCPApprovalStatus.active, True),
+            # Legacy rows: NULL predates the approval workflow; "approved" is
+            # a legacy alias for "active" still present in older deployments.
+            # Both must continue to load to match the DB-level filter in
+            # reload_servers_from_database().
+            (None, True),
+            ("approved", True),
+        ],
+    )
+    async def test_add_server_respects_approval_status(
+        self, approval_status, expect_in_registry
+    ):
+        manager = MCPServerManager()
+        server_id = f"sid-{approval_status}"
+        await manager.add_server(self._make_server(server_id, approval_status))
+        assert (server_id in manager.registry) is expect_in_registry
+
+    async def test_update_server_evicts_when_transitioned_away_from_active(self):
+        # An admin updates a previously-active server to rejected (or pending).
+        # The stale registry entry must be evicted so subsequent tool calls
+        # and health probes can't reach it.
+        manager = MCPServerManager()
+        await manager.add_server(
+            self._make_server("evict-me", MCPApprovalStatus.active)
+        )
+        assert "evict-me" in manager.registry
+
+        await manager.update_server(
+            self._make_server("evict-me", MCPApprovalStatus.rejected)
+        )
+        assert "evict-me" not in manager.registry
+
+    async def test_update_server_noop_for_unregistered_pending(self):
+        # update_server called with a pending row that was never registered
+        # should silently return without adding it. Locks in the early-return
+        # so a future refactor can't accidentally route the pending row to
+        # build_mcp_server_from_table.
+        manager = MCPServerManager()
+        await manager.update_server(
+            self._make_server("never-seen", MCPApprovalStatus.pending_review)
+        )
+        assert "never-seen" not in manager.registry
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -2492,6 +2492,32 @@ class TestMCPApprovalWorkflow:
         assert "team" in str(exc_info.value.detail).lower()
 
     @pytest.mark.asyncio
+    async def test_register_mcp_server_rejects_stdio_transport(self):
+        # stdio servers spawn a local subprocess on the proxy host. Accepting
+        # them from the non-admin submission endpoint would let a team member
+        # propose a config that an admin could rubber-stamp into local code
+        # execution. Admins use POST /v1/mcp/server or config.yaml instead.
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            register_mcp_server,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="local",
+            transport=MCPTransport.stdio,
+            command="python3",
+            args=["-m", "mcp_server_filesystem", "/tmp"],
+        )
+        user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            team_id="team-123",
+            user_id="user-abc",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await register_mcp_server(payload=payload, user_api_key_dict=user_auth)
+        assert exc_info.value.status_code == 400
+        assert "stdio" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
     async def test_register_mcp_server_sets_pending_review(self):
         from litellm.proxy._types import MCPApprovalStatus
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (


### PR DESCRIPTION
## Type

🐛 Bug Fix
✅ Test

## Changes

Two related tightenings to the MCP server registration paths.

### 1. `add_server` / `update_server` honor `approval_status`

`MCPServerManager.reload_servers_from_database()` already filters at the DB layer, loading only rows whose `approval_status` is `"active"`, the legacy `"approved"` alias, or `NULL`. The single-row paths (`add_server`, `update_server`) didn't enforce the same filter — any caller passing a freshly-loaded `LiteLLM_MCPServerTable` row could land it in the in-memory registry regardless of approval status. The `GET /v1/mcp/server/{id}` handler called `add_server` followed by `health_check_server` for whatever DB row it loaded, including rows still in `pending_review` from `/v1/mcp/server/register`.

`add_server` early-returns when `approval_status` is not in the eligible set. `update_server` does the same and additionally evicts any stale registry entry, so a previously active server transitioning to `rejected` or `pending_review` no longer leaves a usable entry behind.

### 2. `POST /v1/mcp/server/register` rejects `transport=stdio`

The user submission endpoint accepts pending MCP servers from non-admin team-scoped keys. stdio servers spawn a local subprocess on the proxy host with the configured `command` + `args`. Accepting them from the submission queue lets a team member propose a server config that an admin could rubber-stamp into local code execution on shared infra.

Reject `transport=stdio` at the endpoint with an explicit error pointing operators to the admin `POST /v1/mcp/server` path or to the `config.yaml` `mcp_servers` block. `sse` and `http` continue to flow through unchanged.

## Compatibility

- **Operators using only the documented submission/approval flow with sse/http transports:** unaffected.
- **Legacy rows with `approval_status=NULL` or `approval_status="approved"`:** unchanged. Both values match the existing bulk-load filter.
- **Operators registering stdio MCP servers via the admin `POST /v1/mcp/server` path or via `config.yaml`:** unchanged.
- **Operators submitting stdio MCP servers through the user submission endpoint (`POST /v1/mcp/server/register`):** now receive a 400 with a message pointing them to the admin path or `config.yaml`. The stdio submission path had no coherent security model (a non-admin asking the proxy to spawn a process under proxy privilege on shared infra), and config.yaml is the existing supported declaration mechanism.
- **Admin reviewing a pending submission via `GET /v1/mcp/server/{id}`:** previously got a synchronous health probe in the response (which spawned the underlying transport for stdio servers); now sees `status: "unknown"` with `health_check_error: "Server not found"` from `health_check_server`'s existing graceful path for unregistered server IDs.

## Test Plan

- `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py` — new `TestApprovalStatusGate` covering pending / rejected / active / NULL / legacy-approved branches of `add_server`, eviction on `update_server` transition away from active, and the no-op path for `update_server` called with an unregistered pending row. Three existing `MagicMock`-based tests in `tests/mcp_tests/test_mcp_server.py` had to set `approval_status="active"` to match the new gate.
- `tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py` — new `test_register_mcp_server_rejects_stdio_transport` exercising the BYOM rejection.

```
uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py tests/mcp_tests/test_mcp_server.py -q
241 passed, 1 skipped in 127s

uv run black --check litellm/proxy/_experimental/mcp_server/mcp_server_manager.py litellm/proxy/management_endpoints/mcp_management_endpoints.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py tests/mcp_tests/test_mcp_server.py
All done!
```