### PR TITLE
Fix Redis async increment TTL timeout path

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -55,6 +55,26 @@ else:
     Span = Any
 
 
+_ASYNC_INCREMENT_WITH_TTL_SCRIPT = """
+local new_value = redis.call('INCRBYFLOAT', KEYS[1], ARGV[1])
+local ttl = tonumber(ARGV[2])
+local refresh_ttl = ARGV[3] == '1'
+
+if ttl ~= nil and ttl > 0 then
+    if refresh_ttl then
+        redis.call('EXPIRE', KEYS[1], ttl)
+    else
+        local current_ttl = redis.call('TTL', KEYS[1])
+        if current_ttl == -1 then
+            redis.call('EXPIRE', KEYS[1], ttl)
+        end
+    end
+end
+
+return new_value
+"""
+
+
 def _get_call_stack_info(num_frames: int = 2) -> str:
     """
     Get the function names from the previous 1-2 functions in the call stack.
@@ -834,21 +854,23 @@ class RedisCache(BaseCache):
         parent_otel_span: Optional[Span] = None,
         refresh_ttl: bool = False,
     ) -> float:
-        from redis.asyncio import Redis
-
-        _redis_client: Redis = self.init_async_client()  # type: ignore
+        _redis_client: Any = self.init_async_client()
         start_time = time.time()
         _used_ttl = self.get_ttl(ttl=ttl)
         key = self.check_and_fix_namespace(key=key)
         try:
-            result = await _redis_client.incrbyfloat(name=key, amount=value)
-            if _used_ttl is not None:
-                if refresh_ttl:
-                    await _redis_client.expire(key, _used_ttl)
-                else:
-                    current_ttl = await _redis_client.ttl(key)
-                    if current_ttl == -1:
-                        await _redis_client.expire(key, _used_ttl)
+            if _used_ttl is None:
+                result = await _redis_client.incrbyfloat(name=key, amount=value)
+            else:
+                result = await _redis_client.eval(
+                    _ASYNC_INCREMENT_WITH_TTL_SCRIPT,
+                    1,
+                    key,
+                    value,
+                    _used_ttl,
+                    "1" if refresh_ttl else "0",
+                )
+                result = float(result)
 
             ## LOGGING ##
             end_time = time.time()

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,14 +1,14 @@
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
-from unittest.mock import AsyncMock
 
 from litellm.caching.redis_cache import RedisCache
 
@@ -29,6 +29,7 @@ async def test_redis_cache_async_increment(namespace, monkeypatch, redis_no_ping
     redis_cache = RedisCache(namespace=namespace)
     # Create an AsyncMock for the Redis client
     mock_redis_instance = AsyncMock()
+    mock_redis_instance.eval.return_value = b"1"
 
     # Make sure the mock can be used as an async context manager
     mock_redis_instance.__aenter__.return_value = mock_redis_instance
@@ -41,26 +42,77 @@ async def test_redis_cache_async_increment(namespace, monkeypatch, redis_no_ping
     with patch.object(
         redis_cache, "init_async_client", return_value=mock_redis_instance
     ):
-        # Call async_set_cache
         await redis_cache.async_increment(key=expected_key, value=1)
 
-        # Verify that the set method was called on the mock Redis instance
-        mock_redis_instance.incrbyfloat.assert_called_once_with(
-            name=expected_key, amount=1
+        mock_redis_instance.eval.assert_awaited_once()
+        assert mock_redis_instance.eval.await_args.args[2:] == (
+            expected_key,
+            1,
+            60,
+            "0",
         )
+        mock_redis_instance.incrbyfloat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_async_increment_uses_single_redis_call_for_default_ttl(
+    monkeypatch, redis_no_ping
+):
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.eval.return_value = b"1.25"
+    mock_redis_instance.ttl.side_effect = RedisTimeoutError(
+        "Timeout reading from redis"
+    )
+
+    with patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        result = await redis_cache.async_increment(key="spend:counter", value=1.25)
+
+    assert result == 1.25
+    mock_redis_instance.eval.assert_awaited_once()
+    mock_redis_instance.ttl.assert_not_awaited()
+    mock_redis_instance.expire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_async_increment_refresh_ttl_uses_single_redis_call(
+    monkeypatch, redis_no_ping
+):
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.eval.return_value = "2.5"
+    mock_redis_instance.expire.side_effect = RedisTimeoutError(
+        "Timeout reading from redis"
+    )
+
+    with patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        result = await redis_cache.async_increment(
+            key="spend:counter", value=1.25, refresh_ttl=True
+        )
+
+    assert result == 2.5
+    mock_redis_instance.eval.assert_awaited_once()
+    mock_redis_instance.ttl.assert_not_awaited()
+    mock_redis_instance.expire.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_redis_cache_async_increment_refresh_ttl_true_bumps_existing_ttl(
     monkeypatch, redis_no_ping
 ):
-    """With refresh_ttl=True, every increment should call expire() to bump
-    the TTL, even when the key already has a TTL (counter-style use)."""
+    """refresh_ttl=True tells the Redis-side increment script to bump the TTL."""
     monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
     redis_cache = RedisCache()
     mock_redis_instance = AsyncMock()
     mock_redis_instance.__aenter__.return_value = mock_redis_instance
     mock_redis_instance.__aexit__.return_value = None
+    mock_redis_instance.eval.return_value = b"0.05"
     mock_redis_instance.ttl.return_value = 42  # key already has ~42s left
 
     with patch.object(
@@ -70,20 +122,27 @@ async def test_redis_cache_async_increment_refresh_ttl_true_bumps_existing_ttl(
             key="spend:team_member:u:t", value=0.05, refresh_ttl=True
         )
 
-    mock_redis_instance.expire.assert_awaited_once_with("spend:team_member:u:t", 60)
+    mock_redis_instance.eval.assert_awaited_once()
+    assert mock_redis_instance.eval.await_args.args[2:] == (
+        "spend:team_member:u:t",
+        0.05,
+        60,
+        "1",
+    )
+    mock_redis_instance.expire.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_redis_cache_async_increment_default_does_not_bump_existing_ttl(
     monkeypatch, redis_no_ping
 ):
-    """Default (refresh_ttl=False) preserves window-style semantics: TTL is
-    set only on first creation, never refreshed (used by rate-limit windows)."""
+    """refresh_ttl=False tells the Redis-side script to preserve window TTLs."""
     monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
     redis_cache = RedisCache()
     mock_redis_instance = AsyncMock()
     mock_redis_instance.__aenter__.return_value = mock_redis_instance
     mock_redis_instance.__aexit__.return_value = None
+    mock_redis_instance.eval.return_value = b"1"
     mock_redis_instance.ttl.return_value = 42  # key already has ~42s left
 
     with patch.object(
@@ -91,6 +150,13 @@ async def test_redis_cache_async_increment_default_does_not_bump_existing_ttl(
     ):
         await redis_cache.async_increment(key="rate_limit:window", value=1)
 
+    mock_redis_instance.eval.assert_awaited_once()
+    assert mock_redis_instance.eval.await_args.args[2:] == (
+        "rate_limit:window",
+        1,
+        60,
+        "0",
+    )
     mock_redis_instance.expire.assert_not_awaited()
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`async_increment` could successfully mutate Redis and then fail on a follow-up TTL maintenance round trip, producing fallback warnings and ambiguous counter state. This changes TTL handling to run inside a single-key Redis script so increment plus expiry maintenance happen in one Redis call while preserving the existing refresh and non-refresh semantics.

## Repro
Call `async_increment` with a default TTL where the Redis increment succeeds but the subsequent TTL or expire call times out. Before this change, the method raises and callers fall back even though Redis may already have been incremented.

## Evidence
```bash
$ uv run pytest tests/test_litellm/caching/test_redis_cache.py tests/test_litellm/caching/test_redis_cluster_cache.py tests/test_litellm/caching/test_dual_cache.py -q
.................................................                        [100%]
=============================== warnings summary ===============================
tests/test_litellm/caching/test_redis_cache.py::test_handle_lpop_count_for_older_redis_versions
  /workspace/litellm/caching/redis_cache.py:1539: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    pipe.lpop(key)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
49 passed, 1 warning in 0.66s

$ (cd litellm && uv run --no-sync black --check --exclude /enterprise/ .)

$ (cd litellm && uv run --no-sync ruff check .)
All checks passed!

$ (cd litellm && uv run --no-sync mypy .)
Success: no issues found in 1945 source files
```

## Tests
- Added regression tests in `tests/test_litellm/caching/test_redis_cache.py` covering the single-call default-TTL path and refresh-TTL path.
- `uv run pytest tests/test_litellm/caching/test_redis_cache.py tests/test_litellm/caching/test_redis_cluster_cache.py tests/test_litellm/caching/test_dual_cache.py -q` -> 49 passed, 1 existing warning.
- `(cd litellm && uv run --no-sync black --check --exclude '/enterprise/' .)` -> passed.
- `(cd litellm && uv run --no-sync ruff check .)` -> passed.
- `(cd litellm && uv run --no-sync mypy .)` -> passed.
- `make test-unit` reached 4643 passed / 41 skipped before stopping on unrelated external-provider authentication failures in existing tests.

## CI
- GitHub Actions and granular CircleCI checks observed via PR checks are green, including `ci/circleci: redis_caching_unit_tests`, `lint`, unit shards, UI build, and Codecov patch.
- `ci/circleci: build_and_test` is the only observed failing aggregate status (`https://circleci.com/gh/BerriAI/litellm/1639541`). Detailed CircleCI logs were not available from this environment because the required CI API credential is unavailable; the public PR check list shows all granular CircleCI jobs green.

## Review
- No Greptile review was present after the post-PR wait, so there were no review threads to address.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1882949a-50c7-42e6-adc1-e1ddce4d10a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1882949a-50c7-42e6-adc1-e1ddce4d10a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

