### PR TITLE
fix(groq): strip provider_specific_fields from assistant messages in multi-turn tool calls

### DIFF
--- a/litellm/llms/groq/chat/transformation.py
+++ b/litellm/llms/groq/chat/transformation.py
@@ -144,6 +144,11 @@ class GroqChatConfig(OpenAILikeChatConfig):
                 for k, v in _message.items():
                     if v is not None:
                         new_message[k] = v  # type: ignore
+                # `provider_specific_fields` is a litellm-internal field (carries
+                # tool call metadata across turns) that Groq (and other strict
+                # OpenAI-compatible providers) reject as an unrecognised property.
+                # Strip it here so it never reaches the wire. Fixes #25595.
+                new_message.pop("provider_specific_fields", None)  # type: ignore[misc]
                 messages[idx] = new_message
 
         if is_async:

--- a/tests/llm_translation/test_groq_provider_specific_fields.py
+++ b/tests/llm_translation/test_groq_provider_specific_fields.py
@@ -1,0 +1,83 @@
+"""
+Tests for issue #25595:
+GroqChatConfig._transform_messages must strip `provider_specific_fields` from
+assistant messages before the request reaches the Groq API.
+
+Groq is strict about extra properties on messages and rejects them with
+"provider_specific_fields is unsupported".
+"""
+import pytest
+
+from litellm.llms.groq.chat.transformation import GroqChatConfig
+
+_GROQ = GroqChatConfig()
+
+
+def _make_messages(with_psf: bool):
+    """Build a simple multi-turn messages list.
+
+    When with_psf=True, the assistant message carries provider_specific_fields
+    as litellm would set them after processing a streaming tool-call response.
+    """
+    assistant_msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_abc",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"},
+            }
+        ],
+    }
+    if with_psf:
+        assistant_msg["provider_specific_fields"] = {"some_internal_key": "value"}
+
+    return [
+        {"role": "user", "content": "What is the weather?"},
+        assistant_msg,
+        {"role": "tool", "tool_call_id": "call_abc", "content": "Sunny, 25°C"},
+    ]
+
+
+def test_provider_specific_fields_stripped_from_assistant_message():
+    """Core regression test: provider_specific_fields must not survive _transform_messages."""
+    messages = _make_messages(with_psf=True)
+    transformed = _GROQ._transform_messages(messages, model="llama3-8b-8192")
+
+    assistant = next(m for m in transformed if m.get("role") == "assistant")
+    assert "provider_specific_fields" not in assistant, (
+        f"provider_specific_fields must be stripped before sending to Groq, "
+        f"but found: {assistant.get('provider_specific_fields')}"
+    )
+
+
+def test_messages_without_provider_specific_fields_unchanged():
+    """Verify that messages without the field are unaffected."""
+    messages = _make_messages(with_psf=False)
+    transformed = _GROQ._transform_messages(messages, model="llama3-8b-8192")
+
+    assistant = next(m for m in transformed if m.get("role") == "assistant")
+    assert "provider_specific_fields" not in assistant
+    # Tool calls should be preserved
+    assert assistant.get("tool_calls") is not None
+
+
+def test_non_assistant_messages_not_modified():
+    """user / tool messages must pass through without provider_specific_fields being injected."""
+    messages = _make_messages(with_psf=True)
+    transformed = _GROQ._transform_messages(messages, model="llama3-8b-8192")
+
+    for msg in transformed:
+        if msg.get("role") != "assistant":
+            assert "provider_specific_fields" not in msg
+
+
+def test_null_fields_stripped_from_assistant_message():
+    """Existing null-field-stripping behaviour is not regressed (issue #5839)."""
+    messages = [
+        {"role": "assistant", "content": "Hello", "function_call": None}
+    ]
+    transformed = _GROQ._transform_messages(messages, model="llama3-8b-8192")
+    assistant = transformed[0]
+    assert assistant.get("function_call") is None or "function_call" not in assistant


### PR DESCRIPTION
## Problem

During multi-turn tool-calling conversations with Groq models, the second turn (after receiving a tool result) fails with:

```
BadRequestError: provider_specific_fields is unsupported
```

`drop_params: true` does not help because it only removes top-level API parameters, not fields nested inside message objects. Fixes #25595.

## Root cause

LiteLLM attaches `provider_specific_fields` to assistant messages in the streaming chunk builder (`main.py`) to carry tool call metadata across turns. In `GroqChatConfig._transform_messages` this field is then copied verbatim into the outgoing `ChatCompletionAssistantMessage`:

```python
for k, v in _message.items():
    if v is not None:
        new_message[k] = v  # ← copies provider_specific_fields
```

Groq's API is strict about extra properties on messages and rejects the request.

## Fix

Pop `provider_specific_fields` from the rebuilt assistant message before it is sent:

```python
new_message.pop("provider_specific_fields", None)
```

`provider_specific_fields` is a litellm-internal field with no meaning to any OpenAI-compatible provider. Removing it at the Groq layer is consistent with the existing null-field stripping already done in this method (fixes #5839).

## Tests

Added `tests/llm_translation/test_groq_provider_specific_fields.py`:
- `provider_specific_fields` is stripped from assistant messages
- Messages without the field are unaffected
- Non-assistant messages (user/tool) are not modified
- Existing null-field-stripping behaviour is not regressed
