### PR TITLE
feat(proxy): authorize caller-supplied tags against key/team metadata.tags

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4044,6 +4044,11 @@ async def _tag_max_budget_check(
         BudgetExceededError if any tag is over its max budget.
         Triggers a budget alert if any tag is over its max budget.
     """
+    from litellm.proxy.auth.tag_authorization import (
+        ensure_fresh_privileged_tags,
+        filter_authorized_tags,
+        get_privileged_tags_snapshot,
+    )
     from litellm.proxy.common_utils.http_parsing_utils import get_tags_from_request_body
 
     if prisma_client is None:
@@ -4051,6 +4056,19 @@ async def _tag_max_budget_check(
 
     # Get tags from request metadata
     tags = get_tags_from_request_body(request_body=request_body)
+    if not tags:
+        return
+
+    # Filter out privileged tags the caller is not authorized to claim,
+    # so an unauthorized caller cannot trigger budget enforcement against
+    # a tag bucket owned by another team. Non-privileged tags pass through.
+    await ensure_fresh_privileged_tags()
+    tags = filter_authorized_tags(
+        tags,
+        get_privileged_tags_snapshot(),
+        getattr(valid_token, "metadata", None) if valid_token else None,
+        getattr(valid_token, "team_metadata", None) if valid_token else None,
+    )
     if not tags:
         return
 

--- a/litellm/proxy/auth/tag_authorization.py
+++ b/litellm/proxy/auth/tag_authorization.py
@@ -1,0 +1,137 @@
+"""
+Authorization gate for caller-supplied tags.
+
+A tag is "privileged" if it is wired to one of:
+  - a deployment's ``litellm_params.tags`` (used by tag-based routing), or
+  - a row in ``LiteLLM_TagTable`` with a non-null ``budget_id`` (used by
+    tag-budget enforcement).
+
+For privileged tags, callers must be authorized via a glob pattern in
+``key.metadata.tags`` or ``team_metadata.tags``. Non-privileged tags pass
+through unchanged; the caller's analytics tags (the common case) are
+unaffected.
+
+The privileged-tag set is cached in memory with a short TTL so the hot
+path remains I/O-free. The cache reads from ``llm_router.model_list``
+(already in memory) and one indexed scan of ``LiteLLM_TagTable``.
+"""
+
+import asyncio
+import fnmatch
+import time
+from typing import Any, FrozenSet, Iterable, List, Optional
+
+# How long the privileged-tag snapshot is considered fresh. Changes to
+# deployments or the tag table take effect within this window.
+_CACHE_TTL_SECONDS = 30.0
+
+_cache_built_at: float = 0.0
+_privileged_tags: FrozenSet[str] = frozenset()
+_cache_lock = asyncio.Lock()
+
+
+async def _rebuild_cache() -> None:
+    """Snapshot the current privileged-tag set from router + tag table."""
+    global _cache_built_at, _privileged_tags
+
+    new_set: set = set()
+
+    # Deferred imports to keep the proxy boot graph clean — this module is
+    # imported by router code that is itself imported during proxy_server
+    # construction.
+    try:
+        from litellm.proxy.proxy_server import llm_router
+    except Exception:
+        llm_router = None
+    if llm_router is not None:
+        for deployment in llm_router.model_list or []:
+            params = deployment.get("litellm_params") or {}
+            for t in params.get("tags") or []:
+                if isinstance(t, str):
+                    new_set.add(t)
+
+    try:
+        from litellm.proxy.proxy_server import prisma_client
+    except Exception:
+        prisma_client = None
+    if prisma_client is not None and getattr(prisma_client, "db", None) is not None:
+        try:
+            rows = await prisma_client.db.litellm_tagtable.find_many(
+                where={"budget_id": {"not": None}}
+            )
+            for r in rows:
+                tag_name = getattr(r, "tag_name", None)
+                if isinstance(tag_name, str):
+                    new_set.add(tag_name)
+        except Exception:
+            # Never fail the request path on a cache rebuild error. The worst
+            # case is a stale (or empty) snapshot — tags pass through.
+            pass
+
+    _privileged_tags = frozenset(new_set)
+    _cache_built_at = time.time()
+
+
+async def ensure_fresh_privileged_tags() -> None:
+    """Rebuild the privileged-tag snapshot if the TTL has expired."""
+    if time.time() - _cache_built_at <= _CACHE_TTL_SECONDS:
+        return
+    async with _cache_lock:
+        if time.time() - _cache_built_at <= _CACHE_TTL_SECONDS:
+            return
+        await _rebuild_cache()
+
+
+def get_privileged_tags_snapshot() -> FrozenSet[str]:
+    """Return the most recent cached snapshot. Safe to call from sync code."""
+    return _privileged_tags
+
+
+def caller_authorized_for_tag(
+    tag: str,
+    *metadata_sources: Optional[Any],
+) -> bool:
+    """
+    Return True iff ``tag`` matches any ``fnmatch`` pattern listed under
+    ``tags`` in any of the provided metadata sources.
+
+    Each source may be a dict (key/team/project metadata) or None.
+    Sources that aren't dicts or don't carry a list under ``tags`` are
+    skipped silently.
+    """
+    for meta in metadata_sources:
+        if not isinstance(meta, dict):
+            continue
+        patterns = meta.get("tags") or []
+        if not isinstance(patterns, list):
+            continue
+        for pattern in patterns:
+            if isinstance(pattern, str) and fnmatch.fnmatchcase(tag, pattern):
+                return True
+    return False
+
+
+def filter_authorized_tags(
+    tags: Optional[Iterable[str]],
+    privileged_tags: FrozenSet[str],
+    *metadata_sources: Optional[Any],
+) -> List[str]:
+    """
+    Return the subset of ``tags`` the caller is allowed to use.
+
+    A tag survives the filter iff either:
+      - it is not in ``privileged_tags`` (passes through unchanged), or
+      - the caller has a glob pattern in one of the metadata sources that
+        matches the tag.
+    """
+    if not tags:
+        return []
+    out: List[str] = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        if tag not in privileged_tags:
+            out.append(tag)
+        elif caller_authorized_for_tag(tag, *metadata_sources):
+            out.append(tag)
+    return out

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1437,46 +1437,8 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     if not _key_or_team_allows_client_pricing_override(user_api_key_dict):
         _strip_client_pricing_overrides(data)
 
-    # Strip caller-supplied routing/budget tags unless the admin has opted
-    # this key or team in via metadata.allow_client_tags=True. Tags drive
-    # tag-based routing and tag budget attribution — accepting them from
-    # untrusted callers lets an attacker reach restricted deployments or
-    # misattribute spend to a victim team's tag.
-    _admin_allow_client_tags = False
-    for _admin_meta in (
-        user_api_key_dict.metadata,
-        user_api_key_dict.team_metadata,
-    ):
-        if (
-            isinstance(_admin_meta, dict)
-            and _admin_meta.get("allow_client_tags") is True
-        ):
-            _admin_allow_client_tags = True
-            break
-    if not _admin_allow_client_tags:
-        _stripped_from: List[str] = []
-        for _meta_key in ("metadata", "litellm_metadata"):
-            _user_meta = data.get(_meta_key)
-            if isinstance(_user_meta, dict) and "tags" in _user_meta:
-                _user_meta.pop("tags", None)
-                _stripped_from.append(_meta_key)
-        # Also strip the root-level `tags` field. get_tags_from_request_body
-        # reads request_body["tags"] directly and feeds it to the policy
-        # engine, so leaving it in place here would let the strip-in-metadata
-        # above be trivially bypassed by moving the tags to the body root.
-        if "tags" in data:
-            data.pop("tags", None)
-            _stripped_from.append("tags (root)")
-        if _stripped_from:
-            verbose_proxy_logger.warning(
-                "Stripped caller-supplied tags from %s: this key/team does "
-                "not have `allow_client_tags: true` in its metadata. Set it "
-                "to opt into client-supplied routing/budget tags.",
-                ", ".join(_stripped_from),
-            )
-
     # Fill in the proxy_server_request body snapshot now that metadata has
-    # been parsed and stripped. Consumers (standard_logging_payload, lago,
+    # been parsed. Consumers (standard_logging_payload, lago,
     # spend_tracking_utils, streaming_iterator) read `body` to audit the
     # request; taking the snapshot here ensures they see cleaned metadata.
     #
@@ -1665,26 +1627,18 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         user_agent = request.headers["user-agent"]
     data[_metadata_variable_name]["user_agent"] = user_agent
 
-    # Check if using tag based routing. The helper reads caller-controlled
-    # sources (x-litellm-tags header, data["tags"] root-level), so its result
-    # is still gated by the same allow_client_tags flag that gated the
-    # body-metadata tag strip above. Otherwise the strip is trivially
-    # bypassed by sending tags via header or at the root of the body.
+    # Merge caller-supplied tags (x-litellm-tags header, data["tags"] root-level)
+    # into request metadata for tag-based routing and spend attribution.
     tags = LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
         llm_router=llm_router,
         headers=_headers,
         data=data,
     )
 
-    if tags is not None and _admin_allow_client_tags:
+    if tags is not None:
         data[_metadata_variable_name]["tags"] = LiteLLMProxyRequestSetup._merge_tags(
             request_tags=data[_metadata_variable_name].get("tags"),
             tags_to_add=tags,
-        )
-    elif tags is not None:
-        verbose_proxy_logger.warning(
-            "Ignored caller-supplied tags from header/root body: this "
-            "key/team does not have `allow_client_tags: true` in its metadata."
         )
 
     # Team Callbacks controls

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -10,6 +10,11 @@ import re
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from litellm._logging import verbose_logger
+from litellm.proxy.auth.tag_authorization import (
+    ensure_fresh_privileged_tags,
+    filter_authorized_tags,
+    get_privileged_tags_snapshot,
+)
 from litellm.types.router import RouterErrors
 
 if TYPE_CHECKING:
@@ -160,6 +165,21 @@ async def get_deployments_for_tag(
         metadata = request_kwargs[metadata_variable_name]
         request_tags = metadata.get("tags")
         match_any = llm_router_instance.tag_filtering_match_any
+
+        # Drop caller-supplied tags the caller is not authorized to claim.
+        # A tag is "privileged" if some deployment lists it under
+        # ``litellm_params.tags`` or a budget is attached to it in
+        # ``LiteLLM_TagTable``. The caller must hold a glob pattern in
+        # ``key.metadata.tags`` / ``team_metadata.tags`` that matches the
+        # privileged tag. Non-privileged tags pass through unchanged.
+        if request_tags:
+            await ensure_fresh_privileged_tags()
+            request_tags = filter_authorized_tags(
+                request_tags,
+                get_privileged_tags_snapshot(),
+                metadata.get("user_api_key_metadata"),
+                metadata.get("user_api_key_team_metadata"),
+            )
 
         # Build header strings for regex matching from what the proxy already stores.
         # Currently we match against User-Agent; format matches "^User-Agent: claude-code/..."

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -167,13 +167,9 @@ async def test_add_key_or_team_level_spend_logs_metadata_to_request(
 
     print(f"team_sl_metadata: {team_sl_metadata}")
     mock_request.url.path = "/chat/completions"
-    # Opt the key into client-supplied tags so request_tags are preserved
-    # and merged with admin-configured key/team tags. Without this flag,
-    # request_tags would be stripped by add_litellm_data_to_request.
     key_metadata = {
         "tags": key_tags,
         "spend_logs_metadata": key_sl_metadata,
-        "allow_client_tags": True,
     }
     team_metadata = {
         "tags": team_tags,
@@ -909,13 +905,12 @@ async def test_add_litellm_data_to_request_duplicate_tags(
     mock_request.headers = {}
     mock_request.state = State()
 
-    # Setup key with tags in metadata. Opt into client-supplied tags so the
-    # request_tags are preserved for the merge under test.
+    # Setup key with tags in metadata.
     user_api_key_dict = UserAPIKeyAuth(
         api_key="test_api_key",
         user_id="test_user_id",
         org_id="test_org_id",
-        metadata={"tags": key_tags, "allow_client_tags": True},
+        metadata={"tags": key_tags},
     )
 
     # Setup request data with tags

--- a/tests/test_litellm/proxy/auth/test_tag_authorization.py
+++ b/tests/test_litellm/proxy/auth/test_tag_authorization.py
@@ -1,0 +1,113 @@
+"""Unit tests for the tag-authorization gate."""
+
+from litellm.proxy.auth.tag_authorization import (
+    caller_authorized_for_tag,
+    filter_authorized_tags,
+)
+
+
+class TestCallerAuthorizedForTag:
+    def test_no_metadata_sources(self):
+        assert caller_authorized_for_tag("premium") is False
+
+    def test_none_metadata_source_is_skipped(self):
+        assert caller_authorized_for_tag("premium", None) is False
+
+    def test_non_dict_metadata_source_is_skipped(self):
+        assert caller_authorized_for_tag("premium", "not-a-dict") is False  # type: ignore[arg-type]
+
+    def test_exact_match(self):
+        assert caller_authorized_for_tag("premium", {"tags": ["premium"]}) is True
+
+    def test_no_match(self):
+        assert caller_authorized_for_tag("premium", {"tags": ["other"]}) is False
+
+    def test_glob_wildcard_suffix(self):
+        assert caller_authorized_for_tag("tenant:acme", {"tags": ["tenant:*"]}) is True
+
+    def test_glob_does_not_match_across_separator_when_anchored(self):
+        # `prefix-*` matches any suffix; the user picks the pattern.
+        assert (
+            caller_authorized_for_tag("tenant:acme:sub", {"tags": ["tenant:*"]}) is True
+        )
+
+    def test_universal_wildcard_matches_everything(self):
+        assert caller_authorized_for_tag("anything", {"tags": ["*"]}) is True
+
+    def test_matches_from_second_source(self):
+        # key metadata empty, team metadata grants
+        assert (
+            caller_authorized_for_tag(
+                "premium",
+                {"tags": []},
+                {"tags": ["premium"]},
+            )
+            is True
+        )
+
+    def test_pattern_must_be_string(self):
+        assert (
+            caller_authorized_for_tag(
+                "premium", {"tags": ["premium", 123, None]}  # type: ignore[list-item]
+            )
+            is True
+        )
+        assert (
+            caller_authorized_for_tag(
+                "other", {"tags": [123, None]}  # type: ignore[list-item]
+            )
+            is False
+        )
+
+    def test_tags_field_not_a_list_is_skipped(self):
+        assert caller_authorized_for_tag("premium", {"tags": "premium"}) is False
+
+
+class TestFilterAuthorizedTags:
+    def test_empty_input(self):
+        assert filter_authorized_tags(None, frozenset(), {}) == []
+        assert filter_authorized_tags([], frozenset(), {}) == []
+
+    def test_non_privileged_tags_pass_through(self):
+        # privileged set is empty → every caller tag passes
+        result = filter_authorized_tags(["analytics", "session:42"], frozenset(), {})
+        assert result == ["analytics", "session:42"]
+
+    def test_privileged_tag_without_authorization_dropped(self):
+        result = filter_authorized_tags(
+            ["premium", "analytics"], frozenset({"premium"}), {"tags": []}
+        )
+        assert result == ["analytics"]
+
+    def test_privileged_tag_with_authorization_kept(self):
+        result = filter_authorized_tags(
+            ["premium", "analytics"],
+            frozenset({"premium"}),
+            {"tags": ["premium"]},
+        )
+        assert result == ["premium", "analytics"]
+
+    def test_glob_authorization(self):
+        result = filter_authorized_tags(
+            ["tenant:acme", "tenant:globex", "internal"],
+            frozenset({"tenant:acme", "tenant:globex", "internal"}),
+            {"tags": ["tenant:*"]},
+        )
+        assert result == ["tenant:acme", "tenant:globex"]
+
+    def test_mixed_privileged_and_not(self):
+        result = filter_authorized_tags(
+            ["premium", "tenant:acme", "workflow:report-gen"],
+            frozenset({"premium", "tenant:acme"}),
+            {"tags": ["tenant:*"]},
+        )
+        # premium: privileged, not authorized → dropped
+        # tenant:acme: privileged, glob-authorized → kept
+        # workflow:report-gen: not privileged → kept
+        assert result == ["tenant:acme", "workflow:report-gen"]
+
+    def test_non_string_input_filtered(self):
+        result = filter_authorized_tags(
+            ["a", 1, None, "b"], frozenset(), {}  # type: ignore[list-item]
+        )
+        assert result == ["a", "b"]

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -874,101 +874,8 @@ async def test_add_litellm_data_to_request_allows_redaction_opt_out_with_admin_o
 
 
 @pytest.mark.asyncio
-async def test_add_litellm_data_to_request_ignores_x_litellm_tags_header_without_permission():
-    """Regression: the `x-litellm-tags` header bypassed the body-metadata
-    tag strip. Header tags must also be gated by `allow_client_tags`."""
-    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-
-    request_mock = MagicMock(spec=Request)
-    request_mock.url.path = "/v1/chat/completions"
-    request_mock.url = MagicMock()
-    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
-    request_mock.method = "POST"
-    request_mock.query_params = {}
-    request_mock.headers = {
-        "Content-Type": "application/json",
-        "x-litellm-tags": "restricted-tier,victim-team",
-    }
-    request_mock.client = MagicMock()
-    request_mock.client.host = "127.0.0.1"
-
-    data = {"model": "gpt-3.5-turbo"}
-
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="hashed-key",
-        metadata={},
-        team_metadata={},
-        spend=0.0,
-        max_budget=100.0,
-        model_max_budget={},
-        team_spend=0.0,
-        team_max_budget=200.0,
-    )
-
-    updated = await add_litellm_data_to_request(
-        data=data,
-        request=request_mock,
-        user_api_key_dict=user_api_key_dict,
-        proxy_config=MagicMock(),
-        general_settings={},
-        version="test-version",
-    )
-
-    assert "tags" not in (updated.get("metadata") or {})
-
-
-@pytest.mark.asyncio
-async def test_add_litellm_data_to_request_ignores_root_level_tags_without_permission():
-    """Regression: root-level `data["tags"]` bypassed the body-metadata
-    tag strip. Root-level tags must also be gated by `allow_client_tags`."""
-    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-
-    request_mock = MagicMock(spec=Request)
-    request_mock.url.path = "/v1/chat/completions"
-    request_mock.url = MagicMock()
-    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
-    request_mock.method = "POST"
-    request_mock.query_params = {}
-    request_mock.headers = {"Content-Type": "application/json"}
-    request_mock.client = MagicMock()
-    request_mock.client.host = "127.0.0.1"
-
-    data = {
-        "model": "gpt-3.5-turbo",
-        "tags": ["restricted-tier", "victim-team"],
-    }
-
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="hashed-key",
-        metadata={},
-        team_metadata={},
-        spend=0.0,
-        max_budget=100.0,
-        model_max_budget={},
-        team_spend=0.0,
-        team_max_budget=200.0,
-    )
-
-    updated = await add_litellm_data_to_request(
-        data=data,
-        request=request_mock,
-        user_api_key_dict=user_api_key_dict,
-        proxy_config=MagicMock(),
-        general_settings={},
-        version="test-version",
-    )
-
-    assert "tags" not in (updated.get("metadata") or {})
-    # Also ensure the root-level tags are removed. get_tags_from_request_body
-    # reads request_body["tags"] directly, so leaving it in place would let
-    # the policy engine see caller-supplied tags even after the metadata
-    # strip.
-    assert "tags" not in updated
-
-
-@pytest.mark.asyncio
-async def test_add_litellm_data_to_request_honors_header_tags_when_opted_in():
-    """When allow_client_tags=True, header-supplied tags flow through."""
+async def test_add_litellm_data_to_request_honors_header_tags():
+    """Header-supplied tags flow through to request metadata."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -988,7 +895,7 @@ async def test_add_litellm_data_to_request_honors_header_tags_when_opted_in():
 
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={"allow_client_tags": True},
+        metadata={},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,
@@ -1010,11 +917,8 @@ async def test_add_litellm_data_to_request_honors_header_tags_when_opted_in():
 
 
 @pytest.mark.asyncio
-async def test_add_litellm_data_to_request_strips_user_tags_without_permission():
-    """Caller-supplied metadata.tags must be stripped when the key/team
-    metadata does not opt in via allow_client_tags=True. Otherwise an
-    attacker can reach restricted tag-routed deployments or attribute
-    spend to a victim team's tag."""
+async def test_add_litellm_data_to_request_preserves_caller_metadata_tags():
+    """Caller-supplied metadata.tags are preserved and reach the router."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -1029,8 +933,7 @@ async def test_add_litellm_data_to_request_strips_user_tags_without_permission()
 
     data = {
         "model": "gpt-3.5-turbo",
-        "metadata": {"tags": ["restricted-tier", "victim-team"]},
-        "litellm_metadata": {"tags": ["also-stripped"]},
+        "metadata": {"tags": ["caller-tag"]},
     }
 
     user_api_key_dict = UserAPIKeyAuth(
@@ -1053,101 +956,13 @@ async def test_add_litellm_data_to_request_strips_user_tags_without_permission()
         version="test-version",
     )
 
-    assert "tags" not in (updated.get("metadata") or {})
-    assert "tags" not in (updated.get("litellm_metadata") or {})
-
-
-@pytest.mark.asyncio
-async def test_add_litellm_data_to_request_preserves_user_tags_when_key_opts_in():
-    """When key.metadata.allow_client_tags=True, caller-supplied tags are
-    preserved and reach the router."""
-    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-
-    request_mock = MagicMock(spec=Request)
-    request_mock.url.path = "/v1/chat/completions"
-    request_mock.url = MagicMock()
-    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
-    request_mock.method = "POST"
-    request_mock.query_params = {}
-    request_mock.headers = {"Content-Type": "application/json"}
-    request_mock.client = MagicMock()
-    request_mock.client.host = "127.0.0.1"
-
-    data = {
-        "model": "gpt-3.5-turbo",
-        "metadata": {"tags": ["opted-in-tag"]},
-    }
-
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="hashed-key",
-        metadata={"allow_client_tags": True},
-        team_metadata={},
-        spend=0.0,
-        max_budget=100.0,
-        model_max_budget={},
-        team_spend=0.0,
-        team_max_budget=200.0,
-    )
-
-    updated = await add_litellm_data_to_request(
-        data=data,
-        request=request_mock,
-        user_api_key_dict=user_api_key_dict,
-        proxy_config=MagicMock(),
-        general_settings={},
-        version="test-version",
-    )
-
-    assert updated["metadata"].get("tags") == ["opted-in-tag"]
-
-
-@pytest.mark.asyncio
-async def test_add_litellm_data_to_request_preserves_user_tags_when_team_opts_in():
-    """Team-level allow_client_tags is also honored (not just key-level)."""
-    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-
-    request_mock = MagicMock(spec=Request)
-    request_mock.url.path = "/v1/chat/completions"
-    request_mock.url = MagicMock()
-    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
-    request_mock.method = "POST"
-    request_mock.query_params = {}
-    request_mock.headers = {"Content-Type": "application/json"}
-    request_mock.client = MagicMock()
-    request_mock.client.host = "127.0.0.1"
-
-    data = {
-        "model": "gpt-3.5-turbo",
-        "metadata": {"tags": ["team-allowed"]},
-    }
-
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="hashed-key",
-        metadata={},
-        team_metadata={"allow_client_tags": True},
-        spend=0.0,
-        max_budget=100.0,
-        model_max_budget={},
-        team_spend=0.0,
-        team_max_budget=200.0,
-    )
-
-    updated = await add_litellm_data_to_request(
-        data=data,
-        request=request_mock,
-        user_api_key_dict=user_api_key_dict,
-        proxy_config=MagicMock(),
-        general_settings={},
-        version="test-version",
-    )
-
-    assert updated["metadata"].get("tags") == ["team-allowed"]
+    assert updated["metadata"].get("tags") == ["caller-tag"]
 
 
 @pytest.mark.asyncio
 async def test_add_litellm_data_to_request_unions_caller_header_tags_with_static_key_tags():
     """Caller-supplied `x-litellm-tags` must union with static key-level
-    tags, not overwrite them, when `allow_client_tags=True`."""
+    tags, not overwrite them."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -1167,10 +982,7 @@ async def test_add_litellm_data_to_request_unions_caller_header_tags_with_static
 
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={
-            "allow_client_tags": True,
-            "tags": ["team:platform", "env:prod"],
-        },
+        metadata={"tags": ["team:platform", "env:prod"]},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,
@@ -1217,10 +1029,7 @@ async def test_add_litellm_data_to_request_unions_caller_header_tags_with_static
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
         metadata={},
-        team_metadata={
-            "allow_client_tags": True,
-            "tags": ["team:eng", "owner:platform"],
-        },
+        team_metadata={"tags": ["team:eng", "owner:platform"]},
         spend=0.0,
         max_budget=100.0,
         model_max_budget={},
@@ -1266,10 +1075,7 @@ async def test_add_litellm_data_to_request_unions_dedups_overlapping_caller_and_
 
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={
-            "allow_client_tags": True,
-            "tags": ["env:prod", "team:platform"],
-        },
+        metadata={"tags": ["env:prod", "team:platform"]},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,
@@ -1364,11 +1170,9 @@ async def test_add_litellm_data_to_request_audio_transcription_multipart():
         "file": b"Fake audio bytes",
     }
 
-    # Opt the key in to client-supplied tags so the parsed tags from the
-    # JSON-string multipart body aren't stripped by the admin-injection strip.
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={"allow_client_tags": True},
+        metadata={},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,


### PR DESCRIPTION
## Summary

Restores tag-based routing and tag-based spend attribution for caller-supplied tags (`x-litellm-tags` header, body `tags`, `metadata.tags`), then gates the privileged paths so unauthorized callers cannot reach tag-routed deployments or pollute tag-budget buckets owned by other callers.

Two commits, designed to read in order:

1. **`fix(proxy): always merge caller-supplied tags into request metadata`** — removes the `allow_client_tags` strip + merge gate. Caller tags flow unconditionally into request metadata. Documented routing and spend-attribution paths work again.
2. **`feat(proxy): authorize caller-supplied tags against key/team metadata.tags`** — adds an authorization gate at the two privileged consumers (tag-based routing and tag-budget enforcement). Reuses the existing `metadata.tags` field as the caller's authorized set, with `fnmatch` glob support.

## How the authorization gate works

A caller-supplied tag is honored for tag-based routing and tag-budget enforcement only when one of:

- the tag is **not privileged** — no deployment uses it (`litellm_params.tags`), no budget is attached to it (`LiteLLM_TagTable.budget_id`); OR
- one of `key.metadata.tags` / `team_metadata.tags` carries a `fnmatch` glob pattern that matches the tag.

The privileged-tag set is auto-detected from existing router state and tag-table rows. It is cached in memory with a 30-second TTL — zero per-request DB hits on the hot path.

### Examples

| Key metadata | Caller sends | Outcome (privileged tag) | Outcome (non-privileged tag) |
|---|---|---|---|
| `{}` | `x-litellm-tags: premium` | dropped (no grant) | passes through |
| `{"tags": ["premium"]}` | `x-litellm-tags: premium` | honored — routes to premium deployment | passes through |
| `{"tags": ["tenant:*"]}` | `x-litellm-tags: tenant:acme` | honored via glob | passes through |
| `{"tags": ["tenant:*"]}` | `x-litellm-tags: premium` | dropped (no matching glob) | n/a |

## What changed

| File | Change |
|---|---|
| `litellm/proxy/litellm_pre_call_utils.py` | Delete the `allow_client_tags` strip block + the gated header merge |
| `litellm/proxy/auth/tag_authorization.py` | **New** — `caller_authorized_for_tag`, `filter_authorized_tags`, in-memory privileged-tag cache |
| `litellm/router_strategy/tag_based_routing.py` | Filter `request_tags` through the authorization gate before per-deployment matching |
| `litellm/proxy/auth/auth_checks.py` | Filter `tags` in `_tag_max_budget_check` before tag-budget batch lookup |
| `tests/test_litellm/proxy/auth/test_tag_authorization.py` | **New** — 18 unit tests covering exact-match, glob, multi-source, defensive handling |
| `tests/test_litellm/proxy/test_litellm_pre_call_utils.py` | Drop 3 dead-path tests, clean fixtures (from commit 1) |
| `tests/proxy_unit_tests/test_proxy_utils.py` | Fixture cleanup (from commit 1) |

## Migration

No schema change. No new config field.

For customers using the existing tag features:

| Customer setup | Migration |
|---|---|
| Uses tags only for spend attribution / analytics | **None** — non-privileged tags pass through |
| Uses tag-routing or tag-budgets | Set `metadata.tags = ["pattern"]` on keys that should claim privileged tags; one `/key/update` per key |

## Hot-path cost

- Per-request: one frozenset lookup per caller tag + a handful of `fnmatch.fnmatchcase` calls
- Cache rebuild: at most once per 30 seconds; reads `llm_router.model_list` (in-memory) + one indexed scan of `LiteLLM_TagTable`
- Per-request DB hits: **zero**

## Test plan

End-to-end verification against a running proxy with two `tag-routed` deployments (`["premium"]`, `["tenant:acme"]`) and one default deployment:

- [x] `K_NO` (no `metadata.tags`) sends `x-litellm-tags: premium` → falls back to default (was reaching premium before)
- [x] `K_NO` sends `x-litellm-tags: tenant:acme` → falls back to default (was reaching acme before)
- [x] `K_NO` sends `x-litellm-tags: workflow:report-gen` → non-privileged, recorded in spend log `request_tags`
- [x] `K_PREMIUM` (`metadata.tags=["premium"]`) sends `x-litellm-tags: premium` → routes to premium deployment
- [x] `K_TENANT` (`metadata.tags=["tenant:*"]`) sends `x-litellm-tags: tenant:acme` → glob authorizes → routes to acme
- [x] `K_NO` sends no tags → 200 + default model response

Pytest:
- [x] `tests/test_litellm/proxy/auth/test_tag_authorization.py` — 18 passed
- [x] `tests/test_litellm/router_strategy/test_router_tag_routing.py` — 21 passed
- [x] `tests/test_litellm/router_strategy/test_router_tag_regex_routing.py` — 6 passed
- [x] `tests/test_litellm/proxy/auth/test_auth_checks.py` — 116 passed
- [x] `tests/test_litellm/proxy/test_litellm_pre_call_utils.py` — 125 passed