### PR TITLE
fix(stream_chunk_builder): handle 'reasoning' delta field from providers like Scaleway 

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -430,7 +430,10 @@ class ChunkProcessor:
     def get_combined_reasoning_content(
         self, chunks: List[Dict[str, Any]]
     ) -> ChatCompletionAssistantContentValue:
-        return self.get_combined_content(chunks, delta_key="reasoning_content")
+        result = self.get_combined_content(chunks, delta_key="reasoning_content")
+        if result:
+            return result
+        return self.get_combined_content(chunks, delta_key="reasoning")
 
     def get_combined_audio_content(
         self, chunks: List[Dict[str, Any]]

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7542,6 +7542,7 @@ def stream_chunk_builder(  # noqa: PLR0915
                 delta.get("tool_calls") is not None
                 or delta.get("function_call") is not None
                 or delta.get("reasoning_content") is not None
+                or delta.get("reasoning") is not None
                 or delta.get("thinking_blocks") is not None
                 or delta.get("annotations") is not None
                 or delta.get("audio") is not None
@@ -7649,14 +7650,15 @@ def stream_chunk_builder(  # noqa: PLR0915
             chunk
             for chunk in chunks
             if len(chunk["choices"]) > 0
-            and "reasoning_content" in chunk["choices"][0]["delta"]
-            and chunk["choices"][0]["delta"]["reasoning_content"] is not None
+            and ("reasoning_content" in chunk["choices"][0]["delta"] or "reasoning" in chunk["choices"][0]["delta"])
+            and (chunk["choices"][0]["delta"].get("reasoning_content") is not None or chunk["choices"][0]["delta"].get("reasoning") is not None)
         ]
 
         if len(reasoning_chunks) > 0:
             response["choices"][0]["message"]["reasoning_content"] = (
                 processor.get_combined_reasoning_content(reasoning_chunks)
             )
+    
 
         annotation_chunks = [
             chunk

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -2516,3 +2516,30 @@ def test_get_base_model_from_metadata():
     # Test 6: None input
     result = _get_base_model_from_metadata(None)
     assert result is None, f"Expected None for None input, got {result}"
+
+
+def test_stream_chunk_builder_reasoning_field():
+    """Test that 'reasoning' delta field from providers like Scaleway is mapped to 'reasoning_content'"""
+    from litellm.main import stream_chunk_builder
+
+    chunks = [
+        {
+            "id": "test-1",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "scaleway/gemma-4-26b-a4b-it",
+            "choices": [{"index": 0, "delta": {"role": "assistant", "reasoning": "thinking..."}, "finish_reason": None}],
+        },
+        {
+            "id": "test-1",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "scaleway/gemma-4-26b-a4b-it",
+            "choices": [{"index": 0, "delta": {"content": "Hello!"}, "finish_reason": "stop"}],
+        },
+    ]
+
+    result = stream_chunk_builder(chunks)
+    assert result is not None
+    assert result.choices[0].message.reasoning_content == "thinking..."
+    assert result.choices[0].message.content == "Hello!"


### PR DESCRIPTION
 ## Relevant issues                     

  Fixes #27670

  ## Linear ticket

  N/A

  ## Pre-Submission checklist

  - [x] I have Added testing in the `tests/litellm_utils_tests/test_utils.py`, **Adding at least 1 test is a hard requirement**
  - [ ] My PR passes all unit tests on `make test-unit`
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

  ## Screenshots / Proof of Fix

  Test passes locally:
  `1 passed in 0.34s` for `test_stream_chunk_builder_reasoning_field`

  ## Type

  🐛 Bug Fix

  ## Changes

  - `litellm/main.py`: Add `reasoning` to simple-stream fast-path detection and `reasoning_chunks` collection
  - `litellm/litellm_core_utils/streaming_chunk_builder_utils.py`: Fall back to `reasoning` key in `get_combined_reasoning_content()`
  - `tests/litellm_utils_tests/test_utils.py`: Add test for `reasoning` delta field mapping to `reasoning_content`

  Some providers (e.g. Scaleway) send `reasoning` in streaming delta objects instead of `reasoning_content`. This caused `acompletion()` to return `None`, crashing `async for` iteration. Output is always
  normalized to `reasoning_content` for consistency.


## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->




