### PR TITLE
fix(langfuse): guard against None standard_callback_dynamic_params

### DIFF
--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -36,12 +36,7 @@ class LangFuseHandler:
 
         """
         temp_langfuse_logger: Optional[LangFuseLogger] = globalLangfuseLogger
-        if (
-            LangFuseHandler._dynamic_langfuse_credentials_are_passed(
-                standard_callback_dynamic_params
-            )
-            is False
-        ):
+        if LangFuseHandler._dynamic_langfuse_credentials_are_passed(standard_callback_dynamic_params) is False:
             return LangFuseHandler._return_global_langfuse_logger(
                 globalLangfuseLogger=globalLangfuseLogger,
                 in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
@@ -61,11 +56,9 @@ class LangFuseHandler:
 
         # if not cached, create a new langfuse logger and cache it
         if temp_langfuse_logger is None:
-            temp_langfuse_logger = (
-                LangFuseHandler._create_langfuse_logger_from_credentials(
-                    credentials=credentials_dict,
-                    in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
-                )
+            temp_langfuse_logger = LangFuseHandler._create_langfuse_logger_from_credentials(
+                credentials=credentials_dict,
+                in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
             )
 
         return temp_langfuse_logger
@@ -86,19 +79,17 @@ class LangFuseHandler:
         if globalLangfuseLogger is not None:
             return globalLangfuseLogger
 
-        credentials_dict: Dict[str, Any] = (
-            {}
-        )  # the global langfuse logger uses Environment Variables, there are no dynamic credentials
+        credentials_dict: Dict[
+            str, Any
+        ] = {}  # the global langfuse logger uses Environment Variables, there are no dynamic credentials
         globalLangfuseLogger = in_memory_dynamic_logger_cache.get_cache(
             credentials=credentials_dict,
             service_name="langfuse",
         )
         if globalLangfuseLogger is None:
-            globalLangfuseLogger = (
-                LangFuseHandler._create_langfuse_logger_from_credentials(
-                    credentials=credentials_dict,
-                    in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
-                )
+            globalLangfuseLogger = LangFuseHandler._create_langfuse_logger_from_credentials(
+                credentials=credentials_dict,
+                in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
             )
         return globalLangfuseLogger
 
@@ -115,8 +106,7 @@ class LangFuseHandler:
 
         langfuse_logger = LangFuseLogger(
             langfuse_public_key=credentials.get("langfuse_public_key"),
-            langfuse_secret=credentials.get("langfuse_secret")
-            or credentials.get("langfuse_secret_key"),
+            langfuse_secret=credentials.get("langfuse_secret") or credentials.get("langfuse_secret_key"),
             langfuse_host=credentials.get("langfuse_host"),
             allow_env_credentials=credentials.get("langfuse_host") is None,
         )
@@ -143,8 +133,7 @@ class LangFuseHandler:
         # Guard against None to handle the case where no per-request params are passed
         params = standard_callback_dynamic_params or {}
         return LangfuseLoggingConfig(
-            langfuse_secret=params.get("langfuse_secret")
-            or params.get("langfuse_secret_key"),
+            langfuse_secret=params.get("langfuse_secret") or params.get("langfuse_secret_key"),
             langfuse_public_key=params.get("langfuse_public_key"),
             langfuse_host=params.get("langfuse_host"),
         )

--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -140,13 +140,15 @@ class LangFuseHandler:
         If no dynamic parameters are provided, it uses the `globalLangfuseLogger` values
         """
         # only use dynamic params if langfuse credentials are passed dynamically
