### PR TITLE
feat : enhance prompt caching deployment checks for OpenAI models

### DIFF
--- a/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
+++ b/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
@@ -33,9 +33,9 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import CallTypes, StandardLoggingPayload
 from litellm.utils import is_prompt_caching_valid_prompt
 
-from ..prompt_caching_cache import PromptCachingCache, PromptCachingCacheValue
-
 # Redis namespace for OpenAI prompt_cache_key affinity (distinct from PromptCachingCache keys).
+# PromptCachingCache / PromptCachingCacheValue are imported inside methods to avoid a module-level
+# cycle (litellm/__init__ -> Router -> this module -> prompt_caching_cache -> ...).
 _OPENAI_PC_AFFINITY_KEY_PREFIX = "openai_pc_aff"
 
 
@@ -164,6 +164,8 @@ class PromptCachingDeploymentCheck(CustomLogger):
         ):
             return typed_healthy_deployments
 
+        from litellm.router_utils.prompt_caching_cache import PromptCachingCache
+
         prompt_cache = PromptCachingCache(
             cache=self.cache,
         )
@@ -239,6 +241,11 @@ class PromptCachingDeploymentCheck(CustomLogger):
                 "litellm.router_utils.pre_call_checks.prompt_caching_deployment_check: skipping adding model id to prompt caching cache, MODEL ID IS NONE"
             )
             return
