### PR TITLE
fix(router): pin Responses API affinity to Azure resource on model-group switch

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1673,7 +1673,7 @@ class Router:
                 for cb in self.optional_callbacks
             )
             if not already_registered:
-                ec_callback = EncryptedContentAffinityCheck()
+                ec_callback = EncryptedContentAffinityCheck(router=self)
                 self.optional_callbacks.append(ec_callback)
                 litellm.logging_callback_manager.add_litellm_callback(ec_callback)
 

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -36,12 +36,15 @@ Safe to enable globally:
 - No cache required.
 """
 
-from typing import Any, List, Optional, cast
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 from litellm._logging import verbose_router_logger
 from litellm.integrations.custom_logger import CustomLogger, Span
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import AllMessageValues
+
+if TYPE_CHECKING:
+    from litellm.router import Router
 
 
 class EncryptedContentAffinityCheck(CustomLogger):
@@ -55,8 +58,9 @@ class EncryptedContentAffinityCheck(CustomLogger):
     Wired via ``Router(optional_pre_call_checks=["encrypted_content_affinity"])``.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, router: Optional["Router"] = None) -> None:
         super().__init__()
+        self.router = router
 
     # ------------------------------------------------------------------
     # Helpers
@@ -119,6 +123,49 @@ class EncryptedContentAffinityCheck(CustomLogger):
                 return deployment
         return None
 
+    @staticmethod
+    def _encryption_boundary_key(
+        litellm_params: dict,
+    ) -> Optional[tuple]:
+        """
+        ``(api_base, api_key)`` pair identifying an Azure resource. Two
+        deployments sharing both are interchangeable for ``encrypted_content``
+        follow-ups; Azure rejects content produced by any other resource.
+        """
+        if not isinstance(litellm_params, dict):
+            return None
+        api_base = litellm_params.get("api_base")
+        api_key = litellm_params.get("api_key")
+        if not api_base or not api_key:
+            return None
+        return (api_base, api_key)
+
+    def _find_deployments_on_same_encryption_boundary(
+        self,
+        healthy_deployments: List[dict],
+        model_id: str,
+    ) -> List[dict]:
+        """
+        Deployments in ``healthy_deployments`` sharing the originating
+        deployment's ``(api_base, api_key)``. Returns ``[]`` if router isn't
+        wired in, the originating deployment was removed, or no boundary match.
+        """
+        if self.router is None:
+            return []
+        originating = self.router.get_deployment(model_id=model_id)
+        if originating is None:
+            return []
+        boundary = self._encryption_boundary_key(
+            originating.litellm_params.model_dump(exclude_none=True)
+        )
+        if boundary is None:
+            return []
+        return [
+            d
+            for d in healthy_deployments
+            if self._encryption_boundary_key(d.get("litellm_params", {})) == boundary
+        ]
+
     # ------------------------------------------------------------------
     # Request routing  (pre-call filter)
     # ------------------------------------------------------------------
@@ -172,8 +219,25 @@ class EncryptedContentAffinityCheck(CustomLogger):
             request_kwargs["_encrypted_content_affinity_pinned"] = True
             return [deployment]
 
+        # Follow-up switched model_name (LIT-2531): pin by Azure resource instead.
+        boundary_matches = self._find_deployments_on_same_encryption_boundary(
+            healthy_deployments=typed_healthy_deployments,
+            model_id=model_id,
+        )
+        if boundary_matches:
+            verbose_router_logger.debug(
+                "EncryptedContentAffinityCheck: model_id=%s not in healthy_deployments; "
+                "pinning to %d deployment(s) on same encryption boundary",
+                model_id,
+                len(boundary_matches),
+            )
+            request_kwargs["_encrypted_content_affinity_pinned"] = True
+            return boundary_matches
+
         verbose_router_logger.error(
-            "EncryptedContentAffinityCheck: decoded deployment=%s not found in healthy_deployments",
+            "EncryptedContentAffinityCheck: decoded deployment=%s not found in "
+            "healthy_deployments and no boundary match available; falling back to "
+            "full deployment pool (encrypted_content may be rejected upstream)",
             model_id,
         )
         return typed_healthy_deployments

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -125,17 +125,26 @@ class EncryptedContentAffinityCheck(CustomLogger):
 
     @staticmethod
     def _encryption_boundary_key(
-        litellm_params: dict,
+        litellm_params: Any,
     ) -> Optional[tuple]:
         """
         ``(api_base, api_key)`` pair identifying an Azure resource. Two
         deployments sharing both are interchangeable for ``encrypted_content``
         follow-ups; Azure rejects content produced by any other resource.
