### PR TITLE
Fix pass-through endpoint filter when access group has no PT routes (re: #27344)

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2576,12 +2576,20 @@ async def _filter_endpoints_by_team_allowed_routes(
     if not isinstance(team_access_group_ids, list):
         team_access_group_ids = []
     if team_access_group_ids:
-        has_passthrough_route_constraints = True
-        allowed_passthrough_routes.extend(
+        access_group_passthrough_routes = (
             await _get_pass_through_routes_from_access_groups(
                 access_group_ids=team_access_group_ids,
             )
         )
+        # Only treat the access group as a pass-through constraint when
+        # it actually contributes pass-through routes. Access groups can
+        # be used to gate other resource types (models, MCP servers,
+        # vector stores) without saying anything about pass-through
+        # routes - in that case the team's pass-through visibility must
+        # not be affected.
+        if access_group_passthrough_routes:
+            has_passthrough_route_constraints = True
+            allowed_passthrough_routes.extend(access_group_passthrough_routes)
 
     if has_passthrough_route_constraints:
         ## FILTER pass_through_endpoints by allowed_passthrough_routes

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1949,6 +1949,157 @@ async def test_filter_endpoints_by_team_allowed_routes_partial_match():
 
 
 @pytest.mark.asyncio
+async def test_filter_endpoints_by_team_allowed_routes_access_group_without_pt_routes():
+    """
+    Regression test: a team with an access group that contains only non-pass-through
+    resources (e.g. model names) must NOT be filtered down to 0 endpoints.
+
+    Previously, `has_passthrough_route_constraints` was set to True whenever the
+    team had any `access_group_ids`, even if those access groups resolved to an
+    empty pass-through route list. That caused every endpoint to be filtered out.
+
+    The fix: only apply the constraint when the access group actually contributes
+    pass-through routes (i.e. the resolved list is non-empty) AND the team has no
+    other allowed_passthrough_routes metadata.
+    """
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    # Create test endpoints
+    endpoints = [
+        PassThroughGenericEndpoint(
+            id="endpoint-1", path="/api/route1", target="http://example.com/api1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-2", path="/api/route2", target="http://example.com/api2"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-3", path="/api/route3", target="http://example.com/api3"
+        ),
+    ]
+
+    # Team has an access group, but the access group contains only model names
+    # (or other non-pass-through resources), so the resolved PT route list is empty.
+    mock_prisma_client = MagicMock()
+    mock_team = SimpleNamespace(
+        metadata=None,
+        access_group_ids=["ag-with-models-only"],
+    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team
+    )
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-b",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    # Should return ALL endpoints because the access group does not constrain
+    # pass-through routes at all.
+    assert len(result) == 3
+    assert {ep.path for ep in result} == {"/api/route1", "/api/route2", "/api/route3"}
+
+
+@pytest.mark.asyncio
+async def test_filter_endpoints_by_team_allowed_routes_access_group_with_pt_routes():
+    """
+    Test that a team with an access group that DOES contain pass-through routes
+    is correctly filtered down to just those routes.
+    """
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    endpoints = [
+        PassThroughGenericEndpoint(
+            id="endpoint-1", path="/api/route1", target="http://example.com/api1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-2", path="/api/route2", target="http://example.com/api2"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-3", path="/api/route3", target="http://example.com/api3"
+        ),
+    ]
+
+    mock_prisma_client = MagicMock()
+    mock_team = SimpleNamespace(
+        metadata=None,
+        access_group_ids=["ag-with-pt-routes"],
+    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team
+    )
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=["/api/route1"]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-a",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    assert len(result) == 1
+    assert result[0].path == "/api/route1"
+
+
+@pytest.mark.asyncio
+async def test_filter_endpoints_by_team_allowed_routes_metadata_and_access_group_routes_union():
+    """
+    When both team metadata and access groups contribute pass-through routes,
+    the union of routes is allowed.
+    """
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    endpoints = [
+        PassThroughGenericEndpoint(
+            id="endpoint-1", path="/api/route1", target="http://example.com/api1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-2", path="/api/route2", target="http://example.com/api2"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-3", path="/api/route3", target="http://example.com/api3"
+        ),
+    ]
+
+    mock_prisma_client = MagicMock()
+    mock_team = SimpleNamespace(
+        metadata={"allowed_passthrough_routes": ["/api/route1"]},
+        access_group_ids=["ag-with-route2"],
+    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team
+    )
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=["/api/route2"]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-c",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    # Union of metadata routes + access group routes
+    assert {ep.path for ep in result} == {"/api/route1", "/api/route2"}
+
+
+@pytest.mark.asyncio
 async def test_bedrock_router_passthrough_metadata_initialization():
     """
     Test that bedrock router passthrough properly initializes metadata for hooks.


### PR DESCRIPTION
## Summary

Targets PR #27344. When a team's access group contains only non-pass-through resources (model names, MCP servers, vector stores), `_filter_endpoints_by_team_allowed_routes` was filtering the team down to **0** endpoints on `GET /config/pass_through_endpoint?team_id=...`.

The previous fix in #27344 raised `has_passthrough_route_constraints=True` for any non-empty `team.access_group_ids`, regardless of whether the resolved pass-through route list was empty. With an empty `allowed_passthrough_routes`, the filter then discarded every endpoint.

This change only treats the access group as a pass-through constraint when it actually contributes pass-through routes — so teams with model-only / MCP-only / vector-store-only access groups keep seeing the full set of pass-through endpoints (the same behavior they had before access groups were extended to PT routes).

## Repro

1. Configure 3 pass-through endpoints (e.g. `/api/route1`, `/api/route2`, `/api/route3`).
2. Create an access group whose `access_pass_through_routes` is empty but that lists model names in `access_model_ids` (or analogous resources for MCP/vector-store-only access groups).
3. Assign that access group to a team. Set `team.metadata.allowed_passthrough_routes = None` and `team.access_group_ids = ["<ag-id>"]`.
4. As an admin, `GET /config/pass_through_endpoint?team_id=<team-id>`.

Before this PR (on top of #27344): response is `{"endpoints": []}` (0 of 3 endpoints).
After this PR: response is all 3 endpoints — the access group does not constrain pass-through visibility since it carries no PT routes.

## Evidence

Pytest output demonstrating the regression on the pre-fix code and the fix:

```
$ uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_filter_endpoints_by_team_allowed_routes_access_group_without_pt_routes -v

# On PR #27344 head (pre-fix) — FAILS:
>       assert len(result) == 3
E       assert 0 == 3
E        +  where 0 = len([])

# With this PR's fix applied — PASSES:
PASSED [100%]
```

Full test suite for the filter (all 9 tests) passes after the fix:

```
$ uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py -v -k "filter_endpoints_by_team"
======================= 9 passed, 41 deselected in 4.06s =======================
```

## Tests

Added three new regression tests in `tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py`:

- `test_filter_endpoints_by_team_allowed_routes_access_group_without_pt_routes` — pins the regression. Team has `access_group_ids` but the AG resolves to `[]` pass-through routes; all endpoints must be returned. **Fails on pre-fix code, passes with this fix.**
- `test_filter_endpoints_by_team_allowed_routes_access_group_with_pt_routes` — happy path: AG contributes a PT route, filter restricts to that route only.
- `test_filter_endpoints_by_team_allowed_routes_metadata_and_access_group_routes_union` — sanity check that `team.metadata.allowed_passthrough_routes` and AG-resolved routes union correctly.

All 50 tests in the file pass:

```
============================== 50 passed in 3.71s ==============================
```

Lint (matches CI scope on the changed files):

```
$ uv run black --check litellm/proxy/pass_through_endpoints/pass_through_endpoints.py tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
All done!  2 files would be left unchanged.

$ uv run ruff check litellm/proxy/pass_through_endpoints/pass_through_endpoints.py tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
All checks passed!
```
