### PR TITLE
fix(responses): register cooldowns on failure + fail fast on stale encrypted_content

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1138,7 +1138,11 @@ def responses(
                 "aresponses": _is_async,
                 "litellm_call_id": litellm_call_id,
                 "model_info": kwargs.get("model_info"),
-                "metadata": kwargs.get("litellm_metadata") or kwargs.get("metadata"),
+                "metadata": (
+                    kwargs["litellm_metadata"]
+                    if "litellm_metadata" in kwargs
+                    else kwargs.get("metadata")
+                ),
             },
             custom_llm_provider=custom_llm_provider,
         )

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1128,7 +1128,6 @@ def responses(
             )
         )
 
-        # Pre Call logging
         litellm_logging_obj.update_from_kwargs(
             kwargs=kwargs,
             model=model,
@@ -1138,6 +1137,8 @@ def responses(
                 **responses_api_request_params,
                 "aresponses": _is_async,
                 "litellm_call_id": litellm_call_id,
+                "model_info": kwargs.get("model_info"),
+                "metadata": kwargs.get("litellm_metadata") or kwargs.get("metadata"),
             },
             custom_llm_provider=custom_llm_provider,
         )

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -36,12 +36,20 @@ Safe to enable globally:
 - No cache required.
 """
 
+import time
 from typing import TYPE_CHECKING, Any, List, Optional, cast
 
+import httpx
+
 from litellm._logging import verbose_router_logger
-from litellm.exceptions import BadRequestError, ServiceUnavailableError
+from litellm.exceptions import (
+    BadRequestError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
 from litellm.integrations.custom_logger import CustomLogger, Span
 from litellm.responses.utils import ResponsesAPIRequestUtils
+from litellm.router_utils.cooldown_cache import CooldownCacheValue
 from litellm.types.llms.openai import AllMessageValues
 
 if TYPE_CHECKING:
@@ -191,9 +199,13 @@ class EncryptedContentAffinityCheck(CustomLogger):
         """
         If the request ``input`` contains litellm-encoded item IDs, decode the
         embedded ``model_id`` and pin the request to that deployment. Raises
