### PR TITLE
test(gemini): add parity test between native and chat schema normalization

### DIFF
--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -359,6 +359,11 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             return
 
         if use_json_schema:
+            if json_schema_key is not None:
+                # Caller already supplied responseJsonSchema; preserve it and
+                # drop the redundant responseSchema rather than clobbering.
+                generate_content_config_dict.pop(schema_key)
+                return
             generate_content_config_dict.pop(schema_key)
             generate_content_config_dict["responseJsonSchema"] = _build_json_schema(
                 deepcopy(value)

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -13,7 +13,6 @@ from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
 )
 from litellm.llms.vertex_ai.common_utils import (
-    _build_json_schema,
     _build_vertex_schema,
     supports_response_json_schema,
 )
@@ -329,14 +328,8 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             None,
         )
 
-        use_json_schema = supports_response_json_schema(model)
-
-        if json_schema_key is not None:
-            value = generate_content_config_dict[json_schema_key]
-            if isinstance(value, dict):
-                generate_content_config_dict[json_schema_key] = _build_json_schema(
-                    deepcopy(value)
-                )
+        # responseJsonSchema is forwarded as-is — Gemini 2.0+ accepts standard
+        # JSON Schema natively, so no transformation (and no deepcopy) is needed.
 
         if schema_key is None:
             return
@@ -345,14 +338,12 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         if not isinstance(value, dict):
             return
 
-        if use_json_schema:
+        if supports_response_json_schema(model):
             if json_schema_key is not None:
                 generate_content_config_dict.pop(schema_key)
                 return
             generate_content_config_dict.pop(schema_key)
-            generate_content_config_dict["responseJsonSchema"] = _build_json_schema(
-                deepcopy(value)
-            )
+            generate_content_config_dict["responseJsonSchema"] = value
         else:
             generate_content_config_dict[schema_key] = _build_vertex_schema(
                 parameters=deepcopy(value), add_property_ordering=True

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -328,9 +328,6 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             None,
         )
 
-        # responseJsonSchema is forwarded as-is — Gemini 2.0+ accepts standard
-        # JSON Schema natively, so no transformation (and no deepcopy) is needed.
-
         if schema_key is None:
             return
 

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -2,6 +2,7 @@
 Transformation for Calling Google models in their native format.
 """
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import httpx
@@ -10,6 +11,11 @@ import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
+)
+from litellm.llms.vertex_ai.common_utils import (
+    _build_json_schema,
+    _build_vertex_schema,
+    supports_response_json_schema,
 )
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
 from litellm.types.router import GenericLiteLLMParams
@@ -302,6 +308,66 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             litellm_params=litellm_params,
         )
 
+    @staticmethod
+    def _normalize_response_schema(
+        generate_content_config_dict: Dict, model: str
+    ) -> None:
+        """
+        Normalize ``responseSchema`` / ``responseJsonSchema`` in-place so the
+        native ``generateContent`` passthrough mirrors the chat/completions
+        path. Without this, schemas containing ``$defs``/``$ref``, ``anyOf``
+        with ``null``, ``default``, ``title``, etc. are forwarded verbatim and
+        Gemini rejects them.
+
+        - Gemini 2.0+ supports ``responseJsonSchema`` natively (preserves
+          ``$defs``/``$ref``). Promote ``responseSchema`` to
+          ``responseJsonSchema`` for those models.
+        - Older models keep ``responseSchema`` but the schema is flattened to
+          the OpenAPI subset via ``_build_vertex_schema``.
+        """
+        schema_key = next(
+            (
+                k
+                for k in ("responseSchema", "response_schema")
+                if k in generate_content_config_dict
+            ),
+            None,
+        )
+        json_schema_key = next(
+            (
+                k
+                for k in ("responseJsonSchema", "response_json_schema")
+                if k in generate_content_config_dict
+            ),
+            None,
+        )
+
+        use_json_schema = supports_response_json_schema(model)
+
+        if json_schema_key is not None:
+            value = generate_content_config_dict[json_schema_key]
+            if isinstance(value, dict):
+                generate_content_config_dict[json_schema_key] = _build_json_schema(
+                    deepcopy(value)
+                )
+
+        if schema_key is None:
+            return
+
+        value = generate_content_config_dict[schema_key]
+        if not isinstance(value, dict):
+            return
+
+        if use_json_schema:
+            generate_content_config_dict.pop(schema_key)
+            generate_content_config_dict["responseJsonSchema"] = _build_json_schema(
+                deepcopy(value)
+            )
+        else:
+            generate_content_config_dict[schema_key] = _build_vertex_schema(
+                parameters=deepcopy(value), add_property_ordering=True
+            )
+
     def transform_generate_content_request(
         self,
         model: str,
@@ -314,6 +380,8 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             GenerateContentConfigDict,
             GenerateContentRequestDict,
         )
+
+        self._normalize_response_schema(generate_content_config_dict, model)
 
         typed_generate_content_request = GenerateContentRequestDict(
             model=model,

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -312,19 +312,6 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
     def _normalize_response_schema(
         generate_content_config_dict: Dict, model: str
     ) -> None:
-        """
-        Normalize ``responseSchema`` / ``responseJsonSchema`` in-place so the
-        native ``generateContent`` passthrough mirrors the chat/completions
-        path. Without this, schemas containing ``$defs``/``$ref``, ``anyOf``
-        with ``null``, ``default``, ``title``, etc. are forwarded verbatim and
-        Gemini rejects them.
-
-        - Gemini 2.0+ supports ``responseJsonSchema`` natively (preserves
-          ``$defs``/``$ref``). Promote ``responseSchema`` to
-          ``responseJsonSchema`` for those models.
-        - Older models keep ``responseSchema`` but the schema is flattened to
-          the OpenAPI subset via ``_build_vertex_schema``.
-        """
         schema_key = next(
             (
                 k
@@ -360,8 +347,6 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
 
         if use_json_schema:
             if json_schema_key is not None:
-                # Caller already supplied responseJsonSchema; preserve it and
-                # drop the redundant responseSchema rather than clobbering.
                 generate_content_config_dict.pop(schema_key)
                 return
             generate_content_config_dict.pop(schema_key)

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -342,6 +342,8 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             generate_content_config_dict.pop(schema_key)
             generate_content_config_dict["responseJsonSchema"] = value
         else:
+            if json_schema_key is not None:
+                generate_content_config_dict.pop(json_schema_key)
             generate_content_config_dict[schema_key] = _build_vertex_schema(
                 parameters=deepcopy(value), add_property_ordering=True
             )

--- a/litellm/llms/vertex_ai/google_genai/transformation.py
+++ b/litellm/llms/vertex_ai/google_genai/transformation.py
@@ -79,6 +79,9 @@ class VertexAIGoogleGenAIConfig(GoogleGenAIConfig):
         Transform the generate content request for Vertex AI.
         Since Vertex AI natively supports Google GenAI format, we can pass most fields directly.
         """
