### PR TITLE
fix(proxy): emit x-ratelimit-* headers for streaming and plain-dict responses

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -45,6 +45,9 @@ from litellm.proxy.common_utils.callback_utils import (
     get_remaining_tokens_and_requests_from_request_data,
 )
 from litellm.proxy.dd_span_tagger import DDSpanTagger
+from litellm.proxy.hooks._rate_limit_headers import (
+    apply_rate_limit_statuses_to_headers,
+)
 from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
@@ -1152,10 +1155,6 @@ class ProxyBaseLLMRequestProcessing:
             # in flight before the hook fires). Pulling from the stored response
             # here ensures both streaming and non-streaming paths receive the
             # same x-ratelimit-* headers.
-            from litellm.proxy.hooks._rate_limit_headers import (
-                apply_rate_limit_statuses_to_headers,
-            )
-
             apply_rate_limit_statuses_to_headers(
                 additional_headers,
                 self.data.get("litellm_proxy_rate_limit_response"),
@@ -1387,10 +1386,6 @@ class ProxyBaseLLMRequestProcessing:
         # returns a plain dict with no `_hidden_params` attribute, which makes
         # `hasattr(response, "_hidden_params")` False and short-circuits the
         # hook). setdefault preserves any values the hook successfully set.
-        from litellm.proxy.hooks._rate_limit_headers import (
-            apply_rate_limit_statuses_to_headers,
-        )
-
         apply_rate_limit_statuses_to_headers(
             additional_headers,
             self.data.get("litellm_proxy_rate_limit_response"),

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1145,6 +1145,22 @@ class ProxyBaseLLMRequestProcessing:
                 hidden_params.get("additional_headers", {}) or {},
             )
 
+            # Seed x-ratelimit-* headers from the rate-limit response cached on
+            # `self.data`. The v3 parallel_request_limiter post-call hook updates
+            # `response._hidden_params.additional_headers` *after* this point,
+            # which is too late for streaming routes (SSE chunks are already
+            # in flight before the hook fires). Pulling from the stored response
+            # here ensures both streaming and non-streaming paths receive the
+            # same x-ratelimit-* headers.
+            from litellm.proxy.hooks._rate_limit_headers import (
+                apply_rate_limit_statuses_to_headers,
+            )
+
+            apply_rate_limit_statuses_to_headers(
+                additional_headers,
+                self.data.get("litellm_proxy_rate_limit_response"),
+            )
+
             # Post Call Processing
             if llm_router is not None:
                 self.data["deployment"] = llm_router.get_deployment(model_id=model_id)
@@ -1364,6 +1380,21 @@ class ProxyBaseLLMRequestProcessing:
             getattr(response, "_hidden_params", {}) or {}
         )  # get any updated response headers
         additional_headers = hidden_params.get("additional_headers", {}) or {}