-        ``ServiceUnavailableError`` / ``BadRequestError`` when the originating
-        deployment is unavailable and no encryption-boundary peer exists,
-        rather than dispatching a doomed request to a non-peer deployment.
+        ``RateLimitError`` / ``ServiceUnavailableError`` / ``BadRequestError``
+        when the originating deployment is unavailable and no encryption-boundary
+        peer exists, rather than dispatching a doomed request to a non-peer
+        deployment. The 429/503 split mirrors the originating cooldown's status:
+        a 429-induced cooldown surfaces as 429 (with ``Retry-After`` set to the
+        remaining cooldown window) so OpenAI-compatible clients back off and
+        retry after the deployment is eligible again.
         """
         request_kwargs = request_kwargs or {}
         typed_healthy_deployments = cast(List[dict], healthy_deployments)
@@ -249,32 +261,95 @@ class EncryptedContentAffinityCheck(CustomLogger):
 
         # Dispatching to a non-peer would guarantee an upstream
         # `invalid_encrypted_content` 400, so fail fast with a clearer error.
-        raise self._unavailable_origin_error(model=model, model_id=model_id)
+        raise await self._unavailable_origin_error(
+            model=model,
+            model_id=model_id,
+            parent_otel_span=parent_otel_span,
+        )
 
-    def _unavailable_origin_error(self, model: str, model_id: str) -> Exception:
+    async def _unavailable_origin_error(
+        self,
+        model: str,
+        model_id: str,
+        parent_otel_span: Optional[Span],
+    ) -> Exception:
         originating = (
             self.router.get_deployment(model_id=model_id)
             if self.router is not None
             else None
         )
-        if originating is not None:
-            return ServiceUnavailableError(
+        if originating is None:
+            return BadRequestError(
                 message=(
-                    f"Deployment id={model_id} that produced this encrypted_content "
-                    "is currently unavailable (likely cooled down), and no deployment "
-                    "on the same encryption boundary is configured. Retry later or "
-                    "configure a deployment with the same (api_base, api_key)."
+                    f"Deployment id={model_id} that produced this encrypted_content is "
+                    "no longer configured on this router, and no deployment on the same "
+                    "encryption boundary is available. Re-issue the request without the "
+                    "stale encrypted_content items, or restore the originating deployment."
+                ),
+                model=model,
+                llm_provider="",
+            )
+
+        cooldown = await self._get_origin_cooldown(
+            model_id=model_id, parent_otel_span=parent_otel_span
+        )
+
+        if cooldown is not None and str(cooldown.get("status_code")) == "429":
+            retry_after = self._cooldown_seconds_remaining(cooldown)
+            return RateLimitError(
+                message=(
+                    f"Deployment id={model_id} that produced this encrypted_content is "
+                    f"rate-limited (cooling down for ~{retry_after}s), and no deployment "
+                    "on the same encryption boundary is configured. Retry after the "
+                    "Retry-After window or configure a deployment with the same "
+                    "(api_base, api_key)."
                 ),
                 llm_provider="",
                 model=model,
+                response=httpx.Response(
+                    status_code=429,
+                    headers={"retry-after": str(retry_after)},
+                    request=httpx.Request("POST", "https://litellm.ai/"),
+                ),
             )
-        return BadRequestError(
+
+        return ServiceUnavailableError(
             message=(
-                f"Deployment id={model_id} that produced this encrypted_content is "
-                "no longer configured on this router, and no deployment on the same "
-                "encryption boundary is available. Re-issue the request without the "
-                "stale encrypted_content items, or restore the originating deployment."
+                f"Deployment id={model_id} that produced this encrypted_content "
+                "is currently unavailable (likely cooled down), and no deployment "
+                "on the same encryption boundary is configured. Retry later or "
+                "configure a deployment with the same (api_base, api_key)."
             ),
-            model=model,
             llm_provider="",
+            model=model,
         )
+
+    async def _get_origin_cooldown(
+        self,
+        model_id: str,
+        parent_otel_span: Optional[Span],
+    ) -> Optional[CooldownCacheValue]:
+        if self.router is None:
+            return None
+        cooldown_cache = getattr(self.router, "cooldown_cache", None)
+        if cooldown_cache is None:
+            return None
+        try:
+            active = await cooldown_cache.async_get_active_cooldowns(
+                model_ids=[model_id], parent_otel_span=parent_otel_span
+            )
+        except Exception:
+            return None
+        for cached_model_id, value in active:
+            if cached_model_id == model_id:
+                return value
+        return None
+
+    @staticmethod
+    def _cooldown_seconds_remaining(cooldown: CooldownCacheValue) -> int:
+        remaining = (
+            float(cooldown.get("timestamp", 0.0))
+            + float(cooldown.get("cooldown_time", 0.0))
+            - time.time()
+        )
+        return max(1, int(remaining))

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -39,6 +39,7 @@ Safe to enable globally:
 from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 from litellm._logging import verbose_router_logger
+from litellm.exceptions import BadRequestError, ServiceUnavailableError
 from litellm.integrations.custom_logger import CustomLogger, Span
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import AllMessageValues
@@ -189,7 +190,10 @@ class EncryptedContentAffinityCheck(CustomLogger):
     ) -> List[dict]:
         """
         If the request ``input`` contains litellm-encoded item IDs, decode the
-        embedded ``model_id`` and pin the request to that deployment.
+        embedded ``model_id`` and pin the request to that deployment. Raises
+        ``ServiceUnavailableError`` / ``BadRequestError`` when the originating
+        deployment is unavailable and no encryption-boundary peer exists,
+        rather than dispatching a doomed request to a non-peer deployment.
         """
         request_kwargs = request_kwargs or {}
         typed_healthy_deployments = cast(List[dict], healthy_deployments)
@@ -243,10 +247,34 @@ class EncryptedContentAffinityCheck(CustomLogger):
             request_kwargs["_encrypted_content_affinity_pinned"] = True
             return boundary_matches
 
-        verbose_router_logger.error(
-            "EncryptedContentAffinityCheck: decoded deployment=%s not found in "
-            "healthy_deployments and no boundary match available; falling back to "
-            "full deployment pool (encrypted_content may be rejected upstream)",
-            model_id,
+        # Dispatching to a non-peer would guarantee an upstream
+        # `invalid_encrypted_content` 400, so fail fast with a clearer error.
+        raise self._unavailable_origin_error(model=model, model_id=model_id)
+
+    def _unavailable_origin_error(self, model: str, model_id: str) -> Exception:
+        originating = (
+            self.router.get_deployment(model_id=model_id)
+            if self.router is not None
+            else None
         )
-        return typed_healthy_deployments
+        if originating is not None:
+            return ServiceUnavailableError(
+                message=(
+                    f"Deployment id={model_id} that produced this encrypted_content "
+                    "is currently unavailable (likely cooled down), and no deployment "
+                    "on the same encryption boundary is configured. Retry later or "
+                    "configure a deployment with the same (api_base, api_key)."
+                ),
+                llm_provider="",
+                model=model,
+            )
+        return BadRequestError(
+            message=(
+                f"Deployment id={model_id} that produced this encrypted_content is "
+                "no longer configured on this router, and no deployment on the same "
+                "encryption boundary is available. Re-issue the request without the "
+                "stale encrypted_content items, or restore the originating deployment."
+            ),
+            model=model,
+            llm_provider="",
+        )

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -162,27 +162,31 @@ class EncryptedContentAffinityCheck(CustomLogger):
         self,
         healthy_deployments: List[dict],
         model_id: str,
-    ) -> List[dict]:
+    ) -> tuple[List[dict], Any]:
         """
         Deployments in ``healthy_deployments`` sharing the originating
