### PR TITLE
fix: reduce spend update overhead

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -305,7 +305,7 @@ MAX_SIZE_IN_MEMORY_QUEUE = int(
     os.getenv("MAX_SIZE_IN_MEMORY_QUEUE", int(LITELLM_ASYNCIO_QUEUE_MAXSIZE * 0.8))
 )
 MAX_IN_MEMORY_QUEUE_FLUSH_COUNT = int(
-    os.getenv("MAX_IN_MEMORY_QUEUE_FLUSH_COUNT", 1000)
+    os.getenv("MAX_IN_MEMORY_QUEUE_FLUSH_COUNT", LITELLM_ASYNCIO_QUEUE_MAXSIZE)
 )
 ###############################################################################################
 MINIMUM_PROMPT_CACHE_TOKEN_COUNT = int(

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -407,71 +407,180 @@ class DBSpendUpdateWriter:
             )
 
         try:
-            await self.add_spend_log_transaction_to_daily_user_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_user_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_end_user_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_end_user_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_agent_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_agent_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_team_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_team_transaction failed: %s",
-                traceback.format_exc(),
-            )
-
-        try:
-            await self.add_spend_log_transaction_to_daily_org_transaction(
+            await self._enqueue_daily_spend_updates(
                 payload=payload_copy,
                 org_id=org_id,
                 prisma_client=prisma_client,
             )
         except Exception:
             verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_org_transaction failed: %s",
+                "_batch_database_updates: _enqueue_daily_spend_updates failed: %s",
                 traceback.format_exc(),
             )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_tag_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
+    async def _enqueue_daily_spend_updates(
+        self,
+        payload: SpendLogsPayload,
+        org_id: Optional[str],
+        prisma_client: Optional[PrismaClient],
+    ) -> None:
+        """
+        Enqueue all daily spend rows for one request after computing the shared
+        daily payload once. This avoids repeated JSON parsing and request-status
+        resolution on the logging hot path.
+        """
+        if prisma_client is None:
             verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_tag_transaction failed: %s",
-                traceback.format_exc(),
+                "prisma_client is None. Skipping writing spend logs to db."
             )
