### PR TITLE
fix(proxy): enforce tag budgets for tags passed via x-litellm-tags header

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -64,6 +64,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     _safe_get_request_headers,
     _safe_get_request_query_params,
+    merge_header_tags_into_request_body,
     populate_request_with_path_params,
 )
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
@@ -2053,6 +2054,16 @@ async def user_api_key_auth(
     request_data = await _read_request_body(request=request)
     request_data = populate_request_with_path_params(
         request_data=request_data, request=request
+    )
+    # Fold `x-litellm-tags` header into request_body["metadata"]["tags"] so
+    # auth-time tag-aware checks (_tag_max_budget_check, budget_reservation,
+    # _reject_clientside_metadata_tags_check) see header-supplied tags as
+    # part of the request body. The allow_client_tags strip in
+    # add_litellm_data_to_request remains the single gatekeeper for whether
+    # those tags survive into routing/spend.
+    merge_header_tags_into_request_body(
+        request_body=request_data,
+        headers=_safe_get_request_headers(request=request),
     )
     route: str = get_request_route(request=request)
     ## CHECK IF ROUTE IS ALLOWED

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Collection, Dict, List, Optional
+from typing import Any, Collection, Dict, List, Mapping, Optional
 
 import orjson
 from fastapi import Request, UploadFile, status
@@ -449,6 +449,78 @@ def get_tags_from_request_body(request_body: dict) -> List[str]:
         combined_tags.extend(tags_in_request_body)
     ######################################
     return [tag for tag in combined_tags if isinstance(tag, str)]
+
+
+def _parse_x_litellm_tags_header(raw: Any) -> List[str]:
+    """Normalize the ``x-litellm-tags`` header value into a list of strings.
+
+    Accepts the same shapes as ``add_request_tag_to_metadata``:
+    - comma-separated string (e.g. ``"a,b,c"``)
+    - already-parsed list of strings
+    """
+    if isinstance(raw, str):
+        return [t.strip() for t in raw.split(",") if t.strip()]
+    if isinstance(raw, list):
+        return [t for t in raw if isinstance(t, str)]
+    return []
+
+
+def merge_header_tags_into_request_body(
+    request_body: dict, headers: Mapping[str, Any]
+) -> None:
+    """Mutate ``request_body`` in place to fold ``x-litellm-tags`` into
+    ``metadata.tags`` so auth-time tag-aware checks see one source of truth.
+
+    Why this exists:
+    - ``_tag_max_budget_check`` (auth) and ``budget_reservation`` read tags
+      via ``get_tags_from_request_body``, which only inspects the body.
+    - ``add_request_tag_to_metadata`` does the header→metadata merge, but it
+      runs inside ``add_litellm_data_to_request`` *after* the auth chain has
+      already finished. That means tag-budget enforcement was bypassed for
+      header-tagged requests (header → no body tags at auth time → silent
+      pass).
+
+    Security model preserved by *not* gating on ``allow_client_tags`` here:
+    the strip in ``add_litellm_data_to_request`` already removes
+    ``metadata.tags``, ``litellm_metadata.tags``, and root ``tags`` when the
+    key/team is not opted in. Header tags merged here flow through that same
+    strip and are removed for callers without the opt-in. Duplicating the
+    opt-in check at this layer would create two places to keep in sync.
+
+    Edge cases:
+    - JSON-string ``metadata`` (multipart/form-data, ``extra_body``): bail
+      out without mutation. Matches ``_coerce_metadata_to_dict`` semantics
+      used by other auth-time bouncers — they read but don't mutate the
+      string form. The downstream ``add_request_tag_to_metadata`` still
+      handles header tags after metadata is parsed to a dict.
+    - Missing ``metadata`` key: create an empty dict so the merge has a
+      home. The strip downstream handles cleanup if the caller is not
+      allowed to set tags.
+    """
+    raw = headers.get("x-litellm-tags") if headers else None
+    header_tags = _parse_x_litellm_tags_header(raw)
+    if not header_tags:
+        return
+
+    metadata = request_body.get("metadata")
+    if metadata is None:
+        metadata = {}
+        request_body["metadata"] = metadata
+    elif not isinstance(metadata, dict):
+        # JSON-string or other non-dict shape — leave alone, downstream
+        # parses and merges via add_request_tag_to_metadata.
+        return
+
+    existing = metadata.get("tags")
+    if not isinstance(existing, list):
+        existing = []
+    # Preserve order: existing body tags first, then header tags not already
+    # present. Avoids set() to keep ordering deterministic for tests/logs.
+    merged = list(existing)
+    for tag in header_tags:
+        if tag not in merged:
+            merged.append(tag)
+    metadata["tags"] = merged
 
 
 def populate_request_with_path_params(request_data: dict, request: Request) -> dict:

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -2359,6 +2359,122 @@ async def test_tag_budget_check_reads_from_spend_counter():
 
 
 @pytest.mark.asyncio
+async def test_tag_budget_check_enforces_when_header_tags_pre_merged():
+    """Regression: x-litellm-tags header tags must be enforced by the
+    auth-time tag budget gate.
+
+    Previously _tag_max_budget_check only read body tags, so requests that
+    passed tags via the documented `x-litellm-tags` header bypassed
+    enforcement and silently exceeded budgets. The fix folds header tags
+    into request_body["metadata"]["tags"] in user_api_key_auth, before
+    common_checks runs. This test exercises that contract from the auth
+    function's perspective: given a body that already has the header tags
+    merged in, enforcement fires.
+    """
+    from litellm.proxy.common_utils.http_parsing_utils import (
+        merge_header_tags_into_request_body,
+    )
+    from litellm.proxy.utils import ProxyLogging
+
+    tag_object = LiteLLM_TagTable(
+        tag_name="tenant:acme",
+        spend=0.0,
+        litellm_budget_table=LiteLLM_BudgetTable(max_budget=0.10),
+    )
+
+    async def mock_get_current_spend(counter_key, fallback_spend):
+        if counter_key == "spend:tag:tenant:acme":
+            return 0.25
+        return fallback_spend
+
+    # Mirror what user_api_key_auth does at request entry: read the body
+    # (no body tags) and fold the x-litellm-tags header into it.
+    request_body: dict = {"model": "gpt-4"}
+    merge_header_tags_into_request_body(
+        request_body=request_body,
+        headers={"x-litellm-tags": "tenant:acme"},
+    )
+    assert request_body["metadata"]["tags"] == ["tenant:acme"]
+
+    with (
+        patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+            new_callable=AsyncMock,
+            return_value={"tenant:acme": tag_object},
+        ),
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await _tag_max_budget_check(
+                request_body=request_body,
+                prisma_client=MagicMock(),
+                user_api_key_cache=MagicMock(),
+                proxy_logging_obj=ProxyLogging(user_api_key_cache=None),
+                valid_token=UserAPIKeyAuth(token="test-token"),
+            )
+        assert exc_info.value.current_cost == 0.25
+        assert exc_info.value.max_budget == 0.10
+        assert "tenant:acme" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_tag_budget_check_enforces_on_union_of_header_and_body_tags():
+    """Header and body tags together: both must be evaluated."""
+    from litellm.proxy.common_utils.http_parsing_utils import (
+        merge_header_tags_into_request_body,
+    )
+    from litellm.proxy.utils import ProxyLogging
+
+    body_tag = LiteLLM_TagTable(
+        tag_name="from-body",
+        spend=0.0,
+        litellm_budget_table=LiteLLM_BudgetTable(max_budget=10.0),
+    )
+    header_tag = LiteLLM_TagTable(
+        tag_name="from-header",
+        spend=0.0,
+        litellm_budget_table=LiteLLM_BudgetTable(max_budget=0.01),
+    )
+
+    async def mock_get_current_spend(counter_key, fallback_spend):
+        if counter_key == "spend:tag:from-header":
+            return 5.0
+        if counter_key == "spend:tag:from-body":
+            return 0.0
+        return fallback_spend
+
+    request_body: dict = {
+        "model": "gpt-4",
+        "metadata": {"tags": ["from-body"]},
+    }
+    merge_header_tags_into_request_body(
+        request_body=request_body,
+        headers={"x-litellm-tags": "from-header"},
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+            new_callable=AsyncMock,
+            return_value={
+                "from-body": body_tag,
+                "from-header": header_tag,
+            },
+        ),
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await _tag_max_budget_check(
+                request_body=request_body,
+                prisma_client=MagicMock(),
+                user_api_key_cache=MagicMock(),
+                proxy_logging_obj=ProxyLogging(user_api_key_cache=None),
+                valid_token=UserAPIKeyAuth(token="test-token"),
+            )
+        assert "from-header" in exc_info.value.message
+
+
+@pytest.mark.asyncio
 async def test_team_member_budget_check_reads_from_spend_counter():
     """Team member budget check should use get_current_spend when counter exists."""
     from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_TeamMembership

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -24,6 +24,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     get_form_data,
     get_request_body,
     get_tags_from_request_body,
+    merge_header_tags_into_request_body,
     populate_request_with_path_params,
 )
 
