### PR TITLE
chore: add README marker comment (workflow smoke test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- hello from shin -->
 <h1 align="center">
         🚅 LiteLLM
     </h1>

--- a/tests/test_litellm/test_readme_comment_marker.py
+++ b/tests/test_litellm/test_readme_comment_marker.py
@@ -1,0 +1,17 @@
+# Tiny pin test for the README marker comment added by the workflow smoke test.
+# Asserts the HTML comment present in README.md so the marker can't be silently
+# removed.
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_readme_contains_hello_marker_comment():
+    readme = REPO_ROOT / "README.md"
+    assert readme.is_file(), f"expected README.md at {readme}"
+    content = readme.read_text(encoding="utf-8")
+    assert "<!-- hello from shin -->" in content, (
+        "README.md is missing the expected one-line marker comment "
+        "'<!-- hello from shin -->'"
+    )


### PR DESCRIPTION
## Summary

Adds a one-line HTML comment marker (`<!-- hello from shin -->`) to the top of `README.md` as a smoke test of the automated PR workflow. Also adds a tiny unit test that pins the marker so it can't be silently removed.

## Repro

The originating request was a workflow smoke-test issue asking for a one-line comment in `README.md`. No production bug — this exercises end-to-end branch / commit / PR plumbing.

## Evidence

Terminal transcript of the new test failing before the change and passing after:

```
# starting ref (README untouched) — pin test fails as expected
$ git stash push README.md
$ uv run pytest tests/test_litellm/test_readme_comment_marker.py -v
...
FAILED tests/test_litellm/test_readme_comment_marker.py::test_readme_contains_hello_marker_comment
AssertionError: README.md is missing the expected one-line marker comment '<!-- hello from shin -->'

# with the change applied — pin test passes
$ git stash pop
$ uv run pytest tests/test_litellm/test_readme_comment_marker.py -v
...
tests/test_litellm/test_readme_comment_marker.py::test_readme_contains_hello_marker_comment PASSED
============================== 1 passed in 0.14s ===============================
```

## Tests

- Added `tests/test_litellm/test_readme_comment_marker.py` — asserts the marker comment is present in `README.md`. Fails on the starting ref and passes after the change (transcript above).
- `uv run black --check tests/test_litellm/test_readme_comment_marker.py` — clean.
- `uv run ruff check tests/test_litellm/test_readme_comment_marker.py` — clean.
- `uv run mypy tests/test_litellm/test_readme_comment_marker.py` — clean.
