### PR TITLE
fix(ci): unbreak realtime + bedrock batch tests

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1212,7 +1212,7 @@ class Logging(LiteLLMLoggingBaseClass):
         # Log the exact result from the LLM API, for streaming - log the type of response received
         litellm.error_logs["POST_CALL"] = locals()
         if isinstance(original_response, dict):
-            original_response = json.dumps(original_response)
+            original_response = json.dumps(original_response, default=str)
         try:
             self.model_call_details["input"] = input
             self.model_call_details["api_key"] = api_key

--- a/tests/batches_tests/test_bedrock_files_and_batches.py
+++ b/tests/batches_tests/test_bedrock_files_and_batches.py
@@ -157,16 +157,16 @@ async def test_bedrock_retrieve_batch():
     """
     print("Testing bedrock batch retrieval")
 
-    # Mock bedrock batch response
     mock_bedrock_response = {
         "jobArn": "arn:aws:bedrock:us-west-2:123456789012:model-invocation-job/test-job-123",
         "jobName": "test-job-123",
         "modelId": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "roleArn": "arn:aws:iam::123456789012:role/service-role/AmazonBedrockExecutionRoleForAgents_TEST",
-        "status": "InProgress",
-        "message": "Job is in progress",
+        "status": "Completed",
+        "message": "",
         "submitTime": "2024-01-01T12:00:00Z",
         "lastModifiedTime": "2024-01-01T12:30:00Z",
+        "endTime": "2024-01-01T13:00:00Z",
         "inputDataConfig": {
             "s3InputDataConfig": {"s3Uri": "s3://test-bucket/input/test-input.jsonl"}
         },
@@ -175,43 +175,38 @@ async def test_bedrock_retrieve_batch():
         },
     }
 
-    # Mock the HTTP response
-    mock_response = MagicMock()
-    mock_response.json.return_value = mock_bedrock_response
-    mock_response.status_code = 200
+    mock_bedrock_client = MagicMock()
+    mock_bedrock_client.get_model_invocation_job.return_value = mock_bedrock_response
+    mock_creds = MagicMock(access_key="ak", secret_key="sk", token="tok")
 
-    # Print the mock response to debug
-    print("MOCK RESPONSE DATA:", mock_bedrock_response)
-
-    with patch(
-        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get"
-    ) as mock_get:
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        # Test retrieve batch
+    with (
+        patch("boto3.client", return_value=mock_bedrock_client),
+        patch(
+            "litellm.llms.bedrock.batches.transformation.BedrockBatchesConfig.get_credentials",
+            return_value=mock_creds,
+        ),
+    ):
         batch_response = await litellm.aretrieve_batch(
             batch_id="arn:aws:bedrock:us-west-2:123456789012:model-invocation-job/test-job-123",
             custom_llm_provider="bedrock",
             model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
         )
 
-        print("MOCKED BATCH RESPONSE=", batch_response)
-
-        # Validate the response
         assert (
             batch_response.id
             == "arn:aws:bedrock:us-west-2:123456789012:model-invocation-job/test-job-123"
         )
         assert batch_response.object == "batch"
-        assert (
-            batch_response.status == "in_progress"
-        )  # Bedrock "InProgress" maps to "in_progress"
+        assert batch_response.status == "completed"
         assert batch_response.endpoint == "/v1/chat/completions"
 
-        # Validate input and output file IDs in the final transformed response
         assert batch_response.input_file_id == "s3://test-bucket/input/test-input.jsonl"
-        assert batch_response.output_file_id == "s3://test-bucket/output/"
+        # Bedrock returns only the output *prefix*; the handler predicts the
+        # actual output object as <prefix>/<job-id>/<basename(input)>.out.
+        assert (
+            batch_response.output_file_id
+            == "s3://test-bucket/output/test-job-123/test-input.jsonl.out"
+        )
 
 
 def test_bedrock_batch_with_encryption_key_in_post_request():

--- a/tests/llm_translation/realtime/test_realtime_guardrails_openai.py
+++ b/tests/llm_translation/realtime/test_realtime_guardrails_openai.py
@@ -104,7 +104,8 @@ async def test_text_message_blocked_by_guardrail_no_ai_response():
     Send a text message containing the blocked phrase.
     Guardrail must:
       - Send error event (guardrail_violation) to client.
-      - Send response.audio_transcript.delta with the block message to client.
+      - Send response.output_audio_transcript.delta (or beta-protocol
+        response.audio_transcript.delta) with the block message to client.
       - NOT forward response.create to OpenAI (no AI response).
     """
     import websockets
