### PR TITLE
chore: reject bare str at file-input sinks to prevent local-file read

### DIFF
--- a/litellm/litellm_core_utils/audio_utils/utils.py
+++ b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -53,8 +53,19 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
         # Raw bytes
         filename = "audio.wav"
         file_content = bytes(audio_file)
-    elif isinstance(audio_file, (str, os.PathLike)):
-        # File path or PathLike
+    elif isinstance(audio_file, str):
+        # Bare strings are rejected — see extract_file_data for the same
+        # rationale: in a proxy request handler the string is
+        # attacker-controlled, and opening it as a path is an arbitrary
+        # file read.
+        raise ValueError(
+            "process_audio_file does not accept bare str inputs. Pass bytes, "
+            "an open file handle, a (filename, content) tuple, or a "
+            "pathlib.Path."
+        )
+    elif isinstance(audio_file, os.PathLike):
+        # File path or PathLike — PathLike is a Python-level type that
+        # HTTP form values can't fabricate.
         file_path = str(audio_file)
         with open(file_path, "rb") as f:
             file_content = f.read()
@@ -66,8 +77,14 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
             content = audio_file[1]
             if isinstance(content, (bytes, bytearray)):
                 file_content = bytes(content)
-            elif isinstance(content, (str, os.PathLike)):
-                # File path or PathLike
+            elif isinstance(content, str):
+                raise ValueError(
+                    "process_audio_file does not accept bare str tuple "
+                    "contents. Pass bytes, an open file handle, or a "
+                    "pathlib.Path."
+                )
+            elif isinstance(content, os.PathLike):
+                # PathLike: SDK convenience for local-file uploads.
                 with open(str(content), "rb") as f:
                     file_content = f.read()
             elif hasattr(content, "read"):
@@ -149,7 +166,14 @@ def get_audio_file_content_hash(file_obj: FileTypes) -> str:
     try:
         if isinstance(file_content_obj, (bytes, bytearray)):
             file_content = bytes(file_content_obj)
-        elif isinstance(file_content_obj, (str, os.PathLike)):
+        elif isinstance(file_content_obj, str):
+            # Bare strings are not treated as file paths in this helper —
+            # the cache-key path is reached from request handlers where the
+            # value is attacker-controlled. Fall back to hashing the string
+            # itself rather than opening it.
+            fallback_filename = file_content_obj
+            file_content = None
+        elif isinstance(file_content_obj, os.PathLike):
             try:
                 with open(str(file_content_obj), "rb") as f:
                     file_content = f.read()
@@ -229,8 +253,15 @@ def calculate_request_duration(file: FileTypes) -> Optional[float]:
         if isinstance(file, (bytes, bytearray)):
             # Raw bytes
             file_content = bytes(file)
-        elif isinstance(file, (str, os.PathLike)):
-            # File path
+        elif isinstance(file, str):
+            # Bare strings are rejected — see extract_file_data.
+            raise ValueError(
+                "calculate_request_duration does not accept bare str inputs. "
+                "Pass bytes, an open file handle, a (filename, content) "
+                "tuple, or a pathlib.Path."
+            )
+        elif isinstance(file, os.PathLike):
+            # File path (PathLike): SDK convenience.
             with open(str(file), "rb") as f:
                 file_content = f.read()
         elif isinstance(file, tuple):

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -755,14 +755,25 @@ def extract_file_data(file_data: FileTypes) -> ExtractedFileData:
     else:
         file_content = file_data
     # Convert content to bytes
-    if isinstance(file_content, (str, PathLike)):
-        # If it's a path, open and read the file
-        # Extract filename from path if not already set
+    if isinstance(file_content, str):
+        # Bare string inputs are rejected: when this helper runs in a proxy
+        # request handler the string came from an attacker-controlled form
+        # field, and opening it as a path is an arbitrary file read on the
+        # proxy host. SDK callers who want to upload from a path should
+        # either pass a pathlib.Path (a PathLike instance — see the branch
+        # below) or open the file themselves and pass the handle / bytes.
+        raise ValueError(
+            "extract_file_data does not accept bare str inputs. Pass bytes, "
+            "an open file handle, a (filename, content) tuple, or a "
+            "pathlib.Path. To upload a local file from a path, call "
+            "open(path, 'rb') yourself."
+        )
+    if isinstance(file_content, PathLike):
+        # PathLike (pathlib.Path) is a Python-level type that HTTP form
+        # values can't fabricate. Treat as a local file path for SDK
+        # convenience.
         if filename is None:
-            if isinstance(file_content, PathLike):
-                filename = Path(file_content).name
-            else:
-                filename = Path(str(file_content)).name
+            filename = Path(file_content).name
         with open(file_content, "rb") as f:
             content = f.read()
     elif isinstance(file_content, io.IOBase):

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -7,7 +7,7 @@ from litellm.utils import (
     _is_explicitly_disabled_factory,
     _supports_factory,
 )
-
+ 
 from .gpt_transformation import OpenAIGPTConfig
 
 

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -7,7 +7,7 @@ from litellm.utils import (
     _is_explicitly_disabled_factory,
     _supports_factory,
 )
- 
+
 from .gpt_transformation import OpenAIGPTConfig
 
 

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -3,7 +3,11 @@
 from typing import Optional, Union
 
 import litellm
-from litellm.utils import _is_explicitly_disabled_factory, _supports_factory
+from litellm.utils import (
+    _is_explicitly_disabled_factory,
+    _supports_factory,
+    strip_reasoning_summary_aliases_from_openai_completion_params,
+)
 
 from .gpt_transformation import OpenAIGPTConfig
 
@@ -191,6 +195,16 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             if param not in non_supported_params
         ]
 
+    @staticmethod
+    def _strip_reasoning_summary_aliases_for_chat_completions(
+        non_default_params: dict,
+        optional_params: dict,
+    ) -> None:
+        """Remove Responses-style reasoning summary keys; invalid on Chat Completions."""
+        strip_reasoning_summary_aliases_from_openai_completion_params(
+            non_default_params, optional_params
+        )
+
     def map_openai_params(
         self,
         non_default_params: dict,
@@ -209,6 +223,12 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                 model=model,
                 drop_params=drop_params,
             )
+
+        # AI SDK / Responses-style aliases; never valid on Chat Completions when not
+        # bridged to Responses API (see main.responses_api_bridge_check).
+        self._strip_reasoning_summary_aliases_for_chat_completions(
+            non_default_params, optional_params
+        )
 
         # Get raw reasoning_effort and effective effort level for all guards.
         # Use effective_effort (extracted string) for xhigh validation, "none" checks, and

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -6,7 +6,6 @@ import litellm
 from litellm.utils import (
     _is_explicitly_disabled_factory,
     _supports_factory,
-    strip_reasoning_summary_aliases_from_openai_completion_params,
 )
 
 from .gpt_transformation import OpenAIGPTConfig
