### PR TITLE
feat: add Xiaomi MiMo-V2.5-Pro and MiMo-V2.5 OpenRouter model entries

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27374,6 +27374,7 @@
     "openrouter/xiaomi/mimo-v2.5-pro": {
         "input_cost_per_token": 1e-06,
         "output_cost_per_token": 3e-06,
+        "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 2e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 1048576,
@@ -27390,6 +27391,7 @@
     "openrouter/xiaomi/mimo-v2.5": {
         "input_cost_per_token": 4e-07,
         "output_cost_per_token": 2e-06,
+        "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 8e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 1048576,
@@ -27400,6 +27402,8 @@
         "supports_tool_choice": true,
         "supports_reasoning": true,
         "supports_vision": true,
+        "supports_audio_input": true,
+        "supports_video_input": true,
         "supports_response_schema": true,
         "supports_prompt_caching": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27356,10 +27356,10 @@
         "supports_tool_choice": true
     },
     "openrouter/xiaomi/mimo-v2-flash": {
-        "input_cost_per_token": 9e-08,
-        "output_cost_per_token": 2.9e-07,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 3e-07,
         "cache_creation_input_token_cost": 0.0,
-        "cache_read_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 1e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
         "max_output_tokens": 16384,
@@ -27369,7 +27369,39 @@
         "supports_tool_choice": true,
         "supports_reasoning": true,
         "supports_vision": false,
-        "supports_prompt_caching": false
+        "supports_prompt_caching": true
+    },
+    "openrouter/xiaomi/mimo-v2.5-pro": {
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_response_schema": true,
+        "supports_prompt_caching": true
+    },
+    "openrouter/xiaomi/mimo-v2.5": {
+        "input_cost_per_token": 4e-07,
+        "output_cost_per_token": 2e-06,
+        "cache_read_input_token_cost": 8e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true,
+        "supports_response_schema": true,
+        "supports_prompt_caching": true
     },
     "openrouter/z-ai/glm-4.7": {
         "input_cost_per_token": 4e-07,


### PR DESCRIPTION
## Summary

Adds missing model entries for Xiaomi's MiMo-V2.5 family on OpenRouter, and fixes stale pricing for the existing MiMo-V2-Flash entry.

### Changes

| Entry | Action | Details |
|-------|--------|---------|
| `openrouter/xiaomi/mimo-v2.5-pro` | **ADD** | 1M context, text-only, reasoning, tools, $1/$3 per M tokens |
| `openrouter/xiaomi/mimo-v2.5` | **ADD** | 1M context, multimodal (vision+audio+video), reasoning, tools, $0.40/$2 per M tokens |
| `openrouter/xiaomi/mimo-v2-flash` | **FIX** | Update pricing to current OR rates ($0.10/$0.30 per M), enable prompt caching (`cache_read_input_token_cost: 1e-08`) |

### Source

All pricing and context window data scraped from the OpenRouter models API:
`https://openrouter.ai/api/v1/models`

### Motivation

MiMo-V2.5-Pro has been available on OpenRouter but is missing from LiteLLM's model registry, causing broken context window resolution when routing through the OpenRouter provider.