### PR TITLE
fix(proxy): suppress parse_search_tools init log spam on router refreshes

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2920,7 +2920,7 @@ class ProxyConfig:
             credential_list = [CredentialItem(**cred) for cred in credential_list_dict]
         return credential_list
 
-    def parse_search_tools(self, config: dict) -> Optional[List[SearchToolTypedDict]]:
+    def parse_search_tools(self, config: dict, print_initialization_message: bool = True) -> Optional[List[SearchToolTypedDict]]:
         """
         Parse and validate search tools from config.
         Loads environment variables and casts to SearchToolTypedDict.
@@ -2943,9 +2943,10 @@ class ProxyConfig:
 
         search_tools_parsed: List[SearchToolTypedDict] = []
 
-        print(  # noqa
-            "\033[32mLiteLLM: Proxy initialized with Search Tools:\033[0m"
-        )  # noqa
+        if print_initialization_message:
+            print(  # noqa
+                "\033[32mLiteLLM: Proxy initialized with Search Tools:\033[0m"
+            )  # noqa
 
         for search_tool in search_tools_raw:
             # Display loaded search tool
@@ -2953,7 +2954,8 @@ class ProxyConfig:
             search_provider = search_tool.get("litellm_params", {}).get(
                 "search_provider", ""
             )
-            print(f"\033[32m    {search_tool_name} ({search_provider})\033[0m")  # noqa
+            if print_initialization_message:
+                print(f"\033[32m    {search_tool_name} ({search_provider})\033[0m")  # noqa
 
             # Handle os.environ/ variables in litellm_params
             litellm_params = search_tool.get("litellm_params", {})
@@ -4104,7 +4106,7 @@ class ProxyConfig:
         search_tools = None
         try:
             config_data = await proxy_config.get_config()
-            search_tools = self.parse_search_tools(config_data)
+            search_tools = self.parse_search_tools(config_data, print_initialization_message=False)
         except Exception as e:
             verbose_proxy_logger.warning(
                 "Failed to load config in _update_llm_router: %s. "

--- a/tests/proxy_unit_tests/test_parse_search_tools_log_spam.py
+++ b/tests/proxy_unit_tests/test_parse_search_tools_log_spam.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for the parse_search_tools print_initialization_message fix.
+
+Verifies that parse_search_tools does not print the "Proxy initialized with
+Search Tools" banner when print_initialization_message=False, which is the
+value passed by _update_llm_router() on every periodic router refresh.
+
+Regression: before the fix, print() was called unconditionally, causing the
+banner to appear on every request when Brave Search (or any search tool) was
+configured.
+
+Fixes: https://github.com/BerriAI/litellm/issues/27645
+"""
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+
+def _make_proxy_config(search_tool_name="brave_search", search_provider="Brave"):
+    """
+    Return a minimal config dict that parse_search_tools recognises as having
+    one search tool configured.
+    """
+    return {
+        "general_settings": {
+            "search_tools": [
+                {
+                    "search_tool_name": search_tool_name,
+                    "litellm_params": {
+                        "search_provider": search_provider,
+                        "api_key": "fake-key",
+                    },
+                }
+            ]
+        }
+    }
+
+
+class TestParseSearchToolsPrintInitializationMessage:
+    """parse_search_tools must only print when print_initialization_message=True."""
+
+    def _get_proxy_config_instance(self):
+        from litellm.proxy.proxy_server import ProxyConfig
+        return ProxyConfig()
+
+    def test_no_print_when_flag_is_false(self, capsys):
+        """
+        _update_llm_router() passes print_initialization_message=False.
+        No output should reach stdout.
+        """
+        pc = self._get_proxy_config_instance()
+        config = _make_proxy_config()
+        pc.parse_search_tools(config, print_initialization_message=False)
+
+        captured = capsys.readouterr()
+        assert "Search Tools" not in captured.out, (
+            f"Banner was printed despite print_initialization_message=False: "
+            f"{captured.out!r}"
+        )
+        assert "brave_search" not in captured.out.lower(), (
+            f"Tool name was printed despite print_initialization_message=False: "
+            f"{captured.out!r}"
+        )
+
+    def test_prints_when_flag_is_true(self, capsys):
+        """
+        load_config() uses the default (True). The startup banner must appear.
+        """
+        pc = self._get_proxy_config_instance()
+        config = _make_proxy_config()
+        pc.parse_search_tools(config, print_initialization_message=True)
+
+        captured = capsys.readouterr()
+        assert "Search Tools" in captured.out, (
+            f"Expected banner not found in stdout: {captured.out!r}"
+        )
+
+    def test_default_is_true(self, capsys):
+        """
+        The default value for print_initialization_message must be True so
+        load_config() callers (which don't pass the argument) still see the
+        startup banner.
+        """
+        pc = self._get_proxy_config_instance()
+        config = _make_proxy_config()
+        pc.parse_search_tools(config)  # no explicit flag
+
+        captured = capsys.readouterr()
+        assert "Search Tools" in captured.out, (
+            "Default behaviour (no flag) must print the banner — "
+            f"stdout was: {captured.out!r}"
+        )
+
+    def test_returns_list_regardless_of_flag(self):
+        """
+        The return value (list of SearchToolTypedDicts) must be the same
+        whether we print or not.
+        """
+        pc = self._get_proxy_config_instance()
+        config = _make_proxy_config("exa_search", "Exa")
+        result_silent = pc.parse_search_tools(config, print_initialization_message=False)
+        result_verbose = pc.parse_search_tools(config, print_initialization_message=True)
+
+        assert result_silent == result_verbose, (
+            "parse_search_tools returned different results based on "
+            "print_initialization_message flag"
+        )
+        assert result_silent is not None and len(result_silent) == 1


