### PR TITLE
Fix pass-through endpoint filter when access groups carry no routes

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2576,12 +2576,16 @@ async def _filter_endpoints_by_team_allowed_routes(
     if not isinstance(team_access_group_ids, list):
         team_access_group_ids = []
     if team_access_group_ids:
-        has_passthrough_route_constraints = True
-        allowed_passthrough_routes.extend(
-            await _get_pass_through_routes_from_access_groups(
-                access_group_ids=team_access_group_ids,
-            )
+        # Only impose pass-through-route constraints when the access groups
+        # actually contribute pass-through routes. A team that uses access
+        # groups solely for model (or other resource) gating must still see
+        # the full pass-through endpoint list.
+        ag_pass_through_routes = await _get_pass_through_routes_from_access_groups(
+            access_group_ids=team_access_group_ids,
         )
+        if ag_pass_through_routes:
+            has_passthrough_route_constraints = True
+            allowed_passthrough_routes.extend(ag_pass_through_routes)
 
     if has_passthrough_route_constraints:
         ## FILTER pass_through_endpoints by allowed_passthrough_routes

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1949,6 +1949,160 @@ async def test_filter_endpoints_by_team_allowed_routes_partial_match():
 
 
 @pytest.mark.asyncio
+async def test_filter_endpoints_by_team_allowed_routes_access_group_no_pt_routes():
+    """
+    Regression test: a team whose access groups contain no pass-through
+    routes (e.g. model-only access groups) must continue to see ALL
+    pass-through endpoints — having an access_group_ids list alone must
+    not impose a constraint.
+
+    Before the fix, _filter_endpoints_by_team_allowed_routes set
+    has_passthrough_route_constraints=True whenever access_group_ids was
+    non-empty, even when the looked-up routes from those AGs were empty,
+    which caused the filter to discard every endpoint and a team that
+    used AGs only for models saw 0 endpoints on
+    GET /config/pass_through_endpoint?team_id=...
+    """
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    endpoints = [
+        PassThroughGenericEndpoint(
+            id="endpoint-1", path="/api/test1", target="http://example.com/api1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-2", path="/api/test2", target="http://example.com/api2"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-3", path="/api/test3", target="http://example.com/api3"
+        ),
+    ]
+
+    # Team has access_group_ids (e.g. for models) but the AGs contain NO
+    # pass-through routes; team has no allowed_passthrough_routes metadata.
+    mock_prisma_client = MagicMock()
+    mock_team = MagicMock()
+    mock_team.metadata = None
+    mock_team.access_group_ids = ["model-only-ag"]
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team
+    )
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-b",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    # With NO PT-route constraints from either metadata or AGs, the team
+    # should see all 3 endpoints (used to see 0).
+    assert len(result) == 3
+    assert {ep.path for ep in result} == {
+        "/api/test1",
+        "/api/test2",
+        "/api/test3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_filter_endpoints_by_team_allowed_routes_access_group_with_pt_routes():
+    """
+    Team has access groups that DO contribute pass-through routes — the
+    filter must restrict the endpoint list to only those routes (in
+    addition to anything in team metadata).
+    """
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    endpoints = [
+        PassThroughGenericEndpoint(
+            id="endpoint-1", path="/api/shared1", target="http://example.com/s1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-2", path="/api/shared2", target="http://example.com/s2"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-3", path="/api/forbidden", target="http://example.com/f"
+        ),
+    ]
+
+    mock_prisma_client = MagicMock()
+    mock_team = MagicMock()
+    mock_team.metadata = None
+    mock_team.access_group_ids = ["ag-with-pt-routes"]
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team
+    )
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=["/api/shared1", "/api/shared2"]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-a",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    assert len(result) == 2
+    assert {ep.path for ep in result} == {"/api/shared1", "/api/shared2"}
+
+
+@pytest.mark.asyncio
+async def test_filter_endpoints_by_team_allowed_routes_metadata_and_access_group_union():
+    """
+    Team has BOTH metadata-allowed routes AND access groups that
+    contribute additional pass-through routes — the filter must union
+    the two lists rather than only honoring one source.
+    """
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    endpoints = [
+        PassThroughGenericEndpoint(
+            id="endpoint-1", path="/api/team1", target="http://example.com/t1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-2", path="/api/ag1", target="http://example.com/ag1"
+        ),
+        PassThroughGenericEndpoint(
+            id="endpoint-3", path="/api/other", target="http://example.com/other"
+        ),
+    ]
+
+    mock_prisma_client = MagicMock()
+    mock_team = MagicMock()
+    mock_team.metadata = {"allowed_passthrough_routes": ["/api/team1"]}
+    mock_team.access_group_ids = ["ag-with-pt-routes"]
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team
+    )
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=["/api/ag1"]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-c",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    assert len(result) == 2
+    assert {ep.path for ep in result} == {"/api/team1", "/api/ag1"}
+
+
+@pytest.mark.asyncio
 async def test_bedrock_router_passthrough_metadata_initialization():
     """
     Test that bedrock router passthrough properly initializes metadata for hooks.


### PR DESCRIPTION
## Summary

Fixes the regression flagged on #27344 (Greptile call-out): in
`_filter_endpoints_by_team_allowed_routes`, having `access_group_ids`
set on a team unconditionally flipped `has_passthrough_route_constraints`
to `True`, even when the resolved pass-through routes from those access
groups were empty. A team that used access groups solely for model
gating (or any non-pass-through resource) then saw zero endpoints from
`GET /config/pass_through_endpoint?team_id=...`, when previously it
would have seen the full list.

Only flip the constraint flag when the access-group lookup actually
returns pass-through routes.

## Repro (shape)

1. Create three pass-through endpoints (paths `/api/test1`, `/api/test2`,
   `/api/test3`).
2. Create an access group whose only resources are models (no
   `access_pass_through_routes`).
3. Assign the access group to a team via `access_group_ids`. The team has
   no `allowed_passthrough_routes` in its metadata.
4. As that team, `GET /config/pass_through_endpoint?team_id=<team>`.

Before this change: response contains 0 endpoints.
After this change: response contains all 3 endpoints (no PT constraints
apply, since neither the team metadata nor the AG contribute any
pass-through routes).

## Tests

Added three regression tests in
`tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py`:

- `test_filter_endpoints_by_team_allowed_routes_access_group_no_pt_routes`
  — model-only access group: expects the full endpoint list (this is the
  regression guard; fails on the pre-fix code with `assert 0 == 3`).
- `test_filter_endpoints_by_team_allowed_routes_access_group_with_pt_routes`
  — AG that DOES contribute PT routes: expects the filtered list.
- `test_filter_endpoints_by_team_allowed_routes_metadata_and_access_group_union`
  — both metadata-allowed routes and AG-contributed routes apply (union).

Verified locally:

- `uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py` — 50 passed.
- `uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py tests/proxy_unit_tests/test_auth_checks.py tests/test_litellm/proxy/auth/test_route_checks.py tests/test_litellm/proxy/management_endpoints/test_access_group_endpoints.py` — 442 passed.
- `uv run ruff check .` (under `litellm/`) — All checks passed.
- `uv run black --check --exclude '/enterprise/' .` (under `litellm/`) — clean.
