### PR TITLE
Add Cloud agent starter skill and perf runner

### DIFF
--- a/.cursor/skills/litellm-cloud-agent-starter/SKILL.md
+++ b/.cursor/skills/litellm-cloud-agent-starter/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: litellm-cloud-agent-starter
+description: Practical Cloud-agent runbook for setting up, running, testing, and perf-checking LiteLLM.
+---
+
+# LiteLLM Cloud Agent Starter
+
+Use this skill when a Cloud agent needs to run, test, debug, or perf-check this repository.
+
+## Repo setup
+
+- Work from the repo root: `/workspace`.
+- Use the existing virtualenv via `uv run ...`; `uv` is on `PATH` in Cursor Cloud.
+- Install only what the task needs:
+  - Core/dev: `make install-dev`
+  - Proxy/dev: `uv sync --group proxy-dev --extra proxy`
+  - Full local tests and Prisma client: `make install-test-deps`
+- Before committing Python changes, run `uv run black .`.
+
+## Proxy backend
+
+Start a minimal local proxy with a fake OpenAI-compatible upstream:
+
+```yaml
+# config.yaml
+model_list:
+  - model_name: fake-openai-endpoint
+    litellm_params:
+      model: openai/fake-model
+      api_key: fake-key
+      api_base: https://fake-api.example.com
+
+general_settings:
+  master_key: sk-1234
+
+litellm_settings:
+  drop_params: True
+  telemetry: False
+```
+
+Run it:
+
+```bash
+uv run litellm --config config.yaml --port 4000
+```
+
+Wait for readiness before testing:
+
+```bash
+curl -s http://localhost:4000/health
+```
+
+Smoke test:
+
+```bash
+curl -s http://localhost:4000/chat/completions \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"fake-openai-endpoint","messages":[{"role":"user","content":"hi"}]}'
+```
+
+Testing workflow:
+
+- Targeted proxy tests: `uv run pytest tests/test_litellm/proxy/<area> -x -vv`
+- Split proxy suite: `make test-unit-proxy-core`, `make test-unit-proxy-guardrails`, or `make test-unit-proxy-misc`
+- Fast lint for backend edits: `cd litellm && uv run ruff check .`
+
+Feature flags and paid features:
+
+- Prefer config/env flags over code edits. Common local toggles include `STORE_MODEL_IN_DB=True`, `LITELLM_LICENSE=<mock-or-real-license>`, and `LITELLM_WORKER_STARTUP_HOOKS=<hook-path>`.
+- For enterprise-gated behavior, test the non-premium path without `LITELLM_LICENSE` and mock `premium_user` only in focused unit tests.
+- For UI settings stored in the DB, use the settings endpoints or test mocks instead of hard-coding defaults.
+
+## Core library and providers
+
+Testing workflow:
+
+- Target one provider or transform: `uv run pytest tests/test_litellm/llms/<provider> -x -vv`
+- Core utilities: `make test-unit-core-utils`
+- Router changes: `uv run pytest tests/test_litellm/router_utils tests/test_litellm/router_strategy -x -vv`
+- Translation/provider contract tests often live under `tests/llm_translation/`.
+
+When provider credentials are unavailable:
+
+- Use mocked unit tests for request transformation, response transformation, streaming chunks, and exception mapping.
+- Keep real-provider tests opt-in and guarded by environment variables.
+
+## UI dashboard
+
+The UI source is in `ui/litellm-dashboard/`.
+
+Run the dev UI:
+
+```bash
+cd ui/litellm-dashboard
+npm run dev
+```
+
+Test UI changes:
+
+```bash
+cd ui/litellm-dashboard
+npx vitest run
+```
+
+If the proxy must serve updated static UI assets:
+
+```bash
+cd ui/litellm-dashboard
+npm run build
+cp -r out/* ../../litellm/proxy/_experimental/out/
+```
+
+Login and auth workflow:
+
+- Local proxy admin auth uses the configured master key, commonly `sk-1234`.
+- Store temporary UI tokens in `sessionStorage`; never write LiteLLM keys to `localStorage`.
+- In component tests, mock feature flags through `useFeatureFlags` and mock network calls rather than depending on a running proxy.
+
+## MCP, skills, and agent features
+
+Testing workflow:
+
+- MCP proxy/server tests: `uv run pytest tests/test_litellm/proxy/_experimental tests/test_litellm/experimental_mcp_client -x -vv`
+- Skill translation tests: `uv run pytest tests/llm_translation -k skill -x -vv`
+- For MCP OAuth/OpenAPI work, map UI-only `openapi` transport to backend `http` before API calls.
+
+## Basic perf testing
+
+Use the Cloud-agent perf runner for quick RPS and overhead checks:
+
+```bash
+uv run python scripts/cloud_agent_perf.py \
+  --proxy-url http://localhost:4000/chat/completions \
+  --proxy-api-key sk-1234 \
+  --model fake-openai-endpoint \
+  --requests 100 \
+  --concurrency 10
+```
+
+Compare proxy overhead against a direct provider-compatible endpoint:
+
+```bash
+uv run python scripts/cloud_agent_perf.py \
+  --proxy-url http://localhost:4000/chat/completions \
+  --proxy-api-key sk-1234 \
+  --model fake-openai-endpoint \
+  --direct-url "$PROVIDER_URL" \
+  --direct-api-key "$PROVIDER_API_KEY" \
+  --direct-model "$PROVIDER_MODEL" \
+  --requests 200 \
+  --concurrency 20 \
+  --output-json /tmp/litellm_perf.json
+```
+
+Perf checklist:
+
+- Warm the endpoint first; keep `--warmup-requests` enabled unless testing cold start.
+- Run proxy and direct tests sequentially to avoid shared resource interference.
+- Report `rps`, `successful_rps`, p50/p95/p99 latency, and overhead in milliseconds and percent.
+- Use small request counts for PR proof and larger repeated runs for regression investigation.
+
+## Updating this skill
+
+When an agent discovers a reliable new runbook step, test workaround, feature-flag setup, or perf trick:
+
+1. Add the shortest reproducible command or workflow to the relevant codebase area.
+2. Note required environment variables and whether credentials can be mocked.
+3. Keep examples safe for Cursor Cloud and avoid real secrets.
+4. Remove stale commands when the repo workflow changes.

