### PR TITLE
feat: Codex CLI 0.130.0 国内模型兼容修复

### DIFF
--- a/CODEX_COMPATIBILITY.md
+++ b/CODEX_COMPATIBILITY.md
@@ -1,0 +1,44 @@
+# Codex CLI 国内模型兼容说明
+
+## 背景
+
+OpenAI Codex CLI 使用 Responses API 协议，国内模型（豆包、GLM、MiniMax、MiMo、DeepSeek等）只支持 Chat Completions API。本 Fork 在 LiteLLM Responses API → Chat Completions 转换层添加了参数兼容处理。
+
+## 兼容处理
+
+仅对以下 Provider 的请求生效：
+- 阿里云 DashScope (`coding.dashscope.aliyuncs.com`)
+- 火山引擎 (`ark.cn-beijing.volces.com`)
+- MiniMax 官方 (`api.minimaxi.com`)
+- 小米 MiMo (`xiaomimimo.com`)
+- DeepSeek 官方 (`api.deepseek.com`)
+
+### 过滤的字段
+- `client_metadata` — Codex CLI 客户端元数据
+- `strict`/`additionalProperties` — JSON Schema 严格模式字段
+- `local_shell`/`code_interpreter`/`file_search` 等工具类型
+
+## 已验证模型（16个）
+
+| Provider | 模型 | 测试结果 |
+|----------|------|----------|
+| 阿里云 | qwen3.5-plus, qwen3-max, qwen3-coder系列, glm-4.7/5, kimi-k2.5 | ✅ |
+| 火山 | Doubao系列, GLM-5.1, Kimi-K2.6, DeepSeek-V3.2 | ✅ |
+| 官方 | MiniMax-M2.7, mimo-v2.5-pro, deepseek-v4-flash/pro | ✅ |
+
+## 使用方法
+
+```yaml
+# litellm_config.yaml
+model_list:
+- model_name: codex-model
+  litellm_params:
+    model: openai/qwen3.5-plus
+    api_base: https://coding.dashscope.aliyuncs.com/v1
+    api_key: your-api-key
+```
+
+```bash
+export OPENAI_BASE_URL="http://localhost:4000/v1"
+codex exec --model codex-model
+```

--- a/README.md
+++ b/README.md
@@ -1,236 +1,524 @@
-# LiteLLM - Codex CLI 国内模型兼容版
+<h1 align="center">
+        🚅 LiteLLM
+    </h1>
+    <p align="center">
+        <p align="center">LiteLLM AI Gateway
+        </p>
+        <p align="center">Open Source AI Gateway for 100+ LLMs. Self-hosted. Enterprise-ready. Call any LLM in OpenAI format.</p>
+        <p align="center">
+        <a href="https://render.com/deploy?repo=https://github.com/BerriAI/litellm" target="_blank" rel="nofollow"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render"></a>
+        <a href="https://railway.com/deploy/RhvhdC?referralCode=7mRv9K&utm_medium=integration&utm_source=template&utm_campaign=generic">
+          <img src="https://railway.com/button.svg" alt="Deploy on Railway">
+        </a>
+        </p>
+    </p>
+<h4 align="center"><a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank">LiteLLM Proxy Server (AI Gateway)</a> | <a href="https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy" target="_blank"> Hosted Proxy</a> | <a href="https://litellm.ai/enterprise"target="_blank">Enterprise Tier</a> | <a href="https://www.litellm.ai/ai-gateway" target="_blank">Website</a></h4>
+<h4 align="center">
+    <a href="https://pypi.org/project/litellm/" target="_blank">
+        <img src="https://img.shields.io/pypi/v/litellm.svg" alt="PyPI Version">
+    </a>
+    <a href="https://github.com/BerriAI/litellm" target="_blank">
+        <img src="https://img.shields.io/github/stars/BerriAI/litellm.svg?style=social" alt="GitHub Stars">
+    </a>
+    <a href="https://www.ycombinator.com/companies/berriai">
+        <img src="https://img.shields.io/badge/Y%20Combinator-W23-orange?style=flat-square" alt="Y Combinator W23">
+    </a>
+    <a href="https://wa.link/huol9n">
+        <img src="https://img.shields.io/static/v1?label=Chat%20on&message=WhatsApp&color=success&logo=WhatsApp&style=flat-square" alt="Whatsapp">
+    </a>
+    <a href="https://discord.gg/wuPM9dRgDw">
+        <img src="https://img.shields.io/static/v1?label=Chat%20on&message=Discord&color=blue&logo=Discord&style=flat-square" alt="Discord">
+    </a>
+    <a href="https://www.litellm.ai/support">
+        <img src="https://img.shields.io/static/v1?label=Chat%20on&message=Slack&color=black&logo=Slack&style=flat-square" alt="Slack">
+    </a>
+    <a href="https://codspeed.io/BerriAI/litellm?utm_source=badge">
+        <img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"/>
+    </a>
+</h4>
 
