### PR TITLE
fix(passthrough): only constrain when AG actually has pass-through routes (#27344)

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2576,12 +2576,16 @@ async def _filter_endpoints_by_team_allowed_routes(
     if not isinstance(team_access_group_ids, list):
         team_access_group_ids = []
     if team_access_group_ids:
-        has_passthrough_route_constraints = True
-        allowed_passthrough_routes.extend(
-            await _get_pass_through_routes_from_access_groups(
-                access_group_ids=team_access_group_ids,
-            )
+        routes_from_access_groups = await _get_pass_through_routes_from_access_groups(
+            access_group_ids=team_access_group_ids,
         )
+        # Only flip the constraint flag when the AG actually contributes
+        # pass-through routes. Otherwise an AG that only scopes model names
+        # would incorrectly filter every endpoint out (regression observed in
+        # production: team with model-only AG saw 0 of 3 endpoints).
+        if routes_from_access_groups:
+            has_passthrough_route_constraints = True
+            allowed_passthrough_routes.extend(routes_from_access_groups)
 
     if has_passthrough_route_constraints:
         ## FILTER pass_through_endpoints by allowed_passthrough_routes

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2617,4 +2617,46 @@ def test_get_response_headers_strips_server_and_date():
     lowered = {k.lower(): v for k, v in result.items()}
     assert lowered["content-type"] == "application/json"
     assert lowered["x-request-id"] == "req_abc"
+
+
+@pytest.mark.asyncio
+async def test_filter_endpoints_by_team_access_group_no_passthrough_routes_returns_all():
+    """Regression for #27344: a team whose AccessGroup contains only model names
+    (no pass-through routes) must see ALL pass-through endpoints, not zero.
+
+    Repro scenario: 3 endpoints total → Team B (AG with `access_model_names`
+    only, empty `access_pass_through_routes`) used to see all 3, now sees 0.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy._types import PassThroughGenericEndpoint
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _filter_endpoints_by_team_allowed_routes,
+    )
+
+    endpoints = [
+        PassThroughGenericEndpoint(id="endpoint-1", path="/api/openai", target="http://example.com/openai"),
+        PassThroughGenericEndpoint(id="endpoint-2", path="/api/anthropic", target="http://example.com/anthropic"),
+        PassThroughGenericEndpoint(id="endpoint-3", path="/api/azure", target="http://example.com/azure"),
+    ]
+
+    mock_prisma_client = MagicMock()
+    mock_team = MagicMock()
+    mock_team.metadata = None  # no team-level allowed_passthrough_routes
+    mock_team.access_group_ids = ["ag-models-only"]
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_team)
+
+    # AG exists but contributes no pass-through routes (model-only AG).
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints._get_pass_through_routes_from_access_groups",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await _filter_endpoints_by_team_allowed_routes(
+            team_id="team-b",
+            pass_through_endpoints=endpoints,
+            prisma_client=mock_prisma_client,
+        )
+
+    assert len(result) == 3, f"expected all 3 endpoints, got {len(result)}"
+    assert {e.id for e in result} == {"endpoint-1", "endpoint-2", "endpoint-3"}
     assert lowered["anthropic-ratelimit-requests-remaining"] == "100"


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #27344 where a team whose AccessGroup contains only model names (no `access_pass_through_routes`) sees 0 of N pass-through endpoints on `GET /config/pass_through_endpoint?team_id=...` instead of all.

Root cause: `_filter_endpoints_by_team_allowed_routes` flips `has_passthrough_route_constraints=True` as soon as the team has any AG attached, regardless of whether the AG actually contributes pass-through routes. With an AG of `access_model_names` only, `_get_pass_through_routes_from_access_groups()` returns `[]`, so `allowed_passthrough_routes` stays `[]`, but the constraint flag is on — the filter then strips every endpoint out.

## Fix

Only flip the constraint flag when the AG-derived route list is non-empty. Mirrors the existing team-metadata branch, which already only flips the flag when `allowed_passthrough_routes` is `not None`.

## Test

Adds `test_filter_endpoints_by_team_access_group_no_passthrough_routes_returns_all` which mocks an AG that returns `[]` for pass-through routes and asserts all 3 endpoints come back. Fails on the unfixed code, passes after the fix.

## Base branch

This PR targets `litellm_access-groups-pass-through-vector-stores-d3df` (the source branch of #27344) so the fix can be merged into #27344 before #27344 lands on `main`.

Reported via Slack on a live reproduction (3 endpoints total → Team B saw 0).