-        deployment's ``(api_base, api_key)``. Returns ``[]`` if router isn't
-        wired in, the originating deployment was removed, or no boundary match.
+        deployment's ``(api_base, api_key)``, alongside the originating
+        deployment object (or ``None`` if it was removed / router unavailable).
+        Returns ``([], originating_or_None)`` when no boundary match exists,
+        so the caller can reuse the looked-up ``originating`` rather than
+        re-querying the router.
         """
         if self.router is None:
-            return []
+            return [], None
         originating = self.router.get_deployment(model_id=model_id)
         if originating is None:
-            return []
+            return [], None
         boundary = self._encryption_boundary_key(
             originating.litellm_params.model_dump(exclude_none=True)
         )
         if boundary is None:
-            return []
-        return [
+            return [], originating
+        matches = [
             d
             for d in healthy_deployments
             if self._encryption_boundary_key(d.get("litellm_params", {})) == boundary
         ]
+        return matches, originating
 
     # ------------------------------------------------------------------
     # Request routing  (pre-call filter)
@@ -245,9 +249,11 @@ class EncryptedContentAffinityCheck(CustomLogger):
             return [deployment]
 
         # Follow-up switched model_name (LIT-2531): pin by Azure resource instead.
-        boundary_matches = self._find_deployments_on_same_encryption_boundary(
-            healthy_deployments=typed_healthy_deployments,
-            model_id=model_id,
+        boundary_matches, originating = (
+            self._find_deployments_on_same_encryption_boundary(
+                healthy_deployments=typed_healthy_deployments,
+                model_id=model_id,
+            )
         )
         if boundary_matches:
             verbose_router_logger.debug(
@@ -264,6 +270,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         raise await self._unavailable_origin_error(
             model=model,
             model_id=model_id,
+            originating=originating,
             parent_otel_span=parent_otel_span,
         )
 
@@ -271,20 +278,20 @@ class EncryptedContentAffinityCheck(CustomLogger):
         self,
         model: str,
         model_id: str,
+        originating: Any,
         parent_otel_span: Optional[Span],
     ) -> Exception:
-        originating = (
-            self.router.get_deployment(model_id=model_id)
-            if self.router is not None
-            else None
-        )
+        # Public error messages intentionally omit the originating ``model_id`` so
+        # an authenticated caller forging encrypted-content markers cannot use the
+        # error surface to enumerate which deployment IDs exist on this router.
         if originating is None:
             return BadRequestError(
                 message=(
-                    f"Deployment id={model_id} that produced this encrypted_content is "
-                    "no longer configured on this router, and no deployment on the same "
-                    "encryption boundary is available. Re-issue the request without the "
-                    "stale encrypted_content items, or restore the originating deployment."
+                    "The deployment that produced this encrypted_content is no "
+                    "longer configured on this router, and no deployment on the "
+                    "same encryption boundary is available. Re-issue the request "
+                    "without the stale encrypted_content items, or restore the "
+                    "originating deployment."
                 ),
                 model=model,
                 llm_provider="",
@@ -298,11 +305,11 @@ class EncryptedContentAffinityCheck(CustomLogger):
             retry_after = self._cooldown_seconds_remaining(cooldown)
             return RateLimitError(
                 message=(
-                    f"Deployment id={model_id} that produced this encrypted_content is "
-                    f"rate-limited (cooling down for ~{retry_after}s), and no deployment "
-                    "on the same encryption boundary is configured. Retry after the "
-                    "Retry-After window or configure a deployment with the same "
-                    "(api_base, api_key)."
+                    "The deployment that produced this encrypted_content is "
+                    f"rate-limited (cooling down for ~{retry_after}s), and no "
+                    "deployment on the same encryption boundary is configured. "
+                    "Retry after the Retry-After window or configure a deployment "
+                    "with the same (api_base, api_key)."
                 ),
                 llm_provider="",
                 model=model,
@@ -315,8 +322,8 @@ class EncryptedContentAffinityCheck(CustomLogger):
 
         return ServiceUnavailableError(
             message=(
-                f"Deployment id={model_id} that produced this encrypted_content "
-                "is currently unavailable (likely cooled down), and no deployment "
+                "The deployment that produced this encrypted_content is "
+                "currently unavailable (likely cooled down), and no deployment "
                 "on the same encryption boundary is configured. Retry later or "
                 "configure a deployment with the same (api_base, api_key)."
             ),

--- a/tests/test_litellm/responses/test_responses_router_cooldown.py
+++ b/tests/test_litellm/responses/test_responses_router_cooldown.py
@@ -1,0 +1,88 @@
+"""
+Regression: Responses API router must register cooldowns on deployment
+failures. Previously the Responses API path built ``litellm_params`` without
+``model_info``, so ``Router.deployment_callback_on_failure`` exited early via
+the "No model_info found" branch and the failing deployment was never added
+to the cooldown set.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.router_utils.cooldown_handlers import _async_get_cooldown_deployments
+
+
+@pytest.mark.asyncio
+async def test_responses_api_rate_limit_marks_deployment_for_cooldown():
+    failing_deployment_id = "deployment-rate-limited"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-1",
+                },
+                "model_info": {"id": failing_deployment_id},
+            },
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-2",
+                },
+                "model_info": {"id": "deployment-healthy"},
+            },
+        ],
+        num_retries=0,
+        cooldown_time=60,
+    )
+
+    rate_limit_error = litellm.RateLimitError(
+        message="upstream throttled",
+        llm_provider="openai",
+        model="openai/gpt-5.1-codex",
+        response=httpx.Response(
+            status_code=429,
+            request=httpx.Request("POST", "https://api.openai.com/v1/responses"),
+        ),
+    )
+
+    def pin_to_failing_deployment(seq):
+        for d in seq:
+            if d["model_info"]["id"] == failing_deployment_id:
+                return d
+        return seq[0]
+
+    with (
+        patch(
+            "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.async_response_api_handler",
+            new_callable=AsyncMock,
+            side_effect=rate_limit_error,
+        ),
+        patch(
+            "litellm.router_strategy.simple_shuffle.random.choice",
+            side_effect=pin_to_failing_deployment,
+        ),
+    ):
+        with pytest.raises(litellm.RateLimitError):
+            await router.aresponses(
+                model="openai.gpt-5.1-codex",
+                input="hi",
+            )
+
+    cooldown_ids = await _async_get_cooldown_deployments(
+        litellm_router_instance=router, parent_otel_span=None
+    )
+    assert failing_deployment_id in cooldown_ids, (
+        f"Responses API failure callback did not register cooldown for "
+        f"{failing_deployment_id!r}; cooldown set was {cooldown_ids}"
+    )

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -1172,3 +1172,154 @@ def test_boundary_key_rejects_non_dict_like_inputs():
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast when originating deployment is unavailable and no boundary peer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_affinity_raises_service_unavailable_when_origin_cooled_down():
+    """
+    Originating deployment is in the router config but absent from
+    healthy_deployments (e.g. in cooldown), and no boundary peer is configured.
+    The check must fail fast with a transient 503 rather than dispatching to a
+    non-peer deployment that would 400 with invalid_encrypted_content.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.exceptions import ServiceUnavailableError
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    originating = MagicMock()
+    originating.litellm_params.model_dump.return_value = {
+        "api_base": "https://account-a.openai.azure.com/",
+        "api_key": "key-a",
+    }
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = originating
+
+    check = EncryptedContentAffinityCheck(router=mock_router)
+    encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        "deployment-a-cooled", "rs_test"
+    )
+    healthy_only_b = [
+        {
+            "model_info": {"id": "deployment-b"},
+            "litellm_params": {
+                "api_base": "https://account-b.openai.azure.com/",
+                "api_key": "key-b",
+                "model": "azure/gpt-5.4",
+            },
+        }
+    ]
+    request_kwargs = {
+        "input": [{"id": encoded_id, "type": "reasoning"}],
+    }
+
+    with pytest.raises(ServiceUnavailableError) as excinfo:
+        await check.async_filter_deployments(
+            model="gpt-5.4",
+            healthy_deployments=healthy_only_b,
+            messages=None,
+            request_kwargs=request_kwargs,
+        )
+
+    assert "deployment-a-cooled" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_affinity_raises_bad_request_when_origin_removed():
+    """
+    Originating deployment was removed from the router config and no boundary
+    peer is available. This is permanent (the stale encrypted_content cannot
+    be honored), so surface a 400 with actionable text.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.exceptions import BadRequestError
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = None
+
+    check = EncryptedContentAffinityCheck(router=mock_router)
+    encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        "deployment-removed", "rs_test"
+    )
+    healthy_only_b = [
+        {
+            "model_info": {"id": "deployment-b"},
+            "litellm_params": {
+                "api_base": "https://account-b.openai.azure.com/",
+                "api_key": "key-b",
+                "model": "azure/gpt-5.4",
+            },
+        }
+    ]
+    request_kwargs = {
+        "input": [{"id": encoded_id, "type": "reasoning"}],
+    }
+
+    with pytest.raises(BadRequestError) as excinfo:
+        await check.async_filter_deployments(
+            model="gpt-5.4",
+            healthy_deployments=healthy_only_b,
+            messages=None,
+            request_kwargs=request_kwargs,
+        )
+
+    assert "deployment-removed" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_affinity_does_not_raise_when_boundary_peer_available():
+    """
+    Even when the originating deployment is filtered out, if a peer on the
+    same (api_base, api_key) is in healthy_deployments, the boundary-match
+    path must succeed silently — no exception.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    originating = MagicMock()
+    originating.litellm_params.model_dump.return_value = {
+        "api_base": "https://account-a.openai.azure.com/",
+        "api_key": "key-a",
+    }
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = originating
+
+    check = EncryptedContentAffinityCheck(router=mock_router)
+    encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        "deployment-a", "rs_test"
+    )
+    peer = {
+        "model_info": {"id": "deployment-a-peer"},
+        "litellm_params": {
+            "api_base": "https://account-a.openai.azure.com/",
+            "api_key": "key-a",
+            "model": "azure/gpt-5.4",
+        },
+    }
+    request_kwargs = {
+        "input": [{"id": encoded_id, "type": "reasoning"}],
+    }
+
+    result = await check.async_filter_deployments(
+        model="gpt-5.4",
+        healthy_deployments=[peer],
+        messages=None,
+        request_kwargs=request_kwargs,
+    )
+
+    assert result == [peer]
+    assert request_kwargs.get("_encrypted_content_affinity_pinned") is True

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -1069,11 +1069,12 @@ def test_boundary_fallback_no_router_ref_returns_empty():
             "litellm_params": {"api_base": "https://x", "api_key": "k"},
         }
     ]
-    matches = check._find_deployments_on_same_encryption_boundary(
+    matches, originating = check._find_deployments_on_same_encryption_boundary(
         healthy_deployments=healthy,
         model_id="dep-2",
     )
     assert matches == []
+    assert originating is None
 
 
 def test_boundary_fallback_originating_deployment_removed_returns_empty():
@@ -1098,11 +1099,12 @@ def test_boundary_fallback_originating_deployment_removed_returns_empty():
             "litellm_params": {"api_base": "https://x", "api_key": "k"},
         }
     ]
-    matches = check._find_deployments_on_same_encryption_boundary(
+    matches, originating = check._find_deployments_on_same_encryption_boundary(
         healthy_deployments=healthy,
         model_id="dep-removed",
     )
     assert matches == []
+    assert originating is None
     mock_router.get_deployment.assert_called_once_with(model_id="dep-removed")
 
 
@@ -1264,7 +1266,9 @@ async def test_affinity_raises_service_unavailable_when_origin_cooled_for_non_42
             request_kwargs=request_kwargs,
         )
 
-    assert "deployment-a-cooled" in str(excinfo.value)
+    # Public error message intentionally omits the originating model_id to
+    # avoid an authenticated-caller probing oracle.
+    assert "deployment-a-cooled" not in str(excinfo.value)
     assert excinfo.value.status_code == 503
 
 
@@ -1324,7 +1328,7 @@ async def test_affinity_raises_rate_limit_with_retry_after_when_origin_cooled_fo
             request_kwargs=request_kwargs,
         )
 
-    assert "deployment-a-cooled-429" in str(excinfo.value)
+    assert "deployment-a-cooled-429" not in str(excinfo.value)
     assert excinfo.value.status_code == 429
     retry_after = excinfo.value.response.headers.get("retry-after")
     assert retry_after is not None
@@ -1418,7 +1422,7 @@ async def test_affinity_raises_bad_request_when_origin_removed():
             request_kwargs=request_kwargs,
         )
 
-    assert "deployment-removed" in str(excinfo.value)
+    assert "deployment-removed" not in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -17,6 +17,8 @@ The mechanism works without any cache and supports two encoding strategies:
 
 import os
 import sys
+import time
+from typing import List, Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1179,28 +1181,62 @@ def test_boundary_key_rejects_non_dict_like_inputs():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_affinity_raises_service_unavailable_when_origin_cooled_down():
-    """
-    Originating deployment is in the router config but absent from
-    healthy_deployments (e.g. in cooldown), and no boundary peer is configured.
-    The check must fail fast with a transient 503 rather than dispatching to a
-    non-peer deployment that would 400 with invalid_encrypted_content.
-    """
+def _make_originating_mock(api_base: str, api_key: str):
     from unittest.mock import MagicMock
 
+    originating = MagicMock()
+    originating.litellm_params.model_dump.return_value = {
+        "api_base": api_base,
+        "api_key": api_key,
+    }
+    return originating
+
+
+def _make_router_mock_with_cooldown(
+    originating, cooldown_entries: Optional[List[tuple]] = None
+):
+    """
+    Build a MagicMock router whose ``cooldown_cache.async_get_active_cooldowns``
+    returns ``cooldown_entries`` (defaulting to ``[]`` — no active cooldown).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = originating
+    mock_router.cooldown_cache.async_get_active_cooldowns = AsyncMock(
+        return_value=list(cooldown_entries or [])
+    )
+    return mock_router
+
+
+@pytest.mark.asyncio
+async def test_affinity_raises_service_unavailable_when_origin_cooled_for_non_429():
+    """
+    Originating deployment is in the router config, in cooldown for a non-429
+    cause (e.g. a 500), and no boundary peer is configured. The check must
+    surface this as a 503 (transient, but not rate-limit-specific) rather than
+    dispatching to a non-peer deployment.
+    """
     from litellm.exceptions import ServiceUnavailableError
     from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
         EncryptedContentAffinityCheck,
     )
 
