### PR TITLE
fix(responses): normalize chat tool_choice for completions→responses bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -119,6 +119,19 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     def __init__(self):
         pass
 
+    def _normalize_tool_choice_for_responses_api(self, tool_choice: Any) -> Any:
+        """Chat tool_choice uses function.name; Responses API expects top-level name."""
+        if not isinstance(tool_choice, dict) or tool_choice.get("type") != "function":
+            return tool_choice
+        if isinstance(tool_choice.get("name"), str) and tool_choice.get("name"):
+            return tool_choice
+        fn = tool_choice.get("function")
+        if isinstance(fn, dict):
+            fn_name = fn.get("name")
+            if isinstance(fn_name, str) and fn_name:
+                return {"type": "function", "name": fn_name}
+        return tool_choice
+
     def _handle_raw_dict_response_item(
         self, item: Dict[str, Any], index: int
     ) -> Tuple[Optional[Any], int]:
@@ -309,6 +322,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 text_format = self._transform_response_format_to_text_format(value)
                 if text_format:
                     responses_api_request["text"] = text_format  # type: ignore
+            elif key == "tool_choice":
+                responses_api_request["tool_choice"] = (  # type: ignore[assignment]
+                    self._normalize_tool_choice_for_responses_api(value)
+                )
             elif key in ResponsesAPIOptionalRequestParams.__annotations__.keys():
                 responses_api_request[key] = value  # type: ignore
             elif key == "previous_response_id":

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -124,7 +124,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         if not isinstance(tool_choice, dict) or tool_choice.get("type") != "function":
             return tool_choice
         if isinstance(tool_choice.get("name"), str) and tool_choice.get("name"):
-            return tool_choice
+            # Return only Responses shape so stray chat ``function`` key is not sent upstream.
+            return {"type": "function", "name": tool_choice["name"]}
         fn = tool_choice.get("function")
         if isinstance(fn, dict):
             fn_name = fn.get("name")

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2123,6 +2123,31 @@ def test_map_optional_params_tool_choice_chat_nested_to_responses_api():
     }
 
 
+@pytest.mark.parametrize(
+    ("tool_choice", "expected"),
+    [
+        ("auto", "auto"),
+        ("none", "none"),
+        (
+            {"type": "function", "name": "Echo"},
+            {"type": "function", "name": "Echo"},
+        ),
+        (
+            {"type": "function", "name": "foo", "function": {"name": "bar"}},
+            {"type": "function", "name": "foo"},
+        ),
+        ({"type": "required"}, {"type": "required"}),
+    ],
+)
+def test_normalize_tool_choice_for_responses_api(tool_choice, expected):
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+    assert handler._normalize_tool_choice_for_responses_api(tool_choice) == expected
+
+
 def test_convert_chat_completion_file_type_to_input_file():
     """
     Test that Chat Completion content with type 'file' is correctly mapped

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2098,6 +2098,31 @@ def test_map_optional_params_preserves_reasoning_summary():
     assert responses_api_request["reasoning"]["summary"] == "detailed"
 
 
+def test_map_optional_params_tool_choice_chat_nested_to_responses_api():
+    """Chat tool_choice must become Responses ToolChoiceFunction (top-level name)."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
+
+    handler = LiteLLMResponsesTransformationHandler()
+    responses_api_request = ResponsesAPIOptionalRequestParams()
+    handler._map_optional_params_to_responses_api_request(
+        {
+            "stream": False,
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "Echo"},
+            },
+        },
+        responses_api_request,
+    )
+    assert responses_api_request["tool_choice"] == {
+        "type": "function",
+        "name": "Echo",
+    }
+
+
 def test_convert_chat_completion_file_type_to_input_file():
     """
     Test that Chat Completion content with type 'file' is correctly mapped


### PR DESCRIPTION
When routing chat completions to the Responses API, OpenAI rejects chat-style `tool_choice` (`{type, function: {name}}`) with `unknown_parameter: tool_choice.function`.

- Add `LiteLLMResponsesTransformationHandler._normalize_tool_choice_for_responses_api` and apply it in `_map_optional_params_to_responses_api_request` for `tool_choice`.
- Regression test: `test_map_optional_params_tool_choice_chat_nested_to_responses_api`.

<img width="1252" height="701" alt="image" src="https://github.com/user-attachments/assets/89aab68e-cc0c-4b0e-af67-a11528ec4276" />


**Curl in litellm**
<img width="1252" height="701" alt="image" src="https://github.com/user-attachments/assets/84bbca36-83db-4e9a-b5c3-f6271f601001" />

Fixes #27611
Fixes [LIT-2975](https://linear.app/litellm-ai/issue/LIT-2975/bug-in-responses-mode-for-gpt-5455)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small request-shaping change limited to `tool_choice` mapping with targeted regression tests; main risk is unintended normalization of uncommon `tool_choice` dict shapes.
> 
> **Overview**
> Fixes a Responses API compatibility issue when routing Chat Completions requests by **normalizing `tool_choice`** from chat-style `{type:"function", function:{name}}` to the Responses API shape `{type:"function", name}` and stripping the stray `function` key before sending upstream.
> 
> Adds regression coverage to ensure nested chat `tool_choice` is converted correctly and that non-function/standard values (e.g., `auto`, `none`, `required`) pass through unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd31f2de539f67fe656f9098854bde9c1eb6865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->