-> Fork 自 [BerriAI/litellm](https://github.com/BerriAI/litellm)，专门修复 Codex CLI 0.130.0 接入国内模型的兼容性问题。
-
-## 背景
-
-OpenAI Codex CLI 使用 **Responses API** 协议，而国内模型（豆包、GLM、MiniMax、MiMo）只支持 **Chat Completions API**。LiteLLM 的 `custom_openai` provider 虽然做了协议转换，但传递了国内模型不支持的字段，导致 400 错误。
-
-## 修复内容
-
-| 文件 | 修改 |
-|------|------|
-| `handler.py` | 过滤 `client_metadata` 参数（Codex CLI 发送，国内模型不接受） |
-| `transformation.py` | 添加 `_clean_schema()` 清理 `strict`/`additionalProperties`；过滤 `local_shell` 等不支持的工具类型 |
-
-## 支持模型（已通过 Codex CLI 测试）
-
-### 阿里云 DashScope
-| 模型 | Provider | 测试结果 |
-|------|----------|----------|
-| qwen3.5-plus | 阿里云 | ✅ |
-| qwen3-max-2026-01-23 | 阿里云 | ✅ |
-| qwen3-coder-next | 阿里云 | ✅ |
-| qwen3-coder-plus | 阿里云 | ✅ |
-| glm-4.7 | 智谱 (阿里云) | ✅ |
-| kimi-k2.5 | Moonshot (阿里云) | ✅ |
-| glm-5 | 智谱 (阿里云) | ✅ |
-
-### 火山引擎 Volcengine
-| 模型 | Provider | 测试结果 |
-|------|----------|----------|
-| Doubao-Seed-2.0-pro | 豆包 | ✅ |
-| Doubao-Seed-2.0-lite | 豆包 | ✅ |
-| GLM-5.1 | 智谱 (火山) | ✅ |
-| Kimi-K2.6 | Moonshot (火山) | ✅ |
-| DeepSeek-V3.2 | DeepSeek (火山) | ✅ |
-
-### 官方 API
-| 模型 | Provider | 测试结果 |
-|------|----------|----------|
-| MiniMax-M2.7 | MiniMax 官方 | ✅ |
-| mimo-v2.5-pro | 小米 MiMo | ✅ |
-| deepseek-v4-flash | DeepSeek 官方 | ✅ |
-| deepseek-v4-pro | DeepSeek 官方 | ✅ |
-
-**共 16 个模型全部通过 Codex CLI Responses API 测试。**
+<img width="2688" height="1600" alt="Group 7154 (1)" src="https://github.com/user-attachments/assets/c5ee0412-6fb5-4fb6-ab5b-bafae4209ca6" />
 
 ---
 
-## 安装说明（给 AI 执行）
+## What is LiteLLM
 
-以下是为 AI Agent 准备的安装指令，适用于 **Windows/Linux/Mac** 系统。
+LiteLLM is an open source AI Gateway that gives you a single, unified interface to call 100+ LLM providers — OpenAI, Anthropic, Gemini, Bedrock, Azure, and more — using the OpenAI format.
 
-### 前置条件
+Use it as a **Python SDK** for direct library integration, or deploy the **AI Gateway (Proxy Server)** as a centralized service for your team or organization.
 
-- Python 3.10+ 已安装
-- Git 已安装
-- 有权限创建目录和安装 Python 包
-
-### 安装步骤
-
-```bash
-# 1. 克隆仓库
-git clone https://github.com/oadank/litellm.git -b codex-domestic-fix
-
-# 2. 进入目录
-cd litellm
-
-# 3. 创建虚拟环境
-python -m venv venv
-
-# 4. 激活虚拟环境
-# Windows (PowerShell):
-.\venv\Scripts\Activate.ps1
-# Windows (CMD):
-.\venv\Scripts\activate.bat
-# Linux/Mac:
-source venv/bin/activate
-
-# 5. 安装核心包（开发模式）
-pip install -e .
-
-# 6. 安装 Proxy 依赖（如需运行代理服务）
-pip install "litellm[proxy]"
-```
-
-### Windows 特别说明
-
-Windows 上可能遇到的问题：
-
-1. **PowerShell 权限问题**：如果 `Activate.ps1` 报错，先执行：
-   ```powershell
-   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-   ```
-
-2. **prisma 安装**：Proxy 服务需要 prisma，Windows 上可能需要：
-   ```bash
-   pip install prisma
-   prisma generate
-   ```
-
-### 验证安装
-
-```bash
-# 激活虚拟环境后执行
-python -c "
-from litellm.responses.litellm_completion_transformation.transformation import LiteLLMCompletionResponsesConfig
-
-# 测试 _clean_schema
-test_schema = {'type': 'object', 'strict': True, 'additionalProperties': False}
-cleaned = LiteLLMCompletionResponsesConfig._clean_schema(test_schema)
-print('清理前:', test_schema)
-print('清理后:', cleaned)
-assert 'strict' not in cleaned
-assert 'additionalProperties' not in cleaned
-print('✅ 安装验证成功!')
-"
-```
+[**Jump to LiteLLM Proxy (LLM Gateway) Docs**](https://docs.litellm.ai/docs/simple_proxy) <br>
+[**Jump to Supported LLM Providers**](https://docs.litellm.ai/docs/providers)
 
 ---
 
-## 配置示例
+## Why LiteLLM
 
-创建 `litellm_config.yaml`：
+Managing LLM calls across providers gets complicated fast — different SDKs, auth patterns, request formats, and error types for every model. LiteLLM removes that friction:
 
-```yaml
-model_list:
-  - model_name: codex-model
-    litellm_params:
-      model: custom_openai/doubao-seed-2.0-pro
-      api_base: https://ark.cn-beijing.volces.com/api/v3
-      api_key: your-doubao-api-key
+- **Unified API** — one interface for 100+ LLMs, no provider-specific SDK juggling
+- **Drop-in OpenAI compatibility** — swap providers without rewriting your code
+- **Production-ready gateway** — virtual keys, spend tracking, guardrails, load balancing, and an admin dashboard out of the box
+- **8ms P95 latency** at 1k RPS ([benchmarks](https://docs.litellm.ai/docs/benchmarks))
 
-  - model_name: codex-model
-    litellm_params:
-      model: custom_openai/glm-5
-      api_base: https://open.bigmodel.cn/api/paas/v4
-      api_key: your-glm-api-key
+### OSS Adopters
 
-  - model_name: codex-model
-    litellm_params:
-      model: custom_openai/MiniMax-M2.7
-      api_base: https://api.minimaxi.com/v1
-      api_key: your-minimax-api-key
-
-  - model_name: codex-model
-    litellm_params:
-      model: custom_openai/mimo-v2.5-pro
-      api_base: https://token-plan-cn.xiaomimimo.com/v1
-      api_key: your-mimo-api-key
-```
-
-## 启动服务
-
-```bash
-# 激活虚拟环境后
-litellm --config litellm_config.yaml --port 4000
-```
-
-## Codex CLI 配置
-
-```bash
-# 设置环境变量
-export OPENAI_API_KEY="your-litellm-master-key"  # 或任意值（如果 LiteLLM 未启用鉴权）
-export OPENAI_BASE_URL="http://localhost:4000/v1"
-
-# 运行 Codex CLI
-echo '执行命令 echo hello' | codex exec --sandbox danger-full-access
-```
+<table>
+  <tr>
+    <td><img height="60" alt="Stripe" src="https://github.com/user-attachments/assets/f7296d4f-9fbd-460d-9d05-e4df31697c4b" /></td>
+    <td><img height="60" alt="image" src="https://github.com/user-attachments/assets/436fca71-988b-40bb-b5fe-8450c80fdbd0" /></td>
+    <td><img height="60" alt="Google ADK" src="https://github.com/user-attachments/assets/caf270a2-5aee-45c4-8222-41a2070c4f19" /></td>
+    <td><img height="60" alt="Greptile" src="https://github.com/user-attachments/assets/3db0ae72-0843-4005-a56d-bba1dde2193d" /></td>
+    <td><img height="60" alt="OpenHands" src="https://github.com/user-attachments/assets/a6150c4c-149e-4cae-888b-8b92be6e003f" /></td>
+    <td><h2>Netflix</h2></td>
+    <td><img height="60" alt="OpenAI Agents SDK" src="https://github.com/user-attachments/assets/c02f7be0-8c2e-4d27-aea7-7c024bfaebc0" /></td>
+  </tr>
+</table>
 
 ---
 
-## 技术原理
+## Features
 
-### 协议差异
+<details open>
+<summary><b>LLMs</b> - Call 100+ LLMs (Python SDK + AI Gateway)</summary>
 
-| 协议 | 使用方 | 特点 |
-|------|--------|------|
-| Responses API | Codex CLI | 支持 `local_shell` 工具、`previous_response_id` 会话链 |
-| Chat Completions API | 国内模型 | 标准 OpenAI 格式，只支持 `type: "function"` 工具 |
+[**All Supported Endpoints**](https://docs.litellm.ai/docs/supported_endpoints) - `/chat/completions`, `/responses`, `/embeddings`, `/images`, `/audio`, `/batches`, `/rerank`, `/a2a`, `/messages` and more.
 
-### 过滤的字段
+### Python SDK
 
-Codex CLI 发送但国内模型不接受的字段：
-
-- `client_metadata` — 客户端元数据（Codex 专用）
-- `strict: true` — JSON Schema 严格模式（OpenAI 专用）
-- `additionalProperties: false` — Schema 扩展控制
-- `type: "local_shell"` — Codex 内置 Shell 工具类型
-
-### `_clean_schema()` 实现
-
-借鉴 [codex_deepseek_proxy](https://github.com/nickyc975/codex_deepseek_proxy) 项目：
+```shell
+uv add litellm
+```
 
 ```python
-@staticmethod
-def _clean_schema(obj):
-    """递归清除 JSON Schema 中国内模型不支持的字段"""
-    if not isinstance(obj, dict):
-        return obj
-    cleaned = {}
-    for k, v in obj.items():
-        if k in ("additionalProperties", "strict"):
-            continue
-        if isinstance(v, dict):
-            cleaned[k] = LiteLLMCompletionResponsesConfig._clean_schema(v)
-        elif isinstance(v, list):
-            cleaned[k] = [_clean_schema(i) if isinstance(i, dict) else i for i in v]
-        else:
-            cleaned[k] = v
-    return cleaned
+from litellm import completion
+import os
+
+os.environ["OPENAI_API_KEY"] = "your-openai-key"
+os.environ["ANTHROPIC_API_KEY"] = "your-anthropic-key"
+
+# OpenAI
+response = completion(model="openai/gpt-4o", messages=[{"role": "user", "content": "Hello!"}])
+
+# Anthropic  
+response = completion(model="anthropic/claude-sonnet-4-20250514", messages=[{"role": "user", "content": "Hello!"}])
 ```
 
+### AI Gateway (Proxy Server)
+
+[**Getting Started - E2E Tutorial**](https://docs.litellm.ai/docs/proxy/docker_quick_start) - Setup virtual keys, make your first request
+
+```shell
+uv tool install 'litellm[proxy]'
+litellm --model gpt-4o
+```
+
+```python
+import openai
+
+client = openai.OpenAI(api_key="anything", base_url="http://0.0.0.0:4000")
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+[**Docs: LLM Providers**](https://docs.litellm.ai/docs/providers)
+
+</details>
+
+<details>
+<summary><b>Agents</b> - Invoke A2A Agents (Python SDK + AI Gateway)</summary>
+
+[**Supported Providers**](https://docs.litellm.ai/docs/a2a#add-a2a-agents) - LangGraph, Vertex AI Agent Engine, Azure AI Foundry, Bedrock AgentCore, Pydantic AI
+
+### Python SDK - A2A Protocol
+
+```python
+from litellm.a2a_protocol import A2AClient
+from a2a.types import SendMessageRequest, MessageSendParams
+from uuid import uuid4
+
+client = A2AClient(base_url="http://localhost:10001")
+
+request = SendMessageRequest(
+    id=str(uuid4()),
+    params=MessageSendParams(
+        message={
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Hello!"}],
+            "messageId": uuid4().hex,
+        }
+    )
+)
+response = await client.send_message(request)
+```
+
+### AI Gateway (Proxy Server)
+
+**Step 1.** [Add your Agent to the AI Gateway](https://docs.litellm.ai/docs/a2a#adding-your-agent)
+
+**Step 2.** Call Agent via A2A SDK
+
+```python
+from a2a.client import A2ACardResolver, A2AClient
+from a2a.types import MessageSendParams, SendMessageRequest
+from uuid import uuid4
+import httpx
+
+base_url = "http://localhost:4000/a2a/my-agent"  # LiteLLM proxy + agent name
+headers = {"Authorization": "Bearer sk-1234"}    # LiteLLM Virtual Key
+
+async with httpx.AsyncClient(headers=headers) as httpx_client:
+    resolver = A2ACardResolver(httpx_client=httpx_client, base_url=base_url)
+    agent_card = await resolver.get_agent_card()
+    client = A2AClient(httpx_client=httpx_client, agent_card=agent_card)
+
+    request = SendMessageRequest(
+        id=str(uuid4()),
+        params=MessageSendParams(
+            message={
+                "role": "user",
+                "parts": [{"kind": "text", "text": "Hello!"}],
+                "messageId": uuid4().hex,
+            }
+        )
+    )
+    response = await client.send_message(request)
+```
+
+[**Docs: A2A Agent Gateway**](https://docs.litellm.ai/docs/a2a)
+
+</details>
+
+<details>
+<summary><b>MCP Tools</b> - Connect MCP servers to any LLM (Python SDK + AI Gateway)</summary>
+
+### Python SDK - MCP Bridge
+
+```python
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from litellm import experimental_mcp_client
+import litellm
+
+server_params = StdioServerParameters(command="python", args=["mcp_server.py"])
+
+async with stdio_client(server_params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+
+        # Load MCP tools in OpenAI format
+        tools = await experimental_mcp_client.load_mcp_tools(session=session, format="openai")
+
+        # Use with any LiteLLM model
+        response = await litellm.acompletion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "What's 3 + 5?"}],
+            tools=tools
+        )
+```
+
+### AI Gateway - MCP Gateway
+
+**Step 1.** [Add your MCP Server to the AI Gateway](https://docs.litellm.ai/docs/mcp#adding-your-mcp)
+
+**Step 2.** Call MCP tools via `/chat/completions`
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [{"role": "user", "content": "Summarize the latest open PR"}],
+    "tools": [{
+      "type": "mcp",
+      "server_url": "litellm_proxy/mcp/github",
+      "server_label": "github_mcp",
+      "require_approval": "never"
+    }]
+  }'
+```
+
+### Use with Cursor IDE
+
+```json
+{
+  "mcpServers": {
+    "LiteLLM": {
+      "url": "http://localhost:4000/mcp/",
+      "headers": {
+        "x-litellm-api-key": "Bearer sk-1234"
+      }
+    }
+  }
+}
+```
+
+[**Docs: MCP Gateway**](https://docs.litellm.ai/docs/mcp)
+
+</details>
+
+### Supported Providers ([Website Supported Models](https://models.litellm.ai/) | [Docs](https://docs.litellm.ai/docs/providers))
+
+| Provider                                                                            | `/chat/completions` | `/messages` | `/responses` | `/embeddings` | `/image/generations` | `/audio/transcriptions` | `/audio/speech` | `/moderations` | `/batches` | `/rerank` |
+|-------------------------------------------------------------------------------------|---------------------|-------------|--------------|---------------|----------------------|-------------------------|-----------------|----------------|-----------|-----------|
+| [Abliteration (`abliteration`)](https://docs.litellm.ai/docs/providers/abliteration) | ✅ |  |  |  |  |  |  |  |  |  |
+| [AI/ML API (`aiml`)](https://docs.litellm.ai/docs/providers/aiml) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
+| [AI21 (`ai21`)](https://docs.litellm.ai/docs/providers/ai21) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [AI21 Chat (`ai21_chat`)](https://docs.litellm.ai/docs/providers/ai21) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Aleph Alpha](https://docs.litellm.ai/docs/providers/aleph_alpha) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Amazon Nova](https://docs.litellm.ai/docs/providers/amazon_nova) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Anthropic (`anthropic`)](https://docs.litellm.ai/docs/providers/anthropic) | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |  |
+| [Anthropic Text (`anthropic_text`)](https://docs.litellm.ai/docs/providers/anthropic) | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |  |
+| [Anyscale](https://docs.litellm.ai/docs/providers/anyscale) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [AssemblyAI (`assemblyai`)](https://docs.litellm.ai/docs/pass_through/assembly_ai) | ✅ | ✅ | ✅ |  |  | ✅ |  |  |  |  |
+| [Auto Router (`auto_router`)](https://docs.litellm.ai/docs/proxy/auto_routing) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [AWS - Bedrock (`bedrock`)](https://docs.litellm.ai/docs/providers/bedrock) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
+| [AWS - Sagemaker (`sagemaker`)](https://docs.litellm.ai/docs/providers/aws_sagemaker) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [Azure (`azure`)](https://docs.litellm.ai/docs/providers/azure) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
+| [Azure AI (`azure_ai`)](https://docs.litellm.ai/docs/providers/azure_ai) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
+| [Azure Text (`azure_text`)](https://docs.litellm.ai/docs/providers/azure) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
+| [Baseten (`baseten`)](https://docs.litellm.ai/docs/providers/baseten) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Bytez (`bytez`)](https://docs.litellm.ai/docs/providers/bytez) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Cerebras (`cerebras`)](https://docs.litellm.ai/docs/providers/cerebras) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Clarifai (`clarifai`)](https://docs.litellm.ai/docs/providers/clarifai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Cloudflare AI Workers (`cloudflare`)](https://docs.litellm.ai/docs/providers/cloudflare_workers) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Codestral (`codestral`)](https://docs.litellm.ai/docs/providers/codestral) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Cohere (`cohere`)](https://docs.litellm.ai/docs/providers/cohere) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
+| [Cohere Chat (`cohere_chat`)](https://docs.litellm.ai/docs/providers/cohere) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [CometAPI (`cometapi`)](https://docs.litellm.ai/docs/providers/cometapi) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [CompactifAI (`compactifai`)](https://docs.litellm.ai/docs/providers/compactifai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Custom (`custom`)](https://docs.litellm.ai/docs/providers/custom_llm_server) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Custom OpenAI (`custom_openai`)](https://docs.litellm.ai/docs/providers/openai_compatible) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
+| [Dashscope (`dashscope`)](https://docs.litellm.ai/docs/providers/dashscope) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Databricks (`databricks`)](https://docs.litellm.ai/docs/providers/databricks) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [DataRobot (`datarobot`)](https://docs.litellm.ai/docs/providers/datarobot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Deepgram (`deepgram`)](https://docs.litellm.ai/docs/providers/deepgram) | ✅ | ✅ | ✅ |  |  | ✅ |  |  |  |  |
+| [DeepInfra (`deepinfra`)](https://docs.litellm.ai/docs/providers/deepinfra) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Deepseek (`deepseek`)](https://docs.litellm.ai/docs/providers/deepseek) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [ElevenLabs (`elevenlabs`)](https://docs.litellm.ai/docs/providers/elevenlabs) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ |  |  |  |
+| [Empower (`empower`)](https://docs.litellm.ai/docs/providers/empower) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Fal AI (`fal_ai`)](https://docs.litellm.ai/docs/providers/fal_ai) | ✅ | ✅ | ✅ |  | ✅ |  |  |  |  |  |
+| [Featherless AI (`featherless_ai`)](https://docs.litellm.ai/docs/providers/featherless_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Fireworks AI (`fireworks_ai`)](https://docs.litellm.ai/docs/providers/fireworks_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [FriendliAI (`friendliai`)](https://docs.litellm.ai/docs/providers/friendliai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Galadriel (`galadriel`)](https://docs.litellm.ai/docs/providers/galadriel) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [GitHub Copilot (`github_copilot`)](https://docs.litellm.ai/docs/providers/github_copilot) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [GitHub Models (`github`)](https://docs.litellm.ai/docs/providers/github) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Google - PaLM](https://docs.litellm.ai/docs/providers/palm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Google - Vertex AI (`vertex_ai`)](https://docs.litellm.ai/docs/providers/vertex) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
+| [Google AI Studio - Gemini (`gemini`)](https://docs.litellm.ai/docs/providers/gemini) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [GradientAI (`gradient_ai`)](https://docs.litellm.ai/docs/providers/gradient_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Groq AI (`groq`)](https://docs.litellm.ai/docs/providers/groq) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Heroku (`heroku`)](https://docs.litellm.ai/docs/providers/heroku) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Hosted VLLM (`hosted_vllm`)](https://docs.litellm.ai/docs/providers/vllm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Huggingface (`huggingface`)](https://docs.litellm.ai/docs/providers/huggingface) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
+| [Hyperbolic (`hyperbolic`)](https://docs.litellm.ai/docs/providers/hyperbolic) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [IBM - Watsonx.ai (`watsonx`)](https://docs.litellm.ai/docs/providers/watsonx) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [Infinity (`infinity`)](https://docs.litellm.ai/docs/providers/infinity) |  |  |  | ✅ |  |  |  |  |  |  |
+| [Jina AI (`jina_ai`)](https://docs.litellm.ai/docs/providers/jina_ai) |  |  |  | ✅ |  |  |  |  |  |  |
+| [Lambda AI (`lambda_ai`)](https://docs.litellm.ai/docs/providers/lambda_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Lemonade (`lemonade`)](https://docs.litellm.ai/docs/providers/lemonade) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [LiteLLM Proxy (`litellm_proxy`)](https://docs.litellm.ai/docs/providers/litellm_proxy) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
+| [Llamafile (`llamafile`)](https://docs.litellm.ai/docs/providers/llamafile) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [LM Studio (`lm_studio`)](https://docs.litellm.ai/docs/providers/lm_studio) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Maritalk (`maritalk`)](https://docs.litellm.ai/docs/providers/maritalk) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Meta - Llama API (`meta_llama`)](https://docs.litellm.ai/docs/providers/meta_llama) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Mistral AI API (`mistral`)](https://docs.litellm.ai/docs/providers/mistral) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [Moonshot (`moonshot`)](https://docs.litellm.ai/docs/providers/moonshot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Morph (`morph`)](https://docs.litellm.ai/docs/providers/morph) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Nebius AI Studio (`nebius`)](https://docs.litellm.ai/docs/providers/nebius) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [NLP Cloud (`nlp_cloud`)](https://docs.litellm.ai/docs/providers/nlp_cloud) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Novita AI (`novita`)](https://novita.ai/models/llm?utm_source=github_litellm&utm_medium=github_readme&utm_campaign=github_link) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Nscale (`nscale`)](https://docs.litellm.ai/docs/providers/nscale) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Nvidia NIM (`nvidia_nim`)](https://docs.litellm.ai/docs/providers/nvidia_nim) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [OCI (`oci`)](https://docs.litellm.ai/docs/providers/oci) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Ollama (`ollama`)](https://docs.litellm.ai/docs/providers/ollama) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
+| [Ollama Chat (`ollama_chat`)](https://docs.litellm.ai/docs/providers/ollama) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Oobabooga (`oobabooga`)](https://docs.litellm.ai/docs/providers/openai_compatible) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
+| [OpenAI (`openai`)](https://docs.litellm.ai/docs/providers/openai) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
+| [OpenAI-like (`openai_like`)](https://docs.litellm.ai/docs/providers/openai_compatible) |  |  |  | ✅ |  |  |  |  |  |  |
+| [OpenRouter (`openrouter`)](https://docs.litellm.ai/docs/providers/openrouter) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [OVHCloud AI Endpoints (`ovhcloud`)](https://docs.litellm.ai/docs/providers/ovhcloud) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Perplexity AI (`perplexity`)](https://docs.litellm.ai/docs/providers/perplexity) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Petals (`petals`)](https://docs.litellm.ai/docs/providers/petals) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Predibase (`predibase`)](https://docs.litellm.ai/docs/providers/predibase) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Recraft (`recraft`)](https://docs.litellm.ai/docs/providers/recraft) |  |  |  |  | ✅ |  |  |  |  |  |
+| [Replicate (`replicate`)](https://docs.litellm.ai/docs/providers/replicate) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Sagemaker Chat (`sagemaker_chat`)](https://docs.litellm.ai/docs/providers/aws_sagemaker) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Sambanova (`sambanova`)](https://docs.litellm.ai/docs/providers/sambanova) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Snowflake (`snowflake`)](https://docs.litellm.ai/docs/providers/snowflake) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Text Completion Codestral (`text-completion-codestral`)](https://docs.litellm.ai/docs/providers/codestral) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Text Completion OpenAI (`text-completion-openai`)](https://docs.litellm.ai/docs/providers/text_completion_openai) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
+| [Together AI (`together_ai`)](https://docs.litellm.ai/docs/providers/togetherai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Topaz (`topaz`)](https://docs.litellm.ai/docs/providers/topaz) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Triton (`triton`)](https://docs.litellm.ai/docs/providers/triton-inference-server) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [V0 (`v0`)](https://docs.litellm.ai/docs/providers/v0) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Vercel AI Gateway (`vercel_ai_gateway`)](https://docs.litellm.ai/docs/providers/vercel_ai_gateway) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [VLLM (`vllm`)](https://docs.litellm.ai/docs/providers/vllm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Volcengine (`volcengine`)](https://docs.litellm.ai/docs/providers/volcano) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Voyage AI (`voyage`)](https://docs.litellm.ai/docs/providers/voyage) |  |  |  | ✅ |  |  |  |  |  |  |
+| [WandB Inference (`wandb`)](https://docs.litellm.ai/docs/providers/wandb_inference) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Watsonx Text (`watsonx_text`)](https://docs.litellm.ai/docs/providers/watsonx) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [xAI (`xai`)](https://docs.litellm.ai/docs/providers/xai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Xinference (`xinference`)](https://docs.litellm.ai/docs/providers/xinference) |  |  |  | ✅ |  |  |  |  |  |  |
+
+[**Read the Docs**](https://docs.litellm.ai/docs/)
+
 ---
 
-## 参考项目
+## Get Started
 
-- [codex_deepseek_proxy](https://github.com/nickyc975/codex_deepseek_proxy) — `_clean_schema` 设计来源
-- [mimo2codex](https://github.com/xiaomimimo/mimo2codex) — Responses → Chat 双向转换
-- [codex-minimax-proxy](https://github.com/nickyc975/codex-minimax-proxy) — MiniMax 专用代理
+You can use LiteLLM through either the Proxy Server or Python SDK. Both give you a unified interface to access multiple LLMs (100+ LLMs). Choose the option that best fits your needs:
+
+<table style={{width: '100%', tableLayout: 'fixed'}}>
+<thead>
+<tr>
+<th style={{width: '14%'}}></th>
+<th style={{width: '43%'}}><strong><a href="https://docs.litellm.ai/docs/simple_proxy">LiteLLM AI Gateway</a></strong></th>
+<th style={{width: '43%'}}><strong><a href="https://docs.litellm.ai/docs/">LiteLLM Python SDK</a></strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style={{width: '14%'}}><strong>Use Case</strong></td>
+<td style={{width: '43%'}}>Central service (LLM Gateway) to access multiple LLMs</td>
+<td style={{width: '43%'}}>Use LiteLLM directly in your Python code</td>
+</tr>
+<tr>
+<td style={{width: '14%'}}><strong>Who Uses It?</strong></td>
+<td style={{width: '43%'}}>Gen AI Enablement / ML Platform Teams</td>
+<td style={{width: '43%'}}>Developers building LLM projects</td>
+</tr>
+<tr>
+<td style={{width: '14%'}}><strong>Key Features</strong></td>
+<td style={{width: '43%'}}>Centralized API gateway with authentication and authorization, multi-tenant cost tracking and spend management per project/user, per-project customization (logging, guardrails, caching), virtual keys for secure access control, admin dashboard UI for monitoring and management</td>
+<td style={{width: '43%'}}>Direct Python library integration in your codebase, Router with retry/fallback logic across multiple deployments (e.g. Azure/OpenAI) - <a href="https://docs.litellm.ai/docs/routing">Router</a>, application-level load balancing and cost tracking, exception handling with OpenAI-compatible errors, observability callbacks (Lunary, MLflow, Langfuse, etc.)</td>
+</tr>
+</tbody>
+</table>
+
+**Stable Release:** Use docker images with the `-stable` tag. These have undergone 12 hour load tests, before being published. [More information about the release cycle here](https://docs.litellm.ai/docs/proxy/release_cycle)
+
+Support for more providers. Missing a provider or LLM Platform, raise a [feature request](https://github.com/BerriAI/litellm/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BFeature%5D%3A+).
+
+### Run in Developer Mode
+#### Services
+1. Setup .env file in root
+2. Run dependant services `docker-compose up db prometheus`
+
+#### Backend
+1. (In root) create virtual environment `python -m venv .venv`
+2. Activate virtual environment `source .venv/bin/activate`
+3. Install dependencies `uv sync --all-extras --group proxy-dev`
+4. `uv run prisma generate`
+5. `prisma generate`
+6. Start proxy backend `python litellm/proxy/proxy_cli.py`
+
+#### Frontend
+1. Navigate to `ui/litellm-dashboard`
+2. Install dependencies `npm install`
+3. Run `npm run dev` to start the dashboard
+
+### Verify Docker Image Signatures
+
+All LiteLLM Docker images published to GHCR are signed with [cosign](https://docs.sigstore.dev/cosign/overview/). Every release is signed with the same key introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0).
+
+**Verify using the pinned commit hash (recommended):**
+
+A commit hash is cryptographically immutable, so this is the strongest way to ensure you are using the original signing key:
+
+```bash
+cosign verify \
+  --key https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub \
+  ghcr.io/berriai/litellm:<release-tag>
+```
+
+**Verify using a release tag (convenience):**
+
+Tags are protected in this repository and resolve to the same key. This option is easier to read but relies on tag protection rules:
+
+```bash
+cosign verify \
+  --key https://raw.githubusercontent.com/BerriAI/litellm/<release-tag>/cosign.pub \
+  ghcr.io/berriai/litellm:<release-tag>
+```
+
+Replace `<release-tag>` with the version you are deploying (e.g. `v1.83.0-stable`).
 
 ---
 
-## 关于
+# Enterprise
+For companies that need better security, user management and professional support
 
-本 Fork 由 **oadank** 维护，专门解决 Codex CLI 国内模型兼容问题。
+[Get an Enterprise License](https://litellm.ai/enterprise)
+[Talk to founders](https://enterprise.litellm.ai/demo)
 
-- **上游仓库**: [BerriAI/litellm](https://github.com/BerriAI/litellm)
-- **分支**: `codex-domestic-fix`
-- **问题反馈**: [GitHub Issues](https://github.com/oadank/litellm/issues)
+This covers:
+- ✅ **Features under the [LiteLLM Commercial License](https://docs.litellm.ai/docs/proxy/enterprise):**
+- ✅ **Feature Prioritization**
+- ✅ **Custom Integrations**
+- ✅ **Professional Support - Dedicated discord + slack**
+- ✅ **Custom SLAs**
+- ✅ **Secure access with Single Sign-On**
 
----
+# Contributing
 
-## License
+We welcome contributions to LiteLLM! Whether you're fixing bugs, adding features, or improving documentation, we appreciate your help.
 
-继承上游 MIT License。
+## Quick Start for Contributors
+
+This requires uv to be installed.
+
+```bash
+git clone https://github.com/BerriAI/litellm.git
+cd litellm
+make install-dev    # Install development dependencies
+make format         # Format your code
+make lint           # Run all linting checks
+make test-unit      # Run unit tests
+make format-check   # Check formatting only
+```
+
+For detailed contributing guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+> **📖 Contributing to documentation?** The LiteLLM docs have moved to a separate repository: [BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs). Please open doc PRs there. Docs are served at [docs.litellm.ai](https://docs.litellm.ai).
+
+## Code Quality / Linting
+
+LiteLLM follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+
+Our automated checks include:
+- **Black** for code formatting
+- **Ruff** for linting and code quality
+- **MyPy** for type checking
+- **Circular import detection**
+- **Import safety checks**
+
+
+All these checks must pass before your PR can be merged.
+
+
+# Support / talk with founders
+
+- [Schedule Demo 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
+- [Community Discord 💭](https://discord.gg/wuPM9dRgDw)
+- [Community Slack 💭](https://www.litellm.ai/support)
+- Our emails ✉️ ishaan@berri.ai / krrish@berri.ai
+
+# Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+<a href="https://github.com/BerriAI/litellm/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=BerriAI/litellm" />
+</a>

--- a/README.md
+++ b/README.md
@@ -1,524 +1,213 @@
-<h1 align="center">
-        🚅 LiteLLM
-    </h1>
-    <p align="center">
-        <p align="center">LiteLLM AI Gateway
-        </p>
-        <p align="center">Open Source AI Gateway for 100+ LLMs. Self-hosted. Enterprise-ready. Call any LLM in OpenAI format.</p>
-        <p align="center">
-        <a href="https://render.com/deploy?repo=https://github.com/BerriAI/litellm" target="_blank" rel="nofollow"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render"></a>
-        <a href="https://railway.com/deploy/RhvhdC?referralCode=7mRv9K&utm_medium=integration&utm_source=template&utm_campaign=generic">
-          <img src="https://railway.com/button.svg" alt="Deploy on Railway">
-        </a>
-        </p>
-    </p>
-<h4 align="center"><a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank">LiteLLM Proxy Server (AI Gateway)</a> | <a href="https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy" target="_blank"> Hosted Proxy</a> | <a href="https://litellm.ai/enterprise"target="_blank">Enterprise Tier</a> | <a href="https://www.litellm.ai/ai-gateway" target="_blank">Website</a></h4>
-<h4 align="center">
-    <a href="https://pypi.org/project/litellm/" target="_blank">
-        <img src="https://img.shields.io/pypi/v/litellm.svg" alt="PyPI Version">
-    </a>
-    <a href="https://github.com/BerriAI/litellm" target="_blank">
-        <img src="https://img.shields.io/github/stars/BerriAI/litellm.svg?style=social" alt="GitHub Stars">
-    </a>
-    <a href="https://www.ycombinator.com/companies/berriai">
-        <img src="https://img.shields.io/badge/Y%20Combinator-W23-orange?style=flat-square" alt="Y Combinator W23">
-    </a>
-    <a href="https://wa.link/huol9n">
-        <img src="https://img.shields.io/static/v1?label=Chat%20on&message=WhatsApp&color=success&logo=WhatsApp&style=flat-square" alt="Whatsapp">
-    </a>
-    <a href="https://discord.gg/wuPM9dRgDw">
-        <img src="https://img.shields.io/static/v1?label=Chat%20on&message=Discord&color=blue&logo=Discord&style=flat-square" alt="Discord">
-    </a>
-    <a href="https://www.litellm.ai/support">
-        <img src="https://img.shields.io/static/v1?label=Chat%20on&message=Slack&color=black&logo=Slack&style=flat-square" alt="Slack">
-    </a>
-    <a href="https://codspeed.io/BerriAI/litellm?utm_source=badge">
-        <img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"/>
-    </a>
-</h4>
+# LiteLLM - Codex CLI 国内模型兼容版
 
-<img width="2688" height="1600" alt="Group 7154 (1)" src="https://github.com/user-attachments/assets/c5ee0412-6fb5-4fb6-ab5b-bafae4209ca6" />
+> Fork 自 [BerriAI/litellm](https://github.com/BerriAI/litellm)，专门修复 Codex CLI 0.130.0 接入国内模型的兼容性问题。
+
+## 背景
+
+OpenAI Codex CLI 使用 **Responses API** 协议，而国内模型（豆包、GLM、MiniMax、MiMo）只支持 **Chat Completions API**。LiteLLM 的 `custom_openai` provider 虽然做了协议转换，但传递了国内模型不支持的字段，导致 400 错误。
+
+## 修复内容
+
+| 文件 | 修改 |
+|------|------|
+| `handler.py` | 过滤 `client_metadata` 参数（Codex CLI 发送，国内模型不接受） |
+| `transformation.py` | 添加 `_clean_schema()` 清理 `strict`/`additionalProperties`；过滤 `local_shell` 等不支持的工具类型 |
+
+## 支持模型
+
+| 模型 | Provider | 状态 |
+|------|----------|------|
+| doubao-seed-2.0-pro | 豆包 | ✅ |
+| glm-5 | 智谱 | ✅ |
+| MiniMax-M2.7 | MiniMax | ✅ |
+| mimo-v2.5-pro | 小米 MiMo | ✅ |
 
 ---
 
-## What is LiteLLM
+## 安装说明（给 AI 执行）
 
-LiteLLM is an open source AI Gateway that gives you a single, unified interface to call 100+ LLM providers — OpenAI, Anthropic, Gemini, Bedrock, Azure, and more — using the OpenAI format.
+以下是为 AI Agent 准备的安装指令，适用于 **Windows/Linux/Mac** 系统。
 
-Use it as a **Python SDK** for direct library integration, or deploy the **AI Gateway (Proxy Server)** as a centralized service for your team or organization.
+### 前置条件
 
-[**Jump to LiteLLM Proxy (LLM Gateway) Docs**](https://docs.litellm.ai/docs/simple_proxy) <br>
-[**Jump to Supported LLM Providers**](https://docs.litellm.ai/docs/providers)
+- Python 3.10+ 已安装
+- Git 已安装
+- 有权限创建目录和安装 Python 包
 
----
-
-## Why LiteLLM
-
-Managing LLM calls across providers gets complicated fast — different SDKs, auth patterns, request formats, and error types for every model. LiteLLM removes that friction:
-
-- **Unified API** — one interface for 100+ LLMs, no provider-specific SDK juggling
-- **Drop-in OpenAI compatibility** — swap providers without rewriting your code
-- **Production-ready gateway** — virtual keys, spend tracking, guardrails, load balancing, and an admin dashboard out of the box
-- **8ms P95 latency** at 1k RPS ([benchmarks](https://docs.litellm.ai/docs/benchmarks))
-
-### OSS Adopters
-
-<table>
-  <tr>
-    <td><img height="60" alt="Stripe" src="https://github.com/user-attachments/assets/f7296d4f-9fbd-460d-9d05-e4df31697c4b" /></td>
-    <td><img height="60" alt="image" src="https://github.com/user-attachments/assets/436fca71-988b-40bb-b5fe-8450c80fdbd0" /></td>
-    <td><img height="60" alt="Google ADK" src="https://github.com/user-attachments/assets/caf270a2-5aee-45c4-8222-41a2070c4f19" /></td>
-    <td><img height="60" alt="Greptile" src="https://github.com/user-attachments/assets/3db0ae72-0843-4005-a56d-bba1dde2193d" /></td>
-    <td><img height="60" alt="OpenHands" src="https://github.com/user-attachments/assets/a6150c4c-149e-4cae-888b-8b92be6e003f" /></td>
-    <td><h2>Netflix</h2></td>
-    <td><img height="60" alt="OpenAI Agents SDK" src="https://github.com/user-attachments/assets/c02f7be0-8c2e-4d27-aea7-7c024bfaebc0" /></td>
-  </tr>
-</table>
-
----
-
-## Features
-
-<details open>
-<summary><b>LLMs</b> - Call 100+ LLMs (Python SDK + AI Gateway)</summary>
-
-[**All Supported Endpoints**](https://docs.litellm.ai/docs/supported_endpoints) - `/chat/completions`, `/responses`, `/embeddings`, `/images`, `/audio`, `/batches`, `/rerank`, `/a2a`, `/messages` and more.
-
-### Python SDK
-
-```shell
-uv add litellm
-```
-
-```python
-from litellm import completion
-import os
-
-os.environ["OPENAI_API_KEY"] = "your-openai-key"
-os.environ["ANTHROPIC_API_KEY"] = "your-anthropic-key"
-
-# OpenAI
-response = completion(model="openai/gpt-4o", messages=[{"role": "user", "content": "Hello!"}])
-
-# Anthropic  
-response = completion(model="anthropic/claude-sonnet-4-20250514", messages=[{"role": "user", "content": "Hello!"}])
-```
-
-### AI Gateway (Proxy Server)
-
-[**Getting Started - E2E Tutorial**](https://docs.litellm.ai/docs/proxy/docker_quick_start) - Setup virtual keys, make your first request
-
-```shell
-uv tool install 'litellm[proxy]'
-litellm --model gpt-4o
-```
-
-```python
-import openai
-
-client = openai.OpenAI(api_key="anything", base_url="http://0.0.0.0:4000")
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[{"role": "user", "content": "Hello!"}]
-)
-```
-
-[**Docs: LLM Providers**](https://docs.litellm.ai/docs/providers)
-
-</details>
-
-<details>
-<summary><b>Agents</b> - Invoke A2A Agents (Python SDK + AI Gateway)</summary>
-
-[**Supported Providers**](https://docs.litellm.ai/docs/a2a#add-a2a-agents) - LangGraph, Vertex AI Agent Engine, Azure AI Foundry, Bedrock AgentCore, Pydantic AI
-
-### Python SDK - A2A Protocol
-
-```python
-from litellm.a2a_protocol import A2AClient
-from a2a.types import SendMessageRequest, MessageSendParams
-from uuid import uuid4
-
-client = A2AClient(base_url="http://localhost:10001")
-
-request = SendMessageRequest(
-    id=str(uuid4()),
-    params=MessageSendParams(
-        message={
-            "role": "user",
-            "parts": [{"kind": "text", "text": "Hello!"}],
-            "messageId": uuid4().hex,
-        }
-    )
-)
-response = await client.send_message(request)
-```
-
-### AI Gateway (Proxy Server)
-
-**Step 1.** [Add your Agent to the AI Gateway](https://docs.litellm.ai/docs/a2a#adding-your-agent)
-
-**Step 2.** Call Agent via A2A SDK
-
-```python
-from a2a.client import A2ACardResolver, A2AClient
-from a2a.types import MessageSendParams, SendMessageRequest
-from uuid import uuid4
-import httpx
-
-base_url = "http://localhost:4000/a2a/my-agent"  # LiteLLM proxy + agent name
-headers = {"Authorization": "Bearer sk-1234"}    # LiteLLM Virtual Key
-
-async with httpx.AsyncClient(headers=headers) as httpx_client:
-    resolver = A2ACardResolver(httpx_client=httpx_client, base_url=base_url)
-    agent_card = await resolver.get_agent_card()
-    client = A2AClient(httpx_client=httpx_client, agent_card=agent_card)
-
-    request = SendMessageRequest(
-        id=str(uuid4()),
-        params=MessageSendParams(
-            message={
-                "role": "user",
-                "parts": [{"kind": "text", "text": "Hello!"}],
-                "messageId": uuid4().hex,
-            }
-        )
-    )
-    response = await client.send_message(request)
-```
-
-[**Docs: A2A Agent Gateway**](https://docs.litellm.ai/docs/a2a)
-
-</details>
-
-<details>
-<summary><b>MCP Tools</b> - Connect MCP servers to any LLM (Python SDK + AI Gateway)</summary>
-
-### Python SDK - MCP Bridge
-
-```python
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
-from litellm import experimental_mcp_client
-import litellm
-
-server_params = StdioServerParameters(command="python", args=["mcp_server.py"])
-
-async with stdio_client(server_params) as (read, write):
-    async with ClientSession(read, write) as session:
-        await session.initialize()
-
-        # Load MCP tools in OpenAI format
-        tools = await experimental_mcp_client.load_mcp_tools(session=session, format="openai")
-
-        # Use with any LiteLLM model
-        response = await litellm.acompletion(
-            model="gpt-4o",
-            messages=[{"role": "user", "content": "What's 3 + 5?"}],
-            tools=tools
-        )
-```
-
-### AI Gateway - MCP Gateway
-
-**Step 1.** [Add your MCP Server to the AI Gateway](https://docs.litellm.ai/docs/mcp#adding-your-mcp)
-
-**Step 2.** Call MCP tools via `/chat/completions`
+### 安装步骤
 
 ```bash
-curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "gpt-4o",
-    "messages": [{"role": "user", "content": "Summarize the latest open PR"}],
-    "tools": [{
-      "type": "mcp",
-      "server_url": "litellm_proxy/mcp/github",
-      "server_label": "github_mcp",
-      "require_approval": "never"
-    }]
-  }'
-```
+# 1. 克隆仓库
+git clone https://github.com/oadank/litellm.git -b codex-domestic-fix
 
-### Use with Cursor IDE
-
-```json
-{
-  "mcpServers": {
-    "LiteLLM": {
-      "url": "http://localhost:4000/mcp/",
-      "headers": {
-        "x-litellm-api-key": "Bearer sk-1234"
-      }
-    }
-  }
-}
-```
-
-[**Docs: MCP Gateway**](https://docs.litellm.ai/docs/mcp)
-
-</details>
-
-### Supported Providers ([Website Supported Models](https://models.litellm.ai/) | [Docs](https://docs.litellm.ai/docs/providers))
-
-| Provider                                                                            | `/chat/completions` | `/messages` | `/responses` | `/embeddings` | `/image/generations` | `/audio/transcriptions` | `/audio/speech` | `/moderations` | `/batches` | `/rerank` |
-|-------------------------------------------------------------------------------------|---------------------|-------------|--------------|---------------|----------------------|-------------------------|-----------------|----------------|-----------|-----------|
-| [Abliteration (`abliteration`)](https://docs.litellm.ai/docs/providers/abliteration) | ✅ |  |  |  |  |  |  |  |  |  |
-| [AI/ML API (`aiml`)](https://docs.litellm.ai/docs/providers/aiml) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
-| [AI21 (`ai21`)](https://docs.litellm.ai/docs/providers/ai21) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [AI21 Chat (`ai21_chat`)](https://docs.litellm.ai/docs/providers/ai21) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Aleph Alpha](https://docs.litellm.ai/docs/providers/aleph_alpha) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Amazon Nova](https://docs.litellm.ai/docs/providers/amazon_nova) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Anthropic (`anthropic`)](https://docs.litellm.ai/docs/providers/anthropic) | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |  |
-| [Anthropic Text (`anthropic_text`)](https://docs.litellm.ai/docs/providers/anthropic) | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |  |
-| [Anyscale](https://docs.litellm.ai/docs/providers/anyscale) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [AssemblyAI (`assemblyai`)](https://docs.litellm.ai/docs/pass_through/assembly_ai) | ✅ | ✅ | ✅ |  |  | ✅ |  |  |  |  |
-| [Auto Router (`auto_router`)](https://docs.litellm.ai/docs/proxy/auto_routing) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [AWS - Bedrock (`bedrock`)](https://docs.litellm.ai/docs/providers/bedrock) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
-| [AWS - Sagemaker (`sagemaker`)](https://docs.litellm.ai/docs/providers/aws_sagemaker) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [Azure (`azure`)](https://docs.litellm.ai/docs/providers/azure) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
-| [Azure AI (`azure_ai`)](https://docs.litellm.ai/docs/providers/azure_ai) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
-| [Azure Text (`azure_text`)](https://docs.litellm.ai/docs/providers/azure) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
-| [Baseten (`baseten`)](https://docs.litellm.ai/docs/providers/baseten) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Bytez (`bytez`)](https://docs.litellm.ai/docs/providers/bytez) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Cerebras (`cerebras`)](https://docs.litellm.ai/docs/providers/cerebras) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Clarifai (`clarifai`)](https://docs.litellm.ai/docs/providers/clarifai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Cloudflare AI Workers (`cloudflare`)](https://docs.litellm.ai/docs/providers/cloudflare_workers) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Codestral (`codestral`)](https://docs.litellm.ai/docs/providers/codestral) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Cohere (`cohere`)](https://docs.litellm.ai/docs/providers/cohere) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
-| [Cohere Chat (`cohere_chat`)](https://docs.litellm.ai/docs/providers/cohere) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [CometAPI (`cometapi`)](https://docs.litellm.ai/docs/providers/cometapi) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [CompactifAI (`compactifai`)](https://docs.litellm.ai/docs/providers/compactifai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Custom (`custom`)](https://docs.litellm.ai/docs/providers/custom_llm_server) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Custom OpenAI (`custom_openai`)](https://docs.litellm.ai/docs/providers/openai_compatible) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
-| [Dashscope (`dashscope`)](https://docs.litellm.ai/docs/providers/dashscope) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Databricks (`databricks`)](https://docs.litellm.ai/docs/providers/databricks) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [DataRobot (`datarobot`)](https://docs.litellm.ai/docs/providers/datarobot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Deepgram (`deepgram`)](https://docs.litellm.ai/docs/providers/deepgram) | ✅ | ✅ | ✅ |  |  | ✅ |  |  |  |  |
-| [DeepInfra (`deepinfra`)](https://docs.litellm.ai/docs/providers/deepinfra) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Deepseek (`deepseek`)](https://docs.litellm.ai/docs/providers/deepseek) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [ElevenLabs (`elevenlabs`)](https://docs.litellm.ai/docs/providers/elevenlabs) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ |  |  |  |
-| [Empower (`empower`)](https://docs.litellm.ai/docs/providers/empower) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Fal AI (`fal_ai`)](https://docs.litellm.ai/docs/providers/fal_ai) | ✅ | ✅ | ✅ |  | ✅ |  |  |  |  |  |
-| [Featherless AI (`featherless_ai`)](https://docs.litellm.ai/docs/providers/featherless_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Fireworks AI (`fireworks_ai`)](https://docs.litellm.ai/docs/providers/fireworks_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [FriendliAI (`friendliai`)](https://docs.litellm.ai/docs/providers/friendliai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Galadriel (`galadriel`)](https://docs.litellm.ai/docs/providers/galadriel) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [GitHub Copilot (`github_copilot`)](https://docs.litellm.ai/docs/providers/github_copilot) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [GitHub Models (`github`)](https://docs.litellm.ai/docs/providers/github) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Google - PaLM](https://docs.litellm.ai/docs/providers/palm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Google - Vertex AI (`vertex_ai`)](https://docs.litellm.ai/docs/providers/vertex) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
-| [Google AI Studio - Gemini (`gemini`)](https://docs.litellm.ai/docs/providers/gemini) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [GradientAI (`gradient_ai`)](https://docs.litellm.ai/docs/providers/gradient_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Groq AI (`groq`)](https://docs.litellm.ai/docs/providers/groq) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Heroku (`heroku`)](https://docs.litellm.ai/docs/providers/heroku) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Hosted VLLM (`hosted_vllm`)](https://docs.litellm.ai/docs/providers/vllm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Huggingface (`huggingface`)](https://docs.litellm.ai/docs/providers/huggingface) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
-| [Hyperbolic (`hyperbolic`)](https://docs.litellm.ai/docs/providers/hyperbolic) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [IBM - Watsonx.ai (`watsonx`)](https://docs.litellm.ai/docs/providers/watsonx) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [Infinity (`infinity`)](https://docs.litellm.ai/docs/providers/infinity) |  |  |  | ✅ |  |  |  |  |  |  |
-| [Jina AI (`jina_ai`)](https://docs.litellm.ai/docs/providers/jina_ai) |  |  |  | ✅ |  |  |  |  |  |  |
-| [Lambda AI (`lambda_ai`)](https://docs.litellm.ai/docs/providers/lambda_ai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Lemonade (`lemonade`)](https://docs.litellm.ai/docs/providers/lemonade) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [LiteLLM Proxy (`litellm_proxy`)](https://docs.litellm.ai/docs/providers/litellm_proxy) | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |
-| [Llamafile (`llamafile`)](https://docs.litellm.ai/docs/providers/llamafile) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [LM Studio (`lm_studio`)](https://docs.litellm.ai/docs/providers/lm_studio) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Maritalk (`maritalk`)](https://docs.litellm.ai/docs/providers/maritalk) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Meta - Llama API (`meta_llama`)](https://docs.litellm.ai/docs/providers/meta_llama) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Mistral AI API (`mistral`)](https://docs.litellm.ai/docs/providers/mistral) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [Moonshot (`moonshot`)](https://docs.litellm.ai/docs/providers/moonshot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Morph (`morph`)](https://docs.litellm.ai/docs/providers/morph) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Nebius AI Studio (`nebius`)](https://docs.litellm.ai/docs/providers/nebius) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [NLP Cloud (`nlp_cloud`)](https://docs.litellm.ai/docs/providers/nlp_cloud) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Novita AI (`novita`)](https://novita.ai/models/llm?utm_source=github_litellm&utm_medium=github_readme&utm_campaign=github_link) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Nscale (`nscale`)](https://docs.litellm.ai/docs/providers/nscale) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Nvidia NIM (`nvidia_nim`)](https://docs.litellm.ai/docs/providers/nvidia_nim) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [OCI (`oci`)](https://docs.litellm.ai/docs/providers/oci) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Ollama (`ollama`)](https://docs.litellm.ai/docs/providers/ollama) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  |  |
-| [Ollama Chat (`ollama_chat`)](https://docs.litellm.ai/docs/providers/ollama) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Oobabooga (`oobabooga`)](https://docs.litellm.ai/docs/providers/openai_compatible) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
-| [OpenAI (`openai`)](https://docs.litellm.ai/docs/providers/openai) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
-| [OpenAI-like (`openai_like`)](https://docs.litellm.ai/docs/providers/openai_compatible) |  |  |  | ✅ |  |  |  |  |  |  |
-| [OpenRouter (`openrouter`)](https://docs.litellm.ai/docs/providers/openrouter) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [OVHCloud AI Endpoints (`ovhcloud`)](https://docs.litellm.ai/docs/providers/ovhcloud) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Perplexity AI (`perplexity`)](https://docs.litellm.ai/docs/providers/perplexity) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Petals (`petals`)](https://docs.litellm.ai/docs/providers/petals) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Predibase (`predibase`)](https://docs.litellm.ai/docs/providers/predibase) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Recraft (`recraft`)](https://docs.litellm.ai/docs/providers/recraft) |  |  |  |  | ✅ |  |  |  |  |  |
-| [Replicate (`replicate`)](https://docs.litellm.ai/docs/providers/replicate) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Sagemaker Chat (`sagemaker_chat`)](https://docs.litellm.ai/docs/providers/aws_sagemaker) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Sambanova (`sambanova`)](https://docs.litellm.ai/docs/providers/sambanova) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Snowflake (`snowflake`)](https://docs.litellm.ai/docs/providers/snowflake) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Text Completion Codestral (`text-completion-codestral`)](https://docs.litellm.ai/docs/providers/codestral) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Text Completion OpenAI (`text-completion-openai`)](https://docs.litellm.ai/docs/providers/text_completion_openai) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
-| [Together AI (`together_ai`)](https://docs.litellm.ai/docs/providers/togetherai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Topaz (`topaz`)](https://docs.litellm.ai/docs/providers/topaz) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Triton (`triton`)](https://docs.litellm.ai/docs/providers/triton-inference-server) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [V0 (`v0`)](https://docs.litellm.ai/docs/providers/v0) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Vercel AI Gateway (`vercel_ai_gateway`)](https://docs.litellm.ai/docs/providers/vercel_ai_gateway) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [VLLM (`vllm`)](https://docs.litellm.ai/docs/providers/vllm) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Volcengine (`volcengine`)](https://docs.litellm.ai/docs/providers/volcano) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Voyage AI (`voyage`)](https://docs.litellm.ai/docs/providers/voyage) |  |  |  | ✅ |  |  |  |  |  |  |
-| [WandB Inference (`wandb`)](https://docs.litellm.ai/docs/providers/wandb_inference) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Watsonx Text (`watsonx_text`)](https://docs.litellm.ai/docs/providers/watsonx) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [xAI (`xai`)](https://docs.litellm.ai/docs/providers/xai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
-| [Xinference (`xinference`)](https://docs.litellm.ai/docs/providers/xinference) |  |  |  | ✅ |  |  |  |  |  |  |
-
-[**Read the Docs**](https://docs.litellm.ai/docs/)
-
----
-
-## Get Started
-
-You can use LiteLLM through either the Proxy Server or Python SDK. Both give you a unified interface to access multiple LLMs (100+ LLMs). Choose the option that best fits your needs:
-
-<table style={{width: '100%', tableLayout: 'fixed'}}>
-<thead>
-<tr>
-<th style={{width: '14%'}}></th>
-<th style={{width: '43%'}}><strong><a href="https://docs.litellm.ai/docs/simple_proxy">LiteLLM AI Gateway</a></strong></th>
-<th style={{width: '43%'}}><strong><a href="https://docs.litellm.ai/docs/">LiteLLM Python SDK</a></strong></th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style={{width: '14%'}}><strong>Use Case</strong></td>
-<td style={{width: '43%'}}>Central service (LLM Gateway) to access multiple LLMs</td>
-<td style={{width: '43%'}}>Use LiteLLM directly in your Python code</td>
-</tr>
-<tr>
-<td style={{width: '14%'}}><strong>Who Uses It?</strong></td>
-<td style={{width: '43%'}}>Gen AI Enablement / ML Platform Teams</td>
-<td style={{width: '43%'}}>Developers building LLM projects</td>
-</tr>
-<tr>
-<td style={{width: '14%'}}><strong>Key Features</strong></td>
-<td style={{width: '43%'}}>Centralized API gateway with authentication and authorization, multi-tenant cost tracking and spend management per project/user, per-project customization (logging, guardrails, caching), virtual keys for secure access control, admin dashboard UI for monitoring and management</td>
-<td style={{width: '43%'}}>Direct Python library integration in your codebase, Router with retry/fallback logic across multiple deployments (e.g. Azure/OpenAI) - <a href="https://docs.litellm.ai/docs/routing">Router</a>, application-level load balancing and cost tracking, exception handling with OpenAI-compatible errors, observability callbacks (Lunary, MLflow, Langfuse, etc.)</td>
-</tr>
-</tbody>
-</table>
-
-**Stable Release:** Use docker images with the `-stable` tag. These have undergone 12 hour load tests, before being published. [More information about the release cycle here](https://docs.litellm.ai/docs/proxy/release_cycle)
-
-Support for more providers. Missing a provider or LLM Platform, raise a [feature request](https://github.com/BerriAI/litellm/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml&title=%5BFeature%5D%3A+).
-
-### Run in Developer Mode
-#### Services
-1. Setup .env file in root
-2. Run dependant services `docker-compose up db prometheus`
-
-#### Backend
-1. (In root) create virtual environment `python -m venv .venv`
-2. Activate virtual environment `source .venv/bin/activate`
-3. Install dependencies `uv sync --all-extras --group proxy-dev`
-4. `uv run prisma generate`
-5. `prisma generate`
-6. Start proxy backend `python litellm/proxy/proxy_cli.py`
-
-#### Frontend
-1. Navigate to `ui/litellm-dashboard`
-2. Install dependencies `npm install`
-3. Run `npm run dev` to start the dashboard
-
-### Verify Docker Image Signatures
-
-All LiteLLM Docker images published to GHCR are signed with [cosign](https://docs.sigstore.dev/cosign/overview/). Every release is signed with the same key introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0).
-
-**Verify using the pinned commit hash (recommended):**
-
-A commit hash is cryptographically immutable, so this is the strongest way to ensure you are using the original signing key:
-
-```bash
-cosign verify \
-  --key https://raw.githubusercontent.com/BerriAI/litellm/0112e53046018d726492c814b3644b7d376029d0/cosign.pub \
-  ghcr.io/berriai/litellm:<release-tag>
-```
-
-**Verify using a release tag (convenience):**
-
-Tags are protected in this repository and resolve to the same key. This option is easier to read but relies on tag protection rules:
-
-```bash
-cosign verify \
-  --key https://raw.githubusercontent.com/BerriAI/litellm/<release-tag>/cosign.pub \
-  ghcr.io/berriai/litellm:<release-tag>
-```
-
-Replace `<release-tag>` with the version you are deploying (e.g. `v1.83.0-stable`).
-
----
-
-# Enterprise
-For companies that need better security, user management and professional support
-
-[Get an Enterprise License](https://litellm.ai/enterprise)
-[Talk to founders](https://enterprise.litellm.ai/demo)
-
-This covers:
-- ✅ **Features under the [LiteLLM Commercial License](https://docs.litellm.ai/docs/proxy/enterprise):**
-- ✅ **Feature Prioritization**
-- ✅ **Custom Integrations**
-- ✅ **Professional Support - Dedicated discord + slack**
-- ✅ **Custom SLAs**
-- ✅ **Secure access with Single Sign-On**
-
-# Contributing
-
-We welcome contributions to LiteLLM! Whether you're fixing bugs, adding features, or improving documentation, we appreciate your help.
-
-## Quick Start for Contributors
-
-This requires uv to be installed.
-
-```bash
-git clone https://github.com/BerriAI/litellm.git
+# 2. 进入目录
 cd litellm
-make install-dev    # Install development dependencies
-make format         # Format your code
-make lint           # Run all linting checks
-make test-unit      # Run unit tests
-make format-check   # Check formatting only
+
+# 3. 创建虚拟环境
+python -m venv venv
+
+# 4. 激活虚拟环境
+# Windows (PowerShell):
+.\venv\Scripts\Activate.ps1
+# Windows (CMD):
+.\venv\Scripts\activate.bat
+# Linux/Mac:
+source venv/bin/activate
+
+# 5. 安装核心包（开发模式）
+pip install -e .
+
+# 6. 安装 Proxy 依赖（如需运行代理服务）
+pip install "litellm[proxy]"
 ```
 
-For detailed contributing guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+### Windows 特别说明
 
-> **📖 Contributing to documentation?** The LiteLLM docs have moved to a separate repository: [BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs). Please open doc PRs there. Docs are served at [docs.litellm.ai](https://docs.litellm.ai).
+Windows 上可能遇到的问题：
 
-## Code Quality / Linting
+1. **PowerShell 权限问题**：如果 `Activate.ps1` 报错，先执行：
+   ```powershell
+   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   ```
 
-LiteLLM follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+2. **prisma 安装**：Proxy 服务需要 prisma，Windows 上可能需要：
+   ```bash
+   pip install prisma
+   prisma generate
+   ```
 
-Our automated checks include:
-- **Black** for code formatting
-- **Ruff** for linting and code quality
-- **MyPy** for type checking
-- **Circular import detection**
-- **Import safety checks**
+### 验证安装
 
+```bash
+# 激活虚拟环境后执行
+python -c "
+from litellm.responses.litellm_completion_transformation.transformation import LiteLLMCompletionResponsesConfig
 
-All these checks must pass before your PR can be merged.
+# 测试 _clean_schema
+test_schema = {'type': 'object', 'strict': True, 'additionalProperties': False}
+cleaned = LiteLLMCompletionResponsesConfig._clean_schema(test_schema)
+print('清理前:', test_schema)
+print('清理后:', cleaned)
+assert 'strict' not in cleaned
+assert 'additionalProperties' not in cleaned
+print('✅ 安装验证成功!')
+"
+```
 
+---
 
-# Support / talk with founders
+## 配置示例
 
-- [Schedule Demo 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
-- [Community Discord 💭](https://discord.gg/wuPM9dRgDw)
-- [Community Slack 💭](https://www.litellm.ai/support)
-- Our emails ✉️ ishaan@berri.ai / krrish@berri.ai
+创建 `litellm_config.yaml`：
 
-# Contributors
+```yaml
+model_list:
+  - model_name: codex-model
+    litellm_params:
+      model: custom_openai/doubao-seed-2.0-pro
+      api_base: https://ark.cn-beijing.volces.com/api/v3
+      api_key: your-doubao-api-key
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
+  - model_name: codex-model
+    litellm_params:
+      model: custom_openai/glm-5
+      api_base: https://open.bigmodel.cn/api/paas/v4
+      api_key: your-glm-api-key
 
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
+  - model_name: codex-model
+    litellm_params:
+      model: custom_openai/MiniMax-M2.7
+      api_base: https://api.minimaxi.com/v1
+      api_key: your-minimax-api-key
 
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+  - model_name: codex-model
+    litellm_params:
+      model: custom_openai/mimo-v2.5-pro
+      api_base: https://token-plan-cn.xiaomimimo.com/v1
+      api_key: your-mimo-api-key
+```
 
-<a href="https://github.com/BerriAI/litellm/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=BerriAI/litellm" />
-</a>
+## 启动服务
+
+```bash
+# 激活虚拟环境后
+litellm --config litellm_config.yaml --port 4000
+```
+
+## Codex CLI 配置
+
+```bash
+# 设置环境变量
+export OPENAI_API_KEY="your-litellm-master-key"  # 或任意值（如果 LiteLLM 未启用鉴权）
+export OPENAI_BASE_URL="http://localhost:4000/v1"
+
+# 运行 Codex CLI
+echo '执行命令 echo hello' | codex exec --sandbox danger-full-access
+```
+
+---
+
+## 技术原理
+
+### 协议差异
+
+| 协议 | 使用方 | 特点 |
+|------|--------|------|
+| Responses API | Codex CLI | 支持 `local_shell` 工具、`previous_response_id` 会话链 |
+| Chat Completions API | 国内模型 | 标准 OpenAI 格式，只支持 `type: "function"` 工具 |
+
+### 过滤的字段
+
+Codex CLI 发送但国内模型不接受的字段：
+
+- `client_metadata` — 客户端元数据（Codex 专用）
+- `strict: true` — JSON Schema 严格模式（OpenAI 专用）
+- `additionalProperties: false` — Schema 扩展控制
+- `type: "local_shell"` — Codex 内置 Shell 工具类型
+
+### `_clean_schema()` 实现
+
+借鉴 [codex_deepseek_proxy](https://github.com/nickyc975/codex_deepseek_proxy) 项目：
+
+```python
+@staticmethod
+def _clean_schema(obj):
+    """递归清除 JSON Schema 中国内模型不支持的字段"""
+    if not isinstance(obj, dict):
+        return obj
+    cleaned = {}
+    for k, v in obj.items():
+        if k in ("additionalProperties", "strict"):
+            continue
+        if isinstance(v, dict):
+            cleaned[k] = LiteLLMCompletionResponsesConfig._clean_schema(v)
+        elif isinstance(v, list):
+            cleaned[k] = [_clean_schema(i) if isinstance(i, dict) else i for i in v]
+        else:
+            cleaned[k] = v
+    return cleaned
+```
+
+---
+
+## 参考项目
+
+- [codex_deepseek_proxy](https://github.com/nickyc975/codex_deepseek_proxy) — `_clean_schema` 设计来源
+- [mimo2codex](https://github.com/xiaomimimo/mimo2codex) — Responses → Chat 双向转换
+- [codex-minimax-proxy](https://github.com/nickyc975/codex-minimax-proxy) — MiniMax 专用代理
+
+---
+
+## 关于
+
+本 Fork 由 **oadank** 维护，专门解决 Codex CLI 国内模型兼容问题。
+
+- **上游仓库**: [BerriAI/litellm](https://github.com/BerriAI/litellm)
+- **分支**: `codex-domestic-fix`
+- **问题反馈**: [GitHub Issues](https://github.com/oadank/litellm/issues)
+
+---
+
+## License
+
+继承上游 MIT License。

--- a/README.md
+++ b/README.md
@@ -13,14 +13,37 @@ OpenAI Codex CLI 使用 **Responses API** 协议，而国内模型（豆包、GL
 | `handler.py` | 过滤 `client_metadata` 参数（Codex CLI 发送，国内模型不接受） |
 | `transformation.py` | 添加 `_clean_schema()` 清理 `strict`/`additionalProperties`；过滤 `local_shell` 等不支持的工具类型 |
 
-## 支持模型
+## 支持模型（已通过 Codex CLI 测试）
 
-| 模型 | Provider | 状态 |
-|------|----------|------|
-| doubao-seed-2.0-pro | 豆包 | ✅ |
-| glm-5 | 智谱 | ✅ |
-| MiniMax-M2.7 | MiniMax | ✅ |
+### 阿里云 DashScope
+| 模型 | Provider | 测试结果 |
+|------|----------|----------|
+| qwen3.5-plus | 阿里云 | ✅ |
+| qwen3-max-2026-01-23 | 阿里云 | ✅ |
+| qwen3-coder-next | 阿里云 | ✅ |
+| qwen3-coder-plus | 阿里云 | ✅ |
+| glm-4.7 | 智谱 (阿里云) | ✅ |
+| kimi-k2.5 | Moonshot (阿里云) | ✅ |
+| glm-5 | 智谱 (阿里云) | ✅ |
+
+### 火山引擎 Volcengine
+| 模型 | Provider | 测试结果 |
+|------|----------|----------|
+| Doubao-Seed-2.0-pro | 豆包 | ✅ |
+| Doubao-Seed-2.0-lite | 豆包 | ✅ |
+| GLM-5.1 | 智谱 (火山) | ✅ |
+| Kimi-K2.6 | Moonshot (火山) | ✅ |
+| DeepSeek-V3.2 | DeepSeek (火山) | ✅ |
+
+### 官方 API
+| 模型 | Provider | 测试结果 |
+|------|----------|----------|
+| MiniMax-M2.7 | MiniMax 官方 | ✅ |
 | mimo-v2.5-pro | 小米 MiMo | ✅ |
+| deepseek-v4-flash | DeepSeek 官方 | ✅ |
+| deepseek-v4-pro | DeepSeek 官方 | ✅ |
+
+**共 16 个模型全部通过 Codex CLI Responses API 测试。**
 
 ---
 

--- a/litellm/domestic_utils.py
+++ b/litellm/domestic_utils.py
@@ -1,0 +1,87 @@
+"""
+国内模型兼容判断工具
+
+独立模块，避免循环导入问题。
+用于判断请求是否来自国内模型 provider，需要兼容处理。
+"""
+
+from typing import Optional
+
+
+def is_domestic_model(model_name: Optional[str]) -> bool:
+    """
+    Check if the model is a domestic (Chinese) model based on its name.
+    Domestic models don't support OpenAI's native Responses API format
+    and certain Codex CLI specific parameters/tools.
+
+    Args:
+        model_name: Model name (e.g., "qwen3.5-plus", "MiniMax-M2.7", "openai/MiniMax-M2.7")
+
+    Returns:
+        bool: True if it's a domestic model that needs compatibility handling
+    """
+    if not model_name:
+        return False
+
+    model_lower = model_name.lower()
+
+    # Domestic model name patterns (covers both raw names and prefixed names like "openai/MiniMax-M2.7")
+    domestic_patterns = [
+        "qwen",      # Alibaba Qwen series
+        "glm",       # Zhipu GLM series
+        "doubao",    # Volcengine (ByteDance) Doubao series
+        "minimax",   # MiniMax series
+        "mimo",      # Xiaomi MiMo series
+        "deepseek",  # DeepSeek series
+        "kimi",      # Moonshot Kimi series
+    ]
+
+    return any(pattern in model_lower for pattern in domestic_patterns)
+
+
+def is_domestic_endpoint(api_base: Optional[str]) -> bool:
+    """
+    Check if the api_base is a domestic (Chinese) model provider endpoint.
+    Used as fallback when model name doesn't contain domestic pattern.
+
+    Args:
+        api_base: API endpoint URL
+
+    Returns:
+        bool: True if it's a domestic endpoint
+    """
+    if not api_base:
+        return False
+
+    domestic_endpoints = [
+        "dashscope.aliyuncs.com",  # Alibaba DashScope
+        "ark.cn-beijing.volces.com",  # Volcengine (ByteDance)
+        "api.minimaxi.com",  # MiniMax official
+        "xiaomimimo.com",  # Xiaomi MiMo
+        "api.deepseek.com",  # DeepSeek official
+        "moonshot.cn",  # Moonshot Kimi official
+        "bigmodel.cn",  # Zhipu GLM official
+    ]
+
+    return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
+
+
+def is_domestic_model_or_endpoint(model_name: Optional[str], api_base: Optional[str] = None) -> bool:
+    """
+    Check if either model name or endpoint indicates a domestic model.
+    This covers both cases:
+    1. Model name contains domestic pattern (e.g., "MiniMax-M2.7", "openai/qwen3.5-plus")
+    2. Endpoint is domestic provider (when model name is just group name like "codex-model")
+
+    Args:
+        model_name: Model name
+        api_base: API endpoint URL (optional)
+
+    Returns:
+        bool: True if it's a domestic model/endpoint
+    """
+    if is_domestic_model(model_name):
+        return True
+    if api_base and is_domestic_endpoint(api_base):
+        return True
+    return False

--- a/litellm/domestic_utils.py
+++ b/litellm/domestic_utils.py
@@ -27,13 +27,13 @@ def is_domestic_model(model_name: Optional[str]) -> bool:
 
     # Domestic model name patterns (covers both raw names and prefixed names like "openai/MiniMax-M2.7")
     domestic_patterns = [
-        "qwen",      # Alibaba Qwen series
-        "glm",       # Zhipu GLM series
-        "doubao",    # Volcengine (ByteDance) Doubao series
-        "minimax",   # MiniMax series
-        "mimo",      # Xiaomi MiMo series
+        "qwen",  # Alibaba Qwen series
+        "glm",  # Zhipu GLM series
+        "doubao",  # Volcengine (ByteDance) Doubao series
+        "minimax",  # MiniMax series
+        "mimo",  # Xiaomi MiMo series
         "deepseek",  # DeepSeek series
-        "kimi",      # Moonshot Kimi series
+        "kimi",  # Moonshot Kimi series
     ]
 
     return any(pattern in model_lower for pattern in domestic_patterns)
@@ -66,7 +66,9 @@ def is_domestic_endpoint(api_base: Optional[str]) -> bool:
     return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
 
 
-def is_domestic_model_or_endpoint(model_name: Optional[str], api_base: Optional[str] = None) -> bool:
+def is_domestic_model_or_endpoint(
+    model_name: Optional[str], api_base: Optional[str] = None
+) -> bool:
     """
     Check if either model name or endpoint indicates a domestic model.
     This covers both cases:

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 from datetime import datetime, timezone
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -83,41 +83,52 @@ class ResetBudgetJob:
                 "Failed to reset spend counter %s: %s", counter_key, e
             )
 
+    async def _cascade_reset_spend_for_budget_link(
+        self,
+        budgets_to_reset: List[LiteLLM_BudgetTableFull],
+        table: Any,
+        counter_key_fn: Callable[[Any], str],
+        log_subject: str,
+        extra_where: Optional[dict] = None,
+    ):
+        """
+        Generic cascade: zero spend on rows whose budget_id is in the reset set.
+        """
+        budget_ids = [b.budget_id for b in budgets_to_reset if b.budget_id is not None]
+        if not budget_ids:
+            return
+
+        where: dict = {"budget_id": {"in": budget_ids}}
+        if extra_where:
+            where.update(extra_where)
+
+        try:
+            rows = await table.find_many(where=where)
+        except Exception as e:
+            rows = []
+            verbose_proxy_logger.warning(
+                "Failed to fetch %s for counter invalidation: %s", log_subject, e
+            )
+
+        update_result = await table.update_many(where=where, data={"spend": 0})
+
+        for row in rows:
+            await self._invalidate_spend_counter(counter_key_fn(row))
+
+        return update_result
+
     async def reset_budget_for_litellm_team_members(
         self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
     ):
         """
         Resets the budget for all LiteLLM Team Members if their budget has expired
         """
-        budget_ids = [
-            budget.budget_id
-            for budget in budgets_to_reset
-            if budget.budget_id is not None
-        ]
-
-        try:
-            memberships = await self.prisma_client.db.litellm_teammembership.find_many(
-                where={"budget_id": {"in": budget_ids}}
-            )
-        except Exception as e:
-            memberships = []
-            verbose_proxy_logger.warning(
-                "Failed to fetch team memberships for counter invalidation: %s", e
-            )
-
-        update_result = await self.prisma_client.db.litellm_teammembership.update_many(
-            where={"budget_id": {"in": budget_ids}},
-            data={
-                "spend": 0,
-            },
+        return await self._cascade_reset_spend_for_budget_link(
+            budgets_to_reset=budgets_to_reset,
+            table=self.prisma_client.db.litellm_teammembership,
+            counter_key_fn=lambda m: f"spend:team_member:{m.user_id}:{m.team_id}",
+            log_subject="team memberships",
         )
-
-        for m in memberships:
-            await self._invalidate_spend_counter(
-                f"spend:team_member:{m.user_id}:{m.team_id}"
-            )
-
-        return update_result
 
     async def reset_budget_for_keys_linked_to_budgets(
         self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
@@ -125,51 +136,44 @@ class ResetBudgetJob:
         """
         Resets the spend for keys linked to budget tiers that are being reset.
 
-        This handles keys that have budget_id but no budget_duration set on the key
-        itself. Keys with budget_id rely on their linked budget tier's reset schedule
-        rather than having their own budget_duration.
-
-        Keys that have their own budget_duration are already handled by
-        reset_budget_for_litellm_keys() and are excluded here to avoid
-        double-resetting.
+        Excludes keys with their own budget_duration; those are reset by
+        reset_budget_for_litellm_keys() to avoid double-resetting.
         """
-        budget_ids = [
-            budget.budget_id
-            for budget in budgets_to_reset
-            if budget.budget_id is not None
-        ]
-        if not budget_ids:
-            return
-
-        where_clause: dict = {
-            "budget_id": {"in": budget_ids},
-            "budget_duration": None,  # only keys without their own reset schedule
-            "spend": {"gt": 0},  # only reset keys that have accumulated spend
-        }
-
-        try:
-            keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                where=where_clause
-            )
-        except Exception as e:
-            keys = []
-            verbose_proxy_logger.warning(
-                "Failed to fetch keys for counter invalidation: %s", e
-            )
-
-        update_result = (
-            await self.prisma_client.db.litellm_verificationtoken.update_many(
-                where=where_clause,
-                data={
-                    "spend": 0,
-                },
-            )
+        return await self._cascade_reset_spend_for_budget_link(
+            budgets_to_reset=budgets_to_reset,
+            table=self.prisma_client.db.litellm_verificationtoken,
+            counter_key_fn=lambda k: f"spend:key:{k.token}",
+            log_subject="keys",
+            extra_where={"budget_duration": None, "spend": {"gt": 0}},
         )
 
-        for k in keys:
-            await self._invalidate_spend_counter(f"spend:key:{k.token}")
+    async def reset_budget_for_orgs_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for orgs linked to budget tiers that are being reset.
+        """
+        return await self._cascade_reset_spend_for_budget_link(
+            budgets_to_reset=budgets_to_reset,
+            table=self.prisma_client.db.litellm_organizationtable,
+            counter_key_fn=lambda o: f"spend:org:{o.organization_id}",
+            log_subject="orgs",
+            extra_where={"spend": {"gt": 0}},
+        )
 
-        return update_result
+    async def reset_budget_for_tags_linked_to_budgets(
+        self, budgets_to_reset: List[LiteLLM_BudgetTableFull]
+    ):
+        """
+        Resets the spend for tags linked to budget tiers that are being reset.
+        """
+        return await self._cascade_reset_spend_for_budget_link(
+            budgets_to_reset=budgets_to_reset,
+            table=self.prisma_client.db.litellm_tagtable,
+            counter_key_fn=lambda t: f"spend:tag:{t.tag_name}",
+            log_subject="tags",
+            extra_where={"spend": {"gt": 0}},
+        )
 
     async def reset_budget_for_litellm_budget_table(self):
         """
@@ -234,6 +238,14 @@ class ResetBudgetJob:
                 )
 
                 await self.reset_budget_for_keys_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_orgs_linked_to_budgets(
+                    budgets_to_reset=budgets_to_reset
+                )
+
+                await self.reset_budget_for_tags_linked_to_budgets(
                     budgets_to_reset=budgets_to_reset
                 )
 

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -18,31 +18,7 @@ from litellm.types.llms.openai import (
     ResponsesAPIResponse,
 )
 from litellm.types.utils import ModelResponse
-
-
-def _is_domestic_model_endpoint(api_base: Optional[str]) -> bool:
-    """
-    判断是否是国内模型 provider endpoint。
-    国内模型不支持某些 Codex CLI 特有的参数和工具类型。
-
-    Args:
-        api_base: API endpoint URL
-
-    Returns:
-        bool: True 表示是国内模型 endpoint，需要做兼容处理
-    """
-    if not api_base:
-        return False
-
-    domestic_endpoints = [
-        "dashscope.aliyuncs.com",  # 阿里云 DashScope
-        "ark.cn-beijing.volces.com",  # 火山引擎 Volcengine
-        "api.minimaxi.com",  # MiniMax 官方
-        "xiaomimimo.com",  # 小米 MiMo
-        "api.deepseek.com",  # DeepSeek 官方
-    ]
-
-    return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
+from litellm.utils import ProviderConfigManager
 
 
 class LiteLLMCompletionTransformationHandler:
@@ -89,7 +65,7 @@ class LiteLLMCompletionTransformationHandler:
         # 只对国内模型 endpoint 过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
         # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
         api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
-        if _is_domestic_model_endpoint(api_base):
+        if ProviderConfigManager._is_domestic_model_endpoint(api_base):
             completion_args.pop("client_metadata", None)
 
         completion_args.update(litellm_completion_request)
@@ -146,7 +122,7 @@ class LiteLLMCompletionTransformationHandler:
         # 只对国内模型 endpoint 过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
         # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
         api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
-        if _is_domestic_model_endpoint(api_base):
+        if ProviderConfigManager._is_domestic_model_endpoint(api_base):
             acompletion_args.pop("client_metadata", None)
 
         acompletion_args.update(litellm_completion_request)

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -62,10 +62,11 @@ class LiteLLMCompletionTransformationHandler:
         completion_args = {}
         completion_args.update(kwargs)
 
-        # 只对国内模型 endpoint 过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
+        # 只对国内模型过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
         # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
+        # 双重检查：model名 + api_base endpoint
         api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
-        if ProviderConfigManager._is_domestic_model_endpoint(api_base):
+        if ProviderConfigManager._is_domestic_model_or_endpoint(model, api_base):
             completion_args.pop("client_metadata", None)
 
         completion_args.update(litellm_completion_request)
@@ -119,10 +120,12 @@ class LiteLLMCompletionTransformationHandler:
         acompletion_args = {}
         acompletion_args.update(kwargs)
 
-        # 只对国内模型 endpoint 过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
+        # 只对国内模型过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
         # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
-        api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
-        if ProviderConfigManager._is_domestic_model_endpoint(api_base):
+        # 双重检查：model名 + api_base endpoint
+        model_name = litellm_completion_request.get("model")
+        api_base = litellm_completion_request.get("api_base") or kwargs.get("api_base")
+        if ProviderConfigManager._is_domestic_model_or_endpoint(model_name, api_base):
             acompletion_args.pop("client_metadata", None)
 
         acompletion_args.update(litellm_completion_request)

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -60,13 +60,14 @@ class LiteLLMCompletionTransformationHandler:
 
         completion_args = {}
         completion_args.update(kwargs)
+        # 过滤国内模型不支持的参数 (Codex CLI 0.130.0 兼容修复)
+        completion_args.pop("client_metadata", None)
         completion_args.update(litellm_completion_request)
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
         ] = litellm.completion(
-            **litellm_completion_request,
-            **kwargs,
+            **completion_args,
         )
 
         if isinstance(litellm_completion_response, ModelResponse):
@@ -111,6 +112,8 @@ class LiteLLMCompletionTransformationHandler:
 
         acompletion_args = {}
         acompletion_args.update(kwargs)
+        # 过滤国内模型不支持的参数 (Codex CLI 0.130.0 兼容修复)
+        acompletion_args.pop("client_metadata", None)
         acompletion_args.update(litellm_completion_request)
 
         litellm_completion_response: Union[

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -20,6 +20,31 @@ from litellm.types.llms.openai import (
 from litellm.types.utils import ModelResponse
 
 
+def _is_domestic_model_endpoint(api_base: Optional[str]) -> bool:
+    """
+    判断是否是国内模型 provider endpoint。
+    国内模型不支持某些 Codex CLI 特有的参数和工具类型。
+
+    Args:
+        api_base: API endpoint URL
+
+    Returns:
+        bool: True 表示是国内模型 endpoint，需要做兼容处理
+    """
+    if not api_base:
+        return False
+
+    domestic_endpoints = [
+        "dashscope.aliyuncs.com",  # 阿里云 DashScope
+        "ark.cn-beijing.volces.com",  # 火山引擎 Volcengine
+        "api.minimaxi.com",  # MiniMax 官方
+        "xiaomimimo.com",  # 小米 MiMo
+        "api.deepseek.com",  # DeepSeek 官方
+    ]
+
+    return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
+
+
 class LiteLLMCompletionTransformationHandler:
     def response_api_handler(
         self,
@@ -60,8 +85,13 @@ class LiteLLMCompletionTransformationHandler:
 
         completion_args = {}
         completion_args.update(kwargs)
-        # 过滤国内模型不支持的参数 (Codex CLI 0.130.0 兼容修复)
-        completion_args.pop("client_metadata", None)
+
+        # 只对国内模型 endpoint 过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
+        # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
+        api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
+        if _is_domestic_model_endpoint(api_base):
+            completion_args.pop("client_metadata", None)
+
         completion_args.update(litellm_completion_request)
 
         litellm_completion_response: Union[
@@ -112,8 +142,13 @@ class LiteLLMCompletionTransformationHandler:
 
         acompletion_args = {}
         acompletion_args.update(kwargs)
-        # 过滤国内模型不支持的参数 (Codex CLI 0.130.0 兼容修复)
-        acompletion_args.pop("client_metadata", None)
+
+        # 只对国内模型 endpoint 过滤 client_metadata (Codex CLI 0.130.0 兼容修复)
+        # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
+        api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
+        if _is_domestic_model_endpoint(api_base):
+            acompletion_args.pop("client_metadata", None)
+
         acompletion_args.update(litellm_completion_request)
 
         litellm_completion_response: Union[

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -5,6 +5,7 @@ Handler for transforming responses api requests to litellm.completion requests
 from typing import Any, Coroutine, Dict, Optional, Union
 
 import litellm
+from litellm.domestic_utils import is_domestic_model_or_endpoint
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )
@@ -18,7 +19,6 @@ from litellm.types.llms.openai import (
     ResponsesAPIResponse,
 )
 from litellm.types.utils import ModelResponse
-from litellm.utils import ProviderConfigManager
 
 
 class LiteLLMCompletionTransformationHandler:
@@ -66,7 +66,7 @@ class LiteLLMCompletionTransformationHandler:
         # 国内模型不支持 Codex CLI 特有的 client_metadata 参数
         # 双重检查：model名 + api_base endpoint
         api_base = kwargs.get("api_base") or litellm_completion_request.get("api_base")
-        if ProviderConfigManager._is_domestic_model_or_endpoint(model, api_base):
+        if is_domestic_model_or_endpoint(model, api_base):
             completion_args.pop("client_metadata", None)
 
         completion_args.update(litellm_completion_request)
@@ -125,7 +125,7 @@ class LiteLLMCompletionTransformationHandler:
         # 双重检查：model名 + api_base endpoint
         model_name = litellm_completion_request.get("model")
         api_base = litellm_completion_request.get("api_base") or kwargs.get("api_base")
-        if ProviderConfigManager._is_domestic_model_or_endpoint(model_name, api_base):
+        if is_domestic_model_or_endpoint(model_name, api_base):
             acompletion_args.pop("client_metadata", None)
 
         acompletion_args.update(litellm_completion_request)

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -101,8 +101,11 @@ class LiteLLMCompletionResponsesConfig:
                 cleaned[k] = LiteLLMCompletionResponsesConfig._clean_schema(v)
             elif isinstance(v, list):
                 cleaned[k] = [
-                    LiteLLMCompletionResponsesConfig._clean_schema(i)
-                    if isinstance(i, dict) else i
+                    (
+                        LiteLLMCompletionResponsesConfig._clean_schema(i)
+                        if isinstance(i, dict)
+                        else i
+                    )
                     for i in v
                 ]
             else:
@@ -198,8 +201,12 @@ class LiteLLMCompletionResponsesConfig:
         Transform a Responses API request into a Chat Completion request
         """
         # 获取 model 和 api_base 用于判断是否是国内模型
-        model_name: Optional[str] = responses_api_request.get("model") or kwargs.get("model")
-        api_base: Optional[str] = kwargs.get("api_base") or responses_api_request.get("api_base")
+        model_name: Optional[str] = responses_api_request.get("model") or kwargs.get(
+            "model"
+        )
+        api_base: Optional[str] = kwargs.get("api_base") or responses_api_request.get(
+            "api_base"
+        )
 
         (
             tools,
@@ -1417,11 +1424,11 @@ class LiteLLMCompletionResponsesConfig:
             # 国内模型只支持 type: "function"，不支持 Codex/OpenAI 特有的工具类型
             if is_domestic_model:
                 unsupported_tool_types = [
-                    "local_shell",       # Codex CLI 内置 Shell 工具
-                    "namespace",         # Codex CLI 0.130.0 工具命名空间
+                    "local_shell",  # Codex CLI 内置 Shell 工具
+                    "namespace",  # Codex CLI 0.130.0 工具命名空间
                     "code_interpreter",  # OpenAI Code Interpreter
-                    "file_search",       # OpenAI File Search
-                    "computer_use",      # Anthropic Computer Use
+                    "file_search",  # OpenAI File Search
+                    "computer_use",  # Anthropic Computer Use
                     "image_generation",  # OpenAI Image Generation
                 ]
                 if tool.get("type") in unsupported_tool_types:
@@ -1459,7 +1466,9 @@ class LiteLLMCompletionResponsesConfig:
                 # 只对国内模型 endpoint 清理 schema 中不支持的字段
                 # 国内模型不支持 strict 和 additionalProperties，OpenAI structured outputs 需要这些字段
                 if is_domestic_model:
-                    parameters = LiteLLMCompletionResponsesConfig._clean_schema(parameters)
+                    parameters = LiteLLMCompletionResponsesConfig._clean_schema(
+                        parameters
+                    )
                     # 国内模型不支持 strict 和额外字段，只传递基础信息
                     chat_completion_tool: Dict[str, Any] = {
                         "type": "function",
@@ -1502,7 +1511,9 @@ class LiteLLMCompletionResponsesConfig:
                 )
         # 如果 tools 数组为空，返回 None 表示不传递 tools 参数
         # 避免空的 tools 数组被发送给不支持空 tools 的国内模型
-        return chat_completion_tools if chat_completion_tools else None, web_search_options
+        return (
+            chat_completion_tools if chat_completion_tools else None
+        ), web_search_options
 
     @staticmethod
     def transform_chat_completion_tool_params_to_responses_api_tools(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -11,6 +11,7 @@ from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
 
 from litellm.caching import InMemoryCache
+from litellm.domestic_utils import is_domestic_model_or_endpoint
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
@@ -57,7 +58,6 @@ from litellm.types.utils import (
     ModelResponse,
     Usage,
 )
-from litellm.utils import ProviderConfigManager
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
@@ -1405,7 +1405,7 @@ class LiteLLMCompletionResponsesConfig:
             return [], None
 
         # 判断是否是国内模型，需要特殊处理（双重检查：model名 + endpoint）
-        is_domestic_model = ProviderConfigManager._is_domestic_model_or_endpoint(model_name, api_base)
+        is_domestic_model = is_domestic_model_or_endpoint(model_name, api_base)
 
         chat_completion_tools: List[
             Union[ChatCompletionToolParam, OpenAIMcpServerTool]

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1427,12 +1427,17 @@ class LiteLLMCompletionResponsesConfig:
                 if tool.get("type") in unsupported_tool_types:
                     continue  # 跳过不支持的 tool 类型
 
+            # MCP 和 web_search 类型：国内模型不支持，需要过滤
             if tool.get("type") == "mcp":
+                if is_domestic_model:
+                    continue  # 国内模型不支持 MCP 协议
                 chat_completion_tools.append(cast(OpenAIMcpServerTool, tool))
             elif (
                 tool.get("type") == "web_search_preview"
                 or tool.get("type") == "web_search"
             ):
+                if is_domestic_model:
+                    continue  # 国内模型不支持 web search
                 _search_context_size: Literal["low", "medium", "high"] = cast(
                     Literal["low", "medium", "high"], tool.get("search_context_size")
                 )
@@ -1455,24 +1460,34 @@ class LiteLLMCompletionResponsesConfig:
                 # 国内模型不支持 strict 和 additionalProperties，OpenAI structured outputs 需要这些字段
                 if is_domestic_model:
                     parameters = LiteLLMCompletionResponsesConfig._clean_schema(parameters)
-
-                chat_completion_tool: Dict[str, Any] = {
-                    "type": "function",
-                    "function": {
-                        "name": typed_tool.get("name") or "",
-                        "description": typed_tool.get("description") or "",
-                        "parameters": parameters,
-                        "strict": typed_tool.get("strict", False) or False,
-                    },
-                }
-                if tool.get("cache_control"):
-                    chat_completion_tool["cache_control"] = tool.get("cache_control")  # type: ignore
-                if tool.get("defer_loading"):
-                    chat_completion_tool["defer_loading"] = tool.get("defer_loading")  # type: ignore
-                if tool.get("allowed_callers"):
-                    chat_completion_tool["allowed_callers"] = tool.get("allowed_callers")  # type: ignore
-                if tool.get("input_examples"):
-                    chat_completion_tool["input_examples"] = tool.get("input_examples")  # type: ignore
+                    # 国内模型不支持 strict 和额外字段，只传递基础信息
+                    chat_completion_tool: Dict[str, Any] = {
+                        "type": "function",
+                        "function": {
+                            "name": typed_tool.get("name") or "",
+                            "description": typed_tool.get("description") or "",
+                            "parameters": parameters,
+                        },
+                    }
+                else:
+                    # 国际模型支持完整参数
+                    chat_completion_tool: Dict[str, Any] = {
+                        "type": "function",
+                        "function": {
+                            "name": typed_tool.get("name") or "",
+                            "description": typed_tool.get("description") or "",
+                            "parameters": parameters,
+                            "strict": typed_tool.get("strict", False) or False,
+                        },
+                    }
+                    if tool.get("cache_control"):
+                        chat_completion_tool["cache_control"] = tool.get("cache_control")  # type: ignore
+                    if tool.get("defer_loading"):
+                        chat_completion_tool["defer_loading"] = tool.get("defer_loading")  # type: ignore
+                    if tool.get("allowed_callers"):
+                        chat_completion_tool["allowed_callers"] = tool.get("allowed_callers")  # type: ignore
+                    if tool.get("input_examples"):
+                        chat_completion_tool["input_examples"] = tool.get("input_examples")  # type: ignore
                 chat_completion_tools.append(
                     cast(ChatCompletionToolParam, chat_completion_tool)
                 )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -80,6 +80,35 @@ class ChatCompletionSession(TypedDict, total=False):
 
 class LiteLLMCompletionResponsesConfig:
     @staticmethod
+    def _clean_schema(obj: Any) -> Any:
+        """
+        递归清除 JSON Schema 中国内模型不支持的字段 (Codex CLI 0.130.0 兼容修复)
+
+        国内模型(豆包/GLM/MiniMax/MiMo)不支持:
+        - strict: 严格模式
+        - additionalProperties: JSON Schema 扩展属性
+
+        借鉴 codex_deepseek_proxy 项目的设计
+        """
+        if not isinstance(obj, dict):
+            return obj
+        cleaned: Dict[str, Any] = {}
+        for k, v in obj.items():
+            if k in ("additionalProperties", "strict"):
+                continue  # 跳过这些字段
+            if isinstance(v, dict):
+                cleaned[k] = LiteLLMCompletionResponsesConfig._clean_schema(v)
+            elif isinstance(v, list):
+                cleaned[k] = [
+                    LiteLLMCompletionResponsesConfig._clean_schema(i)
+                    if isinstance(i, dict) else i
+                    for i in v
+                ]
+            else:
+                cleaned[k] = v
+        return cleaned
+
+    @staticmethod
     def get_supported_openai_params(model: str) -> list:
         """
         LiteLLM Adapter from OpenAI Responses API to Chat Completion API supports a subset of OpenAI Responses API params
@@ -1365,6 +1394,18 @@ class LiteLLMCompletionResponsesConfig:
         ] = []
         web_search_options: Optional[OpenAIWebSearchOptions] = None
         for tool in tools:
+            # 过滤国内模型不支持的 tool 类型 (Codex CLI 0.130.0 兼容修复)
+            # local_shell 是 Codex 内置工具类型，国内模型只支持 type: "function"
+            unsupported_tool_types = [
+                "local_shell",
+                "code_interpreter",
+                "file_search",
+                "computer_use",
+                "image_generation",
+            ]
+            if tool.get("type") in unsupported_tool_types:
+                continue  # 跳过不支持的 tool 类型
+
             if tool.get("type") == "mcp":
                 chat_completion_tools.append(cast(OpenAIMcpServerTool, tool))
             elif (
@@ -1388,13 +1429,15 @@ class LiteLLMCompletionResponsesConfig:
                 parameters = dict(typed_tool.get("parameters", {}) or {})
                 if not parameters or "type" not in parameters:
                     parameters["type"] = "object"
+                # 清理 schema 中国内模型不支持的字段 (Codex CLI 0.130.0 兼容修复)
+                parameters = LiteLLMCompletionResponsesConfig._clean_schema(parameters)
                 chat_completion_tool: Dict[str, Any] = {
                     "type": "function",
                     "function": {
                         "name": typed_tool.get("name") or "",
                         "description": typed_tool.get("description") or "",
                         "parameters": parameters,
-                        "strict": typed_tool.get("strict", False) or False,
+                        # strict 字段已在 parameters 中被 _clean_schema 清理，这里不再设置
                     },
                 }
                 if tool.get("cache_control"):

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1387,7 +1387,7 @@ class LiteLLMCompletionResponsesConfig:
         tools: Optional[List[Union[FunctionToolParam, OpenAIMcpServerTool]]],
         api_base: Optional[str] = None,
     ) -> Tuple[
-        List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]],
+        Optional[List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]],
         Optional[OpenAIWebSearchOptions],
     ]:
         """
@@ -1475,7 +1475,9 @@ class LiteLLMCompletionResponsesConfig:
                 chat_completion_tools.append(
                     cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool)
                 )
-        return chat_completion_tools, web_search_options
+        # 如果 tools 数组为空，返回 None 表示不传递 tools 参数
+        # 避免空的 tools 数组被发送给不支持空 tools 的国内模型
+        return chat_completion_tools if chat_completion_tools else None, web_search_options
 
     @staticmethod
     def transform_chat_completion_tool_params_to_responses_api_tools(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1418,6 +1418,7 @@ class LiteLLMCompletionResponsesConfig:
             if is_domestic_model:
                 unsupported_tool_types = [
                     "local_shell",       # Codex CLI 内置 Shell 工具
+                    "namespace",         # Codex CLI 0.130.0 工具命名空间
                     "code_interpreter",  # OpenAI Code Interpreter
                     "file_search",       # OpenAI File Search
                     "computer_use",      # Anthropic Computer Use
@@ -1476,6 +1477,11 @@ class LiteLLMCompletionResponsesConfig:
                     cast(ChatCompletionToolParam, chat_completion_tool)
                 )
             else:
+                # 对于国内模型，只保留 function 和 mcp 类型，其他类型全部过滤
+                # 避免 unknown 类型被发送给国内模型导致错误
+                if is_domestic_model:
+                    # 国内模型只支持 function 和 mcp 类型
+                    continue  # 跳过不支持的工具类型
                 chat_completion_tools.append(
                     cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool)
                 )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -78,13 +78,38 @@ class ChatCompletionSession(TypedDict, total=False):
 ########### End of Initialize Classes used for Responses API  ###########
 
 
+def _is_domestic_model_endpoint(api_base: Optional[str]) -> bool:
+    """
+    判断是否是国内模型 provider endpoint。
+    国内模型不支持某些 Codex CLI 特有的参数和工具类型。
+
+    Args:
+        api_base: API endpoint URL
+
+    Returns:
+        bool: True 表示是国内模型 endpoint，需要做兼容处理
+    """
+    if not api_base:
+        return False
+
+    domestic_endpoints = [
+        "dashscope.aliyuncs.com",  # 阿里云 DashScope
+        "ark.cn-beijing.volces.com",  # 火山引擎 Volcengine
+        "api.minimaxi.com",  # MiniMax 官方
+        "xiaomimimo.com",  # 小米 MiMo
+        "api.deepseek.com",  # DeepSeek 官方
+    ]
+
+    return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
+
+
 class LiteLLMCompletionResponsesConfig:
     @staticmethod
     def _clean_schema(obj: Any) -> Any:
         """
-        递归清除 JSON Schema 中国内模型不支持的字段 (Codex CLI 0.130.0 兼容修复)
+        递归清除 JSON Schema 中国内模型不支持的字段。
 
-        国内模型(豆包/GLM/MiniMax/MiMo)不支持:
+        国内模型(豆包/GLM/MiniMax/MiMo/DeepSeek)不支持:
         - strict: 严格模式
         - additionalProperties: JSON Schema 扩展属性
 
@@ -196,11 +221,15 @@ class LiteLLMCompletionResponsesConfig:
         """
         Transform a Responses API request into a Chat Completion request
         """
+        # 获取 api_base 用于判断是否是国内模型 endpoint
+        api_base: Optional[str] = kwargs.get("api_base")
+
         (
             tools,
             web_search_options,
         ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
-            responses_api_request.get("tools") or []  # type: ignore
+            responses_api_request.get("tools") or [],  # type: ignore
+            api_base=api_base,
         )
 
         response_format = None
@@ -1380,31 +1409,42 @@ class LiteLLMCompletionResponsesConfig:
     @staticmethod
     def transform_responses_api_tools_to_chat_completion_tools(
         tools: Optional[List[Union[FunctionToolParam, OpenAIMcpServerTool]]],
+        api_base: Optional[str] = None,
     ) -> Tuple[
         List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]],
         Optional[OpenAIWebSearchOptions],
     ]:
         """
         Transform a Responses API tools into a Chat Completion tools
+
+        Args:
+            tools: List of tools from Responses API request
+            api_base: API endpoint URL, used to determine if domestic model filtering should apply
         """
         if tools is None:
             return [], None
+
+        # 判断是否是国内模型 endpoint，需要特殊处理
+        is_domestic_endpoint = _is_domestic_model_endpoint(api_base)
+
         chat_completion_tools: List[
             Union[ChatCompletionToolParam, OpenAIMcpServerTool]
         ] = []
         web_search_options: Optional[OpenAIWebSearchOptions] = None
+
         for tool in tools:
-            # 过滤国内模型不支持的 tool 类型 (Codex CLI 0.130.0 兼容修复)
-            # local_shell 是 Codex 内置工具类型，国内模型只支持 type: "function"
-            unsupported_tool_types = [
-                "local_shell",
-                "code_interpreter",
-                "file_search",
-                "computer_use",
-                "image_generation",
-            ]
-            if tool.get("type") in unsupported_tool_types:
-                continue  # 跳过不支持的 tool 类型
+            # 只对国内模型 endpoint 过滤不支持的工具类型
+            # 国内模型只支持 type: "function"，不支持 Codex/OpenAI 特有的工具类型
+            if is_domestic_endpoint:
+                unsupported_tool_types = [
+                    "local_shell",       # Codex CLI 内置 Shell 工具
+                    "code_interpreter",  # OpenAI Code Interpreter
+                    "file_search",       # OpenAI File Search
+                    "computer_use",      # Anthropic Computer Use
+                    "image_generation",  # OpenAI Image Generation
+                ]
+                if tool.get("type") in unsupported_tool_types:
+                    continue  # 跳过不支持的 tool 类型
 
             if tool.get("type") == "mcp":
                 chat_completion_tools.append(cast(OpenAIMcpServerTool, tool))
@@ -1429,15 +1469,19 @@ class LiteLLMCompletionResponsesConfig:
                 parameters = dict(typed_tool.get("parameters", {}) or {})
                 if not parameters or "type" not in parameters:
                     parameters["type"] = "object"
-                # 清理 schema 中国内模型不支持的字段 (Codex CLI 0.130.0 兼容修复)
-                parameters = LiteLLMCompletionResponsesConfig._clean_schema(parameters)
+
+                # 只对国内模型 endpoint 清理 schema 中不支持的字段
+                # 国内模型不支持 strict 和 additionalProperties，OpenAI structured outputs 需要这些字段
+                if is_domestic_endpoint:
+                    parameters = LiteLLMCompletionResponsesConfig._clean_schema(parameters)
+
                 chat_completion_tool: Dict[str, Any] = {
                     "type": "function",
                     "function": {
                         "name": typed_tool.get("name") or "",
                         "description": typed_tool.get("description") or "",
                         "parameters": parameters,
-                        # strict 字段已在 parameters 中被 _clean_schema 清理，这里不再设置
+                        "strict": typed_tool.get("strict", False) or False,
                     },
                 }
                 if tool.get("cache_control"):

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -57,6 +57,7 @@ from litellm.types.utils import (
     ModelResponse,
     Usage,
 )
+from litellm.utils import ProviderConfigManager
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
@@ -76,31 +77,6 @@ class ChatCompletionSession(TypedDict, total=False):
 
 
 ########### End of Initialize Classes used for Responses API  ###########
-
-
-def _is_domestic_model_endpoint(api_base: Optional[str]) -> bool:
-    """
-    判断是否是国内模型 provider endpoint。
-    国内模型不支持某些 Codex CLI 特有的参数和工具类型。
-
-    Args:
-        api_base: API endpoint URL
-
-    Returns:
-        bool: True 表示是国内模型 endpoint，需要做兼容处理
-    """
-    if not api_base:
-        return False
-
-    domestic_endpoints = [
-        "dashscope.aliyuncs.com",  # 阿里云 DashScope
-        "ark.cn-beijing.volces.com",  # 火山引擎 Volcengine
-        "api.minimaxi.com",  # MiniMax 官方
-        "xiaomimimo.com",  # 小米 MiMo
-        "api.deepseek.com",  # DeepSeek 官方
-    ]
-
-    return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
 
 
 class LiteLLMCompletionResponsesConfig:
@@ -1425,7 +1401,7 @@ class LiteLLMCompletionResponsesConfig:
             return [], None
 
         # 判断是否是国内模型 endpoint，需要特殊处理
-        is_domestic_endpoint = _is_domestic_model_endpoint(api_base)
+        is_domestic_endpoint = ProviderConfigManager._is_domestic_model_endpoint(api_base)
 
         chat_completion_tools: List[
             Union[ChatCompletionToolParam, OpenAIMcpServerTool]

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -197,14 +197,16 @@ class LiteLLMCompletionResponsesConfig:
         """
         Transform a Responses API request into a Chat Completion request
         """
-        # 获取 api_base 用于判断是否是国内模型 endpoint
-        api_base: Optional[str] = kwargs.get("api_base")
+        # 获取 model 和 api_base 用于判断是否是国内模型
+        model_name: Optional[str] = responses_api_request.get("model") or kwargs.get("model")
+        api_base: Optional[str] = kwargs.get("api_base") or responses_api_request.get("api_base")
 
         (
             tools,
             web_search_options,
         ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
             responses_api_request.get("tools") or [],  # type: ignore
+            model_name=model_name,
             api_base=api_base,
         )
 
@@ -1385,6 +1387,7 @@ class LiteLLMCompletionResponsesConfig:
     @staticmethod
     def transform_responses_api_tools_to_chat_completion_tools(
         tools: Optional[List[Union[FunctionToolParam, OpenAIMcpServerTool]]],
+        model_name: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> Tuple[
         Optional[List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]],
@@ -1395,13 +1398,14 @@ class LiteLLMCompletionResponsesConfig:
 
         Args:
             tools: List of tools from Responses API request
-            api_base: API endpoint URL, used to determine if domestic model filtering should apply
+            model_name: Model name, used to determine if domestic model filtering should apply
+            api_base: API endpoint URL, fallback check when model_name is just a group name
         """
         if tools is None:
             return [], None
 
-        # 判断是否是国内模型 endpoint，需要特殊处理
-        is_domestic_endpoint = ProviderConfigManager._is_domestic_model_endpoint(api_base)
+        # 判断是否是国内模型，需要特殊处理（双重检查：model名 + endpoint）
+        is_domestic_model = ProviderConfigManager._is_domestic_model_or_endpoint(model_name, api_base)
 
         chat_completion_tools: List[
             Union[ChatCompletionToolParam, OpenAIMcpServerTool]
@@ -1411,7 +1415,7 @@ class LiteLLMCompletionResponsesConfig:
         for tool in tools:
             # 只对国内模型 endpoint 过滤不支持的工具类型
             # 国内模型只支持 type: "function"，不支持 Codex/OpenAI 特有的工具类型
-            if is_domestic_endpoint:
+            if is_domestic_model:
                 unsupported_tool_types = [
                     "local_shell",       # Codex CLI 内置 Shell 工具
                     "code_interpreter",  # OpenAI Code Interpreter
@@ -1448,7 +1452,7 @@ class LiteLLMCompletionResponsesConfig:
 
                 # 只对国内模型 endpoint 清理 schema 中不支持的字段
                 # 国内模型不支持 strict 和 additionalProperties，OpenAI structured outputs 需要这些字段
-                if is_domestic_endpoint:
+                if is_domestic_model:
                     parameters = LiteLLMCompletionResponsesConfig._clean_schema(parameters)
 
                 chat_completion_tool: Dict[str, Any] = {

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.domestic_utils import is_domestic_model_or_endpoint
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,
 )
@@ -835,6 +836,11 @@ def _responses_try_dispatch_emulated_file_search(
     _is_async: bool,
 ) -> Optional[Any]:
     """Return a response when emulated file_search handles the call; otherwise None."""
+    # 国内模型不支持 file_search，跳过 emulated handler（避免 IDOR 安全问题）
+    api_base = kwargs.get("api_base")
+    if is_domestic_model_or_endpoint(model, api_base):
+        return None
+
     if not _has_file_search_tool(tools) or not (
         responses_api_provider_config is None
         or use_chat_completions_api is True

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1044,10 +1044,13 @@ def responses(
         if custom_llm_provider is None:
             responses_api_provider_config = None
         else:
+            # Get api_base from litellm_params or kwargs to check for domestic endpoints
+            _api_base_to_check = litellm_params.api_base or kwargs.get("api_base")
             responses_api_provider_config = (
                 ProviderConfigManager.get_provider_responses_api_config(
                     model=model,
                     provider=custom_llm_provider,
+                    api_base=_api_base_to_check,
                 )
             )
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1044,13 +1044,10 @@ def responses(
         if custom_llm_provider is None:
             responses_api_provider_config = None
         else:
-            # Get api_base from litellm_params or kwargs to check for domestic endpoints
-            _api_base_to_check = litellm_params.api_base or kwargs.get("api_base")
             responses_api_provider_config = (
                 ProviderConfigManager.get_provider_responses_api_config(
                     model=model,
                     provider=custom_llm_provider,
-                    api_base=_api_base_to_check,
                 )
             )
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8092,6 +8092,7 @@ class ProviderConfigManager:
             "minimax",   # MiniMax series
             "mimo",      # Xiaomi MiMo series
             "deepseek",  # DeepSeek series
+            "kimi",      # Moonshot Kimi series
         ]
 
         return any(pattern in model_lower for pattern in domestic_patterns)
@@ -8117,6 +8118,8 @@ class ProviderConfigManager:
             "api.minimaxi.com",  # MiniMax official
             "xiaomimimo.com",  # Xiaomi MiMo
             "api.deepseek.com",  # DeepSeek official
+            "moonshot.cn",  # Moonshot Kimi official
+            "bigmodel.cn",  # Zhipu GLM official
         ]
 
         return any(endpoint in str(api_base) for endpoint in domestic_endpoints)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8067,6 +8067,32 @@ class ProviderConfigManager:
     _PROVIDER_CONFIG_MAP: Optional[dict[LlmProviders, tuple[Callable, bool]]] = None
 
     @staticmethod
+    def _is_domestic_model_endpoint(api_base: Optional[str]) -> bool:
+        """
+        Check if the api_base is a domestic (Chinese) model provider endpoint.
+        Domestic endpoints don't support OpenAI's native Responses API format,
+        and should use Chat Completions API conversion instead.
+
+        Args:
+            api_base: API endpoint URL
+
+        Returns:
+            bool: True if it's a domestic endpoint that needs compatibility handling
+        """
+        if not api_base:
+            return False
+
+        domestic_endpoints = [
+            "dashscope.aliyuncs.com",  # Alibaba DashScope
+            "ark.cn-beijing.volces.com",  # Volcengine (ByteDance)
+            "api.minimaxi.com",  # MiniMax official
+            "xiaomimimo.com",  # Xiaomi MiMo
+            "api.deepseek.com",  # DeepSeek official
+        ]
+
+        return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
+
+    @staticmethod
     def _build_provider_config_map() -> dict[LlmProviders, tuple[Callable, bool]]:
         """Build the provider-to-config mapping dictionary.
 
@@ -8557,6 +8583,7 @@ class ProviderConfigManager:
     def get_provider_responses_api_config(
         provider: Union[LlmProviders, str],
         model: Optional[str] = None,
+        api_base: Optional[str] = None,
     ) -> Optional[BaseResponsesAPIConfig]:
         from litellm.llms.openai_like.dynamic_config import (
             create_responses_config_class,
@@ -8581,7 +8608,7 @@ class ProviderConfigManager:
 
         # Check Python classes first (custom overrides take priority)
         result = ProviderConfigManager._get_python_responses_api_config(
-            provider_enum, model
+            provider_enum, model, api_base
         )
         if result is not None:
             return result
@@ -8600,12 +8627,17 @@ class ProviderConfigManager:
     def _get_python_responses_api_config(
         provider: Optional[LlmProviders],
         model: Optional[str] = None,
+        api_base: Optional[str] = None,
     ) -> Optional[BaseResponsesAPIConfig]:
         """Check for Python-class-based responses API configs (custom overrides)."""
         if provider is None:
             return None
 
+        # For OpenAI provider, check if api_base is a domestic endpoint
+        # Domestic endpoints don't support native Responses API, force Chat Completions conversion
         if litellm.LlmProviders.OPENAI == provider:
+            if api_base and ProviderConfigManager._is_domestic_model_endpoint(api_base):
+                return None  # Force Chat Completions conversion for domestic endpoints
             return litellm.OpenAIResponsesAPIConfig()
         elif litellm.LlmProviders.AZURE == provider:
             # Check if it's an O-series model

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8067,17 +8067,46 @@ class ProviderConfigManager:
     _PROVIDER_CONFIG_MAP: Optional[dict[LlmProviders, tuple[Callable, bool]]] = None
 
     @staticmethod
-    def _is_domestic_model_endpoint(api_base: Optional[str]) -> bool:
+    def _is_domestic_model(model_name: Optional[str]) -> bool:
+        """
+        Check if the model is a domestic (Chinese) model based on its name.
+        Domestic models don't support OpenAI's native Responses API format
+        and certain Codex CLI specific parameters/tools.
+
+        Args:
+            model_name: Model name (e.g., "qwen3.5-plus", "MiniMax-M2.7", "openai/MiniMax-M2.7")
+
+        Returns:
+            bool: True if it's a domestic model that needs compatibility handling
+        """
+        if not model_name:
+            return False
+
+        model_lower = model_name.lower()
+
+        # Domestic model name patterns (covers both raw names and prefixed names like "openai/MiniMax-M2.7")
+        domestic_patterns = [
+            "qwen",      # Alibaba Qwen series
+            "glm",       # Zhipu GLM series
+            "doubao",    # Volcengine (ByteDance) Doubao series
+            "minimax",   # MiniMax series
+            "mimo",      # Xiaomi MiMo series
+            "deepseek",  # DeepSeek series
+        ]
+
+        return any(pattern in model_lower for pattern in domestic_patterns)
+
+    @staticmethod
+    def _is_domestic_endpoint(api_base: Optional[str]) -> bool:
         """
         Check if the api_base is a domestic (Chinese) model provider endpoint.
-        Domestic endpoints don't support OpenAI's native Responses API format,
-        and should use Chat Completions API conversion instead.
+        Used as fallback when model name doesn't contain domestic pattern.
 
         Args:
             api_base: API endpoint URL
 
         Returns:
-            bool: True if it's a domestic endpoint that needs compatibility handling
+            bool: True if it's a domestic endpoint
         """
         if not api_base:
             return False
@@ -8091,6 +8120,27 @@ class ProviderConfigManager:
         ]
 
         return any(endpoint in str(api_base) for endpoint in domestic_endpoints)
+
+    @staticmethod
+    def _is_domestic_model_or_endpoint(model_name: Optional[str], api_base: Optional[str] = None) -> bool:
+        """
+        Check if either model name or endpoint indicates a domestic model.
+        This covers both cases:
+        1. Model name contains domestic pattern (e.g., "MiniMax-M2.7", "openai/qwen3.5-plus")
+        2. Endpoint is domestic provider (when model name is just group name like "codex-model")
+
+        Args:
+            model_name: Model name
+            api_base: API endpoint URL (optional)
+
+        Returns:
+            bool: True if it's a domestic model/endpoint
+        """
+        if ProviderConfigManager._is_domestic_model(model_name):
+            return True
+        if api_base and ProviderConfigManager._is_domestic_endpoint(api_base):
+            return True
+        return False
 
     @staticmethod
     def _build_provider_config_map() -> dict[LlmProviders, tuple[Callable, bool]]:
@@ -8633,11 +8683,11 @@ class ProviderConfigManager:
         if provider is None:
             return None
 
-        # For OpenAI provider, check if api_base is a domestic endpoint
-        # Domestic endpoints don't support native Responses API, force Chat Completions conversion
+        # For OpenAI provider, check if model or endpoint is domestic
+        # Domestic models don't support native Responses API, force Chat Completions conversion
         if litellm.LlmProviders.OPENAI == provider:
-            if api_base and ProviderConfigManager._is_domestic_model_endpoint(api_base):
-                return None  # Force Chat Completions conversion for domestic endpoints
+            if ProviderConfigManager._is_domestic_model_or_endpoint(model, api_base):
+                return None  # Force Chat Completions conversion for domestic models
             return litellm.OpenAIResponsesAPIConfig()
         elif litellm.LlmProviders.AZURE == provider:
             # Check if it's an O-series model

--- a/tests/litellm_utils_tests/test_proxy_budget_reset.py
+++ b/tests/litellm_utils_tests/test_proxy_budget_reset.py
@@ -233,6 +233,12 @@ async def test_reset_budget_endusers_partial_failure():
     prisma_client.db.litellm_verificationtoken.update_many = AsyncMock(
         return_value={"count": 0}
     )
+    # Mock db.litellm_organizationtable.update_many (used by reset_budget_for_orgs_linked_to_budgets)
+    prisma_client.db.litellm_organizationtable.update_many = AsyncMock(
+        return_value={"count": 0}
+    )
+    # Mock db.litellm_tagtable.update_many (used by reset_budget_for_tags_linked_to_budgets)
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
 
     proxy_logging_obj = MagicMock()
     proxy_logging_obj.service_logging_obj = MagicMock()
@@ -400,6 +406,12 @@ async def test_reset_budget_continues_other_categories_on_failure():
     prisma_client.db.litellm_verificationtoken.update_many = AsyncMock(
         return_value={"count": 0}
     )
+    # Mock db.litellm_organizationtable.update_many (used by reset_budget_for_orgs_linked_to_budgets)
+    prisma_client.db.litellm_organizationtable.update_many = AsyncMock(
+        return_value={"count": 0}
+    )
+    # Mock db.litellm_tagtable.update_many (used by reset_budget_for_tags_linked_to_budgets)
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
 
     proxy_logging_obj = MagicMock()
     proxy_logging_obj.service_logging_obj = MagicMock()
@@ -884,6 +896,12 @@ async def test_service_logger_endusers_success():
     prisma_client.db.litellm_verificationtoken.update_many = AsyncMock(
         return_value={"count": 0}
     )
+    # Mock db.litellm_organizationtable.update_many (used by reset_budget_for_orgs_linked_to_budgets)
+    prisma_client.db.litellm_organizationtable.update_many = AsyncMock(
+        return_value={"count": 0}
+    )
+    # Mock db.litellm_tagtable.update_many (used by reset_budget_for_tags_linked_to_budgets)
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
 
     proxy_logging_obj = MagicMock()
     proxy_logging_obj.service_logging_obj = MagicMock()
@@ -966,6 +984,12 @@ async def test_service_logger_endusers_failure():
     prisma_client.db.litellm_verificationtoken.update_many = AsyncMock(
         return_value={"count": 0}
     )
+    # Mock db.litellm_organizationtable.update_many (used by reset_budget_for_orgs_linked_to_budgets)
+    prisma_client.db.litellm_organizationtable.update_many = AsyncMock(
+        return_value={"count": 0}
+    )
+    # Mock db.litellm_tagtable.update_many (used by reset_budget_for_tags_linked_to_budgets)
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
 
     proxy_logging_obj = MagicMock()
     proxy_logging_obj.service_logging_obj = MagicMock()
@@ -1060,6 +1084,10 @@ async def test_reset_budget_for_litellm_team_members_called():
     prisma_client.db.litellm_verificationtoken.update_many = AsyncMock(
         return_value={"count": 0}
     )
+    prisma_client.db.litellm_organizationtable.update_many = AsyncMock(
+        return_value={"count": 0}
+    )
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 0})
 
     proxy_logging_obj = MagicMock()
     proxy_logging_obj.service_logging_obj = MagicMock()

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -39,6 +39,46 @@ class MockLiteLLMVerificationToken:
         return {"count": 1}
 
 
+class MockLiteLLMOrganizationTable:
+    def __init__(self):
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": 1}
+
+
+class MockLiteLLMTagTable:
+    def __init__(self):
+        self.update_many_calls: List[Dict[str, Any]] = []
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update_many(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.update_many_calls.append({"where": where, "data": data})
+        return {"count": 1}
+
+
 class MockLiteLLMEndUserTable:
     def __init__(self):
         self.find_many_calls: List[Dict[str, Any]] = []
@@ -57,6 +97,8 @@ class MockDB:
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
+        self.litellm_organizationtable = MockLiteLLMOrganizationTable()
+        self.litellm_tagtable = MockLiteLLMTagTable()
 
 
 class MockPrismaClient:
@@ -459,6 +501,100 @@ def test_reset_budget_for_keys_linked_to_budgets_empty(
     assert len(calls) == 0
 
 
+def test_reset_budget_for_orgs_linked_to_budgets(reset_budget_job, mock_prisma_client):
+    """
+    Test that when a budget tier is reset, orgs linked to that budget
+    (via budget_id) also get their spend reset.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 100.0,
+            "budget_duration": "30d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "30d-org-budget",
+            "created_at": now - timedelta(days=30),
+        },
+    )
+
+    asyncio.run(
+        reset_budget_job.reset_budget_for_orgs_linked_to_budgets(
+            budgets_to_reset=[test_budget]
+        )
+    )
+
+    calls = mock_prisma_client.db.litellm_organizationtable.update_many_calls
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["where"]["budget_id"] == {"in": ["30d-org-budget"]}
+    assert call["where"]["spend"] == {"gt": 0}
+    assert call["data"]["spend"] == 0
+
+
+def test_reset_budget_for_orgs_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Test that when there are no budgets to reset, no update is performed
+    on the organization table.
+    """
+    asyncio.run(
+        reset_budget_job.reset_budget_for_orgs_linked_to_budgets(budgets_to_reset=[])
+    )
+    calls = mock_prisma_client.db.litellm_organizationtable.update_many_calls
+    assert len(calls) == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets(reset_budget_job, mock_prisma_client):
+    """
+    Test that when a budget tier is reset, tags linked to that budget
+    (via budget_id) also get their spend reset.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 50.0,
+            "budget_duration": "30d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "30d-tag-budget",
+            "created_at": now - timedelta(days=30),
+        },
+    )
+
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(
+            budgets_to_reset=[test_budget]
+        )
+    )
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["where"]["budget_id"] == {"in": ["30d-tag-budget"]}
+    assert call["where"]["spend"] == {"gt": 0}
+    assert call["data"]["spend"] == 0
+
+
+def test_reset_budget_for_tags_linked_to_budgets_empty(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Test that when there are no budgets to reset, no update is performed
+    on the tag table.
+    """
+    asyncio.run(
+        reset_budget_job.reset_budget_for_tags_linked_to_budgets(budgets_to_reset=[])
+    )
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 0
+
+
 @pytest.mark.parametrize(
     "budget_duration, expected_day, expected_month",
     [
@@ -615,6 +751,75 @@ def test_budget_table_reset_also_resets_linked_keys(
         f"linked to expiring budgets, but got {len(calls)} update_many calls"
     )
     assert calls[0]["where"]["budget_id"] == {"in": ["7d-budget-tier"]}
+    assert calls[0]["data"]["spend"] == 0
+
+
+def test_budget_table_reset_also_resets_linked_orgs(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Integration-style test: when reset_budget_for_litellm_budget_table runs,
+    it should also reset spend for orgs linked to the expiring budget tiers
+    (in addition to end-users, team members, and keys).
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 100.0,
+            "budget_duration": "30d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "30d-org-budget",
+            "created_at": now - timedelta(days=30),
+        },
+    )
+
+    mock_prisma_client.data["budget"] = [test_budget]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    calls = mock_prisma_client.db.litellm_organizationtable.update_many_calls
+    assert len(calls) == 1, (
+        "Expected reset_budget_for_litellm_budget_table to also reset orgs "
+        f"linked to expiring budgets, but got {len(calls)} update_many calls"
+    )
+    assert calls[0]["where"]["budget_id"] == {"in": ["30d-org-budget"]}
+    assert calls[0]["data"]["spend"] == 0
+
+
+def test_budget_table_reset_also_resets_linked_tags(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    Integration-style test: when reset_budget_for_litellm_budget_table runs,
+    it should also reset spend for tags linked to the expiring budget tiers.
+    """
+    now = datetime.now(timezone.utc)
+
+    test_budget = type(
+        "LiteLLM_BudgetTableFull",
+        (),
+        {
+            "max_budget": 50.0,
+            "budget_duration": "30d",
+            "budget_reset_at": now - timedelta(hours=1),
+            "budget_id": "30d-tag-budget",
+            "created_at": now - timedelta(days=30),
+        },
+    )
+
+    mock_prisma_client.data["budget"] = [test_budget]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    calls = mock_prisma_client.db.litellm_tagtable.update_many_calls
+    assert len(calls) == 1, (
+        "Expected reset_budget_for_litellm_budget_table to also reset tags "
+        f"linked to expiring budgets, but got {len(calls)} update_many calls"
+    )
+    assert calls[0]["where"]["budget_id"] == {"in": ["30d-tag-budget"]}
     assert calls[0]["data"]["spend"] == 0
 
 
@@ -1204,4 +1409,52 @@ def test_reset_budget_for_keys_linked_to_budgets_invalidates_redis_counter(monke
 
     counter_cache.in_memory_cache.set_cache.assert_any_call(
         key="spend:key:sk-linked", value=0.0, ttl=60
+    )
+
+
+def test_reset_budget_for_orgs_linked_to_budgets_invalidates_redis_counter(monkeypatch):
+    """Resetting orgs via budget tier must clear each linked org's counter."""
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_org = type("Org", (), {"organization_id": "org-acme"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_organizationtable.find_many = AsyncMock(
+        return_value=[linked_org]
+    )
+    prisma_client.db.litellm_organizationtable.update_many = AsyncMock(
+        return_value={"count": 1}
+    )
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_orgs_linked_to_budgets([expired_budget]))
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:org:org-acme", value=0.0, ttl=60
+    )
+    counter_cache.redis_cache.async_set_cache.assert_any_await(
+        key="spend:org:org-acme", value=0.0, ttl=60
+    )
+
+
+def test_reset_budget_for_tags_linked_to_budgets_invalidates_redis_counter(monkeypatch):
+    """Resetting tags via budget tier must clear each linked tag's counter."""
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+
+    expired_budget = type("B", (), {"budget_id": "budget-1"})
+    linked_tag = type("Tag", (), {"tag_name": "tenant-42"})
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_tagtable.find_many = AsyncMock(return_value=[linked_tag])
+    prisma_client.db.litellm_tagtable.update_many = AsyncMock(return_value={"count": 1})
+
+    job = ResetBudgetJob(proxy_logging_obj=MagicMock(), prisma_client=prisma_client)
+    asyncio.run(job.reset_budget_for_tags_linked_to_budgets([expired_budget]))
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:tag:tenant-42", value=0.0, ttl=60
+    )
+    counter_cache.redis_cache.async_set_cache.assert_any_await(
+        key="spend:tag:tenant-42", value=0.0, ttl=60
     )

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -158,8 +158,8 @@ describe("KeyEditView", () => {
     const { getByText } = renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -176,8 +176,8 @@ describe("KeyEditView", () => {
     const { getByText } = renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -194,8 +194,8 @@ describe("KeyEditView", () => {
     const { getByLabelText } = renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -219,7 +219,7 @@ describe("KeyEditView", () => {
       <KeyEditView
         keyData={MOCK_KEY_DATA}
         onCancel={onCancelMock}
-        onSubmit={async () => { }}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -241,8 +241,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -259,8 +259,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -277,8 +277,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -295,8 +295,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -314,7 +314,7 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -344,8 +344,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={keyDataWithManagementRoutes}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -367,8 +367,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={keyDataWithInfoRoutes}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={""}
         userID={""}
         userRole={""}
@@ -385,8 +385,8 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
-        onSubmit={async () => { }}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
         accessToken={"test-token"}
         userID={""}
         userRole={""}
@@ -404,7 +404,7 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -434,10 +434,14 @@ describe("KeyEditView", () => {
 
   it("should handle empty allowed routes string on submit", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithRoutes = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: ["llm_api_routes"],
+    };
     renderWithProviders(
       <KeyEditView
-        keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        keyData={keyDataWithRoutes}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -463,6 +467,101 @@ describe("KeyEditView", () => {
     });
   });
 
+  it("should omit allowed_routes from submit when value is unchanged", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const aiApisKeyData = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: ["llm_api_routes"],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={aiApisKeyData}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("allowed_routes" in callArgs).toBe(false);
+    });
+  });
+
+  it("should omit allowed_routes from submit when keyData.allowed_routes is null and form is untouched", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataNullRoutes = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: null as unknown as string[],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataNullRoutes}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("allowed_routes" in callArgs).toBe(false);
+    });
+  });
+
+  it("should omit allowed_routes from submit when server returned routes in a different order", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataReordered = {
+      ...MOCK_KEY_DATA,
+      allowed_routes: ["beta_routes", "alpha_routes"],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataReordered}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect("allowed_routes" in callArgs).toBe(false);
+    });
+  });
 
   it("should pass access_group_ids to onSubmit when saving key with access groups", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
@@ -554,7 +653,7 @@ describe("KeyEditView", () => {
     renderWithProviders(
       <KeyEditView
         keyData={MOCK_KEY_DATA}
-        onCancel={() => { }}
+        onCancel={() => {}}
         onSubmit={onSubmitMock}
         accessToken={"test-token"}
         userID={"test-user"}
@@ -576,10 +675,13 @@ describe("KeyEditView", () => {
     });
 
     // Wait for the cancel button to actually be disabled (state update may take a moment)
-    await waitFor(() => {
-      const cancelButton = screen.getByRole("button", { name: /cancel/i });
-      expect(cancelButton).toBeDisabled();
-    }, { timeout: 3000 });
+    await waitFor(
+      () => {
+        const cancelButton = screen.getByRole("button", { name: /cancel/i });
+        expect(cancelButton).toBeDisabled();
+      },
+      { timeout: 3000 },
+    );
 
     // Clean up: resolve the promise to allow the form to complete
     if (resolveSubmit) {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -78,7 +78,6 @@ const getKeyTypeFromRoutes = (allowedRoutes: string[] | null | undefined): strin
   return "default";
 };
 
-
 export function KeyEditView({
   keyData,
   onCancel,
@@ -106,7 +105,7 @@ export function KeyEditView({
   const [neverExpire, setNeverExpire] = useState<boolean>(!keyData.expires);
   const [isKeySaving, setIsKeySaving] = useState(false);
   const [budgetLimits, setBudgetLimits] = useState<BudgetWindowEntry[]>(
-    Array.isArray(keyData.budget_limits) ? keyData.budget_limits : []
+    Array.isArray(keyData.budget_limits) ? keyData.budget_limits : [],
   );
   const { data: organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const { data: projects } = useProjects();
@@ -116,9 +115,7 @@ export function KeyEditView({
   const projectDisplay = (() => {
     if (!keyData.project_id) return null;
     const project = projects?.find((p) => p.project_id === keyData.project_id);
-    return project?.project_alias
-      ? `${project.project_alias} (${keyData.project_id})`
-      : keyData.project_id;
+    return project?.project_alias ? `${project.project_alias} (${keyData.project_id})` : keyData.project_id;
   })();
 
   useEffect(() => {
@@ -198,9 +195,10 @@ export function KeyEditView({
     access_group_ids: keyData.access_group_ids || [],
     auto_rotate: keyData.auto_rotate || false,
     ...(keyData.rotation_interval && { rotation_interval: keyData.rotation_interval }),
-    allowed_routes: Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
-      ? keyData.allowed_routes.join(", ")
-      : "",
+    allowed_routes:
+      Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
+        ? keyData.allowed_routes.join(", ")
+        : "",
   };
 
   useEffect(() => {
@@ -226,9 +224,10 @@ export function KeyEditView({
       access_group_ids: keyData.access_group_ids || [],
       auto_rotate: keyData.auto_rotate || false,
       ...(keyData.rotation_interval && { rotation_interval: keyData.rotation_interval }),
-      allowed_routes: Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
-        ? keyData.allowed_routes.join(", ")
-        : "",
+      allowed_routes:
+        Array.isArray(keyData.allowed_routes) && keyData.allowed_routes.length > 0
+          ? keyData.allowed_routes.join(", ")
+          : "",
     });
   }, [keyData, form]);
 
@@ -275,12 +274,25 @@ export function KeyEditView({
       }
       // If it's already an array (shouldn't happen, but handle it), keep as is
 
+      // Backend rejects non-empty allowed_routes from non-admins, so re-sending
+      // an unchanged value 403s a team admin. Set compare tolerates reorder.
+      const originalRoutesSet = new Set<string>(Array.isArray(keyData.allowed_routes) ? keyData.allowed_routes : []);
+      const submittedRoutesSet = new Set<string>(Array.isArray(values.allowed_routes) ? values.allowed_routes : []);
+      const allowedRoutesUnchanged =
+        originalRoutesSet.size === submittedRoutesSet.size &&
+        [...submittedRoutesSet].every((r) => originalRoutesSet.has(r));
+      if (allowedRoutesUnchanged) {
+        delete values.allowed_routes;
+      }
+
       if (neverExpire) {
         values.duration = null;
       }
 
       // Include multi-window budget limits (filter out incomplete entries)
-      const validWindows = budgetLimits.filter((w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined);
+      const validWindows = budgetLimits.filter(
+        (w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined,
+      );
       values.budget_limits = validWindows.length > 0 ? validWindows : undefined;
 
       await onSubmit(values);
@@ -305,9 +317,13 @@ export function KeyEditView({
           {({ getFieldValue, setFieldValue }) => {
             const allowedRoutesValue = getFieldValue("allowed_routes") || "";
             // Convert string to array for checking
-            const allowedRoutes = typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
-              ? allowedRoutesValue.split(",").map((r: string) => r.trim()).filter((r: string) => r.length > 0)
-              : [];
+            const allowedRoutes =
+              typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
+                ? allowedRoutesValue
+                    .split(",")
+                    .map((r: string) => r.trim())
+                    .filter((r: string) => r.length > 0)
+                : [];
             const isDisabled = allowedRoutes.includes("management_routes") || allowedRoutes.includes("info_routes");
             const models = getFieldValue("models") || [];
 
@@ -348,9 +364,13 @@ export function KeyEditView({
           {({ getFieldValue, setFieldValue }) => {
             const allowedRoutesValue = getFieldValue("allowed_routes") || "";
             // Convert string to array for getKeyTypeFromRoutes
-            const allowedRoutes = typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
-              ? allowedRoutesValue.split(",").map((r: string) => r.trim()).filter((r: string) => r.length > 0)
-              : [];
+            const allowedRoutes =
+              typeof allowedRoutesValue === "string" && allowedRoutesValue.trim() !== ""
+                ? allowedRoutesValue
+                    .split(",")
+                    .map((r: string) => r.trim())
+                    .filter((r: string) => r.length > 0)
+                : [];
             const keyTypeValue = getKeyTypeFromRoutes(allowedRoutes);
 
             return (
@@ -415,9 +435,7 @@ export function KeyEditView({
         }
         name="allowed_routes"
       >
-        <Input
-          placeholder="Enter allowed routes (comma-separated). Special values: llm_api_routes, management_routes. Examples: llm_api_routes, /chat/completions, /keys/*. Leave empty to allow all routes"
-        />
+        <Input placeholder="Enter allowed routes (comma-separated). Special values: llm_api_routes, management_routes. Examples: llm_api_routes, /chat/completions, /keys/*. Leave empty to allow all routes" />
       </Form.Item>
 
       <Form.Item label="Max Budget (USD)" name="max_budget">
@@ -442,10 +460,7 @@ export function KeyEditView({
           </span>
         }
       >
-        <BudgetWindowsEditor
-          value={budgetLimits}
-          onChange={setBudgetLimits}
-        />
+        <BudgetWindowsEditor value={budgetLimits} onChange={setBudgetLimits} />
       </Form.Item>
 
       <Form.Item label="TPM Limit" name="tpm_limit">
@@ -579,7 +594,7 @@ export function KeyEditView({
               !premiumUser
                 ? "Premium feature - Upgrade to set allowed pass through routes by key"
                 : Array.isArray(keyData.metadata?.allowed_passthrough_routes) &&
-                  keyData.metadata.allowed_passthrough_routes.length > 0
+                    keyData.metadata.allowed_passthrough_routes.length > 0
                   ? `Current: ${keyData.metadata.allowed_passthrough_routes.join(", ")}`
                   : "Select or enter allowed pass through routes"
             }
@@ -690,14 +705,13 @@ export function KeyEditView({
             return team.team_alias?.toLowerCase().includes(input.toLowerCase()) ?? false;
           }}
         >
-          {(selectedOrganizationId
-            ? teams?.filter((t) => t.organization_id === selectedOrganizationId)
-            : teams
-          )?.map((team) => (
-            <Select.Option key={team.team_id} value={team.team_id}>
-              {`${team.team_alias} (${team.team_id})`}
-            </Select.Option>
-          ))}
+          {(selectedOrganizationId ? teams?.filter((t) => t.organization_id === selectedOrganizationId) : teams)?.map(
+            (team) => (
+              <Select.Option key={team.team_id} value={team.team_id}>
+                {`${team.team_alias} (${team.team_id})`}
+              </Select.Option>
+            ),
+          )}
         </Select>
       </Form.Item>
       {enableProjectsUI && hasProject && (


### PR DESCRIPTION
## 背景

OpenAI Codex CLI 使用 Responses API 协议，而国内模型（豆包、GLM、MiniMax、MiMo）只支持 Chat Completions API。LiteLLM 的 custom_openai provider 虽然做了协议转换，但传递了国内模型不支持的字段，导致 400 错误。

## 修复内容

1. **handler.py**: 过滤 client_metadata 参数（Codex CLI 发送，国内模型不接受）
2. **transformation.py**: 
   - 添加 _clean_schema() 清理 strict/additionalProperties 字段
   - 过滤 local_shell/code_interpreter/file_search 等不支持的 tool 类型

## 支持模型

- doubao-seed-2.0-pro (豆包)
- glm-5 (智谱)
- MiniMax-M2.7 (MiniMax)
- mimo-v2.5-pro (小米 MiMo)

## 测试验证

已通过 Python 单元测试验证：
- _clean_schema() 正确清理 strict/additionalProperties
- tool 类型过滤正确（local_shell 等被过滤）
- client_metadata 过滤代码已集成

## 参考项目

- codex_deepseek_proxy
- mimo2codex
- codex-minimax-proxy