### PR TITLE
fix(bedrock): use InvokeModel for Anthropic-shape CountTokens (was silently falling back to local)

### DIFF
--- a/litellm/llms/bedrock/count_tokens/transformation.py
+++ b/litellm/llms/bedrock/count_tokens/transformation.py
@@ -32,8 +32,26 @@ class BedrockCountTokensConfig(BaseAWSLLM):
         Returns:
             'converse' or 'invokeModel'
         """
-        # If the request has messages in the expected Anthropic format, use converse
-        if "messages" in request_data and isinstance(request_data["messages"], list):
+        # When messages are present, distinguish Anthropic-shape from Converse-shape
+        # content blocks. Anthropic uses ``{"type": "text"|"tool_use"|"tool_result"|...}``;
+        # Converse uses ``{"text": ...}`` / ``{"toolUse": ...}`` / ``{"toolResult": ...}``.
+        # ``/v1/messages/count_tokens`` callers send Anthropic-shape content; previously
+        # the unconditional ``"converse"`` branch coerced those blocks into Bedrock
+        # Converse without translation, which Bedrock rejects with
+        # "messages.N.content: Field required" — falling back to local tokeniser
+        # and silently producing very different counts than billing. InvokeModel
+        # preserves the body verbatim, which is the right choice for any
+        # Anthropic-shape request.
+        messages = request_data.get("messages")
+        if isinstance(messages, list):
+            for msg in messages:
+                if not isinstance(msg, dict):
+                    continue
+                content = msg.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and "type" in block:
+                            return "invokeModel"
             return "converse"
 
         # For raw text or other formats, use invokeModel
@@ -167,14 +185,29 @@ class BedrockCountTokensConfig(BaseAWSLLM):
     def _transform_to_invoke_model_format(
         self, request_data: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Transform to InvokeModel input format."""
+        """Transform to InvokeModel input format.
+
+        The Bedrock CountTokens API spec calls the ``invokeModel.body`` field
+        a "Base64-encoded blob". Sending it as a raw JSON string fails with
+        ``Unable to parse request body`` for any non-trivial payload.
+        """
+        import base64
         import json
 
         # For InvokeModel, we need to provide the raw body that would be sent to the model
         # Remove the 'model' field from the body as it's not part of the model input
         body_data = {k: v for k, v in request_data.items() if k != "model"}
 