@@ -195,16 +194,6 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             if param not in non_supported_params
         ]
 
-    @staticmethod
-    def _strip_reasoning_summary_aliases_for_chat_completions(
-        non_default_params: dict,
-        optional_params: dict,
-    ) -> None:
-        """Remove Responses-style reasoning summary keys; invalid on Chat Completions."""
-        strip_reasoning_summary_aliases_from_openai_completion_params(
-            non_default_params, optional_params
-        )
-
     def map_openai_params(
         self,
         non_default_params: dict,
@@ -212,12 +201,6 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        # AI SDK / Responses-style aliases; never valid on Chat Completions when not
-        # bridged to Responses API (see main.responses_api_bridge_check).
-        self._strip_reasoning_summary_aliases_for_chat_completions(
-            non_default_params, optional_params
-        )
-
         if self.is_model_gpt_5_search_model(model):
             if "max_tokens" in non_default_params:
                 optional_params["max_completion_tokens"] = non_default_params.pop(

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -212,6 +212,12 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
+        # AI SDK / Responses-style aliases; never valid on Chat Completions when not
+        # bridged to Responses API (see main.responses_api_bridge_check).
+        self._strip_reasoning_summary_aliases_for_chat_completions(
+            non_default_params, optional_params
+        )
+
         if self.is_model_gpt_5_search_model(model):
             if "max_tokens" in non_default_params:
                 optional_params["max_completion_tokens"] = non_default_params.pop(
@@ -223,12 +229,6 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                 model=model,
                 drop_params=drop_params,
             )
-
-        # AI SDK / Responses-style aliases; never valid on Chat Completions when not
-        # bridged to Responses API (see main.responses_api_bridge_check).
-        self._strip_reasoning_summary_aliases_for_chat_completions(
-            non_default_params, optional_params
-        )
 
         # Get raw reasoning_effort and effective effort level for all guards.
         # Use effective_effort (extracted string) for xhigh validation, "none" checks, and

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1005,14 +1005,8 @@ def responses_api_bridge_check(
         and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
         and reasoning_effort is not None
         and (
-            (
-                OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
-                and (tools or reasoning_summary is not None)
-            )
-            or (
-                not OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
-                and reasoning_summary is not None
-            )
+            reasoning_summary is not None
+            or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools)
         )
     ):
         model_info["mode"] = "responses"

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1684,6 +1684,8 @@ def completion(  # type: ignore # noqa: PLR0915
                         "effort": eff,
                         "summary": rs_val,
                     }
+                else:
+                    optional_params["reasoning_effort"] = {"summary": rs_val}
 
             return responses_api_bridge.completion(
                 model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1696,6 +1696,16 @@ def completion(  # type: ignore # noqa: PLR0915
                 encoding=_get_encoding(),
                 stream=stream,
             )
+        elif (
+            custom_llm_provider == "openai"
+            and OpenAIGPT5Config.is_model_gpt_5_model(model)
+        ) or (
+            custom_llm_provider == "azure"
+            and litellm.AzureOpenAIGPT5Config.is_model_gpt_5_model(model)
+        ):
+            optional_params, _ = strip_reasoning_summary_aliases_from_optional_params(
+                optional_params
+            )
 
         if custom_llm_provider == "azure":
             # azure configs

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1,3 +1,5 @@
+# LiteLLM main module: public completion, embedding, streaming, and moderation entrypoints.
+#
 # +-----------------------------------------------+
 # |                                               |
 # |           Give Feedback / Get Help            |
@@ -59,7 +61,13 @@ import litellm
 from litellm import client
 
 # Other utils are imported directly to avoid circular imports
-from litellm.utils import exception_type, get_litellm_params, get_optional_params
+from litellm.utils import (
+    exception_type,
+    get_litellm_params,
+    get_optional_params,
+    peek_reasoning_summary_aliases,
+    strip_reasoning_summary_aliases_from_optional_params,
+)
 
 # Logging is imported lazily when needed to avoid loading litellm_logging at import time
 if TYPE_CHECKING:
@@ -946,6 +954,7 @@ def responses_api_bridge_check(
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
     tools: Optional[List[Any]] = None,
     reasoning_effort: Optional[Any] = None,
+    reasoning_summary: Optional[Any] = None,
 ) -> Tuple[dict, str]:
     model_info: Dict[str, Any] = {}
 
@@ -982,13 +991,16 @@ def responses_api_bridge_check(
             mode = "responses"
             model_info["mode"] = mode
 
-    # OpenAI/Azure gpt-5.4+ chat-completions calls with both tools + reasoning_effort
-    # must be bridged to Responses API.
+    # OpenAI/Azure gpt-5.4+ chat-completions calls that need Responses-only fields
+    # (e.g. reasoning summary) must be bridged. SDKs send ``reasoningSummary`` /
+    # ``reasoning_summary`` alongside ``reasoning_effort``; Chat Completions rejects
+    # those keys, so route when tools+reasoning_effort (original case) or when a
+    # reasoning summary is requested without tools.
     if (
         custom_llm_provider in ("openai", "azure")
         and OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
-        and tools
         and reasoning_effort is not None
+        and (tools or reasoning_summary is not None)
         and model_info.get("mode") != "responses"
     ):
         model_info["mode"] = "responses"
@@ -1634,8 +1646,10 @@ def completion(  # type: ignore # noqa: PLR0915
         ## RESPONSES API BRIDGE LOGIC ## - check if model has 'mode: responses' in litellm.model_cost map
         # Only run the second bridge check if the first one didn't already
         # detect responses mode (e.g. via the "responses/" prefix).  The second
-        # check handles cases like gpt-5.4+ with tools+reasoning_effort that
-        # the first (early) check doesn't cover.
+        # check handles cases like gpt-5.4+ with tools+reasoning_effort or
+        # reasoningSummary/reasoning_summary without tools (AI SDK) that the first
+        # (early) check doesn't cover.
+        _reasoning_summary_for_bridge = peek_reasoning_summary_aliases(optional_params)
         if responses_api_model_info.get("mode") != "responses":
             responses_api_model_info, model = responses_api_bridge_check(
                 model=model,
@@ -1643,14 +1657,27 @@ def completion(  # type: ignore # noqa: PLR0915
                 web_search_options=web_search_options,
                 tools=tools,
                 reasoning_effort=reasoning_effort,
+                reasoning_summary=_reasoning_summary_for_bridge,
             )
 
         if responses_api_model_info.get("mode") == "responses":
             from litellm.completion_extras import responses_api_bridge
 
+            optional_params, rs_val = (
+                strip_reasoning_summary_aliases_from_optional_params(optional_params)
+            )
+
             if isinstance(reasoning_effort, dict) and "summary" in reasoning_effort:
-                optional_params = dict(optional_params)
                 optional_params["reasoning_effort"] = reasoning_effort
+            elif rs_val is not None:
+                eff = optional_params.get("reasoning_effort", reasoning_effort)
+                if isinstance(eff, dict):
+                    optional_params["reasoning_effort"] = {**eff, "summary": rs_val}
+                elif eff is not None:
+                    optional_params["reasoning_effort"] = {
+                        "effort": eff,
+                        "summary": rs_val,
+                    }
 
             return responses_api_bridge.completion(
                 model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -991,17 +991,29 @@ def responses_api_bridge_check(
             mode = "responses"
             model_info["mode"] = mode
 
-    # OpenAI/Azure gpt-5.4+ chat-completions calls that need Responses-only fields
-    # (e.g. reasoning summary) must be bridged. SDKs send ``reasoningSummary`` /
-    # ``reasoning_summary`` alongside ``reasoning_effort``; Chat Completions rejects
-    # those keys, so route when tools+reasoning_effort (original case) or when a
-    # reasoning summary is requested without tools.
+    # OpenAI/Azure GPT-5 chat-completions that need Responses-only fields (e.g.
+    # ``reasoningSummary`` in ``extra_body``) must be bridged; Chat Completions rejects
+    # those keys.
+    #
+    # - gpt-5.4+: tools + reasoning_effort (original) or any reasoning-summary alias.
+    # - Older GPT-5 names (e.g. ``gpt-5``, ``gpt-5.1``): bridge only when a reasoning
+    #   summary alias is present with ``reasoning_effort`` (tools alone stay on chat).
     if (
         custom_llm_provider in ("openai", "azure")
-        and OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
-        and reasoning_effort is not None
-        and (tools or reasoning_summary is not None)
         and model_info.get("mode") != "responses"
+        and OpenAIGPT5Config.is_model_gpt_5_model(model)
+        and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
+        and reasoning_effort is not None
+        and (
+            (
+                OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
+                and (tools or reasoning_summary is not None)
+            )
+            or (
+                not OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
+                and reasoning_summary is not None
+            )
+        )
     ):
         model_info["mode"] = "responses"
         model = model.replace("responses/", "")

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -376,10 +376,12 @@ def convert_file_document_to_url_document(document: Dict[str, Any]) -> Dict[str,
     with an inline base64 data URI.
 
     Accepts document dicts like:
-        {"type": "file", "file": "/path/to/document.pdf"}        # file path string
         {"type": "file", "file": Path("/path/to/doc.pdf")}       # pathlib.Path
         {"type": "file", "file": <binary file-like object>}      # file-like object (BinaryIO)
         {"type": "file", "file": b"raw bytes"}                   # raw bytes
+
+    Bare ``str`` paths are not accepted — pass a ``pathlib.Path`` or
+    ``open(path, "rb")`` instead. See the str check below for the rationale.
 
     Returns:
         {"type": "document_url", "document_url": "data:<mime>;base64,<data>"}
@@ -389,14 +391,28 @@ def convert_file_document_to_url_document(document: Dict[str, Any]) -> Dict[str,
     if file_input is None:
         raise ValueError(
             "document with type='file' must include a 'file' field containing "
-            "a file path (str), pathlib.Path, file-like object, or bytes"
+            "a pathlib.Path, file-like object, or bytes"
         )
 
     file_bytes: bytes
     mime_type: str = "application/octet-stream"
     file_name: Optional[str] = None
 
-    if isinstance(file_input, (str, Path)):
+    if isinstance(file_input, str):
+        # Bare strings are rejected here. The OCR ``document`` accepts a
+        # ``{"type": "file", "file": <value>}`` shape, and when this helper
+        # runs in a proxy request handler ``<value>`` is attacker-controlled.
+        # Opening it as a path is an arbitrary local file read on the proxy
+        # host, which is then base64-encoded and forwarded to the OCR
+        # provider — an exfiltration primitive.
+        raise ValueError(
+            "OCR file input does not accept bare str values. Pass bytes, "
+            "a pathlib.Path, or a file-like object. To OCR a local file "
+            "from a path, call open(path, 'rb') yourself."
+        )
+    if isinstance(file_input, Path):
+        # pathlib.Path is a Python-level type that HTTP form values can't
+        # fabricate. Treat as a local file path for SDK ergonomics.
         file_path = str(file_input)
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
@@ -417,7 +433,7 @@ def convert_file_document_to_url_document(document: Dict[str, Any]) -> Dict[str,
     else:
         raise ValueError(
             f"Unsupported file input type: {type(file_input)}. "
-            "Expected str (file path), pathlib.Path, bytes, or a file-like object."
+            "Expected pathlib.Path, bytes, or a file-like object."
         )
 
     if not file_bytes:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for LiteLLM core request handling and provider support."""
+
 # from __future__ import annotations must be the first non-comment statement
 from __future__ import annotations
 
@@ -9488,6 +9490,60 @@ def get_non_default_completion_params(kwargs: dict) -> dict:
     }  # model-specific params - pass them straight to the model/provider
 
     return non_default_params
+
+
+def peek_reasoning_summary_aliases(optional_params: dict) -> Optional[Any]:
+    """Read AI-SDK-style reasoning summary from optional_params or nested extra_body."""
+    rs = optional_params.get("reasoningSummary") or optional_params.get(
+        "reasoning_summary"
+    )
+    if rs is not None:
+        return rs
+    extra_body = optional_params.get("extra_body")
+    if isinstance(extra_body, dict):
+        return extra_body.get("reasoningSummary") or extra_body.get("reasoning_summary")
+    return None
+
+
+def strip_reasoning_summary_aliases_from_optional_params(
+    optional_params: dict,
+) -> Tuple[dict, Optional[Any]]:
+    """Copy optional_params; remove reasoningSummary aliases from top-level and extra_body."""
+    op = dict(optional_params)
+    rs_val = op.pop("reasoningSummary", None)
+    if rs_val is None:
+        rs_val = op.pop("reasoning_summary", None)
+    eb = op.get("extra_body")
+    if isinstance(eb, dict):
+        eb = dict(eb)
+        if rs_val is None:
+            rs_val = eb.pop("reasoningSummary", None) or eb.pop(
+                "reasoning_summary", None
+            )
+        else:
+            eb.pop("reasoningSummary", None)
+            eb.pop("reasoning_summary", None)
+        if eb:
+            op["extra_body"] = eb
+        else:
+            op.pop("extra_body", None)
+    return op, rs_val
+
+
+def strip_reasoning_summary_aliases_from_openai_completion_params(
+    non_default_params: dict,
+    optional_params: dict,
+) -> None:
+    """Drop AI-SDK reasoning summary keys from chat completion param dicts (in-place).
+
+    These aliases are not valid on OpenAI Chat Completions and may appear on
+    ``non_default_params`` or ``optional_params`` (including nested ``extra_body``).
+    """
+    non_default_params.pop("reasoningSummary", None)
+    non_default_params.pop("reasoning_summary", None)
+    stripped, _ = strip_reasoning_summary_aliases_from_optional_params(optional_params)
+    optional_params.clear()
+    optional_params.update(stripped)
 
 
 def get_non_default_transcription_params(kwargs: dict) -> dict:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9493,18 +9493,20 @@ def get_non_default_completion_params(kwargs: dict) -> dict:
 
 
 def peek_reasoning_summary_aliases(optional_params: dict) -> Optional[Any]:
-    """Read AI-SDK-style reasoning summary from optional_params or nested extra_body."""
-    rs = optional_params.get("reasoningSummary")
-    if rs is None:
-        rs = optional_params.get("reasoning_summary")
-    if rs is not None:
-        return rs
+    """Read AI-SDK-style reasoning summary from optional_params or nested extra_body.
+
+    Uses key membership (not ``or`` chains) so falsy values like ``""`` are not skipped.
+    """
+    if "reasoningSummary" in optional_params:
+        return optional_params["reasoningSummary"]
+    if "reasoning_summary" in optional_params:
+        return optional_params["reasoning_summary"]
     extra_body = optional_params.get("extra_body")
     if isinstance(extra_body, dict):
-        rs = extra_body.get("reasoningSummary")
-        if rs is None:
-            rs = extra_body.get("reasoning_summary")
-        return rs
+        if "reasoningSummary" in extra_body:
+            return extra_body["reasoningSummary"]
+        if "reasoning_summary" in extra_body:
+            return extra_body["reasoning_summary"]
     return None
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9494,14 +9494,17 @@ def get_non_default_completion_params(kwargs: dict) -> dict:
 
 def peek_reasoning_summary_aliases(optional_params: dict) -> Optional[Any]:
     """Read AI-SDK-style reasoning summary from optional_params or nested extra_body."""
-    rs = optional_params.get("reasoningSummary") or optional_params.get(
-        "reasoning_summary"
-    )
+    rs = optional_params.get("reasoningSummary")
+    if rs is None:
+        rs = optional_params.get("reasoning_summary")
     if rs is not None:
         return rs
     extra_body = optional_params.get("extra_body")
     if isinstance(extra_body, dict):
-        return extra_body.get("reasoningSummary") or extra_body.get("reasoning_summary")
+        rs = extra_body.get("reasoningSummary")
+        if rs is None:
+            rs = extra_body.get("reasoning_summary")
+        return rs
     return None
 
 
@@ -9511,18 +9514,18 @@ def strip_reasoning_summary_aliases_from_optional_params(
     """Copy optional_params; remove reasoningSummary aliases from top-level and extra_body."""
     op = dict(optional_params)
     rs_val = op.pop("reasoningSummary", None)
+    snake_rs_val = op.pop("reasoning_summary", None)
     if rs_val is None:
-        rs_val = op.pop("reasoning_summary", None)
+        rs_val = snake_rs_val
     eb = op.get("extra_body")
     if isinstance(eb, dict):
         eb = dict(eb)
+        eb_rs_val = eb.pop("reasoningSummary", None)
+        eb_snake_rs_val = eb.pop("reasoning_summary", None)
         if rs_val is None:
-            rs_val = eb.pop("reasoningSummary", None) or eb.pop(
-                "reasoning_summary", None
-            )
-        else:
-            eb.pop("reasoningSummary", None)
-            eb.pop("reasoning_summary", None)
+            rs_val = eb_rs_val
+            if rs_val is None:
+                rs_val = eb_snake_rs_val
         if eb:
             op["extra_body"] = eb
         else:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9533,22 +9533,6 @@ def strip_reasoning_summary_aliases_from_optional_params(
     return op, rs_val
 
 
-def strip_reasoning_summary_aliases_from_openai_completion_params(
-    non_default_params: dict,
-    optional_params: dict,
-) -> None:
-    """Drop AI-SDK reasoning summary keys from chat completion param dicts (in-place).
-
-    These aliases are not valid on OpenAI Chat Completions and may appear on
-    ``non_default_params`` or ``optional_params`` (including nested ``extra_body``).
-    """
-    non_default_params.pop("reasoningSummary", None)
-    non_default_params.pop("reasoning_summary", None)
-    stripped, _ = strip_reasoning_summary_aliases_from_optional_params(optional_params)
-    optional_params.clear()
-    optional_params.update(stripped)
-
-
 def get_non_default_transcription_params(kwargs: dict) -> dict:
     from litellm.constants import OPENAI_TRANSCRIPTION_PARAMS
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -492,3 +492,57 @@ def test_update_messages_with_model_file_ids_tolerates_non_dict_content_items():
         update_messages_with_model_file_ids(messages_token_ids_batch, "model-A", {})
         == messages_token_ids_batch
     )
+
+
+class TestExtractFileDataBareStr:
+    """``extract_file_data`` used to accept bare ``str`` values and ``open()``
+    them server-side. When the helper runs inside a proxy request handler the
+    value is attacker-controlled, so the open() call was a textbook arbitrary
+    local file read. Lock the new contract: bare ``str`` is rejected with a
+    clear migration message; ``pathlib.Path`` is still accepted for SDK
+    ergonomics because it's a Python-level type that HTTP form values can't
+    fabricate."""
+
+    def test_rejects_bare_str(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+
+        with pytest.raises(ValueError, match="does not accept bare str inputs"):
+            extract_file_data("/etc/passwd")
+
+    def test_accepts_pathlib_path(self):
+        import tempfile
+        from pathlib import Path
+
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+
+        content = b"hello"
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(content)
+            tmp_path = Path(f.name)
+
+        try:
+            extracted = extract_file_data(tmp_path)
+            assert extracted.get("content") == content
+        finally:
+            os.unlink(str(tmp_path))
+
+    def test_accepts_bytes(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+
+        extracted = extract_file_data(b"raw bytes content")
+        assert extracted.get("content") == b"raw bytes content"
+
+    def test_accepts_tuple(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+
+        extracted = extract_file_data(("foo.txt", b"raw bytes content"))
+        assert extracted.get("filename") == "foo.txt"
+        assert extracted.get("content") == b"raw bytes content"

--- a/tests/test_litellm/litellm_core_utils/test_audio_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_audio_utils.py
@@ -42,8 +42,10 @@ class TestProcessAudioFile:
         assert result.filename == "audio.wav"
         assert result.content_type == "audio/wav"
 
-    def test_process_file_path_input(self):
-        """Test processing file path input"""
+    def test_process_pathlib_input(self):
+        """pathlib.Path is a Python-level type HTTP form values can't fabricate."""
+        from pathlib import Path
+
         test_content = b"test audio content"
 
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as temp_file:
@@ -51,14 +53,21 @@ class TestProcessAudioFile:
             temp_file_path = temp_file.name
 
         try:
-            result = process_audio_file(temp_file_path)
+            result = process_audio_file(Path(temp_file_path))
 
             assert isinstance(result, ProcessedAudioFile)
             assert result.file_content == test_content
             assert result.filename == os.path.basename(temp_file_path)
-            assert result.content_type == "audio/mpeg"  # .mp3 should map to audio/mpeg
+            assert result.content_type == "audio/mpeg"
         finally:
             os.unlink(temp_file_path)
+
+    def test_process_bare_str_path_rejected(self):
+        """Bare str paths are rejected — when this runs in a proxy request
+        handler the value is attacker-controlled, and opening it as a path
+        is an arbitrary local file read."""
+        with pytest.raises(ValueError, match="does not accept bare str inputs"):
+            process_audio_file("/etc/passwd")
 
     def test_process_tuple_input_with_bytes(self):
         """Test processing tuple input with bytes content"""
@@ -73,8 +82,10 @@ class TestProcessAudioFile:
         assert result.filename == filename
         assert result.content_type == "audio/wav"
 
-    def test_process_tuple_input_with_file_path(self):
-        """Test processing tuple input with file path content"""
+    def test_process_tuple_input_with_pathlib_content(self):
+        """Tuple input with pathlib.Path content is allowed; bare str content is not."""
+        from pathlib import Path
+
         test_content = b"test audio content"
 
         with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as temp_file:
@@ -83,7 +94,7 @@ class TestProcessAudioFile:
 
         try:
             filename = "custom_name.flac"
-            audio_tuple = (filename, temp_file_path)
+            audio_tuple = (filename, Path(temp_file_path))
 
             result = process_audio_file(audio_tuple)
 

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -94,27 +94,33 @@ def test_github_copilot_config_get_openai_compatible_provider_info():
 
 
 @patch("litellm.llms.github_copilot.authenticator.Authenticator.get_api_key")
+@patch("litellm.main.openai_chat_completions.completion")
 @patch("litellm.llms.openai.openai.OpenAIChatCompletion.completion")
-def test_completion_github_copilot_mock_response(mock_completion, mock_get_api_key):
+def test_completion_github_copilot_mock_response(
+    mock_class_completion, mock_instance_completion, mock_get_api_key, monkeypatch
+):
     """Test the completion function with GitHub Copilot provider."""
 
-    # Mock the API key return value
+    # Force chat path through the patched openai_chat_completions instance even if
+    # a previous test left EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER set in the env.
+    monkeypatch.delenv("EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER", raising=False)
+
     mock_api_key = "gh.test-key-123456789"
     mock_get_api_key.return_value = mock_api_key
 
-    # Mock completion response
     mock_response = MagicMock()
     mock_response.choices = [MagicMock()]
     mock_response.choices[0].message.content = "Hello, I'm GitHub Copilot!"
-    mock_completion.return_value = mock_response
+    # Patch both the class method and the live module-level instance to survive
+    # conftest module reloads that can swap which class object is in use.
+    mock_class_completion.return_value = mock_response
+    mock_instance_completion.return_value = mock_response
 
-    # Test non-streaming completion
     messages = [
         {"role": "system", "content": "You're GitHub Copilot, an AI assistant."},
         {"role": "user", "content": "Hello, who are you?"},
     ]
 
-    # Create a properly formatted headers dictionary
     headers = {
         "editor-version": "Neovim/0.9.0",
         "Copilot-Integration-Id": "vscode-chat",
@@ -128,19 +134,16 @@ def test_completion_github_copilot_mock_response(mock_completion, mock_get_api_k
 
     assert response is not None
 
-    # Verify the get_api_key call was made (can be called multiple times)
     assert mock_get_api_key.call_count >= 1
 
-    # Verify the completion call was made with the expected params
-    mock_completion.assert_called_once()
-    args, kwargs = mock_completion.call_args
+    # Exactly one of the two patched targets should have been used.
+    invoked = [m for m in (mock_class_completion, mock_instance_completion) if m.called]
+    assert len(invoked) == 1
+    invoked[0].assert_called_once()
+    _, kwargs = invoked[0].call_args
 
-    # Check that the proper authorization header is set
     assert "headers" in kwargs
-    # Check that the model name is correctly formatted
-    assert (
-        kwargs.get("model") == "gpt-4"
-    )  # Model name should be without provider prefix
+    assert kwargs.get("model") == "gpt-4"
     assert kwargs.get("messages") == messages
 
 

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1031,7 +1031,6 @@ def test_gpt5_chat_strips_reasoning_summary_aliases_after_bridge_check(
     litellm.completion(
         model="gpt-5",
         messages=[{"role": "user", "content": "ok"}],
-        reasoning_effort="medium",
         reasoningSummary="auto",
         extra_body={"reasoning_summary": "ignored", "metadata": "ok"},
         api_key="fake-key",

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1,6 +1,7 @@
 import pytest
 
 import litellm
+import litellm.main as litellm_main
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai.openai import OpenAIConfig
@@ -1011,32 +1012,35 @@ def test_gpt5_search_drops_unsupported_params(config: OpenAIConfig):
     assert "tools" not in params
 
 
-def test_gpt5_search_strips_reasoning_summary_aliases(gpt5_config: OpenAIGPT5Config):
-    """Search models still strip Responses-only reasoning summary aliases."""
-    non_default_params = {
-        "reasoningSummary": "auto",
-        "reasoning_summary": "ignored",
-    }
-    optional_params = {
-        "extra_body": {
-            "reasoningSummary": "auto",
-            "reasoning_summary": "ignored",
-            "metadata": "ok",
-        }
-    }
+def test_gpt5_chat_strips_reasoning_summary_aliases_after_bridge_check(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-bridged GPT-5 chat calls strip Responses-only reasoning summary aliases."""
+    captured_kwargs = {}
 
-    params = gpt5_config.map_openai_params(
-        non_default_params=non_default_params,
-        optional_params=optional_params,
-        model="gpt-5-search-api",
-        drop_params=False,
+    def fake_openai_completion(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(
+        litellm_main.openai_chat_completions,
+        "completion",
+        fake_openai_completion,
     )
 
-    assert "reasoningSummary" not in non_default_params
-    assert "reasoning_summary" not in non_default_params
-    assert "reasoningSummary" not in params
-    assert "reasoning_summary" not in params
-    assert params["extra_body"] == {"metadata": "ok"}
+    litellm.completion(
+        model="gpt-5",
+        messages=[{"role": "user", "content": "ok"}],
+        reasoning_effort="medium",
+        reasoningSummary="auto",
+        extra_body={"reasoning_summary": "ignored", "metadata": "ok"},
+        api_key="fake-key",
+    )
+
+    optional_params = captured_kwargs["optional_params"]
+    assert "reasoningSummary" not in optional_params
+    assert "reasoning_summary" not in optional_params
+    assert optional_params["extra_body"] == {"metadata": "ok"}
 
 
 def test_reasoning_summary_alias_helpers_preserve_falsy_and_strip_all_aliases():

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -4,7 +4,11 @@ import litellm
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai.openai import OpenAIConfig
-from litellm.utils import _is_explicitly_disabled_factory
+from litellm.utils import (
+    _is_explicitly_disabled_factory,
+    peek_reasoning_summary_aliases,
+    strip_reasoning_summary_aliases_from_optional_params,
+)
 
 
 @pytest.fixture()
@@ -1005,6 +1009,74 @@ def test_gpt5_search_drops_unsupported_params(config: OpenAIConfig):
     assert "n" not in params
     assert "temperature" not in params
     assert "tools" not in params
+
+
+def test_gpt5_search_strips_reasoning_summary_aliases(gpt5_config: OpenAIGPT5Config):
+    """Search models still strip Responses-only reasoning summary aliases."""
+    non_default_params = {
+        "reasoningSummary": "auto",
+        "reasoning_summary": "ignored",
+    }
+    optional_params = {
+        "extra_body": {
+            "reasoningSummary": "auto",
+            "reasoning_summary": "ignored",
+            "metadata": "ok",
+        }
+    }
+
+    params = gpt5_config.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+        model="gpt-5-search-api",
+        drop_params=False,
+    )
+
+    assert "reasoningSummary" not in non_default_params
+    assert "reasoning_summary" not in non_default_params
+    assert "reasoningSummary" not in params
+    assert "reasoning_summary" not in params
+    assert params["extra_body"] == {"metadata": "ok"}
+
+
+def test_reasoning_summary_alias_helpers_preserve_falsy_and_strip_all_aliases():
+    optional_params = {"reasoningSummary": False, "reasoning_summary": "ignored"}
+
+    assert peek_reasoning_summary_aliases(optional_params) is False
+    stripped, rs_val = strip_reasoning_summary_aliases_from_optional_params(
+        optional_params
+    )
+
+    assert rs_val is False
+    assert stripped == {}
+
+    optional_params = {
+        "extra_body": {"reasoningSummary": False, "reasoning_summary": "ignored"}
+    }
+
+    assert peek_reasoning_summary_aliases(optional_params) is False
+    stripped, rs_val = strip_reasoning_summary_aliases_from_optional_params(
+        optional_params
+    )
+
+    assert rs_val is False
+    assert stripped == {}
+
+    optional_params = {
+        "extra_body": {
+            "reasoningSummary": "auto",
+            "reasoning_summary": "ignored",
+            "metadata": "ok",
+        }
+    }
+
+    assert peek_reasoning_summary_aliases(optional_params) == "auto"
+    stripped, rs_val = strip_reasoning_summary_aliases_from_optional_params(
+        optional_params
+    )
+
+    assert rs_val == "auto"
+    assert stripped == {"extra_body": {"metadata": "ok"}}
 
 
 # GPT-5 unsupported params audit (validated via direct API calls)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1454,40 +1454,34 @@ def test_extract_file_data_with_path_object():
         os.unlink(tmp_path)
 
 
-def test_extract_file_data_with_string_path():
-    """Test that filename is correctly extracted from string paths."""
+def test_extract_file_data_with_pathlib_path():
+    """Test that filename is correctly extracted from pathlib.Path inputs.
+    Bare str paths are rejected — when this runs in a proxy request handler
+    the value is attacker-controlled and opening it as a path is an LFI."""
     import os
     import tempfile
+    from pathlib import Path
 
     from litellm.litellm_core_utils.prompt_templates.common_utils import (
         extract_file_data,
     )
 
-    # Create a temporary WAV file
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
         tmp.write(b"fake wav content")
-        tmp_path = tmp.name
+        tmp_path = Path(tmp.name)
 
     try:
-        # Test with string path
         extracted = extract_file_data(tmp_path)
 
-        # Verify filename was extracted
         assert extracted["filename"] is not None
         assert extracted["filename"].endswith(".wav")
-
-        # Verify MIME type was correctly detected (can be audio/wav or audio/x-wav depending on system)
         assert extracted["content_type"] in [
             "audio/wav",
             "audio/x-wav",
         ], f"Expected 'audio/wav' or 'audio/x-wav' but got '{extracted['content_type']}'"
-
-        # Verify content was read
         assert extracted["content"] == b"fake wav content"
-
     finally:
-        # Clean up temporary file
-        os.unlink(tmp_path)
+        os.unlink(str(tmp_path))
 
 
 def test_extract_file_data_with_tuple_format():
@@ -1510,35 +1504,29 @@ def test_extract_file_data_with_tuple_format():
 
 
 def test_extract_file_data_fallback_to_octet_stream():
-    """Test that unknown file types fall back to application/octet-stream."""
+    """Unknown file types fall back to application/octet-stream."""
     import os
     import tempfile
+    from pathlib import Path
 
     from litellm.litellm_core_utils.prompt_templates.common_utils import (
         extract_file_data,
     )
 
-    # Create a temporary file with unknown extension
     with tempfile.NamedTemporaryFile(suffix=".xyz123", delete=False) as tmp:
         tmp.write(b"unknown content")
-        tmp_path = tmp.name
+        tmp_path = Path(tmp.name)
 
     try:
-        # Test with unknown file type
         extracted = extract_file_data(tmp_path)
 
-        # Verify filename was extracted
         assert extracted["filename"] is not None
         assert extracted["filename"].endswith(".xyz123")
-
-        # Verify MIME type falls back to octet-stream
         assert (
             extracted["content_type"] == "application/octet-stream"
         ), f"Expected 'application/octet-stream' for unknown type, got '{extracted['content_type']}'"
-
     finally:
-        # Clean up temporary file
-        os.unlink(tmp_path)
+        os.unlink(str(tmp_path))
 
 
 def test_convert_tool_response_with_pdf_file():

--- a/tests/test_litellm/ocr/test_ocr_file_input.py
+++ b/tests/test_litellm/ocr/test_ocr_file_input.py
@@ -60,14 +60,15 @@ class TestGetMimeType:
 
 
 class TestConvertFileDocumentToUrlDocument:
-    def test_should_convert_pdf_file_path_to_document_url(self):
-        """File path to a PDF should produce type=document_url with base64 data URI."""
+    def test_should_convert_pdf_pathlib_path_to_document_url(self):
+        """pathlib.Path to a PDF should produce type=document_url with base64 data URI.
+        Bare str paths are rejected — see test_should_reject_bare_str_path below."""
         pdf_content = b"%PDF-1.4 test content"
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
             f.write(pdf_content)
             f.flush()
-            tmp_path = f.name
+            tmp_path = Path(f.name)
 
         try:
             result = convert_file_document_to_url_document(
@@ -80,16 +81,16 @@ class TestConvertFileDocumentToUrlDocument:
             b64_data = result["document_url"].split(";base64,")[1]
             assert base64.b64decode(b64_data) == pdf_content
         finally:
-            os.unlink(tmp_path)
+            os.unlink(str(tmp_path))
 
-    def test_should_convert_image_file_path_to_image_url(self):
-        """File path to a PNG image should produce type=image_url with base64 data URI."""
+    def test_should_convert_image_pathlib_path_to_image_url(self):
+        """pathlib.Path to a PNG image should produce type=image_url with base64 data URI."""
         png_content = b"\x89PNG\r\n\x1a\n fake png content"
 
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             f.write(png_content)
             f.flush()
-            tmp_path = f.name
+            tmp_path = Path(f.name)
 
         try:
             result = convert_file_document_to_url_document(
@@ -102,7 +103,16 @@ class TestConvertFileDocumentToUrlDocument:
             b64_data = result["image_url"].split(";base64,")[1]
             assert base64.b64decode(b64_data) == png_content
         finally:
-            os.unlink(tmp_path)
+            os.unlink(str(tmp_path))
+
+    def test_should_reject_bare_str_path(self):
+        """Bare str ``file`` values are rejected — when this runs in a proxy
+        request handler the value is attacker-controlled, and opening it as
+        a path is an arbitrary local file read on the proxy host."""
+        with pytest.raises(ValueError, match="does not accept bare str values"):
+            convert_file_document_to_url_document(
+                {"type": "file", "file": "/etc/passwd"}
+            )
 
     def test_should_convert_pathlib_path(self):
         """pathlib.Path objects should work the same as string paths."""
@@ -189,17 +199,17 @@ class TestConvertFileDocumentToUrlDocument:
         with pytest.raises(ValueError, match="must include a 'file' field"):
             convert_file_document_to_url_document({"type": "file"})
 
-    def test_should_raise_error_for_nonexistent_file_path(self):
-        """Non-existent file path should raise FileNotFoundError."""
+    def test_should_raise_error_for_nonexistent_pathlib_path(self):
+        """Non-existent pathlib.Path should raise FileNotFoundError."""
         with pytest.raises(FileNotFoundError, match="File not found"):
             convert_file_document_to_url_document(
-                {"type": "file", "file": "/nonexistent/path/to/file.pdf"}
+                {"type": "file", "file": Path("/nonexistent/path/to/file.pdf")}
             )
 
     def test_should_raise_error_for_empty_file(self):
         """Empty file should raise ValueError."""
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            tmp_path = f.name
+            tmp_path = Path(f.name)
 
         try:
             with pytest.raises(ValueError, match="File is empty"):
@@ -207,7 +217,7 @@ class TestConvertFileDocumentToUrlDocument:
                     {"type": "file", "file": tmp_path}
                 )
         finally:
-            os.unlink(tmp_path)
+            os.unlink(str(tmp_path))
 
     def test_should_raise_error_for_unsupported_type(self):
         """Unsupported file input types should raise ValueError."""
@@ -226,14 +236,14 @@ class TestConvertFileDocumentToUrlDocument:
                 }
             )
 
-    def test_should_override_mime_type_for_file_path(self):
+    def test_should_override_mime_type_for_pathlib_path(self):
         """Explicit mime_type should override auto-detection from extension."""
         content = b"some content"
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
             f.write(content)
             f.flush()
-            tmp_path = f.name
+            tmp_path = Path(f.name)
 
         try:
             result = convert_file_document_to_url_document(
@@ -243,7 +253,7 @@ class TestConvertFileDocumentToUrlDocument:
             assert result["type"] == "image_url"
             assert result["image_url"].startswith("data:image/png;base64,")
         finally:
-            os.unlink(tmp_path)
+            os.unlink(str(tmp_path))
 
 
 class TestBuildDocumentFromUpload:

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -876,6 +876,30 @@ def test_gpt_5_4_responses_bridge_merges_reasoning_summary_kwarg_without_tools(
 
 
 @patch("litellm.completion_extras.responses_api_bridge.completion")
+def test_responses_bridge_preserves_reasoning_summary_without_effort(
+    mock_responses_completion,
+):
+    """Reasoning summary should survive responses routing even without effort."""
+    mock_responses_completion.return_value = MagicMock()
+
+    import litellm
+
+    with patch.object(litellm, "route_all_chat_openai_to_responses", True):
+        litellm.completion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "ok"}],
+            reasoningSummary="auto",
+            api_key="fake-key",
+        )
+
+    assert mock_responses_completion.called is True
+    optional_params = mock_responses_completion.call_args.kwargs["optional_params"]
+    assert optional_params["reasoning_effort"] == {"summary": "auto"}
+    assert "reasoningSummary" not in optional_params
+    assert "reasoning_summary" not in optional_params
+
+
+@patch("litellm.completion_extras.responses_api_bridge.completion")
 def test_gpt_5_responses_bridge_tools_and_reasoning_summary(
     mock_responses_completion,
 ):

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -757,6 +757,24 @@ def test_responses_api_bridge_check_gpt_5_4_tools_without_reasoning_stays_chat()
     assert model_info.get("mode") != "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_4_reasoning_summary_without_tools_routes_to_responses():
+    """gpt-5.4+ with reasoning_effort + reasoningSummary but no tools should bridge (AI SDK)."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            tools=None,
+            reasoning_effort="medium",
+            reasoning_summary="auto",
+        )
+
+    assert model == "gpt-5.4"
+    assert model_info.get("mode") == "responses"
+
+
 @patch("litellm.completion_extras.responses_api_bridge.completion")
 def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
     mock_responses_completion,
@@ -792,6 +810,33 @@ def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
         "effort": "xhigh",
         "summary": "detailed",
     }
+
+
+@patch("litellm.completion_extras.responses_api_bridge.completion")
+def test_gpt_5_4_responses_bridge_merges_reasoning_summary_kwarg_without_tools(
+    mock_responses_completion,
+):
+    """reasoningSummary without tools should route and merge into reasoning_effort dict."""
+    mock_responses_completion.return_value = MagicMock()
+
+    import litellm
+
+    litellm.completion(
+        model="gpt-5.4",
+        messages=[{"role": "user", "content": "ok"}],
+        reasoning_effort="medium",
+        reasoningSummary="auto",
+        api_key="fake-key",
+    )
+
+    assert mock_responses_completion.called is True
+    optional_params = mock_responses_completion.call_args.kwargs["optional_params"]
+    assert optional_params["reasoning_effort"] == {
+        "effort": "medium",
+        "summary": "auto",
+    }
+    assert "reasoningSummary" not in optional_params
+    assert "reasoning_summary" not in optional_params
 
 
 def test_responses_api_bridge_check_handles_exception():

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -775,6 +775,42 @@ def test_responses_api_bridge_check_gpt_5_4_reasoning_summary_without_tools_rout
     assert model_info.get("mode") == "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_reasoning_summary_routes_to_responses():
+    """Bare ``gpt-5`` with reasoning_effort + reasoningSummary should bridge (not 5.4+)."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5",
+            custom_llm_provider="openai",
+            tools=None,
+            reasoning_effort="medium",
+            reasoning_summary="auto",
+        )
+
+    assert model == "gpt-5"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_tools_without_summary_stays_chat():
+    """gpt-5 with tools + reasoning_effort but no summary should stay on chat."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="medium",
+            reasoning_summary=None,
+        )
+
+    assert model == "gpt-5"
+    assert model_info.get("mode") != "responses"
+
+
 @patch("litellm.completion_extras.responses_api_bridge.completion")
 def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
     mock_responses_completion,
@@ -837,6 +873,42 @@ def test_gpt_5_4_responses_bridge_merges_reasoning_summary_kwarg_without_tools(
     }
     assert "reasoningSummary" not in optional_params
     assert "reasoning_summary" not in optional_params
+
+
+@patch("litellm.completion_extras.responses_api_bridge.completion")
+def test_gpt_5_responses_bridge_tools_and_reasoning_summary(
+    mock_responses_completion,
+):
+    """Bare gpt-5 with tools + reasoningSummary should bridge (OpenCode-style)."""
+    mock_responses_completion.return_value = MagicMock()
+
+    import litellm
+
+    litellm.completion(
+        model="gpt-5",
+        messages=[{"role": "user", "content": "ok"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "apply_patch",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        tool_choice="auto",
+        reasoning_effort="medium",
+        reasoningSummary="auto",
+        stream=True,
+        api_key="fake-key",
+    )
+
+    assert mock_responses_completion.called is True
+    optional_params = mock_responses_completion.call_args.kwargs["optional_params"]
+    assert optional_params.get("reasoning_effort") == {
+        "effort": "medium",
+        "summary": "auto",
+    }
 
 
 def test_responses_api_bridge_check_handles_exception():


### PR DESCRIPTION
## Type

🐛 Bug Fix
✅ Test

## Changes

`extract_file_data`, `audio_utils.process_audio_file` (plus its tuple-content variant), `audio_utils.calculate_request_duration`, and the OCR `_extract_file_metadata` helpers accepted `isinstance(x, (str, PathLike))` inputs and called `open(x, "rb")` on them. When these helpers run inside a proxy request handler the value comes from an attacker-controlled HTTP form field, so the `open()` is an arbitrary local file read on the proxy host — the file content is then forwarded to the upstream provider and base64-encoded into the response, giving the caller an exfiltration primitive (incl. `/proc/self/environ` for env-stored secrets).

Drop the `str` branch from the path-open union at every sink and raise `ValueError` with a clear migration message. `pathlib.Path` is preserved because it's a Python-level type HTTP form values can't fabricate. The same shape was already in place for the Black Forest Labs image-edit handler — this brings the rest of the file/audio/ocr pipeline in line.

Affected sinks (all in the litellm core, not provider-specific):

- `litellm/litellm_core_utils/prompt_templates/common_utils.py:extract_file_data`
- `litellm/litellm_core_utils/audio_utils/utils.py:process_audio_file` (and the tuple-content sub-branch)
- `litellm/litellm_core_utils/audio_utils/utils.py:calculate_request_duration`
- `litellm/litellm_core_utils/audio_utils/utils.py:get_audio_file_content_hash` (bare str now hashes the string itself rather than opening it — the hash function already had this fallback shape)
- `litellm/ocr/main.py:_extract_file_metadata` (also used by `convert_file_document_to_url_document`, the path the OCR proxy endpoint takes for `{"type": "file", "file": ...}` documents)

Variants checked and confirmed already safe in current code (no change needed):

- BFL image-edit handler — raises for non-URL strings, uses `safe_get` for URLs
- Bedrock Nova Canvas image-edit — `str` branch returns base64 as-is, only `PathLike` opens
- Bedrock and Vertex batch files transformations — `str` branch treats as JSONL content, only `PathLike` opens

## Compatibility

- **Operators**: unaffected. The proxy form parser converts multipart `UploadFile` into the tuple shape these helpers accept; nothing in the proxy path supplied bare strings.
- **SDK callers passing `file=open("path", "rb")` / `file=("name", content)` / `file=Path("path")` / `file=b"..."`**: unaffected. Every documented example in `BerriAI/litellm-docs` already uses one of these shapes.
- **SDK callers passing `file="literal/path.csv"` as a bare string**: minor breaking change. Get a `ValueError` pointing to the fix. Migrate to `file=Path("literal/path.csv")` (6 extra characters) or `file=open("literal/path.csv", "rb")` (the OpenAI SDK convention litellm mimics).

## Test Plan

New / updated tests cover bare-str rejection at every patched sink plus the positive `Path()` path and existing tuple/bytes paths. Existing tests that passed bare-string paths to drive open() were updated to use `Path()`.

## Commits

- `chore: reject bare str at file-input sinks to prevent local-file read`
