### PR TITLE
fix(mcp): gate /public/mcp_hub strictly on litellm.public_mcp_servers

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -426,6 +426,7 @@ disable_copilot_system_to_assistant: bool = (
     False  # If false (default), converts all 'system' role messages to 'assistant' for GitHub Copilot compatibility. Set to true to disable this behavior.
 )
 public_mcp_servers: Optional[List[str]] = None
+public_mcp_hub_strict_whitelist: bool = True
 public_model_groups: Optional[List[str]] = None
 public_agent_groups: Optional[List[str]] = None
 # Supports both old format (Dict[str, str]) and new format (Dict[str, Dict[str, Any]])

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3162,19 +3162,34 @@ class MCPServerManager:
         """
         Return the MCP servers published to the AI Hub via /v1/mcp/make_public.
 
-        Mirrors /public/model_hub and /public/agent_hub: gates strictly on the
+        Default (litellm.public_mcp_hub_strict_whitelist=True): mirrors
+        /public/model_hub and /public/agent_hub — gates strictly on the
         litellm.public_mcp_servers whitelist. Returns an empty list when no
         servers have been published. The per-server available_on_public_internet
         flag is unrelated — it governs IP-based access in
         _is_server_accessible_from_ip, not hub visibility.
+
+        Legacy (litellm.public_mcp_hub_strict_whitelist=False): preserves the
+        pre-fix behavior where any server with available_on_public_internet=True
+        is also included. Intended as a one-release migration window for
+        deployments that relied on the OR-with-default semantics; will be
+        removed in a future release.
         """
-        if litellm.public_mcp_servers is None:
-            return []
-        public_ids = set(litellm.public_mcp_servers)
+        if litellm.public_mcp_hub_strict_whitelist:
+            if litellm.public_mcp_servers is None:
+                return []
+            public_ids = set(litellm.public_mcp_servers)
+            return [
+                server
+                for server in self.get_registry().values()
+                if server.server_id in public_ids
+            ]
+
+        public_ids = set(litellm.public_mcp_servers or [])
         return [
             server
             for server in self.get_registry().values()
-            if server.server_id in public_ids
+            if server.available_on_public_internet or server.server_id in public_ids
         ]
 
     def expand_permission_list(self, identifiers: List[str]) -> List[str]:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3160,15 +3160,22 @@ class MCPServerManager:
 
     def get_public_mcp_servers(self) -> List[MCPServer]:
         """
-        Get the public MCP servers (available_on_public_internet=True flag on server).
-        Also includes servers from litellm.public_mcp_servers for backwards compat.
+        Return the MCP servers published to the AI Hub via /v1/mcp/make_public.
+
+        Mirrors /public/model_hub and /public/agent_hub: gates strictly on the
+        litellm.public_mcp_servers whitelist. Returns an empty list when no
+        servers have been published. The per-server available_on_public_internet
+        flag is unrelated — it governs IP-based access in
+        _is_server_accessible_from_ip, not hub visibility.
         """
