### PR TITLE
fix(proxy): remove wildcard entries from /models endpoint response

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -294,6 +294,8 @@ def _get_wildcard_models(
                 return_wildcard_routes
             ):  # will add the wildcard route to the list eg: anthropic/*.
                 all_wildcard_models.append(model)
+                # Also remove from unique_models to avoid duplicate
+                models_to_remove.add(model)
 
             ## get litellm params from model
             if llm_router is not None:
@@ -307,6 +309,10 @@ def _get_wildcard_models(
                             ),
                         )
                         all_wildcard_models.extend(wildcard_models)
+                    # Always remove wildcard from unique_models when return_wildcard_routes=False
+                    # since we're returning the expanded models instead
+                    if not return_wildcard_routes:
+                        models_to_remove.add(model)
                 else:
                     # Router has no deployment for this wildcard (e.g., BYOK team models)
                     # Fall back to expanding from known provider models

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -249,3 +249,68 @@ def test_get_complete_model_list_byok_wildcard_expansion():
     assert len(result) > 0
     assert all(m.startswith("openai/") for m in result)
     assert "openai/*" not in result
+
+
+def test_get_complete_model_list_wildcard_removed_when_return_wildcard_routes_false():
+    """
+    Test that wildcard models (e.g., openai/*) are removed from the model list
+    when return_wildcard_routes=False, even when the router HAS a deployment
+    for the wildcard.
+
+    This addresses the bug where /models endpoint was returning wildcard entries
+    like 'openai/*' as model names when users configured wildcards in their config.
+    See: https://github.com/BerriAI/litellm/issues/13752
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm import Router
+
+    # Router with wildcard deployment (common case - user configures openai/*)
+    model_list = [{"model_name": "openai/*", "litellm_params": {"model": "openai/*"}}]
+    router = Router(model_list=model_list)
+
+    # Test with return_wildcard_routes=False (default)
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*", "gpt-4o"],  # includes wildcard + real model
+        user_model=None,
+        infer_model_from_keys=False,
+        return_wildcard_routes=False,
+        llm_router=router,
+    )
+
+    # Wildcard should NOT appear in the result (no duplicates either)
+    assert "openai/*" not in result
+    assert result.count("openai/*") == 0
+    # But real models should still be there
+    assert "gpt-4o" in result
+
+
+def test_get_complete_model_list_wildcard_kept_when_return_wildcard_routes_true():
+    """
+    Test that wildcard models are kept in the model list when
+    return_wildcard_routes=True (opt-in for admin/debugging).
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm import Router
+
+    model_list = [{"model_name": "openai/*", "litellm_params": {"model": "openai/*"}}]
+    router = Router(model_list=model_list)
+
+    # Test with return_wildcard_routes=True
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=["openai/*", "gpt-4o"],
+        user_model=None,
+        infer_model_from_keys=False,
+        return_wildcard_routes=True,
+        llm_router=router,
+    )
+
+    # Wildcard SHOULD appear in the result when explicitly requested
+    assert "openai/*" in result
+    # Wildcard should appear exactly once (not twice)
+    assert result.count("openai/*") == 1
+    # Real models should still be there
+    assert "gpt-4o" in result


### PR DESCRIPTION
## Summary

When users configure wildcard models (e.g., `openai/*`) in their config, the `/models` endpoint was incorrectly returning the wildcard as a model name alongside the expanded real model names.

## Root Cause

In `_get_wildcard_models()`, wildcards were only removed from the model list when the router had NO deployment for them. When the router HAD a deployment (the common case), the wildcard stayed in the list even when `return_wildcard_routes=False` (the default).

## Fix

Ensure wildcards are always removed from `unique_models` after expansion when `return_wildcard_routes=False` (the default), while still allowing them when `return_wildcard_routes=True` (opt-in for admin/debugging).

## Changes

- **litellm/proxy/auth/model_checks.py**: Add 4 lines to always remove wildcards when `return_wildcard_routes=False`
- **tests/test_litellm/proxy/auth/test_model_checks.py**: Add 2 test cases:
  - Verify wildcards don't appear when `return_wildcard_routes=False` (default)
  - Verify wildcards appear exactly once when `return_wildcard_routes=True`

## Testing

- `return_wildcard_routes=False` (default): Wildcards correctly removed ✅
- `return_wildcard_routes=True`: Wildcards kept in output (exactly once) ✅

Fixes https://github.com/BerriAI/litellm/issues/13752