-        return {"input": {"invokeModel": {"body": json.dumps(body_data)}}}
+        # Bedrock's Anthropic Messages contract requires anthropic_version and
+        # max_tokens fields on InvokeModel bodies; CountTokens via InvokeModel
+        # validates against the same schema. Synthesise sensible defaults when
+        # callers (e.g. ``/v1/messages/count_tokens``) omit them.
+        body_data.setdefault("anthropic_version", "bedrock-2023-05-31")
+        body_data.setdefault("max_tokens", 1024)
+
+        body_bytes = json.dumps(body_data, ensure_ascii=False).encode("utf-8")
+        body_b64 = base64.b64encode(body_bytes).decode("ascii")
+        return {"input": {"invokeModel": {"body": body_b64}}}
 
     def get_bedrock_count_tokens_endpoint(
         self,

--- a/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
@@ -80,6 +80,23 @@ def test_detect_input_type_converse_shape_blocks_stay_converse():
     assert config._detect_input_type(req) == "converse"
 
 
+def test_detect_input_type_skips_non_dict_message_entries():
+    """Defensive: a malformed messages list with non-dict entries shouldn't
+    crash the detector. Skip the bad entry and decide based on the rest."""
+    config = BedrockCountTokensConfig()
+    req = {
+        "messages": [
+            "not-a-dict",  # ignored
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        ],
+    }
+    assert config._detect_input_type(req) == "invokeModel"
+
+    # All non-dict entries falls through to the default "converse" branch
+    req = {"messages": ["not-a-dict", 42]}
+    assert config._detect_input_type(req) == "converse"
+
+
 def test_transform_to_invoke_model_format_base64_encodes_body():
     """The Bedrock CountTokens API spec describes ``invokeModel.body`` as a
     Base64-encoded blob. A raw JSON string fails with ``Unable to parse

--- a/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
@@ -11,13 +11,147 @@ def test_detect_input_type():
     """Test input type detection (converse vs invokeModel)"""
     config = BedrockCountTokensConfig()
 
-    # Test messages format -> converse
+    # String message content is Converse-compatible -> converse
     request_with_messages = {"messages": [{"role": "user", "content": "hi"}]}
     assert config._detect_input_type(request_with_messages) == "converse"
 
     # Test text format -> invokeModel
     request_with_text = {"inputText": "hello"}
     assert config._detect_input_type(request_with_text) == "invokeModel"
+
+
+def test_detect_input_type_anthropic_shape_routes_to_invoke_model():
+    """Anthropic-shape content blocks (``{"type": "text"}``) cannot be sent through
+    the Converse path because Converse expects ``{"text": ...}`` blocks. Detect
+    Anthropic-typed blocks and route to InvokeModel, which preserves the body
+    verbatim and lets Bedrock's tokeniser score it correctly.
+    """
+    config = BedrockCountTokensConfig()
+
+    # Single text block in Anthropic shape
+    req = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        ],
+    }
+    assert config._detect_input_type(req) == "invokeModel"
+
+    # Tool-using turn with tool_use + tool_result blocks
+    req = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Reading the file."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01ABC",
+                        "name": "read_file",
+                        "input": {"path": "main.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_01ABC",
+                        "content": "def main(): pass",
+                    }
+                ],
+            },
+        ],
+    }
+    assert config._detect_input_type(req) == "invokeModel"
+
+
+def test_detect_input_type_converse_shape_blocks_stay_converse():
+    """Converse-shape blocks (``{"text": ...}``, no ``type`` key) should still
+    route to converse to preserve backwards-compatible behaviour for callers
+    already producing Bedrock-shape input.
+    """
+    config = BedrockCountTokensConfig()
+    req = {
+        "messages": [
+            {"role": "user", "content": [{"text": "hi"}]},
+        ],
+    }
+    assert config._detect_input_type(req) == "converse"
+
+
+def test_transform_to_invoke_model_format_base64_encodes_body():
+    """The Bedrock CountTokens API spec describes ``invokeModel.body`` as a
+    Base64-encoded blob. A raw JSON string fails with ``Unable to parse
+    request body`` for non-trivial payloads.
+    """
+    import base64
+    import json
+
+    config = BedrockCountTokensConfig()
+
+    request_data = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        ],
+    }
+
+    result = config._transform_to_invoke_model_format(request_data)
+
+    # Top-level shape: {"input": {"invokeModel": {"body": "<base64>"}}}
+    assert "input" in result
+    assert "invokeModel" in result["input"]
+    body_value = result["input"]["invokeModel"]["body"]
+
+    # Must be Base64; decoding must round-trip to valid JSON
+    decoded = base64.b64decode(body_value).decode("utf-8")
+    parsed = json.loads(decoded)
+
+    # ``model`` is dropped (it's not part of the model input body)
+    assert "model" not in parsed
+
+    # Bedrock InvokeModel requires anthropic_version + max_tokens; transform
+    # supplies sensible defaults if the caller omitted them.
+    assert parsed["anthropic_version"] == "bedrock-2023-05-31"
+    assert "max_tokens" in parsed
+
+    # The original messages are preserved
+    assert parsed["messages"] == request_data["messages"]
+
+
+def test_transform_anthropic_shape_full_request_uses_invoke_model():
+    """End-to-end: a request with Anthropic-shape content blocks should land
+    in InvokeModel format, base64-encoded, with the original body preserved.
+    """
+    import base64
+    import json
+
+    config = BedrockCountTokensConfig()
+    req = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+        ],
+        "system": [{"type": "text", "text": "Be helpful"}],
+        "tools": [
+            {
+                "name": "search",
+                "description": "Search",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+        ],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(req)
+
+    assert "invokeModel" in result["input"]
+    body = json.loads(
+        base64.b64decode(result["input"]["invokeModel"]["body"]).decode("utf-8")
+    )
+    assert body["messages"] == req["messages"]
+    assert body["system"] == req["system"]
+    assert body["tools"] == req["tools"]
 
 
 def test_transform_anthropic_to_bedrock_request():


### PR DESCRIPTION
## Summary

`POST /v1/messages/count_tokens` against a Bedrock-backed Anthropic model silently falls back to local `tiktoken` for any tool-using request. The proxy logs `Provider token counting failed (...). Falling back to local tokenizer.` and returns numbers that diverge significantly from what `bedrock-runtime:CountTokens` reports for the same body — observed under-count of ~50% on tool-heavy payloads.

Two bugs in `litellm/llms/bedrock/count_tokens/transformation.py`:

### 1. `_detect_input_type` always picks Converse when `messages` is present

Anthropic content blocks look like:

```json
{"type": "text", "text": "..."}
{"type": "tool_use", "id": "...", "name": "...", "input": {...}}
{"type": "tool_result", "tool_use_id": "...", "content": "..."}
```

Bedrock Converse content blocks look like:

```json
{"text": "..."}
{"toolUse": {"toolUseId": "...", "name": "...", "input": {...}}}
{"toolResult": {"toolUseId": "...", "content": [{"text": "..."}]}}
```

`_transform_to_converse_format` copies Anthropic blocks into the Converse body verbatim (no shape translation), Bedrock rejects with `messages.N.content: Field required`, and `_try_provider_token_count` falls through to `litellm.token_counter` (local tiktoken).

### 2. `_transform_to_invoke_model_format` ships the body as a JSON string

The Bedrock CountTokens spec describes `invokeModel.body` as a Base64-encoded blob. A raw JSON string fails with `Unable to parse request body` for non-trivial payloads.

## Fix

- `_detect_input_type` inspects content blocks. If any block has a `type` key (Anthropic shape), route to InvokeModel which preserves the body verbatim. Converse-shape blocks (no `type` key) still go through Converse, so existing callers producing Bedrock-shape input are unaffected.
- `_transform_to_invoke_model_format` Base64-encodes the body and supplies the Bedrock-required `anthropic_version` and `max_tokens` defaults.

## Verification

Built locally and exercised against the real `bedrock-runtime:CountTokens` API with a representative Anthropic Messages payload (string-only and tool-using shapes). With the fix, LiteLLM count matches the AWS API count to the token. Without the fix, LiteLLM falls back to local and under-counts.

Reproducible with public `anthropic.claude-sonnet-4-6` access; example with mock content:

```python
request_data = {
    "model": "anthropic.claude-sonnet-4-6",
    "messages": [
        {
            "role": "user",
            "content": [
                {"type": "text", "text": "What is 2 + 2?"},
            ],
        },
        {
            "role": "assistant",
            "content": [
                {"type": "text", "text": "Let me think about this."},
                {
                    "type": "tool_use",
                    "id": "toolu_01ABC",
                    "name": "calculator",
                    "input": {"expression": "2 + 2"},
                },
            ],
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "tool_result",
                    "tool_use_id": "toolu_01ABC",
                    "content": "4",
                }
            ],
        },
    ],
    "tools": [
        {
            "name": "calculator",
            "description": "Evaluate an arithmetic expression",
            "input_schema": {
                "type": "object",
                "properties": {"expression": {"type": "string"}},
                "required": ["expression"],
            },
        }
    ],
}
```

`POST /v1/messages/count_tokens` against this body on `main` returns the local-fallback count and emits a warning about the Bedrock 400. With the patch, no fallback warning is emitted and the response matches direct `bedrock-runtime:CountTokens` to the token.

## Test plan

- 5 new pytest cases added to `tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py`:
  - `test_detect_input_type_anthropic_shape_routes_to_invoke_model` — single text block + tool_use/tool_result combo
  - `test_detect_input_type_converse_shape_blocks_stay_converse` — backwards-compat for callers already in Converse shape
  - `test_transform_to_invoke_model_format_base64_encodes_body` — round-trip + verifies `anthropic_version` / `max_tokens` defaults
  - `test_transform_anthropic_shape_full_request_uses_invoke_model` — end-to-end through `transform_anthropic_to_bedrock_count_tokens`
- All 13 tests pass (5 new + 8 existing); existing tests unchanged in behaviour.

## Type

- [x] Bug fix (non-breaking)
- [x] No breaking changes — Converse-shape callers unaffected; Anthropic-shape callers stop silently falling back to local

## Refs

- Spec: `aws bedrock-runtime count-tokens` — `invokeModel.body` is a Base64-encoded blob
- Bedrock InvokeModel Anthropic schema requires `anthropic_version` + `max_tokens`
