### PR TITLE
fix(responses): emit function-call args from .done event when no deltas were streamed

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -97,7 +97,7 @@ def _build_reasoning_item(
 
 
 def _reasoning_item_to_response_input(
-    r_item: Union[ChatCompletionReasoningItem, Dict[str, Any]]
+    r_item: Union[ChatCompletionReasoningItem, Dict[str, Any]],
 ) -> Dict[str, Any]:
     """Convert a stored ChatCompletionReasoningItem back to a Responses API input item."""
     r_input: Dict[str, Any] = {
@@ -300,10 +300,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             if key in ("max_tokens", "max_completion_tokens"):
                 responses_api_request["max_output_tokens"] = value
             elif key == "tools" and value is not None:
-                responses_api_request[
-                    "tools"
-                ] = self._convert_tools_to_responses_format(
-                    cast(List[Dict[str, Any]], value)
+                responses_api_request["tools"] = (
+                    self._convert_tools_to_responses_format(
+                        cast(List[Dict[str, Any]], value)
+                    )
                 )
             elif key == "response_format":
                 text_format = self._transform_response_format_to_text_format(value)
@@ -1162,9 +1162,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 )
 
                 if provider_specific_fields:
-                    function_chunk[
-                        "provider_specific_fields"
-                    ] = provider_specific_fields
+                    function_chunk["provider_specific_fields"] = (
+                        provider_specific_fields
+                    )
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
@@ -1237,9 +1237,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 # Add provider_specific_fields to function if present
                 if provider_specific_fields:
-                    function_chunk[
-                        "provider_specific_fields"
-                    ] = provider_specific_fields
+                    function_chunk["provider_specific_fields"] = (
+                        provider_specific_fields
+                    )
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -300,10 +300,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             if key in ("max_tokens", "max_completion_tokens"):
                 responses_api_request["max_output_tokens"] = value
             elif key == "tools" and value is not None:
-                responses_api_request["tools"] = (
-                    self._convert_tools_to_responses_format(
-                        cast(List[Dict[str, Any]], value)
-                    )
+                responses_api_request[
+                    "tools"
+                ] = self._convert_tools_to_responses_format(
+                    cast(List[Dict[str, Any]], value)
                 )
             elif key == "response_format":
                 text_format = self._transform_response_format_to_text_format(value)
@@ -1067,6 +1067,10 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         self, streaming_response, sync_stream: bool, json_mode: Optional[bool] = False
     ):
         super().__init__(streaming_response, sync_stream, json_mode)
+        # Tracks which output indices have already emitted at least one
+        # function_call_arguments.delta chunk so the .done handler knows
+        # whether to emit the full arguments or skip (to avoid duplication).
+        self._seen_arg_delta_idxs: set = set()
 
     def _handle_string_chunk(
         self, str_line: Union[str, "BaseModel"]
@@ -1158,9 +1162,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 )
 
                 if provider_specific_fields:
-                    function_chunk["provider_specific_fields"] = (
-                        provider_specific_fields
-                    )
+                    function_chunk[
+                        "provider_specific_fields"
+                    ] = provider_specific_fields
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
@@ -1233,9 +1237,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 # Add provider_specific_fields to function if present
                 if provider_specific_fields:
-                    function_chunk["provider_specific_fields"] = (
-                        provider_specific_fields
-                    )
+                    function_chunk[
+                        "provider_specific_fields"
+                    ] = provider_specific_fields
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
@@ -1390,6 +1394,53 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         verbose_logger.debug(
             f"Chat provider: transform_streaming_response called with chunk: {chunk}"
         )
+
+        event_type = chunk.get("type", "")
+
+        # Track which output indices have received at least one delta chunk so
+        # we can decide whether the .done event carries new information.
+        if event_type == "response.function_call_arguments.delta":
+            self._seen_arg_delta_idxs.add(chunk.get("output_index", 0))
+
+        # Some models (e.g. gpt-5.3-codex-spark via the Responses API) never
+        # emit delta events and deliver the full function arguments only in the
+        # .done event.  When no delta was seen for this output index we emit
+        # the arguments here; when deltas were already streamed we skip to
+        # avoid duplicating content in the reconstructed response.
+        if event_type == "response.function_call_arguments.done":
+            output_index = chunk.get("output_index", 0)
+            if output_index not in self._seen_arg_delta_idxs:
+                from litellm.types.llms.openai import (
+                    ChatCompletionToolCallFunctionChunk,
+                )
+                from litellm.types.utils import (
+                    ChatCompletionToolCallChunk,
+                    Delta,
+                    StreamingChoices,
+                )
+
+                return ModelResponseStream(
+                    choices=[
+                        StreamingChoices(
+                            index=0,
+                            delta=Delta(
+                                tool_calls=[
+                                    ChatCompletionToolCallChunk(
+                                        id=None,
+                                        index=output_index,
+                                        type="function",
+                                        function=ChatCompletionToolCallFunctionChunk(
+                                            name=None,
+                                            arguments=chunk.get("arguments", ""),
+                                        ),
+                                    )
+                                ]
+                            ),
+                            finish_reason=None,
+                        )
+                    ]
+                )
+
         return OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
             chunk
         )

--- a/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
@@ -5,6 +5,7 @@ Test for response_format to text.format conversion in completion -> responses br
 import pytest
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,
+    OpenAiResponsesToChatCompletionStreamIterator,
 )
 
 
@@ -230,3 +231,116 @@ def test_transform_request_drops_user_metadata_with_additional_drop_params():
 
     assert "metadata" not in result
     assert result["litellm_metadata"]["internal_key"] == "secret"