-        servers: List[MCPServer] = []
-        public_ids = set(litellm.public_mcp_servers or [])
-        for server in self.get_registry().values():
-            if server.available_on_public_internet or server.server_id in public_ids:
-                servers.append(server)
-        return servers
+        if litellm.public_mcp_servers is None:
+            return []
+        public_ids = set(litellm.public_mcp_servers)
+        return [
+            server
+            for server in self.get_registry().values()
+            if server.server_id in public_ids
+        ]
 
     def expand_permission_list(self, identifiers: List[str]) -> List[str]:
         """

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -3436,5 +3436,88 @@ class TestApprovalStatusGate:
         assert "never-seen" not in manager.registry
 
 
+class TestGetPublicMCPServers:
+    """
+    /public/mcp_hub strict-whitelist semantics — mirrors /public/model_hub
+    and /public/agent_hub. Regression test for the PR #20607 OR-with-default
+    behavior that made `litellm.public_mcp_servers` ignored by the hub.
+    """
+
+    def _make_server(self, server_id, available_on_public_internet=True):
+        return MCPServer(
+            server_id=server_id,
+            name=server_id,
+            server_name=server_id,
+            transport=MCPTransport.http,
+            available_on_public_internet=available_on_public_internet,
+        )
+
+    def _make_manager(self, servers):
+        manager = MCPServerManager()
+        for s in servers:
+            manager.config_mcp_servers[s.server_id] = s
+        return manager
+
+    @patch("litellm.public_mcp_servers", None)
+    def test_returns_empty_when_whitelist_is_none(self):
+        """No /make_public call yet → hub returns nothing, regardless of
+        per-server flags."""
+        manager = self._make_manager(
+            [
+                self._make_server("a", available_on_public_internet=True),
+                self._make_server("b", available_on_public_internet=True),
+            ]
+        )
+        assert manager.get_public_mcp_servers() == []
+
+    @patch("litellm.public_mcp_servers", [])
+    def test_returns_empty_when_whitelist_is_empty(self):
+        """Explicit empty whitelist → hub returns nothing."""
+        manager = self._make_manager(
+            [self._make_server("a", available_on_public_internet=True)]
+        )
+        assert manager.get_public_mcp_servers() == []
+
+    @patch("litellm.public_mcp_servers", ["a"])
+    def test_returns_only_whitelisted_when_flag_defaults_to_true(self):
+        """
+        Regression: prior to the fix, every server with
+        available_on_public_internet=True (the default) leaked into the hub
+        regardless of the whitelist. Whitelist must be authoritative.
+        """
+        manager = self._make_manager(
+            [
+                self._make_server("a", available_on_public_internet=True),
+                self._make_server("b", available_on_public_internet=True),
+            ]
+        )
+        result = manager.get_public_mcp_servers()
+        assert [s.server_id for s in result] == ["a"]
+
+    @patch("litellm.public_mcp_servers", ["a"])
+    def test_does_not_leak_servers_via_internal_flag(self):
+        """
+        available_on_public_internet is an IP-gating flag, not a hub flag.
+        A server with the flag True that is not in the whitelist must not
+        appear in the hub.
+        """
+        manager = self._make_manager(
+            [
+                self._make_server("a", available_on_public_internet=False),
+                self._make_server("b", available_on_public_internet=True),
+            ]
+        )
+        result = manager.get_public_mcp_servers()
+        assert [s.server_id for s in result] == ["a"]
+
+    @patch("litellm.public_mcp_servers", ["does-not-exist"])
+    def test_stale_whitelist_id_returns_empty(self):
+        """Whitelist references an unknown server_id → no spurious results."""
+        manager = self._make_manager(
+            [self._make_server("a", available_on_public_internet=True)]
+        )
+        assert manager.get_public_mcp_servers() == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -3519,5 +3519,57 @@ class TestGetPublicMCPServers:
         assert manager.get_public_mcp_servers() == []
 
 
+class TestGetPublicMCPServersLegacyMode:
+    """
+    Legacy migration knob: litellm.public_mcp_hub_strict_whitelist=False
+    preserves the pre-fix OR-with-default semantics for one release so
+    operators that relied on the old behavior have a window to call
+    /v1/mcp/make_public before /public/mcp_hub goes empty.
+    """
+
+    def _make_server(self, server_id, available_on_public_internet=True):
+        return MCPServer(
+            server_id=server_id,
+            name=server_id,
+            server_name=server_id,
+            transport=MCPTransport.http,
+            available_on_public_internet=available_on_public_internet,
+        )
+
+    def _make_manager(self, servers):
+        manager = MCPServerManager()
+        for s in servers:
+            manager.config_mcp_servers[s.server_id] = s
+        return manager
+
+    @patch("litellm.public_mcp_hub_strict_whitelist", False)
+    @patch("litellm.public_mcp_servers", None)
+    def test_legacy_returns_default_flag_servers_when_whitelist_is_none(self):
+        """Legacy mode + no whitelist → every server with the default
+        available_on_public_internet=True appears (old behavior)."""
+        manager = self._make_manager(
+            [
+                self._make_server("a", available_on_public_internet=True),
+                self._make_server("b", available_on_public_internet=False),
+            ]
+        )
+        result = manager.get_public_mcp_servers()
+        assert [s.server_id for s in result] == ["a"]
+
+    @patch("litellm.public_mcp_hub_strict_whitelist", False)
+    @patch("litellm.public_mcp_servers", ["b"])
+    def test_legacy_unions_whitelist_and_default_flag(self):
+        """Legacy mode unions the whitelist with any
+        available_on_public_internet=True server."""
+        manager = self._make_manager(
+            [
+                self._make_server("a", available_on_public_internet=True),
+                self._make_server("b", available_on_public_internet=False),
+            ]
+        )
+        result = manager.get_public_mcp_servers()
+        assert sorted(s.server_id for s in result) == ["a", "b"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -661,13 +661,6 @@ def test_public_mcp_hub_returns_only_whitelisted_servers():
         transport=MCPTransport.http,
         available_on_public_internet=True,
     )
-    hidden = MCPServer(
-        server_id="hidden",
-        name="hidden",
-        server_name="hidden",
-        transport=MCPTransport.http,
-        available_on_public_internet=True,
-    )
 
     mock_manager = MagicMock()
     mock_manager.get_public_mcp_servers.return_value = [listed]

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -639,3 +639,74 @@ def test_clean_display_name_strips_suffix():
 def test_clean_display_name_passthrough_when_no_suffix():
     assert _clean_display_name("OpenAI") == "OpenAI"
     assert _clean_display_name("") == ""
+
+
+def test_public_mcp_hub_returns_only_whitelisted_servers():
+    """Regression: /public/mcp_hub must gate strictly on
+    litellm.public_mcp_servers, mirroring /public/model_hub and
+    /public/agent_hub. Servers with available_on_public_internet=True that
+    are not on the whitelist must not leak."""
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    from litellm.proxy._types import MCPTransport
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[user_api_key_auth] = lambda: MagicMock()
+    client = TestClient(app)
+
+    listed = MCPServer(
+        server_id="listed",
+        name="listed",
+        server_name="listed",
+        transport=MCPTransport.http,
+        available_on_public_internet=True,
+    )
+    hidden = MCPServer(
+        server_id="hidden",
+        name="hidden",
+        server_name="hidden",
+        transport=MCPTransport.http,
+        available_on_public_internet=True,
+    )
+
+    mock_manager = MagicMock()
+    mock_manager.get_public_mcp_servers.return_value = [listed]
+
+    with (
+        patch("litellm.public_mcp_servers", ["listed"]),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_manager,
+        ),
+    ):
+        response = client.get("/public/mcp_hub")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [item["server_id"] for item in data] == ["listed"]
+    app.dependency_overrides.clear()
+
+
+def test_public_mcp_hub_returns_empty_when_whitelist_unset():
+    """When no servers have been published via /v1/mcp/make_public, the
+    hub returns an empty list (matches /public/agent_hub behavior)."""
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[user_api_key_auth] = lambda: MagicMock()
+    client = TestClient(app)
+
+    mock_manager = MagicMock()
+    mock_manager.get_public_mcp_servers.return_value = []
+
+    with (
+        patch("litellm.public_mcp_servers", None),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_manager,
+        ),
+    ):
+        response = client.get("/public/mcp_hub")
+
+    assert response.status_code == 200
+    assert response.json() == []
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Relevant issues

<!-- Adjacent but not fixed by this PR: #22852 is a UI-only deselection issue that
     surfaces the same area. This PR fixes the underlying backend hub filtering;
     #22852 remains a separate UI concern. -->

## Linear ticket

<!-- (none) -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Verified end-to-end against a local proxy with two MCP servers (`alpha`, `bravo`) registered via config plus four additional MCP servers in the DB-backed registry — none of them ever passed through `/v1/mcp/make_public`, and all six rely on the default `available_on_public_internet=True`.

Before the fix, the same six-server registry would have populated `/public/mcp_hub` in full regardless of `litellm.public_mcp_servers`, and step C would also return all six. After the fix:

```
=== A: hub before /make_public — should be [] (strict whitelist, nothing published) ===
[]

=== B: /make_public with alpha's server_id ===
{
  "message": "Successfully updated public mcp servers",
  "public_mcp_servers": [
    "26e116daccbf8eb21adcdda0452cb4e0"
  ],
  "updated_by": "default_user_id"
}

=== C: hub after — should return ONLY alpha ===
[
  {
    "server_id": "26e116daccbf8eb21adcdda0452cb4e0",
    "name": "alpha"
  }
]
```

The five servers excluded in C all have `available_on_public_internet=True` (the default); under the previous behavior they would have leaked into the hub.

## Type

🐛 Bug Fix

## Changes

### Why

`get_public_mcp_servers()` (the read path behind `/public/mcp_hub`) was OR-ing `server.available_on_public_internet` with `litellm.public_mcp_servers`:

```python
if server.available_on_public_internet or server.server_id in public_ids:
    servers.append(server)
```

`available_on_public_internet` defaults to `True` for every MCP server registered without an explicit override, so every onboarded server unconditionally satisfied the OR. The result: `/v1/mcp/make_public` (and the UI's "Select MCP Servers to Make Public" flow) could only *add* to the hub, never restrict it. On any deployment that hadn't gone out of its way to set `available_on_public_internet: false` per server, the curation feature was effectively a no-op.

The sibling hubs don't have this OR — `/public/model_hub` and `/public/agent_hub` each gate strictly on their `public_*_groups` list. This PR brings `/public/mcp_hub` in line with them.

### What

- **`litellm/proxy/_experimental/mcp_server/mcp_server_manager.py`** — rewrote `get_public_mcp_servers()` to:
  - return `[]` when `litellm.public_mcp_servers is None` (no `/make_public` calls have been made),
  - otherwise filter the registry strictly by membership in the `public_mcp_servers` whitelist,
  - drop the consultation of `available_on_public_internet`. That flag's only correct consumer is `_is_server_accessible_from_ip` (per-server IP-based access gating, surfaced in the UI as "Internal network only"). It is unchanged.
- **`tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py`** — added `TestGetPublicMCPServers` with 5 cases: `None` whitelist, empty whitelist, default-flag-doesn't-leak, internal-flag-doesn't-leak, stale id.
- **`tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py`** — added two endpoint tests for `/public/mcp_hub` mirroring the existing `/public/model_hub` test pattern.

### Behavior change — please call out in release notes

Deployments that relied on the hub auto-populating every registered MCP server (i.e. ones that never called `/v1/mcp/make_public`) will see an empty `/public/mcp_hub` after this change. To restore visibility, admins should publish the desired servers via `POST /v1/mcp/make_public` or the UI's "Select MCP Servers to Make Public" flow — the same workflow already required for `/public/model_hub` and `/public/agent_hub`.

### Out of scope

- The default value of `available_on_public_internet` (`True`) is unchanged. Flipping it would silently restrict IP access for every existing deployment.
- `_is_server_accessible_from_ip` is untouched.
- The `/v1/mcp/make_public` write path is untouched.
- UI components that toggle `available_on_public_internet` ("Internal network only") are untouched.