### PR TITLE
fix(anthropic-pass-through): preserve tool args when finish_reason and tool_calls arrive in the same streaming chunk

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -161,9 +161,39 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         and processed_chunk["delta"].get("type") == "input_json_delta"
                         and processed_chunk["delta"].get("partial_json")
                     ):
+                        # xAI/Gemini: args bundled with name, no finish_reason
                         self.chunk_queue.append(processed_chunk)
-
-                    self.sent_content_block_finish = False
+                        self.sent_content_block_finish = False
+                    elif processed_chunk.get("type") == "message_delta":
+                        # Combined tool+finish chunk (e.g. GLM-5.1): tool_calls AND
+                        # finish_reason in one chunk. Extract args, close the tool
+                        # block, then queue the message_delta.
+                        _tc = getattr(chunk.choices[0].delta, "tool_calls", None)
+                        if _tc and _tc[0].function:
+                            _args = (
+                                getattr(_tc[0].function, "arguments", None) or ""
+                            )
+                            if _args:
+                                self.chunk_queue.append(
+                                    {
+                                        "type": "content_block_delta",
+                                        "index": self.current_content_block_index,
+                                        "delta": {
+                                            "type": "input_json_delta",
+                                            "partial_json": _args,
+                                        },
+                                    }
+                                )
+                        self.chunk_queue.append(
+                            {
+                                "type": "content_block_stop",
+                                "index": self.current_content_block_index,
+                            }
+                        )
+                        self.sent_content_block_finish = True
+                        self.chunk_queue.append(processed_chunk)
+                    else:
+                        self.sent_content_block_finish = False
                     return self.chunk_queue.popleft()
 
                 if (
@@ -355,10 +385,41 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                             == "input_json_delta"
                             and processed_chunk["delta"].get("partial_json")
                         ):
+                            # xAI/Gemini: args bundled with name, no finish_reason
                             self.chunk_queue.append(processed_chunk)
