### PR TITLE
fix(tests): swap dall-e to gpt-image-1 after openai deprecation

### DIFF
--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -38,9 +38,9 @@ model_list:
     model_info:
       mode: embedding
       base_model: text-embedding-ada-002
-  - model_name: dall-e-2 # some tests use dall-e-2 which is now deprecated, alias to dall-e-3
+  - model_name: dall-e-2 # dall-e-2 and dall-e-3 were deprecated 2026-05-12; alias to gpt-image-1
     litellm_params:
-      model: openai/dall-e-3
+      model: openai/gpt-image-1
   - model_name: openai-dall-e-3
     litellm_params:
       model: dall-e-3

--- a/tests/image_gen_tests/test_image_edits.py
+++ b/tests/image_gen_tests/test_image_edits.py
@@ -133,20 +133,6 @@ class TestOpenAIImageEditGPTImage1(BaseLLMImageEditTest):
         }
 
 
-class TestOpenAIImageEditDallE2(BaseLLMImageEditTest):
-    """
-    Concrete implementation of BaseLLMImageEditTest for OpenAI DALL-E-2 image edits.
-    DALL-E-2 only supports a single image (not an array).
-    """
-
-    def get_base_image_edit_call_args(self) -> dict:
-        """Return base call args for OpenAI DALL-E-2 image edit (single image only)"""
-        return {
-            "model": "dall-e-2",
-            "image": SINGLE_TEST_IMAGE,
-        }
-
-
 class TestAzureAIFlux2ImageEdit(BaseLLMImageEditTest):
     """
     Concrete implementation of BaseLLMImageEditTest for Azure AI FLUX 2 image edits.

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -163,11 +163,6 @@ class TestBedrockNovaCanvasColorGuidedGeneration(BaseImageGenTest):
         }
 
 
-class TestOpenAIDalle3(BaseImageGenTest):
-    def get_base_image_generation_call_args(self) -> dict:
-        return {"model": "dall-e-3"}
-
-
 class TestOpenAIGPTImage1(BaseImageGenTest):
     def get_base_image_generation_call_args(self) -> dict:
         return {"model": "gpt-image-1"}

--- a/tests/local_testing/test_custom_callback_input.py
+++ b/tests/local_testing/test_custom_callback_input.py
@@ -930,7 +930,7 @@ def test_image_generation_openai():
 
         response = litellm.image_generation(
             prompt="A cute baby sea otter",
-            model="openai/dall-e-3",
+            model="openai/gpt-image-1",
             api_key=os.getenv("OPENAI_API_KEY"),
         )
 
@@ -948,7 +948,7 @@ def test_image_generation_openai():
         try:
             response = litellm.image_generation(
                 prompt="A cute baby sea otter",
-                model="dall-e-2",
+                model="gpt-image-1",
                 api_key="my-bad-api-key",
             )
         except Exception:

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -995,15 +995,15 @@ async def test_aimg_gen_on_router():
     try:
         model_list = [
             {
-                "model_name": "dall-e-3",
+                "model_name": "gpt-image-1",
                 "litellm_params": {
-                    "model": "dall-e-3",
+                    "model": "gpt-image-1",
                 },
             }
         ]
         router = Router(model_list=model_list, num_retries=3)
         response = await router.aimage_generation(
-            model="dall-e-3", prompt="A cute baby sea otter"
+            model="gpt-image-1", prompt="A cute baby sea otter"
         )
         print(response)
         assert len(response.data) > 0
@@ -1030,15 +1030,15 @@ def test_img_gen_on_router():
     try:
         model_list = [
             {
-                "model_name": "dall-e-3",
+                "model_name": "gpt-image-1",
                 "litellm_params": {
-                    "model": "dall-e-3",
+                    "model": "gpt-image-1",
                 },
             }
         ]
         router = Router(model_list=model_list)
         response = router.image_generation(
-            model="dall-e-3", prompt="A cute baby sea otter"
+            model="gpt-image-1", prompt="A cute baby sea otter"
         )
         print(response)
         assert len(response.data) > 0

--- a/tests/otel_tests/test_otel.py
+++ b/tests/otel_tests/test_otel.py
@@ -13,7 +13,7 @@ async def generate_key(
     models=[
         "gpt-4",
         "text-embedding-ada-002",
-        "dall-e-2",
+        "gpt-image-1",
         "fake-openai-endpoint",
         "mistral-embed",
     ],

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -31,7 +31,7 @@ async def generate_key(session):
     url = "http://0.0.0.0:4000/key/generate"
     headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
     data = {
-        "models": ["gpt-4", "text-embedding-ada-002", "dall-e-2"],
+        "models": ["gpt-4", "text-embedding-ada-002", "gpt-image-1"],
         "duration": None,
     }
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -62,7 +62,7 @@ async def generate_key(
     i,
     budget=None,
     budget_duration=None,
-    models=["azure-models", "gpt-4", "dall-e-3"],
+    models=["azure-models", "gpt-4", "gpt-image-1"],
     max_parallel_requests: Optional[int] = None,
     user_id: Optional[str] = None,
     team_id: Optional[str] = None,
@@ -235,7 +235,7 @@ async def chat_completion(session, key, model="gpt-4"):
                 pass
 
 
-async def image_generation(session, key, model="dall-e-3"):
+async def image_generation(session, key, model="gpt-image-1"):
     url = "http://0.0.0.0:4000/v1/images/generations"
     headers = {
         "Authorization": f"Bearer {key}",

--- a/tests/test_openai_endpoints.py
+++ b/tests/test_openai_endpoints.py
@@ -23,7 +23,7 @@ async def generate_key(
     models=[
         "gpt-4",
         "text-embedding-ada-002",
-        "dall-e-2",
+        "gpt-image-1",
         "fake-openai-endpoint-2",
         "mistral-embed",
     ],
@@ -56,7 +56,7 @@ async def new_user(session):
     url = "http://0.0.0.0:4000/user/new"
     headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
     data = {
-        "models": ["gpt-4", "text-embedding-ada-002", "dall-e-2"],
+        "models": ["gpt-4", "text-embedding-ada-002", "gpt-image-1"],
         "duration": None,
     }
 
@@ -264,7 +264,7 @@ async def image_generation(session, key):
         "Content-Type": "application/json",
     }
     data = {
-        "model": "dall-e-2",
+        "model": "gpt-image-1",
         "prompt": "A cute baby sea otter",
     }
 


### PR DESCRIPTION
## Summary
- OpenAI removed `dall-e-2` and `dall-e-3` from the API on 2026-05-12, so e2e proxy tests that hit those models now fail with `model does not exist`. CCI failure: https://app.circleci.com/pipelines/github/BerriAI/litellm/77267/workflows/5a032fe4-c80b-4484-b426-ba41b5e033e8/jobs/1645361
- Swap all live-API DALL-E references in proxy-backed tests to `gpt-image-1` (OpenAI's recommended successor).
- Point the `dall-e-2` model alias in `proxy_server_config.yaml` at `openai/gpt-image-1` so any historical callers still resolve.

## Test plan
- [ ] CI: image-generation spend test (`tests/test_keys.py::test_key_info_spend_values_image_generation`) goes green.
- [ ] CI: `tests/test_openai_endpoints.py`, `tests/test_health.py`, `tests/otel_tests/test_otel.py` still pass.