### PR TITLE
[Fix] Replace deprecated dall-e-3 with gpt-image-1 in tests

### DIFF
--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -68,7 +68,7 @@ async def test_azure_embedding_health_check():
 async def test_openai_img_gen_health_check():
     response = await litellm.ahealth_check(
         model_params={
-            "model": "dall-e-3",
+            "model": "gpt-image-1",
             "api_key": os.getenv("OPENAI_API_KEY"),
         },
         mode="image_generation",

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -40,9 +40,9 @@ def model_list():
             },
         },
         {
-            "model_name": "dall-e-3",
+            "model_name": "gpt-image-1",
             "litellm_params": {
-                "model": "dall-e-3",
+                "model": "gpt-image-1",
                 "api_key": os.getenv("OPENAI_API_KEY"),
             },
         },
@@ -207,12 +207,12 @@ async def test_image_generation(model_list, sync_mode):
     router = Router(model_list=model_list)
     if sync_mode:
         response = router._image_generation(
-            model="dall-e-3",
+            model="gpt-image-1",
             prompt="A cute baby sea otter",
         )
     else:
         response = await router._aimage_generation(
-            model="dall-e-3",
+            model="gpt-image-1",
             prompt="A cute baby sea otter",
         )
 
@@ -382,7 +382,7 @@ async def test_router_make_call(model_list):
     ## AIMAGE_GENERATION
     response = await router.make_call(
         original_function=router._aimage_generation,
-        model="dall-e-3",
+        model="gpt-image-1",
         prompt="A cute baby sea otter",
         mock_response="https://example.com/image.png",
     )


### PR DESCRIPTION
## Relevant issues

## Summary

OpenAI's `dall-e-3` model is no longer accessible from the test account — the API returns `The model 'dall-e-3' does not exist`, breaking `test_openai_img_gen_health_check` and `test_image_generation` in CI.

### Failure Path (Before Fix)

- `tests/litellm_utils_tests/test_health_check.py::test_openai_img_gen_health_check` fails with `BadRequestError: OpenAIException - The model 'dall-e-3' does not exist`.
- `tests/router_unit_tests/test_router_helper_utils.py::test_image_generation[False]` fails with the same error.

### Fix

Replace `dall-e-3` with `gpt-image-1` in the two real-API test paths and in the router fixture. `gpt-image-1` matches the existing `TestOpenAIGPTImage1` pattern in `tests/image_gen_tests/test_image_generation.py`.

Two `dall-e-3` references are intentionally left alone:
- `test_health_check.py:102` (`azure/dall-e-3`) is already `@pytest.mark.skip`'d.
- `test_health_check.py:732` is a mocked test where `ahealth_check` is patched via `side_effect`, so no real API call is made.

## Testing

Live-API tests; CI is the verification path.

## Type

✅ Test
🐛 Bug Fix

## Screenshots