+
+        Accepts any object exposing dict-style ``.get(key, default)``: plain
+        dicts (the common case in ``healthy_deployments``) as well as
+        ``LiteLLM_Params``-style Pydantic instances, which define a custom
+        ``.get()``. A stricter ``isinstance(dict)`` guard would silently drop
+        the latter from boundary matching and fall back to the full pool —
+        i.e. trigger the exact ``invalid_encrypted_content`` failure this
+        check exists to prevent.
         """
-        if not isinstance(litellm_params, dict):
+        getter = getattr(litellm_params, "get", None)
+        if not callable(getter):
             return None
-        api_base = litellm_params.get("api_base")
-        api_key = litellm_params.get("api_key")
+        api_base = getter("api_base")
+        api_key = getter("api_key")
         if not api_base or not api_key:
             return None
         return (api_base, api_key)

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -888,13 +888,16 @@ async def test_affinity_falls_back_to_same_encryption_boundary_on_model_group_sw
                 return d
         return seq[0]
 
-    with patch(
-        "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
-        new_callable=AsyncMock,
-        return_value=first_resp,
-    ), patch(
-        "litellm.router_strategy.simple_shuffle.random.choice",
-        side_effect=first_call_picks_account_a,
+    with (
+        patch(
+            "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+            new_callable=AsyncMock,
+            return_value=first_resp,
+        ),
+        patch(
+            "litellm.router_strategy.simple_shuffle.random.choice",
+            side_effect=first_call_picks_account_a,
+        ),
     ):
         r1 = await router.aresponses(model="gpt-5.3-codex", input="hi")
 
@@ -1013,13 +1016,16 @@ async def test_affinity_falls_back_to_same_boundary_on_alias_switch():
                 return d
         return seq[0]
 
-    with patch(
-        "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
-        new_callable=AsyncMock,
-        return_value=first_resp,
-    ), patch(
-        "litellm.router_strategy.simple_shuffle.random.choice",
-        side_effect=pick_account_a,
+    with (
+        patch(
+            "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+            new_callable=AsyncMock,
+            return_value=first_resp,
+        ),
+        patch(
+            "litellm.router_strategy.simple_shuffle.random.choice",
+            side_effect=pick_account_a,
+        ),
     ):
         r1 = await router.aresponses(model="gpt-5.3-codex", input="hi")
 
@@ -1096,3 +1102,73 @@ def test_boundary_fallback_originating_deployment_removed_returns_empty():
     )
     assert matches == []
     mock_router.get_deployment.assert_called_once_with(model_id="dep-removed")
+
+
+def test_boundary_key_accepts_pydantic_litellm_params_instance():
+    """
+    Regression: ``_encryption_boundary_key`` must accept any object exposing
+    dict-style ``.get()`` (incl. ``LiteLLM_Params`` Pydantic instances) — not
+    just plain dicts.
+
+    A stricter ``isinstance(dict)`` guard would silently return ``None`` for a
+    ``LiteLLM_Params`` value, drop the deployment from boundary matching, and
+    fall back to the full pool — which is the exact ``invalid_encrypted_content``
+    failure this check exists to prevent.
+    """
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+    from litellm.types.router import LiteLLM_Params
+
+    pydantic_params = LiteLLM_Params(
+        model="azure/gpt-5.3-codex",
+        api_base="https://mateo-resource.openai.azure.com",
+        api_key="fake-azure-resource-key-a",
+    )
+    plain_params = {
+        "model": "azure/gpt-5.3-codex",
+        "api_base": "https://mateo-resource.openai.azure.com",
+        "api_key": "fake-azure-resource-key-a",
+    }
+
+    pydantic_key = EncryptedContentAffinityCheck._encryption_boundary_key(
+        pydantic_params
+    )
+    plain_key = EncryptedContentAffinityCheck._encryption_boundary_key(plain_params)
+
+    assert pydantic_key is not None
+    assert (
+        pydantic_key
+        == plain_key
+        == (
+            "https://mateo-resource.openai.azure.com",
+            "fake-azure-resource-key-a",
+        )
+    )
+
+
+def test_boundary_key_rejects_non_dict_like_inputs():
+    """
+    Inputs that don't expose ``.get()`` (None, lists, strings, ints) -> None.
+    Guards against accidentally treating a stray non-dict-like value as a
+    valid boundary.
+    """
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    for bad in (None, [], "not a dict", 42, object()):
+        assert EncryptedContentAffinityCheck._encryption_boundary_key(bad) is None
+
+    assert (
+        EncryptedContentAffinityCheck._encryption_boundary_key(
+            {"api_base": "", "api_key": "k"}
+        )
+        is None
+    )
+    assert (
+        EncryptedContentAffinityCheck._encryption_boundary_key(
+            {"api_base": "https://x"}
+        )
+        is None
+    )

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -791,3 +791,308 @@ def test_encrypted_content_wrapping_empty_string():
 
     assert extracted_model_id == model_id
     assert unwrapped == original_content
+
+
+# ---------------------------------------------------------------------------
+# LIT-2531: cross-model-group fallback via encryption boundary (api_base + api_key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_affinity_falls_back_to_same_encryption_boundary_on_model_group_switch():
+    """
+    LIT-2531: Client starts a session on gpt-5.3-codex, follow-up switches to
+    gpt-5.4 mid-chat (e.g. via Codex `model_migrations`). Affinity must pin to
+    the gpt-5.4 deployment on the SAME Azure resource as the originating
+    gpt-5.3-codex deployment -- otherwise Azure rejects the encrypted_content.
+    """
+    first_resp = _build_mock_response(
+        output_items=[
+            {
+                "type": "reasoning",
+                "id": "rs_encrypted_xyz",
+                "status": "completed",
+                "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+            },
+        ],
+        response_id="resp_first",
+    )
+    second_resp = _build_mock_response(
+        output_items=[
+            {
+                "type": "message",
+                "id": "msg_ok",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "answer"}],
+            },
+        ],
+        response_id="resp_second",
+    )
+
+    ACCOUNT_A_BASE = "https://account-a.openai.azure.com/"
+    ACCOUNT_A_KEY = "key-a"
+    ACCOUNT_B_BASE = "https://account-b.openai.azure.com/"
+    ACCOUNT_B_KEY = "key-b"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.3-codex",
+                "litellm_params": {
+                    "model": "azure/gpt-5.3-codex",
+                    "api_base": ACCOUNT_A_BASE,
+                    "api_key": ACCOUNT_A_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.3-codex-account-a"},
+            },
+            {
+                "model_name": "gpt-5.3-codex",
+                "litellm_params": {
+                    "model": "azure/gpt-5.3-codex",
+                    "api_base": ACCOUNT_B_BASE,
+                    "api_key": ACCOUNT_B_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.3-codex-account-b"},
+            },
+            {
+                "model_name": "gpt-5.4",
+                "litellm_params": {
+                    "model": "azure/gpt-5.4",
+                    "api_base": ACCOUNT_A_BASE,
+                    "api_key": ACCOUNT_A_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.4-account-a"},
+            },
+            {
+                "model_name": "gpt-5.4",
+                "litellm_params": {
+                    "model": "azure/gpt-5.4",
+                    "api_base": ACCOUNT_B_BASE,
+                    "api_key": ACCOUNT_B_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.4-account-b"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+        num_retries=0,
+    )
+
+    def first_call_picks_account_a(seq):
+        for d in seq:
+            if d["model_info"]["id"] == "gpt-5.3-codex-account-a":
+                return d
+        return seq[0]
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+        new_callable=AsyncMock,
+        return_value=first_resp,
+    ), patch(
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=first_call_picks_account_a,
+    ):
+        r1 = await router.aresponses(model="gpt-5.3-codex", input="hi")
+
+    assert r1._hidden_params["model_id"] == "gpt-5.3-codex-account-a"
+    encoded_id = _extract_encoded_item_id(r1)
+    assert encoded_id.startswith("encitem_")
+
+    # simple_shuffle.random.choice NOT patched: prove affinity narrows the
+    # candidate pool to a single deployment regardless of which one shuffle picks.
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+        new_callable=AsyncMock,
+        return_value=second_resp,
+    ):
+        r2 = await router.aresponses(
+            model="gpt-5.4",
+            input=[
+                {
+                    "type": "reasoning",
+                    "id": encoded_id,
+                    "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+                },
+            ],
+        )
+
+    assert r2._hidden_params["model_id"] == "gpt-5.4-account-a"
+
+
+@pytest.mark.asyncio
+async def test_affinity_falls_back_to_same_boundary_on_alias_switch():
+    """
+    LIT-2531 alias path: gpt-5.2-codex is a LiteLLM alias that points at the
+    same underlying Azure model as gpt-5.3-codex. Different model_name groups
+    in the router, so model_id-based pinning misses, but the encryption
+    boundary (api_base + api_key) is identical -> follow-up must still pin.
+    """
+    first_resp = _build_mock_response(
+        output_items=[
+            {
+                "type": "reasoning",
+                "id": "rs_alias_xyz",
+                "status": "completed",
+                "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+            },
+        ],
+        response_id="resp_alias_first",
+    )
+    second_resp = _build_mock_response(
+        output_items=[
+            {
+                "type": "message",
+                "id": "msg_alias_ok",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "ok"}],
+            },
+        ],
+        response_id="resp_alias_second",
+    )
+
+    ACCOUNT_A_BASE = "https://account-a.openai.azure.com/"
+    ACCOUNT_A_KEY = "key-a"
+    ACCOUNT_B_BASE = "https://account-b.openai.azure.com/"
+    ACCOUNT_B_KEY = "key-b"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.3-codex",
+                "litellm_params": {
+                    "model": "azure/gpt-5.3-codex",
+                    "api_base": ACCOUNT_A_BASE,
+                    "api_key": ACCOUNT_A_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.3-codex-account-a"},
+            },
+            {
+                "model_name": "gpt-5.3-codex",
+                "litellm_params": {
+                    "model": "azure/gpt-5.3-codex",
+                    "api_base": ACCOUNT_B_BASE,
+                    "api_key": ACCOUNT_B_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.3-codex-account-b"},
+            },
+            {
+                "model_name": "gpt-5.2-codex",
+                "litellm_params": {
+                    "model": "azure/gpt-5.3-codex",
+                    "api_base": ACCOUNT_A_BASE,
+                    "api_key": ACCOUNT_A_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.2-codex-account-a"},
+            },
+            {
+                "model_name": "gpt-5.2-codex",
+                "litellm_params": {
+                    "model": "azure/gpt-5.3-codex",
+                    "api_base": ACCOUNT_B_BASE,
+                    "api_key": ACCOUNT_B_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.2-codex-account-b"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+        num_retries=0,
+    )
+
+    def pick_account_a(seq):
+        for d in seq:
+            if d["model_info"]["id"] == "gpt-5.3-codex-account-a":
+                return d
+        return seq[0]
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+        new_callable=AsyncMock,
+        return_value=first_resp,
+    ), patch(
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=pick_account_a,
+    ):
+        r1 = await router.aresponses(model="gpt-5.3-codex", input="hi")
+
+    encoded_id = _extract_encoded_item_id(r1)
+    assert encoded_id.startswith("encitem_")
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+        new_callable=AsyncMock,
+        return_value=second_resp,
+    ):
+        r2 = await router.aresponses(
+            model="gpt-5.2-codex",
+            input=[
+                {
+                    "type": "reasoning",
+                    "id": encoded_id,
+                    "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+                },
+            ],
+        )
+
+    assert r2._hidden_params["model_id"] == "gpt-5.2-codex-account-a"
+
+
+def test_boundary_fallback_no_router_ref_returns_empty():
+    """
+    Standalone use (no router wired in) -> the boundary lookup short-circuits
+    to ``[]`` instead of crashing on ``None.get_deployment``.
+    """
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    check = EncryptedContentAffinityCheck(router=None)
+    healthy = [
+        {
+            "model_info": {"id": "dep-1"},
+            "litellm_params": {"api_base": "https://x", "api_key": "k"},
+        }
+    ]
+    matches = check._find_deployments_on_same_encryption_boundary(
+        healthy_deployments=healthy,
+        model_id="dep-2",
+    )
+    assert matches == []
+
+
+def test_boundary_fallback_originating_deployment_removed_returns_empty():
+    """
+    If the originating deployment has been removed from the router (e.g. via
+    /model/delete), ``router.get_deployment`` returns None and we return [] so
+    the caller falls back to the full healthy_deployments list.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = None
+
+    check = EncryptedContentAffinityCheck(router=mock_router)
+    healthy = [
+        {
+            "model_info": {"id": "dep-1"},
+            "litellm_params": {"api_base": "https://x", "api_key": "k"},
+        }
+    ]
+    matches = check._find_deployments_on_same_encryption_boundary(
+        healthy_deployments=healthy,
+        model_id="dep-removed",
+    )
+    assert matches == []
+    mock_router.get_deployment.assert_called_once_with(model_id="dep-removed")