### PR DESCRIPTION
## Summary

Fixes #27645.

When a search tool (e.g. Brave Search) is configured in the LiteLLM proxy, the "Proxy initialized with Search Tools" banner is printed on **every request** rather than only at startup. The spam cannot be silenced even with `set_verbose=False` or `disable_error_logs=True` because the code uses `print()` directly, bypassing all logging configuration.

### Root cause

`parse_search_tools()` in `litellm/proxy/proxy_server.py` unconditionally calls `print()` for the initialization banner:

```python
# proxy_server.py — before (simplified)
def parse_search_tools(self, config: dict) -> ...:
    ...
    print("\033[32mLiteLLM: Proxy initialized with Search Tools:\033[0m")  # noqa
    for ...:
        print(f"\033[32m    {search_tool_name} ({search_provider})\033[0m")  # noqa
```

`_update_llm_router()` calls `parse_search_tools(config_data)` on **every periodic router refresh** (not just at startup), so the banner fires on every inbound request when search tools are configured.

### Fix

Add a `print_initialization_message: bool = True` parameter and guard both `print()` calls with it. The two call-sites behave differently:

| Call-site | Value | Result |
|-----------|-------|--------|
| `load_config()` (startup) | `True` (default) | Banner still appears once at startup |
| `_update_llm_router()` (periodic refresh) | `False` | Banner suppressed on reloads |

```python
# proxy_server.py — after
def parse_search_tools(
    self,
    config: dict,
    print_initialization_message: bool = True,   # <-- new
) -> ...:
    ...
    if print_initialization_message:
        print("\033[32mLiteLLM: Proxy initialized with Search Tools:\033[0m")  # noqa
    for ...:
        if print_initialization_message:
            print(f"\033[32m    {search_tool_name} ({search_provider})\033[0m")  # noqa

# _update_llm_router — suppress on every refresh
search_tools = self.parse_search_tools(
    config_data, print_initialization_message=False
)
```

## Changes

| File | Change |
|------|--------|
| `litellm/proxy/proxy_server.py` | Add `print_initialization_message` param; guard both `print()` calls |
| `tests/proxy_unit_tests/test_parse_search_tools_log_spam.py` | New unit-test file (4 tests, no external deps) |

## Test plan

New tests in `tests/proxy_unit_tests/test_parse_search_tools_log_spam.py`:

- `test_no_print_when_flag_is_false` — `print_initialization_message=False` produces no stdout
- `test_prints_when_flag_is_true` — `print_initialization_message=True` prints the banner
- `test_default_is_true` — calling without the flag still prints (backwards-compatible default)
- `test_returns_list_regardless_of_flag` — return value is identical regardless of the flag
