### PR TITLE
Fix Bedrock batch datetime logging

### DIFF
--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import Any, Optional, cast
 
@@ -76,16 +77,14 @@ def _to_epoch(value: Any) -> Optional[int]:
 
 
 def _sanitize_response_for_logging(value: Any) -> Any:
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, dict):
-        return {
-            key: _sanitize_response_for_logging(response_value)
-            for key, response_value in value.items()
-        }
-    if isinstance(value, (list, tuple)):
-        return [_sanitize_response_for_logging(item) for item in value]
-    return value
+    def _default(obj: Any) -> Any:
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(
+            f"Object of type {obj.__class__.__name__} is not JSON serializable"
+        )
+
+    return json.loads(json.dumps(value, default=_default))
 
 
 class BedrockBatchesHandler:

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -75,6 +75,19 @@ def _to_epoch(value: Any) -> Optional[int]:
     return None
 
 
+def _sanitize_response_for_logging(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_response_for_logging(response_value)
+            for key, response_value in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_response_for_logging(item) for item in value]
+    return value
+
+
 class BedrockBatchesHandler:
     """
     Handler for Bedrock Batches.
@@ -270,7 +283,7 @@ class BedrockBatchesHandler:
             logging_obj.post_call(
                 input=batch_id,
                 api_key="",
-                original_response=response,
+                original_response=_sanitize_response_for_logging(response),
                 additional_args={"complete_input_dict": {"jobIdentifier": batch_id}},
             )
 

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -80,9 +80,7 @@ def _sanitize_response_for_logging(value: Any) -> Any:
     def _default(obj: Any) -> Any:
         if isinstance(obj, datetime):
             return obj.isoformat()
-        raise TypeError(
-            f"Object of type {obj.__class__.__name__} is not JSON serializable"
-        )
+        return str(obj)
 
     return json.loads(json.dumps(value, default=_default))
 

--- a/tests/test_litellm/llms/bedrock/batches/test_handler.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_handler.py
@@ -8,6 +8,7 @@ the tests don't hit AWS.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from datetime import datetime, timezone
@@ -22,6 +23,7 @@ from litellm.llms.bedrock.batches.handler import (  # noqa: E402
     _extract_job_id_from_arn,
     _extract_region_from_bedrock_arn,
     _predict_output_file_uri,
+    _sanitize_response_for_logging,
     _to_epoch,
 )
 
@@ -102,6 +104,27 @@ _DT = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc)
 )
 def test_to_epoch_handles_supported_types(value, expected):
     assert _to_epoch(value) == expected
+
+
+def test_sanitize_response_for_logging_converts_nested_datetimes():
+    response = {
+        "submitTime": SUBMIT_TIME,
+        "nested": {
+            "endTimes": [END_TIME],
+            "tupleTimes": (SUBMIT_TIME,),
+        },
+    }
+
+    sanitized_response = _sanitize_response_for_logging(response)
+
+    assert sanitized_response == {
+        "submitTime": SUBMIT_TIME.isoformat(),
+        "nested": {
+            "endTimes": [END_TIME.isoformat()],
+            "tupleTimes": [SUBMIT_TIME.isoformat()],
+        },
+    }
+    assert response["submitTime"] == SUBMIT_TIME
 
 
 def test_extract_job_id_from_arn():
@@ -301,6 +324,20 @@ def test_logging_obj_pre_and_post_call_invoked(patched_boto3):
     post_kwargs = logging_obj.post_call.call_args.kwargs
     assert post_kwargs["input"] == JOB_ARN
     assert post_kwargs["original_response"]["jobArn"] == JOB_ARN
+    assert post_kwargs["original_response"]["submitTime"] == SUBMIT_TIME.isoformat()
+
+
+def test_logging_obj_post_call_gets_json_serializable_response(patched_boto3):
+    class JsonSerializingLogger:
+        def pre_call(self, **kwargs):
+            pass
+
+        def post_call(self, **kwargs):
+            json.dumps(kwargs["original_response"])
+
+    BedrockBatchesHandler._handle_model_invocation_job_status(
+        batch_id=JOB_ARN, logging_obj=JsonSerializingLogger()
+    )
 
 
 def test_missing_boto3_raises_helpful_import_error():

--- a/tests/test_litellm/llms/bedrock/batches/test_handler.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_handler.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from decimal import Decimal
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -112,6 +113,7 @@ def test_sanitize_response_for_logging_converts_nested_datetimes():
         "nested": {
             "endTimes": [END_TIME],
             "tupleTimes": (SUBMIT_TIME,),
+            "cost": Decimal("1.25"),
         },
     }
 
@@ -122,9 +124,11 @@ def test_sanitize_response_for_logging_converts_nested_datetimes():
         "nested": {
             "endTimes": [END_TIME.isoformat()],
             "tupleTimes": [SUBMIT_TIME.isoformat()],
+            "cost": "1.25",
         },
     }
     assert response["submitTime"] == SUBMIT_TIME
+    json.dumps(sanitized_response)
 
 
 def test_extract_job_id_from_arn():
@@ -329,14 +333,21 @@ def test_logging_obj_pre_and_post_call_invoked(patched_boto3):
 
 def test_logging_obj_post_call_gets_json_serializable_response(patched_boto3):
     class JsonSerializingLogger:
+        serialized_response: str
+
         def pre_call(self, **kwargs):
             pass
 
         def post_call(self, **kwargs):
-            json.dumps(kwargs["original_response"])
+            self.serialized_response = json.dumps(kwargs["original_response"])
+
+    logging_obj = JsonSerializingLogger()
 
     BedrockBatchesHandler._handle_model_invocation_job_status(
-        batch_id=JOB_ARN, logging_obj=JsonSerializingLogger()
+        batch_id=JOB_ARN, logging_obj=logging_obj
+    )
+    assert (
+        f'"submitTime": "{SUBMIT_TIME.isoformat()}"' in logging_obj.serialized_response
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bedrock model-invocation-job retrieval used the raw boto3 response as the LiteLLM logging `original_response`. Native `datetime` values in that response were not JSON serializable, so this change JSON-sanitizes the logging copy while preserving the returned `LiteLLMBatch` fields.

## Repro
A Bedrock model-invocation-job retrieve response containing native `datetime` fields in `submitTime`, `lastModifiedTime`, or `endTime` fails when the logger serializes `original_response` as JSON.

## Evidence
```bash
$ uv run pytest tests/test_litellm/llms/bedrock/batches/test_handler.py tests/test_litellm/test_retrieve_batch_bedrock_dispatch.py -q
..........................................                               [100%]
42 passed

$ uv run --no-sync python ./tests/code_coverage_tests/recursive_detector.py
passed

$ cd litellm && uv run --no-sync black --check --exclude '/enterprise/' . && uv run --no-sync ruff check . && uv run --no-sync mypy .
All done! 1806 files would be left unchanged.
All checks passed!
Success: no issues found in 1945 source files

$ cd litellm && uv run --no-sync python ../tests/documentation_tests/test_circular_imports.py && cd .. && uv run --no-sync python -c "from litellm import *"
No LiteLLM type hints found.

$ uv run --frozen --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -q
.                                                                        [100%]
1 passed in 0.33s
```

## Tests
- Added regression coverage in `tests/test_litellm/llms/bedrock/batches/test_handler.py` for nested datetime sanitization, non-datetime fallback serialization, and a logger that explicitly JSON-serializes `original_response`.
- `uv run pytest tests/test_litellm/llms/bedrock/batches/test_handler.py tests/test_litellm/test_retrieve_batch_bedrock_dispatch.py -q` -> 42 passed.
- `uv run --no-sync python ./tests/code_coverage_tests/recursive_detector.py` -> passed.
- CI lint workflow commands passed locally: Black check, Ruff, MyPy, circular import check, and import safety check.
- `uv run --frozen --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -q` -> 1 passed.
- Attempted the named live Bedrock batch test; the local environment failed before the retrieve path because external provider credentials were unavailable.

## CI
- GitHub `lint`: passed on commit `fc35360606`.
- GitHub `code-quality`: passed on commit `fc35360606` after replacing the recursive sanitizer.
- GitHub `secret-scan`, `unit-test`, `test`, `build-ui`, `Vertex AI`, `core-utils`, and several proxy/auth checks: passed in the latest poll.
- Several GitHub test shards were still pending at the latest poll.
- CircleCI checks reported zero-duration failures across the suite; the available read-only job API/page did not expose logs, so I could not attribute those failures to this change.

## Review
- Greptile left two actionable comments; both were addressed in commit `fc35360606` by adding a fallback for other non-serializable values and making the JSON serialization test assertion explicit.
- The review threads still appear unresolved because I do not have a writable review-thread tool in this environment.

## Relevant issues

Fixes the Bedrock model-invocation-job retrieve logging regression.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement.
- [ ] My PR passes all unit tests on `make test-unit`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review.

## Screenshots / Proof of Fix

See terminal transcript in `## Evidence` above.

## Type

Bug Fix
Test

## Changes

- Added a JSON round-trip sanitizer for Bedrock model-invocation-job logging responses.
- Passed the sanitized copy to `post_call` so boto3 datetimes do not break JSON serialization.
- Added regression tests for datetime conversion, fallback serialization, and post-call serialization behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ddd77d3-59be-4262-9e27-c00b13ed83b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ddd77d3-59be-4262-9e27-c00b13ed83b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

