### PR TITLE
fix(ui): resolve created_by to human-readable name for team keys

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -53,6 +53,7 @@ export interface KeyResponse {
   organization_id: string | null;
   org_id?: string | null;
   created_at: string;
+  created_by?: string;
   updated_at: string;
   last_active: string | null;
   team_spend: number;

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -25,7 +25,8 @@ import {
   Text,
 } from "@tremor/react";
 import { InfoCircleOutlined } from "@ant-design/icons";
-import { Popover, Skeleton, Tooltip } from "antd";
+import { Popover, Skeleton, Tooltip, Typography } from "antd";
+import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
@@ -339,18 +340,59 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
         size: 70,
         enableSorting: false,
         cell: (info) => {
-          const value = info.getValue() as string | null;
-          const displayValue = value === "default_user_id" ? "Default Proxy Admin" : value;
+          const userId = info.getValue() as string | null;
+          if (!userId) return "-";
+          const { created_by_user } = info.row.original;
+          const userAlias = created_by_user?.user_alias ?? null;
+          const userEmail = created_by_user?.user_email ?? null;
+          const isDefaultAdmin = userId === "default_user_id";
+          const displayValue = userAlias || userEmail || userId;
           const width = info.cell.column.getSize();
+
+          const popoverContent = (
+            <div className="flex flex-col gap-2 text-xs min-w-[200px] max-w-[300px]">
+              {[
+                { label: "User Alias", value: userAlias },
+                { label: "User Email", value: userEmail },
+                { label: "User ID", value: userId },
+              ].map(({ label, value }) => (
+                <div key={label} className="flex flex-col min-w-0">
+                  <span className="text-gray-400">{label}</span>
+                  {value ? (
+                    <Typography.Text
+                      className="font-mono text-xs"
+                      ellipsis={{ tooltip: value }}
+                      copyable
+                    >
+                      {value}
+                    </Typography.Text>
+                  ) : (
+                    <span className="font-mono">-</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          );
+
+          if (isDefaultAdmin && !userAlias && !userEmail) {
+            return (
+              <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
+                <span className="cursor-default">
+                  <DefaultProxyAdminTag userId={userId} />
+                </span>
+              </Popover>
+            );
+          }
+
           return (
-            <Tooltip title={displayValue}>
+            <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
               <span
-                className="font-mono text-xs truncate block"
+                className="font-mono text-xs truncate block cursor-default"
                 style={{ maxWidth: width, overflow: "hidden" }}
               >
-                {displayValue ?? "-"}
+                {displayValue}
               </span>
-            </Tooltip>
+            </Popover>
           );
         },
       },

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -403,7 +403,11 @@ export default function KeyInfoView({
           keyId: currentKeyData.token_id || currentKeyData.token,
           userId: currentKeyData.user_id || "",
           userEmail: currentKeyData.user_email || "",
-          createdBy: currentKeyData.user_email || currentKeyData.user_id || "",
+          createdBy:
+            currentKeyData.created_by_user?.user_alias ||
+            currentKeyData.created_by_user?.user_email ||
+            currentKeyData.created_by ||
+            "",
           createdAt: currentKeyData.created_at ? formatTimestamp(currentKeyData.created_at) : "",
           lastUpdated: currentKeyData.updated_at ? formatTimestamp(currentKeyData.updated_at) : "",
           lastActive: currentKeyData.last_active ? formatTimestamp(currentKeyData.last_active) : "Never",


### PR DESCRIPTION
## Summary

The team's Virtual Keys table rendered a raw UUID under **Created By** for keys created on behalf of a real user (especially service-account keys), and the key details page header showed `-` because it was reading the wrong field (key owner `user_email` / `user_id` instead of the creator's `created_by_user`). This PR fixes both: the table column and the details-page header now resolve to the same human-readable value (`created_by_user.user_alias` → `user_email` → UUID), with a Popover on hover that surfaces alias / email / user_id, each individually copyable. The Popover matches the existing pattern used in the AllKeys table (`VirtualKeysTable.tsx:344-407`), so both views look and behave identically.

## Screenshots

### Before
<!-- drag the BEFORE screenshots here:
     1. Team's Virtual Keys table — Created By column showing UUID prefix
     2. Key details page Overview → CREATED BY shows "-"
-->
<img width="1321" height="283" alt="Screenshot 2026-05-11 at 5 24 09 PM" src="https://github.com/user-attachments/assets/ee97e586-3388-43b9-9384-2ab683e50d3f" />


### After
<!-- drag the AFTER screenshots here:
     1. Team's Virtual Keys table — Created By column showing email/alias
     2. Key details page Overview → CREATED BY shows human-readable name
     3. Popover on hover showing User Alias / User Email / Us
er ID with copy icons
-->

<img width="996" height="189" alt="Screenshot 2026-05-11 at 5 15 35 PM" src="https://github.com/user-attachments/assets/0653a062-abd2-4bd9-a92b-5a393a4271e4" />
<img width="1158" height="275" alt="Screenshot 2026-05-11 at 5 19 10 PM" src="https://github.com/user-attachments/assets/0f87cf95-278c-49b6-877c-fdf903de11cf" />

## Test plan
- [x] `src/components/templates/KeyInfoHeader.test.tsx` — 20 tests pass
- [x] `src/components/templates/key_info_view.test.tsx` — 25 tests pass
- [x] Manual: team's Virtual Keys table → hover Created By cell → Popover with alias/email/user_id and per-field copy icons
- [x] Manual: click into key details → header strip shows readable Created By instead of `-`
- [x] Regression: default-admin-created keys still render "Default Proxy Admin" tag in both views

Resolves LIT-2517