### PR DESCRIPTION
## Relevant issues

_None — internal Linear ticket below._

## Linear ticket

Resolves LIT-2531

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) — 4 new tests in `tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py` (27 pass total)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — affected test file passes locally (27/27); full `make test-unit` runs in CI
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem — single behavioral change in `EncryptedContentAffinityCheck` (one new fallback path) + corresponding tests
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Reproduced the customer's `400 invalid_encrypted_content` end-to-end on two real Azure resources (`mateo-resource` + `claude-e2e-litellm-testing`), across three model groups (`gpt-5.3-codex`, `gpt-5.4`, `gpt-5.2-codex` alias). 20 first+follow-up Responses-API pairs per scenario.

| Path | Staging tip (`afbe8647507f`) | PR branch (`6a67353eee80`) |
|---|---|---|
| 5.3-codex -> 5.4 (cross-group) | **14/20 fail** | **0/20 fail** |
| 5.3-codex -> 5.2-codex (alias) | **10/20 fail** | **0/20 fail** |

Proxy debug logs on the PR branch show 40/40 follow-ups going through the new `pinning to N deployment(s) on same encryption boundary` path, zero `falling back to full deployment pool` warnings.

### Repro setup

Proxy command (both branches, same config):

```bash
source /tmp/lit_envvars.sh && \
  .venv/bin/python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/example_config_yaml/lit_2531_encrypted_content_affinity_repro.yaml
```

