### PR TITLE
chore(proxy): tighten admin-only field gates on key management endpoints

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1070,17 +1070,93 @@ async def _check_team_key_limits(
     )
 
 
+def _is_proxy_admin_role(user_api_key_dict: UserAPIKeyAuth) -> bool:
+    """True when the caller's user_role is PROXY_ADMIN. Centralised because
+    the same check is repeated across key-management endpoints."""
+    return (
+        user_api_key_dict.user_role is not None
+        and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
+    )
+
+
+# Permission-dict keys that grant admin-equivalent capabilities. Non-admin
+# callers must not be able to set these at key creation / update — letting
+# them would be self-promotion. Currently the only consumer-checked key is
+# ``get_spend_routes`` (read proxy-wide spend logs across every tenant); the
+# set is structured to accept future admin-only flags without needing to
+# touch every call site.
+_ADMIN_ONLY_PERMISSION_KEYS: frozenset = frozenset({"get_spend_routes"})
+
+# Metadata keys that are admin-only because they leverage proxy-side trusted
+# infrastructure (e.g. SMTP / Resend / Sendgrid email senders configured by
+# the operator). Allowing non-admin callers to set ``max_budget_alert_emails``
+# turns the proxy into a phishing relay — alerts are sent FROM the operator's
+# trusted sender to attacker-supplied recipients.
+_ADMIN_ONLY_METADATA_KEYS: frozenset = frozenset({"max_budget_alert_emails"})
+
+
+def _strip_admin_only_fields_for_non_admin(
+    data: Union[GenerateKeyRequest, UpdateKeyRequest],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """Mutate ``data`` in place to remove fields that only PROXY_ADMIN may
+    set. No-op for proxy admins so they retain full control.
+
+    Removed fields:
+      - ``permissions[get_spend_routes]`` — self-grant of cross-tenant spend
+        log read access via ``permissions.get_spend_routes`` was the
+        headline of the PlrNEsyT priv-esc. The whole ``permissions`` dict
+        gets filtered against the admin-only key set; non-admin-only keys
+        survive so user-defined permission flags still work.
+      - ``metadata[max_budget_alert_emails]`` — email recipient injection
+        into the operator's trusted SMTP / Sendgrid / Resend sender.
+    """
+    if _is_proxy_admin_role(user_api_key_dict):
+        return
+
+    permissions = getattr(data, "permissions", None)
+    if isinstance(permissions, dict) and permissions:
+        for key in list(permissions.keys()):
+            if key in _ADMIN_ONLY_PERMISSION_KEYS:
+                permissions.pop(key, None)
+                verbose_proxy_logger.warning(
+                    "Stripped admin-only permission %r from %s by non-admin "
+                    "caller user_id=%s",
+                    key,
+                    type(data).__name__,
+                    user_api_key_dict.user_id,
+                )
+
+    metadata = getattr(data, "metadata", None)
+    if isinstance(metadata, dict) and metadata:
+        for key in list(metadata.keys()):
+            if key in _ADMIN_ONLY_METADATA_KEYS:
+                metadata.pop(key, None)
+                verbose_proxy_logger.warning(
+                    "Stripped admin-only metadata key %r from %s by "
+                    "non-admin caller user_id=%s",
+                    key,
+                    type(data).__name__,
+                    user_api_key_dict.user_id,
+                )
+
+
 async def _check_project_key_limits(
     project_id: str,
     data: Union[GenerateKeyRequest, UpdateKeyRequest],
     prisma_client: PrismaClient,
     user_api_key_cache: UserApiKeyCache,
+    user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     """
     Validate that key's models and budget respect its project's limits.
 
-    - Key models must be a subset of project models
-    - Key max_budget must be <= project max_budget
+    - Caller must be a member of the project's team (or proxy admin) —
+      projects live under a team via ``LiteLLM_ProjectTable.team_id``;
+      without this gate any internal user could enumerate a project_id and
+      mint a key under it, inheriting the victim project's models / budget.
+    - Key models must be a subset of project models.
+    - Key max_budget must be <= project max_budget.
     """
     project_obj = await get_project_object(
         project_id=project_id,
@@ -1093,6 +1169,52 @@ async def _check_project_key_limits(
             status_code=404,
             detail={"error": f"Project not found, project_id={project_id}"},
         )
+
+    # Project IDOR gate: non-admin callers must be a member of the project's
+    # owning team. Project rows that don't have an associated team are
+    # treated as admin-only — no non-admin code path should mint keys against
+    # them.
+    if not _is_proxy_admin_role(user_api_key_dict):
+        project_team_id = getattr(project_obj, "team_id", None)
+        if project_team_id is None:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": (
+                        f"project_id={project_id} has no associated team; "
+                        "only proxy admins may mint keys against it."
+                    )
+                },
+            )
+        try:
+            team_obj = await get_team_object(
+                team_id=project_team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=user_api_key_dict.parent_otel_span,
+                check_db_only=True,
+            )
+        except Exception:
+            team_obj = None
+        member = (
+            _get_user_in_team(
+                team_table=cast(LiteLLM_TeamTableCachedObj, team_obj),
+                user_id=user_api_key_dict.user_id,
+            )
+            if team_obj is not None
+            else None
+        )
+        if member is None:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": (
+                        f"User {user_api_key_dict.user_id} is not a member of "
+                        f"the team={project_team_id} that owns "
+                        f"project_id={project_id}."
+                    )
+                },
+            )
 
     # Validate key models are a subset of project models
     if data.models and len(project_obj.models) > 0:
@@ -1455,6 +1577,14 @@ async def generate_key_fn(
                 prisma_client=prisma_client,
             )
 
+        # Strip admin-only fields (``permissions.get_spend_routes`` self-
+        # grant, ``metadata.max_budget_alert_emails`` SMTP-injection) before
+        # the request reaches the DB write. No-op for proxy admins.
+        _strip_admin_only_fields_for_non_admin(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
+
         # Validate key against project limits if project_id is set
         if data.project_id is not None:
             await _check_project_key_limits(
@@ -1462,6 +1592,7 @@ async def generate_key_fn(
                 data=data,
                 prisma_client=prisma_client,
                 user_api_key_cache=user_api_key_cache,
+                user_api_key_dict=user_api_key_dict,
             )
 
         return await _common_key_generation_helper(
@@ -2211,6 +2342,7 @@ async def _validate_update_key_data(
             data=data,
             prisma_client=prisma_client,
             user_api_key_cache=user_api_key_cache,
+            user_api_key_dict=user_api_key_dict,
         )
 
     # When the caller asks to change the key's organization_id, require that
@@ -2387,6 +2519,14 @@ async def update_key_fn(  # noqa: PLR0915
                     "error": f"max_budget cannot be negative. Received: {data.max_budget}"
                 },
             )
+
+        # Strip admin-only fields (``permissions.get_spend_routes`` self-
+        # grant, ``metadata.max_budget_alert_emails`` SMTP-injection) before
+        # the request reaches the DB write. No-op for proxy admins.
+        _strip_admin_only_fields_for_non_admin(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
 
         data_json: dict = data.model_dump(exclude_unset=True, exclude_none=True)
         key = data_json.pop("key")
@@ -4150,22 +4290,75 @@ async def _execute_virtual_key_regeneration(
     proxy_logging_obj: ProxyLogging,
 ) -> GenerateKeyResponse:
     """Generate new token, update DB, invalidate cache, and return response."""
-    from litellm.proxy.proxy_server import hash_token
+    from litellm.proxy.proxy_server import hash_token, llm_router
+
+    # Strip admin-only fields (``permissions.get_spend_routes`` self-grant,
+    # ``metadata.max_budget_alert_emails`` SMTP-injection) before this
+    # request can reach the DB write. ``/key/regenerate`` accepts the same
+    # ``RegenerateKeyRequest`` shape that lets callers patch fields on the
+    # key — without this filter the non-admin priv-esc surface that
+    # ``/key/generate`` and ``/key/update`` close above re-opens here.
+    if data is not None:
+        _strip_admin_only_fields_for_non_admin(
+            data=data,  # type: ignore[arg-type]
+            user_api_key_dict=user_api_key_dict,
+        )
 
     # Apply the same membership rule used on /key/update: when the caller
     # asks to point the regenerated key at a different organization_id,
     # require they are a member of (or proxy admin over) the target org.
     if data is not None and data.organization_id is not None:
         _existing_org_id = getattr(key_in_db, "organization_id", None)
-        _is_proxy_admin = (
-            user_api_key_dict.user_role is not None
-            and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
-        )
-        if data.organization_id != _existing_org_id and not _is_proxy_admin:
+        if data.organization_id != _existing_org_id and not _is_proxy_admin_role(
+            user_api_key_dict
+        ):
             await _validate_caller_can_assign_key_org(
                 user_api_key_dict=user_api_key_dict,
                 organization_id=data.organization_id,
                 prisma_client=prisma_client,
+            )
+
+    # Same membership rule for team_id changes. ``/key/update`` already runs
+    # ``validate_key_team_change`` when the team changes;
+    # ``/key/regenerate`` was missing this check, so a caller could
+    # re-assign their key's ``team_id`` (and inherit the victim team's
+    # models / budget / rate limits) by hitting regenerate instead of
+    # update. Mirror the ``/key/update`` flow here.
+    if data is not None and data.team_id is not None:
+        _existing_team_id = getattr(key_in_db, "team_id", None)
+        if data.team_id != _existing_team_id and not _is_proxy_admin_role(
+            user_api_key_dict
+        ):
+            if llm_router is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": (
+                            "LLM router not initialised — required to "
+                            "validate team-change on /key/regenerate."
+                        )
+                    },
+                )
+            try:
+                team_obj_for_change = await get_team_object(
+                    team_id=data.team_id,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    parent_otel_span=user_api_key_dict.parent_otel_span,
+                    check_db_only=True,
+                )
+            except Exception:
+                team_obj_for_change = None
+            if team_obj_for_change is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail={"error": f"Team not found for team_id={data.team_id}"},
+                )
+            await validate_key_team_change(
+                key=key_in_db,
+                team=cast(LiteLLM_TeamTable, team_obj_for_change),
+                change_initiated_by=user_api_key_dict,
+                llm_router=llm_router,
             )
 
     new_token = await get_new_token(data=data)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -631,6 +631,16 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         premium_user=premium_user,
     )
 
