### PR TITLE
fix(proxy): serialize lists in jsonify_object and exclude relation fields from key batch update

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2397,7 +2397,7 @@ def jsonify_object(data: dict) -> dict:
     db_data = copy.deepcopy(data)
 
     for k, v in db_data.items():
-        if isinstance(v, dict):
+        if isinstance(v, (dict, list)):
             try:
                 db_data[k] = json.dumps(v)
             except Exception:
@@ -2405,6 +2405,21 @@ def jsonify_object(data: dict) -> dict:
                 db_data[k] = "failed-to-serialize-json"
     return db_data
 
+
+# Prisma does not allow relation scalars (FK fields backing a @relation) or
+# relation objects in a direct update() call.  These must be stripped from the
+# payload to avoid "Field does not exist in enclosing type" errors when batch-
+# updating LiteLLM_VerificationToken rows.
+_VERIFICATION_TOKEN_RELATION_FIELDS: frozenset = frozenset(
+    {
+        "object_permission_id",
+        "object_permission",
+        "litellm_budget_table",
+        "litellm_organization_table",
+        "litellm_project_table",
+        "jwt_key_mappings",
+    }
+)
 
 # In-memory cache for deprecated key lookups: maps old_token_hash -> (active_token_id, expires_at_ts)
 # Avoids a DB query on every auth request for non-deprecated keys.
@@ -2757,7 +2772,7 @@ class PrismaClient:
         db_data = copy.deepcopy(data)
 
         for k, v in db_data.items():
-            if isinstance(v, dict):
+            if isinstance(v, (dict, list)):
                 try:
                     db_data[k] = json.dumps(v)
                 except Exception:
@@ -3704,6 +3719,9 @@ class PrismaClient:
                         )
                     except Exception:
                         data_json = self.jsonify_object(data=t.dict(exclude_none=True))
+                    # Remove relation fields that Prisma rejects in update()
+                    for field in _VERIFICATION_TOKEN_RELATION_FIELDS:
+                        data_json.pop(field, None)
                     batcher.litellm_verificationtoken.update(
                         where={"token": t.token},  # type: ignore
                         data={**data_json},  # type: ignore


### PR DESCRIPTION
## Relevant issues

Fixes #27171
Related to #22201

## Pre-Submission checklist

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The `ResetBudgetJob` crashes globally with two Prisma errors when updating keys that have `budget_limits` or `object_permission_id` set:

```
prisma.errors.DataError: Unable to match input value to any allowed input type for the field.
Parse errors: [
  `updateOneLiteLLM_VerificationToken.data.object_permission_id`: Field does not exist in enclosing type.,
  Invalid argument type. `budget_limits` should be of any of the following types: `NullableJsonNullValueInput`, `Json`
]
```

### Root Cause 1: `budget_limits` not serialized to JSON

`jsonify_object()` only converts `dict` values to JSON strings via `json.dumps()`. The `budget_limits` field is typed as `List[dict]` in the Pydantic model and maps to a `Json?` column in Prisma. Since the helper skipped `list` values, Prisma received a raw Python list and rejected it.

**Fix:** Extend the `isinstance` check to `(dict, list)` so list-typed Json columns are properly serialized.

### Root Cause 2: `object_permission_id` is a relation scalar

`object_permission_id` is the FK field backing the `object_permission` `@relation` in the Prisma schema. Prisma's query engine does not allow direct assignment of relation scalar fields in `update()` operations — the `connect`/`disconnect` relation syntax must be used instead.

The `update_many` batch path for keys serializes the **entire** `LiteLLM_VerificationToken` model via `model_dump(exclude_none=True)` and passes all fields (including relation scalars and relation objects) directly to Prisma's `update(data=...)`. Prisma rejects these with "Field does not exist in enclosing type".

**Fix:** Strip known relation fields (`object_permission_id`, `object_permission`, `litellm_budget_table`, `litellm_organization_table`, `litellm_project_table`, `jwt_key_mappings`) from the update payload before passing to Prisma.

### Impact

Without this fix, the `ResetBudgetJob` fails for **all** keys globally whenever any key in the database has `budget_limits` populated (Budget Windows feature) or `object_permission_id` set. No key budget resets are applied.