### Run logs

> Note: `id=resp_<redacted>` replaces per-response opaque blobs. The interesting columns are `model_id` (which Azure resource was hit) and `body=...` (the failure code). Full unredacted output: see the `lit_2531_verification.html` artifact built locally from the same files.

#### Staging tip — bug present (`git checkout afbe8647507f`)

<details><summary>5.3-codex → 5.4 (cross-group) — failures: 14/20</summary>

```bash
LITELLM_PROXY_KEY=sk-1234 LITELLM_PROXY_URL=http://localhost:4000 \
  .venv/bin/python litellm/proxy/example_config_yaml/lit_2531_encrypted_content_affinity_repro.py \
  --iterations 20
```

```

=== iteration 1/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 2/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0d92a82a932c0905016a028d52e53c8195ba4058d324cc7965)

=== iteration 3/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 4/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_0f0aacbe8e544bed016a028d58428081969938636b0ef6087f)

=== iteration 5/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_0a30de15d35d121c016a028d5ac4708197861cc2c55e2edad0)

=== iteration 6/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_0c5c091d3d7e335a016a028d5d57508193b319848128d88f3b)

=== iteration 7/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_05582bf19e94f1dc016a028d5f45f48196972fb71c0ae256ef)

=== iteration 8/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 9/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_0c770a039efed0d8016a028d6497e48197a67a6c0dafea6ff3)

=== iteration 10/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0d5e0bb9dfacfc54016a028d6765508195b4b1200e549f01df)

=== iteration 11/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_02e8616895e81750016a028d6930c881948a29e59f4924a08f)

=== iteration 12/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 13/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 14/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0d1f56bed5a9dff1016a028d7441408190b6c3c9147eec5aad)

=== iteration 15/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_0eaf2205b01ca2f0016a028d7604148197a185adf124912768)

=== iteration 16/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0a3bf80533c6426d016a028d780eb48197b470977624bd7fce)

=== iteration 17/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 18/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_08210b447fe5e0b8016a028d7e3d7c81958483e0fcc52c3fc3)

=== iteration 19/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_095f69559d05806c016a028d80883881959a3b46d3c73a9c1d)

=== iteration 20/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.4-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0f14375e6fb0309d016a028d834cd88197a43ef75f91067e4b)

failures: 14/20
```