+
+        from litellm.router_utils.prompt_caching_cache import (
+            PromptCachingCache,
+            PromptCachingCacheValue,
+        )
 
         ## PROMPT CACHING - cache model id, if prompt caching valid prompt + provider
         if is_prompt_caching_valid_prompt(

--- a/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
+++ b/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
@@ -1,10 +1,30 @@
 """
-Check if prompt caching is valid for a given deployment
+Deployment affinity for prompt-caching-related routing.
 
-Route to previously cached model id, if valid
+1. **Anthropic-style breakpoints**: When messages include ``cache_control`` blocks
+   (ephemeral), uses :class:`PromptCachingCache` (SHA prefix of the cacheable prefix)
+   to pin ``model_id``. Redis keys look like ``deployment:<hash>:prompt_caching``.
+
+2. **OpenAI prompt-cache affinity** (optional): For ``custom_llm_provider == "openai"``
+   and a non-empty ``prompt_cache_key`` on the request, also stores
+   ``model_id`` under ``openai_pc_aff:<sha256(body)>:prompt_caching`` (parallel to
+   ``deployment:<hash>:prompt_caching``). The hashed ``body`` includes the Router
+   ``model`` alias, ``user_api_key_hash``, and ``prompt_cache_key`` so different
+   model groups do not share affinity entries. Requires the
+   same minimum prompt size as :func:`litellm.utils.is_prompt_caching_valid_prompt`
+   (default 1024 tokens). TTL is 300 seconds (same as ``PromptCachingCache`` writes).
+
+Both behaviors are gated by Router ``optional_pre_call_checks: ["prompt_caching"]``
+only (no separate flag). Lookup order: ``cache_control`` prefix hit first, then
+OpenAI ``prompt_cache_key`` affinity.
+
+**Tenant token**: ``user_api_key_hash`` from ``metadata`` / ``litellm_metadata`` (Proxy
+virtual key identity). Empty string if absent (same key string may then be shared
+across callers—prefer setting metadata in production).
 """
 
-from typing import List, Optional, cast
+import hashlib
+from typing import Any, List, Optional, cast
 
 from litellm import verbose_logger
 from litellm.caching.dual_cache import DualCache
@@ -13,7 +33,80 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import CallTypes, StandardLoggingPayload
 from litellm.utils import is_prompt_caching_valid_prompt
 
-from ..prompt_caching_cache import PromptCachingCache
+from ..prompt_caching_cache import PromptCachingCache, PromptCachingCacheValue
+
+# Redis namespace for OpenAI prompt_cache_key affinity (distinct from PromptCachingCache keys).
+_OPENAI_PC_AFFINITY_KEY_PREFIX = "openai_pc_aff"
+
+
+def _extract_prompt_cache_key(request_kwargs: Optional[dict]) -> Optional[str]:
+    if not request_kwargs:
+        return None
+    raw = request_kwargs.get("prompt_cache_key")
+    if raw is None and isinstance(request_kwargs.get("optional_params"), dict):
+        raw = request_kwargs["optional_params"].get("prompt_cache_key")
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s or None
+
+
+def _tenant_token_for_openai_pc_affinity(request_kwargs: Optional[dict]) -> str:
+    """Stable tenant id for affinity keys: Proxy ``metadata.user_api_key_hash`` when present."""
+    if not request_kwargs:
+        return ""
+    for key in ("litellm_metadata", "metadata"):
+        md = request_kwargs.get(key)
+        if isinstance(md, dict):
+            h = md.get("user_api_key_hash")
+            if h is not None:
+                return str(h)
+    return ""
+
+
+def _tenant_token_from_standard_payload(payload: StandardLoggingPayload) -> str:
+    meta = payload.get("metadata") or {}
+    h = meta.get("user_api_key_hash")
+    return str(h) if h is not None else ""
+
+
+def _openai_prompt_cache_affinity_cache_key(
+    router_model: str, tenant_token: str, prompt_cache_key: str
+) -> str:
+    body = f"{router_model}|{tenant_token}|{prompt_cache_key}"
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    return f"{_OPENAI_PC_AFFINITY_KEY_PREFIX}:{digest}:prompt_caching"
+
+
+def _parse_model_id_from_affinity_cache_value(cache_result: Any) -> Optional[str]:
+    if cache_result is None:
+        return None
+    if isinstance(cache_result, dict):
+        mid = cache_result.get("model_id")
+        return str(mid) if mid is not None else None
+    if isinstance(cache_result, str):
+        return cache_result
+    return None
+
+
+def _healthy_deployments_include_openai(healthy_deployments: List[dict]) -> bool:
+    for deployment in healthy_deployments:
+        lp = deployment.get("litellm_params")
+        if isinstance(lp, dict) and lp.get("custom_llm_provider") == "openai":
+            return True
+    return False
+
+
+def _should_apply_openai_prompt_cache_affinity(
+    model: str,
+    request_kwargs: dict,
+    healthy_deployments: List[dict],
+) -> bool:
+    if model.startswith("openai/"):
+        return True
+    if request_kwargs.get("custom_llm_provider") == "openai":
+        return True
+    return _healthy_deployments_include_openai(healthy_deployments)
 
 
 class PromptCachingDeploymentCheck(CustomLogger):
@@ -28,25 +121,55 @@ class PromptCachingDeploymentCheck(CustomLogger):
         request_kwargs: Optional[dict] = None,
         parent_otel_span: Optional[Span] = None,
     ) -> List[dict]:
-        if messages is not None and is_prompt_caching_valid_prompt(
+        typed_healthy_deployments = cast(List[dict], healthy_deployments)
+        request_kwargs = request_kwargs or {}
+
+        if messages is None or not is_prompt_caching_valid_prompt(
             messages=messages,
             model=model,
-        ):  # prompt > 1024 tokens
-            prompt_cache = PromptCachingCache(
-                cache=self.cache,
-            )
+        ):
+            return typed_healthy_deployments
 
-            model_id_dict = await prompt_cache.async_get_model_id(
-                messages=cast(List[AllMessageValues], messages),
-                tools=None,
-            )
-            if model_id_dict is not None:
-                model_id = model_id_dict["model_id"]
-                for deployment in healthy_deployments:
-                    if deployment["model_info"]["id"] == model_id:
-                        return [deployment]
+        prompt_cache = PromptCachingCache(
+            cache=self.cache,
+        )
 
