### PR TITLE
fix(proxy): reduce spend update overhead

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -305,7 +305,7 @@ MAX_SIZE_IN_MEMORY_QUEUE = int(
     os.getenv("MAX_SIZE_IN_MEMORY_QUEUE", int(LITELLM_ASYNCIO_QUEUE_MAXSIZE * 0.8))
 )
 MAX_IN_MEMORY_QUEUE_FLUSH_COUNT = int(
-    os.getenv("MAX_IN_MEMORY_QUEUE_FLUSH_COUNT", 1000)
+    os.getenv("MAX_IN_MEMORY_QUEUE_FLUSH_COUNT", LITELLM_ASYNCIO_QUEUE_MAXSIZE)
 )
 ###############################################################################################
 MINIMUM_PROMPT_CACHE_TOKEN_COUNT = int(

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -499,7 +499,10 @@ class DBSpendUpdateWriter:
         if isinstance(request_tags, str):
             request_tags = json.loads(request_tags)
         elif not isinstance(request_tags, list):
-            raise ValueError(f"Invalid request_tags: {request_tags}")
+            verbose_proxy_logger.debug(
+                "Invalid request_tags for daily tag spend update: %s", request_tags
+            )
+            return
 
         for tag in request_tags:
             daily_transaction_key = f"{tag}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -407,71 +407,175 @@ class DBSpendUpdateWriter:
             )
 
         try:
-            await self.add_spend_log_transaction_to_daily_user_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_user_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_end_user_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_end_user_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_agent_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_agent_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_team_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_team_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_org_transaction(
+            await self._enqueue_daily_spend_updates(
                 payload=payload_copy,
                 org_id=org_id,
                 prisma_client=prisma_client,
             )
         except Exception:
             verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_org_transaction failed: %s",
+                "_batch_database_updates: _enqueue_daily_spend_updates failed: %s",
                 traceback.format_exc(),
             )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_tag_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
+    async def _enqueue_daily_spend_updates(
+        self,
+        payload: SpendLogsPayload,
+        org_id: Optional[str],
+        prisma_client: Optional[PrismaClient],
+    ) -> None:
+        """
+        Enqueue all daily spend rows for one request after computing the shared
+        daily payload once. This avoids repeated JSON parsing and request-status
+        resolution on the logging hot path.
+        """
+        if prisma_client is None:
             verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_tag_transaction failed: %s",
-                traceback.format_exc(),
+                "prisma_client is None. Skipping writing spend logs to db."
             )
