### PR TITLE
feat(ui): add Expires to key Overview header; merge User into one field

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -53,6 +53,7 @@ export interface KeyResponse {
   organization_id: string | null;
   org_id?: string | null;
   created_at: string;
+  created_by?: string;
   updated_at: string;
   last_active: string | null;
   team_spend: number;

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -25,7 +25,8 @@ import {
   Text,
 } from "@tremor/react";
 import { InfoCircleOutlined } from "@ant-design/icons";
-import { Popover, Skeleton, Tooltip } from "antd";
+import { Popover, Skeleton, Tooltip, Typography } from "antd";
+import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
@@ -339,18 +340,59 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
         size: 70,
         enableSorting: false,
         cell: (info) => {
-          const value = info.getValue() as string | null;
-          const displayValue = value === "default_user_id" ? "Default Proxy Admin" : value;
+          const userId = info.getValue() as string | null;
+          if (!userId) return "-";
+          const { created_by_user } = info.row.original;
+          const userAlias = created_by_user?.user_alias ?? null;
+          const userEmail = created_by_user?.user_email ?? null;
+          const isDefaultAdmin = userId === "default_user_id";
+          const displayValue = userAlias || userEmail || userId;
           const width = info.cell.column.getSize();
+
+          const popoverContent = (
+            <div className="flex flex-col gap-2 text-xs min-w-[200px] max-w-[300px]">
+              {[
+                { label: "User Alias", value: userAlias },
+                { label: "User Email", value: userEmail },
+                { label: "User ID", value: userId },
+              ].map(({ label, value }) => (
+                <div key={label} className="flex flex-col min-w-0">
+                  <span className="text-gray-400">{label}</span>
+                  {value ? (
+                    <Typography.Text
+                      className="font-mono text-xs"
+                      ellipsis={{ tooltip: value }}
+                      copyable
+                    >
+                      {value}
+                    </Typography.Text>
+                  ) : (
+                    <span className="font-mono">-</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          );
+
+          if (isDefaultAdmin && !userAlias && !userEmail) {
+            return (
+              <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
+                <span className="cursor-default">
+                  <DefaultProxyAdminTag userId={userId} />
+                </span>
+              </Popover>
+            );
+          }
+
           return (
-            <Tooltip title={displayValue}>
+            <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
               <span
-                className="font-mono text-xs truncate block"
+                className="font-mono text-xs truncate block cursor-default"
                 style={{ maxWidth: width, overflow: "hidden" }}
               >
-                {displayValue ?? "-"}
+                {displayValue}
               </span>
-            </Tooltip>
+            </Popover>
           );
         },
       },

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.test.tsx
@@ -8,10 +8,12 @@ const MOCK_DATA: KeyInfoData = {
   keyId: "sk-1234567890abcdef",
   userId: "user-abc-123",
   userEmail: "test@example.com",
+  userAlias: null,
   createdBy: "admin@example.com",
   createdAt: "Oct 29, 2025 at 1:26 AM",
   lastUpdated: "Oct 29, 2025 at 1:47 AM",
   lastActive: "Oct 29, 2025 at 2:00 AM",
+  expires: "Never",
 };
 
 describe("KeyInfoHeader", () => {
@@ -28,12 +30,11 @@ describe("KeyInfoHeader", () => {
 
   it("should render all metadata fields", () => {
     render(<KeyInfoHeader data={MOCK_DATA} />);
-    expect(screen.getByText("User Email")).toBeInTheDocument();
+    expect(screen.getByText("User")).toBeInTheDocument();
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
-    expect(screen.getByText("User ID")).toBeInTheDocument();
-    expect(screen.getByText("user-abc-123")).toBeInTheDocument();
     expect(screen.getByText("Created At")).toBeInTheDocument();
     expect(screen.getByText("Created By")).toBeInTheDocument();
+    expect(screen.getByText("Expires")).toBeInTheDocument();
     expect(screen.getByText("Last Updated")).toBeInTheDocument();
     expect(screen.getByText("Last Active")).toBeInTheDocument();
   });
@@ -122,8 +123,8 @@ describe("KeyInfoHeader", () => {
   });
 
   describe("default_user_id handling", () => {
-    it("should show Default Proxy Admin tag for User ID when value is default_user_id", () => {
-      const data = { ...MOCK_DATA, userId: "default_user_id" };
+    it("should show Default Proxy Admin tag for User when userId is default_user_id and no alias/email", () => {
+      const data = { ...MOCK_DATA, userId: "default_user_id", userEmail: "", userAlias: null };
       render(<KeyInfoHeader data={data} />);
       expect(screen.getAllByText("Default Proxy Admin").length).toBeGreaterThanOrEqual(1);
     });
@@ -135,9 +136,20 @@ describe("KeyInfoHeader", () => {
     });
   });
 
-  describe("empty value handling", () => {
-    it("should show '-' for User Email when value is empty", () => {
-      const data = { ...MOCK_DATA, userEmail: "" };
+  describe("User field fallbacks", () => {
+    it("should display userEmail when alias is null", () => {
+      render(<KeyInfoHeader data={MOCK_DATA} />);
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    });
+
+    it("should fall back to userId when alias and email are missing", () => {
+      const data = { ...MOCK_DATA, userEmail: "", userAlias: null };
+      render(<KeyInfoHeader data={data} />);
+      expect(screen.getByText("user-abc-123")).toBeInTheDocument();
+    });
+
+    it("should show '-' when alias, email, and userId are all empty", () => {
+      const data = { ...MOCK_DATA, userId: "", userEmail: "", userAlias: null };
       render(<KeyInfoHeader data={data} />);
       expect(screen.getByText("-")).toBeInTheDocument();
     });

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.test.tsx
@@ -137,6 +137,13 @@ describe("KeyInfoHeader", () => {
   });
 
   describe("User field fallbacks", () => {
+    it("should display userAlias as primary when set, overriding email and userId", () => {
+      const data = { ...MOCK_DATA, userAlias: "alice" };
+      render(<KeyInfoHeader data={data} />);
+      expect(screen.getByText("alice")).toBeInTheDocument();
+      expect(screen.queryByText("test@example.com")).not.toBeInTheDocument();
+    });
+
     it("should display userEmail when alias is null", () => {
       render(<KeyInfoHeader data={MOCK_DATA} />);
       expect(screen.getByText("test@example.com")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
@@ -5,7 +5,7 @@ import {
   SyncOutlined,
   DeleteOutlined,
   PlusOutlined,
-  MailOutlined,
+  UserOutlined,
   CalendarOutlined,
   ClockCircleOutlined,
   ThunderboltOutlined,
@@ -55,7 +55,7 @@ function UserField({
 }) {
   const labelEl = (
     <Space size={4}>
-      <Text type="secondary"><MailOutlined /></Text>
+      <Text type="secondary"><UserOutlined /></Text>
       <Text type="secondary" style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>
         User
       </Text>

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
@@ -1,19 +1,20 @@
 import React from "react";
-import { Button, Typography, Tooltip, Space, Divider, Flex } from "antd";
+import { Button, Typography, Tooltip, Space, Divider, Flex, Popover } from "antd";
 import {
   ArrowLeftOutlined,
   SyncOutlined,
   DeleteOutlined,
   PlusOutlined,
-  UserOutlined,
   MailOutlined,
   CalendarOutlined,
   ClockCircleOutlined,
   ThunderboltOutlined,
   SafetyCertificateOutlined,
   TransactionOutlined,
+  FieldTimeOutlined,
 } from "@ant-design/icons";
 import LabeledField from "../common_components/LabeledField";
+import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
 
 const { Title, Text } = Typography;
 
@@ -22,10 +23,12 @@ export interface KeyInfoData {
   keyId: string;
   userId: string;
   userEmail: string;
+  userAlias?: string | null;
   createdBy: string;
   createdAt: string;
   lastUpdated: string;
   lastActive: string;
+  expires: string;
 }
 
 interface KeyInfoHeaderProps {
@@ -39,6 +42,83 @@ interface KeyInfoHeaderProps {
   backButtonText?: string;
   regenerateDisabled?: boolean;
   regenerateTooltip?: string;
+}
+
+function UserField({
+  userAlias,
+  userEmail,
+  userId,
+}: {
+  userAlias?: string | null;
+  userEmail: string;
+  userId: string;
+}) {
+  const labelEl = (
+    <Space size={4}>
+      <Text type="secondary"><MailOutlined /></Text>
+      <Text type="secondary" style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        User
+      </Text>
+    </Space>
+  );
+
+  const isEmpty = !userAlias && !userEmail && !userId;
+  if (isEmpty) {
+    return (
+      <div>
+        {labelEl}
+        <div><Text strong>-</Text></div>
+      </div>
+    );
+  }
+
+  const isDefaultAdmin = userId === "default_user_id";
+  const displayValue = userAlias || userEmail || userId;
+
+  const popoverContent = (
+    <div className="flex flex-col gap-2 text-xs min-w-[200px] max-w-[300px]">
+      {[
+        { label: "User Alias", value: userAlias ?? null },
+        { label: "User Email", value: userEmail || null },
+        { label: "User ID", value: userId || null },
+      ].map(({ label, value }) => (
+        <div key={label} className="flex flex-col min-w-0">
+          <span className="text-gray-400">{label}</span>
+          {value ? (
+            <Typography.Text className="font-mono text-xs" ellipsis={{ tooltip: value }} copyable>
+              {value}
+            </Typography.Text>
+          ) : (
+            <span className="font-mono">-</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
+  if (isDefaultAdmin && !userAlias && !userEmail) {
+    return (
+      <div>
+        {labelEl}
+        <div>
+          <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
+            <span className="cursor-default"><DefaultProxyAdminTag userId={userId} /></span>
+          </Popover>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {labelEl}
+      <div>
+        <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
+          <Text strong style={{ cursor: "default" }}>{displayValue}</Text>
+        </Popover>
+      </div>
+    </div>
+  );
 }
 
 export function KeyInfoHeader({
@@ -101,11 +181,11 @@ export function KeyInfoHeader({
 
       <Flex align="stretch" gap={40} style={{ marginBottom: 40 }}>
         <Space direction="vertical" size={16}>
-          <LabeledField label="User Email" value={data.userEmail} icon={<MailOutlined />} />
+          <UserField userAlias={data.userAlias} userEmail={data.userEmail} userId={data.userId} />
           <LabeledField
-            label="User ID"
-            value={data.userId}
-            icon={<UserOutlined />}
+            label="Created By"
+            value={data.createdBy}
+            icon={<SafetyCertificateOutlined />}
             truncate
             copyable
             defaultUserIdCheck
@@ -116,14 +196,7 @@ export function KeyInfoHeader({
 
         <Space direction="vertical" size={16}>
           <LabeledField label="Created At" value={data.createdAt} icon={<CalendarOutlined />} />
-          <LabeledField
-            label="Created By"
-            value={data.createdBy}
-            icon={<SafetyCertificateOutlined />}
-            truncate
-            copyable
-            defaultUserIdCheck
-          />
+          <LabeledField label="Expires" value={data.expires} icon={<FieldTimeOutlined />} />
         </Space>
 
         <Divider type="vertical" style={{ height: "auto" }} />

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
@@ -85,7 +85,12 @@ function UserField({
         <div key={label} className="flex flex-col min-w-0">
           <span className="text-gray-400">{label}</span>
           {value ? (
-            <Typography.Text className="font-mono text-xs" ellipsis={{ tooltip: value }} copyable>
+            <Typography.Text
+              className="font-mono text-xs"
+              style={{ maxWidth: 220 }}
+              ellipsis={{ tooltip: value }}
+              copyable
+            >
               {value}
             </Typography.Text>
           ) : (
@@ -114,7 +119,13 @@ function UserField({
       {labelEl}
       <div>
         <Popover content={popoverContent} trigger="hover" placement="bottomLeft">
-          <Text strong style={{ cursor: "default" }}>{displayValue}</Text>
+          <Text
+            strong
+            ellipsis
+            style={{ cursor: "default", maxWidth: 200, display: "block" }}
+          >
+            {displayValue}
+          </Text>
         </Popover>
       </div>
     </div>
@@ -182,6 +193,13 @@ export function KeyInfoHeader({
       <Flex align="stretch" gap={40} style={{ marginBottom: 40 }}>
         <Space direction="vertical" size={16}>
           <UserField userAlias={data.userAlias} userEmail={data.userEmail} userId={data.userId} />
+          <LabeledField label="Expires" value={data.expires} icon={<FieldTimeOutlined />} />
+        </Space>
+
+        <Divider type="vertical" style={{ height: "auto" }} />
+
+        <Space direction="vertical" size={16}>
+          <LabeledField label="Created At" value={data.createdAt} icon={<CalendarOutlined />} />
           <LabeledField
             label="Created By"
             value={data.createdBy}
@@ -190,13 +208,6 @@ export function KeyInfoHeader({
             copyable
             defaultUserIdCheck
           />
-        </Space>
-
-        <Divider type="vertical" style={{ height: "auto" }} />
-
-        <Space direction="vertical" size={16}>
-          <LabeledField label="Created At" value={data.createdAt} icon={<CalendarOutlined />} />
-          <LabeledField label="Expires" value={data.expires} icon={<FieldTimeOutlined />} />
         </Space>
 
         <Divider type="vertical" style={{ height: "auto" }} />

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -403,7 +403,11 @@ export default function KeyInfoView({
           keyId: currentKeyData.token_id || currentKeyData.token,
           userId: currentKeyData.user_id || "",
           userEmail: currentKeyData.user_email || "",
-          createdBy: currentKeyData.user_email || currentKeyData.user_id || "",
+          createdBy:
+            currentKeyData.created_by_user?.user_alias ||
+            currentKeyData.created_by_user?.user_email ||
+            currentKeyData.created_by ||
+            "",
           createdAt: currentKeyData.created_at ? formatTimestamp(currentKeyData.created_at) : "",
           lastUpdated: currentKeyData.updated_at ? formatTimestamp(currentKeyData.updated_at) : "",
           lastActive: currentKeyData.last_active ? formatTimestamp(currentKeyData.last_active) : "Never",

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -403,6 +403,7 @@ export default function KeyInfoView({
           keyId: currentKeyData.token_id || currentKeyData.token,
           userId: currentKeyData.user_id || "",
           userEmail: currentKeyData.user_email || "",
+          userAlias: currentKeyData.user?.user_alias ?? null,
           createdBy:
             currentKeyData.created_by_user?.user_alias ||
             currentKeyData.created_by_user?.user_email ||
@@ -411,6 +412,7 @@ export default function KeyInfoView({
           createdAt: currentKeyData.created_at ? formatTimestamp(currentKeyData.created_at) : "",
           lastUpdated: currentKeyData.updated_at ? formatTimestamp(currentKeyData.updated_at) : "",
           lastActive: currentKeyData.last_active ? formatTimestamp(currentKeyData.last_active) : "Never",
+          expires: currentKeyData.expires ? formatTimestamp(currentKeyData.expires) : "Never",
         }}
         onBack={onClose}
         onRegenerate={() => setIsRegenerateModalOpen(true)}


### PR DESCRIPTION
## Summary

Follow-up to #27694 (Created By fix). The key details page Overview header now also includes the `Expires` field — previously only visible on the Settings tab — and merges the separate **User Email** / **User ID** stacked rows into a single **User** field. The User cell shows the alias/email/user_id (in fallback order) as its visible value, with a hover Popover exposing all three values, each individually copyable. The pattern mirrors the AllKeys and Team Virtual Keys tables' Created By column (`VirtualKeysTable.tsx:344-407`, `TeamVirtualKeysTable.tsx`) for consistency.

## Note on stacked PR

This branch is stacked on top of #27694

## Screenshots

### Before
<!-- drag the BEFORE screenshot here:
     Key details Overview header showing separate User Email / User ID rows
     and no Expires field
-->
<img width="612" height="188" alt="Screenshot 2026-05-11 at 5 31 19 PM" src="https://github.com/user-attachments/assets/8dc1f5b6-4b93-45a8-a96f-ee2ee1779082" />

### After
<!-- drag the AFTER screenshots here:
     1. Header with merged User field and Expires below Created At
     2. User cell on hover — Popover with alias/email/user_id + copy icons
-->
<img width="697" height="231" alt="Screenshot 2026-05-11 at 5 57 59 PM" src="https://github.com/user-attachments/assets/922dbfec-5afe-4522-99e0-fa797690ac70" />

<img width="665" height="230" alt="Screenshot 2026-05-11 at 6 00 29 PM" src="https://github.com/user-attachments/assets/7960064d-0ab0-41a9-bfd1-2c847b9516e1" />



## Test plan
- [x] `src/components/templates/KeyInfoHeader.test.tsx` — 21 tests pass (added User-fallback coverage, updated default-admin assertions)
- [x] `src/components/templates/key_info_view.test.tsx` — 25 tests pass (unchanged)
- [x] `npx tsc --noEmit` clean on production sources
- [x] Manual: header shows EXPIRES under CREATED AT
- [x] Manual: hover the User cell → Popover with alias/email/user_id and per-field copy icons
- [x] Regression: default-admin keys still render the "Default Proxy Admin" tag (both User and Created By cells)

Resolves LIT-2517