### PR TITLE
feat(mcp): support MCP access group names in URL-based namespacing

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1573,9 +1573,7 @@ DEFAULT_ACCESS_GROUP_CACHE_TTL = int(os.getenv("DEFAULT_ACCESS_GROUP_CACHE_TTL",
 # callers from forcing a DB query per request for unknown names, while bounding
 # staleness so a transient DB error (which surfaces as an empty list) cannot
 # hide a real group for long.
-DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL = int(
-    os.getenv("DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL", 10)
-)
+DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL = 10
 
 # Sentry Scrubbing Configuration
 SENTRY_DENYLIST = [

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1574,6 +1574,10 @@ DEFAULT_ACCESS_GROUP_CACHE_TTL = int(os.getenv("DEFAULT_ACCESS_GROUP_CACHE_TTL",
 # staleness so a transient DB error (which surfaces as an empty list) cannot
 # hide a real group for long.
 DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL = 10
+# Maximum number of comma-separated MCP server / access-group tokens accepted
+# in a single ``/{name1,name2,...}/mcp`` URL. Bounds the per-request DB / cache
+# fan-out an authenticated caller can trigger by stuffing the path with tokens.
+DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS = 16
 
 # Sentry Scrubbing Configuration
 SENTRY_DENYLIST = [

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1569,6 +1569,13 @@ DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL = int(
     os.getenv("DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL", 60)
 )
 DEFAULT_ACCESS_GROUP_CACHE_TTL = int(os.getenv("DEFAULT_ACCESS_GROUP_CACHE_TTL", 600))
+# Short TTL for negative MCP access-group existence lookups. Keeps unauthenticated
+# callers from forcing a DB query per request for unknown names, while bounding
+# staleness so a transient DB error (which surfaces as an empty list) cannot
+# hide a real group for long.
+DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL = int(
+    os.getenv("DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL", 10)
+)
 
 # Sentry Scrubbing Configuration
 SENTRY_DENYLIST = [

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15155,10 +15155,12 @@ async def _resolve_mcp_csv_tokens(
 
     For each token, check (in order) whether it is a registered MCP server
     alias / name or an MCP access group tag (cached). Tokens are stripped,
-    deduped (case-insensitive, keeping first occurrence in original order),
-    and capped at ``DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS`` to bound the
+    deduped (exact-match, keeping first occurrence in original order), and
+    capped at ``DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS`` to bound the
     per-request DB / cache fan-out an authenticated caller can trigger by
-    stuffing the path with tokens.
+    stuffing the path with tokens. Dedup is case-sensitive on purpose:
+    downstream resolvers may treat names case-sensitively, so collapsing
+    ``MyGroup`` and ``mygroup`` would risk dropping a valid distinct token.
 
     Toolset names are intentionally NOT resolved here — toolsets bind a single
     toolset id into request scope and have no defined semantics inside a
@@ -15175,16 +15177,13 @@ async def _resolve_mcp_csv_tokens(
         global_mcp_server_manager,
     )
 
-    seen_lower: set = set()
+    seen: set = set()
     deduped: List[str] = []
     for raw in csv_segment.split(","):
         token = raw.strip()
-        if not token:
+        if not token or token in seen:
             continue
-        lower = token.lower()
-        if lower in seen_lower:
-            continue
-        seen_lower.add(lower)
+        seen.add(token)
         deduped.append(token)
         if len(deduped) >= DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS:
             break

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15135,6 +15135,58 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
         raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
 
 
+async def _mcp_forward_as_path(path_segment: str, request: Request):
+    """Rewrite path to /mcp/{path_segment} and buffer the response."""
+    from litellm.proxy._experimental.mcp_server.server import (
+        handle_streamable_http_mcp,
+    )
+    from starlette.responses import Response
+
+    scope = dict(request.scope)
+    scope["path"] = f"/mcp/{path_segment}"
+
+    response_body = b""
+    response_status = 200
+    response_headers: list = []
+
+    async def custom_send(message):
+        nonlocal response_body, response_status, response_headers
+        if message["type"] == "http.response.start":
+            response_status = message["status"]
+            response_headers = message.get("headers", [])
+        elif message["type"] == "http.response.body":
+            response_body += message.get("body", b"")
+
+    await handle_streamable_http_mcp(scope, receive=request.receive, send=custom_send)
+    headers_dict = {k.decode(): v.decode() for k, v in response_headers}
+    return Response(
+        content=response_body,
+        status_code=response_status,
+        headers=headers_dict,
+        media_type=headers_dict.get("content-type", "application/json"),
+    )
+
+
+async def _is_mcp_access_group_cached(name: str) -> bool:
+    """Return True if *name* is a known MCP access group tag, caching the result."""
+    from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+
+    cache_key = f"mcp_access_group_exists:{name}"
+    cached = await user_api_key_cache.async_get_cache(key=cache_key)
+    if cached is not None:
+        return bool(cached)
+    result = bool(await MCPRequestHandler._get_mcp_servers_from_access_groups([name]))
+    await user_api_key_cache.async_set_cache(
+        key=cache_key,
+        value=result,
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    return result
+
+
 # Dynamic MCP server routes - handle /{mcp_server_name}/mcp
 @app.api_route(
     "/{mcp_server_name}/mcp",
@@ -15157,48 +15209,15 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
 
         client_ip = IPAddressUtils.get_mcp_client_ip(request)
 
-        async def _forward_as_mcp_path(path_segment: str):
-            from litellm.proxy._experimental.mcp_server.server import (
-                handle_streamable_http_mcp,
-            )
-            from starlette.responses import Response
-
-            scope = dict(request.scope)
-            scope["path"] = f"/mcp/{path_segment}"
-
-            response_body = b""
-            response_status = 200
-            response_headers: list = []
-
-            async def custom_send(message):
-                nonlocal response_body, response_status, response_headers
-                if message["type"] == "http.response.start":
-                    response_status = message["status"]
-                    response_headers = message.get("headers", [])
-                elif message["type"] == "http.response.body":
-                    response_body += message.get("body", b"")
-
-            await handle_streamable_http_mcp(
-                scope, receive=request.receive, send=custom_send
-            )
-            headers_dict = {k.decode(): v.decode() for k, v in response_headers}
-            return Response(
-                content=response_body,
-                status_code=response_status,
-                headers=headers_dict,
-                media_type=headers_dict.get("content-type", "application/json"),
-            )
-
         # 1. Registered MCP server alias
-        mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
+        if global_mcp_server_manager.get_mcp_server_by_name(
             mcp_server_name, client_ip=client_ip
-        )
-        if mcp_server is not None:
-            return await _forward_as_mcp_path(mcp_server_name)
+        ):
+            return await _mcp_forward_as_path(mcp_server_name, request)
 
         # 2. Comma-separated list — forward directly before any DB call.
         if "," in mcp_server_name:
-            return await _forward_as_mcp_path(mcp_server_name)
+            return await _mcp_forward_as_path(mcp_server_name, request)
 
         # 3. Toolset name (cached)
         if prisma_client is not None:
@@ -15221,29 +15240,9 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
                 finally:
                     _mcp_active_toolset_id.reset(token)
 
-        # 4. Single segment: check if it is a known MCP access group tag (cached).
-        from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
-        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
-            MCPRequestHandler,
-        )
-
-        cache_key = f"mcp_access_group_exists:{mcp_server_name}"
-        cached_result = await user_api_key_cache.async_get_cache(key=cache_key)
-        if cached_result is None:
-            group_server_ids = (
-                await MCPRequestHandler._get_mcp_servers_from_access_groups(
-                    [mcp_server_name]
-                )
-            )
-            cached_result = bool(group_server_ids)
-            await user_api_key_cache.async_set_cache(
-                key=cache_key,
-                value=cached_result,
-                ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
-            )
-
-        if cached_result:
-            return await _forward_as_mcp_path(mcp_server_name)
+        # 4. MCP access group tag (cached)
+        if await _is_mcp_access_group_cached(mcp_server_name):
+            return await _mcp_forward_as_path(mcp_server_name, request)
 
         raise HTTPException(
             status_code=404,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15145,9 +15145,9 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
 
     Resolution order:
     1. Registered MCP server alias / name
-    2. Toolset name (DB lookup)
-    3. MCP access group tag — resolves to all servers in that group
-    4. Comma-separated mix of any of the above (e.g. /github_mcp,zapier/mcp)
+    2. Comma-separated list (short-circuits before any DB call)
+    3. Toolset name (DB lookup, cached)
+    4. MCP access group tag (DB lookup, cached)
     """
     try:
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -15158,7 +15158,6 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
         client_ip = IPAddressUtils.get_mcp_client_ip(request)
 
         async def _forward_as_mcp_path(path_segment: str):
-            """Rewrite path to /mcp/{path_segment} and stream through the MCP handler."""
             from litellm.proxy._experimental.mcp_server.server import (
                 handle_streamable_http_mcp,
             )
@@ -15167,15 +15166,13 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
             scope = dict(request.scope)
             scope["path"] = f"/mcp/{path_segment}"
 
-            response_started = False
             response_body = b""
             response_status = 200
             response_headers: list = []
 
             async def custom_send(message):
-                nonlocal response_started, response_body, response_status, response_headers
+                nonlocal response_body, response_status, response_headers
                 if message["type"] == "http.response.start":
-                    response_started = True
                     response_status = message["status"]
                     response_headers = message.get("headers", [])
                 elif message["type"] == "http.response.body":
@@ -15199,7 +15196,11 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
         if mcp_server is not None:
             return await _forward_as_mcp_path(mcp_server_name)
 
-        # 2. Toolset name
+        # 2. Comma-separated list — forward directly before any DB call.
+        if "," in mcp_server_name:
+            return await _forward_as_mcp_path(mcp_server_name)
+
+        # 3. Toolset name (cached)
         if prisma_client is not None:
             from litellm.proxy._experimental.mcp_server.server import (
                 _mcp_active_toolset_id,
@@ -15220,25 +15221,28 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
                 finally:
                     _mcp_active_toolset_id.reset(token)
 
-        # 3 & 4. MCP access group tag OR comma-separated list of servers/groups.
-        # The MCP handler's _get_mcp_servers_in_path already parses comma lists
-        # from /mcp/<csv>, so we just need to ensure the segment is forwarded as
-        # a path under /mcp/. For a single segment that is an access group we
-        # verify it resolves to at least one server before forwarding so that
-        # unknown names still produce a 404.
-        if "," in mcp_server_name:
-            # Comma-separated — forward directly; the MCP handler resolves each token.
-            return await _forward_as_mcp_path(mcp_server_name)
-
-        # Single segment: check whether it is a known MCP access group tag.
+        # 4. Single segment: check if it is a known MCP access group tag (cached).
+        from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
         from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
             MCPRequestHandler,
         )
 
-        group_server_ids = await MCPRequestHandler._get_mcp_servers_from_access_groups(
-            [mcp_server_name]
-        )
-        if group_server_ids:
+        cache_key = f"mcp_access_group_exists:{mcp_server_name}"
+        cached_result = await user_api_key_cache.async_get_cache(key=cache_key)
+        if cached_result is None:
+            group_server_ids = (
+                await MCPRequestHandler._get_mcp_servers_from_access_groups(
+                    [mcp_server_name]
+                )
+            )
+            cached_result = bool(group_server_ids)
+            await user_api_key_cache.async_set_cache(
+                key=cache_key,
+                value=cached_result,
+                ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            )
+
+        if cached_result:
             return await _forward_as_mcp_path(mcp_server_name)
 
         raise HTTPException(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15148,6 +15148,57 @@ async def _mcp_forward_as_path(path_segment: str, request: Request):
     )
 
 
+async def _resolve_mcp_csv_tokens(
+    csv_segment: str, client_ip: Optional[str]
+) -> List[str]:
+    """Validate a comma-separated ``/{name1,name2,...}/mcp`` segment.
+
+    For each token, check (in order) whether it is a registered MCP server
+    alias / name or an MCP access group tag (cached). Tokens are stripped,
+    deduped (case-insensitive, keeping first occurrence in original order),
+    and capped at ``DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS`` to bound the
+    per-request DB / cache fan-out an authenticated caller can trigger by
+    stuffing the path with tokens.
+
+    Toolset names are intentionally NOT resolved here — toolsets bind a single
+    toolset id into request scope and have no defined semantics inside a
+    comma-separated server list.
+
+    Returns the subset of resolved tokens in original order. An empty list
+    means the segment did not resolve to any known server / group; the caller
+    should treat that as a 404 instead of forwarding it downstream (where an
+    all-unmatched server filter falls back to the full ``allowed_mcp_servers``
+    list and silently broadens the request scope).
+    """
+    from litellm.constants import DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    seen_lower: set = set()
+    deduped: List[str] = []
+    for raw in csv_segment.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        lower = token.lower()
+        if lower in seen_lower:
+            continue
+        seen_lower.add(lower)
+        deduped.append(token)
+        if len(deduped) >= DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS:
+            break
+
+    resolved: List[str] = []
+    for token in deduped:
+        if global_mcp_server_manager.get_mcp_server_by_name(token, client_ip=client_ip):
+            resolved.append(token)
+            continue
+        if await _is_mcp_access_group_cached(token):
+            resolved.append(token)
+    return resolved
+
+
 async def _is_mcp_access_group_cached(name: str) -> bool:
     """Return True if *name* is a known MCP access group tag.
 
@@ -15211,9 +15262,21 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
         ):
             return await _mcp_forward_as_path(mcp_server_name, request)
 
-        # 2. Comma-separated list — forward directly before any DB call.
+        # 2. Comma-separated list — validate every token resolves to a known
+        # server alias or access group before forwarding. Bounds DB / cache
+        # fan-out and prevents the downstream filter from silently falling back
+        # to the full allowed_mcp_servers list when no token matches.
         if "," in mcp_server_name:
-            return await _mcp_forward_as_path(mcp_server_name, request)
+            resolved_tokens = await _resolve_mcp_csv_tokens(mcp_server_name, client_ip)
+            if not resolved_tokens:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"No MCP server, toolset, or access group in "
+                        f"'{mcp_server_name}' resolved to a known target"
+                    ),
+                )
+            return await _mcp_forward_as_path(",".join(resolved_tokens), request)
 
         # 3. Toolset name (cached)
         if prisma_client is not None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15168,7 +15168,7 @@ async def _mcp_forward_as_path(path_segment: str, request: Request):
 
 
 async def _is_mcp_access_group_cached(name: str) -> bool:
-    """Return True if *name* is a known MCP access group tag, caching the result."""
+    """Return True if *name* is a known MCP access group tag, caching positive results."""
     from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
     from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
         MCPRequestHandler,
@@ -15179,11 +15179,12 @@ async def _is_mcp_access_group_cached(name: str) -> bool:
     if cached is not None:
         return bool(cached)
     result = bool(await MCPRequestHandler._get_mcp_servers_from_access_groups([name]))
-    await user_api_key_cache.async_set_cache(
-        key=cache_key,
-        value=result,
-        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
-    )
+    if result:
+        await user_api_key_cache.async_set_cache(
+            key=cache_key,
+            value=result,
+            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        )
     return result
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15136,34 +15136,15 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
 
 
 async def _mcp_forward_as_path(path_segment: str, request: Request):
-    """Rewrite path to /mcp/{path_segment} and buffer the response."""
+    """Rewrite path to /mcp/{path_segment} and stream the response."""
     from litellm.proxy._experimental.mcp_server.server import (
         handle_streamable_http_mcp,
     )
-    from starlette.responses import Response
 
     scope = dict(request.scope)
     scope["path"] = f"/mcp/{path_segment}"
-
-    response_body = b""
-    response_status = 200
-    response_headers: list = []
-
-    async def custom_send(message):
-        nonlocal response_body, response_status, response_headers
-        if message["type"] == "http.response.start":
-            response_status = message["status"]
-            response_headers = message.get("headers", [])
-        elif message["type"] == "http.response.body":
-            response_body += message.get("body", b"")
-
-    await handle_streamable_http_mcp(scope, receive=request.receive, send=custom_send)
-    headers_dict = {k.decode(): v.decode() for k, v in response_headers}
-    return Response(
-        content=response_body,
-        status_code=response_status,
-        headers=headers_dict,
-        media_type=headers_dict.get("content-type", "application/json"),
+    return await _stream_mcp_asgi_response(
+        handle_streamable_http_mcp, scope, request.receive
     )
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15141,89 +15141,109 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
     methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
 )
 async def dynamic_mcp_route(mcp_server_name: str, request: Request):
-    """Handle dynamic MCP server routes like /github_mcp/mcp and toolset routes like /devtooling-prod/mcp"""
+    """Handle /{name}/mcp for MCP server aliases, toolsets, MCP access group tags, and comma-separated lists.
+
+    Resolution order:
+    1. Registered MCP server alias / name
+    2. Toolset name (DB lookup)
+    3. MCP access group tag — resolves to all servers in that group
+    4. Comma-separated mix of any of the above (e.g. /github_mcp,zapier/mcp)
+    """
     try:
-        # Validate that the MCP server exists
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )
         from litellm.proxy.auth.ip_address_utils import IPAddressUtils
-        from litellm.types.mcp import MCPAuth
 
         client_ip = IPAddressUtils.get_mcp_client_ip(request)
+
+        async def _forward_as_mcp_path(path_segment: str):
+            """Rewrite path to /mcp/{path_segment} and stream through the MCP handler."""
+            from litellm.proxy._experimental.mcp_server.server import (
+                handle_streamable_http_mcp,
+            )
+            from starlette.responses import Response
+
+            scope = dict(request.scope)
+            scope["path"] = f"/mcp/{path_segment}"
+
+            response_started = False
+            response_body = b""
+            response_status = 200
+            response_headers: list = []
+
+            async def custom_send(message):
+                nonlocal response_started, response_body, response_status, response_headers
+                if message["type"] == "http.response.start":
+                    response_started = True
+                    response_status = message["status"]
+                    response_headers = message.get("headers", [])
+                elif message["type"] == "http.response.body":
+                    response_body += message.get("body", b"")
+
+            await handle_streamable_http_mcp(
+                scope, receive=request.receive, send=custom_send
+            )
+            headers_dict = {k.decode(): v.decode() for k, v in response_headers}
+            return Response(
+                content=response_body,
+                status_code=response_status,
+                headers=headers_dict,
+                media_type=headers_dict.get("content-type", "application/json"),
+            )
+
+        # 1. Registered MCP server alias
         mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
             mcp_server_name, client_ip=client_ip
         )
-        if mcp_server is None:
-            # Check if this is a toolset name — toolsets are accessible at /{name}/mcp
-            # the same way individual servers are, no separate /toolset/ prefix needed.
-            if prisma_client is not None:
-                from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-                    global_mcp_server_manager,
-                )
-                from litellm.proxy._experimental.mcp_server.server import (
-                    _mcp_active_toolset_id,
-                    handle_streamable_http_mcp,
-                )
+        if mcp_server is not None:
+            return await _forward_as_mcp_path(mcp_server_name)
 
-                toolset = await global_mcp_server_manager.get_toolset_by_name_cached(
-                    prisma_client, mcp_server_name
-                )
-                if toolset is not None:
-                    scope = dict(request.scope)
-                    scope["path"] = "/mcp"
-
-                    token = _mcp_active_toolset_id.set(toolset.toolset_id)
-                    try:
-                        return await _stream_mcp_asgi_response(
-                            handle_streamable_http_mcp, scope, request.receive
-                        )
-                    finally:
-                        _mcp_active_toolset_id.reset(token)
-
-            raise HTTPException(
-                status_code=404, detail=f"MCP server '{mcp_server_name}' not found"
+        # 2. Toolset name
+        if prisma_client is not None:
+            from litellm.proxy._experimental.mcp_server.server import (
+                _mcp_active_toolset_id,
+                handle_streamable_http_mcp,
             )
 
-        # Create a new scope with the correct path format that the MCP handler expects
-        # Transform /{mcp_server_name}/mcp to /mcp/{mcp_server_name}
-        scope = dict(request.scope)
-        scope["path"] = f"/mcp/{mcp_server_name}"
+            toolset = await global_mcp_server_manager.get_toolset_by_name_cached(
+                prisma_client, mcp_server_name
+            )
+            if toolset is not None:
+                scope = dict(request.scope)
+                scope["path"] = "/mcp"
+                token = _mcp_active_toolset_id.set(toolset.toolset_id)
+                try:
+                    return await _stream_mcp_asgi_response(
+                        handle_streamable_http_mcp, scope, request.receive
+                    )
+                finally:
+                    _mcp_active_toolset_id.reset(token)
 
-        # Import the MCP handler
-        from litellm.proxy._experimental.mcp_server.server import (
-            handle_streamable_http_mcp,
+        # 3 & 4. MCP access group tag OR comma-separated list of servers/groups.
+        # The MCP handler's _get_mcp_servers_in_path already parses comma lists
+        # from /mcp/<csv>, so we just need to ensure the segment is forwarded as
+        # a path under /mcp/. For a single segment that is an access group we
+        # verify it resolves to at least one server before forwarding so that
+        # unknown names still produce a 404.
+        if "," in mcp_server_name:
+            # Comma-separated — forward directly; the MCP handler resolves each token.
+            return await _forward_as_mcp_path(mcp_server_name)
+
+        # Single segment: check whether it is a known MCP access group tag.
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
         )
 
-        # Create a custom send function to capture the response
-        response_started = False
-        response_body = b""
-        response_status = 200
-        response_headers = []
-
-        async def custom_send(message):
-            nonlocal response_started, response_body, response_status, response_headers
-            if message["type"] == "http.response.start":
-                response_started = True
-                response_status = message["status"]
-                response_headers = message.get("headers", [])
-            elif message["type"] == "http.response.body":
-                response_body += message.get("body", b"")
-
-        # Call the existing MCP handler
-        await handle_streamable_http_mcp(
-            scope, receive=request.receive, send=custom_send
+        group_server_ids = await MCPRequestHandler._get_mcp_servers_from_access_groups(
+            [mcp_server_name]
         )
+        if group_server_ids:
+            return await _forward_as_mcp_path(mcp_server_name)
 
-        # Return the response
-        from starlette.responses import Response
-
-        headers_dict = {k.decode(): v.decode() for k, v in response_headers}
-        return Response(
-            content=response_body,
-            status_code=response_status,
-            headers=headers_dict,
-            media_type=headers_dict.get("content-type", "application/json"),
+        raise HTTPException(
+            status_code=404,
+            detail=f"MCP server, toolset, or access group '{mcp_server_name}' not found",
         )
 
     except HTTPException as e:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15149,8 +15149,19 @@ async def _mcp_forward_as_path(path_segment: str, request: Request):
 
 
 async def _is_mcp_access_group_cached(name: str) -> bool:
-    """Return True if *name* is a known MCP access group tag, caching positive results."""
-    from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+    """Return True if *name* is a known MCP access group tag.
+
+    Positive results are cached for ``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL``
+    seconds. Negative results are cached for a short
+    ``DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL`` window so unauthenticated
+    callers cannot force a fresh DB lookup per request for unknown names, while
+    bounding staleness so a transient DB error (which surfaces as an empty
+    list) cannot hide a real group for long.
+    """
+    from litellm.constants import (
+        DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL,
+    )
     from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
         MCPRequestHandler,
     )
@@ -15160,12 +15171,15 @@ async def _is_mcp_access_group_cached(name: str) -> bool:
     if cached is not None:
         return bool(cached)
     result = bool(await MCPRequestHandler._get_mcp_servers_from_access_groups([name]))
-    if result:
-        await user_api_key_cache.async_set_cache(
-            key=cache_key,
-            value=result,
-            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
-        )
+    await user_api_key_cache.async_set_cache(
+        key=cache_key,
+        value=result,
+        ttl=(
+            DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+            if result
+            else DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL
+        ),
+    )
     return result
 
 

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -3,10 +3,11 @@ Tests for the dynamic_mcp_route handler in proxy_server.py.
 
 Covers the resolution order:
   1. Registered MCP server alias  → forwards to /mcp/{name}
-  2. Toolset name                  → sets toolset scope, forwards to /mcp
-  3. MCP access group tag          → forwards to /mcp/{name} when the group
+  2. Comma-separated list          → short-circuits before any DB call;
+                                     forwarded to /mcp/{segment}
+  3. Toolset name (cached)         → sets toolset scope, forwards to /mcp
+  4. MCP access group tag (cached) → forwards to /mcp/{name} when the group
                                      resolves to at least one server
-  4. Comma-separated list          → forwarded directly; MCP handler parses
   5. Unknown name                  → 404
 
 Patch targets are at the source modules because dynamic_mcp_route
@@ -30,6 +31,7 @@ _HANDLE_HTTP = (
 )
 _STREAM_ASGI = "litellm.proxy.proxy_server._stream_mcp_asgi_response"
 _PRISMA = "litellm.proxy.proxy_server.prisma_client"
+_CACHE = "litellm.proxy.proxy_server.user_api_key_cache"
 
 
 def _make_request(path: str = "/test/mcp"):
@@ -64,6 +66,14 @@ def _fake_toolset(name: str = "my_toolset", toolset_id: str = "ts-1"):
     t.toolset_id = toolset_id
     t.name = name
     return t
+
+
+def _miss_cache():
+    """Returns a mock user_api_key_cache that always misses (returns None)."""
+    cache = MagicMock()
+    cache.async_get_cache = AsyncMock(return_value=None)
+    cache.async_set_cache = AsyncMock()
+    return cache
 
 
 async def _ok_mcp_handle(scope, receive, send):
@@ -104,7 +114,42 @@ async def test_dynamic_mcp_route_resolves_registered_server():
 
 
 # ---------------------------------------------------------------------------
-# 2. Toolset name
+# 2. Comma-separated list (short-circuits before toolset DB call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_comma_list_forwarded():
+    """A comma-separated segment is forwarded directly to /mcp/{segment}
+    without hitting the toolset or access-group DB lookups."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    segment = "github_mcp,zapier"
+    request = _make_request(f"/{segment}/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+
+    captured_scope = {}
+
+    async def capturing_handle(scope, receive, send):
+        captured_scope.update(scope)
+        await _ok_mcp_handle(scope, receive, send)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_HANDLE_HTTP, new=capturing_handle),
+    ):
+        response = await dynamic_mcp_route(segment, request)
+
+    assert response.status_code == 200
+    assert captured_scope.get("path") == f"/mcp/{segment}"
+    # Toolset lookup must NOT be called for comma names
+    fake_mgr.get_toolset_by_name_cached.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Toolset name
 # ---------------------------------------------------------------------------
 
 
@@ -145,7 +190,7 @@ async def test_dynamic_mcp_route_resolves_toolset():
 
 
 # ---------------------------------------------------------------------------
-# 3. MCP access group tag
+# 4. MCP access group tag (cached)
 # ---------------------------------------------------------------------------
 
 
@@ -170,6 +215,7 @@ async def test_dynamic_mcp_route_resolves_access_group():
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
+        patch(_CACHE, new=_miss_cache()),
         patch(
             f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
             new=AsyncMock(return_value=["server-a", "server-b"]),
@@ -198,49 +244,13 @@ async def test_dynamic_mcp_route_access_group_called_with_correct_name():
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
+        patch(_CACHE, new=_miss_cache()),
         patch(f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups", new=group_lookup),
         patch(_HANDLE_HTTP, new=_ok_mcp_handle),
     ):
         await dynamic_mcp_route("qa_tools", request)
 
     group_lookup.assert_awaited_once_with(["qa_tools"])
-
-
-# ---------------------------------------------------------------------------
-# 4. Comma-separated list
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_dynamic_mcp_route_comma_list_forwarded():
-    """A comma-separated segment is forwarded directly to /mcp/{segment};
-    per-token resolution is delegated to the MCP handler."""
-    from litellm.proxy.proxy_server import dynamic_mcp_route
-
-    segment = "github_mcp,zapier"
-    request = _make_request(f"/{segment}/mcp")
-
-    fake_mgr = MagicMock()
-    # get_mcp_server_by_name must accept a comma-string; return None to fall through
-    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
-    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
-
-    captured_scope = {}
-
-    async def capturing_handle(scope, receive, send):
-        captured_scope.update(scope)
-        await _ok_mcp_handle(scope, receive, send)
-
-    with (
-        patch(_MCP_MANAGER, fake_mgr),
-        patch(_PRISMA, new=MagicMock()),
-        patch(_HANDLE_HTTP, new=capturing_handle),
-    ):
-        response = await dynamic_mcp_route(segment, request)
-
-    assert response.status_code == 200
-    # Comma list forwarded verbatim; MCP handler splits internally
-    assert captured_scope.get("path") == f"/mcp/{segment}"
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +272,7 @@ async def test_dynamic_mcp_route_unknown_name_returns_404():
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
+        patch(_CACHE, new=_miss_cache()),
         patch(
             f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
             new=AsyncMock(return_value=[]),
@@ -288,6 +299,7 @@ async def test_dynamic_mcp_route_empty_access_group_returns_404():
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
+        patch(_CACHE, new=_miss_cache()),
         patch(
             f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
             new=AsyncMock(return_value=[]),

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -25,13 +25,13 @@ from fastapi import HTTPException
 # ---------------------------------------------------------------------------
 
 _MCP_MANAGER = "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
-_MCP_HANDLER = "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler"
 _HANDLE_HTTP = (
     "litellm.proxy._experimental.mcp_server.server.handle_streamable_http_mcp"
 )
 _STREAM_ASGI = "litellm.proxy.proxy_server._stream_mcp_asgi_response"
 _PRISMA = "litellm.proxy.proxy_server.prisma_client"
-_CACHE = "litellm.proxy.proxy_server.user_api_key_cache"
+_IS_ACCESS_GROUP = "litellm.proxy.proxy_server._is_mcp_access_group_cached"
+_FORWARD = "litellm.proxy.proxy_server._mcp_forward_as_path"
 
 
 def _make_request(path: str = "/test/mcp"):
@@ -68,14 +68,6 @@ def _fake_toolset(name: str = "my_toolset", toolset_id: str = "ts-1"):
     return t
 
 
-def _miss_cache():
-    """Returns a mock user_api_key_cache that always misses (returns None)."""
-    cache = MagicMock()
-    cache.async_get_cache = AsyncMock(return_value=None)
-    cache.async_set_cache = AsyncMock()
-    return cache
-
-
 async def _ok_mcp_handle(scope, receive, send):
     """Stub MCP handler that returns HTTP 200."""
     await send({"type": "http.response.start", "status": 200, "headers": []})
@@ -91,26 +83,24 @@ async def _ok_mcp_handle(scope, receive, send):
 async def test_dynamic_mcp_route_resolves_registered_server():
     """When the segment matches a known server alias the request is forwarded
     to /mcp/{name} and the handler returns 200."""
+    from starlette.responses import Response
+
     from litellm.proxy.proxy_server import dynamic_mcp_route
 
     request = _make_request("/my_server/mcp")
     fake_mgr = MagicMock()
     fake_mgr.get_mcp_server_by_name = MagicMock(return_value=_fake_server("my_server"))
 
-    captured_scope = {}
-
-    async def capturing_handle(scope, receive, send):
-        captured_scope.update(scope)
-        await _ok_mcp_handle(scope, receive, send)
+    fake_forward = AsyncMock(return_value=Response(content=b"{}", status_code=200))
 
     with (
         patch(_MCP_MANAGER, fake_mgr),
-        patch(_HANDLE_HTTP, new=capturing_handle),
+        patch(_FORWARD, new=fake_forward),
     ):
         response = await dynamic_mcp_route("my_server", request)
 
     assert response.status_code == 200
-    assert captured_scope.get("path") == "/mcp/my_server"
+    fake_forward.assert_awaited_once_with("my_server", request)
 
 
 # ---------------------------------------------------------------------------
@@ -120,8 +110,10 @@ async def test_dynamic_mcp_route_resolves_registered_server():
 
 @pytest.mark.asyncio
 async def test_dynamic_mcp_route_comma_list_forwarded():
-    """A comma-separated segment is forwarded directly to /mcp/{segment}
-    without hitting the toolset or access-group DB lookups."""
+    """A comma-separated segment is forwarded directly without hitting
+    the toolset or access-group DB lookups."""
+    from starlette.responses import Response
+
     from litellm.proxy.proxy_server import dynamic_mcp_route
 
     segment = "github_mcp,zapier"
@@ -130,20 +122,16 @@ async def test_dynamic_mcp_route_comma_list_forwarded():
     fake_mgr = MagicMock()
     fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
 
-    captured_scope = {}
-
-    async def capturing_handle(scope, receive, send):
-        captured_scope.update(scope)
-        await _ok_mcp_handle(scope, receive, send)
+    fake_forward = AsyncMock(return_value=Response(content=b"{}", status_code=200))
 
     with (
         patch(_MCP_MANAGER, fake_mgr),
-        patch(_HANDLE_HTTP, new=capturing_handle),
+        patch(_FORWARD, new=fake_forward),
     ):
         response = await dynamic_mcp_route(segment, request)
 
     assert response.status_code == 200
-    assert captured_scope.get("path") == f"/mcp/{segment}"
+    fake_forward.assert_awaited_once_with(segment, request)
     # Toolset lookup must NOT be called for comma names
     fake_mgr.get_toolset_by_name_cached.assert_not_called()
 
@@ -196,8 +184,9 @@ async def test_dynamic_mcp_route_resolves_toolset():
 
 @pytest.mark.asyncio
 async def test_dynamic_mcp_route_resolves_access_group():
-    """When the segment is an MCP access group the request is forwarded
-    to /mcp/{group_name} (not 404)."""
+    """When the segment is an MCP access group the request is forwarded (not 404)."""
+    from starlette.responses import Response
+
     from litellm.proxy.proxy_server import dynamic_mcp_route
 
     request = _make_request("/dev_group/mcp")
@@ -206,31 +195,25 @@ async def test_dynamic_mcp_route_resolves_access_group():
     fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
     fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
 
-    captured_scope = {}
-
-    async def capturing_handle(scope, receive, send):
-        captured_scope.update(scope)
-        await _ok_mcp_handle(scope, receive, send)
+    fake_forward = AsyncMock(return_value=Response(content=b"{}", status_code=200))
 
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
-        patch(_CACHE, new=_miss_cache()),
-        patch(
-            f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
-            new=AsyncMock(return_value=["server-a", "server-b"]),
-        ),
-        patch(_HANDLE_HTTP, new=capturing_handle),
+        patch(_IS_ACCESS_GROUP, new=AsyncMock(return_value=True)),
+        patch(_FORWARD, new=fake_forward),
     ):
         response = await dynamic_mcp_route("dev_group", request)
 
     assert response.status_code == 200
-    assert captured_scope.get("path") == "/mcp/dev_group"
+    fake_forward.assert_awaited_once_with("dev_group", request)
 
 
 @pytest.mark.asyncio
 async def test_dynamic_mcp_route_access_group_called_with_correct_name():
     """The access group lookup receives exactly the segment from the URL."""
+    from starlette.responses import Response
+
     from litellm.proxy.proxy_server import dynamic_mcp_route
 
     request = _make_request("/qa_tools/mcp")
@@ -239,18 +222,20 @@ async def test_dynamic_mcp_route_access_group_called_with_correct_name():
     fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
     fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
 
-    group_lookup = AsyncMock(return_value=["server-x"])
+    is_group = AsyncMock(return_value=True)
 
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
-        patch(_CACHE, new=_miss_cache()),
-        patch(f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups", new=group_lookup),
-        patch(_HANDLE_HTTP, new=_ok_mcp_handle),
+        patch(_IS_ACCESS_GROUP, new=is_group),
+        patch(
+            _FORWARD,
+            new=AsyncMock(return_value=Response(content=b"{}", status_code=200)),
+        ),
     ):
         await dynamic_mcp_route("qa_tools", request)
 
-    group_lookup.assert_awaited_once_with(["qa_tools"])
+    is_group.assert_awaited_once_with("qa_tools")
 
 
 # ---------------------------------------------------------------------------
@@ -272,11 +257,7 @@ async def test_dynamic_mcp_route_unknown_name_returns_404():
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
-        patch(_CACHE, new=_miss_cache()),
-        patch(
-            f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
-            new=AsyncMock(return_value=[]),
-        ),
+        patch(_IS_ACCESS_GROUP, new=AsyncMock(return_value=False)),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await dynamic_mcp_route("does_not_exist", request)
@@ -299,11 +280,7 @@ async def test_dynamic_mcp_route_empty_access_group_returns_404():
     with (
         patch(_MCP_MANAGER, fake_mgr),
         patch(_PRISMA, new=MagicMock()),
-        patch(_CACHE, new=_miss_cache()),
-        patch(
-            f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
-            new=AsyncMock(return_value=[]),
-        ),
+        patch(_IS_ACCESS_GROUP, new=AsyncMock(return_value=False)),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await dynamic_mcp_route("empty_group", request)

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -1,0 +1,299 @@
+"""
+Tests for the dynamic_mcp_route handler in proxy_server.py.
+
+Covers the resolution order:
+  1. Registered MCP server alias  → forwards to /mcp/{name}
+  2. Toolset name                  → sets toolset scope, forwards to /mcp
+  3. MCP access group tag          → forwards to /mcp/{name} when the group
+                                     resolves to at least one server
+  4. Comma-separated list          → forwarded directly; MCP handler parses
+  5. Unknown name                  → 404
+
+Patch targets are at the source modules because dynamic_mcp_route
+uses lazy local imports inside the function body.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_MCP_MANAGER = "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+_MCP_HANDLER = "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler"
+_HANDLE_HTTP = (
+    "litellm.proxy._experimental.mcp_server.server.handle_streamable_http_mcp"
+)
+_STREAM_ASGI = "litellm.proxy.proxy_server._stream_mcp_asgi_response"
+_PRISMA = "litellm.proxy.proxy_server.prisma_client"
+
+
+def _make_request(path: str = "/test/mcp"):
+    """Minimal fake Starlette Request."""
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "server": ("localhost", 4000),
+        "scheme": "http",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}"}
+
+    return Request(scope=scope, receive=receive)
+
+
+def _fake_server(name: str = "my_server", server_id: str = "server-id-1"):
+    s = MagicMock()
+    s.name = name
+    s.server_id = server_id
+    return s
+
+
+def _fake_toolset(name: str = "my_toolset", toolset_id: str = "ts-1"):
+    t = MagicMock()
+    t.toolset_id = toolset_id
+    t.name = name
+    return t
+
+
+async def _ok_mcp_handle(scope, receive, send):
+    """Stub MCP handler that returns HTTP 200."""
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"{}"})
+
+
+# ---------------------------------------------------------------------------
+# 1. Registered MCP server alias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_resolves_registered_server():
+    """When the segment matches a known server alias the request is forwarded
+    to /mcp/{name} and the handler returns 200."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    request = _make_request("/my_server/mcp")
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=_fake_server("my_server"))
+
+    captured_scope = {}
+
+    async def capturing_handle(scope, receive, send):
+        captured_scope.update(scope)
+        await _ok_mcp_handle(scope, receive, send)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_HANDLE_HTTP, new=capturing_handle),
+    ):
+        response = await dynamic_mcp_route("my_server", request)
+
+    assert response.status_code == 200
+    assert captured_scope.get("path") == "/mcp/my_server"
+
+
+# ---------------------------------------------------------------------------
+# 2. Toolset name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_resolves_toolset():
+    """When the segment is a toolset name the toolset context var is set
+    and the request is forwarded to /mcp (not /mcp/{name})."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    request = _make_request("/my_toolset/mcp")
+    fake_toolset = _fake_toolset("my_toolset", "ts-42")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=fake_toolset)
+
+    captured_toolset_id = None
+    captured_scope = {}
+
+    async def fake_stream(fn, scope, receive):
+        nonlocal captured_toolset_id
+        from litellm.proxy._experimental.mcp_server.server import (
+            _mcp_active_toolset_id,
+        )
+
+        captured_toolset_id = _mcp_active_toolset_id.get()
+        captured_scope.update(scope)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_PRISMA, new=MagicMock()),
+        patch(_STREAM_ASGI, new=AsyncMock(side_effect=fake_stream)),
+    ):
+        await dynamic_mcp_route("my_toolset", request)
+
+    assert captured_toolset_id == "ts-42"
+    assert captured_scope.get("path") == "/mcp"
+
+
+# ---------------------------------------------------------------------------
+# 3. MCP access group tag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_resolves_access_group():
+    """When the segment is an MCP access group the request is forwarded
+    to /mcp/{group_name} (not 404)."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    request = _make_request("/dev_group/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
+
+    captured_scope = {}
+
+    async def capturing_handle(scope, receive, send):
+        captured_scope.update(scope)
+        await _ok_mcp_handle(scope, receive, send)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_PRISMA, new=MagicMock()),
+        patch(
+            f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
+            new=AsyncMock(return_value=["server-a", "server-b"]),
+        ),
+        patch(_HANDLE_HTTP, new=capturing_handle),
+    ):
+        response = await dynamic_mcp_route("dev_group", request)
+
+    assert response.status_code == 200
+    assert captured_scope.get("path") == "/mcp/dev_group"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_access_group_called_with_correct_name():
+    """The access group lookup receives exactly the segment from the URL."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    request = _make_request("/qa_tools/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
+
+    group_lookup = AsyncMock(return_value=["server-x"])
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_PRISMA, new=MagicMock()),
+        patch(f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups", new=group_lookup),
+        patch(_HANDLE_HTTP, new=_ok_mcp_handle),
+    ):
+        await dynamic_mcp_route("qa_tools", request)
+
+    group_lookup.assert_awaited_once_with(["qa_tools"])
+
+
+# ---------------------------------------------------------------------------
+# 4. Comma-separated list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_comma_list_forwarded():
+    """A comma-separated segment is forwarded directly to /mcp/{segment};
+    per-token resolution is delegated to the MCP handler."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    segment = "github_mcp,zapier"
+    request = _make_request(f"/{segment}/mcp")
+
+    fake_mgr = MagicMock()
+    # get_mcp_server_by_name must accept a comma-string; return None to fall through
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
+
+    captured_scope = {}
+
+    async def capturing_handle(scope, receive, send):
+        captured_scope.update(scope)
+        await _ok_mcp_handle(scope, receive, send)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_PRISMA, new=MagicMock()),
+        patch(_HANDLE_HTTP, new=capturing_handle),
+    ):
+        response = await dynamic_mcp_route(segment, request)
+
+    assert response.status_code == 200
+    # Comma list forwarded verbatim; MCP handler splits internally
+    assert captured_scope.get("path") == f"/mcp/{segment}"
+
+
+# ---------------------------------------------------------------------------
+# 5. Unknown name → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_unknown_name_returns_404():
+    """A segment that is not a server, toolset, or access group → 404."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    request = _make_request("/does_not_exist/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_PRISMA, new=MagicMock()),
+        patch(
+            f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await dynamic_mcp_route("does_not_exist", request)
+
+    assert exc_info.value.status_code == 404
+    assert "does_not_exist" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_empty_access_group_returns_404():
+    """An access group tag that resolves to zero servers still returns 404."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    request = _make_request("/empty_group/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+    fake_mgr.get_toolset_by_name_cached = AsyncMock(return_value=None)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_PRISMA, new=MagicMock()),
+        patch(
+            f"{_MCP_HANDLER}._get_mcp_servers_from_access_groups",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await dynamic_mcp_route("empty_group", request)
+
+    assert exc_info.value.status_code == 404

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -14,7 +14,7 @@ Patch targets are at the source modules because dynamic_mcp_route
 uses lazy local imports inside the function body.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -31,6 +31,11 @@ _HANDLE_HTTP = (
 _STREAM_ASGI = "litellm.proxy.proxy_server._stream_mcp_asgi_response"
 _PRISMA = "litellm.proxy.proxy_server.prisma_client"
 _IS_ACCESS_GROUP = "litellm.proxy.proxy_server._is_mcp_access_group_cached"
+_USER_API_KEY_CACHE = "litellm.proxy.proxy_server.user_api_key_cache"
+_GET_ACCESS_GROUP_SERVERS = (
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp."
+    "MCPRequestHandler._get_mcp_servers_from_access_groups"
+)
 _FORWARD = "litellm.proxy.proxy_server._mcp_forward_as_path"
 
 
@@ -236,6 +241,52 @@ async def test_dynamic_mcp_route_access_group_called_with_correct_name():
         await dynamic_mcp_route("qa_tools", request)
 
     is_group.assert_awaited_once_with("qa_tools")
+
+
+@pytest.mark.asyncio
+async def test_is_mcp_access_group_cached_caches_positive_result():
+    """Known access groups are cached after resolving to one or more servers."""
+    from litellm.proxy.proxy_server import _is_mcp_access_group_cached
+
+    fake_cache = MagicMock()
+    fake_cache.async_get_cache = AsyncMock(return_value=None)
+    fake_cache.async_set_cache = AsyncMock()
+    get_access_group_servers = AsyncMock(return_value=["server-id"])
+
+    with (
+        patch(_USER_API_KEY_CACHE, new=fake_cache),
+        patch(_GET_ACCESS_GROUP_SERVERS, new=get_access_group_servers),
+    ):
+        result = await _is_mcp_access_group_cached("dev_group")
+
+    assert result is True
+    get_access_group_servers.assert_awaited_once_with(["dev_group"])
+    fake_cache.async_set_cache.assert_awaited_once_with(
+        key="mcp_access_group_exists:dev_group",
+        value=True,
+        ttl=ANY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_mcp_access_group_cached_does_not_cache_negative_result():
+    """Empty access-group lookups are not cached because DB errors also return empty."""
+    from litellm.proxy.proxy_server import _is_mcp_access_group_cached
+
+    fake_cache = MagicMock()
+    fake_cache.async_get_cache = AsyncMock(return_value=None)
+    fake_cache.async_set_cache = AsyncMock()
+    get_access_group_servers = AsyncMock(return_value=[])
+
+    with (
+        patch(_USER_API_KEY_CACHE, new=fake_cache),
+        patch(_GET_ACCESS_GROUP_SERVERS, new=get_access_group_servers),
+    ):
+        result = await _is_mcp_access_group_cached("dev_group")
+
+    assert result is False
+    get_access_group_servers.assert_awaited_once_with(["dev_group"])
+    fake_cache.async_set_cache.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -37,6 +37,7 @@ _GET_ACCESS_GROUP_SERVERS = (
     "MCPRequestHandler._get_mcp_servers_from_access_groups"
 )
 _FORWARD = "litellm.proxy.proxy_server._mcp_forward_as_path"
+_RESOLVE_CSV = "litellm.proxy.proxy_server._resolve_mcp_csv_tokens"
 
 
 def _make_request(path: str = "/test/mcp"):
@@ -114,9 +115,11 @@ async def test_dynamic_mcp_route_resolves_registered_server():
 
 
 @pytest.mark.asyncio
-async def test_dynamic_mcp_route_comma_list_forwarded():
-    """A comma-separated segment is forwarded directly without hitting
-    the toolset or access-group DB lookups."""
+async def test_dynamic_mcp_route_comma_list_forwarded_when_tokens_resolve():
+    """A comma-separated segment is forwarded after every token is resolved as
+    a known server / access group. Forwarding uses the deduped, validated
+    token list (so unknown / duplicate tokens cannot leak through). The
+    toolset DB lookup is bypassed entirely for comma names."""
     from starlette.responses import Response
 
     from litellm.proxy.proxy_server import dynamic_mcp_route
@@ -128,17 +131,132 @@ async def test_dynamic_mcp_route_comma_list_forwarded():
     fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
 
     fake_forward = AsyncMock(return_value=Response(content=b"{}", status_code=200))
+    fake_resolve = AsyncMock(return_value=["github_mcp", "zapier"])
 
     with (
         patch(_MCP_MANAGER, fake_mgr),
+        patch(_RESOLVE_CSV, new=fake_resolve),
         patch(_FORWARD, new=fake_forward),
     ):
         response = await dynamic_mcp_route(segment, request)
 
     assert response.status_code == 200
-    fake_forward.assert_awaited_once_with(segment, request)
-    # Toolset lookup must NOT be called for comma names
+    fake_forward.assert_awaited_once_with("github_mcp,zapier", request)
     fake_mgr.get_toolset_by_name_cached.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_comma_list_returns_404_when_no_tokens_resolve():
+    """A comma-separated segment with zero resolved tokens must 404 instead of
+    forwarding (downstream filter falls back to full allowed_mcp_servers when
+    no token matches, which would silently broaden scope)."""
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    segment = "ghost1,ghost2"
+    request = _make_request(f"/{segment}/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_RESOLVE_CSV, new=AsyncMock(return_value=[])),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await dynamic_mcp_route(segment, request)
+
+    assert exc_info.value.status_code == 404
+    assert segment in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_comma_list_forwards_only_resolved_subset():
+    """If only a subset of CSV tokens resolve, the request is forwarded with
+    just that subset (so unknown tokens cannot ride along into the downstream
+    server filter)."""
+    from starlette.responses import Response
+
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+
+    segment = "github_mcp,ghost,zapier"
+    request = _make_request(f"/{segment}/mcp")
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=None)
+
+    fake_forward = AsyncMock(return_value=Response(content=b"{}", status_code=200))
+    fake_resolve = AsyncMock(return_value=["github_mcp", "zapier"])
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_RESOLVE_CSV, new=fake_resolve),
+        patch(_FORWARD, new=fake_forward),
+    ):
+        await dynamic_mcp_route(segment, request)
+
+    fake_forward.assert_awaited_once_with("github_mcp,zapier", request)
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_csv_tokens_dedupes_and_caps():
+    """_resolve_mcp_csv_tokens dedupes tokens case-insensitively, drops empty
+    fragments, and stops looking up after DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
+    unique tokens to bound DB / cache fan-out."""
+    from litellm.constants import DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
+    from litellm.proxy.proxy_server import _resolve_mcp_csv_tokens
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_mcp_server_by_name = MagicMock(return_value=_fake_server())
+
+    csv = ",,github_mcp, GITHUB_MCP," + ",".join(
+        f"srv_{i}" for i in range(DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS + 5)
+    )
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_IS_ACCESS_GROUP, new=AsyncMock(return_value=False)),
+    ):
+        resolved = await _resolve_mcp_csv_tokens(csv, client_ip=None)
+
+    assert len(resolved) == DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
+    assert resolved[0] == "github_mcp"
+    # Case-insensitive dedupe: the second "GITHUB_MCP" must NOT appear.
+    assert "GITHUB_MCP" not in resolved
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_csv_tokens_drops_unknown_and_resolves_access_groups():
+    """Unknown tokens are dropped; access-group tokens are accepted via the
+    cached existence helper (no per-call uncached DB hit)."""
+    from litellm.proxy.proxy_server import _resolve_mcp_csv_tokens
+
+    fake_mgr = MagicMock()
+    # Only "registered_srv" is a known server alias.
+    fake_mgr.get_mcp_server_by_name = MagicMock(
+        side_effect=lambda name, client_ip=None: (
+            _fake_server(name) if name == "registered_srv" else None
+        )
+    )
+
+    # "dev_group" is a real access group; "ghost" is not.
+    is_group = AsyncMock(side_effect=lambda name: name == "dev_group")
+
+    with (
+        patch(_MCP_MANAGER, fake_mgr),
+        patch(_IS_ACCESS_GROUP, new=is_group),
+    ):
+        resolved = await _resolve_mcp_csv_tokens(
+            "registered_srv,dev_group,ghost", client_ip=None
+        )
+
+    assert resolved == ["registered_srv", "dev_group"]
+    # Access-group lookup must NOT be called for "registered_srv" (already
+    # matched as a server alias) but MUST be called for "dev_group" and
+    # "ghost" (the only tokens that fall through to the access-group check).
+    assert {call.args[0] for call in is_group.await_args_list} == {
+        "dev_group",
+        "ghost",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -199,7 +199,8 @@ async def test_dynamic_mcp_route_comma_list_forwards_only_resolved_subset():
 
 @pytest.mark.asyncio
 async def test_resolve_mcp_csv_tokens_dedupes_and_caps():
-    """_resolve_mcp_csv_tokens dedupes tokens case-insensitively, drops empty
+    """_resolve_mcp_csv_tokens dedupes tokens exact-match (so distinct casings
+    are preserved — downstream resolution may be case-sensitive), drops empty
     fragments, and stops looking up after DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
     unique tokens to bound DB / cache fan-out."""
     from litellm.constants import DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
@@ -208,7 +209,10 @@ async def test_resolve_mcp_csv_tokens_dedupes_and_caps():
     fake_mgr = MagicMock()
     fake_mgr.get_mcp_server_by_name = MagicMock(return_value=_fake_server())
 
-    csv = ",,github_mcp, GITHUB_MCP," + ",".join(
+    # "github_mcp" appears twice (once with surrounding whitespace) — must be
+    # collapsed to a single entry. "GITHUB_MCP" is a distinct exact token and
+    # is kept (downstream resolution may be case-sensitive).
+    csv = ",,github_mcp, github_mcp ,GITHUB_MCP," + ",".join(
         f"srv_{i}" for i in range(DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS + 5)
     )
 
@@ -220,8 +224,8 @@ async def test_resolve_mcp_csv_tokens_dedupes_and_caps():
 
     assert len(resolved) == DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
     assert resolved[0] == "github_mcp"
-    # Case-insensitive dedupe: the second "GITHUB_MCP" must NOT appear.
-    assert "GITHUB_MCP" not in resolved
+    assert "GITHUB_MCP" in resolved
+    assert resolved.count("github_mcp") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -269,8 +269,10 @@ async def test_is_mcp_access_group_cached_caches_positive_result():
 
 
 @pytest.mark.asyncio
-async def test_is_mcp_access_group_cached_does_not_cache_negative_result():
-    """Empty access-group lookups are not cached because DB errors also return empty."""
+async def test_is_mcp_access_group_cached_caches_negative_result_briefly():
+    """Empty access-group lookups are cached with a short TTL so unauthenticated
+    callers cannot force a fresh DB lookup per request for unknown names."""
+    from litellm.constants import DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL
     from litellm.proxy.proxy_server import _is_mcp_access_group_cached
 
     fake_cache = MagicMock()
@@ -286,6 +288,31 @@ async def test_is_mcp_access_group_cached_does_not_cache_negative_result():
 
     assert result is False
     get_access_group_servers.assert_awaited_once_with(["dev_group"])
+    fake_cache.async_set_cache.assert_awaited_once_with(
+        key="mcp_access_group_exists:dev_group",
+        value=False,
+        ttl=DEFAULT_MCP_ACCESS_GROUP_NEGATIVE_CACHE_TTL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_mcp_access_group_cached_returns_cached_negative_without_db():
+    """A cached False entry short-circuits the DB lookup on subsequent calls."""
+    from litellm.proxy.proxy_server import _is_mcp_access_group_cached
+
+    fake_cache = MagicMock()
+    fake_cache.async_get_cache = AsyncMock(return_value=False)
+    fake_cache.async_set_cache = AsyncMock()
+    get_access_group_servers = AsyncMock(return_value=["server-id"])
+
+    with (
+        patch(_USER_API_KEY_CACHE, new=fake_cache),
+        patch(_GET_ACCESS_GROUP_SERVERS, new=get_access_group_servers),
+    ):
+        result = await _is_mcp_access_group_cached("never_existed")
+
+    assert result is False
+    get_access_group_servers.assert_not_awaited()
     fake_cache.async_set_cache.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

- `/{name}/mcp` now correctly resolves when `{name}` is an MCP access group tag, closing the gap between the documented behavior and the actual implementation.
- Also handles comma-separated lists like `/github_mcp,zapier/mcp` by forwarding them directly to the MCP handler which already knows how to resolve each token.

## Resolution order in `dynamic_mcp_route`

1. Registered MCP server alias
2. Toolset name (DB lookup)
3. Comma-separated list of servers/groups — forwarded directly
4. Single MCP access group tag — verified against DB before forwarding (404 if unknown)

## Tests

Added `tests/test_litellm/proxy/test_dynamic_mcp_route.py` with 7 unit tests covering:
- Registered server alias resolution
- Toolset resolution
- Single access group resolution (path rewrite verified)
- Comma-separated list passthrough
- Unknown name → 404
- Empty access group result → 404

Fixes LIT-2984
"test" is a mcp access group
**Before**
<img width="1126" height="107" alt="image" src="https://github.com/user-attachments/assets/bb8cbf46-98bb-432c-a7b2-89c4fa730073" />


**After**
<img width="1434" height="156" alt="image" src="https://github.com/user-attachments/assets/a48bafe9-0347-4d98-a409-d536ac61ca61" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing for `/{name}/mcp`, including new validation/caching behavior that can alter which MCP servers are reachable and when requests 404, so mis-resolution could break existing integrations or unintentionally change access scope.
> 
> **Overview**
> Updates the dynamic MCP endpoint `/{name}/mcp` to **also resolve MCP access-group tags** and to **support comma-separated namespaces** (e.g. `/{a,b}/mcp`) by validating/deduping tokens, capping fan-out, and returning 404 when nothing resolves (preventing downstream fallback to an unintended broader server set).
> 
> Adds lightweight caching for access-group existence checks (including a short negative-cache TTL) and introduces new constants to bound negative-cache duration and maximum CSV tokens. Includes a new unit test suite covering server alias, CSV, toolset, access-group, and 404 behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3b8934582b3cd109612765b1d4057542cfc2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->