### PR TITLE
fix(anthropic): auto-inject compact beta header for context_management

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -425,14 +425,21 @@ class AnthropicModelInfo(BaseLLMModelInfo):
                 edits = context_management.get("edits", [])
             elif isinstance(context_management, list):
                 edits = context_management
-            for edit in edits:
-                edit_type = edit.get("type", "")
-                if edit_type in ("compact_20260112", "compaction"):
-                    betas.append(ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value)
-                else:
-                    betas.append(
-                        ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
-                    )
+            has_compact = any(
+                edit.get("type", "") in ("compact_20260112", "compaction")
+                for edit in edits
+            )
+            has_other_edits = any(
+                edit.get("type", "")
+                and edit.get("type", "") not in ("compact_20260112", "compaction")
+                for edit in edits
+            )
+            if has_compact:
+                betas.append(ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value)
+            elif has_other_edits:
+                betas.append(
+                    ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
+                )
 
         return list(set(betas))
 

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -420,17 +420,19 @@ class AnthropicModelInfo(BaseLLMModelInfo):
 
         if optional_params:
             context_management = optional_params.get("context_management")
+            edits: list = []
             if isinstance(context_management, dict) and "edits" in context_management:
-                for edit in context_management.get("edits", []):
-                    edit_type = edit.get("type", "")
-                    if edit_type in ("compact_20260112", "compaction"):
-                        betas.append(
-                            ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value
-                        )
-                    else:
-                        betas.append(
-                            ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
-                        )
+                edits = context_management.get("edits", [])
+            elif isinstance(context_management, list):
+                edits = context_management
+            for edit in edits:
+                edit_type = edit.get("type", "")
+                if edit_type in ("compact_20260112", "compaction"):
+                    betas.append(ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value)
+                else:
+                    betas.append(
+                        ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
+                    )
 
         return list(set(betas))
 

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -14,6 +14,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 from litellm.llms.base_llm.base_utils import BaseLLMModelInfo, BaseTokenCounter
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.anthropic import (
+    ANTHROPIC_BETA_HEADER_VALUES,
     ANTHROPIC_HOSTED_TOOLS,
     ANTHROPIC_OAUTH_BETA_HEADER,
     ANTHROPIC_OAUTH_TOKEN_PREFIX,
@@ -416,6 +417,20 @@ class AnthropicModelInfo(BaseLLMModelInfo):
 
         if mcp_server_used:
             betas.append("mcp-client-2025-04-04")
+
+        if optional_params:
+            context_management = optional_params.get("context_management")
+            if isinstance(context_management, dict) and "edits" in context_management:
+                for edit in context_management.get("edits", []):
+                    edit_type = edit.get("type", "")
+                    if edit_type in ("compact_20260112", "compaction"):
+                        betas.append(
+                            ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value
+                        )
+                    else:
+                        betas.append(
+                            ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
+                        )
 
         return list(set(betas))
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1280,3 +1280,51 @@ class TestAnthropicThinkingSignatureSelfHeal:
         config.transform_anthropic_messages_request_on_http_error(err, data)
         assert "thinking" not in data
         assert data["messages"] == []
+
+
+class TestGetAnthropicBetaListContextManagement:
+    """
+    Regression tests for https://github.com/BerriAI/litellm/issues/27532
+    get_anthropic_beta_list must include compact/context-management betas
+    when context_management is in optional_params, so Bedrock InvokeModel
+    receives the required anthropic_beta field.
+    """
+
+    def test_compact_edit_adds_compact_beta(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        info = AnthropicModelInfo()
+        betas = info.get_anthropic_beta_list(
+            model="claude-sonnet-4-6",
+            optional_params={
+                "context_management": {
+                    "edits": [{"type": "compact_20260112"}],
+                }
+            },
+        )
+        assert "compact-2026-01-12" in betas
+
+    def test_non_compact_edit_adds_context_management_beta(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        info = AnthropicModelInfo()
+        betas = info.get_anthropic_beta_list(
+            model="claude-sonnet-4-6",
+            optional_params={
+                "context_management": {
+                    "edits": [{"type": "summarize"}],
+                }
+            },
+        )
+        assert "context-management-2025-06-27" in betas
+
+    def test_no_context_management_no_extra_betas(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        info = AnthropicModelInfo()
+        betas = info.get_anthropic_beta_list(
+            model="claude-sonnet-4-6",
+            optional_params={"max_tokens": 100},
+        )
+        assert "compact-2026-01-12" not in betas
+        assert "context-management-2025-06-27" not in betas

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1340,3 +1340,21 @@ class TestGetAnthropicBetaListContextManagement:
         )
         assert "compact-2026-01-12" not in betas
         assert "context-management-2025-06-27" not in betas
+
+    def test_mixed_edits_uses_compact_beta(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        info = AnthropicModelInfo()
+        betas = info.get_anthropic_beta_list(
+            model="claude-sonnet-4-6",
+            optional_params={
+                "context_management": {
+                    "edits": [
+                        {"type": "summarize"},
+                        {"type": "compact_20260112"},
+                    ],
+                }
+            },
+        )
+        assert "compact-2026-01-12" in betas
+        assert "context-management-2025-06-27" not in betas

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1318,6 +1318,18 @@ class TestGetAnthropicBetaListContextManagement:
         )
         assert "context-management-2025-06-27" in betas
 
+    def test_openai_list_format_adds_compact_beta(self):
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        info = AnthropicModelInfo()
+        betas = info.get_anthropic_beta_list(
+            model="claude-sonnet-4-6",
+            optional_params={
+                "context_management": [{"type": "compaction"}],
+            },
+        )
+        assert "compact-2026-01-12" in betas
+
     def test_no_context_management_no_extra_betas(self):
         from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 


### PR DESCRIPTION
## Summary

- Fix Bedrock InvokeModel rejecting `context_management` with "Extra inputs are not permitted"
- `get_anthropic_beta_list()` did not detect `context_management` in optional_params, so the required `compact-2026-01-12` beta was never added to the request body's `anthropic_beta` array
- The direct Anthropic path already handled this via `_ensure_context_management_beta_header` (HTTP headers), but the Bedrock path builds betas from `get_anthropic_beta_list()` which feeds the body

Fixes #27532

## Changes

- `litellm/llms/anthropic/common_utils.py`: detect `context_management` edits in `get_anthropic_beta_list()` and add `compact-2026-01-12` for compact edits or `context-management-2025-06-27` for other edits
- `tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py`: 3 tests covering compact edit, non-compact edit, and no context_management

## Test plan

- [x] `test_compact_edit_adds_compact_beta` -- context_management with compact_20260112 edit includes compact-2026-01-12
- [x] `test_non_compact_edit_adds_context_management_beta` -- non-compact edits include context-management-2025-06-27
- [x] `test_no_context_management_no_extra_betas` -- no context_management does not add extra betas