### PR TITLE
fix(proxy): coerce header values to str when adding user info to LLM headers

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -795,7 +795,7 @@ class LiteLLMProxyRequestSetup:
             )
             for k, v in litellm_logging_metadata_headers.items():
                 if v is not None:
-                    returned_headers["x-litellm-{}".format(k)] = v
+                    returned_headers["x-litellm-{}".format(k)] = str(v)
 
         return returned_headers
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import json
 import re
 import time
 from collections import OrderedDict
@@ -795,7 +796,9 @@ class LiteLLMProxyRequestSetup:
             )
             for k, v in litellm_logging_metadata_headers.items():
                 if v is not None:
-                    returned_headers["x-litellm-{}".format(k)] = str(v)
+                    returned_headers["x-litellm-{}".format(k)] = (
+                        json.dumps(v) if isinstance(v, (dict, list)) else str(v)
+                    )
 
         return returned_headers
 

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -591,8 +591,8 @@ def test_foward_litellm_user_info_to_backend_llm_call():
         "x-litellm-user_api_key_user_id": "test_user_id",
         "x-litellm-user_api_key_org_id": "test_org_id",
         "x-litellm-user_api_key_hash": "test_api_key",
-        "x-litellm-user_api_key_spend": 0.0,
-        "x-litellm-user_api_key_auth_metadata": {},
+        "x-litellm-user_api_key_spend": "0.0",
+        "x-litellm-user_api_key_auth_metadata": "{}",
     }
 
     assert json.dumps(data, sort_keys=True) == json.dumps(expected_data, sort_keys=True)

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4043,3 +4043,35 @@ def test_get_guardrail_from_metadata_reads_litellm_metadata_when_no_metadata():
     assert result == [
         "my-guardrail"
     ], f"Expected guardrails from litellm_metadata fallback, got: {result}"
+
+
+def test_add_headers_to_llm_call_coerces_non_string_values():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/27458
+    Float values (spend, max_budget) in user metadata must be coerced to
+    strings before being set as HTTP headers. httpx rejects non-str/bytes
+    header values with TypeError.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        token="sk-test",
+        spend=42.5,
+        max_budget=100.0,
+        team_id="team-1",
+        user_id="user-1",
+    )
+    headers = Headers(raw=[])
+    original = litellm.add_user_information_to_llm_headers
+    litellm.add_user_information_to_llm_headers = True
+    try:
+        result = LiteLLMProxyRequestSetup.add_headers_to_llm_call(
+            headers=headers,
+            user_api_key_dict=user_api_key_dict,
+        )
+        for k, v in result.items():
+            assert isinstance(
+                v, str
+            ), f"Header {k!r} has type {type(v).__name__}, expected str"
+        assert result["x-litellm-user_api_key_spend"] == "42.5"
+        assert result["x-litellm-user_api_key_max_budget"] == "100.0"
+    finally:
+        litellm.add_user_information_to_llm_headers = original

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4058,6 +4058,7 @@ def test_add_headers_to_llm_call_coerces_non_string_values():
         max_budget=100.0,
         team_id="team-1",
         user_id="user-1",
+        metadata={"env": "staging", "tier": "premium"},
     )
     headers = Headers(raw=[])
     original = litellm.add_user_information_to_llm_headers
@@ -4073,5 +4074,10 @@ def test_add_headers_to_llm_call_coerces_non_string_values():
             ), f"Header {k!r} has type {type(v).__name__}, expected str"
         assert result["x-litellm-user_api_key_spend"] == "42.5"
         assert result["x-litellm-user_api_key_max_budget"] == "100.0"
+        # Dict metadata must be JSON, not Python repr
+        auth_meta = result.get("x-litellm-user_api_key_auth_metadata")
+        if auth_meta is not None:
+            parsed = json.loads(auth_meta)
+            assert parsed == {"env": "staging", "tier": "premium"}
     finally:
         litellm.add_user_information_to_llm_headers = original


### PR DESCRIPTION
## Summary

- Fix `TypeError: Header value must be str or bytes, not <class 'float'>` when `add_user_information_to_llm_headers: true` is enabled
- Float values like `spend` and `max_budget` from `UserAPIKeyAuth` are passed directly as HTTP header values in `add_headers_to_llm_call()` -- httpx rejects non-str/bytes values
- Coerce all header values to `str()` before assignment

Fixes #27458

## Changes

- `litellm/proxy/litellm_pre_call_utils.py`: wrap header value in `str()` at the assignment point (line 798)
- `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`: regression test that all header values are strings when user info contains float fields

## Test plan

- [x] New unit test `test_add_headers_to_llm_call_coerces_non_string_values` passes
- [x] Verifies `spend=42.5` and `max_budget=100.0` are converted to `"42.5"` and `"100.0"`
- [x] Asserts every header value is `isinstance(v, str)`