### PR TITLE
fix(parallel_request_limiter): count Embedding / TextCompletion / ResponsesAPI responses toward key/team/org TPM

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -610,7 +610,6 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - User
             # ------------
             if user_api_key_user_id is not None:
-                total_tokens = _extract_total_tokens(response_obj)
 
                 request_count_api_key = (
                     f"{user_api_key_user_id}::{precise_minute}::request_count"
@@ -640,7 +639,6 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - Team
             # ------------
             if user_api_key_team_id is not None:
-                total_tokens = _extract_total_tokens(response_obj)
 
                 request_count_api_key = (
                     f"{user_api_key_team_id}::{precise_minute}::request_count"
@@ -670,7 +668,6 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - End User
             # ------------
             if user_api_key_end_user_id is not None:
-                total_tokens = _extract_total_tokens(response_obj)
 
                 request_count_api_key = (
                     f"{user_api_key_end_user_id}::{precise_minute}::request_count"

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 import litellm
-from litellm import DualCache, ModelResponse
+from litellm import DualCache, EmbeddingResponse, ModelResponse, TextCompletionResponse
+from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
@@ -28,6 +29,23 @@ if TYPE_CHECKING:
 else:
     Span = Any
     InternalUsageCache = Any
+
+
+def _extract_total_tokens(response_obj: Any) -> int:
+    """Get total_tokens from any supported LiteLLM response type.
+
+    Handles ModelResponse / EmbeddingResponse / TextCompletionResponse /
+    ResponsesAPIResponse. Returns 0 for unsupported types so the cache update
+    becomes a silent no-op (matches the prior behavior for unknown types).
+    """
+    if isinstance(
+        response_obj,
+        (ModelResponse, EmbeddingResponse, TextCompletionResponse, ResponsesAPIResponse),
+    ):
+        usage = getattr(response_obj, "usage", None)
+        if usage is not None:
+            return getattr(usage, "total_tokens", 0) or 0
+    return 0
 
 
 class CacheObject(TypedDict):
@@ -506,10 +524,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             current_minute = datetime.now().strftime("%M")
             precise_minute = f"{current_date}-{current_hour}-{current_minute}"
 
-            total_tokens = 0
-
-            if isinstance(response_obj, ModelResponse):
-                total_tokens = response_obj.usage.total_tokens  # type: ignore
+            total_tokens = _extract_total_tokens(response_obj)
 
             # ------------
             # Update usage - API Key
@@ -595,10 +610,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - User
             # ------------
             if user_api_key_user_id is not None:
-                total_tokens = 0
-
-                if isinstance(response_obj, ModelResponse):
-                    total_tokens = response_obj.usage.total_tokens  # type: ignore
+                total_tokens = _extract_total_tokens(response_obj)
 
                 request_count_api_key = (
                     f"{user_api_key_user_id}::{precise_minute}::request_count"
@@ -628,10 +640,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - Team
             # ------------
             if user_api_key_team_id is not None:
-                total_tokens = 0
-
-                if isinstance(response_obj, ModelResponse):
-                    total_tokens = response_obj.usage.total_tokens  # type: ignore
+                total_tokens = _extract_total_tokens(response_obj)
 
                 request_count_api_key = (
                     f"{user_api_key_team_id}::{precise_minute}::request_count"
@@ -661,10 +670,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - End User
             # ------------
             if user_api_key_end_user_id is not None:
-                total_tokens = 0
-
-                if isinstance(response_obj, ModelResponse):
-                    total_tokens = response_obj.usage.total_tokens  # type: ignore
+                total_tokens = _extract_total_tokens(response_obj)
 
                 request_count_api_key = (
                     f"{user_api_key_end_user_id}::{precise_minute}::request_count"

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_response_types.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_response_types.py
@@ -1,0 +1,67 @@
+"""
+Regression tests for response-type coverage in parallel_request_limiter TPM
+counting. Guards against #27738 — EmbeddingResponse /
+TextCompletionResponse / ResponsesAPIResponse were not counted toward
+per-key / per-team / per-org TPM because only `isinstance(response_obj,
+ModelResponse)` was checked.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from litellm import (
+    EmbeddingResponse,
+    ModelResponse,
+    TextCompletionResponse,
+)
+from litellm.proxy.hooks.parallel_request_limiter import _extract_total_tokens
+
+try:
+    from litellm.types.llms.openai import ResponsesAPIResponse
+    _HAS_RESPONSES_API = True
+except ImportError:
+    ResponsesAPIResponse = None
+    _HAS_RESPONSES_API = False
+
+
+def test_extract_total_tokens_model_response():
+    r = ModelResponse()
+    r.usage = MagicMock(total_tokens=123)
+    assert _extract_total_tokens(r) == 123
+
+
+def test_extract_total_tokens_embedding_response():
+    r = EmbeddingResponse()
+    r.usage = MagicMock(total_tokens=456)
+    assert _extract_total_tokens(r) == 456
+
+
+def test_extract_total_tokens_text_completion_response():
+    r = TextCompletionResponse()
+    r.usage = MagicMock(total_tokens=789)
+    assert _extract_total_tokens(r) == 789
+
+
+@pytest.mark.skipif(not _HAS_RESPONSES_API, reason="ResponsesAPIResponse not available in this version")
+def test_extract_total_tokens_responses_api_response():
+    # ResponsesAPIResponse has required Pydantic fields (id, created_at, output)
+    # so we use MagicMock with spec to satisfy isinstance checks without
+    # triggering validation errors.
+    r = MagicMock(spec=ResponsesAPIResponse)
+    r.usage = MagicMock(total_tokens=321)
+    assert _extract_total_tokens(r) == 321
+
+
+def test_extract_total_tokens_unsupported_type_returns_zero():
+    """Silent no-op for unknown response types — matches prior behavior."""
+    class UnknownResponse:
+        pass
+    r = UnknownResponse()
+    r.usage = MagicMock(total_tokens=999)
+    assert _extract_total_tokens(r) == 0
+
+
+def test_extract_total_tokens_none_usage_returns_zero():
+    r = ModelResponse()
+    r.usage = None
+    assert _extract_total_tokens(r) == 0


### PR DESCRIPTION
## Relevant issues

Fixes #27738

## Pre-Submission checklist

- [x] I have added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests (`make test-unit`)
- [x] My PR's scope is as isolated as possible — it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review (got 5/5)

## Type

🐛 Bug Fix

## Changes

### What

`parallel_request_limiter.py` accumulates `total_tokens` into the per-key / per-user / per-team / per-end-user TPM counters using:

```python
total_tokens = 0
if isinstance(response_obj, ModelResponse):
    total_tokens = response_obj.usage.total_tokens
```

This pattern appears in 4 places (one per limit scope). `EmbeddingResponse`, `TextCompletionResponse`, and `ResponsesAPIResponse` are not handled, so requests against `/v1/embeddings`, `/v1/completions`, and `/v1/responses` leave `total_tokens = 0` and the TPM counters never increment. `tpm_limit` configured on a key/user/team/end-user is therefore silently ignored for those endpoints.

This PR introduces an `_extract_total_tokens` helper that handles all supported response types, and replaces the four `isinstance` branches with a single call to it.

### Why

See #27738 for the full reproduction and root cause. Summary:

- `/v1/chat/completions` → `ModelResponse` → counted (the only path that worked)
- `/v1/embeddings` → `EmbeddingResponse` → **not counted**
- `/v1/completions` → `TextCompletionResponse` → **not counted**
- `/v1/responses` → `ResponsesAPIResponse` → **not counted**

Verified reproduction: a key with `tpm_limit=100` sends 10 embedding requests each well over 100 tokens — all return 200, `tpm_used` stays at 0. Same setup with a chat-completions model correctly returns 429 on the second request.

### How

```diff
+ def _extract_total_tokens(response_obj: Any) -> int:
+     if isinstance(
+         response_obj,
+         (ModelResponse, EmbeddingResponse, TextCompletionResponse, ResponsesAPIResponse),
+     ):
+         usage = getattr(response_obj, "usage", None)
+         if usage is not None:
+             return getattr(usage, "total_tokens", 0) or 0
+     return 0

  ... (4 call sites)

- total_tokens = 0
- if isinstance(response_obj, ModelResponse):
-     total_tokens = response_obj.usage.total_tokens
+ total_tokens = _extract_total_tokens(response_obj)
```

Returns 0 for unknown response types — silent no-op matching the prior fall-through behavior, so this is a strict superset of the previous coverage.

### Tests added

`tests/test_litellm/proxy/hooks/test_parallel_request_limiter_response_types.py`:

- `_extract_total_tokens` handles `ModelResponse`, `EmbeddingResponse`, `TextCompletionResponse`, `ResponsesAPIResponse` correctly
- returns 0 for unknown response types (forward-compat guard)
- returns 0 when `usage` is `None`

All existing tests in `tests/test_litellm/proxy/hooks/` still pass (131 passed, 1 skipped).

### Notes

- This is the same root cause that #7486 touched on, but the reproduction in that issue was anecdotal and the closer noted it was working at that point. The bug has resurfaced — code inspection on current `main` and `litellm_oss_staging` confirms the four `isinstance(response_obj, ModelResponse)` branches are unchanged.