-    originating = MagicMock()
-    originating.litellm_params.model_dump.return_value = {
-        "api_base": "https://account-a.openai.azure.com/",
-        "api_key": "key-a",
-    }
-    mock_router = MagicMock()
-    mock_router.get_deployment.return_value = originating
+    originating = _make_originating_mock("https://account-a.openai.azure.com/", "key-a")
+    mock_router = _make_router_mock_with_cooldown(
+        originating,
+        cooldown_entries=[
+            (
+                "deployment-a-cooled",
+                {
+                    "exception_received": "boom",
+                    "status_code": "500",
+                    "timestamp": time.time(),
+                    "cooldown_time": 60.0,
+                },
+            )
+        ],
+    )
 
     check = EncryptedContentAffinityCheck(router=mock_router)
     encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
@@ -1229,6 +1265,114 @@ async def test_affinity_raises_service_unavailable_when_origin_cooled_down():
         )
 
     assert "deployment-a-cooled" in str(excinfo.value)
+    assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_affinity_raises_rate_limit_with_retry_after_when_origin_cooled_for_429():
+    """
+    Originating deployment is in cooldown specifically because of a 429.
+    The check must surface this as a 429 RateLimitError with a Retry-After
+    header derived from the cooldown's remaining window, so OpenAI-compatible
+    clients respect the backoff instead of giving up on a 503.
+    """
+    from litellm.exceptions import RateLimitError
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    originating = _make_originating_mock("https://account-a.openai.azure.com/", "key-a")
+    cooldown_started = time.time() - 5.0
+    mock_router = _make_router_mock_with_cooldown(
+        originating,
+        cooldown_entries=[
+            (
+                "deployment-a-cooled-429",
+                {
+                    "exception_received": "rate limited",
+                    "status_code": "429",
+                    "timestamp": cooldown_started,
+                    "cooldown_time": 60.0,
+                },
+            )
+        ],
+    )
+
+    check = EncryptedContentAffinityCheck(router=mock_router)
+    encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        "deployment-a-cooled-429", "rs_test"
+    )
+    healthy_only_b = [
+        {
+            "model_info": {"id": "deployment-b"},
+            "litellm_params": {
+                "api_base": "https://account-b.openai.azure.com/",
+                "api_key": "key-b",
+                "model": "azure/gpt-5.4",
+            },
+        }
+    ]
+    request_kwargs = {
+        "input": [{"id": encoded_id, "type": "reasoning"}],
+    }
+
+    with pytest.raises(RateLimitError) as excinfo:
+        await check.async_filter_deployments(
+            model="gpt-5.4",
+            healthy_deployments=healthy_only_b,
+            messages=None,
+            request_kwargs=request_kwargs,
+        )
+
+    assert "deployment-a-cooled-429" in str(excinfo.value)
+    assert excinfo.value.status_code == 429
+    retry_after = excinfo.value.response.headers.get("retry-after")
+    assert retry_after is not None
+    assert 1 <= int(retry_after) <= 60
+
+
+@pytest.mark.asyncio
+async def test_affinity_raises_service_unavailable_when_origin_filtered_without_cooldown_entry():
+    """
+    Originating deployment is configured but absent from healthy_deployments
+    with no active cooldown entry. Surface as 503 (we cannot prove the cause
+    was rate-limiting) rather than guessing 429.
+    """
+    from litellm.exceptions import ServiceUnavailableError
+    from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+        EncryptedContentAffinityCheck,
+    )
+
+    originating = _make_originating_mock("https://account-a.openai.azure.com/", "key-a")
+    mock_router = _make_router_mock_with_cooldown(originating, cooldown_entries=[])
+
+    check = EncryptedContentAffinityCheck(router=mock_router)
+    encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+        "deployment-a-filtered", "rs_test"
+    )
+    healthy_only_b = [
+        {
+            "model_info": {"id": "deployment-b"},
+            "litellm_params": {
+                "api_base": "https://account-b.openai.azure.com/",
+                "api_key": "key-b",
+                "model": "azure/gpt-5.4",
+            },
+        }
+    ]
+    request_kwargs = {
+        "input": [{"id": encoded_id, "type": "reasoning"}],
+    }
+
+    with pytest.raises(ServiceUnavailableError) as excinfo:
+        await check.async_filter_deployments(
+            model="gpt-5.4",
+            healthy_deployments=healthy_only_b,
+            messages=None,
+            request_kwargs=request_kwargs,
+        )
+
+    assert excinfo.value.status_code == 503
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