--- a/scripts/cloud_agent_perf.py
+++ b/scripts/cloud_agent_perf.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: T201
 """
 Minimal LiteLLM proxy performance runner for Cloud-agent verification.
 

--- a/scripts/cloud_agent_perf.py
+++ b/scripts/cloud_agent_perf.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""
+Minimal LiteLLM proxy performance runner for Cloud-agent verification.
+
+Measures proxy throughput (RPS) and, when a direct endpoint is provided,
+the proxy latency overhead compared with that direct endpoint.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+
+DEFAULT_PROXY_URL = "http://localhost:4000/chat/completions"
+DEFAULT_MODEL = "fake-openai-endpoint"
+DEFAULT_MESSAGES = [{"role": "user", "content": "Say hello in one sentence."}]
+
+
+@dataclass(frozen=True)
+class EndpointConfig:
+    name: str
+    url: str
+    model: str
+    api_key: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RequestSample:
+    success: bool
+    latency_s: float
+    status_code: int = 0
+    error: str = ""
+
+
+@dataclass
+class LoadTestResult:
+    endpoint_name: str
+    total_requests: int
+    wall_time_s: float
+    samples: List[RequestSample] = field(default_factory=list)
+
+    @property
+    def successful_requests(self) -> int:
+        return sum(1 for sample in self.samples if sample.success)
+
+    @property
+    def failed_requests(self) -> int:
+        return self.total_requests - self.successful_requests
+
+    @property
+    def successful_latencies_s(self) -> List[float]:
+        return [sample.latency_s for sample in self.samples if sample.success]
+
+    def to_summary(self) -> Dict[str, Any]:
+        latencies = self.successful_latencies_s
+        summary: Dict[str, Any] = {
+            "endpoint": self.endpoint_name,
+            "requests": self.total_requests,
+            "successful_requests": self.successful_requests,
+            "failed_requests": self.failed_requests,
+            "wall_time_s": self.wall_time_s,
+            "rps": (
+                self.total_requests / self.wall_time_s if self.wall_time_s > 0 else 0.0
+            ),
+            "successful_rps": (
+                self.successful_requests / self.wall_time_s
+                if self.wall_time_s > 0
+                else 0.0
+            ),
+        }
+        if latencies:
+            summary["latency_ms"] = {
+                "mean": statistics.mean(latencies) * 1000,
+                "p50": percentile(latencies, 50) * 1000,
+                "p95": percentile(latencies, 95) * 1000,
+                "p99": percentile(latencies, 99) * 1000,
+                "min": min(latencies) * 1000,
+                "max": max(latencies) * 1000,
+            }
+        return summary
+
+
+def percentile(values: List[float], percentile_value: int) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    index = round((percentile_value / 100) * (len(sorted_values) - 1))
+    return sorted_values[index]
+
+
+def headers_for(api_key: Optional[str]) -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def parse_json_arg(raw_value: Optional[str], label: str) -> Optional[Any]:
+    if raw_value is None:
+        return None
+    try:
+        return json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} must be valid JSON: {exc}") from exc
+
+
+def build_payload(
+    model: str,
+    messages_json: Optional[str] = None,
+    payload_json: Optional[str] = None,
+) -> Dict[str, Any]:
+    custom_payload = parse_json_arg(payload_json, "--payload-json")
+    if custom_payload is not None:
+        if not isinstance(custom_payload, dict):
+            raise ValueError("--payload-json must decode to a JSON object")
+        return {**custom_payload, "model": custom_payload.get("model", model)}
+
+    messages = parse_json_arg(messages_json, "--messages-json") or DEFAULT_MESSAGES
+    if not isinstance(messages, list):
+        raise ValueError("--messages-json must decode to a JSON array")
+    return {"model": model, "messages": messages, "max_tokens": 16}
+
+
+async def send_request(
+    session: aiohttp.ClientSession,
+    endpoint: EndpointConfig,
+    payload: Dict[str, Any],
+    timeout: aiohttp.ClientTimeout,
+    validate_json: bool,
+) -> RequestSample:
+    start = time.perf_counter()
+    try:
+        async with session.post(
+            endpoint.url,
+            headers=headers_for(endpoint.api_key),
+            json=payload,
+            timeout=timeout,
+        ) as response:
+            body = await response.read()
+            latency_s = time.perf_counter() - start
+            if not 200 <= response.status < 300:
+                body_preview = body.decode("utf-8", errors="replace")[:200]
+                return RequestSample(
+                    success=False,
+                    latency_s=latency_s,
+                    status_code=response.status,
+                    error=f"HTTP {response.status}: {body_preview}",
+                )
+            if validate_json:
+                try:
+                    json.loads(body)
+                except json.JSONDecodeError as exc:
+                    return RequestSample(
+                        success=False,
+                        latency_s=latency_s,
+                        status_code=response.status,
+                        error=f"invalid JSON response: {exc}",
+                    )
+            return RequestSample(
+                success=True,
+                latency_s=latency_s,
+                status_code=response.status,
+            )
+    except Exception as exc:
+        return RequestSample(
+            success=False,
+            latency_s=time.perf_counter() - start,
+            error=str(exc)[:200],
+        )
+
+
+async def run_batch(
+    endpoint: EndpointConfig,
+    payload: Dict[str, Any],
+    request_count: int,
+    concurrency: int,
+    timeout_s: float,
+    validate_json: bool,
+) -> List[RequestSample]:
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    semaphore = asyncio.Semaphore(concurrency)
+    connector = aiohttp.TCPConnector(
+        limit=max(concurrency * 2, 1),
+        limit_per_host=max(concurrency, 1),
+        ttl_dns_cache=300,
+        force_close=False,
+        enable_cleanup_closed=True,
+    )
+
+    async def guarded_request(session: aiohttp.ClientSession) -> RequestSample:
+        async with semaphore:
+            return await send_request(
+                session=session,
+                endpoint=endpoint,
+                payload=payload,
+                timeout=timeout,
+                validate_json=validate_json,
+            )
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        return await asyncio.gather(
+            *[guarded_request(session) for _ in range(request_count)]
+        )
+
+
+async def run_load_test(
+    endpoint: EndpointConfig,
+    payload: Dict[str, Any],
+    requests: int,
+    concurrency: int,
+    warmup_requests: int,
+    timeout_s: float,
+    validate_json: bool = True,
+) -> LoadTestResult:
+    if requests < 1:
+        raise ValueError("--requests must be at least 1")
+    if concurrency < 1:
+        raise ValueError("--concurrency must be at least 1")
+
+    if warmup_requests > 0:
+        await run_batch(
+            endpoint=endpoint,
+            payload=payload,
+            request_count=warmup_requests,
+            concurrency=min(concurrency, warmup_requests),
+            timeout_s=timeout_s,
+            validate_json=validate_json,
+        )
+
+    start = time.perf_counter()
+    samples = await run_batch(
+        endpoint=endpoint,
+        payload=payload,
+        request_count=requests,
+        concurrency=concurrency,
+        timeout_s=timeout_s,
+        validate_json=validate_json,
+    )
+    wall_time_s = time.perf_counter() - start
+    return LoadTestResult(
+        endpoint_name=endpoint.name,
+        total_requests=requests,
+        wall_time_s=wall_time_s,
+        samples=list(samples),
+    )
+
+
+def compare_overhead(
+    proxy_summary: Dict[str, Any], direct_summary: Dict[str, Any]
+) -> Dict[str, float]:
+    proxy_latency = proxy_summary.get("latency_ms", {})
+    direct_latency = direct_summary.get("latency_ms", {})
+    comparison: Dict[str, float] = {}
+    for metric in ("mean", "p50", "p95", "p99"):
+        proxy_value = proxy_latency.get(metric)
+        direct_value = direct_latency.get(metric)
+        if proxy_value is None or direct_value is None:
+            continue
+        overhead_ms = proxy_value - direct_value
+        comparison[f"{metric}_overhead_ms"] = overhead_ms
+        comparison[f"{metric}_overhead_pct"] = (
+            (overhead_ms / direct_value) * 100 if direct_value > 0 else 0.0
+        )
+    return comparison
+
+
+def print_summary(summary: Dict[str, Any]) -> None:
+    print(f"\n{summary['endpoint']}")
+    print(f"  requests:       {summary['requests']}")
+    print(f"  successes:      {summary['successful_requests']}")
+    print(f"  failures:       {summary['failed_requests']}")
+    print(f"  wall time:      {summary['wall_time_s']:.2f}s")
+    print(f"  rps:            {summary['rps']:.2f}")
+    print(f"  successful rps: {summary['successful_rps']:.2f}")
+    latency = summary.get("latency_ms")
+    if latency:
+        print(f"  mean latency:   {latency['mean']:.2f} ms")
+        print(f"  p50 latency:    {latency['p50']:.2f} ms")
+        print(f"  p95 latency:    {latency['p95']:.2f} ms")
+        print(f"  p99 latency:    {latency['p99']:.2f} ms")
+
+
+def print_overhead(overhead: Dict[str, float]) -> None:
+    if not overhead:
+        return
+    print("\nProxy overhead vs direct endpoint")
+    for metric in ("mean", "p50", "p95", "p99"):
+        ms_key = f"{metric}_overhead_ms"
+        pct_key = f"{metric}_overhead_pct"
+        if ms_key in overhead:
+            print(f"  {metric}: {overhead[ms_key]:+.2f} ms ({overhead[pct_key]:+.2f}%)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Measure LiteLLM proxy RPS and optional proxy overhead.",
+    )
+    parser.add_argument(
+        "--proxy-url",
+        default=os.getenv("LITELLM_PROXY_URL", DEFAULT_PROXY_URL),
+        help="LiteLLM /chat/completions URL.",
+    )
+    parser.add_argument(
+        "--proxy-api-key",
+        default=os.getenv("LITELLM_PROXY_API_KEY", "sk-1234"),
+        help="LiteLLM proxy API key.",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.getenv("LITELLM_PERF_MODEL", DEFAULT_MODEL),
+        help="Model name to send to the proxy.",
+    )
+    parser.add_argument(
+        "--direct-url",
+        default=os.getenv("LITELLM_DIRECT_URL"),
+        help="Optional direct provider /chat/completions URL for overhead comparison.",
+    )
+    parser.add_argument(
+        "--direct-api-key",
+        default=os.getenv("LITELLM_DIRECT_API_KEY"),
+        help="Optional direct provider API key.",
+    )
+    parser.add_argument(
+        "--direct-model",
+        default=os.getenv("LITELLM_DIRECT_MODEL"),
+        help="Optional model name to send to the direct provider.",
+    )
+    parser.add_argument("--requests", type=int, default=100)
+    parser.add_argument("--concurrency", type=int, default=10)
+    parser.add_argument("--warmup-requests", type=int, default=5)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument(
+        "--messages-json",
+        help="JSON array of OpenAI-compatible chat messages.",
+    )
+    parser.add_argument(
+        "--payload-json",
+        help="Full JSON request body. The model field is filled from --model if absent.",
+    )
+    parser.add_argument(
+        "--no-validate-json",
+        action="store_true",
+        help="Do not require 2xx responses to contain JSON.",
+    )
+    parser.add_argument(
+        "--output-json",
+        help="Optional path to write machine-readable results.",
+    )
+    return parser
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    validate_json = not args.no_validate_json
+    proxy_endpoint = EndpointConfig(
+        name="LiteLLM proxy",
+        url=args.proxy_url,
+        model=args.model,
+        api_key=args.proxy_api_key,
+    )
+    proxy_payload = build_payload(
+        model=args.model,
+        messages_json=args.messages_json,
+        payload_json=args.payload_json,
+    )
+
+    proxy_result = await run_load_test(
+        endpoint=proxy_endpoint,
+        payload=proxy_payload,
+        requests=args.requests,
+        concurrency=args.concurrency,
+        warmup_requests=args.warmup_requests,
+        timeout_s=args.timeout,
+        validate_json=validate_json,
+    )
+    proxy_summary = proxy_result.to_summary()
+    print_summary(proxy_summary)
+
+    result_doc: Dict[str, Any] = {"proxy": proxy_summary}
+
+    if args.direct_url:
+        direct_model = args.direct_model or args.model
+        direct_endpoint = EndpointConfig(
+            name="Direct endpoint",
+            url=args.direct_url,
+            model=direct_model,
+            api_key=args.direct_api_key,
+        )
+        direct_payload = {**proxy_payload, "model": direct_model}
+        direct_result = await run_load_test(
+            endpoint=direct_endpoint,
+            payload=direct_payload,
+            requests=args.requests,
+            concurrency=args.concurrency,
+            warmup_requests=args.warmup_requests,
+            timeout_s=args.timeout,
+            validate_json=validate_json,
+        )
+        direct_summary = direct_result.to_summary()
+        overhead = compare_overhead(proxy_summary, direct_summary)
+        print_summary(direct_summary)
+        print_overhead(overhead)
+        result_doc["direct"] = direct_summary
+        result_doc["overhead"] = overhead
+
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as output_file:
+            json.dump(result_doc, output_file, indent=2, sort_keys=True)
+            output_file.write("\n")
+        print(f"\nWrote JSON results to {args.output_json}")
+
+    return 0 if proxy_result.failed_requests == 0 else 1
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return asyncio.run(async_main(args))
+    except KeyboardInterrupt:
+        print("\nInterrupted", file=sys.stderr)
+        return 130
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_litellm/scripts/test_cloud_agent_perf.py
+++ b/tests/test_litellm/scripts/test_cloud_agent_perf.py
@@ -9,6 +9,7 @@ from scripts.cloud_agent_perf import (
     EndpointConfig,
     build_payload,
     compare_overhead,
+    main,
     run_load_test,
 )
 
@@ -100,3 +101,44 @@ def test_should_calculate_proxy_overhead_from_latency_summaries() -> None:
     assert overhead["mean_overhead_pct"] == 50.0
     assert overhead["p95_overhead_ms"] == 5.0
     assert overhead["p99_overhead_pct"] == 25.0
+
+
+def test_should_run_cli_against_mock_chat_endpoint(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    server, url, requests = _start_mock_chat_server()
+    output_path = tmp_path / "perf.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "cloud_agent_perf.py",
+            "--proxy-url",
+            url,
+            "--proxy-api-key",
+            "sk-test",
+            "--model",
+            "fake-openai-endpoint",
+            "--requests",
+            "2",
+            "--concurrency",
+            "1",
+            "--warmup-requests",
+            "0",
+            "--output-json",
+            str(output_path),
+        ],
+    )
+    try:
+        exit_code = main()
+    finally:
+        server.shutdown()
+        server.server_close()
+        server.thread.join(timeout=5)  # type: ignore[attr-defined]
+
+    output = capsys.readouterr().out
+    data = json.loads(output_path.read_text())
+    assert exit_code == 0
+    assert "rps:" in output
+    assert "Wrote JSON results" in output
+    assert data["proxy"]["successful_requests"] == 2
+    assert len(requests) == 2

--- a/tests/test_litellm/scripts/test_cloud_agent_perf.py
+++ b/tests/test_litellm/scripts/test_cloud_agent_perf.py
@@ -1,0 +1,102 @@
+import asyncio
+import json
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import List, Tuple
+
+from scripts.cloud_agent_perf import (
+    EndpointConfig,
+    build_payload,
+    compare_overhead,
+    run_load_test,
+)
+
+
+def _start_mock_chat_server() -> Tuple[ThreadingHTTPServer, str, List[dict]]:
+    requests: List[dict] = []
+
+    class MockChatHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(content_length)
+            requests.append(json.loads(body))
+            response_body = json.dumps(
+                {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "hello"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            ).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), MockChatHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    server.thread = thread  # type: ignore[attr-defined]
+    url = f"http://127.0.0.1:{server.server_address[1]}/chat/completions"
+    return server, url, requests
+
+
+def test_should_measure_rps_against_mock_chat_endpoint() -> None:
+    server, url, requests = _start_mock_chat_server()
+    try:
+        payload = build_payload(model="fake-openai-endpoint")
+        result = asyncio.run(
+            run_load_test(
+                endpoint=EndpointConfig(
+                    name="mock proxy",
+                    url=url,
+                    model="fake-openai-endpoint",
+                    api_key="sk-test",
+                ),
+                payload=payload,
+                requests=4,
+                concurrency=2,
+                warmup_requests=1,
+                timeout_s=5,
+            )
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        server.thread.join(timeout=5)  # type: ignore[attr-defined]
+
+    summary = result.to_summary()
+    assert summary["requests"] == 4
+    assert summary["successful_requests"] == 4
+    assert summary["failed_requests"] == 0
+    assert summary["rps"] > 0
+    assert summary["successful_rps"] > 0
+    assert summary["latency_ms"]["mean"] > 0
+    assert len(requests) == 5
+    assert all(request["model"] == "fake-openai-endpoint" for request in requests)
+
+
+def test_should_calculate_proxy_overhead_from_latency_summaries() -> None:
+    overhead = compare_overhead(
+        proxy_summary={
+            "latency_ms": {"mean": 15.0, "p50": 12.0, "p95": 25.0, "p99": 40.0}
+        },
+        direct_summary={
+            "latency_ms": {"mean": 10.0, "p50": 8.0, "p95": 20.0, "p99": 32.0}
+        },
+    )
+
+    assert overhead["mean_overhead_ms"] == 5.0
+    assert overhead["mean_overhead_pct"] == 50.0
+    assert overhead["p95_overhead_ms"] == 5.0
+    assert overhead["p99_overhead_pct"] == 25.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

- `uv run pytest tests/test_litellm/scripts/test_cloud_agent_perf.py -vv`
- `uv run ruff check scripts/cloud_agent_perf.py tests/test_litellm/scripts/test_cloud_agent_perf.py`
- `uv run python scripts/cloud_agent_perf.py --help`

## Type

📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

- Adds a Cursor Cloud-agent starter skill with setup, execution, testing, feature-flag, UI, MCP, and perf workflows.
- Adds `scripts/cloud_agent_perf.py` for basic proxy RPS and optional direct-endpoint overhead measurement.
- Adds tests for the perf runner, including the CLI path against a local mock chat endpoint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0245e42-ab55-4c5e-982c-8a919fde2fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0245e42-ab55-4c5e-982c-8a919fde2fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

