### PR TITLE
fix(sap): forward dimensions param in SAP embedding requests

### DIFF
--- a/litellm/llms/sap/embed/transformation.py
+++ b/litellm/llms/sap/embed/transformation.py
@@ -136,6 +136,10 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+        for key, value in non_default_params.items():
+            if key in supported_params:
+                optional_params[key] = value
         return optional_params
 
     def validate_environment(self, headers: dict, *args, **kwargs) -> dict:
@@ -163,7 +167,12 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
         model_dict = {}
         model_dict["name"] = model
         model_dict["version"] = optional_params.get("version", "latest")
-        model_dict["params"] = optional_params.get("parameters", {})
+        params = optional_params.get("parameters", {}).copy()
+        if "dimensions" in optional_params:
+            params["dimensions"] = optional_params["dimensions"]
+        if "encoding_format" in optional_params:
+            params["encoding_format"] = optional_params["encoding_format"]
+        model_dict["params"] = params
         timeout = optional_params.get("timeout", None)
         if timeout is not None:
             model_dict["timeout"] = timeout

--- a/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
@@ -106,3 +106,130 @@ def test_embed_with_masking(fake_token_creator, fake_deployment_url):
             headers={},
         )
         assert body["config"]["modules"]["masking"] == masking_config
+
+
+def test_dimensions_forwarded_to_model_params(fake_token_creator, fake_deployment_url):
+    """Test that dimensions from optional_params is placed into model.params."""
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        body = GenAIHubEmbeddingConfig().transform_embedding_request(
+            model="text-embedding-3-large",
+            input="Hello",
+            optional_params={"dimensions": 2000},
+            headers={},
+        )
+        assert body["config"]["modules"]["embeddings"]["model"]["params"] == {
+            "dimensions": 2000
+        }
+
+
+def test_dimensions_merged_with_existing_parameters(
+    fake_token_creator, fake_deployment_url
+):
+    """Test that dimensions is merged with explicitly provided parameters."""
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        body = GenAIHubEmbeddingConfig().transform_embedding_request(
+            model="text-embedding-3-large",
+            input="Hello",
+            optional_params={"dimensions": 2000, "parameters": {"truncate": "END"}},
+            headers={},
+        )
+        assert body["config"]["modules"]["embeddings"]["model"]["params"] == {
+            "dimensions": 2000,
+            "truncate": "END",
+        }
+
+
+def test_encoding_format_forwarded_to_model_params(
+    fake_token_creator, fake_deployment_url
+):
+    """Test that encoding_format from optional_params is placed into model.params."""
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        body = GenAIHubEmbeddingConfig().transform_embedding_request(
+            model="text-embedding-3-large",
+            input="Hello",
+            optional_params={"encoding_format": "float"},
+            headers={},
+        )
+        assert body["config"]["modules"]["embeddings"]["model"]["params"] == {
+            "encoding_format": "float"
+        }
+
+
+def test_map_openai_params_forwards_supported_params(
+    fake_token_creator, fake_deployment_url
+):
+    """Test that map_openai_params correctly maps non_default_params to optional_params."""
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        config = GenAIHubEmbeddingConfig()
+        result = config.map_openai_params(
+            non_default_params={"dimensions": 2000, "unsupported_param": "value"},
+            optional_params={},
+            model="text-embedding-3-large",
+            drop_params=False,
+        )
+        assert result == {"dimensions": 2000}
+
+
+def test_map_openai_params_no_dimensions_for_non_v3_model(
+    fake_token_creator, fake_deployment_url
+):
+    """Test that dimensions is not forwarded for models that don't support it."""
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        config = GenAIHubEmbeddingConfig()
+        result = config.map_openai_params(
+            non_default_params={"dimensions": 2000},
+            optional_params={},
+            model="text-embedding-ada-002",
+            drop_params=False,
+        )
+        assert result == {}


### PR DESCRIPTION
## Relevant issues

N/A (discovered while integrating litellm with SAP AI Core for pgvector storage)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The SAP embedding provider (`litellm/llms/sap/embed/transformation.py`) declares `dimensions` as a supported OpenAI parameter for `text-embedding-3` models via `get_supported_openai_params()`, but fails to actually include it in the API request body sent to SAP AI Core's orchestration endpoint.

### Root Cause

Two bugs in `GenAIHubEmbeddingConfig`:

1. **`map_openai_params()`** returns the empty `optional_params` dict without copying supported params from `non_default_params`. This means `dimensions` (and `encoding_format`) are silently dropped before reaching `transform_embedding_request()`.

2. **`transform_embedding_request()`** only reads `optional_params.get("parameters", {})` for the model params dict, but never extracts `dimensions` or `encoding_format` even if they were present in `optional_params`.

### Fix

- `map_openai_params()` now iterates `non_default_params` and copies keys listed in `get_supported_openai_params()` into `optional_params`
- `transform_embedding_request()` now extracts `dimensions` and `encoding_format` from `optional_params` and merges them into `model_dict["params"]`

### Impact

Without this fix, `litellm.embedding(model="sap/text-embedding-3-large", input=[...], dimensions=2000)` always returns a 3072-dim vector. With this fix, it correctly returns a 2000-dim vector.

## Screenshots / Proof of Fix

Before fix:
```
>>> resp = await litellm.aembedding(model='sap/text-embedding-3-large', input=['test'], dimensions=2000)
>>> len(resp.data[0]["embedding"])
3072  # dimensions parameter ignored
```

After fix:
```
>>> resp = await litellm.aembedding(model='sap/text-embedding-3-large', input=['test'], dimensions=2000)
>>> len(resp.data[0]["embedding"])
2000  # dimensions parameter correctly forwarded
```

## Tests Added

5 new tests in `tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py`:
- `test_dimensions_forwarded_to_model_params` — dimensions is placed into model.params
- `test_dimensions_merged_with_existing_parameters` — dimensions merges with explicit parameters
- `test_encoding_format_forwarded_to_model_params` — encoding_format is placed into model.params
- `test_map_openai_params_forwards_supported_params` — map_openai_params correctly filters supported params
- `test_map_openai_params_no_dimensions_for_non_v3_model` — dimensions not forwarded for unsupported models