### PR TITLE
fix(router): sync deployment TPM counter across pods in usage-based-routing-v2

### DIFF
--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -10,7 +10,6 @@ from litellm import token_counter
 from litellm._logging import verbose_logger, verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.types.router import RouterErrors
 from litellm.types.utils import LiteLLMPydanticObjectBase, StandardLoggingPayload
 from litellm.utils import get_utc_datetime, print_verbose
@@ -304,13 +303,19 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
             # Update usage
             # ------------
             # update cache
-            parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
             ## TPM
-            await self.router_cache.async_increment_cache(
+            # Route TPM increments through the queue-based sync mechanism so per-pod
+            # in-memory counters get the cross-pod sum merged in by the periodic
+            # `_sync_in_memory_spend_with_redis` task. Without this, each replica's
+            # in-memory TPM counter only reflects its locally-processed responses,
+            # and the prefilter in `_return_potential_deployments` compares that local
+            # value against the limit — effectively allowing `tpm_limit * N_replica`.
+            # RPM was migrated to the queue-based path by #9357; this completes the
+            # migration for TPM. See #27736 for full root-cause analysis.
+            await self._increment_value_in_current_window(
                 key=tpm_key,
                 value=total_tokens,
                 ttl=self.routing_args.ttl,
-                parent_otel_span=parent_otel_span,
             )
 
             ### TESTING ###

--- a/tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2_multi_instance.py
+++ b/tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2_multi_instance.py
@@ -1,0 +1,85 @@
+"""
+Regression tests for multi-instance TPM sync in lowest_tpm_rpm_v2.
+
+These guard against the regression described in issue #27736:
+deployment-level TPM enforcement was per-pod (not cross-pod), so the
+effective limit became `tpm_limit * N_replica`.
+
+The fix routes TPM increments through `_increment_value_in_current_window`
+(same path RPM uses since #9357), which registers the key in
+`redis_increment_operation_queue` and `in_memory_keys_to_update` so the
+periodic `_sync_in_memory_spend_with_redis` task can pull cross-pod sums
+back into the local in-memory cache.
+"""
+
+import pytest
+
+from litellm.caching.dual_cache import DualCache
+from litellm.router_strategy.lowest_tpm_rpm_v2 import LowestTPMLoggingHandler_v2
+
+
+def _logging_payload(model_id: str, model: str, total_tokens: int) -> dict:
+    return {
+        "standard_logging_object": {
+            "model_group": "test-model",
+            "hidden_params": {"litellm_model_name": model},
+            "model_id": model_id,
+            "total_tokens": total_tokens,
+        },
+        "litellm_params": {"metadata": {}, "model_info": {"id": model_id}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_tpm_key_registered_for_cross_pod_sync():
+    """After `async_log_success_event`, the TPM key must be in
+    `in_memory_keys_to_update` so the periodic sync task pulls cross-pod
+    sums back from Redis. Without this, the per-pod in-memory counter
+    only reflects locally-processed responses (issue #27736)."""
+    cache = DualCache()
+    handler = LowestTPMLoggingHandler_v2(router_cache=cache, routing_args={})
+
+    await handler.async_log_success_event(
+        _logging_payload("deploy-1", "test-model", 100), None, None, None
+    )
+
+    keys = handler.get_in_memory_keys_to_update()
+    assert any(
+        "tpm" in k for k in keys
+    ), f"TPM key not registered for cross-pod sync. Got: {keys}"
+
+
+@pytest.mark.asyncio
+async def test_tpm_increment_queued_for_redis_push():
+    """The increment must land in `redis_increment_operation_queue` so it
+    is batched to Redis by the periodic sync, instead of being written to
+    Redis directly (the pre-fix behavior bypassed the sync mechanism)."""
+    cache = DualCache()
+    handler = LowestTPMLoggingHandler_v2(router_cache=cache, routing_args={})
+
+    await handler.async_log_success_event(
+        _logging_payload("deploy-1", "test-model", 100), None, None, None
+    )
+
+    assert any(
+        "tpm" in op["key"] and op["increment_value"] == 100
+        for op in handler.redis_increment_operation_queue
+    ), f"TPM increment not queued. Queue: {handler.redis_increment_operation_queue}"
+
+
+@pytest.mark.asyncio
+async def test_tpm_local_in_memory_increment_still_immediate():
+    """The local in-memory counter must still be incremented immediately
+    so the same pod sees its own usage right away. Only the Redis write
+    is deferred to the periodic sync task."""
+    cache = DualCache()
+    handler = LowestTPMLoggingHandler_v2(router_cache=cache, routing_args={})
+
+    await handler.async_log_success_event(
+        _logging_payload("deploy-1", "test-model", 100), None, None, None
+    )
+
+    tpm_keys = [k for k in handler.get_in_memory_keys_to_update() if "tpm" in k]
+    assert tpm_keys, "no TPM key registered"
+    value = await cache.in_memory_cache.async_get_cache(key=tpm_keys[0])
+    assert value == 100, f"in-memory TPM counter not incremented. Got: {value}"


### PR DESCRIPTION
## Relevant issues

Fixes #27736

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

All 3 new tests pass, and all 339 existing `tests/test_litellm/router_strategy/` tests continue to pass.

```
tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2_multi_instance.py::test_tpm_increment_queued_for_redis_push PASSED
tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2_multi_instance.py::test_tpm_key_registered_for_cross_pod_sync PASSED
tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2_multi_instance.py::test_tpm_local_in_memory_increment_still_immediate PASSED
339 passed, 4 skipped in 104.55s
```

## Type

🐛 Bug Fix

## Changes

### What

A 1-line behavior change in `litellm/router_strategy/lowest_tpm_rpm_v2.py:async_log_success_event` to route TPM increments through the queue-based sync mechanism that RPM already uses (since #9357).

```diff
- parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
  ## TPM
- await self.router_cache.async_increment_cache(
-     key=tpm_key, value=total_tokens, ttl=self.routing_args.ttl,
-     parent_otel_span=parent_otel_span,
- )
+ await self._increment_value_in_current_window(
+     key=tpm_key, value=total_tokens, ttl=self.routing_args.ttl,
+ )
```

### Why

See #27736 for the full root-cause analysis. Summary:

In a multi-replica LiteLLM proxy deployment with `usage-based-routing-v2`, the deployment-level TPM limit is enforced against each replica's local in-memory counter rather than the cross-pod sum. The effective TPM ceiling becomes `tpm_limit × N_replica`, and traffic up to that ceiling passes through with zero 429 responses.

`_return_potential_deployments` reads `item_tpm` from each pod's in-memory cache (via `DualCache.async_batch_get_cache`, which short-circuits on local hits) — never seeing the cross-pod Redis sum. The pre-fix code wrote TPM directly to both in-memory and Redis but did not register the key with `_sync_in_memory_spend_with_redis`, so other pods' increments were never merged back into the local cache.

#9357 already handled this for RPM by routing through `_increment_value_in_current_window`. This PR does the same for TPM.

### Verified reproduction (5 replicas)

`tpm_limit = 500`, mock backend latency 0.5s, ~1.5 RPS for 50s:

| | Before fix | After fix |
|---|---|---|
| Requests passed | 72/72 (100%) | 35/72 (49%) |
| LayerB 429 rejections | 0 | 37 |
| Redis counter at T+45s | 975 (1.95x over) | 525 (1.05x over) |

The remaining ~5% over-limit is the unavoidable race window equal to response latency — post-call accounting is intrinsic to TPM (response token count is only known after the call completes).

### Performance impact

Minimal. TPM is updated only on response completion, much less frequent than RPM (incremented on every request). The batched sync runs at `DEFAULT_REDIS_SYNC_INTERVAL` (default 0.1s) regardless of how many keys are queued.

### Tests added

`tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2_multi_instance.py`:

1. `test_tpm_key_registered_for_cross_pod_sync` — verifies the TPM key lands in `in_memory_keys_to_update`
2. `test_tpm_increment_queued_for_redis_push` — verifies it lands in `redis_increment_operation_queue`
3. `test_tpm_local_in_memory_increment_still_immediate` — verifies same-pod local in-memory counter is still updated immediately

### Notes

- The sync variant `log_success_event` is left unchanged in this PR — it is rarely on the main flow and can be addressed in a follow-up if desired.
- This mirrors the RPM fix in #9357 for TPM.