-        return healthy_deployments
+        model_id_dict = await prompt_cache.async_get_model_id(
+            messages=cast(List[AllMessageValues], messages),
+            tools=None,
+        )
+        if model_id_dict is not None:
+            model_id = model_id_dict["model_id"]
+            for deployment in typed_healthy_deployments:
+                if deployment["model_info"]["id"] == model_id:
+                    return [deployment]
+
+        prompt_cache_key = _extract_prompt_cache_key(request_kwargs)
+        if prompt_cache_key is None:
+            return typed_healthy_deployments
+
+        if not _should_apply_openai_prompt_cache_affinity(
+            model=model,
+            request_kwargs=request_kwargs,
+            healthy_deployments=typed_healthy_deployments,
+        ):
+            return typed_healthy_deployments
+
+        cache_key = _openai_prompt_cache_affinity_cache_key(
+            router_model=model,
+            tenant_token=_tenant_token_for_openai_pc_affinity(request_kwargs),
+            prompt_cache_key=prompt_cache_key,
+        )
+        cache_result = await self.cache.async_get_cache(key=cache_key)
+        pinned_id = _parse_model_id_from_affinity_cache_value(cache_result)
+        if pinned_id is None:
+            return typed_healthy_deployments
+
+        for deployment in typed_healthy_deployments:
+            if deployment["model_info"]["id"] == pinned_id:
+                return [deployment]
+
+        return typed_healthy_deployments
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
@@ -96,5 +219,39 @@ class PromptCachingDeploymentCheck(CustomLogger):
                 messages=messages,
                 tools=None,  # [TODO]: add tools once standard_logging_object supports it
             )
+
+        prompt_cache_key = _extract_prompt_cache_key(kwargs)
+        custom_llm_provider = standard_logging_object.get("custom_llm_provider")
+        if custom_llm_provider is None:
+            custom_llm_provider = kwargs.get("custom_llm_provider")
+
+        if (
+            prompt_cache_key is not None
+            and custom_llm_provider == "openai"
+            and is_prompt_caching_valid_prompt(
+                model=model,
+                messages=cast(List[AllMessageValues], messages),
+            )
+        ):
+            router_model = standard_logging_object.get("model_group") or model
+            cache_key = _openai_prompt_cache_affinity_cache_key(
+                router_model=str(router_model),
+                tenant_token=_tenant_token_from_standard_payload(
+                    standard_logging_object
+                ),
+                prompt_cache_key=prompt_cache_key,
+            )
+            try:
+                await self.cache.async_set_cache(
+                    cache_key,
+                    PromptCachingCacheValue(model_id=str(model_id)),
+                    ttl=300,
+                )
+            except Exception as e:
+                verbose_logger.debug(
+                    "PromptCachingDeploymentCheck: failed to set openai prompt_cache_key affinity cache router_model=%s error=%s",
+                    router_model,
+                    e,
+                )
 
         return

