### PR TITLE
fix(proxy): redact credential callback_vars in management responses

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -449,6 +449,97 @@ def convert_key_logging_metadata_to_callback(
     return team_callback_settings_obj
 
 
+# SensitiveDataMasker offers pattern-based redaction with partial masking;
+# callback_vars uses an explicit allowlist because the field set is small,
+# known, and we want full opacity over partial reveal.
+PUBLIC_CALLBACK_VARS = frozenset(
+    {
+        "langfuse_public_key",
+        "langfuse_host",
+        "langfuse_prompt_version",
+        "langsmith_project",
+        "langsmith_base_url",
+        "langsmith_sampling_rate",
+        "langsmith_tenant_id",
+        "arize_space_key",
+        "arize_space_id",
+        "posthog_host",
+        "posthog_api_url",
+        "braintrust_project",
+        "braintrust_host",
+        "lunary_public_key",
+        "gcs_bucket_name",
+        "weave_project_id",
+        "turn_off_message_logging",
+        "litellm_disabled_callbacks",
+    }
+)
+
+CALLBACK_VAR_MASK = "****"
+
+
+def redact_callback_vars(callback_vars: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        key: (value if key in PUBLIC_CALLBACK_VARS else CALLBACK_VAR_MASK)
+        for key, value in callback_vars.items()
+    }
+
+
+def redact_metadata_for_response(metadata: Any) -> Any:
+    if not isinstance(metadata, dict) or "logging" not in metadata:
+        return metadata
+    entries = metadata.get("logging")
+    if not isinstance(entries, list):
+        return metadata
+    redacted_entries: List[Any] = []
+    for entry in entries:
+        if isinstance(entry, dict) and isinstance(entry.get("callback_vars"), dict):
+            redacted_entries.append(
+                {
+                    **entry,
+                    "callback_vars": redact_callback_vars(entry["callback_vars"]),
+                }
+            )
+        else:
+            redacted_entries.append(entry)
+    return {**metadata, "logging": redacted_entries}
+
+
+def restore_masked_callback_vars(new_metadata: Any, existing_metadata: Any) -> Any:
+    """When an update payload re-submits the mask sentinel for a callback_vars
+    field, substitute the stored value from existing_metadata so a GET-then-PUT
+    round-trip does not overwrite the original credential. Existing entries are
+    matched by callback_name."""
+    if not isinstance(new_metadata, dict) or "logging" not in new_metadata:
+        return new_metadata
+    new_entries = new_metadata.get("logging")
+    if not isinstance(new_entries, list):
+        return new_metadata
+
+    existing_lookup: Dict[str, Dict[str, Any]] = {}
+    if isinstance(existing_metadata, dict):
+        for entry in existing_metadata.get("logging") or []:
+            if isinstance(entry, dict) and isinstance(entry.get("callback_vars"), dict):
+                existing_lookup[entry.get("callback_name", "")] = entry["callback_vars"]
+
+    restored_entries: List[Any] = []
+    for entry in new_entries:
+        if isinstance(entry, dict) and isinstance(entry.get("callback_vars"), dict):
+            existing_vars = existing_lookup.get(entry.get("callback_name", ""), {})
+            restored_vars = {
+                key: (
+                    existing_vars[key]
+                    if value == CALLBACK_VAR_MASK and key in existing_vars
+                    else value
+                )
+                for key, value in entry["callback_vars"].items()
+            }
+            restored_entries.append({**entry, "callback_vars": restored_vars})
+        else:
+            restored_entries.append(entry)
+    return {**new_metadata, "logging": restored_entries}
+
+
 def _get_validated_callback_metadata(
     item: dict, *, source: str
 ) -> Optional[AddTeamCallback]:

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -508,24 +508,47 @@ def redact_metadata_for_response(metadata: Any) -> Any:
 def restore_masked_callback_vars(new_metadata: Any, existing_metadata: Any) -> Any:
     """When an update payload re-submits the mask sentinel for a callback_vars
     field, substitute the stored value from existing_metadata so a GET-then-PUT
-    round-trip does not overwrite the original credential. Existing entries are
-    matched by callback_name."""
+    round-trip does not overwrite the original credential.
+
+    Entries are matched by position then by callback_name as a fallback
+    (callback_name is not unique at this layer, so name-only matching can
+    silently swap stored credentials between entries that share a name)."""
     if not isinstance(new_metadata, dict) or "logging" not in new_metadata:
         return new_metadata
     new_entries = new_metadata.get("logging")
     if not isinstance(new_entries, list):
         return new_metadata
 
-    existing_lookup: Dict[str, Dict[str, Any]] = {}
+    existing_entries: List[Any] = []
     if isinstance(existing_metadata, dict):
-        for entry in existing_metadata.get("logging") or []:
-            if isinstance(entry, dict) and isinstance(entry.get("callback_vars"), dict):
-                existing_lookup[entry.get("callback_name", "")] = entry["callback_vars"]
+        candidate = existing_metadata.get("logging")
+        if isinstance(candidate, list):
+            existing_entries = candidate
+
+    def _resolve_existing_vars(index: int, name: str) -> Dict[str, Any]:
+        if index < len(existing_entries):
+            positional = existing_entries[index]
+            if (
+                isinstance(positional, dict)
+                and positional.get("callback_name", "") == name
+                and isinstance(positional.get("callback_vars"), dict)
+            ):
+                return positional["callback_vars"]
+        for candidate in existing_entries:
+            if (
+                isinstance(candidate, dict)
+                and candidate.get("callback_name", "") == name
+                and isinstance(candidate.get("callback_vars"), dict)
+            ):
+                return candidate["callback_vars"]
+        return {}
 
     restored_entries: List[Any] = []
-    for entry in new_entries:
+    for index, entry in enumerate(new_entries):
         if isinstance(entry, dict) and isinstance(entry.get("callback_vars"), dict):
-            existing_vars = existing_lookup.get(entry.get("callback_name", ""), {})
+            existing_vars = _resolve_existing_vars(
+                index, entry.get("callback_name", "")
+            )
             restored_vars = {
                 key: (
                     existing_vars[key]

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2478,7 +2478,13 @@ async def update_key_fn(  # noqa: PLR0915
         if response is None:
             raise ValueError("Failed to update key got response = None")
 
-        return {"key": key, **response["data"]}
+        response_data = response["data"]
+        if hasattr(response_data, "model_dump"):
+            response_data = response_data.model_dump()
+        elif hasattr(response_data, "dict"):
+            response_data = response_data.dict()
+        response_data = _prepare_key_row_for_response(response_data)
+        return {"key": key, **response_data}
         # update based on remaining passed in values
     except Exception as e:
         verbose_proxy_logger.exception(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -72,6 +72,10 @@ from litellm.proxy.management_helpers.object_permission_utils import (
 from litellm.proxy.management_helpers.team_member_permission_checks import (
     TeamMemberPermissionChecks,
 )
+from litellm.proxy.litellm_pre_call_utils import (
+    redact_metadata_for_response,
+    restore_masked_callback_vars,
+)
 from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
 from litellm.proxy.spend_tracking.spend_tracking_utils import _is_master_key
 from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
@@ -863,6 +867,7 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         )
     )
 
+    response.metadata = redact_metadata_for_response(response.metadata)
     return response
 
 
@@ -1642,6 +1647,10 @@ def prepare_metadata_fields(
     """
     Check LiteLLM_ManagementEndpoint_MetadataFields (proxy/_types.py) for fields that are allowed to be updated
     """
+    if "metadata" in non_default_values:
+        non_default_values["metadata"] = restore_masked_callback_vars(
+            non_default_values["metadata"], existing_metadata
+        )
     if "metadata" not in non_default_values:  # allow user to set metadata to none
         non_default_values["metadata"] = existing_metadata.copy()
 
@@ -2028,9 +2037,7 @@ async def _process_single_key_update(
     elif hasattr(updated_key_info, "dict"):
         updated_key_info = updated_key_info.dict()
 
-    updated_key_info.pop("token", None)
-
-    return updated_key_info
+    return _prepare_key_row_for_response(updated_key_info)
 
 
 async def _validate_mcp_servers_for_key_update(
@@ -3072,6 +3079,18 @@ async def delete_key_fn(
         raise handle_exception_on_proxy(e)
 
 
+def _prepare_key_row_for_response(key_row_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Single chokepoint for shaping a verification-token row before it leaves
+    a /key/* endpoint or audit log. Drops the hashed token field and masks
+    credential-bearing callback_vars inside metadata.logging."""
+    key_row_dict.pop("token", None)
+    if "metadata" in key_row_dict:
+        key_row_dict["metadata"] = redact_metadata_for_response(
+            key_row_dict.get("metadata")
+        )
+    return key_row_dict
+
+
 @router.post(
     "/v2/key/info",
     tags=["key management"],
@@ -3143,8 +3162,7 @@ async def info_key_fn_v2(
                 k_dict = k.model_dump()
             except Exception:
                 k_dict = k.dict()
-            k_dict.pop("token", None)
-            filtered_key_info.append(k_dict)
+            filtered_key_info.append(_prepare_key_row_for_response(k_dict))
         return {"key": data.keys, "info": filtered_key_info}
 
     except Exception as e:
@@ -3225,10 +3243,10 @@ async def info_key_fn(
         except Exception:
             # if using pydantic v1
             key_info = key_info.dict()
-        key_info.pop("token")
 
         # Attach object_permission if object_permission_id is set
         key_info = await attach_object_permission_to_dict(key_info, prisma_client)
+        key_info = _prepare_key_row_for_response(key_info)
 
         return {"key": key, "info": key_info}
     except Exception as e:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -71,6 +71,10 @@ from litellm.proxy.auth.auth_checks import (
     get_user_object,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.litellm_pre_call_utils import (
+    redact_metadata_for_response,
+    restore_masked_callback_vars,
+)
 from litellm.proxy.management_endpoints.common_utils import (
     _is_user_org_admin_for_team,
     _is_user_team_admin,
@@ -1193,9 +1197,12 @@ async def new_team(  # noqa: PLR0915
             )
 
         try:
-            return team_row.model_dump()
+            team_dict = team_row.model_dump()
         except Exception:
-            return team_row.dict()
+            team_dict = team_row.dict()
+        if "metadata" in team_dict:
+            team_dict["metadata"] = redact_metadata_for_response(team_dict["metadata"])
+        return team_dict
     except Exception as e:
         raise handle_exception_on_proxy(e)
 
@@ -1762,6 +1769,9 @@ async def update_team(  # noqa: PLR0915
             TeamMemberBudgetHandler.strip_system_managed_metadata_keys(
                 updated_kv["metadata"]
             )
+            updated_kv["metadata"] = restore_masked_callback_vars(
+                updated_kv["metadata"], existing_team_row.metadata
+            )
 
         # Check budget_duration and budget_reset_at
         _set_budget_reset_at(data, updated_kv)
@@ -1861,6 +1871,9 @@ async def update_team(  # noqa: PLR0915
                 litellm_proxy_admin_name=litellm_proxy_admin_name,
             )
 
+        existing_team_metadata = getattr(team_row, "metadata", None)
+        if existing_team_metadata is not None:
+            team_row.metadata = redact_metadata_for_response(existing_team_metadata)
         return {"team_id": team_row.team_id, "data": team_row}
     except Exception as e:
         raise handle_exception_on_proxy(e)
@@ -3450,6 +3463,18 @@ async def team_info(
 
         # Resolve resources inherited from access groups
         await _resolve_team_access_group_resources(_team_info)
+
+        _team_info.metadata = redact_metadata_for_response(_team_info.metadata)
+        keys = [
+            (
+                key.model_copy(
+                    update={"metadata": redact_metadata_for_response(key.metadata)}
+                )
+                if hasattr(key, "metadata") and hasattr(key, "model_copy")
+                else key
+            )
+            for key in keys
+        ]
 
         response_object = TeamInfoResponseObject(
             team_id=team_id,

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -28,16 +28,31 @@ ALLOW_LITELLM_CHANGED_BY_HEADER_METADATA_KEY = "allow_litellm_changed_by_header"
 def _redact_callback_vars_in_audit_payload(payload):
     """Audit log payloads are stringified key/team rows. Redact
     credential-bearing callback_vars inside metadata.logging before the
-    payload is dispatched to callbacks or persisted to the DB."""
+    payload is dispatched to callbacks or persisted to the DB.
+
+    Handles both single-encoded ({...}) and double-encoded
+    (json.dumps(model.json(...)) -> "{...}") shapes — the latter is what
+    new_team, _create_team_update_audit_log, and async_key_updated_hook
+    produce."""
     if not isinstance(payload, str):
         return payload
     try:
         obj = json.loads(payload)
     except (json.JSONDecodeError, TypeError):
         return payload
+
+    double_encoded = isinstance(obj, str)
+    if double_encoded:
+        try:
+            obj = json.loads(obj)
+        except (json.JSONDecodeError, TypeError):
+            return payload
+
     if not isinstance(obj, dict):
         return payload
+
     metadata = obj.get("metadata")
+    redacted = False
     if isinstance(metadata, str):
         try:
             metadata_dict = json.loads(metadata)
@@ -47,12 +62,18 @@ def _redact_callback_vars_in_audit_payload(payload):
             obj["metadata"] = json.dumps(
                 redact_metadata_for_response(metadata_dict), default=str
             )
-            return json.dumps(obj, default=str)
-        return payload
-    if isinstance(metadata, dict):
+            redacted = True
+    elif isinstance(metadata, dict):
         obj["metadata"] = redact_metadata_for_response(metadata)
-        return json.dumps(obj, default=str)
-    return payload
+        redacted = True
+
+    if not redacted:
+        return payload
+
+    result = json.dumps(obj, default=str)
+    if double_encoded:
+        result = json.dumps(result, default=str)
+    return result
 
 
 def _allows_litellm_changed_by_header(user_api_key_dict: UserAPIKeyAuth) -> bool:

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -18,10 +18,41 @@ from litellm.proxy._types import (
     Optional,
     UserAPIKeyAuth,
 )
+from litellm.proxy.litellm_pre_call_utils import redact_metadata_for_response
 from litellm.types.utils import StandardAuditLogPayload
 
 _audit_log_callback_cache: Dict[str, CustomLogger] = {}
 ALLOW_LITELLM_CHANGED_BY_HEADER_METADATA_KEY = "allow_litellm_changed_by_header"
+
+
+def _redact_callback_vars_in_audit_payload(payload):
+    """Audit log payloads are stringified key/team rows. Redact
+    credential-bearing callback_vars inside metadata.logging before the
+    payload is dispatched to callbacks or persisted to the DB."""
+    if not isinstance(payload, str):
+        return payload
+    try:
+        obj = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return payload
+    if not isinstance(obj, dict):
+        return payload
+    metadata = obj.get("metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata_dict = json.loads(metadata)
+        except (json.JSONDecodeError, TypeError):
+            return payload
+        if isinstance(metadata_dict, dict):
+            obj["metadata"] = json.dumps(
+                redact_metadata_for_response(metadata_dict), default=str
+            )
+            return json.dumps(obj, default=str)
+        return payload
+    if isinstance(metadata, dict):
+        obj["metadata"] = redact_metadata_for_response(metadata)
+        return json.dumps(obj, default=str)
+    return payload
 
 
 def _allows_litellm_changed_by_header(user_api_key_dict: UserAPIKeyAuth) -> bool:
@@ -231,6 +262,13 @@ async def create_audit_log_for_update(request_data: LiteLLM_AuditLogs):
 
     if isinstance(request_data.before_value, dict):
         request_data.before_value = json.dumps(request_data.before_value)
+
+    request_data.updated_values = _redact_callback_vars_in_audit_payload(
+        request_data.updated_values
+    )
+    request_data.before_value = _redact_callback_vars_in_audit_payload(
+        request_data.before_value
+    )
 
     # Dispatch to external audit log callbacks regardless of DB availability
     await _dispatch_audit_log_to_callbacks(request_data)

--- a/tests/test_litellm/proxy/management_helpers/test_audit_log_callbacks.py
+++ b/tests/test_litellm/proxy/management_helpers/test_audit_log_callbacks.py
@@ -18,8 +18,10 @@ from litellm.proxy.management_helpers.audit_logs import (
     _audit_log_task_done_callback,
     _build_audit_log_payload,
     _dispatch_audit_log_to_callbacks,
+    _redact_callback_vars_in_audit_payload,
     create_audit_log_for_update,
 )
+from litellm.proxy.litellm_pre_call_utils import CALLBACK_VAR_MASK
 from litellm.types.utils import StandardAuditLogPayload
 
 
@@ -469,3 +471,73 @@ class TestS3AuditCallbackParamsDecoupling:
             assert second is not None
             assert id(second) != id(first)
             assert second.s3_bucket_name == "second"
+
+
+class TestRedactCallbackVarsInAuditPayload:
+    """Audit-log payloads carry stringified key/team rows. Verify the
+    redactor masks credential callback_vars across both single-encoded
+    ({...}) and double-encoded (json.dumps(model.json(...))) shapes."""
+
+    def _row_with_secret(self):
+        return {
+            "team_id": "t1",
+            "metadata": {
+                "logging": [
+                    {
+                        "callback_name": "langfuse",
+                        "callback_vars": {
+                            "langfuse_secret_key": "sk-real",
+                            "langfuse_host": "https://h",
+                        },
+                    }
+                ]
+            },
+        }
+
+    def test_redacts_single_encoded_payload(self):
+        payload = json.dumps(self._row_with_secret())
+        result = _redact_callback_vars_in_audit_payload(payload)
+        parsed = json.loads(result)
+        vars_out = parsed["metadata"]["logging"][0]["callback_vars"]
+        assert vars_out["langfuse_secret_key"] == CALLBACK_VAR_MASK
+        assert vars_out["langfuse_host"] == "https://h"
+
+    def test_redacts_double_encoded_payload(self):
+        # Simulates json.dumps(model.json(...), default=str) — what
+        # new_team, _create_team_update_audit_log, async_key_updated_hook
+        # produce.
+        inner = json.dumps(self._row_with_secret())
+        payload = json.dumps(inner, default=str)
+        result = _redact_callback_vars_in_audit_payload(payload)
+        # Result should still be double-encoded.
+        once_unwrapped = json.loads(result)
+        assert isinstance(once_unwrapped, str)
+        parsed = json.loads(once_unwrapped)
+        vars_out = parsed["metadata"]["logging"][0]["callback_vars"]
+        assert vars_out["langfuse_secret_key"] == CALLBACK_VAR_MASK
+        assert vars_out["langfuse_host"] == "https://h"
+
+    def test_redacts_metadata_stored_as_json_string(self):
+        row = self._row_with_secret()
+        row["metadata"] = json.dumps(row["metadata"])  # nested JSON string
+        payload = json.dumps(row)
+        result = _redact_callback_vars_in_audit_payload(payload)
+        parsed = json.loads(result)
+        inner_metadata = json.loads(parsed["metadata"])
+        vars_out = inner_metadata["logging"][0]["callback_vars"]
+        assert vars_out["langfuse_secret_key"] == CALLBACK_VAR_MASK
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            42,
+            "not-json",
+            json.dumps({"name": "no-metadata-here"}),
+            json.dumps({"metadata": None}),
+            json.dumps({"metadata": "plain-string-not-json"}),
+            json.dumps([1, 2, 3]),
+        ],
+    )
+    def test_passes_through_payloads_without_callback_metadata(self, payload):
+        assert _redact_callback_vars_in_audit_payload(payload) == payload

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -13,6 +13,8 @@ from starlette.datastructures import Headers
 import litellm
 from litellm.proxy._types import AddTeamCallback, TeamCallbackMetadata, UserAPIKeyAuth
 from litellm.proxy.litellm_pre_call_utils import (
+    CALLBACK_VAR_MASK,
+    PUBLIC_CALLBACK_VARS,
     KeyAndTeamLoggingSettings,
     LiteLLMProxyRequestSetup,
     _apply_credential_overrides_from_model_config,
@@ -27,6 +29,9 @@ from litellm.proxy.litellm_pre_call_utils import (
     add_litellm_data_to_request,
     check_if_token_is_service_account,
     clean_headers,
+    redact_callback_vars,
+    redact_metadata_for_response,
+    restore_masked_callback_vars,
 )
 from litellm.types.utils import CredentialItem
 
@@ -4060,9 +4065,7 @@ def test_resolve_provider_from_deployment_uses_litellm_params_model():
     deployment.litellm_params.custom_llm_provider = None
     router.get_deployment_by_model_group_name.return_value = deployment
 
-    assert (
-        _resolve_provider_from_deployment(router, "claude-sonnet-4.6") == "bedrock"
-    )
+    assert _resolve_provider_from_deployment(router, "claude-sonnet-4.6") == "bedrock"
 
 
 def test_resolve_provider_from_deployment_prefers_custom_llm_provider():
@@ -4073,9 +4076,7 @@ def test_resolve_provider_from_deployment_prefers_custom_llm_provider():
     deployment.litellm_params.custom_llm_provider = "bedrock"
     router.get_deployment_by_model_group_name.return_value = deployment
 
-    assert (
-        _resolve_provider_from_deployment(router, "claude-sonnet-4.6") == "bedrock"
-    )
+    assert _resolve_provider_from_deployment(router, "claude-sonnet-4.6") == "bedrock"
 
 
 def test_resolve_provider_from_deployment_no_match():
@@ -4215,3 +4216,151 @@ def test_apply_overrides_provider_prefix_in_model_skips_router_lookup(
     assert data["api_base"] == "https://hotel-eastus.openai.azure.com/"
     assert data["api_key"] == "key-hotel-eastus"
     router.get_deployment_by_model_group_name.assert_not_called()
+
+
+class TestCallbackMetadataRedaction:
+    """Verifies that credential-bearing callback_vars fields are masked while
+    public fields pass through, and that update payloads using the mask
+    sentinel preserve stored values."""
+
+    def test_redact_callback_vars_masks_secrets_and_unknowns_preserves_public(self):
+        # slack_webhook_url is bearer-token-bearing despite the "_url" suffix;
+        # newintegration_api_key exercises deny-by-default for future fields.
+        callback_vars = {
+            "langfuse_secret_key": "sk-real",
+            "langsmith_api_key": "ls-real",
+            "slack_webhook_url": "https://hooks.slack.com/services/T0/B0/abc",
+            "gcs_path_service_account": "/etc/secrets/sa.json",
+            "newintegration_api_key": "future-secret",
+            "langfuse_host": "https://cloud.langfuse.com",
+            "langsmith_project": "my-project",
+        }
+        snapshot = dict(callback_vars)
+        result = redact_callback_vars(callback_vars)
+
+        assert result == {
+            "langfuse_secret_key": CALLBACK_VAR_MASK,
+            "langsmith_api_key": CALLBACK_VAR_MASK,
+            "slack_webhook_url": CALLBACK_VAR_MASK,
+            "gcs_path_service_account": CALLBACK_VAR_MASK,
+            "newintegration_api_key": CALLBACK_VAR_MASK,
+            "langfuse_host": "https://cloud.langfuse.com",
+            "langsmith_project": "my-project",
+        }
+        assert callback_vars == snapshot  # immutability
+
+    def test_redact_metadata_for_response_redacts_callback_vars_only(self):
+        metadata = {
+            "team_alias": "my-team",
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {
+                        "langfuse_secret_key": "sk-real",
+                        "langfuse_host": "https://h1",
+                    },
+                },
+                {
+                    "callback_name": "langsmith",
+                    "callback_vars": {
+                        "langsmith_api_key": "ls-real",
+                        "langsmith_project": "my-project",
+                    },
+                },
+            ],
+        }
+        snapshot = json.loads(json.dumps(metadata))
+        result = redact_metadata_for_response(metadata)
+
+        assert result["team_alias"] == "my-team"
+        first, second = result["logging"]
+        assert first["callback_vars"]["langfuse_secret_key"] == CALLBACK_VAR_MASK
+        assert first["callback_vars"]["langfuse_host"] == "https://h1"
+        assert second["callback_vars"]["langsmith_api_key"] == CALLBACK_VAR_MASK
+        assert second["callback_vars"]["langsmith_project"] == "my-project"
+        assert metadata == snapshot  # immutability
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            None,
+            "not-a-dict",
+            [],
+            {"foo": "bar"},
+            {"logging": []},
+            {"logging": "not-a-list"},
+            {"logging": ["not-a-dict", None, 42]},
+            {"logging": [{"callback_name": "langfuse"}]},  # entry w/o callback_vars
+        ],
+    )
+    def test_redact_metadata_for_response_passes_through_malformed_inputs(
+        self, metadata
+    ):
+        assert redact_metadata_for_response(metadata) == metadata
+
+    def test_restore_masked_callback_vars_substitutes_existing_for_mask(self):
+        existing = {
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {
+                        "langfuse_secret_key": "sk-stored-original",
+                        "langfuse_host": "https://old-host",
+                    },
+                }
+            ]
+        }
+        incoming = {
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {
+                        "langfuse_secret_key": CALLBACK_VAR_MASK,
+                        "langfuse_host": "https://new-host",
+                        "langfuse_public_key": "pk-newly-added",
+                    },
+                }
+            ]
+        }
+        existing_snapshot = json.loads(json.dumps(existing))
+        incoming_snapshot = json.loads(json.dumps(incoming))
+        result = restore_masked_callback_vars(incoming, existing)
+
+        restored_vars = result["logging"][0]["callback_vars"]
+        assert restored_vars["langfuse_secret_key"] == "sk-stored-original"
+        assert restored_vars["langfuse_host"] == "https://new-host"
+        assert restored_vars["langfuse_public_key"] == "pk-newly-added"
+        assert existing == existing_snapshot  # immutability
+        assert incoming == incoming_snapshot
+
+    def test_restore_masked_callback_vars_keeps_mask_when_no_existing_value(self):
+        # If the existing metadata has no stored value for a masked field,
+        # the mask is left in place so a downstream check can flag it.
+        existing = {"logging": [{"callback_name": "langfuse", "callback_vars": {}}]}
+        incoming = {
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {"langfuse_secret_key": CALLBACK_VAR_MASK},
+                }
+            ]
+        }
+        result = restore_masked_callback_vars(incoming, existing)
+        assert (
+            result["logging"][0]["callback_vars"]["langfuse_secret_key"]
+            == CALLBACK_VAR_MASK
+        )
+
+    @pytest.mark.parametrize(
+        "incoming",
+        [
+            None,
+            "x",
+            {"foo": "bar"},
+            {"logging": "not-a-list"},
+        ],
+    )
+    def test_restore_masked_callback_vars_passes_through_malformed_inputs(
+        self, incoming
+    ):
+        assert restore_masked_callback_vars(incoming, {"logging": []}) == incoming

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4333,6 +4333,44 @@ class TestCallbackMetadataRedaction:
         assert existing == existing_snapshot  # immutability
         assert incoming == incoming_snapshot
 
+    def test_restore_masked_callback_vars_uses_positional_match_for_duplicate_names(
+        self,
+    ):
+        # Two logging entries with the same callback_name — positional
+        # matching keeps each entry's masked value mapped to its own
+        # stored credential, instead of collapsing both to the second.
+        existing = {
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {"langfuse_secret_key": "sk-entry-0"},
+                },
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {"langfuse_secret_key": "sk-entry-1"},
+                },
+            ]
+        }
+        incoming = {
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {"langfuse_secret_key": CALLBACK_VAR_MASK},
+                },
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {"langfuse_secret_key": CALLBACK_VAR_MASK},
+                },
+            ]
+        }
+        result = restore_masked_callback_vars(incoming, existing)
+        assert (
+            result["logging"][0]["callback_vars"]["langfuse_secret_key"] == "sk-entry-0"
+        )
+        assert (
+            result["logging"][1]["callback_vars"]["langfuse_secret_key"] == "sk-entry-1"
+        )
+
     def test_restore_masked_callback_vars_keeps_mask_when_no_existing_value(self):
         # If the existing metadata has no stored value for a masked field,
         # the mask is left in place so a downstream check can flag it.


### PR DESCRIPTION
## Summary

Credential-bearing fields inside `metadata.logging[*].callback_vars` were returned verbatim from `/key/info`, `/v2/key/info`, `/key/generate`, `/key/update`, `/team/info`, `/team/new`, `/team/update`, and recorded plaintext in audit-log entries.

This PR adds a per-resource response chokepoint that masks credential fields against an explicit `PUBLIC_CALLBACK_VARS` allowlist. Public fields (`langfuse_host`, `langfuse_public_key`, `langsmith_project`, etc.) pass through unchanged so operators can still verify wiring.

Update endpoints (`/key/update`, `/team/update`) treat the `"****"` mask sentinel as a no-op, restoring the existing stored value during merge — supports the GET-then-PUT round-trip used by the UI.

Audit-log payloads (`before_value` + `updated_values`) go through the same redaction at the chokepoint, so observability sinks don't receive raw credentials either.

## Files

- `litellm/proxy/litellm_pre_call_utils.py` — adds `PUBLIC_CALLBACK_VARS`, `redact_callback_vars`, `redact_metadata_for_response`, `restore_masked_callback_vars`
- `litellm/proxy/management_endpoints/key_management_endpoints.py` — `_prepare_key_row_for_response` helper; wired into `/key/info`, `/v2/key/info`, `/key/update`, `/key/generate`; mask-as-noop in `prepare_metadata_fields`
- `litellm/proxy/management_endpoints/team_endpoints.py` — redaction in `/team/new`, `/team/update` (response + merge), `/team/info` (team metadata + per-key `model_copy` on the keys list)
- `litellm/proxy/management_helpers/audit_logs.py` — `_redact_callback_vars_in_audit_payload` applied to `before_value` and `updated_values`

## Field classification

`PUBLIC_CALLBACK_VARS` (surfaced as-is): `langfuse_public_key`, `langfuse_host`, `langfuse_prompt_version`, `langsmith_project`, `langsmith_base_url`, `langsmith_sampling_rate`, `langsmith_tenant_id`, `arize_space_key`, `arize_space_id`, `posthog_host`, `posthog_api_url`, `braintrust_project`, `braintrust_host`, `lunary_public_key`, `gcs_bucket_name`, `weave_project_id`, `turn_off_message_logging`, `litellm_disabled_callbacks`.

Everything else (including any future field added without explicit review) is masked. `slack_webhook_url` is masked despite the `_url` suffix because Slack incoming webhook URLs are bearer-token-bearing.

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py::TestCallbackMetadataRedaction -q` — 16 passed (new)
- [x] `uv run pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py -q` — 374 passed (no regressions)
- [x] `uv run pytest tests/test_litellm/proxy/management_helpers/test_audit_log_callbacks.py -q` — 21 passed (no regressions)
- [x] End-to-end verified against a live proxy (`/key/generate`, `/key/info`, `/key/update`, `/team/new`, `/team/info` with literal Langfuse + Langsmith credentials in callback_vars; DB introspection confirms GET-then-PUT round-trip preserves stored secrets)