### PR TITLE
fix(proxy): add Retry-After header on RouterRateLimitError

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -49,6 +49,7 @@ from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
 from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.router import RouterRateLimitError
 from litellm.types.utils import ServerToolUse
 
 # Type alias for streaming chunk serializer (chunk after hooks + cost injection -> wire format)
@@ -1714,6 +1715,12 @@ class ProxyBaseLLMRequestProcessing:
                 if _response_headers:
                     headers = get_response_headers(dict(_response_headers))
         headers.update(custom_headers)
+
+        # Add Retry-After header when router has all deployments in cooldown
+        if isinstance(e, RouterRateLimitError):
+            cooldown_time = getattr(e, "cooldown_time", None)
+            if cooldown_time is not None:
+                headers["retry-after"] = str(int(cooldown_time))
 
         # Call response headers hook for failure
         try:

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2156,3 +2156,60 @@ class TestHandleLLMApiExceptionDictDetail:
         proxy_exc = await self._invoke(exc)
         assert proxy_exc.message == "Content blocked by guardrail"
         assert proxy_exc.provider_specific_fields is None
+
+
+@pytest.mark.asyncio
+class TestHandleLLMApiExceptionRetryAfterHeader:
+    """
+    Verify that RouterRateLimitError produces a Retry-After header
+    so downstream clients can programmatically determine when to retry.
+    """
+
+    async def _invoke(self, exc: Exception):
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        processor = ProxyBaseLLMRequestProcessing(data={})
+        user_api_key_dict = UserAPIKeyAuth(api_key="sk-test")
+        proxy_logging_obj = MagicMock()
+        proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+
+        try:
+            await processor._handle_llm_api_exception(
+                e=exc,
+                user_api_key_dict=user_api_key_dict,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except ProxyException as raised:
+            return raised
+        raise AssertionError("ProxyException was not raised")
+
+    async def test_router_rate_limit_error_includes_retry_after_header(self):
+        from litellm.types.router import RouterRateLimitError
+
+        exc = RouterRateLimitError(
+            model="glm-5.1",
+            cooldown_time=60.0,
+            enable_pre_call_checks=True,
+            cooldown_list=["abc123"],
+        )
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.headers is not None
+        assert proxy_exc.headers.get("retry-after") == "60"
+
+    async def test_router_rate_limit_error_cooldown_time_zero(self):
+        from litellm.types.router import RouterRateLimitError
+
+        exc = RouterRateLimitError(
+            model="test-model",
+            cooldown_time=0.0,
+            enable_pre_call_checks=False,
+            cooldown_list=[],
+        )
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.headers.get("retry-after") == "0"
+
+    async def test_non_rate_limit_error_has_no_retry_after_header(self):
+        exc = ValueError("some other error")
+        proxy_exc = await self._invoke(exc)
+        assert proxy_exc.headers.get("retry-after") is None


### PR DESCRIPTION
## Problem

When all deployments for a model are in cooldown (e.g. after upstream 429 rate limits), LiteLLM raises `RouterRateLimitError` with a human-readable message like:

```
No deployments available for selected model, Try again in 120 seconds.
```

However, no `Retry-After` HTTP header is set on the response. This means downstream clients (OpenAI SDK, custom agents, API gateways) cannot programmatically determine when to retry — they must parse the error message string, which is fragile and non-standard.

## Fix

The `cooldown_time` is already available as a float attribute on `RouterRateLimitError`. This PR promotes it to a standard `Retry-After` HTTP header in `_handle_llm_api_exception()`, so clients get:

```
HTTP/1.1 429 Too Many Requests
Retry-After: 60
```

## Changes

- `litellm/proxy/common_request_processing.py`: After `headers.update(custom_headers)`, check if the exception is a `RouterRateLimitError` and add `retry-after` header from `e.cooldown_time`.
- `tests/test_litellm/proxy/test_common_request_processing.py`: New test class `TestHandleLLMApiExceptionRetryAfterHeader` with 3 tests:
  - `RouterRateLimitError` with `cooldown_time=60` → header `"60"`
  - `RouterRateLimitError` with `cooldown_time=0` → header `"0"`
  - Non-rate-limit error → no `retry-after` header

## Testing

```bash
pytest tests/test_litellm/proxy/test_common_request_processing.py -k "TestHandleLLMApiExceptionRetryAfterHeader" -v
```

Fixes #27823

> **Note:** Previous PR #27825 was targeting `main` directly — closed and retargeted to `litellm_oss_staging` per repo contribution policy.