### PR TITLE
fix(otel): use JSON encoding for dict/list values in OTEL span attributes

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -862,8 +862,11 @@ class OpenTelemetry(CustomLogger):
             "mcp_tool_call_metadata",
             "vector_store_request_metadata",
         ]:
-            if md.get(key) is not None:
-                common_attrs[f"metadata.{key}"] = str(md[key])
+            val = md.get(key)
+            if val is not None:
+                common_attrs[f"metadata.{key}"] = (
+                    safe_dumps(val) if isinstance(val, (dict, list)) else str(val)
+                )
 
         # get hidden params
         hidden_params = getattr(std_log, "hidden_params", None) or (std_log or {}).get(
@@ -1440,6 +1443,8 @@ class OpenTelemetry(CustomLogger):
             return ""
         if isinstance(value, (str, bool, int, float)):
             return value
+        if isinstance(value, (dict, list)):
+            return safe_dumps(value)
         try:
             return str(value)
         except Exception:

--- a/tests/proxy_unit_tests/test_otel_dict_json_encoding.py
+++ b/tests/proxy_unit_tests/test_otel_dict_json_encoding.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for the OpenTelemetry dict/list JSON encoding fix.
+
+Verifies that _cast_as_primitive_value_type serialises dict and list values
+using valid JSON (safe_dumps), not Python repr (str()).
+
+Regression: before the fix, {"key": "value"} was emitted as {'key': 'value'}
+in OTEL span attributes, making spend_logs_metadata unparseable in downstream
+observability tools (Jaeger, Honeycomb, Grafana Tempo).
+
+Fixes: https://github.com/BerriAI/litellm/issues/27451
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+
+def _get_otel_logger():
+    """Return an OpenTelemetryLogger instance without any real OTEL dependency."""
+    from litellm.integrations.opentelemetry import OpenTelemetryLogger
+
+    return OpenTelemetryLogger.__new__(OpenTelemetryLogger)
+
+
+class TestCastAsPrimitiveValueType:
+    """_cast_as_primitive_value_type must produce valid JSON for dict/list."""
+
+    def test_dict_produces_valid_json_not_repr(self):
+        """
+        A dict value must be JSON-encoded, not Python-repr'd.
+        Python repr uses single quotes; JSON uses double quotes.
+        """
+        logger = _get_otel_logger()
+        result = logger._cast_as_primitive_value_type({"key": "value"})
+
+        # Must be parseable as JSON
+        parsed = json.loads(result)
+        assert parsed == {"key": "value"}, f"Unexpected parsed value: {parsed}"
+
+        # Must NOT be Python repr (single-quoted keys)
+        assert "'key'" not in result, (
+            f"Result looks like Python repr, not JSON: {result!r}"
+        )
+
+    def test_nested_dict_produces_valid_json(self):
+        """Nested dicts (e.g. spend_logs_metadata with custom keys) must JSON-encode."""
+        logger = _get_otel_logger()
+        payload = {"env": "prod", "team": "platform", "request_id": "abc-123"}
+        result = logger._cast_as_primitive_value_type(payload)
+
+        parsed = json.loads(result)
+        assert parsed == payload
+
+    def test_list_produces_valid_json_not_repr(self):
+        """List values must also be JSON-encoded."""
+        logger = _get_otel_logger()
+        result = logger._cast_as_primitive_value_type(["a", "b", "c"])
+
+        parsed = json.loads(result)
+        assert parsed == ["a", "b", "c"]
+
+    def test_primitives_unchanged(self):
+        """str, bool, int, float must pass through without modification."""
+        logger = _get_otel_logger()
+        assert logger._cast_as_primitive_value_type("hello") == "hello"
+        assert logger._cast_as_primitive_value_type(True) is True
+        assert logger._cast_as_primitive_value_type(42) == 42
+        assert logger._cast_as_primitive_value_type(3.14) == 3.14
+
+    def test_none_returns_empty_string(self):
+        """None must return empty string (existing behaviour must be preserved)."""
+        logger = _get_otel_logger()
+        assert logger._cast_as_primitive_value_type(None) == ""
+
+    def test_dict_with_nested_list_produces_valid_json(self):
+        """Real-world spend_logs_metadata may contain lists inside dicts."""
+        logger = _get_otel_logger()
+        payload = {"tags": ["prod", "us-east"], "version": 2}
+        result = logger._cast_as_primitive_value_type(payload)
+
+        parsed = json.loads(result)
+        assert parsed == payload


### PR DESCRIPTION
## Summary

Fixes #27451.

When using the [custom spend log metadata](https://docs.litellm.ai/docs/proxy/cost_tracking#-custom-spend-log-metadata) feature, the `spend_logs_metadata` value appeared in OpenTelemetry span attributes as a Python repr string (`{'key': 'value'}`) instead of valid JSON (`{"key": "value"}`). This made the field unparseable in downstream observability tools like Jaeger, Honeycomb, and Grafana Tempo.

### Root cause

Two places in `litellm/integrations/opentelemetry.py` serialised `dict`/`list` values with `str()`, which uses Python's repr format (single-quoted keys):

**1. `_cast_as_primitive_value_type`** — generic fallback path for all non-primitive span attribute values (used by `safe_set_attribute` → `set_attributes`):

```python
# before — dict becomes {'key': 'value'} (not valid JSON)
try:
    return str(value)
except Exception:
    return ""
```

**2. `_record_metrics`** — explicit metadata loop that includes `spend_logs_metadata`, `requester_metadata`, `applied_guardrails`, etc.:

```python
# before — same str() problem
if md.get(key) is not None:
    common_attrs[f"metadata.{key}"] = str(md[key])
```

### Fix

`safe_dumps` is already imported at the top of the file and used throughout (e.g. for `hidden_params`). Adding an `isinstance(value, (dict, list))` branch before the `str()` fallback routes composite types through `safe_dumps` instead:

```python
# _cast_as_primitive_value_type — after
if isinstance(value, (dict, list)):
    return safe_dumps(value)       # valid JSON: {"key": "value"}
try:
    return str(value)
except Exception:
    return ""

# _record_metrics — after
val = md.get(key)
if val is not None:
    common_attrs[f"metadata.{key}"] = (
        safe_dumps(val) if isinstance(val, (dict, list)) else str(val)
    )
```

All primitive types (`str`, `bool`, `int`, `float`) and the `None → ""` behaviour are unchanged.

## Changes

| File | Change |
|------|--------|
| `litellm/integrations/opentelemetry.py` | Add `isinstance(dict, list)` → `safe_dumps` branch in `_cast_as_primitive_value_type` and `_record_metrics` |
| `tests/proxy_unit_tests/test_otel_dict_json_encoding.py` | New unit-test file (6 tests, no external OTEL deps) |

## Test plan

New tests in `tests/proxy_unit_tests/test_otel_dict_json_encoding.py`:

- `test_dict_produces_valid_json_not_repr` — dict is JSON-decodable, no single-quoted keys
- `test_nested_dict_produces_valid_json` — realistic spend_logs_metadata payload
- `test_list_produces_valid_json_not_repr` — lists also JSON-encoded
- `test_primitives_unchanged` — str/bool/int/float pass through unchanged
- `test_none_returns_empty_string` — existing None behaviour preserved
- `test_dict_with_nested_list_produces_valid_json` — dict containing list
