### PR TITLE
fix(proxy): always merge caller-supplied tags into request metadata

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1427,46 +1427,8 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     if not _key_or_team_allows_client_pricing_override(user_api_key_dict):
         _strip_client_pricing_overrides(data)
 
-    # Strip caller-supplied routing/budget tags unless the admin has opted
-    # this key or team in via metadata.allow_client_tags=True. Tags drive
-    # tag-based routing and tag budget attribution — accepting them from
-    # untrusted callers lets an attacker reach restricted deployments or
-    # misattribute spend to a victim team's tag.
-    _admin_allow_client_tags = False
-    for _admin_meta in (
-        user_api_key_dict.metadata,
-        user_api_key_dict.team_metadata,
-    ):
-        if (
-            isinstance(_admin_meta, dict)
-            and _admin_meta.get("allow_client_tags") is True
-        ):
-            _admin_allow_client_tags = True
-            break
-    if not _admin_allow_client_tags:
-        _stripped_from: List[str] = []
-        for _meta_key in ("metadata", "litellm_metadata"):
-            _user_meta = data.get(_meta_key)
-            if isinstance(_user_meta, dict) and "tags" in _user_meta:
-                _user_meta.pop("tags", None)
-                _stripped_from.append(_meta_key)
-        # Also strip the root-level `tags` field. get_tags_from_request_body
-        # reads request_body["tags"] directly and feeds it to the policy
-        # engine, so leaving it in place here would let the strip-in-metadata
-        # above be trivially bypassed by moving the tags to the body root.
-        if "tags" in data:
-            data.pop("tags", None)
-            _stripped_from.append("tags (root)")
-        if _stripped_from:
-            verbose_proxy_logger.warning(
-                "Stripped caller-supplied tags from %s: this key/team does "
-                "not have `allow_client_tags: true` in its metadata. Set it "
-                "to opt into client-supplied routing/budget tags.",
-                ", ".join(_stripped_from),
-            )
-
     # Fill in the proxy_server_request body snapshot now that metadata has
-    # been parsed and stripped. Consumers (standard_logging_payload, lago,
+    # been parsed. Consumers (standard_logging_payload, lago,
     # spend_tracking_utils, streaming_iterator) read `body` to audit the
     # request; taking the snapshot here ensures they see cleaned metadata.
     #
@@ -1655,23 +1617,18 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         user_agent = request.headers["user-agent"]
     data[_metadata_variable_name]["user_agent"] = user_agent
 
-    # Check if using tag based routing. The helper reads caller-controlled
-    # sources (x-litellm-tags header, data["tags"] root-level), so its result
-    # is still gated by the same allow_client_tags flag that gated the
-    # body-metadata tag strip above. Otherwise the strip is trivially
-    # bypassed by sending tags via header or at the root of the body.
+    # Merge caller-supplied tags (x-litellm-tags header, data["tags"] root-level)
+    # into request metadata for tag-based routing and spend attribution.
     tags = LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
         llm_router=llm_router,
         headers=_headers,
         data=data,
     )
 
