### PR TITLE
fix: invalidate cached tag object on tag budget reset (#27481)

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -83,6 +83,29 @@ class ResetBudgetJob:
                 "Failed to reset spend counter %s: %s", counter_key, e
             )
 
+    async def _invalidate_source_cache(self, source_cache_key: str) -> None:
+        """Drop a cached entity so the next budget check re-reads spend from DB.
+
+        Without this, a row whose spend was just zeroed in DB can still be
+        served from user_api_key_cache (e.g. ``tag:<name>``) with the
+        pre-reset spend value, which is consulted as the cold-start /
+        DB-unavailable fallback in get_current_spend(). Run this AFTER the
+        DB write commits, mirroring _invalidate_spend_counter.
+        """
+        if self.proxy_logging_obj is None:
+            return
+        user_api_key_cache = self.proxy_logging_obj.call_details.get(
+            "user_api_key_cache"
+        )
+        if user_api_key_cache is None:
+            return
+        try:
+            await user_api_key_cache.async_delete_cache(key=source_cache_key)
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Failed to invalidate source cache key %s: %s", source_cache_key, e
+            )
+
     async def _cascade_reset_spend_for_budget_link(
         self,
         budgets_to_reset: List[LiteLLM_BudgetTableFull],
@@ -90,9 +113,14 @@ class ResetBudgetJob:
         counter_key_fn: Callable[[Any], str],
         log_subject: str,
         extra_where: Optional[dict] = None,
+        source_cache_key_fn: Optional[Callable[[Any], str]] = None,
     ):
         """
         Generic cascade: zero spend on rows whose budget_id is in the reset set.
+
+        When ``source_cache_key_fn`` is supplied, the corresponding entry in
+        user_api_key_cache is also evicted so the next request re-reads the
+        zeroed spend from DB rather than the stale cached object.
         """
         budget_ids = [b.budget_id for b in budgets_to_reset if b.budget_id is not None]
         if not budget_ids:
@@ -114,6 +142,8 @@ class ResetBudgetJob:
 
         for row in rows:
             await self._invalidate_spend_counter(counter_key_fn(row))
+            if source_cache_key_fn is not None:
+                await self._invalidate_source_cache(source_cache_key_fn(row))
 
         return update_result
 
