### PR TITLE
fix(deepseek): map reasoning_effort=none to thinking disabled

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -47,18 +47,20 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         thinking_value = optional_params.pop("thinking", None)
         reasoning_effort = optional_params.pop("reasoning_effort", None)
 
-        # Handle thinking parameter - only accept {"type": "enabled"}
+        # Handle thinking parameter
         if thinking_value is not None:
-            if (
-                isinstance(thinking_value, dict)
-                and thinking_value.get("type") == "enabled"
+            if isinstance(thinking_value, dict) and thinking_value.get("type") in (
+                "enabled",
+                "disabled",
             ):
-                # DeepSeek only accepts {"type": "enabled"}, ignore budget_tokens
-                optional_params["thinking"] = {"type": "enabled"}
+                optional_params["thinking"] = {"type": thinking_value["type"]}
 
-        # Handle reasoning_effort - map to thinking enabled
-        elif reasoning_effort is not None and reasoning_effort != "none":
-            optional_params["thinking"] = {"type": "enabled"}
+        # Handle reasoning_effort - map to thinking enabled/disabled
+        elif reasoning_effort is not None:
+            if reasoning_effort == "none":
+                optional_params["thinking"] = {"type": "disabled"}
+            else:
+                optional_params["thinking"] = {"type": "enabled"}
 
         return optional_params
 

--- a/tests/test_litellm/llms/deepseek/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/test_deepseek_chat_transformation.py
@@ -1,0 +1,90 @@
+"""
+Tests for DeepSeekChatConfig.map_openai_params thinking/reasoning_effort handling.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/27453
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import pytest
+
+from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
+
+
+@pytest.fixture
+def config():
+    return DeepSeekChatConfig()
+
+
+class TestReasoningEffortNone:
+    """reasoning_effort='none' should disable thinking."""
+
+    def test_reasoning_effort_none_disables_thinking(self, config):
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "none"},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "disabled"}
+
+    def test_reasoning_effort_high_enables_thinking(self, config):
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "high"},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+
+    def test_reasoning_effort_low_enables_thinking(self, config):
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "low"},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+
+
+class TestThinkingParam:
+    """Direct thinking parameter should be passed through."""
+
+    def test_thinking_enabled(self, config):
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled", "budget_tokens": 5000}},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+
+    def test_thinking_disabled(self, config):
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "disabled"}},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "disabled"}
+
+    def test_thinking_strips_budget_tokens(self, config):
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled", "budget_tokens": 5000}},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert "budget_tokens" not in result["thinking"]
+
+    def test_no_thinking_params_leaves_thinking_unset(self, config):
+        result = config.map_openai_params(
+            non_default_params={"temperature": 0.5},
+            optional_params={},
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+        assert "thinking" not in result


### PR DESCRIPTION
## Summary
- When `reasoning_effort="none"` is passed, DeepSeek V4 now receives `thinking: {"type": "disabled"}` instead of silently ignoring the value and leaving the model in its default thinking-enabled state.
- Also passes through `thinking: {"type": "disabled"}` when set directly, which was previously dropped by the enabled-only filter.

## Test plan
- [x] `test_reasoning_effort_none_disables_thinking` -- verifies `reasoning_effort="none"` maps to `thinking: {"type": "disabled"}`
- [x] `test_reasoning_effort_high_enables_thinking` -- verifies non-none values still enable thinking
- [x] `test_thinking_disabled` -- verifies direct `thinking: {"type": "disabled"}` is passed through
- [x] `test_thinking_strips_budget_tokens` -- verifies `budget_tokens` is stripped (DeepSeek does not support it)
- [x] `test_no_thinking_params_leaves_thinking_unset` -- verifies no thinking param when neither is set

Fixes #27453