-    if tags is not None and _admin_allow_client_tags:
-        data[_metadata_variable_name]["tags"] = tags
-    elif tags is not None:
-        verbose_proxy_logger.warning(
-            "Ignored caller-supplied tags from header/root body: this "
-            "key/team does not have `allow_client_tags: true` in its metadata."
+    if tags is not None:
+        data[_metadata_variable_name]["tags"] = LiteLLMProxyRequestSetup._merge_tags(
+            request_tags=data[_metadata_variable_name].get("tags"),
+            tags_to_add=tags,
         )
 
     # Team Callbacks controls

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1438,19 +1438,21 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     _body_snapshot = {k: v for k, v in data.items() if k != "secret_fields"}
     data["proxy_server_request"]["body"] = _body_snapshot
 
-    # Snapshot the (now-cleaned) requester-supplied metadata for downstream
-    # consumers. Taking the deepcopy AFTER the strip prevents attacker-
-    # injected admin slots (user_api_key_*, tags without opt-in,
-    # _pipeline_managed_guardrails) from surviving in requester_metadata
-    # where guardrails and audit paths may read from it.
+    # Snapshot the requester-supplied metadata for downstream consumers.
+    # Taking the deepcopy after the user_api_key_* / _pipeline_managed_guardrails
+    # strip above prevents those proxy-internal slots — if a caller forged
+    # them — from leaking into requester_metadata where guardrails and audit
+    # paths may read from it.
     if "metadata" in data and isinstance(data["metadata"], dict):
         data[_metadata_variable_name]["requester_metadata"] = copy.deepcopy(
             data["metadata"]
         )
 
-    # Now merge litellm_metadata into the metadata variable (preserving existing
-    # values) — runs AFTER the strip so attacker injections in litellm_metadata
-    # cannot cross-contaminate the admin-authoritative metadata dict.
+    # Merge litellm_metadata into the metadata variable (preserving existing
+    # values). Runs after the user_api_key_* / _pipeline_managed_guardrails
+    # strip above so those proxy-internal slots — if a caller forged them
+    # into litellm_metadata — cannot cross-contaminate the admin-authoritative
+    # metadata dict.
     if "litellm_metadata" in data and isinstance(data["litellm_metadata"], dict):
         for key, value in data["litellm_metadata"].items():
             if key not in data[_metadata_variable_name]:

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -167,13 +167,9 @@ async def test_add_key_or_team_level_spend_logs_metadata_to_request(
 
     print(f"team_sl_metadata: {team_sl_metadata}")
     mock_request.url.path = "/chat/completions"
-    # Opt the key into client-supplied tags so request_tags are preserved
-    # and merged with admin-configured key/team tags. Without this flag,
-    # request_tags would be stripped by add_litellm_data_to_request.
     key_metadata = {
         "tags": key_tags,
         "spend_logs_metadata": key_sl_metadata,
-        "allow_client_tags": True,
     }
     team_metadata = {
         "tags": team_tags,
@@ -891,13 +887,12 @@ async def test_add_litellm_data_to_request_duplicate_tags(
     mock_request.headers = {}
     mock_request.state = State()
 
-    # Setup key with tags in metadata. Opt into client-supplied tags so the
-    # request_tags are preserved for the merge under test.
+    # Setup key with tags in metadata.
     user_api_key_dict = UserAPIKeyAuth(
         api_key="test_api_key",
         user_id="test_user_id",
         org_id="test_org_id",
-        metadata={"tags": key_tags, "allow_client_tags": True},
+        metadata={"tags": key_tags},
     )
 
     # Setup request data with tags

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -873,101 +873,8 @@ async def test_add_litellm_data_to_request_allows_redaction_opt_out_with_admin_o
 
 
 @pytest.mark.asyncio
-async def test_add_litellm_data_to_request_ignores_x_litellm_tags_header_without_permission():
-    """Regression: the `x-litellm-tags` header bypassed the body-metadata
-    tag strip. Header tags must also be gated by `allow_client_tags`."""
-    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-
-    request_mock = MagicMock(spec=Request)
-    request_mock.url.path = "/v1/chat/completions"
-    request_mock.url = MagicMock()
-    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
-    request_mock.method = "POST"
-    request_mock.query_params = {}
-    request_mock.headers = {
-        "Content-Type": "application/json",
-        "x-litellm-tags": "restricted-tier,victim-team",
-    }
-    request_mock.client = MagicMock()
-    request_mock.client.host = "127.0.0.1"
-
-    data = {"model": "gpt-3.5-turbo"}
-
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="hashed-key",
-        metadata={},
-        team_metadata={},
-        spend=0.0,
-        max_budget=100.0,
-        model_max_budget={},
-        team_spend=0.0,
-        team_max_budget=200.0,
-    )
-
-    updated = await add_litellm_data_to_request(
-        data=data,
-        request=request_mock,
-        user_api_key_dict=user_api_key_dict,
-        proxy_config=MagicMock(),
-        general_settings={},
-        version="test-version",
-    )
-
-    assert "tags" not in (updated.get("metadata") or {})
-
-
-@pytest.mark.asyncio
-async def test_add_litellm_data_to_request_ignores_root_level_tags_without_permission():
-    """Regression: root-level `data["tags"]` bypassed the body-metadata
-    tag strip. Root-level tags must also be gated by `allow_client_tags`."""
-    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-
-    request_mock = MagicMock(spec=Request)
-    request_mock.url.path = "/v1/chat/completions"
-    request_mock.url = MagicMock()
-    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
-    request_mock.method = "POST"
-    request_mock.query_params = {}
-    request_mock.headers = {"Content-Type": "application/json"}
-    request_mock.client = MagicMock()
-    request_mock.client.host = "127.0.0.1"
-
-    data = {
-        "model": "gpt-3.5-turbo",
-        "tags": ["restricted-tier", "victim-team"],
-    }
-
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="hashed-key",
-        metadata={},
-        team_metadata={},
-        spend=0.0,
-        max_budget=100.0,
-        model_max_budget={},
-        team_spend=0.0,
-        team_max_budget=200.0,
-    )
-
-    updated = await add_litellm_data_to_request(
-        data=data,
-        request=request_mock,
-        user_api_key_dict=user_api_key_dict,
-        proxy_config=MagicMock(),
-        general_settings={},
-        version="test-version",
-    )
-
-    assert "tags" not in (updated.get("metadata") or {})
-    # Also ensure the root-level tags are removed. get_tags_from_request_body
-    # reads request_body["tags"] directly, so leaving it in place would let
-    # the policy engine see caller-supplied tags even after the metadata
-    # strip.
-    assert "tags" not in updated
-
-
-@pytest.mark.asyncio
-async def test_add_litellm_data_to_request_honors_header_tags_when_opted_in():
-    """When allow_client_tags=True, header-supplied tags flow through."""
+async def test_add_litellm_data_to_request_honors_header_tags():
+    """Header-supplied tags flow through to request metadata."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -987,7 +894,7 @@ async def test_add_litellm_data_to_request_honors_header_tags_when_opted_in():
 
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={"allow_client_tags": True},
+        metadata={},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,
@@ -1009,11 +916,8 @@ async def test_add_litellm_data_to_request_honors_header_tags_when_opted_in():
 
 
 @pytest.mark.asyncio
-async def test_add_litellm_data_to_request_strips_user_tags_without_permission():
-    """Caller-supplied metadata.tags must be stripped when the key/team
-    metadata does not opt in via allow_client_tags=True. Otherwise an
-    attacker can reach restricted tag-routed deployments or attribute
-    spend to a victim team's tag."""
+async def test_add_litellm_data_to_request_preserves_caller_metadata_tags():
+    """Caller-supplied metadata.tags are preserved and reach the router."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -1028,8 +932,7 @@ async def test_add_litellm_data_to_request_strips_user_tags_without_permission()
 
     data = {
         "model": "gpt-3.5-turbo",
-        "metadata": {"tags": ["restricted-tier", "victim-team"]},
-        "litellm_metadata": {"tags": ["also-stripped"]},
+        "metadata": {"tags": ["caller-tag"]},
     }
 
     user_api_key_dict = UserAPIKeyAuth(
@@ -1052,14 +955,13 @@ async def test_add_litellm_data_to_request_strips_user_tags_without_permission()
         version="test-version",
     )
 
-    assert "tags" not in (updated.get("metadata") or {})
-    assert "tags" not in (updated.get("litellm_metadata") or {})
+    assert updated["metadata"].get("tags") == ["caller-tag"]
 
 
 @pytest.mark.asyncio
-async def test_add_litellm_data_to_request_preserves_user_tags_when_key_opts_in():
-    """When key.metadata.allow_client_tags=True, caller-supplied tags are
-    preserved and reach the router."""
+async def test_add_litellm_data_to_request_unions_caller_header_tags_with_static_key_tags():
+    """Caller-supplied `x-litellm-tags` must union with static key-level
+    tags, not overwrite them."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -1068,18 +970,18 @@ async def test_add_litellm_data_to_request_preserves_user_tags_when_key_opts_in(
     request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
     request_mock.method = "POST"
     request_mock.query_params = {}
-    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.headers = {
+        "Content-Type": "application/json",
+        "x-litellm-tags": "tenant:1681",
+    }
     request_mock.client = MagicMock()
     request_mock.client.host = "127.0.0.1"
 
-    data = {
-        "model": "gpt-3.5-turbo",
-        "metadata": {"tags": ["opted-in-tag"]},
-    }
+    data = {"model": "gpt-3.5-turbo"}
 
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={"allow_client_tags": True},
+        metadata={"tags": ["team:platform", "env:prod"]},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,
@@ -1097,12 +999,15 @@ async def test_add_litellm_data_to_request_preserves_user_tags_when_key_opts_in(
         version="test-version",
     )
 
-    assert updated["metadata"].get("tags") == ["opted-in-tag"]
+    final_tags = updated["metadata"].get("tags") or []
+    assert "team:platform" in final_tags
+    assert "env:prod" in final_tags
+    assert "tenant:1681" in final_tags
 
 
 @pytest.mark.asyncio
-async def test_add_litellm_data_to_request_preserves_user_tags_when_team_opts_in():
-    """Team-level allow_client_tags is also honored (not just key-level)."""
+async def test_add_litellm_data_to_request_unions_caller_header_tags_with_static_team_tags():
+    """Same union behavior must hold for team-level static tags."""
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 
     request_mock = MagicMock(spec=Request)
@@ -1111,19 +1016,19 @@ async def test_add_litellm_data_to_request_preserves_user_tags_when_team_opts_in
     request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
     request_mock.method = "POST"
     request_mock.query_params = {}
-    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.headers = {
+        "Content-Type": "application/json",
+        "x-litellm-tags": "tenant:42",
+    }
     request_mock.client = MagicMock()
     request_mock.client.host = "127.0.0.1"
 
-    data = {
-        "model": "gpt-3.5-turbo",
-        "metadata": {"tags": ["team-allowed"]},
-    }
+    data = {"model": "gpt-3.5-turbo"}
 
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
         metadata={},
-        team_metadata={"allow_client_tags": True},
+        team_metadata={"tags": ["team:eng", "owner:platform"]},
         spend=0.0,
         max_budget=100.0,
         model_max_budget={},
@@ -1140,7 +1045,57 @@ async def test_add_litellm_data_to_request_preserves_user_tags_when_team_opts_in
         version="test-version",
     )
 
-    assert updated["metadata"].get("tags") == ["team-allowed"]
+    final_tags = updated["metadata"].get("tags") or []
+    assert "team:eng" in final_tags
+    assert "owner:platform" in final_tags
+    assert "tenant:42" in final_tags
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_unions_dedups_overlapping_caller_and_static_tags():
+    """A tag that appears in both the static set and the caller header
+    must show up exactly once in the merged list."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {
+        "Content-Type": "application/json",
+        "x-litellm-tags": "env:prod,tenant:7",
+    }
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    data = {"model": "gpt-3.5-turbo"}
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={"tags": ["env:prod", "team:platform"]},
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    final_tags = updated["metadata"].get("tags") or []
+    assert final_tags.count("env:prod") == 1
+    assert "team:platform" in final_tags
+    assert "tenant:7" in final_tags
 
 
 @pytest.mark.asyncio
@@ -1214,11 +1169,9 @@ async def test_add_litellm_data_to_request_audio_transcription_multipart():
         "file": b"Fake audio bytes",
     }
 
-    # Opt the key in to client-supplied tags so the parsed tags from the
-    # JSON-string multipart body aren't stripped by the admin-injection strip.
     user_api_key_dict = UserAPIKeyAuth(
         api_key="hashed-key",
-        metadata={"allow_client_tags": True},
+        metadata={},
         team_metadata={},
         spend=0.0,
         max_budget=100.0,


### PR DESCRIPTION
Backport of [#27784](https://github.com/BerriAI/litellm/pull/27784) onto `litellm_1.84.0rc2`.

## Summary

Caller-supplied tags (`x-litellm-tags` header, body `tags`, `metadata.tags`) were silently dropped from request metadata unless the calling key/team had `metadata.allow_client_tags: true` set. This broke two documented features:

- **Tag-based routing** via `x-litellm-tags` — the documented per-request header for routing to tagged deployments.
- **Tag-based spend attribution** — `request_tags` going into spend logs and `/spend/tags` aggregations.

This PR restores the previous behavior: tags from the request always flow into `metadata.tags` and union with any admin-configured static tags from key/team/project metadata.

## What changed

- `litellm/proxy/litellm_pre_call_utils.py` — drop the conditional strip of caller `tags` from body / `metadata` / `litellm_metadata` and the conditional gate on the `x-litellm-tags` header merge. Both now run unconditionally.
- The `allow_client_tags` flag is removed from the pre-call pipeline. It was only ever read here — no schema, types, or endpoint footprint — so existing values in key/team metadata are inert.

## Test changes

- Drop three tests that exercised the strip-when-not-opted-in path (no longer reachable).
- Drop the `"allow_client_tags": True` fixture lines from the merge/union/multipart tests; their assertions about union behavior continue to hold.

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py` — 117 passed
- [x] `uv run pytest tests/proxy_unit_tests/test_proxy_utils.py -k "spend_logs_metadata or duplicate_tags"` — 69 passed
- [x] `uv run pytest tests/test_litellm/router_strategy/test_router_tag_routing.py tests/test_litellm/proxy/auth/test_auth_checks.py` — 112 passed

End-to-end verification was performed on the parent PR ([#27784](https://github.com/BerriAI/litellm/pull/27784)) against a running proxy.