### PR TITLE
Fix cascading 400 invalid_encrypted_content when originating deployment is cooled down

### DIFF
--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -175,6 +175,34 @@ class EncryptedContentAffinityCheck(CustomLogger):
             if self._encryption_boundary_key(d.get("litellm_params", {})) == boundary
         ]
 
+    def _find_originating_deployment_in_router(self, model_id: str) -> Optional[dict]:
+        """
+        Return the originating deployment dict from the router's full
+        ``model_list``, bypassing cooldown / health filtering. ``None`` if the
+        router isn't wired in or the deployment was removed (e.g. via
+        ``/model/delete``).
+
+        Used as the last-resort pin target: when the originating deployment is
+        cooled down and no boundary peer exists, falling back to the full
+        healthy pool guarantees an ``invalid_encrypted_content`` 400. Pinning
+        to the originating deployment instead surfaces the real upstream error
+        (e.g. 429 from the rate-limited region) or succeeds if the cooldown
+        has cleared by request time.
+        """
+        if self.router is None:
+            return None
+        index_map = getattr(self.router, "model_id_to_deployment_index_map", None)
+        if not isinstance(index_map, dict):
+            return None
+        idx = index_map.get(model_id)
+        if idx is None:
+            return None
+        try:
+            deployment = self.router.model_list[idx]
+        except (IndexError, TypeError):
+            return None
+        return deployment if isinstance(deployment, dict) else None
+
     # ------------------------------------------------------------------
     # Request routing  (pre-call filter)
     # ------------------------------------------------------------------
@@ -243,9 +271,27 @@ class EncryptedContentAffinityCheck(CustomLogger):
             request_kwargs["_encrypted_content_affinity_pinned"] = True
             return boundary_matches
 