-
-                        # Reset state for new block
-                        self.sent_content_block_finish = False
+                            self.sent_content_block_finish = False
+                        elif processed_chunk.get("type") == "message_delta":
+                            # Combined tool+finish chunk (e.g. GLM-5.1): tool_calls AND
+                            # finish_reason in one chunk. Extract args, close the tool
+                            # block, then queue the message_delta.
+                            _tc = getattr(
+                                chunk.choices[0].delta, "tool_calls", None
+                            )
+                            if _tc and _tc[0].function:
+                                _args = (
+                                    getattr(_tc[0].function, "arguments", None) or ""
+                                )
+                                if _args:
+                                    self.chunk_queue.append(
+                                        {
+                                            "type": "content_block_delta",
+                                            "index": self.current_content_block_index,
+                                            "delta": {
+                                                "type": "input_json_delta",
+                                                "partial_json": _args,
+                                            },
+                                        }
+                                    )
+                            self.chunk_queue.append(
+                                {
+                                    "type": "content_block_stop",
+                                    "index": self.current_content_block_index,
+                                }
+                            )
+                            self.sent_content_block_finish = True
+                            self.chunk_queue.append(processed_chunk)
+                        else:
+                            self.sent_content_block_finish = False
                         return self.chunk_queue.popleft()
 
                     if (
@@ -472,7 +533,22 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         # Example logic - customize based on your needs:
         # If chunk indicates a tool call
         if chunk.choices[0].finish_reason is not None:
-            return False
+            # Some providers (e.g., GLM-5.1) bundle tool_calls and finish_reason
+            # in the same chunk. If the chunk also carries a named tool call we
+            # must fall through so the new tool_use content block is detected.
+            _delta = chunk.choices[0].delta
+            _tool_calls = getattr(_delta, "tool_calls", None)
+            _has_named_tool_call = bool(
+                _tool_calls
+                and _tool_calls[0].function is not None
+                and (
+                    getattr(_tool_calls[0].function, "name", None)
+                    or getattr(_tool_calls[0], "id", None)
+                )
+            )
+            if not _has_named_tool_call:
+                return False
+            # Fall through to detect the new tool_use block below
 
         (
             block_type,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
@@ -306,6 +306,166 @@ def test_sync_stream_emits_input_json_delta_for_bundled_tool_args():
     assert events[input_json_delta_idx]["delta"]["partial_json"]
 
 
+@pytest.mark.asyncio
+async def test_async_stream_combined_tool_and_finish_chunk():
+    """
+    Regression test for v1.83.7: when a provider sends tool_calls AND
+    finish_reason in the SAME chunk (e.g., GLM-5.1), the async wrapper must
+    still emit a tool_use content_block_start + input_json_delta before the
+    message_delta, rather than silently dropping the tool call.
+    """
+    # Single chunk: tool call + finish_reason together
+    combined_chunk = _make_chunk(
+        Delta(
+            content=None,
+            role="assistant",
+            tool_calls=[
+                ChatCompletionDeltaToolCall(
+                    id="call_abc123",
+                    function=Function(
+                        name="read_file",
+                        arguments='{"file_path": "test.py"}',
+                    ),
+                    type="function",
+                    index=0,
+                )
+            ],
+        ),
+        finish_reason="tool_calls",
+    )
+
+    async def mock_stream():
+        yield combined_chunk
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=mock_stream(),
+        model="test-model",
+    )
+
+    events = await _collect_events_async(wrapper)
+    event_types = [e.get("type") if isinstance(e, dict) else str(e) for e in events]
+
+    tool_start_idx = None
+    input_json_delta_idx = None
+    message_delta_idx = None
+
+    for i, event in enumerate(events):
+        if not isinstance(event, dict):
+            continue
+        if (
+            event.get("type") == "content_block_start"
+            and isinstance(event.get("content_block"), dict)
+            and event["content_block"].get("type") == "tool_use"
+        ):
+            tool_start_idx = i
+        if (
+            event.get("type") == "content_block_delta"
+            and isinstance(event.get("delta"), dict)
+            and event["delta"].get("type") == "input_json_delta"
+        ):
+            input_json_delta_idx = i
+        if event.get("type") == "message_delta":
+            message_delta_idx = i
+
+    assert tool_start_idx is not None, (
+        f"Expected tool_use content_block_start; events: {event_types}"
+    )
+    assert input_json_delta_idx is not None, (
+        f"Expected input_json_delta for tool arguments; events: {event_types}"
+    )
+    assert message_delta_idx is not None, (
+        f"Expected message_delta with stop_reason; events: {event_types}"
+    )
+    assert tool_start_idx < input_json_delta_idx < message_delta_idx, (
+        f"Events must be ordered tool_start < input_json_delta < message_delta; "
+        f"indices: {tool_start_idx}, {input_json_delta_idx}, {message_delta_idx}"
+    )
+
+    # Verify the tool id and name are present
+    tool_start_event = events[tool_start_idx]
+    assert tool_start_event["content_block"]["id"] == "call_abc123"
+    assert tool_start_event["content_block"]["name"] == "read_file"
+
+    # Verify tool args carried through
+    delta_event = events[input_json_delta_idx]
+    assert delta_event["delta"]["partial_json"] == '{"file_path": "test.py"}'
+
+
+def test_sync_stream_combined_tool_and_finish_chunk():
+    """
+    Regression test for v1.83.7: sync counterpart of the combined chunk test.
+    """
+    combined_chunk = _make_chunk(
+        Delta(
+            content=None,
+            role="assistant",
+            tool_calls=[
+                ChatCompletionDeltaToolCall(
+                    id="call_abc123",
+                    function=Function(
+                        name="read_file",
+                        arguments='{"file_path": "test.py"}',
+                    ),
+                    type="function",
+                    index=0,
+                )
+            ],
+        ),
+        finish_reason="tool_calls",
+    )
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter([combined_chunk]),
+        model="test-model",
+    )
+
+    events = _collect_events_sync(wrapper)
+    event_types = [e.get("type") if isinstance(e, dict) else str(e) for e in events]
+
+    tool_start_idx = None
+    input_json_delta_idx = None
+    message_delta_idx = None
+
+    for i, event in enumerate(events):
+        if not isinstance(event, dict):
+            continue
+        if (
+            event.get("type") == "content_block_start"
+            and isinstance(event.get("content_block"), dict)
+            and event["content_block"].get("type") == "tool_use"
+        ):
+            tool_start_idx = i
+        if (
+            event.get("type") == "content_block_delta"
+            and isinstance(event.get("delta"), dict)
+            and event["delta"].get("type") == "input_json_delta"
+        ):
+            input_json_delta_idx = i
+        if event.get("type") == "message_delta":
+            message_delta_idx = i
+
+    assert tool_start_idx is not None, (
+        f"Expected tool_use content_block_start; events: {event_types}"
+    )
+    assert input_json_delta_idx is not None, (
+        f"Expected input_json_delta for tool arguments; events: {event_types}"
+    )
+    assert message_delta_idx is not None, (
+        f"Expected message_delta with stop_reason; events: {event_types}"
+    )
+    assert tool_start_idx < input_json_delta_idx < message_delta_idx, (
+        f"Events must be ordered tool_start < input_json_delta < message_delta; "
+        f"indices: {tool_start_idx}, {input_json_delta_idx}, {message_delta_idx}"
+    )
+
+    tool_start_event = events[tool_start_idx]
+    assert tool_start_event["content_block"]["id"] == "call_abc123"
+    assert tool_start_event["content_block"]["name"] == "read_file"
+
+    delta_event = events[input_json_delta_idx]
+    assert delta_event["delta"]["partial_json"] == '{"file_path": "test.py"}'
+
+
 def test_sync_stream_no_extra_delta_when_tool_args_empty():
     """
     Sync counterpart: empty args (OpenAI-style) should not emit an extra


### PR DESCRIPTION
## Summary

Fixes #27469 — tool call `function.arguments` silently dropped in the
`/v1/messages` (Anthropic pass-through) streaming path when a provider
bundles `tool_calls` **and** `finish_reason` in the same chunk.

### Root cause

`_should_start_new_content_block` in `AnthropicStreamWrapper` returned
`False` immediately whenever `chunk.choices[0].finish_reason is not None`,
before inspecting the chunk for tool-call data.  For providers that emit
a single combined chunk (tool call + finish reason — e.g. GLM-5.1), this
meant:

* No `content_block_start` (tool_use) was ever queued.
* `translate_streaming_openai_response_to_anthropic` always returned
  `message_delta` for such chunks, so the tool name, id, and arguments
  were silently discarded.
* The Anthropic client received `stop_reason: tool_use` with an empty
  content array — no tool_use block, no arguments.

### Fix

**`_should_start_new_content_block`** — when `finish_reason is not None`,
check whether the chunk also carries a named tool call (name or id
present). If so, fall through to the normal block-detection logic instead
of returning early.

**`__next__` (sync) and `__anext__` (async)** — add a new branch in the
`should_start_new_block` section for the case where `processed_chunk` is
a `message_delta` (finish+tool in one chunk). The branch emits the full
correct event sequence:

```
content_block_stop   (close previous text block)
content_block_start  (open tool_use block)
content_block_delta  (input_json_delta with args, if any)
content_block_stop   (close tool_use block)
message_delta        (stop_reason + usage)
```

The existing xAI/Gemini path (args bundled with name, **no** finish_reason
in the same chunk) is unchanged and all prior tests continue to pass.

## Test plan

- [x] `test_sync_stream_combined_tool_and_finish_chunk` — new regression
  test: single chunk with `tool_calls` + `finish_reason`; asserts
  `content_block_start` (tool_use), `input_json_delta`, and `message_delta`
  all appear in the correct order with correct payload (sync).
- [x] `test_async_stream_combined_tool_and_finish_chunk` — async
  counterpart of the above.
- [x] All 4 pre-existing bundled-args tests continue to pass
  (`test_sync/async_stream_emits_input_json_delta_for_bundled_tool_args`,
  `test_sync/async_stream_no_extra_delta_when_tool_args_empty`).
- [x] Full `tests/test_litellm/llms/anthropic/experimental_pass_through/`
  suite: **192 passed, 0 failed** (fastapi-dependent integration tests
  skipped due to missing dep in sandbox).

=== LOCAL_TEST_PASSED ===