### PR TITLE
deps: widen uvicorn constraint from ==0.33.0 to >=0.33.0,<1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Documentation = "https://docs.litellm.ai"
 [project.optional-dependencies]
 proxy = [
     "gunicorn==23.0.0",
-    "uvicorn==0.33.0",
+    "uvicorn>=0.33.0,<1.0.0",
     "uvloop==0.21.0; sys_platform != 'win32'",
     "fastapi==0.124.4",
     "backoff==2.2.1",


### PR DESCRIPTION
Pinning `uvicorn` to a single point release blocks litellm from being installed alongside libraries that need a different patch — most notably Google ADK. The pin landed in v1.83.1-nightly; v1.81.14-stable and v1.83.0-nightly both used the range `>=0.32.1,<1.0.0`.

Restore the range form while keeping the `0.33.0` floor the hard pin introduced.

Fixes #27746