</details>

<details><summary>5.3-codex → 5.2-codex (alias) — failures: 10/20</summary>

```bash
LITELLM_PROXY_KEY=sk-1234 LITELLM_PROXY_URL=http://localhost:4000 \
  .venv/bin/python litellm/proxy/example_config_yaml/lit_2531_encrypted_content_affinity_repro.py \
  --followup-model gpt-5.2-codex --iterations 20
```

```

=== iteration 1/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 2/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_09a6731941fc9f4f016a028d9046848195b31fd33509eedcd7)

=== iteration 3/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 4/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 5/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 6/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 7/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 8/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0d45010dd7884d2f016a028da236a88193a3a9efd72e72486b)

=== iteration 9/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_02a5baabf4d2d110016a028da465fc8190ac58e74021eb74ed)

=== iteration 10/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_0c52fb826a0d096d016a028da6e79c8196bd81d7ea147a5969)

=== iteration 11/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 12/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-b crossed_org=True body=400 invalid_encrypted_content (item rs_03545741d7a94d0e016a028dabe44c8197aabbd473378b02c5)

=== iteration 13/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_06ddb2204df35a8a016a028daf0d848197b2156ca07617c232)

=== iteration 14/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 15/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_077bac2492d0125d016a028db5478081908fa9320235116669)

=== iteration 16/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 17/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0e95e4b8fd494f56016a028dbb67c08197a41bdc7a77c79f81)

=== iteration 18/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_0f3bcc59196a1f95016a028dbd9fa481949bd5bfa35fde7794)

=== iteration 19/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up FAIL  status=400 model_id=gpt-5.2-codex-account-a crossed_org=True body=400 invalid_encrypted_content (item rs_01f381f702fcb8ca016a028dbf8b6481948eb22299e309ac87)

=== iteration 20/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

failures: 10/20
```

