### PR TITLE
fix(proxy): support wildcard patterns in JWT role_permissions.models

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -874,13 +874,15 @@ class JWTAuthManager:
         if role_based_models is None or model is None:
             return True
 
-        if model not in role_based_models:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Role={rbac_role} not allowed to call model={model}. Allowed models={role_based_models}",
-            )
+        if model in role_based_models or any(
+            fnmatch.fnmatch(model, pattern) for pattern in role_based_models
+        ):
+            return True
 
-        return True
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role={rbac_role} not allowed to call model={model}. Allowed models={role_based_models}",
+        )
 
     @staticmethod
     def check_scope_based_access(

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -875,7 +875,9 @@ class JWTAuthManager:
             return True
 
         if model in role_based_models or any(
-            fnmatch.fnmatch(model, pattern) for pattern in role_based_models
+            fnmatch.fnmatch(model, pattern)
+            for pattern in role_based_models
+            if "*" in pattern
         ):
             return True
 

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -1051,6 +1051,42 @@ def test_can_rbac_role_call_model_no_role_permissions():
     )
 
 
+def test_can_rbac_role_call_model_wildcard():
+    """Wildcard patterns in role_permissions.models should match model names."""
+    from litellm.proxy.auth.handle_jwt import JWTAuthManager
+    from litellm.proxy._types import RoleBasedPermissions
+
+    roles_based_permissions = [
+        RoleBasedPermissions(
+            role=LitellmUserRoles.INTERNAL_USER,
+            models=["bedrock-claude-*"],
+        ),
+        RoleBasedPermissions(
+            role=LitellmUserRoles.PROXY_ADMIN,
+            models=["*"],
+        ),
+    ]
+
+    assert JWTAuthManager.can_rbac_role_call_model(
+        rbac_role=LitellmUserRoles.INTERNAL_USER,
+        general_settings={"role_permissions": roles_based_permissions},
+        model="bedrock-claude-draft-rep-sonnet",
+    )
+
+    assert JWTAuthManager.can_rbac_role_call_model(
+        rbac_role=LitellmUserRoles.PROXY_ADMIN,
+        general_settings={"role_permissions": roles_based_permissions},
+        model="any-model-name",
+    )
+
+    with pytest.raises(HTTPException):
+        JWTAuthManager.can_rbac_role_call_model(
+            rbac_role=LitellmUserRoles.INTERNAL_USER,
+            general_settings={"role_permissions": roles_based_permissions},
+            model="openai-gpt-4",
+        )
+
+
 @pytest.mark.parametrize(
     "route, request_data, expected_model",
     [

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from fastapi import HTTPException
+
 from litellm.proxy._types import (
     JWTLiteLLMRoleMap,
     LiteLLM_JWTAuth,
@@ -13,6 +15,7 @@ from litellm.proxy._types import (
     Member,
     ProxyErrorTypes,
     ProxyException,
+    RoleBasedPermissions,
 )
 from litellm.proxy.auth.handle_jwt import JWTAuthManager, JWTHandler
 
@@ -2680,3 +2683,51 @@ def test_build_decode_kwargs_no_warning_when_scoped(
         if "neither JWT_AUDIENCE nor JWT_ISSUER" in r.getMessage()
     ]
     assert matching == []
+
+
+class TestCanRbacRoleCallModelWildcard:
+    """Wildcard patterns in role_permissions.models should match model names."""
+
+    def _settings(self, permissions):
+        return {"role_permissions": permissions}
+
+    def test_wildcard_prefix_matches(self):
+        perms = [
+            RoleBasedPermissions(
+                role=LitellmUserRoles.INTERNAL_USER,
+                models=["bedrock-claude-*"],
+            ),
+        ]
+        assert JWTAuthManager.can_rbac_role_call_model(
+            rbac_role=LitellmUserRoles.INTERNAL_USER,
+            general_settings=self._settings(perms),
+            model="bedrock-claude-draft-rep-sonnet",
+        )
+
+    def test_star_matches_any_model(self):
+        perms = [
+            RoleBasedPermissions(
+                role=LitellmUserRoles.PROXY_ADMIN,
+                models=["*"],
+            ),
+        ]
+        assert JWTAuthManager.can_rbac_role_call_model(
+            rbac_role=LitellmUserRoles.PROXY_ADMIN,
+            general_settings=self._settings(perms),
+            model="any-model-name",
+        )
+
+    def test_non_matching_wildcard_raises(self):
+        perms = [
+            RoleBasedPermissions(
+                role=LitellmUserRoles.INTERNAL_USER,
+                models=["bedrock-claude-*"],
+            ),
+        ]
+        with pytest.raises(HTTPException) as exc_info:
+            JWTAuthManager.can_rbac_role_call_model(
+                rbac_role=LitellmUserRoles.INTERNAL_USER,
+                general_settings=self._settings(perms),
+                model="openai-gpt-4",
+            )
+        assert exc_info.value.status_code == 403

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -2731,3 +2731,36 @@ class TestCanRbacRoleCallModelWildcard:
                 model="openai-gpt-4",
             )
         assert exc_info.value.status_code == 403
+
+    def test_fnmatch_metacharacters_treated_literally(self):
+        """Model names with ? or [...] are exact aliases, not wildcard patterns."""
+        perms = [
+            RoleBasedPermissions(
+                role=LitellmUserRoles.INTERNAL_USER,
+                models=["prod-[eu]", "model-v2?"],
+            ),
+        ]
+        # Exact match works
+        assert JWTAuthManager.can_rbac_role_call_model(
+            rbac_role=LitellmUserRoles.INTERNAL_USER,
+            general_settings=self._settings(perms),
+            model="prod-[eu]",
+        )
+        assert JWTAuthManager.can_rbac_role_call_model(
+            rbac_role=LitellmUserRoles.INTERNAL_USER,
+            general_settings=self._settings(perms),
+            model="model-v2?",
+        )
+        # fnmatch would have matched these, but they should be rejected
+        with pytest.raises(HTTPException):
+            JWTAuthManager.can_rbac_role_call_model(
+                rbac_role=LitellmUserRoles.INTERNAL_USER,
+                general_settings=self._settings(perms),
+                model="prod-e",
+            )
+        with pytest.raises(HTTPException):
+            JWTAuthManager.can_rbac_role_call_model(
+                rbac_role=LitellmUserRoles.INTERNAL_USER,
+                general_settings=self._settings(perms),
+                model="model-v2x",
+            )


### PR DESCRIPTION
## Summary

Fixes #27536

`JWTAuthManager.can_rbac_role_call_model` used a plain Python `in` membership check against `role_permissions[].models`, so wildcard patterns like `bedrock-claude-*` or `*` were treated as literal strings and never matched concrete model names. This caused 403 errors for users whose JWT role allowed wildcarded model access.

The fix adds `fnmatch` pattern matching (already imported in the file) alongside the exact-match check, so `bedrock-claude-*` matches `bedrock-claude-draft-rep-sonnet` and `*` matches any model name -- consistent with how wildcards work in team and key model gating elsewhere in the proxy.

## Test plan

- [x] `test_can_rbac_role_call_model` -- existing exact-match tests still pass
- [x] `test_can_rbac_role_call_model_no_role_permissions` -- existing no-permissions test still passes
- [x] `test_can_rbac_role_call_model_wildcard` -- new test verifying `bedrock-claude-*` matches, `*` matches all, and non-matching patterns still raise 403