### PR TITLE
fix(vertex_ai/gemini): raise BadRequestError when image_url or url field is missing

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -351,15 +351,28 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                             img_element = element
                             format: Optional[str] = None
                             media_resolution_enum: Optional[Dict[str, str]] = None
-                            if isinstance(img_element["image_url"], dict):
-                                image_url = img_element["image_url"]["url"]
-                                format = img_element["image_url"].get("format")
-                                detail = img_element["image_url"].get("detail")
+                            raw_image_url = img_element.get("image_url")
+                            if raw_image_url is None:
+                                raise litellm.BadRequestError(
+                                    message="Invalid message content: element type is 'image_url' but 'image_url' field is missing",
+                                    model=model,
+                                    llm_provider="vertex_ai",
+                                )
+                            if isinstance(raw_image_url, dict):
+                                image_url = raw_image_url.get("url")
+                                if image_url is None:
+                                    raise litellm.BadRequestError(
+                                        message="Invalid message content: element type is 'image_url' but 'url' field is missing inside 'image_url'",
+                                        model=model,
+                                        llm_provider="vertex_ai",
+                                    )
+                                format = raw_image_url.get("format")
+                                detail = raw_image_url.get("detail")
                                 media_resolution_enum = (
                                     _convert_detail_to_media_resolution_enum(detail)
                                 )
                             else:
-                                image_url = img_element["image_url"]
+                                image_url = raw_image_url
                             _part = _process_gemini_media(
                                 image_url=image_url,
                                 format=format,

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
@@ -1,0 +1,35 @@
+import pytest
+from typing import List, cast
+
+import litellm
+from litellm.llms.vertex_ai.gemini.transformation import (
+    _gemini_convert_messages_with_history,
+)
+from litellm.types.llms.openai import AllMessageValues
+
+
+def test_missing_image_url_field_raises_bad_request_error():
+    """When element type is 'image_url' but 'image_url' field is missing, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url"}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'image_url' field is missing" in str(exc_info.value)
+
+
+def test_missing_url_inside_image_url_dict_raises_bad_request_error():
+    """When image_url is a dict but 'url' key is absent, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"detail": "high"}}],
+            }
+        ],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'url' field is missing inside" in str(exc_info.value)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two adjacent `KeyError` bugs in `_gemini_convert_messages_with_history` in `litellm/llms/vertex_ai/gemini/transformation.py`.

### Problem

1. **Missing `image_url` field** — when an element has `type: "image_url"` but no `image_url` key, bare dict access `img_element["image_url"]` raised an unhandled `KeyError` resulting in a 500 `APIConnectionError`.

2. **Missing `url` inside `image_url` dict** — when `image_url` is a dict but the `url` key is absent (e.g. `{"detail": "high"}`), bare dict access `raw_image_url["url"]` raised another `KeyError`.

### Fix

- Use `.get("image_url")` and raise `litellm.BadRequestError` (400) when the field is `None`
- Use `.get("url")` and raise `litellm.BadRequestError` (400) when `url` is absent inside the dict

### Tests

Added `tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py` with two unit tests:

- `test_missing_image_url_field_raises_bad_request_error`
- `test_missing_url_inside_image_url_dict_raises_bad_request_error`

Both tests call the pure transformation function with no network I/O. All 200 existing vertex_ai/gemini tests continue to pass.

## Type

🐛 Bug Fix

## Checklist

- [x] Added tests in `tests/test_litellm/`
- [x] All unit tests pass (`uv run pytest tests/test_litellm/llms/vertex_ai/gemini/ -v` — 200 passed, 1 skipped)
- [x] Code formatted with `black` and linted with `ruff`
- [x] PR scope is isolated to a single problem
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0771b0b8-bcf1-475d-a49e-1b5c8a169662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0771b0b8-bcf1-475d-a49e-1b5c8a169662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