+        # Originating deployment is not in healthy_deployments and no boundary
+        # peer is available. The most common cause is cooldown (e.g. originating
+        # region is being rate-limited by upstream). Pin to the originating
+        # deployment regardless: the upstream error (e.g. 429) is the correct
+        # signal for the caller, whereas routing to a different deployment
+        # guarantees a misleading invalid_encrypted_content 400.
+        originating = self._find_originating_deployment_in_router(model_id=model_id)
+        if originating is not None:
+            verbose_router_logger.warning(
+                "EncryptedContentAffinityCheck: decoded model_id=%s not in "
+                "healthy_deployments (likely cooled down) and no boundary peer "
+                "available; pinning to originating deployment to surface the "
+                "real upstream error instead of invalid_encrypted_content",
+                model_id,
+            )
+            request_kwargs["_encrypted_content_affinity_pinned"] = True
+            return [originating]
+
         verbose_router_logger.error(
             "EncryptedContentAffinityCheck: decoded deployment=%s not found in "
-            "healthy_deployments and no boundary match available; falling back to "
+            "router model_list (deployment likely removed); falling back to "
             "full deployment pool (encrypted_content may be rejected upstream)",
             model_id,
         )

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -1172,3 +1172,197 @@ def test_boundary_key_rejects_non_dict_like_inputs():
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Cooled-down originating deployment: pin instead of falling back to full pool.
+# Regression for L3Harris cascading 400 invalid_encrypted_content during an
+# Azure 429 storm.
+# ---------------------------------------------------------------------------
+
+
+def test_find_originating_deployment_in_router_returns_dict_from_model_list():
+    """
+    ``_find_originating_deployment_in_router`` reads from the router's full
+    ``model_list`` via ``model_id_to_deployment_index_map``, bypassing
+    cooldown / health filtering.
+    """
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.4",
+                "litellm_params": {
+                    "model": "azure/gpt-5.4",
+                    "api_base": "https://a.openai.azure.com",
+                    "api_key": "key-a",
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "dep-a"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+        num_retries=0,
+    )
+
+    check = EncryptedContentAffinityCheck(router=router)
+    found = check._find_originating_deployment_in_router(model_id="dep-a")
+    assert found is not None
+    assert found["model_info"]["id"] == "dep-a"
+
+    assert check._find_originating_deployment_in_router(model_id="dep-missing") is None
+
+
+def test_find_originating_deployment_in_router_no_router_ref_returns_none():
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    check = EncryptedContentAffinityCheck(router=None)
+    assert check._find_originating_deployment_in_router(model_id="dep-a") is None
+
+
+@pytest.mark.asyncio
+async def test_affinity_pins_to_originating_when_cooled_down_single_region():
+    """
+    L3Harris repro: originating deployment is cooled down (e.g. Azure 429
+    storm), and the model group has no peer on the same (api_base, api_key)
+    boundary. The check MUST pin to the originating deployment so the caller
+    sees the real upstream error (429), instead of falling back to a
+    different deployment that will reject with invalid_encrypted_content 400.
+    """
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    ACCOUNT_A_BASE = "https://account-a.openai.azure.com/"
+    ACCOUNT_A_KEY = "key-a"
+    ACCOUNT_B_BASE = "https://account-b.openai.azure.com/"
+    ACCOUNT_B_KEY = "key-b"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.4",
+                "litellm_params": {
+                    "model": "azure/gpt-5.4",
+                    "api_base": ACCOUNT_A_BASE,
+                    "api_key": ACCOUNT_A_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.4-account-a"},
+            },
+            {
+                "model_name": "gpt-5.4",
+                "litellm_params": {
+                    "model": "azure/gpt-5.4",
+                    "api_base": ACCOUNT_B_BASE,
+                    "api_key": ACCOUNT_B_KEY,
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.4-account-b"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+        num_retries=0,
+    )
+
+    check = EncryptedContentAffinityCheck(router=router)
+
+    # Simulate cooldown by handing the affinity check a healthy_deployments
+    # list that excludes the originating deployment. The peer on a different
+    # encryption boundary is still healthy.
+    healthy_deployments = [
+        d for d in router.model_list if d["model_info"]["id"] == "gpt-5.4-account-b"
+    ]
+
+    request_kwargs: dict = {"litellm_metadata": {}}
+
+    # Build an encoded encitem_ ID pointing at account-a so
+    # _extract_model_id_from_input returns "gpt-5.4-account-a".
+    encoded_item_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        model_id="gpt-5.4-account-a",
+        item_id="rs_orig",
+    )
+    request_kwargs["input"] = [
+        {
+            "type": "reasoning",
+            "id": encoded_item_id,
+            "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+        }
+    ]
+
+    result = await check.async_filter_deployments(
+        model="gpt-5.4",
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs=request_kwargs,
+    )
+
+    # Must pin to originating (cooled-down) deployment, NOT fall back to
+    # the boundary-mismatched account-b peer.
+    assert len(result) == 1
+    assert result[0]["model_info"]["id"] == "gpt-5.4-account-a"
+    assert request_kwargs.get("_encrypted_content_affinity_pinned") is True
+
+
+@pytest.mark.asyncio
+async def test_affinity_falls_back_to_full_pool_when_originating_removed():
+    """
+    If the originating deployment is no longer in the router (deleted via
+    /model/delete, not just cooled down), we cannot pin to it — fall back to
+    the full healthy pool so new sessions keep flowing. The encrypted_content
+    in this request will be rejected upstream, but that is the correct error
+    surface for a deployment that genuinely no longer exists.
+    """
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.4",
+                "litellm_params": {
+                    "model": "azure/gpt-5.4",
+                    "api_base": "https://account-b.openai.azure.com/",
+                    "api_key": "key-b",
+                    "api_version": "2025-04-01-preview",
+                },
+                "model_info": {"id": "gpt-5.4-account-b"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+        num_retries=0,
+    )
+
+    check = EncryptedContentAffinityCheck(router=router)
+    healthy_deployments = list(router.model_list)
+    request_kwargs: dict = {"litellm_metadata": {}}
+
+    # Encoded ID points at a model_id that no longer exists in the router.
+    encoded_item_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        model_id="gpt-5.4-account-a-removed",
+        item_id="rs_orig",
+    )
+    request_kwargs["input"] = [
+        {
+            "type": "reasoning",
+            "id": encoded_item_id,
+            "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+        }
+    ]
+
+    result = await check.async_filter_deployments(
+        model="gpt-5.4",
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs=request_kwargs,
+    )
+
+    # Originating deployment is genuinely gone -> fall back to full healthy pool.
+    assert result == healthy_deployments
+    assert "_encrypted_content_affinity_pinned" not in request_kwargs


### PR DESCRIPTION
## Summary

When a Responses API request carries `encrypted_content` (or an encoded `encitem_…` ID) and the originating deployment is **cooled down** (e.g. during an Azure 429 storm), the affinity check in `encrypted_content_affinity_check.py` was falling back to the full healthy pool. The router then picked a different deployment, which Azure rejected with `400 invalid_encrypted_content` — masking the real signal (the 429 telling the caller to back off the rate-limited region).

This change pins the request to the originating deployment in that case, bypassing cooldown:

- If the cooldown has cleared by request time, the request succeeds.
- If it hasn't, the caller sees the real upstream error (e.g. 429) instead of a misleading 400 pointing at the wrong root cause.

Full-pool fallback now only triggers when the originating deployment was actually removed from the router (e.g. via `/model/delete`).

### What changed

- New helper `EncryptedContentAffinityCheck._find_originating_deployment_in_router(model_id)` reads from `router.model_list` via `model_id_to_deployment_index_map` — unfiltered by cooldown / health.
- `async_filter_deployments` now uses that helper as the last step before the full-pool fallback.

### Reported by

L3Harris — encrypted-content follow-ups during an Azure 429 burst were producing log lines like `decoded deployment=… not found in healthy_deployments` followed by `invalid_encrypted_content` 400s from a different region.

## Test plan

- [x] `pytest tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py` — 33 passed (3 new).
  - `test_find_originating_deployment_in_router_returns_dict_from_model_list`
  - `test_find_originating_deployment_in_router_no_router_ref_returns_none`
  - `test_affinity_pins_to_originating_when_cooled_down_single_region` (L3Harris regression)
  - `test_affinity_falls_back_to_full_pool_when_originating_removed`
- [x] `uv run black` on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds new authentication paths (Azure AD token-based Redis auth, new AWS Bedrock Claude Platform signing) and changes core request/telemetry behavior (OpenTelemetry span dedupe, Responses API bridging), which can affect production connectivity and observability.
> 
> **Overview**
> Adds a **manual mutation-testing GitHub Action** (`mutmut`) that generates and uploads a detailed survivor report artifact, and extends proxy unit-test sharding to include `test_deprecated_key_grace_period.py`.
> 
> Introduces **Azure AD authentication for Redis** (sync + async/cluster + pools) via new credential builders/connect hooks and `AzureADCredentialProvider`, with safe kwarg/env handling and GCP/Azure misconfig warnings.
> 
> Adds a new **AWS Bedrock `claude_platform/` route** (messages + chat configs) signed as `aws-external-anthropic`, updates Bedrock routing/dispatch to use it, and extends batch retrieval to support **`model-invocation-job` ARNs** with correct status/output URI mapping.
> 
> Improves **Responses API / GPT-5 bridging** (reasoning-summary aliases, `tool_choice` normalization) and OpenTelemetry reliability (first-wins logger registration, per-request span dedupe, better system-prompt/output parsing for Responses API). Also hardens file-handling helpers by **rejecting bare `str` paths** in audio/OCR/template upload flows to prevent arbitrary file reads, and normalizes OVHCloud response field migrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648281e346fa8610523416298448215dbcad4dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->