@@ -611,6 +612,146 @@ def test_get_tags_from_request_body_with_null_metadata():
 
     assert result == []
     assert isinstance(result, list)
+
+
+class TestMergeHeaderTagsIntoRequestBody:
+    """Tests for merge_header_tags_into_request_body.
+
+    The helper is the auth-time bridge that lets _tag_max_budget_check (and
+    other tag-aware auth checks) see x-litellm-tags header values, which
+    were previously only merged downstream in add_litellm_data_to_request.
+    """
+
+    def test_should_merge_comma_separated_header_into_metadata_tags(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": "tenant:acme,priority:high"},
+        )
+        assert request_body["metadata"]["tags"] == [
+            "tenant:acme",
+            "priority:high",
+        ]
+
+    def test_should_merge_list_header_into_metadata_tags(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": ["tenant:acme", "priority:high"]},
+        )
+        assert request_body["metadata"]["tags"] == [
+            "tenant:acme",
+            "priority:high",
+        ]
+
+    def test_should_dedupe_when_header_tag_already_in_body(self):
+        request_body = {
+            "model": "gpt-4",
+            "metadata": {"tags": ["tenant:acme", "existing"]},
+        }
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": "tenant:acme,priority:high"},
+        )
+        assert request_body["metadata"]["tags"] == [
+            "tenant:acme",
+            "existing",
+            "priority:high",
+        ]
+
+    def test_should_no_op_when_header_absent(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(request_body=request_body, headers={})
+        assert "metadata" not in request_body
+
+    def test_should_no_op_when_header_value_empty_string(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body, headers={"x-litellm-tags": ""}
+        )
+        assert "metadata" not in request_body
+
+    def test_should_no_op_when_header_value_unsupported_type(self):
+        # ints/dicts/None should be ignored, not raise.
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body, headers={"x-litellm-tags": 42}
+        )
+        assert "metadata" not in request_body
+
+    def test_should_strip_whitespace_in_comma_separated_tags(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": "  a  ,  b  ,  c  "},
+        )
+        assert request_body["metadata"]["tags"] == ["a", "b", "c"]
+
+    def test_should_drop_empty_segments_in_comma_separated_tags(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": "a,,b,"},
+        )
+        assert request_body["metadata"]["tags"] == ["a", "b"]
+
+    def test_should_filter_non_string_entries_in_list_header(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": ["a", 1, None, "b"]},
+        )
+        assert request_body["metadata"]["tags"] == ["a", "b"]
+
+    def test_should_leave_string_metadata_untouched(self):
+        # multipart/form-data and extra_body callers can deliver metadata as
+        # a JSON string. Mutating it would change the request shape; the
+        # downstream add_request_tag_to_metadata still merges header tags
+        # after the string is parsed to a dict.
+        request_body = {
+            "model": "gpt-4",
+            "metadata": '{"tags": ["existing"]}',
+        }
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": "from-header"},
+        )
+        assert request_body["metadata"] == '{"tags": ["existing"]}'
+
+    def test_should_create_metadata_dict_when_missing(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body, headers={"x-litellm-tags": "a"}
+        )
+        assert request_body["metadata"] == {"tags": ["a"]}
+
+    def test_should_replace_non_list_metadata_tags_value(self):
+        # If metadata.tags is already a non-list shape (dict, str), the
+        # helper writes a fresh list with just the header tags. The
+        # original non-list value is dropped — get_tags_from_request_body
+        # already ignores non-list shapes, so dropping is safe.
+        request_body = {
+            "model": "gpt-4",
+            "metadata": {"tags": {"unexpected": "shape"}},
+        }
+        merge_header_tags_into_request_body(
+            request_body=request_body, headers={"x-litellm-tags": "a,b"}
+        )
+        assert request_body["metadata"]["tags"] == ["a", "b"]
+
+    def test_should_handle_none_headers(self):
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(request_body=request_body, headers={})
+        assert "metadata" not in request_body
+
+    def test_should_be_visible_to_get_tags_from_request_body(self):
+        # Round-trip: this is the contract auth-time consumers depend on.
+        request_body = {"model": "gpt-4"}
+        merge_header_tags_into_request_body(
+            request_body=request_body,
+            headers={"x-litellm-tags": "from-header"},
+        )
+        assert get_tags_from_request_body(request_body=request_body) == ["from-header"]
 
 
 def test_populate_request_with_path_params_adds_query_params():

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -917,6 +917,68 @@ async def test_add_litellm_data_to_request_ignores_x_litellm_tags_header_without
 
 
 @pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_pre_merged_header_tags_without_permission():
