### PR TITLE
[Fix] Lazy feature loading under SERVER_ROOT_PATH returns 404

### DIFF
--- a/litellm/proxy/_lazy_features.py
+++ b/litellm/proxy/_lazy_features.py
@@ -257,6 +257,13 @@ class LazyFeatureMiddleware:
         self.app = app
         self._fastapi_app = fastapi_app
         self._features = features
+        # SERVER_ROOT_PATH is a process-startup env var, cache the normalized
+        # form once instead of recomputing per request. Lazy import to avoid
+        # pulling proxy.utils into this module's import graph at startup
+        # (proxy_server imports both).
+        from litellm.proxy.utils import get_server_root_path
+
+        self._root_path = get_server_root_path().rstrip("/")
         # Loaded set / per-feature locks live on app.state so the warm endpoint
         # and the middleware share them — preventing duplicate registrations
         # when both paths fire for the same feature.
@@ -273,10 +280,6 @@ class LazyFeatureMiddleware:
         if scope["type"] in ("http", "websocket") and len(self._loaded) < len(
             self._features
         ):
-            # Lazy import to avoid pulling proxy.utils into this module's
-            # import graph (proxy_server imports both).
-            from litellm.proxy.utils import get_server_root_path
-
             path = scope.get("path", "")
             # Strip SERVER_ROOT_PATH so prefix matching works under a server
             # root path. Without this, requests like /api/v1/policies/... never
@@ -285,9 +288,8 @@ class LazyFeatureMiddleware:
             # `+ "/"` boundary prevents false-positive matches (e.g. /apiv2
             # against root /api). If the path doesn't start with the prefix
             # (e.g. a reverse proxy already stripped it), we leave it alone.
-            root_path = get_server_root_path().rstrip("/")
-            if root_path and path.startswith(root_path + "/"):
-                path = path[len(root_path) :]
+            if self._root_path and path.startswith(self._root_path + "/"):
+                path = path[len(self._root_path) :]
             for feat in self._features:
                 if feat.module_path in self._loaded:
                     continue

--- a/litellm/proxy/_lazy_features.py
+++ b/litellm/proxy/_lazy_features.py
@@ -273,7 +273,21 @@ class LazyFeatureMiddleware:
         if scope["type"] in ("http", "websocket") and len(self._loaded) < len(
             self._features
         ):
+            # Lazy import to avoid pulling proxy.utils into this module's
+            # import graph (proxy_server imports both).
+            from litellm.proxy.utils import get_server_root_path
+
             path = scope.get("path", "")
