### PR TITLE
fix(responses): preserve cache_control on content blocks through Responses->Chat transformation

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1294,14 +1294,19 @@ class LiteLLMCompletionResponsesConfig:
                         text_value = item.get("text")
                         if text_value is None:
                             continue
-                        content_list.append(
-                            {
-                                "type": LiteLLMCompletionResponsesConfig._get_chat_completion_request_content_type(
-                                    item.get("type") or "text"
-                                ),
-                                "text": text_value,
-                            }
-                        )
+                        new_content: Dict[str, Any] = {
+                            "type": LiteLLMCompletionResponsesConfig._get_chat_completion_request_content_type(
+                                item.get("type") or "text"
+                            ),
+                            "text": text_value,
+                        }
+                        # Preserve cache_control on the source block so Anthropic
+                        # prompt-caching markers survive the Responses→Chat hop.
+                        # Mirrors the tool-level passthrough at
+                        # transform_responses_api_tools_to_chat_completion_tools.
+                        if item.get("cache_control") is not None:
+                            new_content["cache_control"] = item.get("cache_control")
+                        content_list.append(new_content)
             return content_list
         else:
             raise ValueError(f"Invalid content type: {type(content)}")

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1304,8 +1304,9 @@ class LiteLLMCompletionResponsesConfig:
                         # prompt-caching markers survive the Responses→Chat hop.
                         # Mirrors the tool-level passthrough at
                         # transform_responses_api_tools_to_chat_completion_tools.
-                        if item.get("cache_control") is not None:
-                            new_content["cache_control"] = item.get("cache_control")
+                        cache_control = item.get("cache_control")
+                        if cache_control is not None:
+                            new_content["cache_control"] = cache_control
                         content_list.append(new_content)
             return content_list
         else:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -992,6 +992,34 @@ class TestContentTypeTransformation:
         assert result[0]["text"] == "valid text"
         assert result[1]["text"] == "another valid"
 
+    def test_cache_control_preserved_on_text_blocks(self):
+        """cache_control on a Responses-API text/input_text block must survive
+        the hop to Chat-Completion content so Anthropic prompt-caching markers
+        actually reach the wire. Without this passthrough the marker is dropped
+        and cache reads silently degrade to 0%."""
+        content = [
+            {"type": "input_text", "text": "system-y prefix"},
+            {
+                "type": "input_text",
+                "text": "cached chunk",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+            content
+        )
+        assert len(result) == 2
+        assert "cache_control" not in result[0]
+        assert result[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_cache_control_absent_when_not_set(self):
+        """Blocks without cache_control don't get an empty/None key added."""
+        content = [{"type": "input_text", "text": "plain"}]
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+            content
+        )
+        assert "cache_control" not in result[0]
+
 
 class TestToolTransformation:
     """Test cases for tool transformation from Responses API to Chat Completion format"""


### PR DESCRIPTION
## Summary

`_transform_responses_api_content_to_chat_completion_content` rebuilds each Responses-API content block as `{type, text}`, dropping `cache_control` on the way to Chat Completions. As a result, callers that attach Anthropic prompt-caching markers on Responses-API input content (e.g. `{"type": "input_text", "text": "...", "cache_control": {"type": "ephemeral"}}`) silently get **0% cache reads** — the marker never reaches the wire.

The downstream pieces are already in place:
- `ChatCompletionTextObject` declares `cache_control` as an optional field (`litellm/types/llms/openai.py:627-630`).
- `AnthropicModelInfo.is_cache_control_set` already inspects content blocks for `cache_control` (`litellm/llms/anthropic/common_utils.py:99-108`).

The only thing missing is preservation through the Responses→Chat hop.

## Change

In `_transform_responses_api_content_to_chat_completion_content`, copy `cache_control` from the source block to the rebuilt one when present. Mirrors the existing tool-level passthrough at `transform_responses_api_tools_to_chat_completion_tools` (lines 1400-1401).

```python
new_content: Dict[str, Any] = {
    "type": ..._get_chat_completion_request_content_type(item.get("type") or "text"),
    "text": text_value,
}
if item.get("cache_control") is not None:
    new_content["cache_control"] = item.get("cache_control")
content_list.append(new_content)
```

The output-side caller at line 2002 shares this helper, so it gets the fix for free.

## Test plan
- [x] `test_cache_control_preserved_on_text_blocks` — marker survives the transformation
- [x] `test_cache_control_absent_when_not_set` — no spurious key added when source has none
- [x] `test_none_text_blocks_filtered_out` — existing behavior unchanged
- [x] Full file: 64/64 tests in `test_litellm_completion_responses.py` pass

## Out of scope

- `input_file` / `input_image` blocks go through dedicated builders that also drop fields; same one-line fix is possible there if needed, but text/input_text is the dominant case for prompt caching.
