### PR TITLE
fix(http): coerce extra_headers values to str to prevent TypeError on float headers

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -171,6 +171,9 @@ class BaseLLMHTTPHandler:
         )
 
         response: Optional[httpx.Response] = None
+        # httpx requires header values to be str or bytes; coerce any non-string
+        # values (e.g. float from YAML-parsed extra_headers) to avoid TypeError.
+        headers = {k: str(v) for k, v in headers.items()}
         for i in range(max(max_retry_on_unprocessable_entity_error, 1)):
             try:
                 response = await async_httpx_client.post(
@@ -230,6 +233,9 @@ class BaseLLMHTTPHandler:
         )
 
         response: Optional[httpx.Response] = None
+        # httpx requires header values to be str or bytes; coerce any non-string
+        # values (e.g. float from YAML-parsed extra_headers) to avoid TypeError.
+        headers = {k: str(v) for k, v in headers.items()}
 
         for i in range(max(max_retry_on_unprocessable_entity_error, 1)):
             try:


### PR DESCRIPTION
## Summary

Fixes #27458.

When `extra_headers` in a `config.yaml` model entry contains a numeric value (YAML parses bare numbers without quotes as `int` or `float`), httpx raises:

```
Header value must be str or bytes, not <class 'float'>
```

This crashes every request for that model group with a 500, even though the header value is semantically valid.

### Root cause

`_make_common_async_call` and `_make_common_sync_call` (`litellm/llms/custom_httpx/llm_http_handler.py`) receive the merged `headers` dict and pass it directly to `httpx.AsyncClient.post()` / `httpx.Client.post()` without any type validation. httpx enforces that all header values are `str` or `bytes`:

```yaml
# config.yaml — triggers the bug
model_list:
  - model_name: kimi-k2.6
    litellm_params:
      model: hosted_vllm/kimi-k2.6
      extra_headers:
        x-some-header: 1.5   # ← YAML parses this as float, not str
```

### Fix

Add a one-line coercion in both `_make_common_async_call` and `_make_common_sync_call`, before the retry loop:

```python
# httpx requires header values to be str or bytes; coerce any non-string
# values (e.g. float from YAML-parsed extra_headers) to avoid TypeError.
headers = {k: str(v) for k, v in headers.items()}
```

These are the common HTTP call bottlenecks for all providers and all call types (chat, embedding, image, audio, etc.), so a single fix in each covers every path without touching any provider-specific code.

## Changes

| File | Change |
|------|--------|
| `litellm/llms/custom_httpx/llm_http_handler.py` | Add `{k: str(v)}` coercion before the retry loop in `_make_common_async_call` and `_make_common_sync_call` |