<!-- No public GitHub issue. -->

## Linear ticket

Resolves LIT-3051
<!-- Add LIT-xxxx if this maps to an internal ticket. -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

**Before:**

For non-encrypted_content_affinity:

It would keep trying the 429'ing deployment each time (and falling back to the working one):

<img width="548" height="700" alt="image" src="https://github.com/user-attachments/assets/9fe298d4-d1db-4e6f-9d43-aa8650a29409" />

For encrypted_content_affinity:

Same story except it wouldn't fall back to the working one:

<img width="211" height="341" alt="image" src="https://github.com/user-attachments/assets/38d493f6-f5ee-4ecf-982c-47ba4bf860f0" />

<img width="1904" height="210" alt="image" src="https://github.com/user-attachments/assets/deac3af0-b144-4824-b8ba-dd49ab049455" />

**After:**

For non-encrypted_content_affinity:

it will mark it as unhealthy and send the requests to the other deployment (note only one 429. Afterwards, it doesn't hit):

<img width="1896" height="350" alt="image" src="https://github.com/user-attachments/assets/73e4a9a7-6eec-4c2b-aead-5c32d207b278" />

<img width="1196" height="142" alt="image" src="https://github.com/user-attachments/assets/18b82222-3700-4900-982f-00a726e9b3b2" />

For encrypted_content_affinity:

Same deal except

For 429's:

<img width="1876" height="232" alt="image" src="https://github.com/user-attachments/assets/4972dc13-9458-46f7-825a-2ef63393eb4a" />

For non-429's:

<img width="1902" height="234" alt="image" src="https://github.com/user-attachments/assets/b1ecfa19-4b8a-47b6-be67-dcd4b70bd0cd" />

(after the (by default) > 50% failure rate AND >= 5 failures within a rolling 60 sec window. Otherwise, it'll keep hitting it)

## Type

🐛 Bug Fix

## Changes

Two related fixes that surfaced together while reproducing a follow-up Responses API request that should have failed over cleanly but instead pinned to a rate-limited deployment forever.

### 1. Responses API never registered cooldowns

`Router.deployment_callback_on_failure` reads the failing deployment id from `kwargs["litellm_params"]["model_info"]["id"]`. The Responses API path in `litellm/responses/main.py` built `litellm_params` from scratch for `litellm_logging_obj.update_from_kwargs(...)` without including `model_info` from the router-set kwargs. The callback consistently hit the `else` branch and logged `Router: Exiting 'deployment_callback_on_failure' without cooldown. No model_info found.` — every 429 on a Responses deployment was a silent no-op for cooldown bookkeeping, so retries kept landing on the same failing target.

Fix: plumb `model_info` (and `metadata`, which the success callback also reads) into the `litellm_params` dict at the same call site.

### 2. EncryptedContentAffinityCheck silently fell back to the full pool

When the originating deployment for an `encrypted_content` follow-up wasn't in `healthy_deployments` *and* no peer on the same `(api_base, api_key)` encryption boundary existed, the check logged an error and returned the full healthy list. Any dispatch from that point is guaranteed to fail upstream with `invalid_encrypted_content` (Azure rejects content produced by a different org), but the failure surfaces as a confusing 400 with a hint to enable a check that's already enabled.

Fix: replace the silent fallback with a cause-aware `raise`. The check now inspects the originating deployment's entry in `router.cooldown_cache` and maps the failure to:

- `RateLimitError` (429) with `Retry-After: <remaining_cooldown_seconds>` when the originating cooldown was triggered by an upstream 429. OpenAI-compatible SDKs respect `Retry-After` on 429s and will back off until the window expires, at which point the deployment is eligible again.
- `ServiceUnavailableError` (503) when the cooldown was triggered by any other cause (5xx, timeout, auth failure, …) or no active cooldown entry is found — keeps the semantics honest when we can't prove it was rate-limiting.
- `BadRequestError` (400) when the originating deployment was removed entirely. The stale `encrypted_content` cannot be honored without restoring the deployment or re-issuing the request without it.

### Interaction

Fix #1 alone makes the affinity case worse on misconfigured pools (different encryption boundaries) — the cooldown now correctly evicts the failing deployment, the affinity fall-through dispatches to a non-peer, and the client sees an `invalid_encrypted_content` 400 with misleading advice. Fix #2 closes that hole: with no peer available, the request fails immediately with structured intent (and, in the rate-limit case, the precise `Retry-After` window) instead of being sent to a deployment that can't possibly decrypt it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes router failure/cooldown bookkeeping and alters routing behavior to raise 400/429/503 instead of silently falling back, which could impact retry semantics for some clients. Scope is limited to Responses API logging params and the `encrypted_content_affinity` pre-call check with added regression tests.
> 
> **Overview**
> Fixes Responses API router cooldown tracking by ensuring `responses()` passes through `model_info` (and consistent `metadata`) in `litellm_params` so deployment failure callbacks can register cooldowns.
> 
> Tightens `EncryptedContentAffinityCheck` behavior: when a follow-up request references encrypted content from an unavailable/removed originating deployment and **no same-boundary peer** exists, it now **fails fast** with `BadRequestError` (removed), `RateLimitError` 429 + `Retry-After` (origin cooled due to 429), or `ServiceUnavailableError` 503 (other/unverified unavailability) instead of falling back to the full deployment pool.
> 
> Adds regression tests covering cooldown registration for Responses API failures and the new fail-fast affinity error paths (including `Retry-After` calculation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27110d713c3e436328603b991026741af8dd093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->