+    """Regression guard for the auth-time header→metadata.tags merge.
+
+    user_api_key_auth folds x-litellm-tags into request_body["metadata"]["tags"]
+    so auth-time tag-aware checks (_tag_max_budget_check, etc.) see them.
+    The allow_client_tags strip in add_litellm_data_to_request must continue
+    to remove those pre-merged tags when the key/team has not opted in.
+    Otherwise header tags would leak into routing/spend attribution despite
+    the strip — exactly the kind of bypass the original strip was added to
+    close.
+
+    This test simulates the post-auth state of `data` (header tags already
+    folded into metadata) and asserts the existing strip still wipes them.
+    """
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {
+        "Content-Type": "application/json",
+        "x-litellm-tags": "restricted-tier,victim-team",
+    }
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    # Simulate what user_api_key_auth produced via
+    # merge_header_tags_into_request_body before delegating to the endpoint.
+    data = {
+        "model": "gpt-3.5-turbo",
+        "metadata": {"tags": ["restricted-tier", "victim-team"]},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={},
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    # Tags must be stripped — both sources end up in the same metadata.tags
+    # slot, and the allow_client_tags=False path deletes that slot wholesale.
+    assert "tags" not in (updated.get("metadata") or {})
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_ignores_root_level_tags_without_permission():
     """Regression: root-level `data["tags"]` bypassed the body-metadata
     tag strip. Root-level tags must also be gated by `allow_client_tags`."""


### PR DESCRIPTION
## Relevant issues

Tag budgets configured against `LiteLLM_TagTable` were silently bypassed when callers passed tags via the documented `x-litellm-tags` HTTP header. Spend continued to grow past `max_budget` and operators only found out from billing.

## Type

🐛 Bug Fix

## Summary

`_tag_max_budget_check` only inspected the request body for tags, so the documented header path bypassed tag-budget enforcement. This PR routes header-supplied tags through the same auth-time gate as body tags. Body-path tag enforcement is unchanged.

## Cause

The proxy has two places that read tags:

1. **Auth time** — `common_checks` → `_tag_max_budget_check` → `get_tags_from_request_body` (`litellm/proxy/auth/auth_checks.py:4053`). Reads only `request_body["metadata"]["tags"]` and `request_body["tags"]`.
2. **Post-auth** — `add_litellm_data_to_request` → `LiteLLMProxyRequestSetup.add_request_tag_to_metadata` (`litellm/proxy/litellm_pre_call_utils.py:1160`). Reads the `x-litellm-tags` header and merges it into `metadata.tags`.

The order is `user_api_key_auth` → `add_litellm_data_to_request`, so by the time header tags are merged, the auth-time budget gate has already returned. For header-tagged requests:

- Auth gate sees `tags = []`, returns silently.
- Post-call spend tracking still attributes to the merged tags.
- Result: `LiteLLM_TagTable.spend` grows unbounded; no `BudgetExceededError` is ever raised.

The body path works because `get_tags_from_request_body` finds tags in the body before the auth gate runs.

## Fix

Add `merge_header_tags_into_request_body` in `litellm/proxy/common_utils/http_parsing_utils.py` and call it in `user_api_key_auth` immediately after `_read_request_body`, so `request_body["metadata"]["tags"]` already contains header-supplied tags by the time `common_checks` runs.

```python
# litellm/proxy/auth/user_api_key_auth.py
request_data = await _read_request_body(request=request)
request_data = populate_request_with_path_params(
    request_data=request_data, request=request
)
merge_header_tags_into_request_body(
    request_body=request_data,
    headers=_safe_get_request_headers(request=request),
)
```

This makes header tags visible to **every** auth-time tag consumer in one place: `_tag_max_budget_check`, `budget_reservation`, and `_reject_clientside_metadata_tags_check`.

### Why this preserves the existing security model

The `allow_client_tags` strip in `add_litellm_data_to_request` (`litellm/proxy/litellm_pre_call_utils.py:1446`) already removes `metadata.tags`, `litellm_metadata.tags`, and root `tags` when the key/team has not opted in. Header tags merged at auth flow through that same strip and are removed for callers without the opt-in — no new path to inject tags into routing or spend attribution. The strip remains the single gatekeeper; this PR does not duplicate that logic at the auth layer.

A regression test (`test_add_litellm_data_to_request_strips_pre_merged_header_tags_without_permission`) pins this property.

## Behavior change for operators

Both items below are bypass-closures, not new restrictions:

1. **Tag budgets now enforce on `x-litellm-tags`-tagged requests.** Deployments that have been silently leaking will start returning `400 budget_exceeded`.
2. **`general_settings.reject_clientside_metadata_tags=true` now also rejects header-supplied tags.** Closes a parallel bypass for the same setting.

## Tests

| File | Tests added |
|---|---|
| `tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py` | 14 unit tests in `TestMergeHeaderTagsIntoRequestBody` (comma-separated, list-form, dedupe, missing/empty/unsupported header values, whitespace stripping, JSON-string metadata bail-out, missing-metadata creation, non-list `tags` replacement, round-trip with `get_tags_from_request_body`) |
| `tests/test_litellm/proxy/auth/test_auth_checks.py` | `test_tag_budget_check_enforces_when_header_tags_pre_merged` (the bug repro), `test_tag_budget_check_enforces_on_union_of_header_and_body_tags` |
| `tests/test_litellm/proxy/test_litellm_pre_call_utils.py` | `test_add_litellm_data_to_request_strips_pre_merged_header_tags_without_permission` (security regression guard) |

Local results:

| Suite | Result |
|---|---|
| `test_http_parsing_utils.py` | 44 passed |
| `test_auth_checks.py` | 118 passed |
| `test_litellm_pre_call_utils.py` | 122 passed |
| `test_user_api_key_auth.py` | 58 passed |
| `test_budget_reservation.py` | 32 passed |

`uv run black .` and `uv run ruff check` both clean on the production source files.

## Pre-Submission checklist

- [x] I have added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit` (relevant suites listed above)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Changes

- `litellm/proxy/common_utils/http_parsing_utils.py` — add `merge_header_tags_into_request_body` and `_parse_x_litellm_tags_header` helpers.
- `litellm/proxy/auth/user_api_key_auth.py` — call the helper right after `_read_request_body` so auth-time tag gates see header tags.
- Tests as listed above.


Made with [Cursor](https://cursor.com)