### PR TITLE
chore(ci): make Guard main branch re-evaluate on base changes

### DIFF
--- a/.github/workflows/guard-main-branch.yml
+++ b/.github/workflows/guard-main-branch.yml
@@ -2,10 +2,6 @@ name: Guard main branch
 
 on:
   pull_request:
-    # Listen on all PRs so that base-branch edits retrigger this workflow.
-    # The job below short-circuits when base != main, so non-main PRs stay
-    # cheap (a few seconds) while a PR retargeted away from main produces a
-    # fresh passing run that supersedes any earlier failed one.
     types: [opened, synchronize, reopened, edited]
   merge_group:
 

--- a/.github/workflows/guard-main-branch.yml
+++ b/.github/workflows/guard-main-branch.yml
@@ -2,8 +2,11 @@ name: Guard main branch
 
 on:
   pull_request:
-    branches:
-      - main
+    # Listen on all PRs so that base-branch edits retrigger this workflow.
+    # The job below short-circuits when base != main, so non-main PRs stay
+    # cheap (a few seconds) while a PR retargeted away from main produces a
+    # fresh passing run that supersedes any earlier failed one.
+    types: [opened, synchronize, reopened, edited]
   merge_group:
 
 permissions: {}
@@ -25,11 +28,17 @@ jobs:
       - name: Check head branch name
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
         run: |
           echo "PR head repo: $HEAD_REPO"
           echo "PR head branch: $HEAD_REF"
+          echo "PR base branch: $BASE_REF"
+          if [ "$BASE_REF" != "main" ]; then
+            echo "Base is '$BASE_REF', not 'main' — branch-name guard does not apply."
+            exit 0
+          fi
           if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
             echo "::error::PRs to main must originate from the canonical repository ($BASE_REPO), not a fork ($HEAD_REPO). External contributors should open PRs against the 'litellm_oss_branch' branch instead."
             exit 1


### PR DESCRIPTION
## Summary

`Guard main branch` (`.github/workflows/guard-main-branch.yml`) currently uses `pull_request.branches: [main]` to gate execution. That filter only matches when the PR's *current* base is `main`. When a PR is opened against `main` and later retargeted (e.g. to `litellm_internal_staging`), the workflow does not refire, so the earlier failed run sticks on the PR even though the branch-name rule no longer applies. This bit #27775, where the PR was briefly opened against `main` before flipping to `litellm_internal_staging`.

## Fix

Drop the `branches: [main]` filter, add `edited` to `types` so base changes retrigger the workflow, and short-circuit inside the job when `github.base_ref != main`. Main-targeted PRs still get the existing head-repo and branch-name checks unchanged; non-main PRs exit cleanly in a few seconds, and a base flip away from `main` produces a fresh passing run that supersedes the old failing status on the PR.

Job name (`Verify PR source branch`) is preserved, so the existing branch-protection requirement on `main` keeps working.

## Files touched

- `.github/workflows/guard-main-branch.yml` — adjust trigger to listen on all PR events (`opened, synchronize, reopened, edited`), add `BASE_REF` to env, exit 0 early when base != main.

## Test plan

- [x] YAML diff is minimal — only the trigger filter and a new base-ref guard at the top of the script
- [ ] Once merged, this PR's own run on `litellm_internal_staging` should pass (`base != main` short-circuit). If we ever rebase another PR onto `main` and back, the run history on the PR should end on a green status

## Type

🛠️ CI / Infra

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a GitHub Actions workflow trigger and adds an early-exit for non-`main` PR bases, without changing application/runtime code paths.
> 
> **Overview**
> Updates the `Guard main branch` GitHub Actions workflow to re-evaluate when a PR’s base branch changes by listening to additional `pull_request` event types (including `edited`) instead of filtering on `branches: [main]`.
> 
> Adds a `github.base_ref` check inside the job to **skip the guard** (exit 0) when the PR is not targeting `main`, while keeping the existing fork and source-branch restrictions for PRs that do target `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8358c9a21d04669ae6c96c1eb4cb5b0876c7b2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->