--- a/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
+++ b/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
@@ -89,24 +89,58 @@ def _parse_model_id_from_affinity_cache_value(cache_result: Any) -> Optional[str
     return None
 
 
-def _healthy_deployments_include_openai(healthy_deployments: List[dict]) -> bool:
+def _model_supports_prompt_cache_key_param(
+    model: str,
+    custom_llm_provider: Optional[str],
+) -> bool:
+    """
+    True when the provider's chat config lists ``prompt_cache_key`` (declared under
+    ``litellm/llms/``, not hardcoded here).
+    """
+    # Import locally to avoid circular import: litellm/__init__ -> Router -> this module.
+    from litellm.litellm_core_utils.get_supported_openai_params import (
+        get_supported_openai_params,
+    )
+
+    try:
+        params = get_supported_openai_params(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+        )
+    except Exception:
+        return False
+    return bool(params and "prompt_cache_key" in params)
+
+
+def _healthy_deployments_include_prompt_cache_key_support(
+    healthy_deployments: List[dict],
+) -> bool:
     for deployment in healthy_deployments:
         lp = deployment.get("litellm_params")
-        if isinstance(lp, dict) and lp.get("custom_llm_provider") == "openai":
+        if not isinstance(lp, dict):
+            continue
+        dep_model = lp.get("model")
+        if dep_model is None:
+            continue
+        if _model_supports_prompt_cache_key_param(
+            str(dep_model),
+            lp.get("custom_llm_provider"),
+        ):
             return True
     return False
 
 
-def _should_apply_openai_prompt_cache_affinity(
+def _should_apply_prompt_cache_key_affinity(
     model: str,
     request_kwargs: dict,
     healthy_deployments: List[dict],
 ) -> bool:
-    if model.startswith("openai/"):
+    if _model_supports_prompt_cache_key_param(
+        model,
+        request_kwargs.get("custom_llm_provider"),
+    ):
         return True
-    if request_kwargs.get("custom_llm_provider") == "openai":
-        return True
-    return _healthy_deployments_include_openai(healthy_deployments)
+    return _healthy_deployments_include_prompt_cache_key_support(healthy_deployments)
 
 
 class PromptCachingDeploymentCheck(CustomLogger):
@@ -148,7 +182,7 @@ class PromptCachingDeploymentCheck(CustomLogger):
         if prompt_cache_key is None:
             return typed_healthy_deployments
 
-        if not _should_apply_openai_prompt_cache_affinity(
+        if not _should_apply_prompt_cache_key_affinity(
             model=model,
             request_kwargs=request_kwargs,
             healthy_deployments=typed_healthy_deployments,
@@ -221,13 +255,13 @@ class PromptCachingDeploymentCheck(CustomLogger):
             )
 
         prompt_cache_key = _extract_prompt_cache_key(kwargs)
-        custom_llm_provider = standard_logging_object.get("custom_llm_provider")
-        if custom_llm_provider is None:
-            custom_llm_provider = kwargs.get("custom_llm_provider")
+        resolved_provider = standard_logging_object.get("custom_llm_provider")
+        if resolved_provider is None:
+            resolved_provider = kwargs.get("custom_llm_provider")
 
         if (
             prompt_cache_key is not None
-            and custom_llm_provider == "openai"
+            and _model_supports_prompt_cache_key_param(model, resolved_provider)
             and is_prompt_caching_valid_prompt(
                 model=model,
                 messages=cast(List[AllMessageValues], messages),

--- a/tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py
@@ -1,0 +1,257 @@
+import asyncio
+import os
+import sys
+from typing import Any, cast
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.caching.dual_cache import DualCache
+from litellm.router_utils.pre_call_checks.prompt_caching_deployment_check import (
+    PromptCachingDeploymentCheck,
+    _openai_prompt_cache_affinity_cache_key,
+)
+from litellm.types.utils import (
+    CallTypes,
+    StandardLoggingModelInformation,
+    StandardLoggingPayload,
+)
+
+
+def _long_user_messages() -> list:
+    # Enough tokens for is_prompt_caching_valid_prompt (default >= 1024).
+    return [{"role": "user", "content": "test long message here" * 1024}]
+
+
+def _make_openai_success_payload() -> StandardLoggingPayload:
+    # TypedDict 构造函数对「缺字段」很敏感；测试里用 dict + cast，避免维护完整 StandardLoggingMetadata 继承链。
+    raw: dict[str, Any] = {
+        "id": "test_id",
+        "trace_id": "trace-1",
+        "litellm_call_id": None,
+        "call_type": CallTypes.acompletion.value,
+        "stream": False,
+        "response_cost": 0.1,
+        "cost_breakdown": None,
+        "response_cost_failure_debug_info": None,
+        "status": "success",
+        "status_fields": {},
+        "custom_llm_provider": "openai",
+        "total_tokens": 30,
+        "prompt_tokens": 20,
+        "completion_tokens": 10,
+        "startTime": 1234567890.0,
+        "endTime": 1234567891.0,
+        "completionStartTime": 1234567890.5,
+        "response_time": 1.0,
+        "model_map_information": StandardLoggingModelInformation(
+            model_map_key="gpt-4o-mini", model_map_value=None
+        ),
+        "model": "openai/gpt-4o-mini",
+        "model_id": "dep-openai-1",
+        "model_group": "gpt-4o-mini",
+        "api_base": "https://api.openai.com",
+        "metadata": {
+            "user_api_key_hash": "hash-abc",
+            "user_api_key_org_id": None,
+            "user_api_key_alias": None,
+            "user_api_key_team_id": None,
+            "user_api_key_user_id": None,
+            "user_api_key_team_alias": None,
+            "spend_logs_metadata": None,
+            "requester_ip_address": None,
+            "requester_metadata": None,
+        },
+        "cache_hit": False,
+        "cache_key": None,
+        "saved_cache_cost": 0.0,
+        "request_tags": [],
+        "end_user": None,
+        "requester_ip_address": None,
+        "user_agent": None,
+        "messages": _long_user_messages(),
+        "response": {"choices": [{"message": {"content": "ok"}}]},
+        "error_str": None,
+        "error_information": None,
+        "model_parameters": {},
+        "hidden_params": {
+            "model_id": "dep-openai-1",
+            "cache_key": None,
+            "api_base": "https://api.openai.com",
+            "response_cost": "0.1",
+            "additional_headers": None,
+            "litellm_overhead_time_ms": None,
+            "batch_models": None,
+            "litellm_model_name": None,
+            "usage_object": None,
+        },
+        "guardrail_information": None,
+        "standard_built_in_tools_params": None,
+    }
+    return cast(StandardLoggingPayload, raw)
+
+
+@pytest.mark.asyncio
+async def test_openai_prompt_cache_key_affinity_writes_and_filters_deployment():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+
+    payload = _make_openai_success_payload()
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "prompt_cache_key": "tenant-doc-v1",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+
+    model_group = "gpt-4o-mini"
+    redis_key = _openai_prompt_cache_affinity_cache_key(
+        router_model=model_group,
+        tenant_token="hash-abc",
+        prompt_cache_key="tenant-doc-v1",
+    )
+    cached = await cache.async_get_cache(key=redis_key)
+    assert cached is not None
+    assert cached["model_id"] == "dep-openai-1"
+
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-1"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-2"},
+        },
+    ]
+
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "prompt_cache_key": "tenant-doc-v1",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+    )
+    assert len(filtered) == 1
+    assert filtered[0]["model_info"]["id"] == "dep-openai-1"
+
+
+@pytest.mark.asyncio
+async def test_openai_prompt_cache_key_affinity_tenant_isolation():
+    """Same prompt_cache_key must not pin another tenant's deployment."""
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+
+    payload = _make_openai_success_payload()
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "prompt_cache_key": "shared-doc-key",
+            "metadata": {"user_api_key_hash": "hash-tenant-a"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+
+    model_group = "gpt-4o-mini"
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-a"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-b"},
+        },
+    ]
+
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "prompt_cache_key": "shared-doc-key",
+            "metadata": {"user_api_key_hash": "hash-tenant-b"},
+        },
+    )
+    assert len(filtered) == 2
+
+
+@pytest.mark.asyncio
+async def test_openai_without_prompt_cache_key_does_not_write_affinity_key():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+
+    payload = _make_openai_success_payload()
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+
+    would_be_key = _openai_prompt_cache_affinity_cache_key(
+        router_model="gpt-4o-mini",
+        tenant_token="hash-abc",
+        prompt_cache_key="if-this-were-sent",
+    )
+    assert await cache.async_get_cache(key=would_be_key) is None
+
+
+@pytest.mark.asyncio
+async def test_anthropic_success_does_not_write_openai_affinity_key():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+
+    payload = _make_openai_success_payload()
+    payload["model"] = "anthropic/claude-3-5-sonnet-20240620"
+    payload["custom_llm_provider"] = "anthropic"
+
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "prompt_cache_key": "should-not-create-openai-key",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+
+    openai_style_key = _openai_prompt_cache_affinity_cache_key(
+        router_model="gpt-4o-mini",
+        tenant_token="hash-abc",
+        prompt_cache_key="should-not-create-openai-key",
+    )
+    assert await cache.async_get_cache(key=openai_style_key) is None