+        if generate_content_config_dict:
+            self._normalize_response_schema(generate_content_config_dict, model)
+
         # Build the request in Google GenAI format that Vertex AI expects
         result = {
             "model": model,

--- a/tests/test_litellm/google_genai/test_google_genai_transformation.py
+++ b/tests/test_litellm/google_genai/test_google_genai_transformation.py
@@ -482,6 +482,69 @@ def test_transform_generate_content_request_preserves_response_json_schema_when_
     assert gen_config["responseJsonSchema"] == caller_json_schema
 
 
+def test_response_schema_normalization_parity_across_chat_and_native_paths():
+    """Parity guard between the two Gemini schema-normalization paths.
+
+    The native ``generateContent`` path (``_normalize_response_schema``) must
+    produce the same normalized schema as the ``/chat/completions`` path
+    (``apply_response_schema_transformation``) for the same input schema, on
+    both Gemini 2.0+ and Gemini 1.5. If either implementation drifts, this
+    test fails — forcing both paths to be updated together.
+    """
+    from copy import deepcopy
+
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    schema = {
+        "$defs": {
+            "Highlight": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "detail": {"type": "string"},
+                },
+                "required": ["title"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "park_name": {"type": "string"},
+            "highlights": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Highlight"},
+            },
+            "rating": {"anyOf": [{"type": "number"}, {"type": "null"}]},
+        },
+        "required": ["park_name", "highlights"],
+    }
+
+    native_config = GoogleGenAIConfig()
+    chat_config = VertexGeminiConfig()
+
+    for model, native_out_key, chat_out_key in (
+        ("gemini-2.5-flash-lite", "responseJsonSchema", "response_json_schema"),
+        ("gemini-1.5-pro", "responseSchema", "response_schema"),
+    ):
+        native_dict = {"responseSchema": deepcopy(schema)}
+        native_config._normalize_response_schema(native_dict, model)
+
+        chat_optional_params: dict = {}
+        chat_config.apply_response_schema_transformation(
+            value={"type": "json_schema", "response_schema": deepcopy(schema)},
+            optional_params=chat_optional_params,
+            model=model,
+        )
+
+        assert native_dict[native_out_key] == chat_optional_params[chat_out_key], (
+            f"Schema normalization drifted between native generateContent and "
+            f"chat/completions paths for {model}. Update both "
+            f"GoogleGenAIConfig._normalize_response_schema and "
+            f"VertexGeminiConfig.apply_response_schema_transformation together."
+        )
+
+
 def test_transform_generate_content_request_without_schema_unchanged():
     """No schema in config → no normalization side effects."""
     config = GoogleGenAIConfig()

