### PR TITLE
fix: load .env from CWD instead of site-packages in non-interactive CLI mode

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -17,7 +17,7 @@ import os
 import dotenv as _dotenv
 
 if os.getenv("LITELLM_MODE", "DEV") == "DEV":
-    _dotenv.load_dotenv()
+    _dotenv.load_dotenv(dotenv_path=_dotenv.find_dotenv(usecwd=True))
 
 from typing import (
     Callable,

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import click
 import httpx
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 import litellm
 from litellm.constants import DEFAULT_NUM_WORKERS_LITELLM_PROXY
@@ -27,7 +27,7 @@ config_filename = "litellm.secrets"
 
 litellm_mode = os.getenv("LITELLM_MODE", "DEV")  # "PRODUCTION", "DEV"
 if litellm_mode == "DEV":
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
 from enum import Enum
 
 telemetry = None


### PR DESCRIPTION
## Summary

`load_dotenv()` without arguments relies on `find_dotenv()` to locate the `.env` file. The `find_dotenv()` function decides the search starting point based on the environment:

- **Interactive** (REPL, `python -c`): `_is_interactive()` returns `True` -> starts from `os.getcwd()` -> **works**
- **Non-interactive** (installed CLI entry point via pip/uv): `_is_interactive()` returns `False` -> walks up the call stack from the caller's frame, which resolves to `site-packages/litellm/` -> **fails to find `.env`**

### Root cause

When litellm is invoked via a CLI entry point script (generated by pip/uv), `__main__` has a `__file__` attribute pointing to the entry point script. The `_is_interactive()` function in `python-dotenv` checks `not hasattr(__main__, "__file__")` -- since the entry point has `__file__`, it returns `False`, causing `find_dotenv()` to search from the site-packages directory instead of the user's working directory.

### Fix

Pass `find_dotenv(usecwd=True)` to `load_dotenv()`, anchoring the search to CWD while preserving python-dotenv's upward directory traversal for users who keep `.env` in a parent directory.

### Testing

Before fix:
```
$ litellm -c config.yaml
INFO: Uvicorn running on http://0.0.0.0:4000  (default port, PORT from .env ignored)
$ curl http://localhost:4000/    -> 200 Swagger UI (ROOT_REDIRECT_URL ignored)
$ curl http://localhost:4000/docs -> 404 (DOCS_URL ignored)
```

After fix:
```
$ litellm -c config.yaml
INFO: Uvicorn running on http://0.0.0.0:4682  (PORT from .env)
$ curl http://localhost:4682/    -> 307 Redirect to /ui (ROOT_REDIRECT_URL works)
$ curl http://localhost:4682/docs -> 200 Swagger UI (DOCS_URL works)
```
