### PR TITLE
Add jp. Bedrock cross-region inference profile for claude-sonnet-4-6

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1448,6 +1448,35 @@
         "supports_native_structured_output": true,
         "supports_minimal_reasoning_effort": true
     },
+    "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_max_reasoning_effort": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_structured_output": true,
+        "supports_minimal_reasoning_effort": true
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,

--- a/tests/test_litellm/test_claude_sonnet_4_6_config.py
+++ b/tests/test_litellm/test_claude_sonnet_4_6_config.py
@@ -1,5 +1,9 @@
 """
 Test Claude Sonnet 4.6 model configurations for Bedrock cross-region inference.
+
+Pins the set of region-prefixed entries in model_prices_and_context_window.json
+so future drops of a region (or pricing drift between regions) is caught.
+
 https://github.com/BerriAI/litellm/issues/22972
 """
 

--- a/tests/test_litellm/test_claude_sonnet_4_6_config.py
+++ b/tests/test_litellm/test_claude_sonnet_4_6_config.py
@@ -1,0 +1,76 @@
+"""
+Test Claude Sonnet 4.6 model configurations for Bedrock cross-region inference.
+https://github.com/BerriAI/litellm/issues/22972
+"""
+
+import json
+import os
+
+
+def test_bedrock_sonnet_4_6_region_prefixes():
+    """All documented Bedrock cross-region inference prefixes for
+    claude-sonnet-4-6 must be present in model_prices_and_context_window.json.
+    """
+    json_path = os.path.join(
+        os.path.dirname(__file__), "../../model_prices_and_context_window.json"
+    )
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    bedrock_sonnet_4_6_models = [
+        "anthropic.claude-sonnet-4-6",
+        "global.anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-sonnet-4-6",
+        "eu.anthropic.claude-sonnet-4-6",
+        "au.anthropic.claude-sonnet-4-6",
+        "jp.anthropic.claude-sonnet-4-6",
+    ]
+
+    for model in bedrock_sonnet_4_6_models:
+        assert model in model_data, f"Model {model} not found in config"
+        model_info = model_data[model]
+
+        assert (
+            model_info["litellm_provider"] == "bedrock_converse"
+        ), f"{model} should use bedrock_converse, got {model_info['litellm_provider']}"
+        assert model_info["mode"] == "chat"
+        assert model_info["max_input_tokens"] == 1000000
+        assert model_info["max_output_tokens"] == 64000
+        assert model_info["max_tokens"] == 64000
+        assert model_info.get("supports_vision") is True
+        assert model_info.get("supports_computer_use") is True
+        assert model_info.get("supports_function_calling") is True
+        assert model_info.get("supports_tool_choice") is True
+        assert model_info.get("supports_prompt_caching") is True
+        assert model_info.get("supports_response_schema") is True
+        assert model_info.get("supports_pdf_input") is True
+        assert model_info.get("supports_assistant_prefill") is True
+        assert model_info.get("supports_reasoning") is True
+        assert model_info.get("tool_use_system_prompt_tokens") == 346
+
+
+def test_bedrock_sonnet_4_6_jp_matches_other_regional_pricing():
+    """The jp. cross-region inference profile shares pricing with the other
+    regional profiles (us./eu./au.), which carry a 10% premium over the
+    base/global entries.
+    """
+    json_path = os.path.join(
+        os.path.dirname(__file__), "../../model_prices_and_context_window.json"
+    )
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    jp_info = model_data["jp.anthropic.claude-sonnet-4-6"]
+    au_info = model_data["au.anthropic.claude-sonnet-4-6"]
+
+    pricing_fields = [
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "cache_creation_input_token_cost",
+        "cache_read_input_token_cost",
+    ]
+    for field in pricing_fields:
+        assert jp_info[field] == au_info[field], (
+            f"{field} mismatch between jp. and au. variants: "
+            f"jp={jp_info[field]}, au={au_info[field]}"
+        )


### PR DESCRIPTION
## Relevant issues

Fixes #22972.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory (`tests/test_litellm/test_claude_sonnet_4_6_config.py`)
- [x] My PR passes all unit tests on `make test-unit` for the affected files
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

**Before:**
```
$ grep "jp.anthropic.claude-sonnet-4-6" model_prices_and_context_window.json
(no results)
```

**After:**
```
$ grep "jp.anthropic.claude-sonnet-4-6" model_prices_and_context_window.json
    "jp.anthropic.claude-sonnet-4-6": {
```

**Tests:**
```
$ uv run pytest tests/test_litellm/test_claude_sonnet_4_6_config.py -v
tests/test_litellm/test_claude_sonnet_4_6_config.py::test_bedrock_sonnet_4_6_jp_matches_other_regional_pricing PASSED [ 50%]
tests/test_litellm/test_claude_sonnet_4_6_config.py::test_bedrock_sonnet_4_6_region_prefixes PASSED [100%]
============================== 2 passed in 0.16s ===============================

$ uv run pytest tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid -v
tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid PASSED [100%]
============================== 1 passed in 0.44s ===============================
```

## Type

🐛 Bug Fix

## Changes

The `model_prices_and_context_window.json` file contains cross-region inference profile entries for `claude-sonnet-4-6` under the prefixes `us.` (line 1363), `eu.` (1393), `au.` (1422), and `global.` (1333), as well as the unprefixed base entry (1303).  The `jp.` (Japan) prefix was missing — even though the analogous `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` and `jp.anthropic.claude-haiku-4-5-20251001-v1:0` entries exist for the adjacent models, confirming this is an oversight rather than a regional unavailability.

This PR:

1. Adds `jp.anthropic.claude-sonnet-4-6` to `model_prices_and_context_window.json`, immediately after the `au.` entry.  Pricing mirrors the `au.`/`eu.`/`us.` regional profiles (the regional cross-region profiles all carry the same +10% premium over the base/`global.` entry).  All capability flags (`supports_vision`, `supports_computer_use`, `supports_function_calling`, etc.) match the other regional entries.
2. Adds `tests/test_litellm/test_claude_sonnet_4_6_config.py`, mirroring the existing `test_claude_haiku_4_5_config.py` pattern, with two tests:
   - `test_bedrock_sonnet_4_6_region_prefixes` — asserts that every documented region prefix (including the new `jp.`) is present in the JSON and uses the `bedrock_converse` provider with the expected token limits and capability set.
   - `test_bedrock_sonnet_4_6_jp_matches_other_regional_pricing` — pins the new `jp.` entry's pricing to match `au.` so future drift is caught.

Verified with `git stash` that both new tests fail against `litellm_internal_staging` without the JSON change, and pass with it.