+            return
+
+        base_daily_transaction = self._get_base_daily_spend_transaction(
+            payload=payload,
+            prisma_client=prisma_client,
+        )
+        if base_daily_transaction is None:
+            return
+
+        endpoint_str = base_daily_transaction.get("endpoint") or ""
+
+        user_id = payload.get("user")
+        if user_id is not None and user_id != "":
+            daily_transaction_key = f"{user_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_user_transaction = DailyUserSpendTransaction(
+                user_id=user_id, **base_daily_transaction
+            )
+            await self.daily_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_user_transaction}
+            )
+
+        team_id = payload.get("team_id")
+        if team_id is not None and team_id != "":
+            daily_transaction_key = f"{team_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_team_transaction = DailyTeamSpendTransaction(
+                team_id=team_id, **base_daily_transaction
+            )
+            await self.daily_team_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_team_transaction}
+            )
+
+        if org_id is not None and org_id != "":
+            daily_transaction_key = f"{org_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_org_transaction = DailyOrganizationSpendTransaction(
+                organization_id=org_id, **base_daily_transaction
+            )
+            await self.daily_org_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_org_transaction}
+            )
+
+        end_user_id = payload.get("end_user")
+        if end_user_id is not None and end_user_id != "":
+            daily_transaction_key = f"{end_user_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_end_user_transaction = DailyEndUserSpendTransaction(
+                end_user_id=end_user_id, **base_daily_transaction
+            )
+            await self.daily_end_user_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_end_user_transaction}
+            )
+
+        agent_id = payload.get("agent_id")
+        if agent_id is not None and agent_id != "":
+            daily_transaction_key = f"{agent_id}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_agent_transaction = DailyAgentSpendTransaction(
+                agent_id=agent_id, **base_daily_transaction
+            )
+            await self.daily_agent_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_agent_transaction}
+            )
+
+        request_tags = payload.get("request_tags")
+        if request_tags is None:
+            return
+        if isinstance(request_tags, str):
+            request_tags = json.loads(request_tags)
+        elif not isinstance(request_tags, list):
+            verbose_proxy_logger.warning(
+                "Skipping daily tag spend update - invalid request_tags type %s: %s",
+                type(request_tags).__name__,
+                request_tags,
+            )
+            return
+
+        for tag in request_tags:
+            daily_transaction_key = f"{tag}_{base_daily_transaction['date']}_{payload['api_key']}_{payload.get('model')}_{payload.get('custom_llm_provider')}_{endpoint_str}"
+            daily_tag_transaction = DailyTagSpendTransaction(
+                tag=tag,
+                **base_daily_transaction,
+                request_id=payload.get("request_id"),
+            )
+            await self.daily_tag_spend_update_queue.add_update(
+                update={daily_transaction_key: daily_tag_transaction}
+            )
+
+    def _get_base_daily_spend_transaction(
+        self,
+        payload: Union[dict, SpendLogsPayload],
+        prisma_client: PrismaClient,
+    ) -> Optional[BaseDailySpendTransaction]:
+        common_expected_keys = ["startTime", "api_key"]
+        if not all(key in payload for key in common_expected_keys):
+            verbose_proxy_logger.debug(
+                f"Missing expected keys: {common_expected_keys}, in payload, skipping from daily_user_spend_transactions"
+            )
+            return None
+
+        any_expected_keys = ["model", "mcp_namespaced_tool_name"]
+        if not any(key in payload for key in any_expected_keys):
+            verbose_proxy_logger.debug(
+                f"Missing any expected keys: {any_expected_keys}, in payload, skipping from daily_user_spend_transactions"
+            )
+            return None
+        if "mcp_namespaced_tool_name" not in payload and (
+            "custom_llm_provider" not in payload or "model_group" not in payload
+        ):
+            verbose_proxy_logger.debug(
+                "Missing custom_llm_provider or model_group in payload, skipping from daily_user_spend_transactions"
+            )
+            return None
+
+        request_status = prisma_client.get_request_status(payload)
+        verbose_proxy_logger.debug(f"Logged request status: {request_status}")
+        _metadata: SpendLogsMetadata = json.loads(payload["metadata"])
+        usage_obj = _metadata.get("usage_object", {}) or {}
+        if isinstance(payload["startTime"], datetime):
+            start_time = payload["startTime"].isoformat()
+            date = start_time.split("T")[0]
+        elif isinstance(payload["startTime"], str):
+            date = payload["startTime"].split("T")[0]
+        else:
+            verbose_proxy_logger.debug(
+                f"Invalid start time: {payload['startTime']}, skipping from daily_user_spend_transactions"
+            )
+            return None
+
+        call_type = payload.get("call_type", None)
+        endpoint = None
+        if call_type:
+            endpoint = ROUTE_ENDPOINT_MAPPING.get(call_type, None)
+
+        return BaseDailySpendTransaction(
+            date=date,
+            api_key=payload["api_key"],
+            model=payload.get("model", None),
+            model_group=payload.get("model_group", None),
+            mcp_namespaced_tool_name=payload.get("mcp_namespaced_tool_name", None),
+            custom_llm_provider=payload.get("custom_llm_provider", None),
+            endpoint=endpoint,
+            prompt_tokens=payload["prompt_tokens"],
+            completion_tokens=payload["completion_tokens"],
+            spend=payload["spend"],
+            api_requests=1,
+            successful_requests=1 if request_status == "success" else 0,
+            failed_requests=1 if request_status != "success" else 0,
+            cache_read_input_tokens=usage_obj.get("cache_read_input_tokens", 0) or 0,
+            cache_creation_input_tokens=usage_obj.get("cache_creation_input_tokens", 0)
+            or 0,
+        )
 
     async def _update_key_db(
         self,

--- a/litellm/proxy/db/db_transaction_queue/base_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/base_update_queue.py
@@ -3,6 +3,7 @@ Base class for in memory buffer for database transactions
 """
 
 import asyncio
+import time
 from typing import Optional
 
 from litellm._logging import verbose_proxy_logger
@@ -24,6 +25,9 @@ class BaseUpdateQueue:
     def __init__(self):
         self.update_queue = asyncio.Queue(maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE)
         self.MAX_SIZE_IN_MEMORY_QUEUE = MAX_SIZE_IN_MEMORY_QUEUE
+        self._aggregation_lock = asyncio.Lock()
+        self._aggregation_task: Optional[asyncio.Task] = None
+        self._last_queue_full_warning_time = 0.0
         if MAX_SIZE_IN_MEMORY_QUEUE >= LITELLM_ASYNCIO_QUEUE_MAXSIZE:
             verbose_proxy_logger.warning(
                 "Misconfigured queue thresholds: MAX_SIZE_IN_MEMORY_QUEUE (%d) >= LITELLM_ASYNCIO_QUEUE_MAXSIZE (%d). "
@@ -32,6 +36,14 @@ class BaseUpdateQueue:
                 MAX_SIZE_IN_MEMORY_QUEUE,
                 LITELLM_ASYNCIO_QUEUE_MAXSIZE,
                 LITELLM_ASYNCIO_QUEUE_MAXSIZE,
+            )
+        if MAX_IN_MEMORY_QUEUE_FLUSH_COUNT < MAX_SIZE_IN_MEMORY_QUEUE:
+            verbose_proxy_logger.warning(
+                "Misconfigured queue flush limit: MAX_IN_MEMORY_QUEUE_FLUSH_COUNT (%d) < MAX_SIZE_IN_MEMORY_QUEUE (%d). "
+                "Spend queue aggregation may need multiple passes under load. "
+                "Set MAX_IN_MEMORY_QUEUE_FLUSH_COUNT to at least MAX_SIZE_IN_MEMORY_QUEUE.",
+                MAX_IN_MEMORY_QUEUE_FLUSH_COUNT,
+                MAX_SIZE_IN_MEMORY_QUEUE,
             )
 
     async def add_update(self, update):
@@ -45,15 +57,64 @@ class BaseUpdateQueue:
     async def flush_all_updates_from_in_memory_queue(self):
         """Get all updates from the queue."""
         updates = []
-        while not self.update_queue.empty():
+        while True:
             # Circuit breaker to ensure we're not stuck dequeuing updates. Protect CPU utilization
             if len(updates) >= MAX_IN_MEMORY_QUEUE_FLUSH_COUNT:
                 verbose_proxy_logger.debug(
                     "Max in memory queue flush count reached, stopping flush"
                 )
                 break
-            updates.append(await self.update_queue.get())
+            try:
+                updates.append(self.update_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
         return updates
+
+    def _schedule_queue_aggregation_if_needed(self) -> None:
+        """Schedule queue aggregation without doing CPU-heavy work on the producer path."""
+        if self.update_queue.qsize() < self.MAX_SIZE_IN_MEMORY_QUEUE:
+            return
+
+        now = time.monotonic()
+        if now - self._last_queue_full_warning_time >= 30:
+            verbose_proxy_logger.warning(
+                "Spend update queue is full. Scheduling background aggregation to concatenate entries."
+            )
+            self._last_queue_full_warning_time = now
+
+        if self._aggregation_task is not None and not self._aggregation_task.done():
+            return
+
+        self._aggregation_task = asyncio.create_task(
+            self._aggregate_queue_updates_if_needed()
+        )
+        self._aggregation_task.add_done_callback(self._log_aggregation_task_exception)
+
+    def _log_aggregation_task_exception(self, task: asyncio.Task) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            verbose_proxy_logger.error(
+                "Spend update queue aggregation failed: %s", str(e)
+            )
+
+    async def _aggregate_queue_updates_if_needed(self) -> None:
+        async with self._aggregation_lock:
+            if self.update_queue.qsize() < self.MAX_SIZE_IN_MEMORY_QUEUE:
+                return
+            await self.aggregate_queue_updates()
+
+    async def _wait_for_pending_aggregation(self) -> None:
+        task = self._aggregation_task
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        await task
+
+    async def aggregate_queue_updates(self):
+        """Subclasses aggregate queue entries into fewer queue entries."""
+        raise NotImplementedError()
 
     async def _emit_new_item_added_to_queue_event(
         self,

--- a/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
@@ -62,11 +62,7 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
         """Enqueue an update."""
         verbose_proxy_logger.debug("Adding update to queue: %s", update)
         await self.update_queue.put(update)
-        if self.update_queue.qsize() >= self.MAX_SIZE_IN_MEMORY_QUEUE:
-            verbose_proxy_logger.warning(
-                "Spend update queue is full. Aggregating all entries in queue to concatenate entries."
-            )
-            await self.aggregate_queue_updates()
+        self._schedule_queue_aggregation_if_needed()
 
     async def aggregate_queue_updates(self):
         """
@@ -85,6 +81,7 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
         self,
     ) -> Dict[str, BaseDailySpendTransaction]:
         """Get all updates from the queue and return all updates aggregated by daily_transaction_key. Works for both user and team spend updates."""