+    # Chokepoint strip — covers both ``/key/generate`` and
+    # ``/key/service-account/generate``. The service-account flow does
+    # not route through ``generate_key_fn``, so applying the filter
+    # only at the request handler would leak the same priv-esc fields
+    # through the service-account path.
+    _strip_admin_only_fields_for_non_admin(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+    )
+
     if (
         data.metadata is not None
         and data.metadata.get("service_account_id") is not None
@@ -1577,14 +1587,6 @@ async def generate_key_fn(
                 prisma_client=prisma_client,
             )
 
-        # Strip admin-only fields (``permissions.get_spend_routes`` self-
-        # grant, ``metadata.max_budget_alert_emails`` SMTP-injection) before
-        # the request reaches the DB write. No-op for proxy admins.
-        _strip_admin_only_fields_for_non_admin(
-            data=data,
-            user_api_key_dict=user_api_key_dict,
-        )
-
         # Validate key against project limits if project_id is set
         if data.project_id is not None:
             await _check_project_key_limits(
@@ -2044,6 +2046,17 @@ async def _process_single_key_update(
     Raises:
         HTTPException: For various validation and permission errors
     """
+    # Chokepoint strip — ``/key/bulk_update`` and ``/team/key/bulk_update``
+    # construct ``UpdateKeyRequest`` instances from user input and call this
+    # helper directly, bypassing ``update_key_fn``'s strip. Apply the filter
+    # here so admin-only fields (``permissions.get_spend_routes`` self-grant,
+    # ``metadata.max_budget_alert_emails`` SMTP-injection) cannot reach the
+    # DB write via the bulk paths.
+    _strip_admin_only_fields_for_non_admin(
+        data=update_key_request,
+        user_api_key_dict=user_api_key_dict,
+    )
+
     # Validate max_budget
     _validate_max_budget(update_key_request.max_budget)
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1096,7 +1096,7 @@ _ADMIN_ONLY_METADATA_KEYS: frozenset = frozenset({"max_budget_alert_emails"})
 
 
 def _strip_admin_only_fields_for_non_admin(
-    data: Union[GenerateKeyRequest, UpdateKeyRequest],
+    data: Union[GenerateKeyRequest, UpdateKeyRequest, "RegenerateKeyRequest"],
     user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     """Mutate ``data`` in place to remove fields that only PROXY_ADMIN may
@@ -1143,7 +1143,7 @@ def _strip_admin_only_fields_for_non_admin(
 
 async def _check_project_key_limits(
     project_id: str,
-    data: Union[GenerateKeyRequest, UpdateKeyRequest],
+    data: Union[GenerateKeyRequest, UpdateKeyRequest, "RegenerateKeyRequest"],
     prisma_client: PrismaClient,
     user_api_key_cache: UserApiKeyCache,
     user_api_key_dict: UserAPIKeyAuth,
@@ -4300,7 +4300,7 @@ async def _execute_virtual_key_regeneration(
     # ``/key/generate`` and ``/key/update`` close above re-opens here.
     if data is not None:
         _strip_admin_only_fields_for_non_admin(
-            data=data,  # type: ignore[arg-type]
+            data=data,
             user_api_key_dict=user_api_key_dict,
         )
 
@@ -4360,6 +4360,35 @@ async def _execute_virtual_key_regeneration(
                 change_initiated_by=user_api_key_dict,
                 llm_router=llm_router,
             )
+
+    # ``RegenerateKeyRequest`` inherits ``project_id`` from
+    # ``GenerateKeyRequest``; ``prepare_key_update_data`` persists every set
+    # field — including ``project_id`` — into the DB row. Without this gate
+    # a non-admin caller could re-target their key at an arbitrary project
+    # they aren't a member of, exactly the same IDOR
+    # ``_check_project_key_limits`` closes on ``/key/generate`` and
+    # ``/key/update``. Use the new project_id if set, otherwise validate
+    # against the existing one when the caller changes ``models`` /
+    # ``max_budget`` (those are the fields the helper bounds).
+    _project_id_for_regen = (
+        getattr(data, "project_id", None) if data is not None else None
+    ) or getattr(key_in_db, "project_id", None)
+    if (
+        _project_id_for_regen is not None
+        and data is not None
+        and (
+            data.project_id is not None
+            or data.models is not None
+            or data.max_budget is not None
+        )
+    ):
+        await _check_project_key_limits(
+            project_id=_project_id_for_regen,
+            data=data,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            user_api_key_dict=user_api_key_dict,
+        )
 
     new_token = await get_new_token(data=data)
     new_token_hash = hash_token(new_token)

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10892,3 +10892,141 @@ class TestRegenerateProjectMembershipGate:
                 )
             assert exc.value.status_code == 403
             assert "not a member" in str(exc.value.detail)
+
+
+class TestServiceAccountStripVariant:
+    """Variant follow-up: ``/key/service-account/generate`` accepts the
+    same ``GenerateKeyRequest`` shape as ``/key/generate`` but does NOT
+    route through ``generate_key_fn``. The strip must live in the shared
+    chokepoint (``_common_key_generation_helper``) so a team admin
+    cannot self-grant ``permissions[get_spend_routes]`` or
+    ``metadata[max_budget_alert_emails]`` via a service-account key."""
+
+    @pytest.mark.asyncio
+    async def test_helper_strips_admin_only_fields_for_non_admin(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _common_key_generation_helper,
+        )
+
+        data = GenerateKeyRequest(
+            permissions={"get_spend_routes": True, "custom": "ok"},
+            metadata={
+                "max_budget_alert_emails": {"warn": ["attacker@evil.example"]},
+                "team": "ops",
+            },
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.common_key_access_checks",
+                new=MagicMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+                new=AsyncMock(
+                    return_value={
+                        "token": "sk-new",
+                        "expires": None,
+                        "user_id": "user-internal",
+                    }
+                ),
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.proxy_server.litellm_proxy_admin_name",
+                "default_user_id",
+            ),
+        ):
+            try:
+                await _common_key_generation_helper(
+                    data=data,
+                    user_api_key_dict=_internal_user_auth(),
+                    litellm_changed_by=None,
+                    team_table=None,
+                )
+            except Exception:
+                # Downstream DB-shape failures are fine — strip runs first.
+                pass
+
+        assert "get_spend_routes" not in (data.permissions or {})
+        assert data.permissions.get("custom") == "ok"
+        assert "max_budget_alert_emails" not in (data.metadata or {})
+        assert data.metadata.get("team") == "ops"
+
+
+class TestBulkUpdateStripVariant:
+    """Variant follow-up: ``/key/bulk_update`` and ``/team/key/bulk_update``
+    build ``UpdateKeyRequest`` instances inside a loop and call
+    ``_process_single_key_update`` directly, bypassing
+    ``update_key_fn``'s strip. The strip must live in the shared
+    chokepoint (``_process_single_key_update``) so a non-admin team
+    admin with ``KEY_UPDATE`` cannot grant
+    ``permissions[get_spend_routes]`` or
+    ``metadata[max_budget_alert_emails]`` via the bulk paths."""
+
+    @pytest.mark.asyncio
+    async def test_process_single_key_update_strips_admin_only_fields(self):
+        from litellm.proxy._types import LiteLLM_VerificationToken
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _process_single_key_update,
+        )
+
+        data = UpdateKeyRequest(
+            key="sk-victim",
+            permissions={"get_spend_routes": True, "custom": "ok"},
+            metadata={
+                "max_budget_alert_emails": {"warn": ["attacker@evil.example"]},
+                "team": "ops",
+            },
+        )
+
+        existing_key_row = LiteLLM_VerificationToken(
+            token="hashed-victim", team_id="team-x"
+        )
+
+        prisma_client = MagicMock()
+        prisma_client.update_data = AsyncMock(return_value={"token": "hashed-victim"})
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._validate_update_key_data",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.prepare_key_update_data",
+                new=AsyncMock(return_value={"token": "hashed-victim"}),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            try:
+                await _process_single_key_update(
+                    update_key_request=data,
+                    user_api_key_dict=_internal_user_auth(),
+                    litellm_changed_by=None,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=MagicMock(),
+                    proxy_logging_obj=MagicMock(),
+                    llm_router=MagicMock(),
+                    existing_key_row=existing_key_row,
+                )
+            except Exception:
+                # Downstream DB-shape failures are fine — strip runs first.
+                pass
+
+        assert "get_spend_routes" not in (data.permissions or {})
+        assert data.permissions.get("custom") == "ok"
+        assert "max_budget_alert_emails" not in (data.metadata or {})
+        assert data.metadata.get("team") == "ops"

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10827,3 +10827,68 @@ class TestProxyAdminRoleHelper:
         assert (
             _is_proxy_admin_role(UserAPIKeyAuth(api_key="x", user_role=None)) is False
         )
+
+
+class TestRegenerateProjectMembershipGate:
+    """Greptile P1 follow-up: ``RegenerateKeyRequest`` inherits
+    ``project_id`` from ``GenerateKeyRequest`` and
+    ``prepare_key_update_data`` persists every set field including
+    ``project_id``. Without an explicit ``_check_project_key_limits``
+    call inside ``_execute_virtual_key_regeneration`` a non-admin caller
+    could enumerate a project_id, regenerate their key into it, and
+    inherit the victim project's models / budget — the same IDOR the
+    /key/generate + /key/update paths close."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_regen_into_non_member_project_blocked(self):
+        from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _execute_virtual_key_regeneration,
+        )
+
+        # Victim project — exists, has a team, caller is NOT a member.
+        project_obj = MagicMock(
+            team_id="team-victim",
+            models=["gpt-4o"],
+            litellm_budget_table=MagicMock(max_budget=999.0),
+        )
+        team_obj = LiteLLM_TeamTableCachedObj(
+            team_id="team-victim",
+            members_with_roles=[
+                Member(role="user", user_id="someone-else", user_email=None)
+            ],
+        )
+
+        key_in_db = LiteLLM_VerificationToken(
+            token="hashed-existing", project_id=None, team_id=None
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_project_object",
+                new=AsyncMock(return_value=project_obj),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+                new=AsyncMock(return_value=team_obj),
+            ),
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch("litellm.proxy.proxy_server.hash_token", return_value="new-hash"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _execute_virtual_key_regeneration(
+                    prisma_client=MagicMock(),
+                    key_in_db=key_in_db,
+                    hashed_api_key="hashed-existing",
+                    key="sk-existing",
+                    data=RegenerateKeyRequest(
+                        key="sk-existing",
+                        project_id="proj-victim",
+                    ),
+                    user_api_key_dict=_internal_user_auth(),
+                    litellm_changed_by=None,
+                    user_api_key_cache=MagicMock(),
+                    proxy_logging_obj=MagicMock(),
+                )
+            assert exc.value.status_code == 403
+            assert "not a member" in str(exc.value.detail)

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10596,3 +10596,234 @@ async def test_bulk_update_team_keys_blocks_metadata_allowed_passthrough_routes(
     assert exc.value.status_code == 403
     assert "allowed_passthrough_routes" in str(exc.value.detail)
     mock.update_data.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PlrNEsyT priv-esc regression suite
+# ---------------------------------------------------------------------------
+
+import pytest
+
+from litellm.proxy.management_endpoints.key_management_endpoints import (
+    _is_proxy_admin_role,
+    _strip_admin_only_fields_for_non_admin,
+)
+
+
+def _internal_user_auth():
+    return UserAPIKeyAuth(
+        api_key="sk-internal",
+        user_id="user-internal",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+
+def _proxy_admin_auth():
+    return UserAPIKeyAuth(
+        api_key="sk-admin",
+        user_id="user-admin",
+        user_role=LitellmUserRoles.PROXY_ADMIN.value,
+    )
+
+
+class TestStripAdminOnlyFields:
+    """Sub-bugs 1 + 4 of PlrNEsyT: ``/key/generate`` and ``/key/update``
+    accepted ``permissions[get_spend_routes]`` (self-grant of cross-tenant
+    spend log read) and ``metadata[max_budget_alert_emails]`` (phishing via
+    proxy's trusted SMTP / Sendgrid / Resend sender) from non-admin
+    callers. The strip helper must zero these for non-admin and pass them
+    through for proxy admin."""
+
+    def test_strips_get_spend_routes_for_non_admin(self):
+        data = GenerateKeyRequest(
+            permissions={"get_spend_routes": True, "custom_flag": "ok"}
+        )
+        _strip_admin_only_fields_for_non_admin(data, _internal_user_auth())
+        assert "get_spend_routes" not in data.permissions
+        # Custom (non-admin-only) permission keys survive — strip is targeted.
+        assert data.permissions.get("custom_flag") == "ok"
+
+    def test_strips_max_budget_alert_emails_for_non_admin(self):
+        data = GenerateKeyRequest(
+            metadata={
+                "max_budget_alert_emails": {"warn": ["attacker@evil.example"]},
+                "team": "core-infra",
+            }
+        )
+        _strip_admin_only_fields_for_non_admin(data, _internal_user_auth())
+        assert "max_budget_alert_emails" not in data.metadata
+        # Unrelated metadata keys survive.
+        assert data.metadata.get("team") == "core-infra"
+
+    def test_admin_caller_unchanged(self):
+        data = GenerateKeyRequest(
+            permissions={"get_spend_routes": True},
+            metadata={"max_budget_alert_emails": {"warn": ["ops@admin.example"]}},
+        )
+        _strip_admin_only_fields_for_non_admin(data, _proxy_admin_auth())
+        assert data.permissions["get_spend_routes"] is True
+        assert "max_budget_alert_emails" in data.metadata
+
+    def test_update_key_request_also_filtered(self):
+        data = UpdateKeyRequest(
+            key="sk-test",
+            permissions={"get_spend_routes": True},
+            metadata={"max_budget_alert_emails": {"warn": ["x@y.example"]}},
+        )
+        _strip_admin_only_fields_for_non_admin(data, _internal_user_auth())
+        assert "get_spend_routes" not in data.permissions
+        assert "max_budget_alert_emails" not in data.metadata
+
+
+class TestProjectKeyLimitsMembershipGate:
+    """Sub-bug 3 of PlrNEsyT: ``_check_project_key_limits`` validated that
+    the project existed but not that the caller was a member. Any
+    enumerated project_id let a non-admin mint keys against the victim
+    project, inheriting its models / budget."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_member_passes(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_project_key_limits,
+        )
+
+        project_obj = MagicMock(
+            team_id="team-victim",
+            models=["gpt-4o"],
+            litellm_budget_table=MagicMock(max_budget=100.0),
+        )
+        team_obj = LiteLLM_TeamTableCachedObj(
+            team_id="team-victim",
+            members_with_roles=[
+                Member(role="user", user_id="user-internal", user_email=None)
+            ],
+        )
+
+        prisma_client = MagicMock()
+        user_api_key_cache = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_project_object",
+                new=AsyncMock(return_value=project_obj),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+                new=AsyncMock(return_value=team_obj),
+            ),
+        ):
+            await _check_project_key_limits(
+                project_id="proj-x",
+                data=GenerateKeyRequest(models=["gpt-4o"], max_budget=10.0),
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                user_api_key_dict=_internal_user_auth(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_admin_non_member_blocked(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_project_key_limits,
+        )
+
+        project_obj = MagicMock(
+            team_id="team-victim",
+            models=["gpt-4o"],
+            litellm_budget_table=MagicMock(max_budget=100.0),
+        )
+        # Team object has no member matching the caller's user_id.
+        team_obj = LiteLLM_TeamTableCachedObj(
+            team_id="team-victim",
+            members_with_roles=[
+                Member(role="user", user_id="someone-else", user_email=None)
+            ],
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_project_object",
+                new=AsyncMock(return_value=project_obj),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+                new=AsyncMock(return_value=team_obj),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _check_project_key_limits(
+                    project_id="proj-x",
+                    data=GenerateKeyRequest(models=["gpt-4o"], max_budget=10.0),
+                    prisma_client=MagicMock(),
+                    user_api_key_cache=MagicMock(),
+                    user_api_key_dict=_internal_user_auth(),
+                )
+            assert exc.value.status_code == 403
+            assert "not a member" in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_proxy_admin_bypasses_membership_gate(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_project_key_limits,
+        )
+
+        project_obj = MagicMock(
+            team_id="team-victim",
+            models=["gpt-4o"],
+            litellm_budget_table=MagicMock(max_budget=100.0),
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_project_object",
+                new=AsyncMock(return_value=project_obj),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            # Admin should not even reach the team-lookup branch.
+            await _check_project_key_limits(
+                project_id="proj-x",
+                data=GenerateKeyRequest(models=["gpt-4o"], max_budget=10.0),
+                prisma_client=MagicMock(),
+                user_api_key_cache=MagicMock(),
+                user_api_key_dict=_proxy_admin_auth(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_orphan_project_with_no_team_blocks_non_admin(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_project_key_limits,
+        )
+
+        # team_id is None — non-admin must not be able to mint against it.
+        project_obj = MagicMock(
+            team_id=None,
+            models=["gpt-4o"],
+            litellm_budget_table=MagicMock(max_budget=100.0),
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_project_object",
+            new=AsyncMock(return_value=project_obj),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _check_project_key_limits(
+                    project_id="proj-orphan",
+                    data=GenerateKeyRequest(),
+                    prisma_client=MagicMock(),
+                    user_api_key_cache=MagicMock(),
+                    user_api_key_dict=_internal_user_auth(),
+                )
+            assert exc.value.status_code == 403
+
+
+class TestProxyAdminRoleHelper:
+    def test_proxy_admin_role_check(self):
+        assert _is_proxy_admin_role(_proxy_admin_auth()) is True
+        assert _is_proxy_admin_role(_internal_user_auth()) is False
+        # No user_role set → not admin.
+        assert (
+            _is_proxy_admin_role(UserAPIKeyAuth(api_key="x", user_role=None)) is False
+        )


### PR DESCRIPTION
## Type

🐛 Bug Fix
✅ Test

## Changes

Four parallel gaps on `/key/generate`, `/key/update`, `/key/regenerate`, and `_check_project_key_limits` let non-admin callers cross the proxy-admin authorization boundary by injecting fields the handlers accepted without role-gating.

### 1. `permissions.get_spend_routes` admin-only on `/key/generate` + `/key/update`

A non-admin could self-grant the `get_spend_routes` permission at key creation / update, then use that key to read `/spend/*` endpoints proxy-wide across every tenant. The runtime enterprise check at `key_management_endpoints.py:3483` only fires when the key is loaded; nothing blocked the permission from being SET in the first place.

### 2. `metadata.max_budget_alert_emails` admin-only on `/key/generate` + `/key/update`

`max_budget_alert_emails` is the recipient list for budget-alert emails sent through the operator's trusted SMTP / Sendgrid / Resend sender. Letting a non-admin set arbitrary recipients turns the proxy into a phishing relay — emails originate from the operator's trusted sender domain.

### 3. `/key/regenerate` missing the gates `/key/update` has

`/key/update` runs `validate_key_team_change` when the caller changes `team_id` (per LIT-1884) and rejects admin-only fields. `/key/regenerate` accepts the same `RegenerateKeyRequest` shape but ran none of those gates — a non-admin could re-target their own key at a victim team (inheriting models / budget / rate limits) or self-grant admin-only fields by going through regenerate instead of update.

### 4. `_check_project_key_limits` missing membership check

The helper validated that the project existed but not that the caller was a member of it. Any enumerated `project_id` let a non-admin mint a key against the victim project, billing against its budget and inheriting its models.

## Fix shape

- **New `_strip_admin_only_fields_for_non_admin` helper.** Mutates the request body to remove `permissions[get_spend_routes]` and `metadata[max_budget_alert_emails]` for non-admin callers. Per-key allowlists (`_ADMIN_ONLY_PERMISSION_KEYS`, `_ADMIN_ONLY_METADATA_KEYS`) keep targeting tight — user-defined permission / metadata keys still pass through. Called from `/key/generate`, `/key/update`, and `/key/regenerate`.
- **`/key/regenerate` now runs `validate_key_team_change`** when the caller asks to change `team_id` and isn't a proxy admin, mirroring the `/key/update` flow.
- **`_check_project_key_limits` now requires** the caller to be a member of the project's owning team (`LiteLLM_ProjectTable.team_id`). Projects without an associated team are admin-only.
- **New shared `_is_proxy_admin_role()` helper** replaces the inlined role check that was duplicated across three call sites.

## Compatibility

- **Proxy admins**: unaffected. The strip helper is a no-op for `LitellmUserRoles.PROXY_ADMIN`; `validate_key_team_change` and the project-membership check both early-return for admin.
- **Non-admin callers passing `permissions[get_spend_routes]` or `metadata[max_budget_alert_emails]`**: the fields are silently stripped (with a `verbose_proxy_logger.warning` for observability), the rest of the request proceeds normally. Non-admin callers had no legitimate reason to set either field — both are admin-equivalent flags by design.
- **Non-admin callers hitting `/key/regenerate` with a different `team_id`**: now go through the same `validate_key_team_change` rule that `/key/update` enforces. Members of the target team still pass; non-members get the same 403 they'd get from `/key/update`.
- **Non-admin callers passing `project_id` for a project they don't belong to**: now blocked with 403 instead of silently accepted.

## Test Plan

New `TestStripAdminOnlyFields`, `TestProjectKeyLimitsMembershipGate`, and `TestProxyAdminRoleHelper` classes cover each path:

- Admin-only key strip: `get_spend_routes` + `max_budget_alert_emails`, admin vs non-admin, `GenerateKeyRequest` + `UpdateKeyRequest` shapes.
- Project membership gate: member passes, non-member blocked, admin bypasses, orphan project (no team) blocks non-admin.
- Shared role helper: PROXY_ADMIN True, INTERNAL_USER False, `user_role=None` False.

Full key-management test suite still passes (248/248, the one excluded test is a pre-existing prisma test-env infra issue unrelated to this change).

## Commits

- `chore(proxy): tighten admin-only field gates on key management endpoints`