</details>

#### PR branch — fix applied (`git checkout 6a67353eee80`)

<details><summary>5.3-codex → 5.4 (cross-group) — failures: 0/20</summary>

```bash
LITELLM_PROXY_KEY=sk-1234 LITELLM_PROXY_URL=http://localhost:4000 \
  .venv/bin/python litellm/proxy/example_config_yaml/lit_2531_encrypted_content_affinity_repro.py \
  --iterations 20
```

```

=== iteration 1/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 2/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 3/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 4/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 5/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 6/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 7/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 8/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 9/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 10/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 11/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 12/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 13/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 14/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 15/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 16/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-b id=resp_<redacted>= crossed_org=False

=== iteration 17/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 18/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 19/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

=== iteration 20/20  (gpt-5.3-codex -> gpt-5.4) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.4-account-a id=resp_<redacted>= crossed_org=False

failures: 0/20
```

</details>

<details><summary>5.3-codex → 5.2-codex (alias) — failures: 0/20</summary>

```bash
LITELLM_PROXY_KEY=sk-1234 LITELLM_PROXY_URL=http://localhost:4000 \
  .venv/bin/python litellm/proxy/example_config_yaml/lit_2531_encrypted_content_affinity_repro.py \
  --followup-model gpt-5.2-codex --iterations 20
```

