### PR TITLE
fix(mcp): honor access groups for MCP servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -757,9 +757,15 @@ class MCPRequestHandler:
                 _get_mcp_server_ids_from_access_groups,
             )
 
-            key_access_group_servers = await _get_mcp_server_ids_from_access_groups(
-                user_api_key_auth.access_group_ids or []
-            )
+            try:
+                key_access_group_servers = await _get_mcp_server_ids_from_access_groups(
+                    user_api_key_auth.access_group_ids or []
+                )
+            except Exception as e:
+                verbose_logger.debug(
+                    f"Failed to expand key access groups for MCP servers: {str(e)}"
+                )
+                key_access_group_servers = []
 
             # Get key object permission (already loaded in main auth flow, or fetch from DB)
             key_object_permission = MCPRequestHandler._get_key_object_permission(
@@ -842,12 +848,20 @@ class MCPRequestHandler:
                 _get_mcp_server_ids_from_access_groups,
             )
 
-            team_access_group_ids = await MCPRequestHandler._get_team_access_group_ids(
-                user_api_key_auth
-            )
-            team_access_group_servers = await _get_mcp_server_ids_from_access_groups(
-                team_access_group_ids
-            )
+            try:
+                team_access_group_ids = (
+                    await MCPRequestHandler._get_team_access_group_ids(
+                        user_api_key_auth
+                    )
+                )
+                team_access_group_servers = (
+                    await _get_mcp_server_ids_from_access_groups(team_access_group_ids)
+                )
+            except Exception as e:
+                verbose_logger.debug(
+                    f"Failed to expand team access groups for MCP servers: {str(e)}"
+                )
+                team_access_group_servers = []
 
             # Get team object permission (already loaded in main auth flow)
             object_permissions = await MCPRequestHandler._get_team_object_permission(
@@ -906,27 +920,37 @@ class MCPRequestHandler:
         and teams may have those groups even when no object_permission row was
         created for the team.
         """
-        from litellm.proxy.auth.auth_checks import get_team_object
-        from litellm.proxy.proxy_server import (
-            prisma_client,
-            proxy_logging_obj,
-            user_api_key_cache,
-        )
+        try:
+            from litellm.proxy.auth.auth_checks import get_team_object
+            from litellm.proxy.proxy_server import (
+                prisma_client,
+                proxy_logging_obj,
+                user_api_key_cache,
+            )
 
-        if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
+            if (
+                not user_api_key_auth
+                or not user_api_key_auth.team_id
+                or not prisma_client
+            ):
+                return []
+
+            team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
+                team_id=user_api_key_auth.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=user_api_key_auth.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+            if team_obj is None:
+                return []
+
+            return list(team_obj.access_group_ids or [])
+        except Exception as e:
+            verbose_logger.debug(
+                f"Failed to get team access group IDs for MCP servers: {str(e)}"
+            )
             return []
-
-        team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
-            team_id=user_api_key_auth.team_id,
-            prisma_client=prisma_client,
-            user_api_key_cache=user_api_key_cache,
-            parent_otel_span=user_api_key_auth.parent_otel_span,
-            proxy_logging_obj=proxy_logging_obj,
-        )
-        if team_obj is None:
-            return []
-
-        return list(team_obj.access_group_ids or [])
 
     # Sentinel stored in cache when an org has no object_permission, so we
     # don't re-query the DB on every MCP request for that org.

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -757,10 +757,8 @@ class MCPRequestHandler:
                 _get_mcp_server_ids_from_access_groups,
             )
 
-            key_access_group_servers = (
-                await _get_mcp_server_ids_from_access_groups(
-                    user_api_key_auth.access_group_ids or []
-                )
+            key_access_group_servers = await _get_mcp_server_ids_from_access_groups(
+                user_api_key_auth.access_group_ids or []
             )
 
             # Get key object permission (already loaded in main auth flow, or fetch from DB)
@@ -847,8 +845,8 @@ class MCPRequestHandler:
             team_access_group_ids = await MCPRequestHandler._get_team_access_group_ids(
                 user_api_key_auth
             )
-            team_access_group_servers = (
-                await _get_mcp_server_ids_from_access_groups(team_access_group_ids)
+            team_access_group_servers = await _get_mcp_server_ids_from_access_groups(
+                team_access_group_ids
             )
 
             # Get team object permission (already loaded in main auth flow)

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -753,20 +753,6 @@ class MCPRequestHandler:
             if user_api_key_auth is None:
                 return []
 
-            from litellm.proxy.auth.auth_checks import (
-                _get_mcp_server_ids_from_access_groups,
-            )
-
-            try:
-                key_access_group_servers = await _get_mcp_server_ids_from_access_groups(
-                    user_api_key_auth.access_group_ids or []
-                )
-            except Exception as e:
-                verbose_logger.debug(
-                    f"Failed to expand key access groups for MCP servers: {str(e)}"
-                )
-                key_access_group_servers = []
-
             # Get key object permission (already loaded in main auth flow, or fetch from DB)
             key_object_permission = MCPRequestHandler._get_key_object_permission(
                 user_api_key_auth
@@ -792,7 +778,7 @@ class MCPRequestHandler:
                         proxy_logging_obj=proxy_logging_obj,
                     )
             if key_object_permission is None:
-                return list(set(key_access_group_servers))
+                return []
 
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -818,12 +804,7 @@ class MCPRequestHandler:
             )
 
             # Combine all lists
-            all_servers = (
-                direct_mcp_servers
-                + access_group_servers
-                + tool_perm_servers
-                + key_access_group_servers
-            )
+            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -825,10 +825,6 @@ class MCPRequestHandler:
             if user_api_key_auth is None or user_api_key_auth.team_id is None:
                 return []
 
-            from litellm.proxy.auth.auth_checks import (
-                _get_mcp_server_ids_from_access_groups,
-            )
-
             try:
                 team_access_group_ids = (
                     await MCPRequestHandler._get_team_access_group_ids(
@@ -836,7 +832,10 @@ class MCPRequestHandler:
                     )
                 )
                 team_access_group_servers = (
-                    await _get_mcp_server_ids_from_access_groups(team_access_group_ids)
+                    await MCPRequestHandler._get_mcp_server_ids_from_team_access_groups(
+                        user_api_key_auth=user_api_key_auth,
+                        team_access_group_ids=team_access_group_ids,
+                    )
                 )
             except Exception as e:
                 verbose_logger.debug(
@@ -886,6 +885,67 @@ class MCPRequestHandler:
         except Exception as e:
             verbose_logger.warning(
                 f"Failed to get allowed MCP servers for team: {str(e)}"
+            )
+            return []
+
+    @staticmethod
+    async def _get_mcp_server_ids_from_team_access_groups(
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+        team_access_group_ids: List[str],
+    ) -> List[str]:
+        """
+        Collect MCP server IDs from unified team access groups.
+
+        A team only receives MCP servers from an access group if the access
+        group row also assigns itself back to the team. This keeps a mutable
+        team.access_group_ids value from granting another team's access group.
+        """
+        if (
+            user_api_key_auth is None
+            or not user_api_key_auth.team_id
+            or not team_access_group_ids
+        ):
+            return []
+
+        try:
+            from litellm.proxy.auth.auth_checks import get_access_object
+            from litellm.proxy.proxy_server import (
+                prisma_client,
+                proxy_logging_obj,
+                user_api_key_cache,
+            )
+
+            if prisma_client is None or user_api_key_cache is None:
+                return []
+
+            mcp_server_ids: List[str] = []
+            for access_group_id in team_access_group_ids:
+                try:
+                    access_group = await get_access_object(
+                        access_group_id=access_group_id,
+                        prisma_client=prisma_client,
+                        user_api_key_cache=user_api_key_cache,
+                        proxy_logging_obj=proxy_logging_obj,
+                    )
+                except Exception as e:
+                    verbose_logger.debug(
+                        "Failed to load team access group %s for MCP servers: %s",
+                        access_group_id,
+                        str(e),
+                    )
+                    continue
+
+                if user_api_key_auth.team_id not in (
+                    access_group.assigned_team_ids or []
+                ):
+                    continue
+
+                mcp_server_ids.extend(access_group.access_mcp_server_ids or [])
+
+            return list(set(mcp_server_ids))
+        except Exception as e:
+            verbose_logger.debug(
+                f"Failed to get MCP servers from team access groups: {str(e)}"
             )
             return []
 

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -750,6 +750,19 @@ class MCPRequestHandler:
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
     ) -> List[str]:
         try:
+            if user_api_key_auth is None:
+                return []
+
+            from litellm.proxy.auth.auth_checks import (
+                _get_mcp_server_ids_from_access_groups,
+            )
+
+            key_access_group_servers = (
+                await _get_mcp_server_ids_from_access_groups(
+                    user_api_key_auth.access_group_ids or []
+                )
+            )
+
             # Get key object permission (already loaded in main auth flow, or fetch from DB)
             key_object_permission = MCPRequestHandler._get_key_object_permission(
                 user_api_key_auth
@@ -775,7 +788,7 @@ class MCPRequestHandler:
                         proxy_logging_obj=proxy_logging_obj,
                     )
             if key_object_permission is None:
-                return []
+                return list(set(key_access_group_servers))
 
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -801,7 +814,12 @@ class MCPRequestHandler:
             )
 
             # Combine all lists
-            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+            all_servers = (
+                direct_mcp_servers
+                + access_group_servers
+                + tool_perm_servers
+                + key_access_group_servers
+            )
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(
@@ -819,13 +837,27 @@ class MCPRequestHandler:
         Note: object_permission is automatically loaded by get_team_object() in main auth flow.
         """
         try:
+            if user_api_key_auth is None or user_api_key_auth.team_id is None:
+                return []
+
+            from litellm.proxy.auth.auth_checks import (
+                _get_mcp_server_ids_from_access_groups,
+            )
+
+            team_access_group_ids = await MCPRequestHandler._get_team_access_group_ids(
+                user_api_key_auth
+            )
+            team_access_group_servers = (
+                await _get_mcp_server_ids_from_access_groups(team_access_group_ids)
+            )
+
             # Get team object permission (already loaded in main auth flow)
             object_permissions = await MCPRequestHandler._get_team_object_permission(
                 user_api_key_auth
             )
 
             if object_permissions is None:
-                return []
+                return list(set(team_access_group_servers))
 
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -851,13 +883,52 @@ class MCPRequestHandler:
             )
 
             # Combine all lists