+        await self._wait_for_pending_aggregation()
         updates = await self.flush_all_updates_from_in_memory_queue()
         if len(updates) > 0:
             verbose_proxy_logger.info(

--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -30,6 +30,7 @@ class SpendUpdateQueue(BaseUpdateQueue):
         self,
     ) -> DBSpendUpdateTransactions:
         """Flush all updates from the queue and return all updates aggregated by entity type."""
+        await self._wait_for_pending_aggregation()
         updates = await self.flush_all_updates_from_in_memory_queue()
         if len(updates) > 0:
             verbose_proxy_logger.info(
@@ -44,12 +45,7 @@ class SpendUpdateQueue(BaseUpdateQueue):
         verbose_proxy_logger.debug("Adding update to queue: %s", update)
         await self.update_queue.put(update)
 
-        # if the queue is full, aggregate the updates
-        if self.update_queue.qsize() >= self.MAX_SIZE_IN_MEMORY_QUEUE:
-            verbose_proxy_logger.warning(
-                "Spend update queue is full. Aggregating all entries in queue to concatenate entries."
-            )
-            await self.aggregate_queue_updates()
+        self._schedule_queue_aggregation_if_needed()
 
     async def aggregate_queue_updates(self):
         """Concatenate all updates in the queue to reduce the size of in-memory queue"""

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -652,9 +652,33 @@ def cleanup_router_config_variables():
     prisma_client = None
 
 
+async def _shutdown_scheduled_background_jobs() -> None:
+    global scheduler, spend_logs_queue_monitor_task
+    if spend_logs_queue_monitor_task is not None:
+        spend_logs_queue_monitor_task.cancel()
+        try:
+            await spend_logs_queue_monitor_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            verbose_proxy_logger.error(
+                f"Error stopping spend logs queue monitor task: {e}"
+            )
+        spend_logs_queue_monitor_task = None
+
+    if scheduler is not None:
+        try:
+            scheduler.shutdown(wait=True)
+            verbose_proxy_logger.info("APScheduler shut down")
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error shutting down APScheduler: {e}")
+        scheduler = None
+
+
 async def proxy_shutdown_event():
     global prisma_client, master_key, user_custom_auth, user_custom_key_generate, user_custom_key_update
     verbose_proxy_logger.info("Shutting down LiteLLM Proxy Server")
+    await _shutdown_scheduled_background_jobs()
     if prisma_client:
         verbose_proxy_logger.debug("Disconnecting from Prisma")
         await prisma_client.disconnect()
@@ -1781,6 +1805,7 @@ celery_fn = None  # Redis Queue for handling requests
 
 # Global variables for model cost map reload scheduling
 scheduler = None
+spend_logs_queue_monitor_task: Optional[asyncio.Task] = None
 last_model_cost_map_reload = None
 
 # Global variable for anthropic beta headers reload scheduling
@@ -6918,7 +6943,7 @@ class ProxyStartupEvent:
         proxy_logging_obj: ProxyLogging,
     ):
         """Initializes scheduled background jobs"""
