### PR TITLE
feat(prometheus): surface provider cached metrics which are independent of LiteLLM cache.

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -511,6 +511,23 @@ class PrometheusLogger(CustomLogger):
                 labelnames=self.get_labels_for_metric("litellm_cached_tokens_metric"),
             )
 
+            # Provider prompt-caching metrics
+            self.litellm_provider_cache_read_input_tokens_metric = self._counter_factory(
+                name="litellm_provider_cache_read_input_tokens_metric",
+                documentation="Total prompt/input tokens read from provider prompt cache (e.g. OpenAI/Anthropic/Gemini/Bedrock)",
+                labelnames=self.get_labels_for_metric(
+                    "litellm_provider_cache_read_input_tokens_metric"
+                ),
+            )
+
+            self.litellm_provider_cache_creation_input_tokens_metric = self._counter_factory(
+                name="litellm_provider_cache_creation_input_tokens_metric",
+                documentation="Total prompt/input tokens written to provider prompt cache (e.g. Anthropic/Bedrock)",
+                labelnames=self.get_labels_for_metric(
+                    "litellm_provider_cache_creation_input_tokens_metric"
+                ),
+            )
+
             # User and Team count metrics
             self.litellm_total_users_metric = self._gauge_factory(
                 "litellm_total_users",
@@ -1458,11 +1475,11 @@ class PrometheusLogger(CustomLogger):
         """
         cache_hit = standard_logging_payload.get("cache_hit")
 
-        # Only track if cache_hit has a definite value (True or False)
         if cache_hit is None:
-            return
-
-        if cache_hit is True:
+            # Historically these metrics only tracked LiteLLM caching.
+            # Provider prompt-caching metrics are still emitted below.
+            pass
+        elif cache_hit is True:
             # Increment cache hits counter
             PrometheusLogger._inc_labeled_counter(
                 self,
@@ -1492,6 +1509,51 @@ class PrometheusLogger(CustomLogger):
                 enum_values,
                 label_context=label_context,
             )
+
+        # Provider prompt caching metrics are independent of LiteLLM cache_hit.
+        provider_cache_read_tokens = 0
+        provider_cache_creation_tokens = 0
+        usage_obj = (standard_logging_payload.get("metadata", {}) or {}).get(
+            "usage_object"
+        )
+        if isinstance(usage_obj, dict):
+            # Prefer explicit provider cache fields when available.
+            _read = usage_obj.get("cache_read_input_tokens")
+            _write = usage_obj.get("cache_creation_input_tokens")
+
+            if isinstance(_read, int):
+                provider_cache_read_tokens = _read
+            if isinstance(_write, int):
+                provider_cache_creation_tokens = _write
+
+            # Fallback to prompt_tokens_details.cached_tokens (common normalization point).
+            # Only fallback when the explicit field is genuinely absent (None).
+            if _read is None:
+                prompt_details = usage_obj.get("prompt_tokens_details")
+                if isinstance(prompt_details, dict):
+                    cached_tokens = prompt_details.get("cached_tokens")
+                    if isinstance(cached_tokens, int):
+                        provider_cache_read_tokens = cached_tokens
+
+            if provider_cache_read_tokens > 0:
+                PrometheusLogger._inc_labeled_counter(
+                    self,
+                    self.litellm_provider_cache_read_input_tokens_metric,
+                    "litellm_provider_cache_read_input_tokens_metric",
+                    enum_values,
+                    label_context=label_context,
+                    amount=float(provider_cache_read_tokens),
+                )
+
+            if provider_cache_creation_tokens > 0:
+                PrometheusLogger._inc_labeled_counter(
+                    self,
+                    self.litellm_provider_cache_creation_input_tokens_metric,
+                    "litellm_provider_cache_creation_input_tokens_metric",
+                    enum_values,
+                    label_context=label_context,
+                    amount=float(provider_cache_creation_tokens),
+                )
 
     async def _increment_remaining_budget_metrics(
         self,

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -238,6 +238,9 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_cache_hits_metric",
     "litellm_cache_misses_metric",
     "litellm_cached_tokens_metric",
+    # Provider prompt-caching metrics (e.g. OpenAI/Anthropic/Bedrock/Gemini)
+    "litellm_provider_cache_read_input_tokens_metric",
+    "litellm_provider_cache_creation_input_tokens_metric",
     "litellm_deployment_tpm_limit",
     "litellm_deployment_rpm_limit",
     "litellm_remaining_api_key_requests_for_model",
@@ -655,6 +658,10 @@ class PrometheusMetricLabels:
     litellm_cache_misses_metric = _cache_metric_labels
     litellm_cached_tokens_metric = _cache_metric_labels
 
+    # Provider prompt-caching metrics - track tokens read/written to provider caches
+    litellm_provider_cache_read_input_tokens_metric = _cache_metric_labels
+    litellm_provider_cache_creation_input_tokens_metric = _cache_metric_labels
+
     # Metrics whose emission paths supply org context (used by get_labels)
     _org_label_metrics: ClassVar[frozenset] = frozenset(
         {
@@ -672,7 +679,6 @@ class PrometheusMetricLabels:
             "litellm_output_tokens_metric",
         }
     )
-
     # Managed batch metrics
     _batch_user_labels = [
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,

--- a/tests/test_litellm/integrations/test_prometheus_cache_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_cache_metrics.py
@@ -35,6 +35,8 @@ class TestPrometheusCacheMetrics:
         assert "litellm_cache_hits_metric" in defined_metrics
         assert "litellm_cache_misses_metric" in defined_metrics
         assert "litellm_cached_tokens_metric" in defined_metrics
+        assert "litellm_provider_cache_read_input_tokens_metric" in defined_metrics
+        assert "litellm_provider_cache_creation_input_tokens_metric" in defined_metrics
 
     def test_cache_metric_labels_defined(self):
         """Test that cache metric labels are properly defined"""
@@ -44,6 +46,13 @@ class TestPrometheusCacheMetrics:
         assert hasattr(PrometheusMetricLabels, "litellm_cache_hits_metric")
         assert hasattr(PrometheusMetricLabels, "litellm_cache_misses_metric")
         assert hasattr(PrometheusMetricLabels, "litellm_cached_tokens_metric")
+        assert hasattr(
+            PrometheusMetricLabels, "litellm_provider_cache_read_input_tokens_metric"
+        )
+        assert hasattr(
+            PrometheusMetricLabels,
+            "litellm_provider_cache_creation_input_tokens_metric",
+        )
 
         # Verify labels include expected keys
         expected_labels = [
@@ -59,6 +68,14 @@ class TestPrometheusCacheMetrics:
             assert label in PrometheusMetricLabels.litellm_cache_hits_metric
             assert label in PrometheusMetricLabels.litellm_cache_misses_metric
             assert label in PrometheusMetricLabels.litellm_cached_tokens_metric
+            assert (
+                label
+                in PrometheusMetricLabels.litellm_provider_cache_read_input_tokens_metric
+            )
+            assert (
+                label
+                in PrometheusMetricLabels.litellm_provider_cache_creation_input_tokens_metric
+            )
 
     def test_increment_cache_metrics_on_cache_hit(self, sample_enum_values):
         """Test that cache hit increments the correct metrics"""
@@ -76,12 +93,20 @@ class TestPrometheusCacheMetrics:
             "completion_tokens": 50,
             "model_group": "openai",
             "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    "cache_read_input_tokens": 25,
+                    "cache_creation_input_tokens": 10,
+                }
+            },
         }
 
         # Create mock metrics
         mock_logger.litellm_cache_hits_metric = MagicMock()
         mock_logger.litellm_cache_misses_metric = MagicMock()
         mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
         mock_logger.get_labels_for_metric = MagicMock(
             return_value=[
                 "model",
@@ -114,6 +139,14 @@ class TestPrometheusCacheMetrics:
         # Verify cache misses metric was NOT called
         mock_logger.litellm_cache_misses_metric.labels.assert_not_called()
 
+        # Verify provider prompt caching metrics were incremented
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(
+            25
+        )
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels().inc.assert_called_once_with(
+            10
+        )
+
     def test_increment_cache_metrics_on_cache_miss(self, sample_enum_values):
         """Test that cache miss increments the correct metrics"""
         # Create mock for PrometheusLogger instance
@@ -129,12 +162,20 @@ class TestPrometheusCacheMetrics:
             "completion_tokens": 50,
             "model_group": "openai",
             "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    # Explicit provider field absent -> fallback should use prompt_tokens_details.cached_tokens
+                    "prompt_tokens_details": {"cached_tokens": 20},
+                }
+            },
         }
 
         # Create mock metrics
         mock_logger.litellm_cache_hits_metric = MagicMock()
         mock_logger.litellm_cache_misses_metric = MagicMock()
         mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
         mock_logger.get_labels_for_metric = MagicMock(
             return_value=[
                 "model",
@@ -162,6 +203,61 @@ class TestPrometheusCacheMetrics:
         mock_logger.litellm_cache_hits_metric.labels.assert_not_called()
         mock_logger.litellm_cached_tokens_metric.labels.assert_not_called()
 
+        # Provider prompt caching metrics should still be emitted
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(
+            20
+        )
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels.assert_not_called()
+
+    def test_provider_cache_read_does_not_fallback_on_explicit_zero(
+        self, sample_enum_values
+    ):
+        """Explicit cache_read_input_tokens=0 must not trigger fallback to cached_tokens."""
+        mock_logger = MagicMock()
+
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        standard_logging_payload = {
+            "cache_hit": False,
+            "total_tokens": 100,
+            "prompt_tokens": 50,
+            "completion_tokens": 50,
+            "model_group": "openai",
+            "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    "cache_read_input_tokens": 0,
+                    "prompt_tokens_details": {"cached_tokens": 20},
+                }
+            },
+        }
+
+        mock_logger.litellm_cache_hits_metric = MagicMock()
+        mock_logger.litellm_cache_misses_metric = MagicMock()
+        mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
+        mock_logger.get_labels_for_metric = MagicMock(
+            return_value=[
+                "model",
+                "hashed_api_key",
+                "api_key_alias",
+                "team",
+                "team_alias",
+                "end_user",
+                "user",
+            ]
+        )
+
+        PrometheusLogger._increment_cache_metrics(
+            mock_logger,
+            standard_logging_payload=standard_logging_payload,
+            enum_values=sample_enum_values,
+        )
+
+        # Should not emit read metric, because explicit provider value is zero.
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels.assert_not_called()
+
     def test_increment_cache_metrics_when_cache_hit_is_none(self, sample_enum_values):
         """Test that no metrics are incremented when cache_hit is None"""
         # Create mock for PrometheusLogger instance
@@ -177,12 +273,19 @@ class TestPrometheusCacheMetrics:
             "completion_tokens": 50,
             "model_group": "openai",
             "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    "cache_read_input_tokens": 25,
+                }
+            },
         }
 
         # Create mock metrics
         mock_logger.litellm_cache_hits_metric = MagicMock()
         mock_logger.litellm_cache_misses_metric = MagicMock()
         mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
         mock_logger.get_labels_for_metric = MagicMock(
             return_value=[
                 "model",
@@ -206,6 +309,12 @@ class TestPrometheusCacheMetrics:
         mock_logger.litellm_cache_hits_metric.labels.assert_not_called()
         mock_logger.litellm_cache_misses_metric.labels.assert_not_called()
         mock_logger.litellm_cached_tokens_metric.labels.assert_not_called()
+
+        # Provider prompt caching metrics should still be emitted
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(
+            25
+        )
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Provider Prompt Cache Metrics

LiteLLM emits Prometheus metrics for *provider-side* prompt caching (OpenAI/Azure OpenAI, Anthropic, Bedrock, Gemini/Vertex, DeepSeek).

This is different from LiteLLM's own response caching metrics:

- LiteLLM response caching: `litellm_cache_hits_metric`, `litellm_cache_misses_metric`, `litellm_cached_tokens_metric` (driven by `cache_hit`)
- Provider prompt caching: metrics below (driven by the provider usage fields LiteLLM normalizes)

## Metrics

| Metric | Meaning |
|---|---|
| `litellm_provider_cache_read_input_tokens_metric` | Total prompt/input tokens read from a provider prompt cache |
| `litellm_provider_cache_creation_input_tokens_metric` | Total prompt/input tokens written to a provider prompt cache |

All metrics use the same label set as other per-request token metrics (model, hashed api key, team, etc). See `PrometheusMetricLabels._cache_metric_labels`.



## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
```
The same test is failing (locally) with or without this commit.
It passes when ran in isolation so it has to be unrelated.
```


- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

LLM response output:
```
  "usage": {
    "completion_tokens": 2004,
    "prompt_tokens": 2016,
    "total_tokens": 4020,
    "completion_tokens_details": {
      "accepted_prediction_tokens": 0,
      "audio_tokens": 0,
      "reasoning_tokens": 0,
      "rejected_prediction_tokens": 0
    },
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 1792
    },
    "latency_checkpoint": {
      "engine_tbt_ms": 3,
      "engine_ttft_ms": 37,
      "engine_ttlt_ms": 6251,
      "pre_inference_ms": 66,
      "service_tbt_ms": 3,
      "service_ttft_ms": 422,
      "service_ttlt_ms": 6390,
      "total_duration_ms": 6333,
      "user_visible_ttft_ms": 356
    }
  },
  "service_tier": "default",
  ```
Prometheus metrics output:
```
$ curl http://localhost:4001/metrics/ 2>/dev/null| grep provider_cache
# HELP litellm_provider_cache_read_input_tokens_metric_total Total prompt/input tokens read from provider prompt cache (e.g. OpenAI/Anthropic/Gemini/Bedrock)
# TYPE litellm_provider_cache_read_input_tokens_metric_total counter
litellm_provider_cache_read_input_tokens_metric_total{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",model="gpt-52",model_id="981eb5f7870d049126162838a28b4bf84bc925a04902a0453d9785352d9d63da",team="None",team_alias="None",user="default_user_id"} 1792.0
# HELP litellm_provider_cache_read_input_tokens_metric_created Total prompt/input tokens read from provider prompt cache (e.g. OpenAI/Anthropic/Gemini/Bedrock)
# TYPE litellm_provider_cache_read_input_tokens_metric_created gauge
litellm_provider_cache_read_input_tokens_metric_created{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",model="gpt-52",model_id="981eb5f7870d049126162838a28b4bf84bc925a04902a0453d9785352d9d63da",team="None",team_alias="None",user="default_user_id"} 1.7784954602383213e+09
# HELP litellm_provider_cache_creation_input_tokens_metric_total Total prompt/input tokens written to provider prompt cache (e.g. Anthropic/Bedrock)
# TYPE litellm_provider_cache_creation_input_tokens_metric_total counter
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