-            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+            all_servers = (
+                direct_mcp_servers
+                + access_group_servers
+                + tool_perm_servers
+                + team_access_group_servers
+            )
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(
                 f"Failed to get allowed MCP servers for team: {str(e)}"
             )
             return []
+
+    @staticmethod
+    async def _get_team_access_group_ids(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[str]:
+        """
+        Get unified access-group IDs assigned to the user's team.
+
+        These are distinct from object_permission.mcp_access_groups: unified
+        access groups can grant MCP servers directly via access_mcp_server_ids,
+        and teams may have those groups even when no object_permission row was
+        created for the team.
+        """
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
+            return []
+
+        team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
+            team_id=user_api_key_auth.team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=user_api_key_auth.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        if team_obj is None:
+            return []
+
+        return list(team_obj.access_group_ids or [])
 
     # Sentinel stored in cache when an org has no object_permission, so we
     # don't re-query the DB on every MCP request for that org.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -1,12 +1,9 @@
 import json
 import os
 import sys
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import orjson
 import pytest
-from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 sys.path.insert(
@@ -19,7 +16,6 @@ from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
 )
 from litellm.proxy._types import SpecialHeaders, UserAPIKeyAuth
-from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 
 @pytest.mark.asyncio
@@ -342,7 +338,7 @@ class TestMCPRequestHandler:
         with patch(
             "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
             side_effect=mock_user_api_key_auth,
-        ) as mock_auth:
+        ):
             # Call the method
             (
                 auth_result,
@@ -1796,6 +1792,75 @@ async def test_get_allowed_mcp_servers_for_team_with_no_object_permission():
 
         # Verify the helper was called
         mock_get_team_perm.assert_called_once_with(mock_user_auth)
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_for_key_uses_unified_access_groups_without_object_permission():
+    """Key access_group_ids grant MCP servers even when no object_permission exists."""
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        access_group_ids=["ag-key"],
+    )
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_key_object_permission",
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+            new_callable=AsyncMock,
+            return_value=["mcp-from-key-group"],
+        ) as mock_get_access_group_servers,
+    ):
+        result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(
+            mock_user_auth
+        )
+
+    assert result == ["mcp-from-key-group"]
+    mock_get_access_group_servers.assert_awaited_once_with(["ag-key"])
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_for_team_uses_unified_access_groups_without_object_permission():
+    """Team access_group_ids grant MCP servers even when no object_permission exists."""
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="team-with-access-group",
+    )
+
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_team_access_group_ids",
+            new_callable=AsyncMock,
+            return_value=["ag-team"],
+        ) as mock_get_team_access_groups,
+        patch.object(
+            MCPRequestHandler,
+            "_get_team_object_permission",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_get_team_perm,
+        patch(
+            "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+            new_callable=AsyncMock,
+            return_value=["mcp-from-team-group"],
+        ) as mock_get_access_group_servers,
+    ):
+        result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(
+            mock_user_auth
+        )
+
+    assert result == ["mcp-from-team-group"]
+    mock_get_team_access_groups.assert_awaited_once_with(mock_user_auth)
+    mock_get_team_perm.assert_awaited_once_with(mock_user_auth)
+    mock_get_access_group_servers.assert_awaited_once_with(["ag-team"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -1842,8 +1842,9 @@ async def test_get_allowed_mcp_servers_for_team_uses_unified_access_groups_witho
             new_callable=AsyncMock,
             return_value=None,
         ) as mock_get_team_perm,
-        patch(
-            "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+        patch.object(
+            MCPRequestHandler,
+            "_get_mcp_server_ids_from_team_access_groups",
             new_callable=AsyncMock,
             return_value=["mcp-from-team-group"],
         ) as mock_get_access_group_servers,
@@ -1855,7 +1856,121 @@ async def test_get_allowed_mcp_servers_for_team_uses_unified_access_groups_witho
     assert result == ["mcp-from-team-group"]
     mock_get_team_access_groups.assert_awaited_once_with(mock_user_auth)
     mock_get_team_perm.assert_awaited_once_with(mock_user_auth)
-    mock_get_access_group_servers.assert_awaited_once_with(["ag-team"])
+    mock_get_access_group_servers.assert_awaited_once_with(
+        user_api_key_auth=mock_user_auth,
+        team_access_group_ids=["ag-team"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_server_ids_from_team_access_groups_requires_assigned_team():
+    """Team access_group_ids only grant MCP servers when the group assigns the team."""
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="authorized-team",
+    )
+    authorized_group = MagicMock(
+        assigned_team_ids=["authorized-team"],
+        access_mcp_server_ids=["mcp-allowed", "mcp-shared"],
+    )
+    other_team_group = MagicMock(
+        assigned_team_ids=["other-team"],
+        access_mcp_server_ids=["mcp-denied"],
+    )
+    duplicate_group = MagicMock(
+        assigned_team_ids=["authorized-team"],
+        access_mcp_server_ids=["mcp-shared"],
+    )
+
+    async def mock_get_access_object(access_group_id, **kwargs):
+        return {
+            "ag-authorized": authorized_group,
+            "ag-other-team": other_team_group,
+            "ag-duplicate": duplicate_group,
+        }[access_group_id]
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_access_object",
+            new_callable=AsyncMock,
+            side_effect=mock_get_access_object,
+        ) as mock_get_access_group,
+    ):
+        result = await MCPRequestHandler._get_mcp_server_ids_from_team_access_groups(
+            user_api_key_auth=mock_user_auth,
+            team_access_group_ids=["ag-authorized", "ag-other-team", "ag-duplicate"],
+        )
+
+    assert sorted(result) == ["mcp-allowed", "mcp-shared"]
+    assert mock_get_access_group.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_server_ids_from_team_access_groups_fails_closed():
+    """Missing auth context, DB cache, or access-group rows do not grant MCP servers."""
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="authorized-team",
+    )
+
+    assert (
+        await MCPRequestHandler._get_mcp_server_ids_from_team_access_groups(
+            user_api_key_auth=None,
+            team_access_group_ids=["ag-authorized"],
+        )
+        == []
+    )
+    assert (
+        await MCPRequestHandler._get_mcp_server_ids_from_team_access_groups(
+            user_api_key_auth=mock_user_auth,
+            team_access_group_ids=[],
+        )
+        == []
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+    ):
+        assert (
+            await MCPRequestHandler._get_mcp_server_ids_from_team_access_groups(
+                user_api_key_auth=mock_user_auth,
+                team_access_group_ids=["ag-authorized"],
+            )
+            == []
+        )
+
+    authorized_group = MagicMock(
+        assigned_team_ids=["authorized-team"],
+        access_mcp_server_ids=["mcp-allowed"],
+    )
+
+    async def mock_get_access_object(access_group_id, **kwargs):
+        if access_group_id == "ag-missing":
+            raise Exception("not found")
+        return authorized_group
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_access_object",
+            new_callable=AsyncMock,
+            side_effect=mock_get_access_object,
+        ),
+    ):
+        assert await MCPRequestHandler._get_mcp_server_ids_from_team_access_groups(
+            user_api_key_auth=mock_user_auth,
+            team_access_group_ids=["ag-missing", "ag-authorized"],
+        ) == ["mcp-allowed"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -1795,8 +1795,8 @@ async def test_get_allowed_mcp_servers_for_team_with_no_object_permission():
 
 
 @pytest.mark.asyncio
-async def test_get_allowed_mcp_servers_for_key_uses_unified_access_groups_without_object_permission():
-    """Key access_group_ids grant MCP servers even when no object_permission exists."""
+async def test_get_allowed_mcp_servers_for_key_ignores_unified_access_groups_without_object_permission():
+    """Key access_group_ids do not grant MCP access without object_permission."""
 
     mock_user_auth = UserAPIKeyAuth(
         api_key="test-key",
@@ -1809,19 +1809,14 @@ async def test_get_allowed_mcp_servers_for_key_uses_unified_access_groups_withou
             MCPRequestHandler,
             "_get_key_object_permission",
             return_value=None,
-        ),
-        patch(
-            "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
-            new_callable=AsyncMock,
-            return_value=["mcp-from-key-group"],
-        ) as mock_get_access_group_servers,
+        ) as mock_get_key_perm,
     ):
         result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(
             mock_user_auth
         )
 
-    assert result == ["mcp-from-key-group"]
-    mock_get_access_group_servers.assert_awaited_once_with(["ag-key"])
+    assert result == []
+    mock_get_key_perm.assert_called_once_with(mock_user_auth)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resolve MCP server IDs from unified key/team `access_group_ids` in the MCP authorization path
- allow team-level access groups to grant MCP servers even when no team object-permission row exists
- keep existing object_permission MCP server, MCP access group, and tool-permission behavior additive

Fixes #27657

## Testing
- `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py -q`
- `uv run ruff check litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py`
- `git diff --check`