### PR TITLE
fix(usage): remove timezone date-window expansion in aggregated dashboard

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
@@ -386,38 +386,20 @@ def _adjust_dates_for_timezone(
     timezone_offset_minutes: Optional[int],
 ) -> Tuple[str, str]:
     """
-    Adjust date range to account for timezone differences.
+    Return the date range unchanged.
 
-    The database stores dates in UTC. When a user in a different timezone
-    selects a local date range, we need to expand the UTC query range to
-    capture all records that fall within their local date range.
+    ``LiteLLM_DailyUserSpend.date`` is stored as a ``YYYY-MM-DD`` UTC string
+    at day granularity, and the UI formats ``start_date``/``end_date`` from
+    the browser's local year/month/day — so the strings already line up with
+    how rows are keyed. The previous ±1 day expansion pulled an adjacent UTC
+    day into the result set, inflating single-day totals for any non-UTC
+    user (e.g. IST users saw two days summed together).
 
-    Args:
-        start_date: Start date in YYYY-MM-DD format (user's local date)
-        end_date: End date in YYYY-MM-DD format (user's local date)
-        timezone_offset_minutes: Minutes behind UTC (positive = west of UTC)
-            This matches JavaScript's Date.getTimezoneOffset() convention.
-            For example: PST = +480 (8 hours * 60 = 480 minutes behind UTC)
-
-    Returns:
-        Tuple of (adjusted_start_date, adjusted_end_date) in YYYY-MM-DD format
+    ``timezone_offset_minutes`` is kept in the signature for compatibility
+    with callers; it is intentionally ignored.
     """