@@ -177,10 +178,7 @@ async def test_text_message_blocked_by_guardrail_no_ai_response():
             len(guardrail_errors) >= 1
         ), f"Expected at least one guardrail_violation error but got: {[e.get('error', {}).get('type') for e in error_events]}"
 
-        # 2. Must have the guardrail message surfaced as an AI transcript delta.
-        # The connection uses GA realtime protocol (no OpenAI-Beta header) so
-        # OpenAI emits ``response.output_audio_transcript.delta``; older
-        # ``response.audio_transcript.delta`` is the beta-protocol name.
+        # 2. Must have the guardrail message surfaced as an AI transcript delta
         transcript_deltas = [
             e
             for e in client_events

--- a/tests/llm_translation/realtime/test_realtime_guardrails_openai.py
+++ b/tests/llm_translation/realtime/test_realtime_guardrails_openai.py
@@ -119,7 +119,6 @@ async def test_text_message_blocked_by_guardrail_no_ai_response():
             OPENAI_REALTIME_URL,
             additional_headers={
                 "Authorization": f"Bearer {OPENAI_API_KEY}",
-                "OpenAI-Beta": "realtime=v1",
             },
         ) as backend_ws:
             streaming, input_queue = await _build_streaming(client_events, backend_ws)
@@ -178,11 +177,18 @@ async def test_text_message_blocked_by_guardrail_no_ai_response():
             len(guardrail_errors) >= 1
         ), f"Expected at least one guardrail_violation error but got: {[e.get('error', {}).get('type') for e in error_events]}"
 
-        # 2. Must have the guardrail message surfaced as an AI transcript delta
+        # 2. Must have the guardrail message surfaced as an AI transcript delta.
+        # The connection uses GA realtime protocol (no OpenAI-Beta header) so
+        # OpenAI emits ``response.output_audio_transcript.delta``; older
+        # ``response.audio_transcript.delta`` is the beta-protocol name.
         transcript_deltas = [
             e
             for e in client_events
-            if e.get("type") == "response.audio_transcript.delta"
+            if e.get("type")
+            in (
+                "response.output_audio_transcript.delta",
+                "response.audio_transcript.delta",
+            )
         ]
         assert (
             len(transcript_deltas) >= 1
@@ -298,7 +304,6 @@ async def test_clean_text_message_passes_through_to_openai():
             OPENAI_REALTIME_URL,
             additional_headers={
                 "Authorization": f"Bearer {OPENAI_API_KEY}",
-                "OpenAI-Beta": "realtime=v1",
             },
         ) as backend_ws:
             streaming, input_queue = await _build_streaming(client_events, backend_ws)

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -36,6 +36,19 @@ def test_get_masked_api_base(logging_obj):
     assert type(masked_api_base) == str
 
 
+def test_post_call_serializes_dict_with_datetime(logging_obj):
+    import datetime
+
+    response = {
+        "status": "InProgress",
+        "submitTime": datetime.datetime(2026, 5, 11, 23, 49, 13, 132000),
+    }
+    logging_obj.post_call(original_response=response)
+    serialized = logging_obj.model_call_details["original_response"]
+    assert isinstance(serialized, str)
+    assert "2026-05-11" in serialized
+
+
 def test_sentry_sample_rate():
     existing_sample_rate = os.getenv("SENTRY_API_SAMPLE_RATE")
     try:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Three independent pre-existing failures on `litellm_internal_staging` that broke CI on every PR. All still reproduce on staging tip.