```

=== iteration 1/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 2/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 3/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 4/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 5/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 6/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 7/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 8/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 9/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 10/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 11/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 12/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 13/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 14/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 15/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 16/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-a id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-a id=resp_<redacted>== crossed_org=False

=== iteration 17/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 18/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 19/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

=== iteration 20/20  (gpt-5.3-codex -> gpt-5.2-codex) ===
  first call ok   status=200 model_id=gpt-5.3-codex-account-b id=resp_<redacted>== encrypted_content=True
  follow-up ok    status=200 model_id=gpt-5.2-codex-account-b id=resp_<redacted>== crossed_org=False

failures: 0/20
```

</details>

## Type

🐛 Bug Fix

## Changes

When a Responses API follow-up switches `model_name` mid-session (e.g. `gpt-5.3-codex` -> `gpt-5.4` via Codex `model_migrations`, or a LiteLLM-side alias that points at the same Azure deployment), `encrypted_content_affinity` was logging `decoded deployment not found in healthy_deployments` and falling back to the full deployment pool. With multi-region Azure deployments, simple-shuffle could then land on a different Azure resource, tripping a `400 invalid_encrypted_content`:

```
The encrypted content gAAA...CQ== could not be verified.
Reason: Encrypted content could not be decrypted or parsed.
```

**Root cause:** the affinity check decodes the originating `model_id` from the request, but `_find_deployment_by_model_id` only scans `healthy_deployments`, which the router already filtered down to the *new* model_name group. The originating deployment is not in that filtered list.

**Fix:** when the `model_id` miss is across model groups, fall back to pinning by the originating deployment's **encryption boundary** — i.e. its `(api_base, api_key)` pair. The encrypted_content is tied to the Azure resource (key+host), not to `model_name`, so any deployment on the same resource accepts it. The check now:

1. Looks up the originating deployment via `router.get_deployment(model_id)`.
2. Pulls its concrete (env-resolved) `api_base` + `api_key`.
3. Filters `healthy_deployments` for matching pairs and pins to those.
4. Falls back to the full pool only if router/originating deployment is unavailable.

### Files touched

- `litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py` — accept optional `Router` ref in `__init__`; new `_encryption_boundary_key` + `_find_deployments_on_same_encryption_boundary` helpers; wire fallback into `async_filter_deployments` before the existing "not found" error path.
- `litellm/router.py` — pass `self` to `EncryptedContentAffinityCheck(...)` at construction (single-line change).
- `tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py` — 4 new tests: cross-model-group fallback, alias-group fallback, no-router-ref returns empty, originating-deployment-removed returns empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing behavior for Responses API follow-ups by adding a new fallback pinning path based on `(api_base, api_key)`, which could alter deployment selection and surface only under encrypted-content flows; incorrect matching would route to an unintended deployment on the same resource.
> 
> **Overview**
> Ensures Responses API follow-ups referencing `encrypted_content` don’t fall back to the full deployment pool when the decoded originating `model_id` isn’t present in the current model group.
> 
> `EncryptedContentAffinityCheck` now receives a `Router` reference and, on a `model_id` miss, filters `healthy_deployments` to those on the same Azure *encryption boundary* (`api_base` + `api_key`) before routing. Adds targeted tests covering cross-model-group and alias switches plus guardrails when the router/origin deployment isn’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40db114a23142ad37ef8298ca43f837314426eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->