### PR TITLE
fix(logging): normalize top-level error fields in spend logs

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3454,19 +3454,28 @@ async def _build_ui_spend_logs_response(
                 if r.get("session_id")
             }
 
-    if enrich_session_counts:
-        enriched: List[dict] = []
-        for row in data:
-            row_dict = dict(row) if isinstance(row, dict) else row.model_dump()
+    enriched: List[dict] = []
+    for row in data:
+        row_dict = dict(row) if isinstance(row, dict) else row.model_dump()
+
+        # 1. Normalize session counts (existing v1/UI logic)
+        if enrich_session_counts:
             sid = row_dict.get("session_id")
             row_dict["session_total_count"] = count_map.get(sid, 1) if sid else 1
-            enriched.append(row_dict)
-        response_data: list = enriched
-    else:
-        # v2 path: return raw Prisma model instances so FastAPI applies its
-        # own Pydantic-aware serialisation (preserves alias handling, custom
-        # serializers, etc.).
-        response_data = data  # type: ignore[assignment]
+
+        # 2. Normalize error fields for failed requests
+        if row_dict.get("status") == "failure":
+            metadata = row_dict.get("metadata")
+            if isinstance(metadata, dict):
+                error_info = metadata.get("error_information")
+                if isinstance(error_info, dict):
+                    for field in ["error_code", "error_class", "error_message"]:
+                        if not row_dict.get(field):
+                            row_dict[field] = error_info.get(field)
+
+        enriched.append(row_dict)
+
+    response_data: list = enriched
 
     return {
         "data": response_data,

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3185,3 +3185,64 @@ async def test_view_spend_logs_date_range_hashes_sk_api_key(client, monkeypatch)
         assert where["api_key"] == "hashed::sk-raw-admin-token"
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_build_ui_spend_logs_response_normalization_failure():
+    """
+    Regression test: _build_ui_spend_logs_response must normalize error_code,
+    error_class, and error_message from metadata.error_information when status is 'failure'.
+    """
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        _build_ui_spend_logs_response,
+    )
+
+    error_info = {
+        "error_code": "401",
+        "error_class": "AuthenticationError",
+        "error_message": "Invalid API Key",
+    }
+
+    dict_rows = [
+        {
+            "request_id": "req-failure",
+            "status": "failure",
+            "spend": 0.0,
+            "total_tokens": 0,
+            "metadata": {"error_information": error_info},
+        },
+        {
+            "request_id": "req-success",
+            "status": "success",
+            "spend": 0.05,
+            "total_tokens": 100,
+            "metadata": {},
+        },
+    ]
+
+    mock_prisma = MagicMock()
+
+    result = await _build_ui_spend_logs_response(
+        prisma_client=mock_prisma,
+        data=dict_rows,
+        total_records=2,
+        page=1,
+        page_size=50,
+        total_pages=1,
+        enrich_session_counts=False,
+    )
+
+    rows = result["data"]
+    assert len(rows) == 2
+
+    # Failure row should be normalized
+    fail_row = rows[0]
+    assert fail_row["request_id"] == "req-failure"
+    assert fail_row["error_code"] == "401"
+    assert fail_row["error_class"] == "AuthenticationError"
+    assert fail_row["error_message"] == "Invalid API Key"
+
+    # Success row should remain unchanged
+    success_row = rows[1]
+    assert success_row["request_id"] == "req-success"
+    assert "error_code" not in success_row


### PR DESCRIPTION
## Relevant issues

Fixes #27735

## Summary

Populate top-level:

* `error_code`
* `error_class`
* `error_message`

from `metadata.error_information` for failed `/spend/logs/v2` responses when those top-level fields are empty.

## Changes

* normalize nested error information during spend log response construction
* preserve existing session enrichment behavior
* add regression test for failed pre-provider requests with nested error metadata

## Motivation

Currently failed spend log rows can return null top-level error fields even when the actual error exists inside `metadata.error_information`, making filtering and summarization difficult for API/UI consumers.

## Type

🐛 Bug Fix
✅ Test