-        global store_model_in_db, scheduler
+        global store_model_in_db, scheduler, spend_logs_queue_monitor_task
 
         # MEMORY LEAK FIX: Configure scheduler with optimized settings
         # Memray analysis showed APScheduler's normalize() and _apply_jitter() causing
@@ -7016,13 +7041,17 @@ class ProxyStartupEvent:
             from litellm.proxy.utils import _monitor_spend_logs_queue
 
             # Start background task to monitor spend logs queue size
-            asyncio.create_task(
-                _monitor_spend_logs_queue(
-                    prisma_client=prisma_client,
-                    db_writer_client=db_writer_client,
-                    proxy_logging_obj=proxy_logging_obj,
+            if (
+                spend_logs_queue_monitor_task is None
+                or spend_logs_queue_monitor_task.done()
+            ):
+                spend_logs_queue_monitor_task = asyncio.create_task(
+                    _monitor_spend_logs_queue(
+                        prisma_client=prisma_client,
+                        db_writer_client=db_writer_client,
+                        proxy_logging_obj=proxy_logging_obj,
+                    )
                 )
-            )
 
         ### ADD NEW MODELS ###
         store_model_in_db = (

--- a/tests/proxy_unit_tests/test_aproxy_startup.py
+++ b/tests/proxy_unit_tests/test_aproxy_startup.py
@@ -94,3 +94,37 @@ async def test_proxy_gunicorn_startup_config_dict():
 
 
 # test_proxy_gunicorn_startup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_shutdown_stops_scheduler_before_prisma_disconnect(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm.proxy.proxy_server as proxy_server
+
+    events = []
+
+    class MockScheduler:
+        def shutdown(self, wait=True):
+            assert wait is True
+            events.append("scheduler_shutdown")
+
+    class MockPrismaClient:
+        async def disconnect(self):
+            events.append("prisma_disconnect")
+
+    mock_jwt_handler = MagicMock()
+    mock_jwt_handler.close = AsyncMock()
+
+    monkeypatch.setattr(proxy_server, "scheduler", MockScheduler())
+    monkeypatch.setattr(proxy_server, "spend_logs_queue_monitor_task", None)
+    monkeypatch.setattr(proxy_server, "prisma_client", MockPrismaClient())
+    monkeypatch.setattr(proxy_server, "jwt_handler", mock_jwt_handler)
+    monkeypatch.setattr(proxy_server, "db_writer_client", None)
+    monkeypatch.setattr(litellm, "cache", None)
+
+    await proxy_server.proxy_shutdown_event()
+
+    assert events == ["scheduler_shutdown", "prisma_disconnect"]
+    assert proxy_server.scheduler is None
+    mock_jwt_handler.close.assert_awaited_once()

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py
@@ -15,6 +15,18 @@ from litellm.constants import MAX_IN_MEMORY_QUEUE_FLUSH_COUNT
 from litellm.proxy.db.db_transaction_queue.base_update_queue import BaseUpdateQueue
 
 
+class AggregatingTestQueue(BaseUpdateQueue):
+    def __init__(self):
+        super().__init__()
+        self.aggregate_calls = 0
+        self.continue_aggregation = asyncio.Event()
+
+    async def aggregate_queue_updates(self):
+        self.aggregate_calls += 1
+        await self.continue_aggregation.wait()
+        await self.flush_all_updates_from_in_memory_queue()
+
+
 @pytest.mark.asyncio
 async def test_queue_flush_limit():
     """
@@ -60,5 +72,96 @@ def test_misconfigured_queue_thresholds_warns():
         patch.object(bq_module.verbose_proxy_logger, "warning") as mock_warning,
     ):
         BaseUpdateQueue()
-        mock_warning.assert_called_once()
-        assert "Misconfigured queue thresholds" in mock_warning.call_args[0][0]
+        assert any(
+            "Misconfigured queue thresholds" in call_args[0][0]
+            for call_args in mock_warning.call_args_list
+        )
+
+
+@pytest.mark.asyncio
+async def test_schedule_queue_aggregation_runs_once_while_pending():
+    queue = AggregatingTestQueue()
+    queue.MAX_SIZE_IN_MEMORY_QUEUE = 2
+    await queue.update_queue.put("first")
+    await queue.update_queue.put("second")
+
+    queue._schedule_queue_aggregation_if_needed()
+    first_task = queue._aggregation_task
+    queue._schedule_queue_aggregation_if_needed()
+
+    assert queue._aggregation_task is first_task
+    assert first_task is not None
+
+    while queue.aggregate_calls == 0:
+        await asyncio.sleep(0)
+
+    queue.continue_aggregation.set()
+    await queue._wait_for_pending_aggregation()
+
+    assert queue.aggregate_calls == 1
+    assert queue.update_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_queue_aggregation_skips_below_threshold():
+    queue = AggregatingTestQueue()
+    queue.MAX_SIZE_IN_MEMORY_QUEUE = 2
+    await queue.update_queue.put("first")
+
+    queue._schedule_queue_aggregation_if_needed()
+    await queue._aggregate_queue_updates_if_needed()
+
+    assert queue._aggregation_task is None
+    assert queue.aggregate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_pending_aggregation_ignores_completed_task():
+    queue = AggregatingTestQueue()
+    queue.continue_aggregation.set()
+    queue._aggregation_task = asyncio.create_task(queue.aggregate_queue_updates())
+    await queue._aggregation_task
+
+    await queue._wait_for_pending_aggregation()
+
+    assert queue.aggregate_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_log_aggregation_task_exception_handles_errors():
+    queue = AggregatingTestQueue()
+
+    async def raise_error():
+        raise RuntimeError("boom")
+
+    task = asyncio.create_task(raise_error())
+    await asyncio.sleep(0)
+
+    with patch(
+        "litellm.proxy.db.db_transaction_queue.base_update_queue.verbose_proxy_logger.error"
+    ) as mock_error:
+        queue._log_aggregation_task_exception(task)
+
+    mock_error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_log_aggregation_task_exception_ignores_cancelled_tasks():
+    queue = AggregatingTestQueue()
+
+    async def wait_forever():
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(wait_forever())
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    with patch(
+        "litellm.proxy.db.db_transaction_queue.base_update_queue.verbose_proxy_logger.error"
+    ) as mock_error:
+        queue._log_aggregation_task_exception(task)
+
+    mock_error.assert_not_called()

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -55,6 +56,26 @@ async def test_add_single_update(daily_spend_update_queue):
     assert len(updates) == 1
     assert test_key in updates[0]
     assert updates[0][test_key] == test_transaction
+
+
+@pytest.mark.asyncio
+async def test_add_update_schedules_aggregation_check(daily_spend_update_queue):
+    test_key = "user1_2023-01-01_key123_gpt-4_openai"
+    test_transaction = {
+        "spend": 1.0,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "api_requests": 1,
+        "successful_requests": 1,
+        "failed_requests": 0,
+    }
+
+    with patch.object(
+        daily_spend_update_queue, "_schedule_queue_aggregation_if_needed"
+    ) as mock_schedule:
+        await daily_spend_update_queue.add_update({test_key: test_transaction})
+
+    mock_schedule.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -291,6 +312,8 @@ async def test_queue_max_size_triggers_aggregation(
     # Add 6 identical updates (exceeding the max size of 5)
     for i in range(6):
         await daily_spend_update_queue.add_update({test_key: test_transaction})
+
+    await daily_spend_update_queue._wait_for_pending_aggregation()
 
     # Queue should have aggregated to a single item
     assert daily_spend_update_queue.update_queue.qsize() == 1

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -32,6 +33,22 @@ async def test_add_update(spend_queue):
 
     # Verify update was added by checking queue size
     assert spend_queue.update_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_add_update_schedules_aggregation_check(spend_queue):
+    update: SpendUpdateQueueItem = {
+        "entity_type": Litellm_EntityType.USER,
+        "entity_id": "user123",
+        "response_cost": 0.5,
+    }
+
+    with patch.object(
+        spend_queue, "_schedule_queue_aggregation_if_needed"
+    ) as mock_schedule:
+        await spend_queue.add_update(update)
+
+    mock_schedule.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -167,6 +184,8 @@ async def test_queue_max_size_triggers_aggregation(monkeypatch, spend_queue):
             "response_cost": 1.0,
         }
         await spend_queue.add_update(update)
+
+    await spend_queue._wait_for_pending_aggregation()
 
     # Queue should have been aggregated, resulting in a single entry
     assert spend_queue.update_queue.qsize() == 1

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -19,7 +19,7 @@ from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
 @pytest.mark.asyncio
 async def test_daily_spend_tracking_with_disabled_spend_logs():
     """
-    Test that add_spend_log_transaction_to_daily_user_transaction is still called
+    Test that daily spend updates are still enqueued
     even when disable_spend_logs is True
     """
     # Setup
@@ -27,7 +27,7 @@ async def test_daily_spend_tracking_with_disabled_spend_logs():
 
     # Mock the methods we want to track
     db_writer._insert_spend_log_to_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
+    db_writer._enqueue_daily_spend_updates = AsyncMock()
 
     # Mock the imported modules/variables
     with (
@@ -59,13 +59,11 @@ async def test_daily_spend_tracking_with_disabled_spend_logs():
         # Verify that _insert_spend_log_to_db was NOT called (since disable_spend_logs is True)
         db_writer._insert_spend_log_to_db.assert_not_called()
 
-        # Verify that add_spend_log_transaction_to_daily_user_transaction WAS called
-        assert db_writer.add_spend_log_transaction_to_daily_user_transaction.called
+        # Verify that daily spend updates were still enqueued
+        assert db_writer._enqueue_daily_spend_updates.called
 
-        # Verify the payload passed to add_spend_log_transaction_to_daily_user_transaction
-        call_args = (
-            db_writer.add_spend_log_transaction_to_daily_user_transaction.call_args[1]
-        )
+        # Verify the payload passed to _enqueue_daily_spend_updates
+        call_args = db_writer._enqueue_daily_spend_updates.call_args[1]
         assert "payload" in call_args
         assert call_args["payload"]["spend"] == 0.1
         assert call_args["payload"]["model"] == "gpt-4"
@@ -1091,6 +1089,203 @@ async def test_endpoint_field_is_correctly_mapped_from_call_type():
 
 
 @pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_builds_shared_payload_once():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+
+    payload = {
+        "request_id": "req-daily-batch",
+        "user": "test-user",
+        "team_id": "test-team",
+        "end_user": "test-end-user",
+        "agent_id": "test-agent",
+        "request_tags": '["tag-a", "tag-b"]',
+        "call_type": "acompletion",
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "gpt-4",
+        "custom_llm_provider": "openai",
+        "model_group": "gpt-4-group",
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "spend": 0.15,
+        "metadata": '{"usage_object": {"cache_read_input_tokens": 3}}',
+    }
+
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    writer.daily_team_spend_update_queue.add_update = AsyncMock()
+    writer.daily_org_spend_update_queue.add_update = AsyncMock()
+    writer.daily_end_user_spend_update_queue.add_update = AsyncMock()
+    writer.daily_agent_spend_update_queue.add_update = AsyncMock()
+    writer.daily_tag_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload=payload,
+        org_id="test-org",
+        prisma_client=mock_prisma,
+    )
+
+    mock_prisma.get_request_status.assert_called_once_with(payload)
+    writer.daily_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_team_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_org_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_end_user_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_agent_spend_update_queue.add_update.assert_awaited_once()
+    assert writer.daily_tag_spend_update_queue.add_update.await_count == 2
+
+    user_update = writer.daily_spend_update_queue.add_update.call_args[1]["update"]
+    user_transaction = next(iter(user_update.values()))
+    assert user_transaction["endpoint"] == "/chat/completions"
+    assert user_transaction["cache_read_input_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_skips_without_prisma():
+    writer = DBSpendUpdateWriter()
+    writer._get_base_daily_spend_transaction = MagicMock()
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload={},
+        org_id="test-org",
+        prisma_client=None,
+    )
+
+    writer._get_base_daily_spend_transaction.assert_not_called()
+    writer.daily_spend_update_queue.add_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_skips_when_base_transaction_missing():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    writer._get_base_daily_spend_transaction = MagicMock(return_value=None)
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload={"user": "test-user"},
+        org_id=None,
+        prisma_client=mock_prisma,
+    )
+
+    writer._get_base_daily_spend_transaction.assert_called_once()
+    writer.daily_spend_update_queue.add_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_daily_spend_updates_skips_invalid_request_tags():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+    payload = {
+        "request_id": "req-invalid-tags",
+        "user": "test-user",
+        "request_tags": {"invalid": "tag-shape"},
+        "startTime": "2024-01-01T12:00:00",
+        "api_key": "test-key",
+        "model": "gpt-4",
+        "custom_llm_provider": "openai",
+        "model_group": "gpt-4-group",
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "spend": 0.15,
+        "metadata": '{"usage_object": {}}',
+    }
+
+    writer.daily_spend_update_queue.add_update = AsyncMock()
+    writer.daily_tag_spend_update_queue.add_update = AsyncMock()
+
+    await writer._enqueue_daily_spend_updates(
+        payload=payload,
+        org_id=None,
+        prisma_client=mock_prisma,
+    )
+
+    writer.daily_spend_update_queue.add_update.assert_awaited_once()
+    writer.daily_tag_spend_update_queue.add_update.assert_not_called()
+
+
+def test_get_base_daily_spend_transaction_rejects_missing_required_keys():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+
+    assert (
+        writer._get_base_daily_spend_transaction(
+            payload={"api_key": "test-key"},
+            prisma_client=mock_prisma,
+        )
+        is None
+    )
+    assert mock_prisma.get_request_status.call_count == 0
+
+
+def test_get_base_daily_spend_transaction_rejects_missing_model_fields():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+
+    assert (
+        writer._get_base_daily_spend_transaction(
+            payload={
+                "startTime": "2024-01-01T12:00:00",
+                "api_key": "test-key",
+                "model": "gpt-4",
+            },
+            prisma_client=mock_prisma,
+        )
+        is None
+    )
+    assert mock_prisma.get_request_status.call_count == 0
+
+
+def test_get_base_daily_spend_transaction_rejects_invalid_start_time():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="success")
+
+    assert (
+        writer._get_base_daily_spend_transaction(
+            payload={
+                "startTime": object(),
+                "api_key": "test-key",
+                "model": "gpt-4",
+                "custom_llm_provider": "openai",
+                "model_group": "gpt-4-group",
+                "metadata": '{"usage_object": {}}',
+            },
+            prisma_client=mock_prisma,
+        )
+        is None
+    )
+    mock_prisma.get_request_status.assert_called_once()
+
+
+def test_get_base_daily_spend_transaction_tracks_failed_requests():
+    writer = DBSpendUpdateWriter()
+    mock_prisma = MagicMock()
+    mock_prisma.get_request_status = MagicMock(return_value="failure")
+
+    result = writer._get_base_daily_spend_transaction(
+        payload={
+            "startTime": datetime(2024, 1, 1, 12, 0, 0),
+            "api_key": "test-key",
+            "mcp_namespaced_tool_name": "server/tool",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "spend": 0.1,
+            "metadata": '{"usage_object": {"cache_creation_input_tokens": 2}}',
+        },
+        prisma_client=mock_prisma,
+    )
+
+    assert result is not None
+    assert result["date"] == "2024-01-01"
+    assert result["successful_requests"] == 0
+    assert result["failed_requests"] == 1
+    assert result["cache_creation_input_tokens"] == 2
+
+
+@pytest.mark.asyncio
 async def test_update_daily_spend_logs_detailed_error_on_batch_upsert_failure():
     """
     Test that when batch upsert fails, detailed error information is logged.
@@ -1354,12 +1549,7 @@ async def test_batch_database_updates_isolation_on_failure():
     db_writer._update_org_db = AsyncMock()
     db_writer._update_tag_db = AsyncMock()
     db_writer._update_agent_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
+    db_writer._enqueue_daily_spend_updates = AsyncMock()
 
     await db_writer._batch_database_updates(
         response_cost=0.1,
@@ -1382,12 +1572,7 @@ async def test_batch_database_updates_isolation_on_failure():
     db_writer._update_org_db.assert_awaited_once()
     db_writer._update_tag_db.assert_awaited_once()
     db_writer._update_agent_db.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_end_user_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_team_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_org_transaction.assert_awaited_once()
-    db_writer.add_spend_log_transaction_to_daily_tag_transaction.assert_awaited_once()
+    db_writer._enqueue_daily_spend_updates.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1402,12 +1587,12 @@ async def test_daily_agent_receives_deepcopied_payload():
     db_writer = DBSpendUpdateWriter()
 
     # Capture the payload object that get_logging_payload returns (the "original")
-    # and the payload the agent handler receives (should be a deepcopy)
+    # and the payload the daily batch helper receives (should be a deepcopy)
     original_payload_ref = {}
-    captured_agent_payloads = []
+    captured_daily_payloads = []
 
-    async def capture_agent_payload(**kwargs):
-        captured_agent_payloads.append(kwargs.get("payload"))
+    async def capture_daily_payload(**kwargs):
+        captured_daily_payloads.append(kwargs.get("payload"))
 
     # Mock all helpers
     db_writer._insert_spend_log_to_db = AsyncMock()
@@ -1417,14 +1602,9 @@ async def test_daily_agent_receives_deepcopied_payload():
     db_writer._update_org_db = AsyncMock()
     db_writer._update_tag_db = AsyncMock()
     db_writer._update_agent_db = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock(
-        side_effect=capture_agent_payload
+    db_writer._enqueue_daily_spend_updates = AsyncMock(
+        side_effect=capture_daily_payload
     )
-    db_writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
-    db_writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
 
     # Mock get_logging_payload to return a known dict and capture its identity
     fake_payload = {
@@ -1463,13 +1643,13 @@ async def test_daily_agent_receives_deepcopied_payload():
         # Let the single batched task run
         await asyncio.sleep(0)
 
-    # The agent handler should have been called
-    assert len(captured_agent_payloads) == 1
+    # The daily batch helper should have been called
+    assert len(captured_daily_payloads) == 1
     # The payload must NOT be the same object as the original (deepcopy occurred)
-    assert captured_agent_payloads[0] is not original_payload_ref["obj"]
+    assert captured_daily_payloads[0] is not original_payload_ref["obj"]
     # But it should have equivalent content
-    assert captured_agent_payloads[0]["model"] == "gpt-4"
-    assert captured_agent_payloads[0]["spend"] == 0.1
+    assert captured_daily_payloads[0]["model"] == "gpt-4"
+    assert captured_daily_payloads[0]["spend"] == 0.1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues
- Replace synchronous in-place aggregation with background task scheduling via `_schedule_queue_aggregation_if_needed()` to avoid blocking the producer hot path when the spend update queue fills up
- Add `_aggregation_task` tracking with deduplication so only one aggregation runs at a time, plus `_wait_for_pending_aggregation()` for safe flush-before-drain semantics
- Consolidate six separate `add_spend_log_transaction_to_daily_*` calls into a single `_enqueue_daily_spend_updates()` method that computes the shared base transaction once via `_get_base_daily_spend_transaction()`, eliminating repeated JSON parsing and request-status resolution per request
- Fix `flush_all_updates_from_in_memory_queue()` to use `get_nowait()` instead of `await get()` so the circuit-breaker loop drains without yielding between items
- Add graceful scheduler shutdown in `proxy_shutdown_event()` via `_shutdown_scheduled_background_jobs()` to stop APScheduler and the queue monitor task before disconnecting Prisma
- Track `spend_logs_queue_monitor_task` globally and guard against duplicate task creation on repeated startup
- Raise `MAX_IN_MEMORY_QUEUE_FLUSH_COUNT` default from 1000 to `LITELLM_ASYNCIO_QUEUE_MAXSIZE` and add a misconfiguration warning when flush count is below queue max size
- Add `_log_aggregation_task_exception` done-callback to surface aggregation failures without crashing the event loop

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
