### PR TITLE
fix(thinking): is_thinking_enabled recognises "adaptive" type, preventing forced tool_choice with response_format

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -110,10 +110,21 @@ class BaseConfig(ABC):
         return type_to_response_format_param(response_format=response_format)
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
-        return (
-            non_default_params.get("thinking", {}).get("type") == "enabled"
-            or non_default_params.get("reasoning_effort") is not None
-        )
+        """Return True when any non-disabled thinking mode is active.
+
+        Covers ``type="enabled"`` (standard), ``type="adaptive"`` (Claude Code /
+        model-chooses-whether-to-think), and any future Anthropic thinking types.
+        When thinking is active, callers must NOT force ``tool_choice`` to a
+        specific tool — Anthropic rejects that combination with a 400.
+        Fixes #26334.
+        """
+        thinking = non_default_params.get("thinking")
+        if thinking is not None and isinstance(thinking, dict):
+            thinking_type = thinking.get("type")
+            # Any explicit non-disabled type counts as thinking enabled.
+            if thinking_type is not None and thinking_type != "disabled":
+                return True
+        return non_default_params.get("reasoning_effort") is not None
 
     def is_max_tokens_in_request(self, non_default_params: dict) -> bool:
         """

--- a/tests/llm_translation/test_is_thinking_enabled.py
+++ b/tests/llm_translation/test_is_thinking_enabled.py
@@ -1,0 +1,87 @@
+"""
+Tests for issue #26334:
+is_thinking_enabled must recognise thinking.type="adaptive" (and any future
+non-disabled type) so that forced tool_choice is never set alongside a thinking
+parameter — Anthropic rejects that combination with HTTP 400.
+"""
+import pytest
+
+from litellm.llms.base_llm.chat.transformation import BaseLLMHTTPHandler
+
+
+# Use a concrete subclass to access the non-abstract method.
+_BASE = BaseLLMHTTPHandler()
+
+
+class TestIsThinkingEnabled:
+    def test_type_enabled_returns_true(self):
+        assert _BASE.is_thinking_enabled({"thinking": {"type": "enabled", "budget_tokens": 5000}})
+
+    def test_type_adaptive_returns_true(self):
+        """Claude Code sends thinking.type="adaptive"; must count as thinking-enabled."""
+        assert _BASE.is_thinking_enabled({"thinking": {"type": "adaptive"}})
+
+    def test_type_disabled_returns_false(self):
+        assert not _BASE.is_thinking_enabled({"thinking": {"type": "disabled"}})
+
+    def test_thinking_absent_returns_false(self):
+        assert not _BASE.is_thinking_enabled({"model": "claude-3"})
+
+    def test_thinking_none_value_returns_false(self):
+        assert not _BASE.is_thinking_enabled({"thinking": None})
+
+    def test_reasoning_effort_returns_true(self):
+        assert _BASE.is_thinking_enabled({"reasoning_effort": "high"})
+
+    def test_reasoning_effort_none_returns_false(self):
+        assert not _BASE.is_thinking_enabled({"reasoning_effort": None})
+
+    def test_unknown_future_type_returns_true(self):
+        """Any unrecognised non-disabled type should be treated as enabled."""
+        assert _BASE.is_thinking_enabled({"thinking": {"type": "extended"}})
+
+
+class TestAnthropicTranslationNoForcedToolChoiceWithThinking:
+    """
+    When thinking is active, map_openai_params must NOT set tool_choice even
+    when response_format is also requested (on non-output_format-supporting models).
+    """
+
+    def _build_params(self, thinking_type: str):
+        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+        config = AnthropicConfig()
+        non_default = {
+            "thinking": {"type": thinking_type, "budget_tokens": 8000},
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "report",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"msg": {"type": "string"}},
+                        "required": ["msg"],
+                    },
+                },
+            },
+            "max_tokens": 1024,
+        }
+        optional_params = config.map_openai_params(
+            non_default_params=non_default,
+            optional_params={},
+            model="claude-3-sonnet-20240229",  # non-output_format model
+            drop_params=False,
+        )
+        return optional_params
+
+    def test_type_enabled_no_forced_tool_choice(self):
+        params = self._build_params("enabled")
+        assert params.get("tool_choice") is None or params.get("tool_choice", {}).get("type") != "tool", (
+            f"tool_choice must not be forced when thinking is enabled, got {params.get('tool_choice')}"
+        )
+
+    def test_type_adaptive_no_forced_tool_choice(self):
+        """Core regression test for #26334."""
+        params = self._build_params("adaptive")
+        assert params.get("tool_choice") is None or params.get("tool_choice", {}).get("type") != "tool", (
+            f"tool_choice must not be forced when thinking is adaptive, got {params.get('tool_choice')}"
+        )


### PR DESCRIPTION
## Problem

`response_format` (Pydantic model) combined with `thinking={"type": "adaptive"}` returns HTTP 400 from Vertex AI Anthropic:

```
invalid_request_error: Thinking may not be enabled when tool_choice forces tool use.
```

Both parameters work individually; only the combination fails. Fixes #26334.

## Root cause

`BaseLLMHTTPHandler.is_thinking_enabled()` in `litellm/llms/base_llm/chat/transformation.py` only returned `True` for `thinking.type == "enabled"`:

```python
# before
return (
    non_default_params.get("thinking", {}).get("type") == "enabled"
    or non_default_params.get("reasoning_effort") is not None
)
```

Claude Code (and some direct SDK users) send `thinking={"type": "adaptive"}` to let the model decide whether to think. Because `"adaptive" != "enabled"`, `is_thinking_enabled` returned `False`.

`AnthropicConfig.map_openai_params` then entered the `if not is_thinking_enabled:` branch and set:

```python
tool_choice = {"type": "tool", "name": RESPONSE_FORMAT_TOOL_NAME}
```

With both `thinking` and a forced `tool_choice` in the same request, Anthropic returns the 400 shown above.

## Fix

Updated `is_thinking_enabled` to treat any non-`None`, non-`"disabled"` thinking type as enabled. This covers `"enabled"`, `"adaptive"`, and any future types Anthropic may introduce:

```python
# after
thinking = non_default_params.get("thinking")
if thinking is not None and isinstance(thinking, dict):
    thinking_type = thinking.get("type")
    if thinking_type is not None and thinking_type != "disabled":
        return True
return non_default_params.get("reasoning_effort") is not None
```

## Tests

Added `tests/llm_translation/test_is_thinking_enabled.py`:
- `type="enabled"` → `True` (existing behaviour preserved)
- `type="adaptive"` → `True` (the bug fix)
- `type="disabled"` → `False`
- thinking absent / `None` → `False`
- `reasoning_effort` → `True` (existing behaviour preserved)
- unknown future type → `True` (defensive)
- `map_openai_params` with `type="adaptive"` + `response_format` → `tool_choice` NOT forced (regression test)