+        # Guard against None to handle the case where no per-request params are passed
+        params = standard_callback_dynamic_params or {}
         return LangfuseLoggingConfig(
-            langfuse_secret=standard_callback_dynamic_params.get("langfuse_secret")
-            or standard_callback_dynamic_params.get("langfuse_secret_key"),
-            langfuse_public_key=standard_callback_dynamic_params.get(
+            langfuse_secret=params.get("langfuse_secret")
+            or params.get("langfuse_secret_key"),
+            langfuse_public_key=params.get(
                 "langfuse_public_key"
             ),
-            langfuse_host=standard_callback_dynamic_params.get("langfuse_host"),
+            langfuse_host=params.get("langfuse_host"),
         )
 
     @staticmethod
@@ -159,12 +161,14 @@ class LangFuseHandler:
         Returns:
             bool: True if the dynamic langfuse credentials are passed, False otherwise
         """
+        # Guard against None to handle the case where no per-request params are passed (credentials come from env vars)
+        params = standard_callback_dynamic_params or {}
 
         if (
-            standard_callback_dynamic_params.get("langfuse_host") is not None
-            or standard_callback_dynamic_params.get("langfuse_public_key") is not None
-            or standard_callback_dynamic_params.get("langfuse_secret") is not None
-            or standard_callback_dynamic_params.get("langfuse_secret_key") is not None
+            params.get("langfuse_host") is not None
+            or params.get("langfuse_public_key") is not None
+            or params.get("langfuse_secret") is not None
+            or params.get("langfuse_secret_key") is not None
         ):
             return True
         return False

--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -145,9 +145,7 @@ class LangFuseHandler:
         return LangfuseLoggingConfig(
             langfuse_secret=params.get("langfuse_secret")
             or params.get("langfuse_secret_key"),
-            langfuse_public_key=params.get(
-                "langfuse_public_key"
-            ),
+            langfuse_public_key=params.get("langfuse_public_key"),
             langfuse_host=params.get("langfuse_host"),
         )
 

--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -36,7 +36,12 @@ class LangFuseHandler:
 
         """
         temp_langfuse_logger: Optional[LangFuseLogger] = globalLangfuseLogger
-        if LangFuseHandler._dynamic_langfuse_credentials_are_passed(standard_callback_dynamic_params) is False:
+        if (
+            LangFuseHandler._dynamic_langfuse_credentials_are_passed(
+                standard_callback_dynamic_params
+            )
+            is False
+        ):
             return LangFuseHandler._return_global_langfuse_logger(
                 globalLangfuseLogger=globalLangfuseLogger,
                 in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
@@ -56,9 +61,11 @@ class LangFuseHandler:
 
         # if not cached, create a new langfuse logger and cache it
         if temp_langfuse_logger is None:
-            temp_langfuse_logger = LangFuseHandler._create_langfuse_logger_from_credentials(
-                credentials=credentials_dict,
-                in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
+            temp_langfuse_logger = (
+                LangFuseHandler._create_langfuse_logger_from_credentials(
+                    credentials=credentials_dict,
+                    in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
+                )
             )
 
         return temp_langfuse_logger
@@ -79,17 +86,19 @@ class LangFuseHandler:
         if globalLangfuseLogger is not None:
             return globalLangfuseLogger
 
-        credentials_dict: Dict[
-            str, Any
-        ] = {}  # the global langfuse logger uses Environment Variables, there are no dynamic credentials
+        credentials_dict: Dict[str, Any] = (
+            {}
+        )  # the global langfuse logger uses Environment Variables, there are no dynamic credentials
         globalLangfuseLogger = in_memory_dynamic_logger_cache.get_cache(
             credentials=credentials_dict,
             service_name="langfuse",
         )
         if globalLangfuseLogger is None:
-            globalLangfuseLogger = LangFuseHandler._create_langfuse_logger_from_credentials(
-                credentials=credentials_dict,
-                in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
+            globalLangfuseLogger = (
+                LangFuseHandler._create_langfuse_logger_from_credentials(
+                    credentials=credentials_dict,
+                    in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
+                )
             )
         return globalLangfuseLogger
 
@@ -106,7 +115,8 @@ class LangFuseHandler:
 
         langfuse_logger = LangFuseLogger(
             langfuse_public_key=credentials.get("langfuse_public_key"),
-            langfuse_secret=credentials.get("langfuse_secret") or credentials.get("langfuse_secret_key"),
+            langfuse_secret=credentials.get("langfuse_secret")
+            or credentials.get("langfuse_secret_key"),
             langfuse_host=credentials.get("langfuse_host"),
             allow_env_credentials=credentials.get("langfuse_host") is None,
         )
@@ -133,7 +143,8 @@ class LangFuseHandler:
         # Guard against None to handle the case where no per-request params are passed
         params = standard_callback_dynamic_params or {}
         return LangfuseLoggingConfig(
-            langfuse_secret=params.get("langfuse_secret") or params.get("langfuse_secret_key"),
+            langfuse_secret=params.get("langfuse_secret")
+            or params.get("langfuse_secret_key"),
             langfuse_public_key=params.get("langfuse_public_key"),
             langfuse_host=params.get("langfuse_host"),
         )

--- a/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
+++ b/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
@@ -127,3 +127,36 @@ def test_langfuse_handler_accepts_secret_key_alias(monkeypatch):
     assert captured["allow_env_credentials"] is False
     assert captured["cached_service_name"] == "langfuse"
     assert captured["cached_logging_obj"] is logger
+
+
+def test_dynamic_langfuse_credentials_are_passed_handles_none(monkeypatch):
+    """Regression test: _dynamic_langfuse_credentials_are_passed must not crash when standard_callback_dynamic_params is None.
+
+    When Langfuse is configured via environment variables (no per-request dynamic params),
+    standard_callback_dynamic_params is None, not {}. The function must not raise
+    AttributeError: 'NoneType' object has no attribute 'get'.
+    """
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
+
+    # Should return False (no dynamic params passed), not raise AttributeError
+    result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(None)
+    assert result is False
+
+
+def test_get_dynamic_langfuse_logging_config_handles_none(monkeypatch):
+    """Regression test: get_dynamic_langfuse_logging_config must not crash when standard_callback_dynamic_params is None.
+
+    When Langfuse is configured via environment variables, standard_callback_dynamic_params is None.
+    The function should return a config with None values (relying on env var fallback downstream).
+    """
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
+
+    # Should not raise AttributeError
+    config = LangFuseHandler.get_dynamic_langfuse_logging_config(None)
+    assert config.langfuse_public_key is None
+    assert config.langfuse_secret is None
+    assert config.langfuse_host is None

--- a/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
+++ b/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
@@ -129,32 +129,24 @@ def test_langfuse_handler_accepts_secret_key_alias(monkeypatch):
     assert captured["cached_logging_obj"] is logger
 
 
-def test_dynamic_langfuse_credentials_are_passed_handles_none(monkeypatch):
+def test_dynamic_langfuse_credentials_are_passed_handles_none():
     """Regression test: _dynamic_langfuse_credentials_are_passed must not crash when standard_callback_dynamic_params is None.
 
     When Langfuse is configured via environment variables (no per-request dynamic params),
     standard_callback_dynamic_params is None, not {}. The function must not raise
     AttributeError: 'NoneType' object has no attribute 'get'.
     """
-    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
-    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
-    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
-
     # Should return False (no dynamic params passed), not raise AttributeError
     result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(None)
     assert result is False
 
 
-def test_get_dynamic_langfuse_logging_config_handles_none(monkeypatch):
+def test_get_dynamic_langfuse_logging_config_handles_none():
     """Regression test: get_dynamic_langfuse_logging_config must not crash when standard_callback_dynamic_params is None.
 
     When Langfuse is configured via environment variables, standard_callback_dynamic_params is None.
     The function should return a config with None values (relying on env var fallback downstream).
     """
-    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
-    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
-    monkeypatch.setenv("LANGFUSE_HOST", "https://langfuse.example")
-
     # Should not raise AttributeError
     config = LangFuseHandler.get_dynamic_langfuse_logging_config(None)
     assert config["langfuse_public_key"] is None

--- a/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
+++ b/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
@@ -157,6 +157,6 @@ def test_get_dynamic_langfuse_logging_config_handles_none(monkeypatch):
 
     # Should not raise AttributeError
     config = LangFuseHandler.get_dynamic_langfuse_logging_config(None)
-    assert config.langfuse_public_key is None
-    assert config.langfuse_secret is None
-    assert config.langfuse_host is None
+    assert config["langfuse_public_key"] is None
+    assert config["langfuse_secret"] is None
+    assert config["langfuse_host"] is None


### PR DESCRIPTION
## Fix: AttributeError when Langfuse is configured via env vars (no per-request dynamic params)

### What was broken
When Langfuse is configured via environment variables (the standard setup with no per-request dynamic params), `standard_callback_dynamic_params` is `None` (not `{}`). The `_dynamic_langfuse_credentials_are_passed()` and `get_dynamic_langfuse_logging_config()` functions called `.get()` directly on `None`, raising:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This caused every Langfuse success callback to fail silently — no traces appeared in Langfuse, and the error only showed up in logs.

### What I fixed
Added a `params = standard_callback_dynamic_params or {}` guard in both functions, so `.get()` is called on an empty dict when `None` is passed.

### Changes
- `litellm/integrations/langfuse/langfuse_handler.py`:
  - `get_dynamic_langfuse_logging_config()`: guard against None in `params` lookup
  - `_dynamic_langfuse_credentials_are_passed()`: guard against None in `params` lookup
- `tests/logging_callback_tests/test_langfuse_dynamic_credentials.py`:
  - Added 2 regression tests for None handling

### Testing
Added regression tests that verify these functions return `False`/`default config` instead of crashing when `None` is passed.

Fixes: BerriAI/litellm#25940