-    if timezone_offset_minutes is None or timezone_offset_minutes == 0:
-        return start_date, end_date
-
-    start = datetime.strptime(start_date, "%Y-%m-%d")
-    end = datetime.strptime(end_date, "%Y-%m-%d")
-
-    if timezone_offset_minutes > 0:
-        # West of UTC (Americas): local evening extends into next UTC day
-        # e.g., Feb 4 23:59 PST = Feb 5 07:59 UTC
-        end = end + timedelta(days=1)
-    else:
-        # East of UTC (Asia/Europe): local morning starts in previous UTC day
-        # e.g., Feb 4 00:00 IST = Feb 3 18:30 UTC
-        start = start - timedelta(days=1)
-
-    return start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")
+    del timezone_offset_minutes
+    return start_date, end_date
 
 
 def _build_where_conditions(

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -9,6 +9,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm.proxy.management_endpoints.common_daily_activity import (
+    _adjust_dates_for_timezone,
     _is_user_agent_tag,
     get_api_key_metadata,
     get_daily_activity,
@@ -55,6 +56,33 @@ async def test_get_daily_activity_empty_entity_id_list():
     # Check that team_id is set to empty list
     assert "team_id" in where_conditions
     assert where_conditions["team_id"] == {"in": []}
+
+
+@pytest.mark.parametrize(
+    "timezone_offset_minutes",
+    [
+        pytest.param(480, id="pst_west_of_utc"),
+        pytest.param(-330, id="ist_east_of_utc"),
+        pytest.param(0, id="utc"),
+        pytest.param(None, id="no_offset"),
+    ],
+)
+def test_adjust_dates_for_timezone_single_day_is_unchanged(timezone_offset_minutes):
+    # Regression: selecting a single local day in any timezone must keep the
+    # query window pinned to that one day. Previously, ±1 day was added based
+    # on the JS timezone offset, which inflated single-day totals on the
+    # aggregated usage dashboard for non-UTC users.
+    start, end = _adjust_dates_for_timezone(
+        "2026-04-15", "2026-04-15", timezone_offset_minutes
+    )
+    assert start == "2026-04-15"
+    assert end == "2026-04-15"
+
+
+def test_adjust_dates_for_timezone_multi_day_range_is_unchanged():
+    start, end = _adjust_dates_for_timezone("2026-04-10", "2026-04-15", -330)
+    assert start == "2026-04-10"
+    assert end == "2026-04-15"
 
 
 def test_is_user_agent_tag():


### PR DESCRIPTION
## Relevant issues

Standalone version of the date-expansion portion of #26810 so the fix can land independently of the workflow-runs work bundled in that PR.

## Linear ticket

Resolves LIT-2698

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Negative-control verification at the unit-test level. The new regression tests pin the exact arithmetic that drove the inflation — running them against the unmodified `_adjust_dates_for_timezone` reproduces the observed bug:

```
FAILED test_adjust_dates_for_timezone_single_day_is_unchanged[pst_west_of_utc]
  AssertionError: assert '2026-04-16' == '2026-04-15'
FAILED test_adjust_dates_for_timezone_single_day_is_unchanged[ist_east_of_utc]
  AssertionError: assert '2026-04-14' == '2026-04-15'
FAILED test_adjust_dates_for_timezone_multi_day_range_is_unchanged
```

After the fix, all five new tests pass (PST `+480`, IST `-330`, UTC `0`, `None`, multi-day range with non-UTC offset):

```
test_adjust_dates_for_timezone_single_day_is_unchanged[pst_west_of_utc] PASSED
test_adjust_dates_for_timezone_single_day_is_unchanged[ist_east_of_utc] PASSED
test_adjust_dates_for_timezone_single_day_is_unchanged[utc] PASSED
test_adjust_dates_for_timezone_single_day_is_unchanged[no_offset] PASSED
test_adjust_dates_for_timezone_multi_day_range_is_unchanged PASSED
```

Walking the patched function for a representative IST single-day case:

```
input                   → start_date="2026-04-15", end_date="2026-04-15", timezone_offset_minutes=-330
old behaviour           → start shifted to "2026-04-14" (east-of-UTC branch: start - timedelta(days=1))
                          downstream SQL "date >= start AND date <= end" then aggregates both 2026-04-14 and 2026-04-15
new behaviour           → passthrough → ("2026-04-15", "2026-04-15")
                          SQL aggregates only 2026-04-15
```

End-to-end dashboard reproduction was not run for this PR.

## Type

🐛 Bug Fix

## Changes

### Problem

`/user/daily/activity/aggregated` returns inflated totals for non-UTC users when the user selects a single local day. In IST (`timezone=-330`), selecting 15 Apr returns the sum of 14 Apr + 15 Apr; in PST (`timezone=+480`), selecting a day returns it plus the next UTC day. UTC users (`timezone=0`) are unaffected.

`_adjust_dates_for_timezone` in `common_daily_activity.py` expands the query window by ±1 day based on the JS `Date.getTimezoneOffset()` value sent by the browser:

```python
if timezone_offset_minutes > 0:
    end = end + timedelta(days=1)   # west of UTC
else:
    start = start - timedelta(days=1)   # east of UTC
```

The downstream SQL (`_build_aggregated_sql_query`) then applies `date >= start AND date <= end` against the expanded window and SUMs across the result via `GROUPING SETS`, never re-mapping rows back to the originally requested local day. The full adjacent UTC day is added to the totals.

The expansion logic is fundamentally flawed for this storage shape: `LiteLLM_DailyUserSpend.date` is a `YYYY-MM-DD` UTC string at day granularity, with no timestamp-level detail available to split a UTC day between two local days. The UI also already formats `start_date`/`end_date` from the browser's local year/month/day, so the dates sent by the frontend already line up with how rows are keyed.

### Fix

`litellm/proxy/management_endpoints/common_daily_activity.py`:

- `_adjust_dates_for_timezone` is now a no-op passthrough — returns `(start_date, end_date)` unchanged.
- Docstring updated to explain why the function is now a no-op (frontend already sends local-formatted dates that match the UTC `date` strings used as keys).
- Drop the now-unused `from datetime import timedelta`.
- `timezone_offset_minutes` is kept in the function signature for caller compatibility. The only callers are `_build_where_conditions` and `_build_aggregated_sql_query`, both inside this same file, both of which forward the parameter through. A follow-up can drop the parameter threading once this lands.

### Tests

`tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py`:

- `test_adjust_dates_for_timezone_single_day_is_unchanged` — parametrized over PST (`+480`), IST (`-330`), UTC (`0`), and `None`. Single-day selection must return exactly that day in every timezone.
- `test_adjust_dates_for_timezone_multi_day_range_is_unchanged` — multi-day range with a non-UTC offset (`-330`) passes through unchanged on both ends.

Targeted test file: `pytest tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py -v` → **16/16 passed**.

Wider `tests/test_litellm/proxy/management_endpoints/` scope: 1136 passed; 5 failures + 3 collection errors are in unrelated files (budget endpoints, key rotation, access groups, config overrides, workflow runs) that don't touch the changed code.

### Backwards compatibility / risk

- Function signature is unchanged — `timezone_offset_minutes` is still accepted, just ignored.
- Only two callers exist, both inside the same file; no external module imports this function.
- No schema, migration, or dependency changes.
- Single-commit revert if needed.