+            return
+
+        base_daily_transaction = self._get_base_daily_spend_transaction(
+            payload=payload,
+            prisma_client=prisma_client,
+        )
+        if base_daily_transaction is None:
+            return
+
+        endpoint_str = base_daily_transaction.get("endpoint") or ""
+
+        user_id = payload.get("user")
+        if user_id is not None and user_id != "":
+            daily_transaction_key = f"{user_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_transaction = DailyUserSpendTransaction(
+                user_id=user_id, **base_daily_transaction
+            )
+            await self.daily_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_transaction}
+            )
+
+        team_id = payload.get("team_id")
+        if team_id is not None and team_id != "":
+            daily_transaction_key = f"{team_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_transaction = DailyTeamSpendTransaction(
+                team_id=team_id, **base_daily_transaction
+            )
+            await self.daily_team_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_transaction}
+            )
+
+        if org_id is not None and org_id != "":
+            daily_transaction_key = f"{org_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_transaction = DailyOrganizationSpendTransaction(
+                organization_id=org_id, **base_daily_transaction
+            )
+            await self.daily_org_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_transaction}
+            )
+
+        end_user_id = payload.get("end_user")
+        if end_user_id is not None and end_user_id != "":
+            daily_transaction_key = f"{end_user_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_transaction = DailyEndUserSpendTransaction(
+                end_user_id=end_user_id, **base_daily_transaction
+            )
+            await self.daily_end_user_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_transaction}
+            )
+
+        agent_id = payload.get("agent_id")
+        if agent_id is not None and agent_id != "":
+            daily_transaction_key = f"{agent_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_transaction = DailyAgentSpendTransaction(
+                agent_id=agent_id, **base_daily_transaction
+            )
+            await self.daily_agent_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_transaction}
+            )
+
+        request_tags = payload.get("request_tags")
+        if request_tags is None:
+            return
+        if isinstance(request_tags, str):
+            request_tags = json.loads(request_tags)
+        elif not isinstance(request_tags, list):
+            raise ValueError(f"Invalid request_tags: {request_tags}")
+
+        for tag in request_tags:
+            daily_transaction_key = f"{tag}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_transaction = DailyTagSpendTransaction(
+                tag=tag,
+                **base_daily_transaction,
+                request_id=payload.get("request_id"),
+            )
+            await self.daily_tag_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_transaction}
+            )
+
+    def _get_base_daily_spend_transaction(
+        self,
+        payload: Union[dict, SpendLogsPayload],
+        prisma_client: PrismaClient,
+    ) -> Optional[BaseDailySpendTransaction]:
+        common_expected_keys = ["startTime", "api_key"]
+        if not all(key in payload for key in common_expected_keys):
+            verbose_proxy_logger.debug(
+                f"Missing expected keys: {common_expected_keys}, in payload, skipping from daily_user_spend_transactions"
+            )
+            return None
+
+        any_expected_keys = ["model", "mcp_namespaced_tool_name"]
+        if not any(key in payload for key in any_expected_keys):
+            verbose_proxy_logger.debug(
+                f"Missing any expected keys: {any_expected_keys}, in payload, skipping from daily_user_spend_transactions"
+            )
+            return None
+        if "mcp_namespaced_tool_name" not in payload and (
+            "custom_llm_provider" not in payload or "model_group" not in payload
+        ):
+            verbose_proxy_logger.debug(
+                "Missing custom_llm_provider or model_group in payload, skipping from daily_user_spend_transactions"
+            )
+            return None
+
+        request_status = prisma_client.get_request_status(payload)
+        verbose_proxy_logger.debug(f"Logged request status: {request_status}")
+        _metadata: SpendLogsMetadata = json.loads(payload["metadata"])
+        usage_obj = _metadata.get("usage_object", {}) or {}
+        if isinstance(payload["startTime"], datetime):
+            start_time = payload["startTime"].isoformat()
+            date = start_time.split("T")[0]
+        elif isinstance(payload["startTime"], str):
+            date = payload["startTime"].split("T")[0]
+        else:
+            verbose_proxy_logger.debug(
+                f"Invalid start time: {payload['startTime']}, skipping from daily_user_spend_transactions"
+            )
+            return None
+
+        call_type = payload.get("call_type", None)
+        endpoint = None
+        if call_type:
+            endpoint = ROUTE_ENDPOINT_MAPPING.get(call_type, None)
+
+        return BaseDailySpendTransaction(
+            date=date,
+            api_key=payload["api_key"],
+            model=payload.get("model", None),
+            model_group=payload.get("model_group", None),
+            mcp_namespaced_tool_name=payload.get("mcp_namespaced_tool_name", None),
+            custom_llm_provider=payload.get("custom_llm_provider", None),
+            endpoint=endpoint,
+            prompt_tokens=payload["prompt_tokens"],
+            completion_tokens=payload["completion_tokens"],
+            spend=payload["spend"],
+            api_requests=1,
+            successful_requests=1 if request_status == "success" else 0,
+            failed_requests=1 if request_status != "success" else 0,
+            cache_read_input_tokens=usage_obj.get("cache_read_input_tokens", 0) or 0,
+            cache_creation_input_tokens=usage_obj.get("cache_creation_input_tokens", 0)
+            or 0,
+        )
 
     async def _update_key_db(
         self,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -447,50 +447,50 @@ class DBSpendUpdateWriter:
         user_id = payload.get("user")
         if user_id is not None and user_id != "":
             daily_transaction_key = f"{user_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
-            daily_transaction = DailyUserSpendTransaction(
+            daily_user_transaction = DailyUserSpendTransaction(
                 user_id=user_id, **base_daily_transaction
             )
             await self.daily_spend_update_queue.add_update(
-                update={daily_transaction_key: daily_transaction}
+                update={daily_transaction_key: daily_user_transaction}
             )
 
         team_id = payload.get("team_id")
         if team_id is not None and team_id != "":
             daily_transaction_key = f"{team_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
-            daily_transaction = DailyTeamSpendTransaction(
+            daily_team_transaction = DailyTeamSpendTransaction(
                 team_id=team_id, **base_daily_transaction
             )
             await self.daily_team_spend_update_queue.add_update(
-                update={daily_transaction_key: daily_transaction}
+                update={daily_transaction_key: daily_team_transaction}
             )
 
         if org_id is not None and org_id != "":
             daily_transaction_key = f"{org_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
-            daily_transaction = DailyOrganizationSpendTransaction(
+            daily_org_transaction = DailyOrganizationSpendTransaction(
                 organization_id=org_id, **base_daily_transaction
             )
             await self.daily_org_spend_update_queue.add_update(
-                update={daily_transaction_key: daily_transaction}
+                update={daily_transaction_key: daily_org_transaction}
             )
 
         end_user_id = payload.get("end_user")
         if end_user_id is not None and end_user_id != "":
             daily_transaction_key = f"{end_user_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
-            daily_transaction = DailyEndUserSpendTransaction(
+            daily_end_user_transaction = DailyEndUserSpendTransaction(
                 end_user_id=end_user_id, **base_daily_transaction
             )
             await self.daily_end_user_spend_update_queue.add_update(
-                update={daily_transaction_key: daily_transaction}
+                update={daily_transaction_key: daily_end_user_transaction}
             )
 
         agent_id = payload.get("agent_id")
         if agent_id is not None and agent_id != "":
             daily_transaction_key = f"{agent_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
-            daily_transaction = DailyAgentSpendTransaction(
+            daily_agent_transaction = DailyAgentSpendTransaction(
                 agent_id=agent_id, **base_daily_transaction
             )
             await self.daily_agent_spend_update_queue.add_update(
-                update={daily_transaction_key: daily_transaction}
+                update={daily_transaction_key: daily_agent_transaction}
             )
 
         request_tags = payload.get("request_tags")
@@ -503,13 +503,13 @@ class DBSpendUpdateWriter:
 
         for tag in request_tags:
             daily_transaction_key = f"{tag}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
-            daily_transaction = DailyTagSpendTransaction(
+            daily_tag_transaction = DailyTagSpendTransaction(
                 tag=tag,
                 **base_daily_transaction,
                 request_id=payload.get("request_id"),
             )
             await self.daily_tag_spend_update_queue.add_update(
-                update={daily_transaction_key: daily_transaction}
+                update={daily_transaction_key: daily_tag_transaction}
             )
 
     def _get_base_daily_spend_transaction(

--- a/litellm/proxy/db/db_transaction_queue/base_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/base_update_queue.py
@@ -3,6 +3,7 @@ Base class for in memory buffer for database transactions
 """
 
 import asyncio
+import time
 from typing import Optional
 
 from litellm._logging import verbose_proxy_logger
@@ -24,6 +25,9 @@ class BaseUpdateQueue:
     def __init__(self):
         self.update_queue = asyncio.Queue(maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE)
         self.MAX_SIZE_IN_MEMORY_QUEUE = MAX_SIZE_IN_MEMORY_QUEUE
+        self._aggregation_lock = asyncio.Lock()
+        self._aggregation_task: Optional[asyncio.Task] = None
+        self._last_queue_full_warning_time = 0.0
         if MAX_SIZE_IN_MEMORY_QUEUE >= LITELLM_ASYNCIO_QUEUE_MAXSIZE:
             verbose_proxy_logger.warning(
                 "Misconfigured queue thresholds: MAX_SIZE_IN_MEMORY_QUEUE (%d) >= LITELLM_ASYNCIO_QUEUE_MAXSIZE (%d). "
@@ -32,6 +36,14 @@ class BaseUpdateQueue:
                 MAX_SIZE_IN_MEMORY_QUEUE,
                 LITELLM_ASYNCIO_QUEUE_MAXSIZE,
                 LITELLM_ASYNCIO_QUEUE_MAXSIZE,
+            )
+        if MAX_IN_MEMORY_QUEUE_FLUSH_COUNT < MAX_SIZE_IN_MEMORY_QUEUE:
+            verbose_proxy_logger.warning(
+                "Misconfigured queue flush limit: MAX_IN_MEMORY_QUEUE_FLUSH_COUNT (%d) < MAX_SIZE_IN_MEMORY_QUEUE (%d). "
+                "Spend queue aggregation may need multiple passes under load. "
+                "Set MAX_IN_MEMORY_QUEUE_FLUSH_COUNT to at least MAX_SIZE_IN_MEMORY_QUEUE.",
+                MAX_IN_MEMORY_QUEUE_FLUSH_COUNT,
+                MAX_SIZE_IN_MEMORY_QUEUE,
             )
 
     async def add_update(self, update):
@@ -45,15 +57,64 @@ class BaseUpdateQueue:
     async def flush_all_updates_from_in_memory_queue(self):
         """Get all updates from the queue."""
         updates = []
-        while not self.update_queue.empty():
+        while True:
             # Circuit breaker to ensure we're not stuck dequeuing updates. Protect CPU utilization
             if len(updates) >= MAX_IN_MEMORY_QUEUE_FLUSH_COUNT:
                 verbose_proxy_logger.debug(
                     "Max in memory queue flush count reached, stopping flush"
                 )
                 break
-            updates.append(await self.update_queue.get())
+            try:
+                updates.append(self.update_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
         return updates
+
+    def _schedule_queue_aggregation_if_needed(self) -> None:
+        """Schedule queue aggregation without doing CPU-heavy work on the producer path."""
+        if self.update_queue.qsize() < self.MAX_SIZE_IN_MEMORY_QUEUE:
+            return
+
+        now = time.monotonic()
+        if now - self._last_queue_full_warning_time >= 30:
+            verbose_proxy_logger.warning(
+                "Spend update queue is full. Scheduling background aggregation to concatenate entries."
+            )
+            self._last_queue_full_warning_time = now
+
+        if self._aggregation_task is not None and not self._aggregation_task.done():
+            return
+
+        self._aggregation_task = asyncio.create_task(
+            self._aggregate_queue_updates_if_needed()
+        )
+        self._aggregation_task.add_done_callback(self._log_aggregation_task_exception)
+
+    def _log_aggregation_task_exception(self, task: asyncio.Task) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            verbose_proxy_logger.error(
+                "Spend update queue aggregation failed: %s", str(e)
+            )
+
+    async def _aggregate_queue_updates_if_needed(self) -> None:
+        async with self._aggregation_lock:
+            if self.update_queue.qsize() < self.MAX_SIZE_IN_MEMORY_QUEUE:
+                return
+            await self.aggregate_queue_updates()
+
+    async def _wait_for_pending_aggregation(self) -> None:
+        task = self._aggregation_task
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        await task
+
+    async def aggregate_queue_updates(self):
+        """Subclasses aggregate queue entries into fewer queue entries."""
+        raise NotImplementedError()
 
     async def _emit_new_item_added_to_queue_event(
         self,

--- a/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
@@ -62,11 +62,7 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
         """Enqueue an update."""
         verbose_proxy_logger.debug("Adding update to queue: %s", update)
         await self.update_queue.put(update)
-        if self.update_queue.qsize() >= self.MAX_SIZE_IN_MEMORY_QUEUE:
-            verbose_proxy_logger.warning(
-                "Spend update queue is full. Aggregating all entries in queue to concatenate entries."
-            )
-            await self.aggregate_queue_updates()
+        self._schedule_queue_aggregation_if_needed()
 
     async def aggregate_queue_updates(self):
         """
@@ -85,6 +81,7 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
         self,
     ) -> Dict[str, BaseDailySpendTransaction]:
         """Get all updates from the queue and return all updates aggregated by daily_transaction_key. Works for both user and team spend updates."""
+        await self._wait_for_pending_aggregation()
         updates = await self.flush_all_updates_from_in_memory_queue()
         if len(updates) > 0:
             verbose_proxy_logger.info(

--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -30,6 +30,7 @@ class SpendUpdateQueue(BaseUpdateQueue):
         self,
     ) -> DBSpendUpdateTransactions:
         """Flush all updates from the queue and return all updates aggregated by entity type."""
+        await self._wait_for_pending_aggregation()
         updates = await self.flush_all_updates_from_in_memory_queue()
         if len(updates) > 0:
             verbose_proxy_logger.info(
@@ -44,12 +45,7 @@ class SpendUpdateQueue(BaseUpdateQueue):
         verbose_proxy_logger.debug("Adding update to queue: %s", update)
         await self.update_queue.put(update)
 
-        # if the queue is full, aggregate the updates
-        if self.update_queue.qsize() >= self.MAX_SIZE_IN_MEMORY_QUEUE:
-            verbose_proxy_logger.warning(
-                "Spend update queue is full. Aggregating all entries in queue to concatenate entries."
-            )
-            await self.aggregate_queue_updates()
+        self._schedule_queue_aggregation_if_needed()
 
     async def aggregate_queue_updates(self):
         """Concatenate all updates in the queue to reduce the size of in-memory queue"""

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -652,9 +652,33 @@ def cleanup_router_config_variables():
     prisma_client = None
 
 
+async def _shutdown_scheduled_background_jobs() -> None:
+    global scheduler, spend_logs_queue_monitor_task
+    if spend_logs_queue_monitor_task is not None:
+        spend_logs_queue_monitor_task.cancel()
+        try:
+            await spend_logs_queue_monitor_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            verbose_proxy_logger.error(
+                f"Error stopping spend logs queue monitor task: {e}"
+            )
+        spend_logs_queue_monitor_task = None
+
+    if scheduler is not None:
+        try:
+            scheduler.shutdown(wait=True)
+            verbose_proxy_logger.info("APScheduler shut down")
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error shutting down APScheduler: {e}")
+        scheduler = None
+
+
 async def proxy_shutdown_event():
     global prisma_client, master_key, user_custom_auth, user_custom_key_generate, user_custom_key_update
     verbose_proxy_logger.info("Shutting down LiteLLM Proxy Server")
+    await _shutdown_scheduled_background_jobs()
     if prisma_client:
         verbose_proxy_logger.debug("Disconnecting from Prisma")
         await prisma_client.disconnect()
@@ -1781,6 +1805,7 @@ celery_fn = None  # Redis Queue for handling requests
 
 # Global variables for model cost map reload scheduling
 scheduler = None
+spend_logs_queue_monitor_task: Optional[asyncio.Task] = None
 last_model_cost_map_reload = None
 
 # Global variable for anthropic beta headers reload scheduling
@@ -2703,11 +2728,9 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(
-            f"""
+        verbose_proxy_logger.debug(f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """
-        )
+        """)
 
 
 def _get_process_rss_mb() -> Optional[float]:
@@ -6918,7 +6941,7 @@ class ProxyStartupEvent:
         proxy_logging_obj: ProxyLogging,
     ):
         """Initializes scheduled background jobs"""
-        global store_model_in_db, scheduler
+        global store_model_in_db, scheduler, spend_logs_queue_monitor_task
 
         # MEMORY LEAK FIX: Configure scheduler with optimized settings
         # Memray analysis showed APScheduler's normalize() and _apply_jitter() causing
@@ -7016,13 +7039,17 @@ class ProxyStartupEvent:
             from litellm.proxy.utils import _monitor_spend_logs_queue
 
             # Start background task to monitor spend logs queue size
-            asyncio.create_task(
-                _monitor_spend_logs_queue(
-                    prisma_client=prisma_client,
-                    db_writer_client=db_writer_client,
-                    proxy_logging_obj=proxy_logging_obj,
+            if (
+                spend_logs_queue_monitor_task is None
+                or spend_logs_queue_monitor_task.done()
+            ):
+                spend_logs_queue_monitor_task = asyncio.create_task(
+                    _monitor_spend_logs_queue(
+                        prisma_client=prisma_client,
+                        db_writer_client=db_writer_client,
+                        proxy_logging_obj=proxy_logging_obj,
+                    )
                 )
-            )
 
         ### ADD NEW MODELS ###
         store_model_in_db = (

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2728,9 +2728,11 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(f"""
+        verbose_proxy_logger.debug(
+            f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """)
+        """
+        )
 
 
 def _get_process_rss_mb() -> Optional[float]:

--- a/scripts/validate_proxy_overhead.py
+++ b/scripts/validate_proxy_overhead.py
@@ -31,6 +31,7 @@ DEFAULT_PAYLOAD = {
     "messages": [{"role": "user", "content": "Reply with a single short sentence."}],
     "max_tokens": 32,
 }
+SSL_CONTEXT = ssl.create_default_context()
 
 
 @dataclass
@@ -132,7 +133,7 @@ def post_json_request(
     try:
         request = make_request(url, headers, payload, timeout_seconds)
         with urllib.request.urlopen(
-            request, timeout=timeout_seconds, context=ssl.create_default_context()
+            request, timeout=timeout_seconds, context=SSL_CONTEXT
         ) as response:
             body = response.read()
         total_seconds = time.perf_counter() - start
@@ -175,7 +176,7 @@ def post_stream_request(
     try:
         request = make_request(url, headers, stream_payload, timeout_seconds)
         with urllib.request.urlopen(
-            request, timeout=timeout_seconds, context=ssl.create_default_context()
+            request, timeout=timeout_seconds, context=SSL_CONTEXT
         ) as response:
             for raw_line in response:
                 line = raw_line.decode("utf-8", errors="ignore").strip()

--- a/scripts/validate_proxy_overhead.py
+++ b/scripts/validate_proxy_overhead.py
@@ -15,15 +15,16 @@ Examples:
 """
 
 import argparse
-import asyncio
+import concurrent.futures
 import json
 import os
+import ssl
 import statistics
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
-
-import aiohttp
 
 DEFAULT_PAYLOAD = {
     "model": "gpt-4o-mini",
@@ -97,30 +98,58 @@ def auth_headers(api_key: Optional[str]) -> Dict[str, str]:
     return headers
 
 
-async def post_json_request(
-    session: aiohttp.ClientSession,
+def post_request(
     url: str,
     headers: Dict[str, str],
     payload: Dict[str, Any],
+    timeout_seconds: float,
+    stream: bool,
+) -> RequestResult:
+    return (
+        post_stream_request(url, headers, payload, timeout_seconds)
+        if stream
+        else post_json_request(url, headers, payload, timeout_seconds)
+    )
+
+
+def make_request(
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+    timeout_seconds: float,
+) -> urllib.request.Request:
+    body = json.dumps(payload).encode("utf-8")
+    return urllib.request.Request(url=url, data=body, headers=headers, method="POST")
+
+
+def post_json_request(
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+    timeout_seconds: float,
 ) -> RequestResult:
     start = time.perf_counter()
     try:
-        async with session.post(url, headers=headers, json=payload) as response:
-            body = await response.read()
-            total_seconds = time.perf_counter() - start
-            if response.status >= 400:
-                return RequestResult(
-                    ok=False,
-                    total_seconds=total_seconds,
-                    error=f"HTTP {response.status}: {body[:200]!r}",
-                )
-            data = json.loads(body)
-            usage = data.get("usage") or {}
-            return RequestResult(
-                ok=True,
-                total_seconds=total_seconds,
-                total_tokens=int(usage.get("total_tokens") or 0),
-            )
+        request = make_request(url, headers, payload, timeout_seconds)
+        with urllib.request.urlopen(
+            request, timeout=timeout_seconds, context=ssl.create_default_context()
+        ) as response:
+            body = response.read()
+        total_seconds = time.perf_counter() - start
+        data = json.loads(body)
+        usage = data.get("usage") or {}
+        return RequestResult(
+            ok=True,
+            total_seconds=total_seconds,
+            total_tokens=int(usage.get("total_tokens") or 0),
+        )
+    except urllib.error.HTTPError as exc:
+        body = exc.read()[:200]
+        return RequestResult(
+            ok=False,
+            total_seconds=time.perf_counter() - start,
+            error=f"HTTP {exc.code}: {body!r}",
+        )
     except Exception as exc:
         return RequestResult(
             ok=False,
@@ -129,11 +158,11 @@ async def post_json_request(
         )
 
 
-async def post_stream_request(
-    session: aiohttp.ClientSession,
+def post_stream_request(
     url: str,
     headers: Dict[str, str],
     payload: Dict[str, Any],
+    timeout_seconds: float,
 ) -> RequestResult:
     stream_payload = {
         **payload,
@@ -144,16 +173,11 @@ async def post_stream_request(
     ttft_seconds: Optional[float] = None
     total_tokens = 0
     try:
-        async with session.post(url, headers=headers, json=stream_payload) as response:
-            if response.status >= 400:
-                body = await response.read()
-                return RequestResult(
-                    ok=False,
-                    total_seconds=time.perf_counter() - start,
-                    error=f"HTTP {response.status}: {body[:200]!r}",
-                )
-
-            async for raw_line in response.content:
+        request = make_request(url, headers, stream_payload, timeout_seconds)
+        with urllib.request.urlopen(
+            request, timeout=timeout_seconds, context=ssl.create_default_context()
+        ) as response:
+            for raw_line in response:
                 line = raw_line.decode("utf-8", errors="ignore").strip()
                 if not line.startswith("data: "):
                     continue
@@ -170,12 +194,20 @@ async def post_stream_request(
                 if usage.get("total_tokens") is not None:
                     total_tokens = int(usage["total_tokens"])
 
-            return RequestResult(
-                ok=True,
-                total_seconds=time.perf_counter() - start,
-                ttft_seconds=ttft_seconds,
-                total_tokens=total_tokens,
-            )
+        return RequestResult(
+            ok=True,
+            total_seconds=time.perf_counter() - start,
+            ttft_seconds=ttft_seconds,
+            total_tokens=total_tokens,
+        )
+    except urllib.error.HTTPError as exc:
+        body = exc.read()[:200]
+        return RequestResult(
+            ok=False,
+            total_seconds=time.perf_counter() - start,
+            ttft_seconds=ttft_seconds,
+            error=f"HTTP {exc.code}: {body!r}",
+        )
     except Exception as exc:
         return RequestResult(
             ok=False,
@@ -185,7 +217,7 @@ async def post_stream_request(
         )
 
 
-async def run_endpoint(
+def run_endpoint(
     label: str,
     url: str,
     api_key: Optional[str],
@@ -195,24 +227,27 @@ async def run_endpoint(
     stream: bool,
     timeout_seconds: float,
 ) -> RunResult:
-    connector = aiohttp.TCPConnector(limit=max(concurrency * 2, 1))
-    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
-    semaphore = asyncio.Semaphore(concurrency)
     headers = auth_headers(api_key)
-    request_fn = post_stream_request if stream else post_json_request
+    for _ in range(min(10, requests)):
+        post_request(url, headers, payload, timeout_seconds, stream)
 
-    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
-        for _ in range(min(10, requests)):
-            await request_fn(session, url, headers, payload)
-
-        async def guarded_request() -> RequestResult:
-            async with semaphore:
-                return await request_fn(session, url, headers, payload)
-
-        start = time.perf_counter()
-        results = await asyncio.gather(*[guarded_request() for _ in range(requests)])
-        wall_seconds = time.perf_counter() - start
-
+    start = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = [
+            executor.submit(
+                post_request,
+                url,
+                headers,
+                payload,
+                timeout_seconds,
+                stream,
+            )
+            for _ in range(requests)
+        ]
+        results = [
+            future.result() for future in concurrent.futures.as_completed(futures)
+        ]
+    wall_seconds = time.perf_counter() - start
     return RunResult(label=label, wall_seconds=wall_seconds, results=results)
 
 
@@ -257,7 +292,7 @@ def load_payload(path: Optional[str]) -> Dict[str, Any]:
         return json.load(file)
 
 
-async def main() -> None:
+def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--baseline-url", default=os.getenv("BASELINE_URL") or os.getenv("PROVIDER_URL")
@@ -289,7 +324,7 @@ async def main() -> None:
         )
 
     payload = load_payload(args.payload_file)
-    baseline = await run_endpoint(
+    baseline = run_endpoint(
         label="baseline",
         url=args.baseline_url,
         api_key=args.baseline_api_key,
@@ -299,7 +334,7 @@ async def main() -> None:
         stream=args.stream,
         timeout_seconds=args.timeout,
     )
-    candidate = await run_endpoint(
+    candidate = run_endpoint(
         label="candidate",
         url=args.candidate_url,
         api_key=args.candidate_api_key,
@@ -313,4 +348,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/scripts/validate_proxy_overhead.py
+++ b/scripts/validate_proxy_overhead.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Validate proxy overhead for RPS, TTFT/latency, and token throughput.
+
+Examples:
+  BASELINE_URL=http://localhost:4000/v1/chat/completions \
+  CANDIDATE_URL=http://localhost:4001/v1/chat/completions \
+  BASELINE_API_KEY=sk-1234 CANDIDATE_API_KEY=sk-1234 \
+  python scripts/validate_proxy_overhead.py --stream --requests 500 --concurrency 100
+
+  PROVIDER_URL=https://api.openai.com/v1/chat/completions \
+  LITELLM_PROXY_URL=http://localhost:4000/v1/chat/completions \
+  PROVIDER_API_KEY=sk-... LITELLM_PROXY_API_KEY=sk-1234 \
+  python scripts/validate_proxy_overhead.py --payload-file payload.json
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+DEFAULT_PAYLOAD = {
+    "model": "gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Reply with a single short sentence."}],
+    "max_tokens": 32,
+}
+
+
+@dataclass
+class RequestResult:
+    ok: bool
+    total_seconds: float
+    ttft_seconds: Optional[float] = None
+    total_tokens: int = 0
+    error: str = ""
+
+
+@dataclass
+class RunResult:
+    label: str
+    wall_seconds: float
+    results: List[RequestResult] = field(default_factory=list)
+
+    @property
+    def successes(self) -> List[RequestResult]:
+        return [result for result in self.results if result.ok]
+
+    def stats(self) -> Dict[str, Any]:
+        successes = self.successes
+        latencies = [result.total_seconds * 1000 for result in successes]
+        ttfts = [
+            result.ttft_seconds * 1000
+            for result in successes
+            if result.ttft_seconds is not None
+        ]
+        total_tokens = sum(result.total_tokens for result in successes)
+        return {
+            "requests": len(self.results),
+            "successes": len(successes),
+            "failures": len(self.results) - len(successes),
+            "rps": len(successes) / self.wall_seconds if self.wall_seconds else 0.0,
+            "tpm": (
+                (total_tokens / self.wall_seconds * 60) if self.wall_seconds else 0.0
+            ),
+            "latency_ms": percentile_stats(latencies),
+            "ttft_ms": percentile_stats(ttfts),
+        }
+
+
+def percentile_stats(values: List[float]) -> Dict[str, float]:
+    if not values:
+        return {"p50": 0.0, "p95": 0.0, "p99": 0.0}
+    values = sorted(values)
+    return {
+        "p50": values[int((len(values) - 1) * 0.50)],
+        "p95": values[int((len(values) - 1) * 0.95)],
+        "p99": values[int((len(values) - 1) * 0.99)],
+    }
+
+
+def percent_delta(candidate: float, baseline: float) -> float:
+    if baseline == 0:
+        return 0.0
+    return (candidate - baseline) / baseline * 100
+
+
+def auth_headers(api_key: Optional[str]) -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+async def post_json_request(
+    session: aiohttp.ClientSession,
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+) -> RequestResult:
+    start = time.perf_counter()
+    try:
+        async with session.post(url, headers=headers, json=payload) as response:
+            body = await response.read()
+            total_seconds = time.perf_counter() - start
+            if response.status >= 400:
+                return RequestResult(
+                    ok=False,
+                    total_seconds=total_seconds,
+                    error=f"HTTP {response.status}: {body[:200]!r}",
+                )
+            data = json.loads(body)
+            usage = data.get("usage") or {}
+            return RequestResult(
+                ok=True,
+                total_seconds=total_seconds,
+                total_tokens=int(usage.get("total_tokens") or 0),
+            )
+    except Exception as exc:
+        return RequestResult(
+            ok=False,
+            total_seconds=time.perf_counter() - start,
+            error=str(exc)[:200],
+        )
+
+
+async def post_stream_request(
+    session: aiohttp.ClientSession,
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+) -> RequestResult:
+    stream_payload = {
+        **payload,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    start = time.perf_counter()
+    ttft_seconds: Optional[float] = None
+    total_tokens = 0
+    try:
+        async with session.post(url, headers=headers, json=stream_payload) as response:
+            if response.status >= 400:
+                body = await response.read()
+                return RequestResult(
+                    ok=False,
+                    total_seconds=time.perf_counter() - start,
+                    error=f"HTTP {response.status}: {body[:200]!r}",
+                )
+
+            async for raw_line in response.content:
+                line = raw_line.decode("utf-8", errors="ignore").strip()
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                if ttft_seconds is None:
+                    ttft_seconds = time.perf_counter() - start
+                usage = chunk.get("usage") or {}
+                if usage.get("total_tokens") is not None:
+                    total_tokens = int(usage["total_tokens"])
+
+            return RequestResult(
+                ok=True,
+                total_seconds=time.perf_counter() - start,
+                ttft_seconds=ttft_seconds,
+                total_tokens=total_tokens,
+            )
+    except Exception as exc:
+        return RequestResult(
+            ok=False,
+            total_seconds=time.perf_counter() - start,
+            ttft_seconds=ttft_seconds,
+            error=str(exc)[:200],
+        )
+
+
+async def run_endpoint(
+    label: str,
+    url: str,
+    api_key: Optional[str],
+    payload: Dict[str, Any],
+    requests: int,
+    concurrency: int,
+    stream: bool,
+    timeout_seconds: float,
+) -> RunResult:
+    connector = aiohttp.TCPConnector(limit=max(concurrency * 2, 1))
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    semaphore = asyncio.Semaphore(concurrency)
+    headers = auth_headers(api_key)
+    request_fn = post_stream_request if stream else post_json_request
+
+    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+        for _ in range(min(10, requests)):
+            await request_fn(session, url, headers, payload)
+
+        async def guarded_request() -> RequestResult:
+            async with semaphore:
+                return await request_fn(session, url, headers, payload)
+
+        start = time.perf_counter()
+        results = await asyncio.gather(*[guarded_request() for _ in range(requests)])
+        wall_seconds = time.perf_counter() - start
+
+    return RunResult(label=label, wall_seconds=wall_seconds, results=results)
+
+
+def print_stats(baseline: RunResult, candidate: RunResult) -> None:
+    baseline_stats = baseline.stats()
+    candidate_stats = candidate.stats()
+
+    print("\nMetric                        Baseline        Candidate       Delta")
+    print("-" * 68)
+    for metric in ("rps", "tpm"):
+        base = baseline_stats[metric]
+        cand = candidate_stats[metric]
+        print(
+            f"{metric.upper():<28}{base:>10.2f}      {cand:>10.2f}      {percent_delta(cand, base):>7.2f}%"
+        )
+
+    for family in ("latency_ms", "ttft_ms"):
+        if family == "ttft_ms" and candidate_stats[family]["p50"] == 0:
+            continue
+        for percentile in ("p50", "p95", "p99"):
+            base = baseline_stats[family][percentile]
+            cand = candidate_stats[family][percentile]
+            print(
+                f"{family}.{percentile:<19}{base:>10.2f} ms   {cand:>10.2f} ms   {percent_delta(cand, base):>7.2f}%"
+            )
+
+    print("-" * 68)
+    print(
+        f"{baseline.label}: {baseline_stats['successes']}/{baseline_stats['requests']} successes, "
+        f"{baseline_stats['failures']} failures"
+    )
+    print(
+        f"{candidate.label}: {candidate_stats['successes']}/{candidate_stats['requests']} successes, "
+        f"{candidate_stats['failures']} failures"
+    )
+
+
+def load_payload(path: Optional[str]) -> Dict[str, Any]:
+    if path is None:
+        return dict(DEFAULT_PAYLOAD)
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline-url", default=os.getenv("BASELINE_URL") or os.getenv("PROVIDER_URL")
+    )
+    parser.add_argument(
+        "--candidate-url",
+        default=os.getenv("CANDIDATE_URL") or os.getenv("LITELLM_PROXY_URL"),
+    )
+    parser.add_argument(
+        "--baseline-api-key",
+        default=os.getenv("BASELINE_API_KEY") or os.getenv("PROVIDER_API_KEY"),
+    )
+    parser.add_argument(
+        "--candidate-api-key",
+        default=os.getenv("CANDIDATE_API_KEY") or os.getenv("LITELLM_PROXY_API_KEY"),
+    )
+    parser.add_argument("--payload-file")
+    parser.add_argument("--requests", type=int, default=500)
+    parser.add_argument("--concurrency", type=int, default=100)
+    parser.add_argument("--timeout", type=float, default=120)
+    parser.add_argument(
+        "--stream", action="store_true", help="Measure TTFT using streaming responses"
+    )
+    args = parser.parse_args()
+
+    if not args.baseline_url or not args.candidate_url:
+        raise SystemExit(
+            "Set --baseline-url and --candidate-url, or BASELINE_URL/CANDIDATE_URL."
+        )
+
+    payload = load_payload(args.payload_file)
+    baseline = await run_endpoint(
+        label="baseline",
+        url=args.baseline_url,
+        api_key=args.baseline_api_key,
+        payload=payload,
+        requests=args.requests,
+        concurrency=args.concurrency,
+        stream=args.stream,
+        timeout_seconds=args.timeout,
+    )
+    candidate = await run_endpoint(
+        label="candidate",
+        url=args.candidate_url,
+        api_key=args.candidate_api_key,
+        payload=payload,
+        requests=args.requests,
+        concurrency=args.concurrency,
+        stream=args.stream,
+        timeout_seconds=args.timeout,
+    )
+    print_stats(baseline, candidate)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/proxy_unit_tests/test_aproxy_startup.py
+++ b/tests/proxy_unit_tests/test_aproxy_startup.py
@@ -94,3 +94,37 @@ async def test_proxy_gunicorn_startup_config_dict():
 
 
 # test_proxy_gunicorn_startup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_shutdown_stops_scheduler_before_prisma_disconnect(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm.proxy.proxy_server as proxy_server
+
+    events = []
+
+    class MockScheduler:
+        def shutdown(self, wait=True):
+            assert wait is True
+            events.append("scheduler_shutdown")
+
+    class MockPrismaClient:
+        async def disconnect(self):
+            events.append("prisma_disconnect")
+
+    mock_jwt_handler = MagicMock()
+    mock_jwt_handler.close = AsyncMock()
+
+    monkeypatch.setattr(proxy_server, "scheduler", MockScheduler())
+    monkeypatch.setattr(proxy_server, "spend_logs_queue_monitor_task", None)
+    monkeypatch.setattr(proxy_server, "prisma_client", MockPrismaClient())
+    monkeypatch.setattr(proxy_server, "jwt_handler", mock_jwt_handler)
+    monkeypatch.setattr(proxy_server, "db_writer_client", None)
+    monkeypatch.setattr(litellm, "cache", None)
+
+    await proxy_server.proxy_shutdown_event()
+
+    assert events == ["scheduler_shutdown", "prisma_disconnect"]
+    assert proxy_server.scheduler is None
+    mock_jwt_handler.close.assert_awaited_once()

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py
@@ -60,5 +60,7 @@ def test_misconfigured_queue_thresholds_warns():
         patch.object(bq_module.verbose_proxy_logger, "warning") as mock_warning,
     ):
         BaseUpdateQueue()
-        mock_warning.assert_called_once()
-        assert "Misconfigured queue thresholds" in mock_warning.call_args[0][0]
+        assert any(
+            "Misconfigured queue thresholds" in call_args[0][0]
+            for call_args in mock_warning.call_args_list
+        )

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py
@@ -15,6 +15,18 @@ from litellm.constants import MAX_IN_MEMORY_QUEUE_FLUSH_COUNT
 from litellm.proxy.db.db_transaction_queue.base_update_queue import BaseUpdateQueue
 
 
+class AggregatingTestQueue(BaseUpdateQueue):
+    def __init__(self):
+        super().__init__()
+        self.aggregate_calls = 0
+        self.continue_aggregation = asyncio.Event()
+
+    async def aggregate_queue_updates(self):
+        self.aggregate_calls += 1
+        await self.continue_aggregation.wait()
+        await self.flush_all_updates_from_in_memory_queue()
+
+
 @pytest.mark.asyncio
 async def test_queue_flush_limit():
     """
@@ -64,3 +76,92 @@ def test_misconfigured_queue_thresholds_warns():
             "Misconfigured queue thresholds" in call_args[0][0]
             for call_args in mock_warning.call_args_list
         )
+
+
+@pytest.mark.asyncio
+async def test_schedule_queue_aggregation_runs_once_while_pending():
+    queue = AggregatingTestQueue()
+    queue.MAX_SIZE_IN_MEMORY_QUEUE = 2
+    await queue.update_queue.put("first")
+    await queue.update_queue.put("second")
+
+    queue._schedule_queue_aggregation_if_needed()
+    first_task = queue._aggregation_task
+    queue._schedule_queue_aggregation_if_needed()
+
+    assert queue._aggregation_task is first_task
+    assert first_task is not None
+
+    while queue.aggregate_calls == 0:
+        await asyncio.sleep(0)
+
+    queue.continue_aggregation.set()
+    await queue._wait_for_pending_aggregation()
+
+    assert queue.aggregate_calls == 1
+    assert queue.update_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_queue_aggregation_skips_below_threshold():
+    queue = AggregatingTestQueue()
+    queue.MAX_SIZE_IN_MEMORY_QUEUE = 2
+    await queue.update_queue.put("first")
+
+    queue._schedule_queue_aggregation_if_needed()
+    await queue._aggregate_queue_updates_if_needed()
+
+    assert queue._aggregation_task is None
+    assert queue.aggregate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_pending_aggregation_ignores_completed_task():
+    queue = AggregatingTestQueue()
+    queue.continue_aggregation.set()
+    queue._aggregation_task = asyncio.create_task(queue.aggregate_queue_updates())
+    await queue._aggregation_task
+
+    await queue._wait_for_pending_aggregation()
+
+    assert queue.aggregate_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_log_aggregation_task_exception_handles_errors():
+    queue = AggregatingTestQueue()
+
+    async def raise_error():
+        raise RuntimeError("boom")
+
+    task = asyncio.create_task(raise_error())
+    await asyncio.sleep(0)
+
+    with patch(
+        "litellm.proxy.db.db_transaction_queue.base_update_queue.verbose_proxy_logger.error"
+    ) as mock_error:
+        queue._log_aggregation_task_exception(task)
+
+    mock_error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_log_aggregation_task_exception_ignores_cancelled_tasks():
+    queue = AggregatingTestQueue()
+
+    async def wait_forever():
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(wait_forever())
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    with patch(
+        "litellm.proxy.db.db_transaction_queue.base_update_queue.verbose_proxy_logger.error"
+    ) as mock_error:
+        queue._log_aggregation_task_exception(task)
+
+    mock_error.assert_not_called()

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
@@ -292,6 +292,8 @@ async def test_queue_max_size_triggers_aggregation(
     for i in range(6):
         await daily_spend_update_queue.add_update({test_key: test_transaction})
 
+    await daily_spend_update_queue._wait_for_pending_aggregation()
+
     # Queue should have aggregated to a single item
     assert daily_spend_update_queue.update_queue.qsize() == 1
 

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -55,6 +56,26 @@ async def test_add_single_update(daily_spend_update_queue):
     assert len(updates) == 1
     assert test_key in updates[0]
     assert updates[0][test_key] == test_transaction
+
+
+@pytest.mark.asyncio
+async def test_add_update_schedules_aggregation_check(daily_spend_update_queue):
+    test_key = "user1_2023-01-01_key123_gpt-4_openai"
+    test_transaction = {
+        "spend": 1.0,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "api_requests": 1,
+        "successful_requests": 1,
+        "failed_requests": 0,
+    }
+
+    with patch.object(
+        daily_spend_update_queue, "_schedule_queue_aggregation_if_needed"
+    ) as mock_schedule:
+        await daily_spend_update_queue.add_update({test_key: test_transaction})
+
+    mock_schedule.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
@@ -168,6 +168,8 @@ async def test_queue_max_size_triggers_aggregation(monkeypatch, spend_queue):
         }
         await spend_queue.add_update(update)
 
+    await spend_queue._wait_for_pending_aggregation()
+
     # Queue should have been aggregated, resulting in a single entry
     assert spend_queue.update_queue.qsize() == 1
 

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -32,6 +33,22 @@ async def test_add_update(spend_queue):
 
     # Verify update was added by checking queue size
     assert spend_queue.update_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_add_update_schedules_aggregation_check(spend_queue):
+    update: SpendUpdateQueueItem = {
+        "entity_type": Litellm_EntityType.USER,
+        "entity_id": "user123",
+        "response_cost": 0.5,
+    }
+
+    with patch.object(
+        spend_queue, "_schedule_queue_aggregation_if_needed"
+    ) as mock_schedule:
+        await spend_queue.add_update(update)
+
+    mock_schedule.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -1141,6 +1141,151 @@ async def test_enqueue_daily_spend_updates_builds_shared_payload_once():
 
 
 @pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_skips_without_prisma():
+    writer = DBSpendUpdateWriter()
+    writer._get_base_daily_spend_transaction = MagicMock()
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload={},
+        org_id="test-org",
+        prisma_client=None,
+    )
+
+    writer._get_base_daily_spend_transaction.assert_not_called()
+    writer.daily_spend_update_queue.add_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_skips_when_base_transaction_missing():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    writer._get_base_daily_spend_transaction = MagicMock(return_value=None)
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload={"user": "test-user"},
+        org_id=None,
+        prisma_client=mock_prisma,
+    )
+
+    writer._get_base_daily_spend_transaction.assert_called_once()
+    writer.daily_spend_update_queue.add_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_skips_invalid_request_tags():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+    payload = {
+        "request_id": "req-invalid-tags",
+        "user": "test-user",
+        "request_tags": {"invalid": "tag-shape"},
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "gpt-4",
+        "custom_llm_provider": "openai",
+        "model_group": "gpt-4-group",
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "spend": 0.15,
+        "metadata": '{"usage_object": {}}',
+    }
+
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    writer.daily_tag_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload=payload,
+        org_id=None,
+        prisma_client=mock_prisma,
+    )
+
+    writer.daily_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_tag_spend_update_queue.add_update.assert_not_called()
+
+
+def test_get_base_daily_spend_transaction_rejects_missing_required_keys():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+
+    assert (
+        writer._get_base_daily_spend_transaction(
+            payload={"api_key": "test-key"},
+            prisma_client=mock_prisma,
+        )
+        is None
+    )
+    assert mock_prisma.get_request_status.call_count == 0
+
+
+def test_get_base_daily_spend_transaction_rejects_missing_model_fields():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+
+    assert (
+        writer._get_base_daily_spend_transaction(
+            payload={
+                "startTime": "2024-01-01T12:00:00",
+                "api_key": "test-key",
+                "model": "gpt-4",
+            },
+            prisma_client=mock_prisma,
+        )
+        is None
+    )
+    assert mock_prisma.get_request_status.call_count == 0
+
+
+def test_get_base_daily_spend_transaction_rejects_invalid_start_time():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+
+    assert (
+        writer._get_base_daily_spend_transaction(
+            payload={
+                "startTime": object(),
+                "api_key": "test-key",
+                "model": "gpt-4",
+                "custom_llm_provider": "openai",
+                "model_group": "gpt-4-group",
+                "metadata": '{"usage_object": {}}',
+            },
+            prisma_client=mock_prisma,
+        )
+        is None
+    )
+    mock_prisma.get_request_status.assert_called_once()
+
+
+def test_get_base_daily_spend_transaction_tracks_failed_requests():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="failure")
+
+    result = writer._get_base_daily_spend_transaction(
+        payload={
+            "startTime": datetime(2024, 1, 1, 12, 0, 0),
+            "api_key": "test-key",
+            "mcp_namespaced_tool_name": "server/tool",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "spend": 0.1,
+            "metadata": '{"usage_object": {"cache_creation_input_tokens": 2}}',
+        },
+        prisma_client=mock_prisma,
+    )
+
+    assert result is not None
+    assert result["date"] == "2024-01-01"
+    assert result["successful_requests"] == 0
+    assert result["failed_requests"] == 1
+    assert result["cache_creation_input_tokens"] == 2
+
+
+@pytest.mark.asyncio
 async def test_update_daily_spend_logs_detailed_error_on_batch_upsert_failure():
     """
     Test that when batch upsert fails, detailed error information is logged.

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -19,7 +19,7 @@ from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
 @pytest.mark.asyncio
 async def test_daily_spend_tracking_with_disabled_spend_logs():
     """
-    Test that add_spend_log_transaction_to_daily_user_transaction is still called
+    Test that daily spend updates are still enqueued
     even when disable_spend_logs is True
     """
     # Setup
@@ -27,7 +27,7 @@ async def test_daily_spend_tracking_with_disabled_spend_logs():
 
     # Mock the methods we want to track
     db_writer._insert_spend_log_to_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
+    db_writer._enqueue_daily_spend_updates = AsyncMock()
 
     # Mock the imported modules/variables
     with (
@@ -59,13 +59,11 @@ async def test_daily_spend_tracking_with_disabled_spend_logs():
         # Verify that _insert_spend_log_to_db was NOT called (since disable_spend_logs is True)
         db_writer._insert_spend_log_to_db.assert_not_called()
 
-        # Verify that add_spend_log_transaction_to_daily_user_transaction WAS called
-        assert db_writer.add_spend_log_transaction_to_daily_user_transaction.called
+        # Verify that daily spend updates were still enqueued
+        assert db_writer._enqueue_daily_spend_updates.called
 
-        # Verify the payload passed to add_spend_log_transaction_to_daily_user_transaction
-        call_args = (
-            db_writer.add_spend_log_transaction_to_daily_user_transaction.call_args[1]
-        )
+        # Verify the payload passed to _enqueue_daily_spend_updates
+        call_args = db_writer._enqueue_daily_spend_updates.call_args[1]
         assert "payload" in call_args
         assert call_args["payload"]["spend"] == 0.1
         assert call_args["payload"]["model"] == "gpt-4"
@@ -1091,6 +1089,58 @@ async def test_endpoint_field_is_correctly_mapped_from_call_type():
 
 
 @pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_builds_shared_payload_once():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+
+    payload = {
+        "request_id": "req-daily-batch",
+        "user": "test-user",
+        "team_id": "test-team",
+        "end_user": "test-end-user",
+        "agent_id": "test-agent",
+        "request_tags": '["tag-a", "tag-b"]',
+        "call_type": "acompletion",
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "gpt-4",
+        "custom_llm_provider": "openai",
+        "model_group": "gpt-4-group",
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "spend": 0.15,
+        "metadata": '{"usage_object": {"cache_read_input_tokens": 3}}',
+    }
+
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    writer.daily_team_spend_update_queue.add_update = AsyncMock()
+    writer.daily_org_spend_update_queue.add_update = AsyncMock()
+    writer.daily_end_user_spend_update_queue.add_update = AsyncMock()
+    writer.daily_agent_spend_update_queue.add_update = AsyncMock()
+    writer.daily_tag_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload=payload,
+        org_id="test-org",
+        prisma_client=mock_prisma,
+    )
+
+    mock_prisma.get_request_status.assert_called_once_with(payload)
+    writer.daily_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_team_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_org_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_end_user_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_agent_spend_update_queue.add_update.assert_awaited_once()
+    assert writer.daily_tag_spend_update_queue.add_update.await_count == 2
+
+    user_update = writer.daily_spend_update_queue.add_update.call_args[1]["update"]
+    user_transaction = next(iter(user_update.values()))
+    assert user_transaction["endpoint"] == "/chat/completions"
+    assert user_transaction["cache_read_input_tokens"] == 3
+
+
+@pytest.mark.asyncio
 async def test_update_daily_spend_logs_detailed_error_on_batch_upsert_failure():
     """
     Test that when batch upsert fails, detailed error information is logged.
@@ -1354,12 +1404,7 @@ async def test_batch_database_updates_isolation_on_failure():
     db_writer._update_org_db = AsyncMock()
     db_writer._update_tag_db = AsyncMock()
     db_writer._update_agent_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
+    db_writer._enqueue_daily_spend_updates = AsyncMock()
 
     await db_writer._batch_database_updates(
         response_cost=0.1,
@@ -1382,12 +1427,7 @@ async def test_batch_database_updates_isolation_on_failure():
     db_writer._update_org_db.assert_awaited_once()
     db_writer._update_tag_db.assert_awaited_once()
     db_writer._update_agent_db.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_end_user_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_team_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_org_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_tag_transaction.assert_awaited_once()
+    db_writer._enqueue_daily_spend_updates.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1402,12 +1442,12 @@ async def test_daily_agent_receives_deepcopied_payload():
     db_writer = DBSpendUpdateWriter()
 
     # Capture the payload object that get_logging_payload returns (the "original")
-    # and the payload the agent handler receives (should be a deepcopy)
+    # and the payload the daily batch helper receives (should be a deepcopy)
     original_payload_ref = {}
-    captured_agent_payloads = []
+    captured_daily_payloads = []
 
-    async def capture_agent_payload(**kwargs):
-        captured_agent_payloads.append(kwargs.get("payload"))
+    async def capture_daily_payload(**kwargs):
+        captured_daily_payloads.append(kwargs.get("payload"))
 
     # Mock all helpers
     db_writer._insert_spend_log_to_db = AsyncMock()
@@ -1417,14 +1457,9 @@ async def test_daily_agent_receives_deepcopied_payload():
     db_writer._update_org_db = AsyncMock()
     db_writer._update_tag_db = AsyncMock()
     db_writer._update_agent_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock(
-        side_effect=capture_agent_payload
+    db_writer._enqueue_daily_spend_updates = AsyncMock(
+        side_effect=capture_daily_payload
     )
-    db_writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
 
     # Mock get_logging_payload to return a known dict and capture its identity
     fake_payload = {
@@ -1463,13 +1498,13 @@ async def test_daily_agent_receives_deepcopied_payload():
         # Let the single batched task run
         await asyncio.sleep(0)
 
-    # The agent handler should have been called
-    assert len(captured_agent_payloads) == 1
+    # The daily batch helper should have been called
+    assert len(captured_daily_payloads) == 1
     # The payload must NOT be the same object as the original (deepcopy occurred)
-    assert captured_agent_payloads[0] is not original_payload_ref["obj"]
+    assert captured_daily_payloads[0] is not original_payload_ref["obj"]
     # But it should have equivalent content
-    assert captured_agent_payloads[0]["model"] == "gpt-4"
-    assert captured_agent_payloads[0]["spend"] == 0.1
+    assert captured_daily_payloads[0]["model"] == "gpt-4"
+    assert captured_daily_payloads[0]["spend"] == 0.1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Performance regression RCA/fix for spend update overhead, queue pressure, and shutdown-time update_spend errors.

## RCA: regression source

The regression appears to be the combined effect of three spend-tracking changes:

1. **PR #20912 — `b7993b14cf` — `Add semgrep & Fix OOMs`**
   - Introduced bounded spend queues with `asyncio.Queue(maxsize=1000)`.
   - This reduced unbounded memory risk, but introduced producer backpressure risk when DB flushing lagged.

2. **PR #21963 — merge `a8456a2a30`, commit `a9c44d8530` — `[Fix] Spend Update Queue Aggregation Never Triggers with Default Presets`**
   - Changed default queue aggregation threshold from `2000` to `0.8 * queue maxsize` (`800`).
   - This made the queue-full aggregation path active under load.
   - Aggregation was still performed inline by enqueue producers, causing CPU/log pressure on the request logging path.

3. **PR #22028 — merge `b9dd36c14b`, commit `86ec2fbf84` — `perf(proxy): batch 11 create_task() calls into 1 in update_database()`**
   - Replaced 11 independent background tasks with 1 sequential task.
   - Reduced task scheduling overhead, but serialized all spend/daily-spend enqueue helpers and retained repeated daily base transaction work.

Related shutdown-log context:

- **PR #17742 — `9a0432d013` — `[Fix] Perf - Reduce memory accumulation of spend_logs`** added the spend-log monitor background task. The scheduler shutdown ordering bug predates this, but this added another DB-using background loop that needed explicit shutdown before Prisma disconnect.

## Focused comparison

| Snapshot | Commit | Queue aggregation | Daily base computes/request | `update_database` task count |
|---|---:|---|---:|---:|
| Before queue regression | `26d561081b` | inline, unbounded queue, threshold 2000 | 6 | 11 |
| Before task-batch regression | `9857643eb4` | inline, maxsize 1000, threshold 800 | 6 | 11 |
| Latest before fix | `8f25942ecf` | inline, maxsize 1000, threshold 800 | 6 | 1 |
| After fix | `fd20b8ee6e` | background/coalesced, maxsize 1000, threshold 800 | 1 | 1 |

Focused daily-spend base transaction micro-test, 100k requests:

| Snapshot | Seconds | Relative |
|---|---:|---:|
| Before PR #22028 | `0.7566s` | `1.00x` |
| Latest before fix | `0.7604s` | `1.00x` |
| After fix | `0.1310s` | `0.17x` |

Queue producer-path micro-test, 500k updates:

| Snapshot | Inline aggregation work |
|---|---:|
| Before PR #20912 | 526k items scanned inline |
| Latest before fix | 571k items scanned inline |
| After fix | 0 items scanned inline |

Interpretation: this PR removes queue aggregation work from the producer/request logging path and cuts repeated daily-spend base transaction computation by ~83% in the focused path.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Verified locally:

```bash
python3 -m py_compile litellm/constants.py litellm/proxy/db/db_spend_update_writer.py litellm/proxy/db/db_transaction_queue/base_update_queue.py litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py litellm/proxy/db/db_transaction_queue/spend_update_queue.py litellm/proxy/proxy_server.py tests/proxy_unit_tests/test_aproxy_startup.py tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py tests/test_litellm/proxy/db/test_db_spend_update_writer.py scripts/validate_proxy_overhead.py
python3 scripts/validate_proxy_overhead.py --help
cd litellm && python3 -m black --check --exclude '/enterprise/' .
```

Targeted pytest could not run in this container because the Python environment is missing pytest and project runtime deps (`python-dotenv` for importing `litellm`).

## Type

🐛 Bug Fix
✅ Test

## Changes

- Move spend queue threshold aggregation out of producer enqueue calls and coalesce it in a background task.
- Build shared daily spend transaction metadata once per request before enqueueing user/team/org/end-user/agent/tag daily rows.
- Stop APScheduler and the spend-log monitor before Prisma disconnect during shutdown.
- Add dependency-free `scripts/validate_proxy_overhead.py` to compare baseline vs candidate RPS, TPM, latency, and TTFT overhead.
- Apply CI-pinned Black formatting to `proxy_server.py`.
- Use branch-specific daily transaction variable names so MyPy keeps each TypedDict type distinct.
- Add focused coverage for queue aggregation scheduling, daily-spend enqueue branches, invalid tag metadata, and base daily transaction resolution.
- Cache the overhead script SSL context and skip invalid `request_tags` for daily tag spend instead of raising.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e18f9024-4fb9-457e-ad8d-129f3bf0086d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e18f9024-4fb9-457e-ad8d-129f3bf0086d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