+            # Strip SERVER_ROOT_PATH so prefix matching works under a server
+            # root path. Without this, requests like /api/v1/policies/... never
+            # match the registered prefixes (/policies/...) and lazy features
+            # stay unloaded — every endpoint under them returns 404. The
+            # `+ "/"` boundary prevents false-positive matches (e.g. /apiv2
+            # against root /api). If the path doesn't start with the prefix
+            # (e.g. a reverse proxy already stripped it), we leave it alone.
+            root_path = get_server_root_path().rstrip("/")
+            if root_path and path.startswith(root_path + "/"):
+                path = path[len(root_path) :]
             for feat in self._features:
                 if feat.module_path in self._loaded:
                     continue

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6379,6 +6379,84 @@ class TestLazyFeatureMiddleware:
         assert loads == ["json"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "server_root_path,request_path,should_load,case",
+        [
+            # SERVER_ROOT_PATH set: incoming path includes prefix → strip and match.
+            ("/api/v1", "/api/v1/dummy/x", True, "root_path strip + match"),
+            # Trailing-slash env var must be normalized.
+            ("/api/v1/", "/api/v1/dummy/x", True, "trailing-slash env normalization"),
+            # Reverse proxy already stripped the prefix → original path still matches.
+            ("/api/v1", "/dummy/x", True, "pre-stripped path still loads"),
+            # No SERVER_ROOT_PATH set → unchanged behavior.
+            ("", "/dummy/x", True, "no root path"),
+            # SERVER_ROOT_PATH=/ must be a no-op (not strip every leading slash).
+            ("/", "/dummy/x", True, "root_path='/' is no-op"),
+            # Boundary check: /apiv2 must not match root /api.
+            ("/api", "/apiv2/foo", False, "boundary check prevents false match"),
+            # Genuine non-match under root_path.
+            ("/api/v1", "/api/v1/unrelated", False, "unrelated path under root"),
+        ],
+    )
+    async def test_root_path_handling(
+        self, monkeypatch, server_root_path, request_path, should_load, case
+    ):
+        """
+        The middleware must strip SERVER_ROOT_PATH before prefix-matching so
+        lazy features load under deployments that set a server root path,
+        while handling boundary, trailing-slash, and reverse-proxy edge cases
+        correctly.
+        """
+        from fastapi import FastAPI
+
+        from litellm.proxy._lazy_features import (
+            LazyFeature,
+            LazyFeatureMiddleware,
+        )
+
+        monkeypatch.setenv("SERVER_ROOT_PATH", server_root_path)
+
+        loads = []
+
+        def fake_register(app, module):
+            loads.append(getattr(module, "__name__", "?"))
+
+        feat = LazyFeature(
+            name=f"dummy_{case}",
+            module_path="json",
+            path_prefixes=("/dummy",),
+            register_fn=fake_register,
+        )
+
+        async def downstream(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        target_app = FastAPI()
+        mw = LazyFeatureMiddleware(downstream, fastapi_app=target_app, features=(feat,))
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            pass
+
+        await mw(
+            {
+                "type": "http",
+                "path": request_path,
+                "method": "GET",
+                "headers": [],
+            },
+            receive,
+            send,
+        )
+        if should_load:
+            assert loads == ["json"], f"{case}: expected feature to load"
+        else:
+            assert loads == [], f"{case}: feature must not load"
+
+    @pytest.mark.asyncio
     async def test_concurrent_first_requests_only_register_once(self):
         """
         Two requests to the same prefix arriving in parallel must result in


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

When the proxy is deployed under a non-empty `SERVER_ROOT_PATH` (e.g. `/api/v1`), requests to lazy-loaded endpoints such as `/api/v1/policies/attachments/list` or `/api/v1/vector_store/list` return 404. The `LazyFeatureMiddleware` matches the raw scope path against the registered prefixes (`/policies`, `/vector_store/`, etc.), so the prefix never matches, the feature module is never imported, and the route is never registered. Starlette's router then 404s because the route doesn't exist. Non-lazy routes work because they're registered at startup.

### Fix

Strip the configured server root path from the request path before the prefix check. The check normalizes a trailing slash on the env var, skips the strip when the value is `/`, and uses a component boundary (`prefix + "/"`) so `/api` does not falsely match `/apiv2`. If the path doesn't carry the prefix (reverse proxy already stripped it), it is left alone.

## Testing

- Reproduced the 404 locally with `SERVER_ROOT_PATH=/api/v1` against `/api/v1/policies/attachments/list` and `/api/v1/vector_store/list`; both return 200 after the fix.
- Added a parametrized test (`test_root_path_handling`) covering: prefix strip + match, trailing-slash env, pre-stripped path (reverse proxy), no root path, root path `/`, boundary collision (`/api` vs `/apiv2`), and unrelated paths under the root.
- `uv run pytest tests/test_litellm/proxy/test_proxy_server.py::TestLazyFeatureMiddleware` — 10 passed.

## Type

🐛 Bug Fix
✅ Test

## Screenshots

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-path matching in `LazyFeatureMiddleware` based on `SERVER_ROOT_PATH`, which could affect when optional routers are imported/registered and thus routing behavior for some deployments.
> 
> **Overview**
> Fixes lazy feature loading when the proxy is deployed behind a non-empty `SERVER_ROOT_PATH` by stripping the configured root path from the incoming request path before prefix/suffix matching, with normalization for trailing slashes and a boundary check to avoid false matches.
> 
> Adds a parametrized test (`test_root_path_handling`) covering root-path stripping, reverse-proxy pre-stripped paths, `SERVER_ROOT_PATH='/'` no-op behavior, boundary collisions, and non-matching paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384fc0b6d0e7809bb4f3e1e82252487e4a9e13ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->