--- a/tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import sys
 from typing import Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -25,7 +26,7 @@ def _long_user_messages() -> list:
 
 
 def _make_openai_success_payload() -> StandardLoggingPayload:
-    # TypedDict 构造函数对「缺字段」很敏感；测试里用 dict + cast，避免维护完整 StandardLoggingMetadata 继承链。
+    # TypedDict is strict; build a dict and cast to avoid maintaining the full metadata hierarchy.
     raw: dict[str, Any] = {
         "id": "test_id",
         "trace_id": "trace-1",
@@ -255,3 +256,396 @@ async def test_anthropic_success_does_not_write_openai_affinity_key():
         prompt_cache_key="should-not-create-openai-key",
     )
     assert await cache.async_get_cache(key=openai_style_key) is None
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_skips_when_standard_logging_object_missing():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    await check.async_log_success_event(
+        kwargs={"prompt_cache_key": "x"},
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    assert await cache.async_get_cache(
+        key=_openai_prompt_cache_affinity_cache_key(
+            router_model="gpt-4o-mini",
+            tenant_token="",
+            prompt_cache_key="x",
+        )
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_skips_embedding_call_type():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    payload["call_type"] = CallTypes.embedding.value
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "prompt_cache_key": "k",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model="gpt-4o-mini",
+        tenant_token="hash-abc",
+        prompt_cache_key="k",
+    )
+    assert await cache.async_get_cache(key=key) is None
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_openai_custom_llm_provider_from_kwargs():
+    """When payload omits custom_llm_provider, fall back to kwargs."""
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    raw = cast(dict[str, Any], payload)
+    raw.pop("custom_llm_provider", None)
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": cast(StandardLoggingPayload, raw),
+            "custom_llm_provider": "openai",
+            "prompt_cache_key": "doc-key",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model="gpt-4o-mini",
+        tenant_token="hash-abc",
+        prompt_cache_key="doc-key",
+    )
+    cached = await cache.async_get_cache(key=key)
+    assert cached is not None
+    assert cached["model_id"] == "dep-openai-1"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_prompt_cache_key_from_optional_params():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "optional_params": {"prompt_cache_key": "from-optional"},
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model="gpt-4o-mini",
+        tenant_token="hash-abc",
+        prompt_cache_key="from-optional",
+    )
+    cached = await cache.async_get_cache(key=key)
+    assert cached is not None
+    assert cached["model_id"] == "dep-openai-1"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_openai_affinity_set_cache_failure_swallowed():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    with patch.object(
+        cache,
+        "async_set_cache",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("redis down"),
+    ):
+        await check.async_log_success_event(
+            kwargs={
+                "standard_logging_object": payload,
+                "prompt_cache_key": "k",
+                "metadata": {"user_api_key_hash": "hash-abc"},
+            },
+            response_obj={},
+            start_time=0.0,
+            end_time=1.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_optional_params_prompt_cache_key():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "optional_params": {"prompt_cache_key": "opt-key"},
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+    model_group = "gpt-4o-mini"
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-1"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-2"},
+        },
+    ]
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "optional_params": {"prompt_cache_key": "opt-key"},
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+    )
+    assert len(filtered) == 1
+    assert filtered[0]["model_info"]["id"] == "dep-openai-1"
+
+
+@pytest.mark.asyncio
+async def test_filter_openai_affinity_inferred_from_deployments_only():
+    """Model string without openai/ prefix still applies affinity when deployments are OpenAI."""
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "prompt_cache_key": "route-inf",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+    model_group = "gpt-4o-mini"
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-1"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-2"},
+        },
+    ]
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "prompt_cache_key": "route-inf",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+    )
+    assert len(filtered) == 1
+    assert filtered[0]["model_info"]["id"] == "dep-openai-1"
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_pinned_id_not_in_healthy_returns_all():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    model_group = "gpt-4o-mini"
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model=model_group,
+        tenant_token="hash-abc",
+        prompt_cache_key="orphan-pin",
+    )
+    await cache.async_set_cache(
+        key,
+        {"model_id": "dep-not-listed"},
+        ttl=300,
+    )
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-1"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-2"},
+        },
+    ]
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "prompt_cache_key": "orphan-pin",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+    )
+    assert len(filtered) == 2
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_cache_dict_without_model_id_returns_all():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    model_group = "gpt-4o-mini"
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model=model_group,
+        tenant_token="hash-abc",
+        prompt_cache_key="bad-dict",
+    )
+    await cache.async_set_cache(key, {"not_model_id": "x"}, ttl=300)
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-1"},
+        },
+    ]
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "prompt_cache_key": "bad-dict",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+    )
+    assert len(filtered) == 1
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_cache_string_model_id():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    model_group = "gpt-4o-mini"
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model=model_group,
+        tenant_token="hash-abc",
+        prompt_cache_key="str-val",
+    )
+    await cache.async_set_cache(key, "dep-openai-1", ttl=300)
+    healthy = [
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-1"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "model_info": {"id": "dep-openai-2"},
+        },
+    ]
+    filtered = await check.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy,
+        messages=_long_user_messages(),
+        request_kwargs={
+            "prompt_cache_key": "str-val",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+    )
+    assert len(filtered) == 1
+    assert filtered[0]["model_info"]["id"] == "dep-openai-1"
+
+
+@pytest.mark.asyncio
+async def test_filter_deployments_short_prompt_returns_all_deployments():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    healthy = [
+        {
+            "model_name": "gpt-4o-mini",
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "model_info": {"id": "a"},
+        },
+        {
+            "model_name": "gpt-4o-mini",
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "model_info": {"id": "b"},
+        },
+    ]
+    filtered = await check.async_filter_deployments(
+        model="gpt-4o-mini",
+        healthy_deployments=healthy,
+        messages=[{"role": "user", "content": "short"}],
+        request_kwargs={
+            "prompt_cache_key": "k",
+            "metadata": {"user_api_key_hash": "h"},
+        },
+    )
+    assert len(filtered) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_completion_call_type_writes_affinity():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    payload = _make_openai_success_payload()
+    payload["call_type"] = CallTypes.completion.value
+    await check.async_log_success_event(
+        kwargs={
+            "standard_logging_object": payload,
+            "prompt_cache_key": "sync-completion",
+            "metadata": {"user_api_key_hash": "hash-abc"},
+        },
+        response_obj={},
+        start_time=0.0,
+        end_time=1.0,
+    )
+    await asyncio.sleep(0.05)
+    key = _openai_prompt_cache_affinity_cache_key(
+        router_model="gpt-4o-mini",
+        tenant_token="hash-abc",
+        prompt_cache_key="sync-completion",
+    )
+    assert await cache.async_get_cache(key=key) is not None


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Unit tests:

```bash
uv run pytest tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py -v
```

Result: **4 passed**.

This change is Router-side behavior only (no UI). Optional: attach logs showing Redis key shape and lookup order (`cache_control` first, then OpenAI affinity).

## Type

🆕 New Feature

## Changes

**Router: OpenAI `prompt_cache_key` deployment affinity**

- Extends the existing **`optional_pre_call_checks: ["prompt_caching"]`** flow (**no new config flag**). In addition to Anthropic-style `cache_control` prefix affinity, when **`custom_llm_provider == "openai"`**, the request includes a non-empty **`prompt_cache_key`**, and **`is_prompt_caching_valid_prompt`** passes (default ≥1024 tokens), the chosen **`model_id`** is stored for subsequent routing affinity.
- Redis key: `openai_pc_aff:<sha256(router_model|user_api_key_hash|prompt_cache_key)>:prompt_caching`, distinct from `deployment:<hash>:prompt_caching`. Lookup order: **`cache_control` hit first**, then OpenAI `prompt_cache_key` affinity.
- **`PromptCachingCache` writes** and **OpenAI affinity writes** both use **TTL 300 seconds** (literal `300`, aligned with existing behavior).
- **Tests**: `tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py` — write + filter deployments, tenant isolation, no write without `prompt_cache_key`, Anthropic success does not write OpenAI affinity keys.

**Files touched (summary)**

- `litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py` — OpenAI affinity read/write and deployment filtering.
- `litellm/router_utils/prompt_caching_cache.py` — Anthropic path TTL remains 300s.
- `tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_openai_prompt_cache_key_affinity.py` — coverage for the above.
