### PR TITLE
feat(pricing): add glm-5.1 model pricing (Z.AI)

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -35176,6 +35176,36 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -35178,9 +35178,9 @@
     },
     "zai/glm-5.1": {
         "cache_creation_input_token_cost": 0,
-        "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 1e-06,
-        "output_cost_per_token": 3.2e-06,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
         "litellm_provider": "zai",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -35176,21 +35176,6 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
-    "glm-5.1": {
-        "cache_creation_input_token_cost": 0,
-        "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 1e-06,
-        "output_cost_per_token": 3.2e-06,
-        "litellm_provider": "zai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "source": "https://docs.z.ai/guides/overview/pricing"
-    },
     "zai/glm-5.1": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 2e-07,


### PR DESCRIPTION
## Summary

Adds pricing for `zai/glm-5.1`, the latest GLM model from Z.AI, accessible via their Anthropic-compatible endpoint (`https://api.z.ai/api/anthropic`).

This model is currently missing from the pricing database, causing cost-tracking tools to report $0 for all token usage.

Only the provider-prefixed key is added, matching the `zai/glm-5` pattern (the glm-5 family has no bare keys).

## Pricing

From the official Z.AI pricing page:

| Token type | Price |
|---|---|
| Input | $1.40 / M tokens |
| Output | $4.40 / M tokens |
| Cache creation | $0.00 / M tokens (limited-time free) |
| Cache read | $0.26 / M tokens |

Source: https://docs.z.ai/guides/overview/pricing

## Related entries already in the database

- `zai/glm-5`
- `zai.glm-5`
- `openrouter/z-ai/glm-5`