### PR TITLE
fix(prometheus): emit `litellm_remaining_tokens_metric` for Bedrock and Vertex

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1226,6 +1226,17 @@ class PrometheusLogger(CustomLogger):
             label_context=label_context,
         )
 
+        # Provider-agnostic fallback: providers like Bedrock and Vertex don't return
+        # x-ratelimit-remaining-* headers, so the gauges above only fire for OpenAI /
+        # Anthropic / Azure. When the proxy router has tpm/rpm configured for the
+        # model_group, derive remaining from configured-limit minus current usage so
+        # the same metric is populated for any provider.
+        await self._async_set_router_remaining_metrics(
+            standard_logging_payload=standard_logging_payload,  # type: ignore
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+
         # cache metrics
         self._increment_cache_metrics(
             standard_logging_payload=standard_logging_payload,  # type: ignore
@@ -2198,6 +2209,99 @@ class PrometheusLogger(CustomLogger):
                 ),
             )
             self.litellm_deployment_rpm_limit.labels(**_labels).set(rpm)
+
+    async def _async_set_router_remaining_metrics(
+        self,
+        standard_logging_payload: StandardLoggingPayload,
+        enum_values: UserAPIKeyLabelValues,
+        label_context: Optional[PrometheusLabelFactoryContext] = None,
+    ) -> None:
+        """
+        Populate ``litellm_remaining_tokens_metric`` /
+        ``litellm_remaining_requests_metric`` from the router's internal usage
+        counters when the upstream provider did not return
+        ``x-ratelimit-remaining-*`` response headers.
+
+        OpenAI / Anthropic / Azure return remaining tokens/requests in response
+        headers, but Bedrock and Vertex AI do not. This fallback computes
+        ``configured_limit - current_usage`` via
+        ``Router.get_remaining_model_group_usage`` so the same gauges are
+        emitted for every provider when tpm/rpm is configured on the
+        deployment.
+        """
+        try:
+            additional_headers = (
+                standard_logging_payload.get("hidden_params", {}) or {}
+            ).get("additional_headers") or {}
+
+            already_have_tokens = (
+                additional_headers.get("x_ratelimit_remaining_tokens") is not None
+            )
+            already_have_requests = (
+                additional_headers.get("x_ratelimit_remaining_requests") is not None
+            )
+            if already_have_tokens and already_have_requests:
+                return
+
+            model_group = standard_logging_payload.get("model_group")
+            if not model_group:
+                return
+
+            try:
+                from litellm.proxy.proxy_server import llm_router
+            except Exception:
+                llm_router = None
+
+            if llm_router is None:
+                return
+
+            try:
+                remaining_usage = await llm_router.get_remaining_model_group_usage(
+                    model_group
+                )
+            except Exception as e:
+                verbose_logger.debug(
+                    "Prometheus: get_remaining_model_group_usage failed for "
+                    "model_group=%s: %s",
+                    model_group,
+                    e,
+                )
+                return
+
+            if not remaining_usage:
+                return
+
+            remaining_tokens = remaining_usage.get("x-ratelimit-remaining-tokens")
+            remaining_requests = remaining_usage.get("x-ratelimit-remaining-requests")
+
+            if not already_have_tokens and remaining_tokens is not None:
+                _labels = prometheus_label_factory(
+                    supported_enum_labels=self.get_labels_for_metric(
+                        metric_name="litellm_remaining_tokens_metric"
+                    ),
+                    enum_values=enum_values,
+                    label_context=label_context,
+                )
+                self.litellm_remaining_tokens_metric.labels(**_labels).set(
+                    remaining_tokens
+                )
+
+            if not already_have_requests and remaining_requests is not None:
+                _labels = prometheus_label_factory(
+                    supported_enum_labels=self.get_labels_for_metric(
+                        metric_name="litellm_remaining_requests_metric"
+                    ),
+                    enum_values=enum_values,
+                    label_context=label_context,
+                )
+                self.litellm_remaining_requests_metric.labels(**_labels).set(
+                    remaining_requests
+                )
+        except Exception as e:
+            verbose_logger.exception(
+                "Prometheus Error: _async_set_router_remaining_metrics. "
+                "Exception occured - {}".format(str(e))
+            )
 
     def set_llm_deployment_success_metrics(
         self,

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2249,7 +2249,7 @@ class PrometheusLogger(CustomLogger):
 
             try:
                 from litellm.proxy.proxy_server import llm_router
-            except Exception:
+            except ImportError:
                 llm_router = None
 
             if llm_router is None:
@@ -2260,7 +2260,7 @@ class PrometheusLogger(CustomLogger):
                     model_group
                 )
             except Exception as e:
-                verbose_logger.debug(
+                verbose_logger.exception(
                     "Prometheus: get_remaining_model_group_usage failed for "
                     "model_group=%s: %s",
                     model_group,

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2274,6 +2274,20 @@ class PrometheusLogger(CustomLogger):
             remaining_tokens = remaining_usage.get("x-ratelimit-remaining-tokens")
             remaining_requests = remaining_usage.get("x-ratelimit-remaining-requests")
 
+            # Router's TPM/RPM counter is incremented by
+            # Router.deployment_callback_on_success, which races with this
+            # prometheus callback in the success-log fan-out. Prometheus wins
+            # the race in practice, so the router value is pre-decrement for
+            # the current request. Vendor headers (OpenAI/Anthropic/Azure)
+            # are post-decrement — the vendor counted the current request
+            # before responding. Subtract the in-flight delta so both paths
+            # report comparable values.
+            in_flight_tokens = standard_logging_payload.get("total_tokens") or 0
+            if remaining_tokens is not None:
+                remaining_tokens = remaining_tokens - in_flight_tokens
+            if remaining_requests is not None:
+                remaining_requests = remaining_requests - 1
+
             if not already_have_tokens and remaining_tokens is not None:
                 _labels = prometheus_label_factory(
                     supported_enum_labels=self.get_labels_for_metric(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2274,20 +2274,6 @@ class PrometheusLogger(CustomLogger):
             remaining_tokens = remaining_usage.get("x-ratelimit-remaining-tokens")
             remaining_requests = remaining_usage.get("x-ratelimit-remaining-requests")
 
-            # Router's TPM/RPM counter is incremented by
-            # Router.deployment_callback_on_success, which races with this
-            # prometheus callback in the success-log fan-out. Prometheus wins
-            # the race in practice, so the router value is pre-decrement for
-            # the current request. Vendor headers (OpenAI/Anthropic/Azure)
-            # are post-decrement — the vendor counted the current request
-            # before responding. Subtract the in-flight delta so both paths
-            # report comparable values.
-            in_flight_tokens = standard_logging_payload.get("total_tokens") or 0
-            if remaining_tokens is not None:
-                remaining_tokens = remaining_tokens - in_flight_tokens
-            if remaining_requests is not None:
-                remaining_requests = remaining_requests - 1
-
             if not already_have_tokens and remaining_tokens is not None:
                 _labels = prometheus_label_factory(
                     supported_enum_labels=self.get_labels_for_metric(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8771,9 +8771,29 @@ class Router:
                     model_group
                 )
 
+                # get_remaining_model_group_usage reads the router's TPM/RPM
+                # counter, which is incremented post-response by
+                # deployment_callback_on_success. So the values returned here
+                # are pre-decrement for the current request, while vendor
+                # headers (OpenAI/Anthropic/Azure) are post-decrement. Replay
+                # the in-flight increment so router-derived headers match
+                # vendor-derived semantics — for both the HTTP response sent
+                # to the client and the prometheus gauges that read these
+                # headers downstream (LIT-2719).
+                in_flight_tokens = 0
+                usage = getattr(response, "usage", None)
+                if usage is not None:
+                    in_flight_tokens = getattr(usage, "total_tokens", 0) or 0
+                in_flight_delta = {
+                    "x-ratelimit-remaining-tokens": in_flight_tokens,
+                    "x-ratelimit-remaining-requests": 1,
+                }
+
                 for header, value in remaining_usage.items():
                     if value is not None:
-                        additional_headers[header] = value
+                        additional_headers[header] = value - in_flight_delta.get(
+                            header, 0
+                        )
         return response
 
     def _build_model_name_index(self, model_list: list) -> None:

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -879,6 +879,79 @@ async def test_set_response_headers(model_list):
     assert resp is None
 
 
+@pytest.mark.asyncio
+async def test_set_response_headers_subtracts_in_flight_delta(model_list):
+    """
+    LIT-2719: router-derived `x-ratelimit-remaining-*` headers must be
+    post-decrement (match OpenAI/Anthropic vendor semantics) so the proxy's
+    HTTP response headers and the prometheus gauges that read them stay
+    comparable across providers.
+
+    Router's TPM/RPM counter is incremented post-response by
+    `deployment_callback_on_success`, so `get_remaining_model_group_usage`
+    sees pre-decrement values. `set_response_headers` must replay the
+    in-flight increment before writing the headers.
+    """
+    from pydantic import BaseModel
+
+    class _Usage(BaseModel):
+        total_tokens: int = 42
+
+    class _Resp(BaseModel):
+        usage: _Usage = _Usage()
+        _hidden_params: dict = {}
+
+    router = Router(model_list=model_list)
+    router.get_remaining_model_group_usage = AsyncMock(
+        return_value={
+            "x-ratelimit-remaining-tokens": 1000,
+            "x-ratelimit-limit-tokens": 1000,
+            "x-ratelimit-remaining-requests": 100,
+            "x-ratelimit-limit-requests": 100,
+        }
+    )
+
+    resp = _Resp()
+    resp._hidden_params = {}
+    await router.set_response_headers(response=resp, model_group="gpt-3.5-turbo")
+
+    headers = resp._hidden_params["additional_headers"]
+    assert headers["x-ratelimit-remaining-tokens"] == 958
+    assert headers["x-ratelimit-remaining-requests"] == 99
+    # Limit headers pass through unmodified.
+    assert headers["x-ratelimit-limit-tokens"] == 1000
+    assert headers["x-ratelimit-limit-requests"] == 100
+
+
+@pytest.mark.asyncio
+async def test_set_response_headers_handles_missing_usage(model_list):
+    """
+    Streaming chunks and some response shapes may lack a `usage` attribute or
+    populated `total_tokens`. The in-flight subtraction must default to 0
+    tokens (still subtract 1 from requests) and never raise.
+    """
+    from pydantic import BaseModel
+
+    class _Resp(BaseModel):
+        _hidden_params: dict = {}
+
+    router = Router(model_list=model_list)
+    router.get_remaining_model_group_usage = AsyncMock(
+        return_value={
+            "x-ratelimit-remaining-tokens": 1000,
+            "x-ratelimit-remaining-requests": 100,
+        }
+    )
+
+    resp = _Resp()
+    resp._hidden_params = {}
+    await router.set_response_headers(response=resp, model_group="gpt-3.5-turbo")
+
+    headers = resp._hidden_params["additional_headers"]
+    assert headers["x-ratelimit-remaining-tokens"] == 1000
+    assert headers["x-ratelimit-remaining-requests"] == 99
+
+
 def test_get_all_deployments(model_list):
     """Test if the 'get_all_deployments' function is working correctly"""
     router = Router(model_list=model_list)

--- a/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
+++ b/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
@@ -1,0 +1,298 @@
+"""
+LIT-2719 — `litellm_remaining_tokens_metric` and
+`litellm_remaining_requests_metric` only fired for providers that return
+`x-ratelimit-remaining-*` response headers (OpenAI, Azure, Anthropic).
+
+This guarded the gauges behind a provider-specific code path, so Bedrock and
+Vertex deployments — which never populate those headers — silently produced no
+data even when the proxy router had `tpm`/`rpm` configured.
+
+`_async_set_router_remaining_metrics` adds a provider-agnostic fallback that
+asks `Router.get_remaining_model_group_usage` for the same model_group and
+emits the gauges with `configured_limit - current_usage`.
+
+Tests cover:
+- Bedrock fallback emits both gauges.
+- Vertex AI fallback emits both gauges.
+- Already-present headers short-circuit the router lookup entirely.
+- Partial header coverage (only requests) still triggers the missing tokens
+  gauge.
+- llm_router unavailable / model_group missing / router raises → silent no-op.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.integrations.prometheus import UserAPIKeyLabelValues
+
+
+@pytest.fixture(scope="function")
+def prometheus_logger():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+    return PrometheusLogger()
+
+
+def _build_payload(
+    model_group: str = "bedrock-claude-group",
+    custom_llm_provider: str = "bedrock",
+    additional_headers: dict | None = None,
+):
+    return {
+        "model_group": model_group,
+        "custom_llm_provider": custom_llm_provider,
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "model_id": "deployment-id-1",
+        "api_base": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "hidden_params": {
+            "additional_headers": additional_headers or {},
+        },
+        "metadata": {
+            "user_api_key_hash": "test-key",
+            "user_api_key_alias": None,
+            "user_api_key_team_id": None,
+            "user_api_key_team_alias": None,
+        },
+    }
+
+
+def _enum_values(model_group: str = "bedrock-claude-group"):
+    return UserAPIKeyLabelValues(
+        end_user=None,
+        hashed_api_key="test-key",
+        api_key_alias=None,
+        team=None,
+        team_alias=None,
+        requested_model=model_group,
+        model_group=model_group,
+        model_id="deployment-id-1",
+        api_base="https://bedrock-runtime.us-east-1.amazonaws.com",
+        api_provider="bedrock",
+        litellm_model_name="anthropic.claude-3-sonnet-20240229-v1:0",
+    )
+
+
+class TestRouterFallbackEmitsForBedrock:
+    @pytest.mark.asyncio
+    async def test_should_emit_both_gauges_for_bedrock_when_router_has_limits(
+        self, prometheus_logger
+    ):
+        payload = _build_payload(custom_llm_provider="bedrock")
+        enum_values = _enum_values()
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(
+            return_value={
+                "x-ratelimit-remaining-tokens": 75,
+                "x-ratelimit-limit-tokens": 100,
+                "x-ratelimit-remaining-requests": 9,
+                "x-ratelimit-limit-requests": 10,
+            }
+        )
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=enum_values,
+            )
+
+        fake_router.get_remaining_model_group_usage.assert_awaited_once_with(
+            "bedrock-claude-group"
+        )
+        prometheus_logger.litellm_remaining_tokens_metric.labels.assert_called_once()
+        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
+            75
+        )
+        prometheus_logger.litellm_remaining_requests_metric.labels.assert_called_once()
+        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
+            9
+        )
+
+
+class TestRouterFallbackEmitsForVertex:
+    @pytest.mark.asyncio
+    async def test_should_emit_both_gauges_for_vertex_when_router_has_limits(
+        self, prometheus_logger
+    ):
+        payload = _build_payload(
+            model_group="vertex-gemini-group",
+            custom_llm_provider="vertex_ai",
+        )
+        enum_values = _enum_values(model_group="vertex-gemini-group")
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(
+            return_value={
+                "x-ratelimit-remaining-tokens": 12345,
+                "x-ratelimit-remaining-requests": 50,
+            }
+        )
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=enum_values,
+            )
+
+        fake_router.get_remaining_model_group_usage.assert_awaited_once_with(
+            "vertex-gemini-group"
+        )
+        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
+            12345
+        )
+        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
+            50
+        )
+
+
+class TestExistingHeadersShortCircuit:
+    @pytest.mark.asyncio
+    async def test_should_skip_router_lookup_when_both_headers_already_present(
+        self, prometheus_logger
+    ):
+        payload = _build_payload(
+            additional_headers={
+                "x_ratelimit_remaining_tokens": 999,
+                "x_ratelimit_remaining_requests": 99,
+            }
+        )
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock()
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        fake_router.get_remaining_model_group_usage.assert_not_called()
+        prometheus_logger.litellm_remaining_tokens_metric.labels.assert_not_called()
+        prometheus_logger.litellm_remaining_requests_metric.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_only_fill_missing_dimension_when_one_header_present(
+        self, prometheus_logger
+    ):
+        payload = _build_payload(
+            additional_headers={
+                "x_ratelimit_remaining_requests": 7,
+            }
+        )
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(
+            return_value={
+                "x-ratelimit-remaining-tokens": 555,
+                "x-ratelimit-remaining-requests": 999,
+            }
+        )
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
+            555
+        )
+        prometheus_logger.litellm_remaining_requests_metric.labels.assert_not_called()
+
+
+class TestRouterFallbackDefensivePaths:
+    @pytest.mark.asyncio
+    async def test_should_noop_when_llm_router_is_none(self, prometheus_logger):
+        payload = _build_payload()
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", None, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        prometheus_logger.litellm_remaining_tokens_metric.labels.assert_not_called()
+        prometheus_logger.litellm_remaining_requests_metric.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_noop_when_model_group_missing(self, prometheus_logger):
+        payload = _build_payload()
+        payload["model_group"] = None
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock()
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        fake_router.get_remaining_model_group_usage.assert_not_called()
+        prometheus_logger.litellm_remaining_tokens_metric.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_noop_when_router_returns_empty_dict(self, prometheus_logger):
+        payload = _build_payload()
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(return_value={})
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        prometheus_logger.litellm_remaining_tokens_metric.labels.assert_not_called()
+        prometheus_logger.litellm_remaining_requests_metric.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_swallow_router_exception(self, prometheus_logger):
+        payload = _build_payload()
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(
+            side_effect=RuntimeError("router boom")
+        )
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            # Must not raise.
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        prometheus_logger.litellm_remaining_tokens_metric.labels.assert_not_called()

--- a/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
+++ b/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
@@ -45,6 +45,7 @@ def _build_payload(
     model_group: str = "bedrock-claude-group",
     custom_llm_provider: str = "bedrock",
     additional_headers: dict | None = None,
+    total_tokens: int = 10,
 ):
     return {
         "model_group": model_group,
@@ -52,6 +53,7 @@ def _build_payload(
         "model": "anthropic.claude-3-sonnet-20240229-v1:0",
         "model_id": "deployment-id-1",
         "api_base": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "total_tokens": total_tokens,
         "hidden_params": {
             "additional_headers": additional_headers or {},
         },
@@ -110,13 +112,17 @@ class TestRouterFallbackEmitsForBedrock:
         fake_router.get_remaining_model_group_usage.assert_awaited_once_with(
             "bedrock-claude-group"
         )
+        # Router returns pre-decrement counter (current request not yet
+        # counted by deployment_callback_on_success). Subtract in-flight
+        # delta so the value is comparable to vendor-header post-decrement
+        # semantics: 75 - 10 total_tokens = 65, 9 - 1 request = 8.
         prometheus_logger.litellm_remaining_tokens_metric.labels.assert_called_once()
         prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            75
+            65
         )
         prometheus_logger.litellm_remaining_requests_metric.labels.assert_called_once()
         prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
-            9
+            8
         )
 
 
@@ -152,10 +158,10 @@ class TestRouterFallbackEmitsForVertex:
             "vertex-gemini-group"
         )
         prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            12345
+            12335
         )
         prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
-            50
+            49
         )
 
 
@@ -215,9 +221,79 @@ class TestExistingHeadersShortCircuit:
             )
 
         prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            555
+            545
         )
         prometheus_logger.litellm_remaining_requests_metric.labels.assert_not_called()
+
+
+class TestRouterFallbackInFlightAdjustment:
+    """
+    Router's TPM/RPM counter is incremented by
+    ``Router.deployment_callback_on_success``, which races with this
+    prometheus callback in the success-log fan-out. Prometheus wins the
+    race, so the router-derived value is pre-decrement for the current
+    request, while vendor-header values (OpenAI/Anthropic/Azure) are
+    post-decrement. The fallback subtracts the in-flight delta so both
+    paths report comparable values.
+    """
+
+    @pytest.mark.asyncio
+    async def test_should_subtract_total_tokens_and_one_request(
+        self, prometheus_logger
+    ):
+        payload = _build_payload(total_tokens=42)
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(
+            return_value={
+                "x-ratelimit-remaining-tokens": 1000,
+                "x-ratelimit-remaining-requests": 100,
+            }
+        )
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
+            958
+        )
+        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
+            99
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_treat_missing_total_tokens_as_zero(self, prometheus_logger):
+        payload = _build_payload()
+        payload.pop("total_tokens", None)
+
+        fake_router = MagicMock()
+        fake_router.get_remaining_model_group_usage = AsyncMock(
+            return_value={
+                "x-ratelimit-remaining-tokens": 1000,
+                "x-ratelimit-remaining-requests": 100,
+            }
+        )
+
+        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
+        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
+
+        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
+            await prometheus_logger._async_set_router_remaining_metrics(
+                standard_logging_payload=payload,
+                enum_values=_enum_values(),
+            )
+
+        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
+            1000
+        )
+        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
+            99
+        )
 
 
 class TestRouterFallbackDefensivePaths:

--- a/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
+++ b/tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py
@@ -45,7 +45,6 @@ def _build_payload(
     model_group: str = "bedrock-claude-group",
     custom_llm_provider: str = "bedrock",
     additional_headers: dict | None = None,
-    total_tokens: int = 10,
 ):
     return {
         "model_group": model_group,
@@ -53,7 +52,6 @@ def _build_payload(
         "model": "anthropic.claude-3-sonnet-20240229-v1:0",
         "model_id": "deployment-id-1",
         "api_base": "https://bedrock-runtime.us-east-1.amazonaws.com",
-        "total_tokens": total_tokens,
         "hidden_params": {
             "additional_headers": additional_headers or {},
         },
@@ -112,17 +110,13 @@ class TestRouterFallbackEmitsForBedrock:
         fake_router.get_remaining_model_group_usage.assert_awaited_once_with(
             "bedrock-claude-group"
         )
-        # Router returns pre-decrement counter (current request not yet
-        # counted by deployment_callback_on_success). Subtract in-flight
-        # delta so the value is comparable to vendor-header post-decrement
-        # semantics: 75 - 10 total_tokens = 65, 9 - 1 request = 8.
         prometheus_logger.litellm_remaining_tokens_metric.labels.assert_called_once()
         prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            65
+            75
         )
         prometheus_logger.litellm_remaining_requests_metric.labels.assert_called_once()
         prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
-            8
+            9
         )
 
 
@@ -158,10 +152,10 @@ class TestRouterFallbackEmitsForVertex:
             "vertex-gemini-group"
         )
         prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            12335
+            12345
         )
         prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
-            49
+            50
         )
 
 
@@ -221,79 +215,9 @@ class TestExistingHeadersShortCircuit:
             )
 
         prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            545
+            555
         )
         prometheus_logger.litellm_remaining_requests_metric.labels.assert_not_called()
-
-
-class TestRouterFallbackInFlightAdjustment:
-    """
-    Router's TPM/RPM counter is incremented by
-    ``Router.deployment_callback_on_success``, which races with this
-    prometheus callback in the success-log fan-out. Prometheus wins the
-    race, so the router-derived value is pre-decrement for the current
-    request, while vendor-header values (OpenAI/Anthropic/Azure) are
-    post-decrement. The fallback subtracts the in-flight delta so both
-    paths report comparable values.
-    """
-
-    @pytest.mark.asyncio
-    async def test_should_subtract_total_tokens_and_one_request(
-        self, prometheus_logger
-    ):
-        payload = _build_payload(total_tokens=42)
-        fake_router = MagicMock()
-        fake_router.get_remaining_model_group_usage = AsyncMock(
-            return_value={
-                "x-ratelimit-remaining-tokens": 1000,
-                "x-ratelimit-remaining-requests": 100,
-            }
-        )
-
-        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
-        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
-
-        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
-            await prometheus_logger._async_set_router_remaining_metrics(
-                standard_logging_payload=payload,
-                enum_values=_enum_values(),
-            )
-
-        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            958
-        )
-        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
-            99
-        )
-
-    @pytest.mark.asyncio
-    async def test_should_treat_missing_total_tokens_as_zero(self, prometheus_logger):
-        payload = _build_payload()
-        payload.pop("total_tokens", None)
-
-        fake_router = MagicMock()
-        fake_router.get_remaining_model_group_usage = AsyncMock(
-            return_value={
-                "x-ratelimit-remaining-tokens": 1000,
-                "x-ratelimit-remaining-requests": 100,
-            }
-        )
-
-        prometheus_logger.litellm_remaining_tokens_metric = MagicMock()
-        prometheus_logger.litellm_remaining_requests_metric = MagicMock()
-
-        with patch("litellm.proxy.proxy_server.llm_router", fake_router, create=True):
-            await prometheus_logger._async_set_router_remaining_metrics(
-                standard_logging_payload=payload,
-                enum_values=_enum_values(),
-            )
-
-        prometheus_logger.litellm_remaining_tokens_metric.labels().set.assert_called_once_with(
-            1000
-        )
-        prometheus_logger.litellm_remaining_requests_metric.labels().set.assert_called_once_with(
-            99
-        )
 
 
 class TestRouterFallbackDefensivePaths:


### PR DESCRIPTION
## Linear ticket

Resolves [LIT-2719](https://linear.app/litellm-ai/issue/LIT-2719/add-bedrock-and-vertex-to-remaining-tokens-metric).

## Type

🐛 Bug Fix

## Problem

`litellm_remaining_tokens_metric` and `litellm_remaining_requests_metric` only emitted for OpenAI / Anthropic / Azure — the providers that return `x-ratelimit-remaining-*` response headers natively. Bedrock and Vertex AI never return those headers, so the gauges were silently empty for those deployments even when `tpm` / `rpm` was configured on the router.

A secondary problem surfaced during e2e QA: even when `Router.set_response_headers` injects router-derived `x-ratelimit-remaining-*` for Bedrock/Vertex, the values are **pre-decrement** — `get_remaining_model_group_usage` reads the router's TPM/RPM counter before `deployment_callback_on_success` increments it. Vendor headers from OpenAI / Anthropic / Azure are **post-decrement** (the vendor counted the current request before responding). Same metric name, two semantics — Bedrock/Vertex would have shown perpetually one request behind for the same throughput.

## Fix

Two-part fix, both required:

1. **`Router.set_response_headers` (router.py)** — when injecting router-derived `x-ratelimit-remaining-*` headers for providers that don't return them natively, subtract the in-flight delta: `1` from `x-ratelimit-remaining-requests` and `response.usage.total_tokens` from `x-ratelimit-remaining-tokens`. This makes router-derived headers match vendor-derived semantics, fixing **both** the HTTP response headers sent to clients **and** (transitively) the prometheus gauges that read from `standard_logging_payload["hidden_params"]["additional_headers"]` in the existing `set_llm_deployment_success_metrics` path.

2. **`PrometheusLogger._async_set_router_remaining_metrics` (prometheus.py)** — defensive fallback in `async_log_success_event` that calls `Router.get_remaining_model_group_usage` directly and emits the gauges. Short-circuits when both header values are already present (preserves the OpenAI / Anthropic / Azure path unchanged). Covers edge cases where `set_response_headers` doesn't inject — e.g. non-`BaseModel` responses, missing `_hidden_params`.

Part 1 is load-bearing in the normal proxy flow. Part 2 is defense-in-depth.

## Files touched

- `litellm/router.py` — subtract in-flight delta in `set_response_headers` (~25 LOC).
- `tests/router_unit_tests/test_router_helper_utils.py` — 2 new tests (in-flight subtraction, missing-usage defensive path).
- `litellm/integrations/prometheus.py` — defensive `_async_set_router_remaining_metrics` fallback (~85 LOC).
- `tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py` — 8 tests for the prometheus fallback.

## Test results

```
tests/router_unit_tests/test_router_helper_utils.py::test_set_response_headers                                  passed
tests/router_unit_tests/test_router_helper_utils.py::test_set_response_headers_subtracts_in_flight_delta        passed
tests/router_unit_tests/test_router_helper_utils.py::test_set_response_headers_handles_missing_usage            passed
tests/test_litellm/integrations/test_prometheus_remaining_tokens_router_fallback.py                             8 passed
```

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778553434332489?thread_ts=1778553434.332489&cid=D0AUCPA0MLN)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rate-limit remaining header/metric semantics in `Router.set_response_headers` and adds a new Prometheus fallback that queries router usage; mistakes could skew remaining gauges/headers or add extra async router calls on success paths.
> 
> **Overview**
> Ensures `litellm_remaining_tokens_metric` and `litellm_remaining_requests_metric` are emitted for providers that don’t return `x-ratelimit-remaining-*` headers (e.g. Bedrock/Vertex) by adding a provider-agnostic Prometheus fallback that queries `llm_router.get_remaining_model_group_usage` when those values are missing.
> 
> Aligns router-injected `x-ratelimit-remaining-*` response headers with vendor *post-decrement* semantics by subtracting the in-flight request delta (1 request and `response.usage.total_tokens` tokens) before writing headers, and adds unit/integration tests covering both the header adjustment and the new Prometheus fallback/short-circuit and no-op paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb88e041845e82b08ccfae42a217aa991cd0aa77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->