### PR TITLE
feat(ui): add Vertex AI Search as vector store provider

### DIFF
--- a/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreForm.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreForm.tsx
@@ -209,6 +209,38 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
           />
         )}
 
+        {/* Vertex AI Search Setup Instructions */}
+        {selectedProvider === "vertex_ai/search_api" && (
+          <Alert
+            message="Vertex AI Search Setup"
+            description={
+              <div>
+                <p>To use Vertex AI Search (Discovery Engine):</p>
+                <ol style={{ marginLeft: "16px", marginTop: "8px" }}>
+                  <li>
+                    Enable the Discovery Engine API on your Google Cloud project and create a data store following the
+                    guide:{" "}
+                    <a
+                      href="https://cloud.google.com/generative-ai-app-builder/docs/create-data-store-es"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ textDecoration: "underline" }}
+                    >
+                      Create a Vertex AI Search data store
+                    </a>
+                  </li>
+                  <li>Pick a supported location: global, us, or eu</li>
+                  <li>Copy the data store ID from the Vertex AI Search console</li>
+                  <li>Enter the data store ID in the Vector Store ID field below</li>
+                </ol>
+              </div>
+            }
+            type="info"
+            showIcon
+            style={{ marginBottom: "16px" }}
+          />
+        )}
+
         <Form.Item
           label={
             <span>
@@ -225,7 +257,9 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
             placeholder={
               selectedProvider === "vertex_rag_engine"
                 ? "6917529027641081856 (Get corpus ID from Vertex AI console)"
-                : "Enter vector store ID from your provider"
+                : selectedProvider === "vertex_ai/search_api"
+                  ? "my-datastore_1234567890 (Get data store ID from Vertex AI Search console)"
+                  : "Enter vector store ID from your provider"
             }
           />
         </Form.Item>
@@ -233,12 +267,14 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
         {/* Provider-specific fields */}
         {getProviderSpecificFields(selectedProvider).map((field: VectorStoreFieldConfig) => {
           if (field.type === "select") {
-            const embeddingModels = modelInfo
-              .filter((option: ModelGroup) => option.mode === "embedding" || option.mode === null)
-              .map((option: ModelGroup) => ({
-                value: option.model_group,
-                label: option.model_group,
-              }));
+            const selectOptions =
+              field.options ??
+              modelInfo
+                .filter((option: ModelGroup) => option.mode === "embedding" || option.mode === null)
+                .map((option: ModelGroup) => ({
+                  value: option.model_group,
+                  label: option.model_group,
+                }));
 
             return (
               <Form.Item
@@ -252,6 +288,7 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
                   </span>
                 }
                 name={field.name}
+                initialValue={field.initialValue}
                 rules={
                   field.required ? [{ required: true, message: `Please select the ${field.label.toLowerCase()}` }] : []
                 }
@@ -260,7 +297,7 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
                   placeholder={field.placeholder}
                   showSearch={true}
                   filterOption={(input, option) => (option?.label ?? "").toLowerCase().includes(input.toLowerCase())}
-                  options={embeddingModels}
+                  options={selectOptions}
                   style={{ width: "100%" }}
                 />
               </Form.Item>

--- a/ui/litellm-dashboard/src/components/vector_store_providers.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_providers.tsx
@@ -92,8 +92,8 @@ export const vectorStoreProviderFields: Record<string, VectorStoreFieldConfig[]>
     {
       name: "vertex_collection_id",
       label: "Collection ID (optional)",
-      tooltip: "Discovery Engine collection ID. Leave blank to use default_collection.",
-      placeholder: "default_collection",
+      tooltip: "Discovery Engine collection ID. Leave blank to use the default collection.",
+      placeholder: "e.g. my-custom-collection",
       required: false,
       type: "text",
     },

--- a/ui/litellm-dashboard/src/components/vector_store_providers.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_providers.tsx
@@ -3,6 +3,7 @@ export enum VectorStoreProviders {
   S3Vectors = "Amazon S3 Vectors",
   PgVector = "PostgreSQL pgvector (LiteLLM Connector)",
   VertexRagEngine = "Vertex AI RAG Engine",
+  VertexAiSearch = "Vertex AI Search",
   OpenAI = "OpenAI",
   Azure = "Azure OpenAI",
   Milvus = "Milvus",
@@ -12,6 +13,7 @@ export const vectorStoreProviderMap: Record<string, string> = {
   Bedrock: "bedrock",
   PgVector: "pg_vector",
   VertexRagEngine: "vertex_ai",
+  VertexAiSearch: "vertex_ai/search_api",
   OpenAI: "openai",
   Azure: "azure",
   Milvus: "milvus",
@@ -24,6 +26,7 @@ export const vectorStoreProviderLogoMap: Record<string, string> = {
   [VectorStoreProviders.Bedrock]: `${asset_logos_folder}bedrock.svg`,
   [VectorStoreProviders.PgVector]: `${asset_logos_folder}postgresql.svg`, // Fallback to a generic database icon if needed
   [VectorStoreProviders.VertexRagEngine]: `${asset_logos_folder}google.svg`,
+  [VectorStoreProviders.VertexAiSearch]: `${asset_logos_folder}google.svg`,
   [VectorStoreProviders.OpenAI]: `${asset_logos_folder}openai_small.svg`,
   [VectorStoreProviders.Azure]: `${asset_logos_folder}microsoft_azure.svg`,
   [VectorStoreProviders.Milvus]: `${asset_logos_folder}milvus.svg`,
@@ -38,6 +41,8 @@ export interface VectorStoreFieldConfig {
   placeholder?: string;
   required: boolean;
   type?: "text" | "password" | "select";
+  options?: { value: string; label: string }[];
+  initialValue?: string;
 }
 
 // Provider-specific field configurations
@@ -62,6 +67,37 @@ export const vectorStoreProviderFields: Record<string, VectorStoreFieldConfig[]>
     },
   ],
   vertex_rag_engine: [],
+  "vertex_ai/search_api": [
+    {
+      name: "vertex_project",
+      label: "Vertex Project",
+      tooltip: "Google Cloud project ID that hosts the Vertex AI Search data store.",
+      placeholder: "my-gcp-project-id",
+      required: true,
+      type: "text",
+    },
+    {
+      name: "vertex_location",
+      label: "Vertex Location",
+      tooltip: "Vertex AI Search data store location. Must be one of global, us, or eu.",
+      required: true,
+      type: "select",
+      options: [
+        { value: "global", label: "global" },
+        { value: "us", label: "us" },
+        { value: "eu", label: "eu" },
+      ],
+      initialValue: "global",
+    },
+    {
+      name: "vertex_collection_id",
+      label: "Collection ID (optional)",
+      tooltip: "Discovery Engine collection ID. Leave blank to use default_collection.",
+      placeholder: "default_collection",
+      required: false,
+      type: "text",
+    },
+  ],
   openai: [
     {
       name: "api_key",


### PR DESCRIPTION
## Summary
- Adds **Vertex AI Search** (Discovery Engine) as a managed vector store provider in the UI alongside the existing Vertex AI RAG Engine entry. Maps to `custom_llm_provider="vertex_ai/search_api"` so the backend constructs the Discovery Engine search URL.
- Form collects `vertex_project`, `vertex_location` (`global` / `us` / `eu`, dropdown defaulted to `global`), and optional `vertex_collection_id`, all flowing into `litellm_params`.
- Extends `VectorStoreFieldConfig` with an optional `options` array so `select`-type fields can render with fixed choices instead of falling through to the embedding-model list (which is what Milvus uses).
- Adds a help Alert mirroring the existing pg_vector / RAG entries, with a link to Google's data store setup docs.

## Test plan
- [x] `npx vitest run` for `VectorStoreForm.test.tsx`, `CreateVectorStore.test.tsx`, `VectorStoreTable.test.tsx` — 47/47 pass
- [x] `npx tsc --noEmit` clean on changed files
- [x] Registered a Vertex AI Search data store via the new form; verified `POST /vector_store/new` payload includes `custom_llm_provider: "vertex_ai/search_api"` and the expected `litellm_params` shape
- [x] End-to-end: `POST /v1/vector_stores/{id}/search` against a real GCP Vertex AI Search data store (Cloud Storage source, Alphabet investor PDFs sample) returns ranked results in the OpenAI `vector_store.search_results.page` shape
- [x] Existing RAG Engine and other provider entries still render correctly

## Screenshots
<img width="985" height="276" alt="Screenshot 2026-05-12 at 4 23 06 PM" src="https://github.com/user-attachments/assets/28feb28e-0ac9-4da1-adda-acd7bdffc88c" />
<img width="1341" height="377" alt="Screenshot 2026-05-12 at 4 25 14 PM" src="https://github.com/user-attachments/assets/5f063f99-4639-4196-bcef-472885eda5e2" />
<img width="1392" height="624" alt="Screenshot 2026-05-12 at 4 25 19 PM" src="https://github.com/user-attachments/assets/d82c3ea5-fe30-4a57-b03e-db7eec911dad" />
<img width="929" height="910" alt="Screenshot 2026-05-12 at 4 27 00 PM" src="https://github.com/user-attachme
<img width="1710" height="1005" alt="Screenshot 2026-05-12 at 4 41 28 PM" src="https://github.com/user-attachments/assets/aa82c174-d257-4610-94b3-a77efe34ef25" />
nts/assets/32912a2b-5886-4c04-97a9-2cfa7861cfd0" />


Resolves LIT-2889