## 1. Realtime guardrail tests — deprecated `OpenAI-Beta: realtime=v1`
**Job:** `realtime_translation_testing`
**Symptom:**
```
{"error": {"code": "invalid_beta", "message": "Unknown beta requested: 'realtime'."}}
TimeoutError: Timed out waiting for 'session.created'. Got so far: ['error']
```
OpenAI deprecated the `OpenAI-Beta: realtime=v1` header on the live Realtime API. Two tests in `tests/llm_translation/realtime/test_realtime_guardrails_openai.py` hardcoded the header on the upstream `websockets.connect(...)`. Library code is unaffected — `litellm/llms/openai/realtime/handler.py` only forwards the beta header when the proxy client sets it, and defaults to GA.

**Fix**
- Drop `"OpenAI-Beta": "realtime=v1"` from both tests' `additional_headers`.
- Accept GA event `response.output_audio_transcript.delta` alongside the beta name `response.audio_transcript.delta` in the transcript-delta assertion (see GA→beta map in `litellm/litellm_core_utils/realtime_streaming.py`).

**Live test results (`OPENAI_API_KEY` set)**

Before (staging file):
```
FAILED tests/llm_translation/realtime/test_realtime_guardrails_openai.py::test_clean_text_message_passes_through_to_openai
FAILED tests/llm_translation/realtime/test_realtime_guardrails_openai.py::test_text_message_blocked_by_guardrail_no_ai_response
========================= 2 failed, 1 passed in 32.05s =========================
```
After:
```
3 passed in 9.99s
```

## 2. `Logging.post_call` crashes on dicts containing `datetime`
**Job:** `batches_testing` (`test_async_file_and_batch`)
**Symptom:**
```
litellm/litellm_core_utils/litellm_logging.py:1215: in post_call
    original_response = json.dumps(original_response)
TypeError: Object of type datetime is not JSON serializable
```
`BedrockBatchesHandler._handle_model_invocation_job_status` passes the raw boto3 response (which contains `datetime` fields like `submitTime`, `lastModifiedTime`, `endTime`) into `logging_obj.post_call(original_response=...)`. `json.dumps` was called without `default=str` and blew up.

**Fix**
- `json.dumps(original_response, default=str)` in `Logging.post_call`. Strictly additive: previously-serializable inputs still serialize identically; non-serializable values now fall back to `str()` instead of crashing.
- Added `test_post_call_serializes_dict_with_datetime` in `tests/test_litellm/litellm_core_utils/test_litellm_logging.py`.

## 3. `test_bedrock_retrieve_batch` patches the wrong layer
**Job:** `batches_testing` (`test_bedrock_retrieve_batch`)
**Symptom:**
```
botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException)
when calling the GetModelInvocationJob operation: The provided resource ARN is from a
different account.
```
The test patched `litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get`, but the handler actually calls `boto3.client("bedrock").get_model_invocation_job(...)`. Each run hit real AWS with a hardcoded test-account ARN.

**Fix**
- Patch `boto3.client` and `BedrockBatchesConfig.get_credentials` so the test never touches AWS.
- Use `status="Completed"` so `output_file_id` is populated (handler intentionally leaves it `None` for non-completed jobs).
- Assert the predicted per-job output object URI (`<prefix>/<job-id>/<basename(input)>.out`) — what the handler actually returns — instead of the bare output prefix the test previously asserted.

## CI
All required CircleCI and GitHub Actions jobs pass on the latest commit. Two transient flakes (`ui_unit_tests` `ReferenceError: window is not defined`; `proxy_pass_through_endpoint_tests` Azure assistants JSON decode) cleared on rerun.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778539463843119?thread_ts=1778539463.843119&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-873a0bdd-a36c-59a1-b5f9-7c7bbb98394d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-873a0bdd-a36c-59a1-b5f9-7c7bbb98394d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