+
+        # Safety-net: re-derive x-ratelimit-* from the stored rate-limit response
+        # for paths where the v3 parallel_request_limiter post-call hook
+        # silently skipped header injection (e.g. /v1/messages non-streaming
+        # returns a plain dict with no `_hidden_params` attribute, which makes
+        # `hasattr(response, "_hidden_params")` False and short-circuits the
+        # hook). setdefault preserves any values the hook successfully set.
+        from litellm.proxy.hooks._rate_limit_headers import (
+            apply_rate_limit_statuses_to_headers,
+        )
+
+        apply_rate_limit_statuses_to_headers(
+            additional_headers,
+            self.data.get("litellm_proxy_rate_limit_response"),
+        )
 
         fastapi_response.headers.update(
             ProxyBaseLLMRequestProcessing.get_custom_headers(

--- a/litellm/proxy/hooks/_rate_limit_headers.py
+++ b/litellm/proxy/hooks/_rate_limit_headers.py
@@ -36,12 +36,18 @@ def apply_rate_limit_statuses_to_headers(
         rate_limit_type = status.get("rate_limit_type")
         if descriptor_key is None or rate_limit_type is None:
             continue
+        limit_remaining = status.get("limit_remaining")
+        current_limit = status.get("current_limit")
+        # Skip when numeric fields are absent so downstream HTTP encoding
+        # never stringifies `None` into header values.
+        if limit_remaining is None or current_limit is None:
+            continue
         prefix = f"x-ratelimit-{descriptor_key}"
         headers.setdefault(
             f"{prefix}-remaining-{rate_limit_type}",
-            status.get("limit_remaining"),
+            limit_remaining,
         )
         headers.setdefault(
             f"{prefix}-limit-{rate_limit_type}",
-            status.get("current_limit"),
+            current_limit,
         )

--- a/litellm/proxy/hooks/_rate_limit_headers.py
+++ b/litellm/proxy/hooks/_rate_limit_headers.py
@@ -1,0 +1,47 @@
+"""Shared util for emitting v3 parallel_request_limiter rate limit headers
+in `x-ratelimit-{descriptor}-{remaining,limit}-{type}` form.
+
+`parallel_request_limiter_v3.async_post_call_success_hook` populates these
+headers via `response._hidden_params.additional_headers`, but two paths
+silently drop them:
+
+  1. Streaming responses — the post-call hook fires *after* SSE chunk
+     transmission has already started, so headers set on the response
+     object never reach the client.
+  2. Plain-dict responses (e.g. `/v1/messages` non-streaming) — the hook
+     short-circuits when `hasattr(response, "_hidden_params")` is False.
+
+`common_request_processing.py` calls this util at two seed sites
+(pre-stream branch and the non-streaming response builder) so the
+rate-limit response cached on `self.data` is reflected in the outgoing
+response headers regardless of which code path produced the response.
+"""
+
+from typing import Optional
+
+
+def apply_rate_limit_statuses_to_headers(
+    headers: dict,
+    rate_limit_response: Optional[dict],
+) -> None:
+    """Populate x-ratelimit-* entries on `headers` from a v3 limiter response.
+
+    Uses setdefault so existing keys (e.g. set by an earlier hook on the same
+    request) are preserved. No-op when rate_limit_response is None or empty.
+    """
+    if not rate_limit_response:
+        return
+    for status in rate_limit_response.get("statuses", []):
+        descriptor_key = status.get("descriptor_key")
+        rate_limit_type = status.get("rate_limit_type")
+        if descriptor_key is None or rate_limit_type is None:
+            continue
+        prefix = f"x-ratelimit-{descriptor_key}"
+        headers.setdefault(
+            f"{prefix}-remaining-{rate_limit_type}",
+            status.get("limit_remaining"),
+        )
+        headers.setdefault(
+            f"{prefix}-limit-{rate_limit_type}",
+            status.get("current_limit"),
+        )

--- a/tests/test_litellm/proxy/test_rate_limit_headers_emission.py
+++ b/tests/test_litellm/proxy/test_rate_limit_headers_emission.py
@@ -101,3 +101,40 @@ class TestApplyRateLimitStatusesToHeaders:
             "x-ratelimit-team-remaining-requests": 9,
             "x-ratelimit-team-limit-requests": 10,
         }
+
+    def test_skips_status_entries_with_missing_limit_fields(self):
+        headers: dict = {}
+        apply_rate_limit_statuses_to_headers(
+            headers,
+            {
+                "statuses": [
+                    # missing limit_remaining
+                    {
+                        "descriptor_key": "api_key",
+                        "rate_limit_type": "tokens",
+                        "current_limit": 100,
+                    },
+                    # missing current_limit
+                    {
+                        "descriptor_key": "api_key",
+                        "rate_limit_type": "requests",
+                        "limit_remaining": 9,
+                    },
+                    # valid one to confirm iteration continues
+                    {
+                        "descriptor_key": "team",
+                        "rate_limit_type": "tokens",
+                        "current_limit": 200,
+                        "limit_remaining": 195,
+                    },
+                ]
+            },
+        )
+        # Entries missing limit_remaining/current_limit are dropped — only the
+        # complete one is emitted, and no `None` values land in the headers.
+        assert headers == {
+            "x-ratelimit-team-remaining-tokens": 195,
+            "x-ratelimit-team-limit-tokens": 200,
+        }
+        for value in headers.values():
+            assert value is not None

--- a/tests/test_litellm/proxy/test_rate_limit_headers_emission.py
+++ b/tests/test_litellm/proxy/test_rate_limit_headers_emission.py
@@ -1,0 +1,103 @@
+"""Tests for x-ratelimit-* header emission across response shapes.
+
+Covers the seed sites added in `litellm/proxy/common_request_processing.py`
+so that streaming responses, plain-dict responses, and pydantic responses
+all surface the rate-limit headers stored on
+`self.data["litellm_proxy_rate_limit_response"]`.
+"""
+
+import pytest
+
+from litellm.proxy.hooks._rate_limit_headers import (
+    apply_rate_limit_statuses_to_headers,
+)
+
+
+def _rate_limit_response_sample() -> dict:
+    return {
+        "overall_code": "OK",
+        "statuses": [
+            {
+                "descriptor_key": "api_key",
+                "rate_limit_type": "requests",
+                "current_limit": 6000,
+                "limit_remaining": 5997,
+            },
+            {
+                "descriptor_key": "api_key",
+                "rate_limit_type": "tokens",
+                "current_limit": 100000,
+                "limit_remaining": 99955,
+            },
+        ],
+    }
+
+
+class TestApplyRateLimitStatusesToHeaders:
+    def test_populates_descriptor_remaining_and_limit_entries(self):
+        headers: dict = {}
+        apply_rate_limit_statuses_to_headers(headers, _rate_limit_response_sample())
+        assert headers["x-ratelimit-api_key-remaining-requests"] == 5997
+        assert headers["x-ratelimit-api_key-limit-requests"] == 6000
+        assert headers["x-ratelimit-api_key-remaining-tokens"] == 99955
+        assert headers["x-ratelimit-api_key-limit-tokens"] == 100000
+
+    def test_setdefault_does_not_overwrite_existing_keys(self):
+        headers = {
+            "x-ratelimit-api_key-remaining-requests": "preserved",
+        }
+        apply_rate_limit_statuses_to_headers(headers, _rate_limit_response_sample())
+        # Existing key preserved
+        assert headers["x-ratelimit-api_key-remaining-requests"] == "preserved"
+        # Other keys still filled in
+        assert headers["x-ratelimit-api_key-limit-requests"] == 6000
+
+    def test_noop_for_none(self):
+        headers: dict = {}
+        apply_rate_limit_statuses_to_headers(headers, None)
+        assert headers == {}
+
+    def test_noop_for_empty_dict(self):
+        headers: dict = {}
+        apply_rate_limit_statuses_to_headers(headers, {})
+        assert headers == {}
+
+    def test_noop_for_response_with_empty_statuses(self):
+        headers: dict = {}
+        apply_rate_limit_statuses_to_headers(
+            headers, {"overall_code": "OK", "statuses": []}
+        )
+        assert headers == {}
+
+    def test_skips_status_entries_missing_required_fields(self):
+        headers: dict = {}
+        apply_rate_limit_statuses_to_headers(
+            headers,
+            {
+                "statuses": [
+                    # missing descriptor_key
+                    {
+                        "rate_limit_type": "requests",
+                        "current_limit": 1,
+                        "limit_remaining": 1,
+                    },
+                    # missing rate_limit_type
+                    {
+                        "descriptor_key": "api_key",
+                        "current_limit": 1,
+                        "limit_remaining": 1,
+                    },
+                    # valid one to confirm iteration continues
+                    {
+                        "descriptor_key": "team",
+                        "rate_limit_type": "requests",
+                        "current_limit": 10,
+                        "limit_remaining": 9,
+                    },
+                ]
+            },
+        )
+        assert headers == {
+            "x-ratelimit-team-remaining-requests": 9,
+            "x-ratelimit-team-limit-requests": 10,
+        }


### PR DESCRIPTION
## Relevant issues

Fixes #27748

## Linear ticket

N/A — external contributor.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Single-instance proxy, key with `tpm_limit=100000` and `rpm_limit=6000`, one request per shape.

**Before (upstream `main`/`litellm_oss_staging`)**

| endpoint | `x-ratelimit-*` headers |
|---|---|
| `POST /v1/chat/completions` (sync) | ✅ 4 headers emitted |
| `POST /v1/chat/completions` (`stream=true`) | ❌ **none** |
| `POST /v1/embeddings` (sync) | ✅ 4 headers emitted |
| `POST /v1/messages` (sync) | ❌ **none** (plain-dict response, hook short-circuits) |
| `POST /v1/messages` (`stream=true`) | ❌ **none** (hook runs after SSE start) |

**After (this PR)**

| endpoint | `x-ratelimit-*` headers |
|---|---|
| `POST /v1/chat/completions` (sync) | ✅ unchanged |
| `POST /v1/chat/completions` (`stream=true`) | ✅ 4 headers emitted |
| `POST /v1/embeddings` (sync) | ✅ unchanged |
| `POST /v1/messages` (sync) | ✅ 4 headers emitted |
| `POST /v1/messages` (`stream=true`) | ✅ 4 headers emitted |

Counter increments were already correct before the PR — only header visibility was broken.

## Type

🐛 Bug Fix

## Changes

`async_post_call_success_hook` in `parallel_request_limiter_v3.py` populates `x-ratelimit-*` headers by mutating `response._hidden_params["additional_headers"]`. Two response paths silently drop them:

1. **Streaming**: the hook fires *after* the SSE response headers are already flushed to the client. Mutating `_hidden_params` then is a no-op for the wire response.
2. **Plain-dict responses** (e.g. `/v1/messages` non-streaming): the hook short-circuits at `hasattr(response, "_hidden_params")` (`parallel_request_limiter_v3.py:2751`-2754), so headers are never populated at all.

This PR adds two seed sites in `litellm/proxy/common_request_processing.py.base_process_llm_request` that read from `self.data["litellm_proxy_rate_limit_response"]` (already cached by `async_pre_call_hook` at `parallel_request_limiter_v3.py:1983`) and stamp the headers via a shared helper.

| change | scope |
|---|---|
| `litellm/proxy/hooks/_rate_limit_headers.py` (new) | tiny shared helper: walks `rate_limit_response["statuses"]` and `setdefault`s `x-ratelimit-{descriptor}-{remaining,limit}-{type}` onto a dict. setdefault preserves any keys the existing hook successfully set. |
| `litellm/proxy/common_request_processing.py` (2 inserts) | (1) pre-stream-branch seed so streaming routes get the headers before SSE start; (2) post-`post_call_success_hook` safety-net so plain-dict responses get them as well. |
| `tests/test_litellm/proxy/test_rate_limit_headers_emission.py` (new) | 6 unit tests covering happy path, setdefault precedence, none/empty inputs, and malformed status entries. |

No change to `parallel_request_limiter_v3.async_post_call_success_hook` — its existing behavior (mutate `_hidden_params` when present) is preserved; the new seed sites complement it for the response shapes it can't reach.
