### PR TITLE
fix(guardrails): classify GuardrailRaisedException as guardrail_intervened in _is_guardrail_intervention

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -739,9 +739,13 @@ class CustomGuardrail(CustomLogger):
         Guardrails signal intentional blocks by raising:
         - HTTPException with status 400 (content policy violation)
         - ModifyResponseException (passthrough mode violation)
+        - GuardrailRaisedException (generic guardrail API block)
         """
 
+        from litellm.exceptions import GuardrailRaisedException
         if isinstance(e, ModifyResponseException):
+            return True
+        if isinstance(e, GuardrailRaisedException):
             return True
         if (
             HTTPException is not None
@@ -750,7 +754,6 @@ class CustomGuardrail(CustomLogger):
         ):
             return True
         return False
-
     def _process_error(
         self,
         e: Exception,

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1102,3 +1102,30 @@ class TestCustomGuardrailSpendLogMatchRedaction:
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_response"]["filters"][0]["regex"] == "[REDACTED]"
         assert raw["filters"][0]["regex"] == r"\d{3}-\d{2}-\d{4}"
+
+
+class TestIsGuardrailIntervention:
+    """Test _is_guardrail_intervention correctly classifies exceptions."""
+
+    def test_guardrail_raised_exception_is_intervention(self):
+        """GuardrailRaisedException must be classified as guardrail_intervened, not guardrail_failed_to_respond"""
+        from litellm.exceptions import GuardrailRaisedException
+
+        e = GuardrailRaisedException(
+            message="PII detected", guardrail_name="privacy-filter"
+        )
+        assert CustomGuardrail._is_guardrail_intervention(e) is True
+
+    def test_modify_response_exception_is_intervention(self):
+        """ModifyResponseException must still be classified as guardrail_intervened"""
+        from litellm.exceptions import ModifyResponseException
+
+        e = ModifyResponseException(
+            message="blocked", model="gpt-4", request_data={}, guardrail_name="test"
+        )
+        assert CustomGuardrail._is_guardrail_intervention(e) is True
+
+    def test_generic_exception_is_not_intervention(self):
+        """A plain Exception must NOT be classified as guardrail intervention"""
+        e = Exception("some random error")
+        assert CustomGuardrail._is_guardrail_intervention(e) is False


### PR DESCRIPTION
## Relevant issues
Fixes #13690

## Pre-Submission checklist
- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes
`generic_guardrail_api` blocked requests were logged as `guardrail_failed_to_respond` 
instead of `guardrail_intervened` in the Guardrails Monitor, causing them to be 
invisible in the UI.

**Root cause:** `_is_guardrail_intervention` in `custom_guardrail.py` checks for 
`ModifyResponseException` and `HTTPException(400)` but not `GuardrailRaisedException`, 
which is what `generic_api_guardrail.py` raises when action is `BLOCKED`.

**Fix:** Added `isinstance(e, GuardrailRaisedException)` check.

## Screenshots / Proof of Fix
See issue #13690 for reproduction details.