+
+
+# ---------------------------------------------------------------------------
+# Tests for OpenAiResponsesToChatCompletionStreamIterator.chunk_parser
+# (specifically the no-delta / .done-only tool-call path fixed in #27797)
+# ---------------------------------------------------------------------------
+
+
+def _make_iterator() -> OpenAiResponsesToChatCompletionStreamIterator:
+    """Return a fresh iterator with an empty (no-op) underlying stream."""
+    return OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+    )
+
+
+def test_chunk_parser_done_without_delta_emits_arguments():
+    """Models that never send .delta (e.g. gpt-5.3-codex-spark) deliver the
+    full function arguments only in the .done event.  chunk_parser must emit a
+    tool-call chunk carrying those arguments rather than silently dropping them
+    (which would produce arguments='{}' in the reconstructed response)."""
+    iterator = _make_iterator()
+    arguments_json = '{"city": "Paris"}'
+
+    done_chunk = {
+        "type": "response.function_call_arguments.done",
+        "output_index": 0,
+        "arguments": arguments_json,
+    }
+
+    result = iterator.chunk_parser(done_chunk)
+
+    assert result.choices is not None and len(result.choices) == 1
+    tool_calls = result.choices[0].delta.tool_calls
+    assert tool_calls is not None and len(tool_calls) == 1
+    assert tool_calls[0].function.arguments == arguments_json
+
+
+def test_chunk_parser_done_after_delta_is_skipped():
+    """When .delta chunks were already streamed for an output_index, the .done
+    event must NOT re-emit arguments (they are already accumulated by the
+    standard delta path, and duplicating them would corrupt the response)."""
+    iterator = _make_iterator()
+    output_index = 2
+
+    # Simulate receiving a delta first
+    delta_chunk = {
+        "type": "response.function_call_arguments.delta",
+        "output_index": output_index,
+        "delta": '{"city":',
+    }
+    iterator.chunk_parser(delta_chunk)  # records output_index in _seen_arg_delta_idxs
+
+    # Now send the corresponding .done — it should delegate to the static
+    # translator, which returns a non-tool-call chunk (no tool_calls in delta).
+    done_chunk = {
+        "type": "response.function_call_arguments.done",
+        "output_index": output_index,
+        "arguments": '{"city": "Paris"}',
+    }
+    result = iterator.chunk_parser(done_chunk)
+
+    # The static translator does not handle .done → no tool_calls emitted
+    delta = result.choices[0].delta
+    assert not delta.tool_calls
+
+
+def test_chunk_parser_done_without_delta_uses_output_index():
+    """The tool-call chunk emitted for the .done-only path must carry the
+    correct output_index so the caller can reassemble multi-tool responses."""
+    iterator = _make_iterator()
+    output_index = 3
+
+    done_chunk = {
+        "type": "response.function_call_arguments.done",
+        "output_index": output_index,
+        "arguments": "{}",
+    }
+
+    result = iterator.chunk_parser(done_chunk)
+    tool_calls = result.choices[0].delta.tool_calls
+    assert tool_calls is not None
+    assert tool_calls[0].index == output_index
+
+
+def test_chunk_parser_seen_delta_idxs_tracked_per_index():
+    """Delta tracking must be per output_index: a delta for index 0 must not
+    suppress the .done emission for index 1."""
+    iterator = _make_iterator()
+
+    # Delta only for index 0
+    iterator.chunk_parser(
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "delta": "x",
+        }
+    )
+
+    # .done for index 1 (no delta seen → should emit)
+    arguments_json = '{"q": 42}'
+    result = iterator.chunk_parser(
+        {
+            "type": "response.function_call_arguments.done",
+            "output_index": 1,
+            "arguments": arguments_json,
+        }
+    )
+
+    tool_calls = result.choices[0].delta.tool_calls
+    assert tool_calls is not None and len(tool_calls) == 1
+    assert tool_calls[0].function.arguments == arguments_json
+    assert tool_calls[0].index == 1


### PR DESCRIPTION
Fixes #27144.

Some models that implement the Responses API — gpt-5.3-codex-spark being the case reported in the issue — never emit `response.function_call_arguments.delta` events. Instead they deliver the complete arguments in a single `response.function_call_arguments.done` event. Because `chunk_parser` delegated everything to `translate_responses_chunk_to_openai_stream`, which handles `.delta` but has no branch for `.done`, these arguments were silently dropped. The reconstructed tool-call chunk came back with `arguments='{}'`.

The fix lives entirely in `chunk_parser` (the instance-level wrapper), so the static `translate_responses_chunk_to_openai_stream` is untouched and any direct callers are unaffected.

**State tracking in `__init__`**

```python
self._seen_arg_delta_idxs: set = set()
```

Records which `output_index` values have already received at least one `.delta` chunk during this stream.

**Pre-delegation logic in `chunk_parser`**

Before falling through to the static method:

- If the event is `response.function_call_arguments.delta`, record the `output_index` in `_seen_arg_delta_idxs`.
- If the event is `response.function_call_arguments.done` and no delta was seen for that output index, emit a `ChatCompletionToolCallChunk` carrying the full `arguments` field. If deltas *were* seen (the standard gpt-4o path), we skip the `.done` event to avoid duplicating content.

The raw SSE from Codex Spark that demonstrates the fix:

```
event: response.function_call_arguments.done
data: {"type":"response.function_call_arguments.done","arguments":"{\"a\":5,\"b\":7}","output_index":1}
```

Before this change that chunk was ignored. After it produces a properly formed tool-call delta carrying `arguments='{"a":5,"b":7}'`.