### PR TITLE
fix(proxy): allow proxy_admin_viewer to list all API keys

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4399,7 +4399,10 @@ async def validate_key_list_check(
     key_hash: Optional[str],
     prisma_client: PrismaClient,
 ) -> Optional[LiteLLM_UserTable]:
-    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
+    if user_api_key_dict.user_role in [
+        LitellmUserRoles.PROXY_ADMIN.value,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+    ]:
         return None
 
     if user_api_key_dict.user_id is None:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6510,6 +6510,27 @@ async def test_validate_key_list_check_proxy_admin():
 
 
 @pytest.mark.asyncio
+async def test_validate_key_list_check_proxy_admin_viewer():
+    mock_prisma_client = AsyncMock()
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        user_id=None,
+    )
+
+    result = await validate_key_list_check(
+        user_api_key_dict=user_api_key_dict,
+        user_id=None,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        prisma_client=mock_prisma_client,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_validate_key_list_check_team_admin_success():
     mock_prisma_client = AsyncMock()
     user_info = LiteLLM_UserTable(


### PR DESCRIPTION
## Summary
- Add `PROXY_ADMIN_VIEW_ONLY` to the role check in `validate_key_list_check()` so Admin Viewer users can access `/key/list`
- Without this fix, Admin Viewer users see "Access Denied" on the API keys page because the function only allowed `PROXY_ADMIN` to bypass the `user_id` requirement

Fixes #26689

## Test plan
- [x] New test `test_validate_key_list_check_proxy_admin_viewer` -- verifies `PROXY_ADMIN_VIEW_ONLY` with `user_id=None` returns `None` (allowed)
- [x] Existing `test_validate_key_list_check_proxy_admin` still passes
- [x] All 7 validate_key_list_check tests pass