--- a/tests/test_litellm/google_genai/test_google_genai_transformation.py
+++ b/tests/test_litellm/google_genai/test_google_genai_transformation.py
@@ -335,6 +335,140 @@ def test_transform_generate_content_request_system_instruction_with_tools():
     assert result["model"] == "gemini-3-flash-preview"
 
 
+def test_transform_generate_content_request_normalizes_response_schema_2_5():
+    """For Gemini 2.0+, ``response_schema`` with ``$defs``/``$ref`` should be
+    promoted to ``responseJsonSchema`` (which Gemini 2.0+ accepts natively),
+    not forwarded as ``responseSchema`` (which rejects ``$defs``)."""
+    config = GoogleGenAIConfig()
+
+    schema = {
+        "$defs": {
+            "Highlight": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "detail": {"type": "string"},
+                },
+                "required": ["title"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "park_name": {"type": "string"},
+            "highlights": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Highlight"},
+            },
+        },
+        "required": ["park_name", "highlights"],
+    }
+
+    result = config.transform_generate_content_request(
+        model="gemini-2.5-flash-lite",
+        contents=[{"role": "user", "parts": [{"text": "hi"}]}],
+        tools=None,
+        generate_content_config_dict={
+            "responseMimeType": "application/json",
+            "responseSchema": schema,
+        },
+        system_instruction=None,
+    )
+
+    gen_config = result["generationConfig"]
+    assert "responseSchema" not in gen_config
+    assert "responseJsonSchema" in gen_config
+    normalized = gen_config["responseJsonSchema"]
+    # _build_json_schema preserves $defs/$ref for 2.0+ models
+    assert "$defs" in normalized
+    assert normalized["properties"]["highlights"]["items"] == {
+        "$ref": "#/$defs/Highlight"
+    }
+
+
+def test_transform_generate_content_request_flattens_response_schema_1_5():
+    """For Gemini 1.5, ``responseSchema`` is kept but flattened via
+    ``_build_vertex_schema`` so ``$defs``/``$ref`` are unpacked."""
+    config = GoogleGenAIConfig()
+
+    schema = {
+        "$defs": {
+            "Highlight": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}},
+                "required": ["title"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "highlights": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Highlight"},
+            }
+        },
+        "required": ["highlights"],
+    }
+
+    result = config.transform_generate_content_request(
+        model="gemini-1.5-pro",
+        contents=[{"role": "user", "parts": [{"text": "hi"}]}],
+        tools=None,
+        generate_content_config_dict={"responseSchema": schema},
+        system_instruction=None,
+    )
+
+    gen_config = result["generationConfig"]
+    assert "responseSchema" in gen_config
+    assert "responseJsonSchema" not in gen_config
+    normalized = gen_config["responseSchema"]
+    # $defs should be stripped, $ref expanded inline
+    assert "$defs" not in normalized
+    items = normalized["properties"]["highlights"]["items"]
+    assert "$ref" not in items
+    assert "title" in items["properties"]
+    assert items["properties"]["title"]["type"].lower() == "string"
+
+
+def test_transform_generate_content_request_passes_through_response_json_schema():
+    """If the caller already used ``responseJsonSchema``, it should be
+    preserved (Gemini 2.0+ accepts standard JSON Schema as-is)."""
+    config = GoogleGenAIConfig()
+
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+
+    result = config.transform_generate_content_request(
+        model="gemini-2.5-flash-lite",
+        contents=[{"role": "user", "parts": [{"text": "hi"}]}],
+        tools=None,
+        generate_content_config_dict={"responseJsonSchema": schema},
+        system_instruction=None,
+    )
+
+    gen_config = result["generationConfig"]
+    assert gen_config["responseJsonSchema"] == schema
+    assert "responseSchema" not in gen_config
+
+
+def test_transform_generate_content_request_without_schema_unchanged():
+    """No schema in config → no normalization side effects."""
+    config = GoogleGenAIConfig()
+
+    result = config.transform_generate_content_request(
+        model="gemini-2.5-flash-lite",
+        contents=[{"role": "user", "parts": [{"text": "hi"}]}],
+        tools=None,
+        generate_content_config_dict={"temperature": 0.7},
+        system_instruction=None,
+    )
+
+    assert result["generationConfig"]["temperature"] == 0.7
+    assert "responseSchema" not in result["generationConfig"]
+    assert "responseJsonSchema" not in result["generationConfig"]
+
+
 def test_validate_environment_with_dict_api_key():
     """
     Test that validate_environment correctly handles api_key as a dict.

--- a/tests/test_litellm/google_genai/test_google_genai_transformation.py
+++ b/tests/test_litellm/google_genai/test_google_genai_transformation.py
@@ -452,6 +452,38 @@ def test_transform_generate_content_request_passes_through_response_json_schema(
     assert "responseSchema" not in gen_config
 
 
+def test_transform_generate_content_request_preserves_response_json_schema_when_response_schema_co_present():
+    """When both ``responseJsonSchema`` and ``responseSchema`` are supplied on
+    Gemini 2.0+, the caller's ``responseJsonSchema`` must win — the
+    ``responseSchema`` value must not clobber it."""
+    config = GoogleGenAIConfig()
+
+    caller_json_schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    redundant_response_schema = {
+        "type": "object",
+        "properties": {"other": {"type": "string"}},
+    }
+
+    result = config.transform_generate_content_request(
+        model="gemini-2.5-flash-lite",
+        contents=[{"role": "user", "parts": [{"text": "hi"}]}],
+        tools=None,
+        generate_content_config_dict={
+            "responseJsonSchema": caller_json_schema,
+            "responseSchema": redundant_response_schema,
+        },
+        system_instruction=None,
+    )
+
+    gen_config = result["generationConfig"]
+    assert "responseSchema" not in gen_config
+    assert gen_config["responseJsonSchema"] == caller_json_schema
+
+
 def test_transform_generate_content_request_without_schema_unchanged():
     """No schema in config → no normalization side effects."""
     config = GoogleGenAIConfig()

--- a/tests/test_litellm/google_genai/test_google_genai_transformation.py
+++ b/tests/test_litellm/google_genai/test_google_genai_transformation.py
@@ -378,7 +378,6 @@ def test_transform_generate_content_request_normalizes_response_schema_2_5():
     assert "responseSchema" not in gen_config
     assert "responseJsonSchema" in gen_config
     normalized = gen_config["responseJsonSchema"]
-    # _build_json_schema preserves $defs/$ref for 2.0+ models
     assert "$defs" in normalized
     assert normalized["properties"]["highlights"]["items"] == {
         "$ref": "#/$defs/Highlight"
@@ -420,7 +419,6 @@ def test_transform_generate_content_request_flattens_response_schema_1_5():
     assert "responseSchema" in gen_config
     assert "responseJsonSchema" not in gen_config
     normalized = gen_config["responseSchema"]
-    # $defs should be stripped, $ref expanded inline
     assert "$defs" not in normalized
     items = normalized["properties"]["highlights"]["items"]
     assert "$ref" not in items


### PR DESCRIPTION
Addresses @Sameerlite review on #27775:

> So if we have a method there as well, can we have a test which makes sure that if any one of the 2 paths method changes, this test fails, so that we make sure that both paths are always updated with the schema changes.

Adds `test_response_schema_normalization_parity_across_chat_and_native_paths` which feeds the same schema through both `GoogleGenAIConfig._normalize_response_schema` (native `generateContent`) and `VertexGeminiConfig.apply_response_schema_transformation` (`/chat/completions`) and asserts equality on Gemini 2.0+ and Gemini 1.5. If either path drifts, the test fails — forcing both to be updated together.

This branch builds on the tip of #27775; the parity test is the only delta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `responseSchema`/`responseJsonSchema` are emitted for Gemini native/Vertex GenAI requests, which can alter structured-output behavior across model versions. Risk is mitigated by extensive new tests, but schema edge cases could still regress.
> 
> **Overview**
> Adds native `generateContent` response-schema normalization so **Gemini 2.0+** promotes `responseSchema` to `responseJsonSchema` (preserving `$defs`/`$ref`), while **Gemini 1.5** keeps `responseSchema` but flattens it via `_build_vertex_schema`.
> 
> Applies the same normalization in the Vertex GenAI transformation path and adds a broad test suite, including a parity test ensuring native (`GoogleGenAIConfig._normalize_response_schema`) and chat (`VertexGeminiConfig.apply_response_schema_transformation`) schema normalization stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf20bd8fff7d06e691e204f41982c06dcabeb437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->