@@ -166,6 +196,14 @@ class ResetBudgetJob:
     ):
         """
         Resets the spend for tags linked to budget tiers that are being reset.
+
+        Also evicts the cached LiteLLM_TagTable object at ``tag:<name>`` in
+        user_api_key_cache. The auth-time tag budget check (see
+        ``_tag_max_budget_check`` in litellm/proxy/auth/auth_checks.py) reads
+        ``tag_object.spend`` as the DB-unavailable fallback in
+        ``get_current_spend``; if that cached object survives a reset it can
+        keep blocking otherwise-unblocked tenants under cold-start /
+        Redis-down scenarios.
         """
         return await self._cascade_reset_spend_for_budget_link(
             budgets_to_reset=budgets_to_reset,
@@ -173,6 +211,7 @@ class ResetBudgetJob:
             counter_key_fn=lambda t: f"spend:tag:{t.tag_name}",
             log_subject="tags",
             extra_where={"spend": {"gt": 0}},
+            source_cache_key_fn=lambda t: f"tag:{t.tag_name}",
         )
 
     async def reset_budget_for_litellm_budget_table(self):

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1458,3 +1458,58 @@ def test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter(monke
     counter_cache.redis_cache.async_set_cache.assert_any_await(
         key="spend:tag:tenant-42", value=0.0, ttl=60
     )
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_source_cache(monkeypatch):
+    """Resetting tags must also evict the cached LiteLLM_TagTable object so
+    the auth-time fallback (``tag_object.spend``) does not keep blocking a
+    tenant after spend has been zeroed in the DB.
+    """
+    _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type("Tag", (), {"tag_name": "tenant-42"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    user_api_key_cache = MagicMock()
+    user_api_key_cache.async_delete_cache = AsyncMock()
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.call_details = {"user_api_key_cache": user_api_key_cache}
+
+    job = ResetBudgetJob(
+        proxy_logging_obj=proxy_logging_obj, prisma_client=prisma_client
+    )
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    user_api_key_cache.async_delete_cache.assert_any_await(key="tag:tenant-42")
+
+
+def test_reset_budget_for_tags_linked_to_budgets_no_user_api_key_cache(monkeypatch):
+    """When user_api_key_cache is not wired up (e.g. early-boot or tests),
+    the cascade must still complete without raising — the spend counter
+    invalidation is the load-bearing path.
+    """
+    _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type("Tag", (), {"tag_name": "tenant-42"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.call_details = {}
+
+    job = ResetBudgetJob(
+        proxy_logging_obj=proxy_logging_obj, prisma_client=prisma_client
+    )
+    # Should not raise even though user_api_key_cache is missing.
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    # The DB write must still have happened.
+    prisma_client.db.litellm_tagtable.update_many.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes #27481. The existing tag-budget reset path on this branch zeros `LiteLLM_TagTable.spend` in the database and invalidates the `spend:tag:<name>` spend counter, but it does not evict the cached `LiteLLM_TagTable` object stored in `user_api_key_cache` under `tag:<name>`. That cached object's `.spend` field is consulted as the DB-unavailable fallback in `_tag_max_budget_check` (via `get_current_spend(fallback_spend=tag_object.spend)`), so under cold-start / Redis-down scenarios a tenant whose spend was just zeroed in DB can still be blocked.

This PR adds `_invalidate_source_cache` to `ResetBudgetJob` and threads an optional `source_cache_key_fn` through the `_cascade_reset_spend_for_budget_link` helper. `reset_budget_for_tags_linked_to_budgets` now passes `lambda t: f"tag:{t.tag_name}"` so the cached entry is dropped after the DB write commits, in the same step as the spend-counter invalidation.

The helper is intentionally generic so the same wiring can later be added for keys / orgs / team memberships if their cached objects pose a similar fallback risk; this PR only flips it on for tags, matching the issue's specific call-out:

> Cache invalidation note: `_tag_max_budget_check` reads through `get_tag_objects_batch`, which uses `DualCache`. The reset handler should also bust the `tag:<name>` cache key after writing — same pattern the end-user reset uses.

## Repro

1. Configure a budget with `max_budget: 0.05`, `budget_duration: "1m"` and link a tag (e.g. `tenant:<id>`) to it.
2. Drive request traffic with that tag past `max_budget`. Subsequent calls return HTTP 400 `budget_exceeded`, as expected.
3. Wait through a reset cycle so `budget_reset_at` advances.
4. Make Redis briefly unavailable (or rely on the in-memory counter expiring) so `get_current_spend` falls through to its fallback chain.
5. Send another request with the tag.

Before this change: the cached `LiteLLM_TagTable` still holds the pre-reset `.spend > max_budget`, `get_current_spend` returns it via `fallback_spend`, and `_tag_max_budget_check` keeps raising `BudgetExceededError`.

After this change: the cached object is gone, `get_tag_objects_batch` re-fetches from DB, `tag_object.spend == 0`, and the request is allowed.

## Evidence

Test run on this branch (terminal):

```
$ uv run pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -v -k tag

tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_budget_table_reset_also_resets_linked_tags PASSED [ 16%]
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets PASSED [ 33%]
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_empty PASSED [ 50%]
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter PASSED [ 66%]
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_invalidates_source_cache PASSED [ 83%]
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py::test_reset_budget_for_tags_linked_to_budgets_no_user_api_key_cache PASSED [100%]

======================= 6 passed, 35 deselected in 7.28s =======================
```

The full file (41 tests) also passes:

```
$ uv run pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -v
...
============================= 41 passed in 42.59s ==============================
```

Verified the new positive test `test_reset_budget_for_tags_linked_to_budgets_invalidates_source_cache` FAILS on the starting ref (`02edaef`) with `AssertionError: async_delete_cache(key='tag:tenant-42') await not found`, and PASSES with this change applied.

## Tests

Two new tests in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py`:

- `test_reset_budget_for_tags_linked_to_budgets_invalidates_source_cache` — pins that `user_api_key_cache.async_delete_cache` is awaited with `key="tag:<name>"` for each linked tag after reset. Fails on starting ref, passes with this fix.
- `test_reset_budget_for_tags_linked_to_budgets_no_user_api_key_cache` — guards the no-op path: when `proxy_logging_obj.call_details` lacks `user_api_key_cache` (early-boot, or unit-test contexts), the cascade still zeros the DB and does not raise. Passes on starting ref and after the fix; pins the contract going forward.

Lint at CI scope:

- `cd litellm && uv run ruff check .` → clean.
- `uv run black --check litellm/proxy/common_utils/reset_budget_job.py tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` → 2 files would be left unchanged.

A pre-existing set of `F401` ruff findings in `tests/test_litellm/proxy/common_utils/test_reset_budget_job.py` (unused `time`, `verbose_proxy_logger`, `ProxyLogging`, and a function-scope `LiteLLM_BudgetTableFull` import) is present on `02edaef` already and is left untouched here — out of scope for this PR.
