### PR TITLE
feat(pricing): add zai/glm-5.1 model pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 | [CompactifAI (`compactifai`)](https://docs.litellm.ai/docs/providers/compactifai) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Custom (`custom`)](https://docs.litellm.ai/docs/providers/custom_llm_server) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Custom OpenAI (`custom_openai`)](https://docs.litellm.ai/docs/providers/openai_compatible) | ✅ | ✅ | ✅ |  |  | ✅ | ✅ | ✅ | ✅ |  |
-| [Dashscope (`dashscope`)](https://docs.litellm.ai/docs/providers/dashscope) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Dashscope (`dashscope`)](https://docs.litellm.ai/docs/providers/dashscope) | ✅ | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |
 | [Databricks (`databricks`)](https://docs.litellm.ai/docs/providers/databricks) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [DataRobot (`datarobot`)](https://docs.litellm.ai/docs/providers/datarobot) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Deepgram (`deepgram`)](https://docs.litellm.ai/docs/providers/deepgram) | ✅ | ✅ | ✅ |  |  | ✅ |  |  |  |  |

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1880,6 +1880,12 @@ if TYPE_CHECKING:
     from .llms.dashscope.chat.transformation import (
         DashScopeChatConfig as DashScopeChatConfig,
     )
+    from .llms.dashscope.embed.transformation import (
+        DashScopeEmbeddingConfig as DashScopeEmbeddingConfig,
+    )
+    from .llms.dashscope.rerank.transformation import (
+        DashScopeRerankConfig as DashScopeRerankConfig,
+    )
     from .llms.moonshot.chat.transformation import (
         MoonshotChatConfig as MoonshotChatConfig,
     )

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -20,6 +20,7 @@ from typing import (
     cast,
 )
 
+import litellm
 from litellm import verbose_logger
 from litellm.router_utils.batch_utils import InMemoryFile
 from litellm.types.llms.openai import (
@@ -1170,9 +1171,16 @@ def migrate_file_to_image_url(
         ChatCompletionImageUrlObject,
     )
 
-    file_id = message["file"].get("file_id")
-    file_data = message["file"].get("file_data")
-    format = message["file"].get("format")
+    file_sub = message.get("file")
+    if file_sub is None:
+        raise litellm.BadRequestError(
+            message="Content block has type='file' but is missing the required 'file' field",
+            model=None,
+            llm_provider=None,
+        )
+    file_id = file_sub.get("file_id")
+    file_data = file_sub.get("file_data")
+    format = file_sub.get("format")
     if not file_id and not file_data:
         raise ValueError("file_id and file_data are both None")
     image_url_object = ChatCompletionImageObject(

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2057,9 +2057,16 @@ def anthropic_process_openai_file_message(
     AnthropicMessagesContainerUploadParam,
 ]:
     file_message = cast(ChatCompletionFileObject, message)
-    file_data = file_message["file"].get("file_data")
-    file_id = file_message["file"].get("file_id")
-    format = file_message["file"].get("format")
+    file_sub = file_message.get("file")
+    if file_sub is None:
+        raise litellm.BadRequestError(
+            message="Content block has type='file' but is missing the required 'file' field",
+            model=None,
+            llm_provider="anthropic",
+        )
+    file_data = file_sub.get("file_data")
+    file_id = file_sub.get("file_id")
+    format = file_sub.get("format")
     if file_data:
         image_chunk = convert_to_anthropic_image_obj(
             openai_image_url=file_data,
@@ -4879,7 +4886,13 @@ class BedrockConverseMessagesProcessor:
 
     @staticmethod
     def _process_file_message(message: ChatCompletionFileObject) -> BedrockContentBlock:
-        file_message = message["file"]
+        file_message = message.get("file")
+        if file_message is None:
+            raise litellm.BadRequestError(
+                message="Content block has type='file' but is missing the required 'file' field",
+                model=None,
+                llm_provider="bedrock",
+            )
         file_data = file_message.get("file_data")
         file_id = file_message.get("file_id")
 
@@ -4900,7 +4913,13 @@ class BedrockConverseMessagesProcessor:
     async def _async_process_file_message(
         message: ChatCompletionFileObject,
     ) -> BedrockContentBlock:
-        file_message = message["file"]
+        file_message = message.get("file")
+        if file_message is None:
+            raise litellm.BadRequestError(
+                message="Content block has type='file' but is missing the required 'file' field",
+                model=None,
+                llm_provider="bedrock",
+            )
         file_data = file_message.get("file_data")
         file_id = file_message.get("file_id")
         format = file_message.get("format")

--- a/litellm/llms/dashscope/common_utils.py
+++ b/litellm/llms/dashscope/common_utils.py
@@ -1,0 +1,28 @@
+"""
+Common utilities for the DashScope LLM provider.
+"""
+
+from typing import Optional
+
+import httpx
+
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+
+class DashScopeError(BaseLLMException):
+    """Exception class for DashScope provider errors."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        headers: Optional[httpx.Headers] = None,
+    ):
+        self.status_code = status_code
+        self.message = message
+        self.headers = headers or httpx.Headers()
+        super().__init__(
+            status_code=status_code,
+            message=message,
+            headers=dict(self.headers),
+        )

--- a/litellm/llms/dashscope/embed/__init__.py
+++ b/litellm/llms/dashscope/embed/__init__.py
@@ -1,0 +1,7 @@
+"""
+DashScope Embedding Module
+"""
+
+from .transformation import DashScopeEmbeddingConfig
+
+__all__ = ["DashScopeEmbeddingConfig"]

--- a/litellm/llms/dashscope/embed/transformation.py
+++ b/litellm/llms/dashscope/embed/transformation.py
@@ -1,0 +1,191 @@
+"""
+Transformation logic from OpenAI /v1/embeddings format to DashScope's /v1/embeddings format.
+
+Supports
+- text-embedding-v4
+- text-embedding-v3
+
+Endpoint
+- https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings
+
+Docs - https://help.aliyun.com/zh/model-studio/text-embedding-synchronous-api
+"""
+
+from typing import List, Optional, Union
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
+from litellm.types.utils import EmbeddingResponse, Usage
+
+from ..common_utils import DashScopeError
+
+DEFAULT_API_BASE = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+class DashScopeEmbeddingConfig(BaseEmbeddingConfig):
+    """
+    Reference: https://help.aliyun.com/zh/model-studio/text-embedding-synchronous-api
+
+    DashScope exposes an OpenAI-compatible /v1/embeddings endpoint, so the
+    request and response shapes are nearly identical to OpenAI's.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        # DashScope's compatible-mode embeddings API accepts the same params as OpenAI.
+        # `dimensions` / `encoding_format` are only honored by text-embedding-v3 / v4;
+        # earlier versions silently ignore them server-side.
+        return ["dimensions", "encoding_format", "user"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool = False,
+    ) -> dict:
+        supported = self.get_supported_openai_params(model)
+        for k, v in non_default_params.items():
+            if v is None:
+                continue
+            if k in supported:
+                optional_params[k] = v
+            # unsupported params are dropped when drop_params=True;
+            # the upstream _check_valid_arg already raised UnsupportedParamsError
+            # for drop_params=False before this method is called.
+        return optional_params
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        if api_key is None:
+            api_key = get_secret_str("DASHSCOPE_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "DashScope API key is required. Set 'DASHSCOPE_API_KEY' env var or pass api_key explicitly."
+            )
+        default_headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        return {**default_headers, **headers}
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        base = api_base or get_secret_str("DASHSCOPE_API_BASE") or DEFAULT_API_BASE
+        base = base.rstrip("/")
+        if base.endswith("/embeddings"):
+            return base
+        return f"{base}/embeddings"
+
+    def transform_embedding_request(
+        self,
+        model: str,
+        input: AllEmbeddingInputValues,
+        optional_params: dict,
+        headers: dict,
+    ) -> dict:
+        data: dict = {
+            "model": model,
+            "input": input,
+        }
+        for key in ("dimensions", "encoding_format", "user"):
+            value = optional_params.get(key)
+            if value is not None:
+                data[key] = value
+        return data
+
+    def transform_embedding_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: EmbeddingResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str],
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> EmbeddingResponse:
+        try:
+            response_json = raw_response.json()
+        except Exception as e:
+            raise DashScopeError(
+                status_code=raw_response.status_code,
+                message=f"Failed to parse DashScope response as JSON: {str(e)}",
+            )
+
+        logging_obj.post_call(
+            input=request_data.get("input"),
+            api_key=api_key,
+            additional_args={"complete_input_dict": request_data},
+            original_response=response_json,
+        )
+
+        if "error" in response_json:
+            error = response_json["error"]
+            message = (
+                error.get("message", str(error))
+                if isinstance(error, dict)
+                else str(error)
+            )
+            raise DashScopeError(
+                status_code=raw_response.status_code,
+                message=message,
+            )
+
+        model_response.object = "list"
+        model_response.data = response_json.get("data", [])
+        model_response.model = response_json.get("model", model)
+
+        usage = response_json.get("usage") or {}
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        total_tokens = usage.get("total_tokens", prompt_tokens)
+        setattr(
+            model_response,
+            "usage",
+            Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=0,
+                total_tokens=total_tokens,
+            ),
+        )
+
+        if "id" in response_json:
+            setattr(model_response, "id", response_json["id"])
+
+        return model_response
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: Union[dict, httpx.Headers],
+    ) -> BaseLLMException:
+        if isinstance(headers, dict):
+            headers = httpx.Headers(headers)
+        return DashScopeError(
+            status_code=status_code,
+            message=error_message,
+            headers=headers,
+        )

--- a/litellm/llms/dashscope/rerank/__init__.py
+++ b/litellm/llms/dashscope/rerank/__init__.py
@@ -1,0 +1,7 @@
+"""
+DashScope Rerank Module
+"""
+
+from .transformation import DashScopeRerankConfig
+
+__all__ = ["DashScopeRerankConfig"]

--- a/litellm/llms/dashscope/rerank/transformation.py
+++ b/litellm/llms/dashscope/rerank/transformation.py
@@ -1,0 +1,238 @@
+"""
+Transformation logic for DashScope's OpenAI-compatible /v1/reranks API.
+
+Supports
+- qwen3-rerank
+
+(Other DashScope rerankers — gte-rerank-v2 / qwen3-vl-rerank — share the same
+endpoint but have not been validated against this transformer. Behavior with
+those models is undefined.)
+
+Endpoint
+- https://dashscope.aliyuncs.com/compatible-api/v1/reranks
+
+Note: chat/embed live under `/compatible-mode/v1/`, but DashScope's rerank
+route is exposed under `/compatible-api/v1/reranks` per the docs. Override
+with `DASHSCOPE_API_BASE_RERANK` to point at a different host or path.
+
+Empirically, qwen3-rerank accepts `return_documents=true` and echoes
+`results[].document.text` back, even though the public docs list the flag
+as supported only for gte-rerank-v2 / qwen3-vl-rerank.
+
+Docs - https://help.aliyun.com/zh/model-studio/text-rerank-api
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from litellm._uuid import uuid
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.rerank import (
+    OptionalRerankParams,
+    RerankBilledUnits,
+    RerankResponse,
+    RerankResponseMeta,
+    RerankTokens,
+)
+
+from ..common_utils import DashScopeError
+
+DEFAULT_RERANK_URL = "https://dashscope.aliyuncs.com/compatible-api/v1/reranks"
+
+
+class DashScopeRerankConfig(BaseRerankConfig):
+    """
+    Reference: https://help.aliyun.com/zh/model-studio/text-rerank-api
+
+    Targets DashScope's qwen3-rerank model. Request fields: model, query,
+    documents, top_n, return_documents. Response: results[].index,
+    results[].relevance_score, optionally results[].document.text (when
+    return_documents=true), plus a top-level usage.total_tokens counter.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        model: str,
+        optional_params: Optional[dict] = None,
+    ) -> str:
+        if api_base is None:
+            api_base = get_secret_str("DASHSCOPE_API_BASE_RERANK") or DEFAULT_RERANK_URL
+
+        if api_base == DEFAULT_RERANK_URL:
+            return DEFAULT_RERANK_URL
+
+        cleaned = api_base.rstrip("/")
+        if cleaned.endswith("/reranks") or cleaned.endswith("/rerank"):
+            return cleaned
+
+        if cleaned.endswith("/v1"):
+            return f"{cleaned}/reranks"
+
+        # Unknown base: append /reranks rather than silently ignoring the caller's api_base.
+        return f"{cleaned}/reranks"
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: Optional[str] = None,
+        optional_params: Optional[dict] = None,
+    ) -> dict:
+        if api_key is None:
+            api_key = get_secret_str("DASHSCOPE_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "DashScope API key is required. Set 'DASHSCOPE_API_KEY' env var or pass api_key explicitly."
+            )
+
+        default_headers = {
+            "Authorization": f"Bearer {api_key}",
+            "accept": "application/json",
+            "content-type": "application/json",
+        }
+        return {**default_headers, **headers}
+
+    def get_supported_cohere_rerank_params(self, model: str) -> list:
+        return ["query", "documents", "top_n", "return_documents"]
+
+    def map_cohere_rerank_params(
+        self,
+        non_default_params: Optional[dict],
+        model: str,
+        drop_params: bool,
+        query: str,
+        documents: List[Union[str, Dict[str, Any]]],
+        custom_llm_provider: Optional[str] = None,
+        top_n: Optional[int] = None,
+        rank_fields: Optional[List[str]] = None,
+        return_documents: Optional[bool] = True,
+        max_chunks_per_doc: Optional[int] = None,
+        max_tokens_per_doc: Optional[int] = None,
+    ) -> Dict:
+        # qwen3-rerank accepts query/documents/top_n/return_documents. The
+        # rest (rank_fields, max_*_per_doc) are silently dropped.
+        params: OptionalRerankParams = OptionalRerankParams(
+            query=query,
+            documents=documents,
+        )
+        if top_n is not None:
+            params["top_n"] = top_n
+        if return_documents is not None:
+            params["return_documents"] = return_documents
+        return dict(params)
+
+    def transform_rerank_request(
+        self,
+        model: str,
+        optional_rerank_params: Dict,
+        headers: dict,
+        litellm_params: Optional[dict] = None,
+    ) -> dict:
+        if "query" not in optional_rerank_params:
+            raise ValueError("query is required for DashScope rerank")
+        if "documents" not in optional_rerank_params:
+            raise ValueError("documents is required for DashScope rerank")
+
+        request: Dict[str, Any] = {
+            "model": model,
+            "query": optional_rerank_params["query"],
+            "documents": optional_rerank_params["documents"],
+        }
+        if optional_rerank_params.get("top_n") is not None:
+            request["top_n"] = optional_rerank_params["top_n"]
+        if optional_rerank_params.get("return_documents") is not None:
+            request["return_documents"] = optional_rerank_params["return_documents"]
+        return request
+
+    def transform_rerank_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: RerankResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str] = None,
+        request_data: dict = {},
+        optional_params: dict = {},
+        litellm_params: dict = {},
+    ) -> RerankResponse:
+        try:
+            response_json = raw_response.json()
+        except Exception:
+            raise DashScopeError(
+                status_code=raw_response.status_code,
+                message=raw_response.text,
+            )
+
+        logging_obj.post_call(
+            input=request_data.get("query"),
+            api_key=api_key,
+            additional_args={"complete_input_dict": request_data},
+            original_response=response_json,
+        )
+
+        # DashScope error envelope: {"code": "...", "message": "...", "request_id": "..."}
+        if "code" in response_json and "results" not in response_json:
+            raise DashScopeError(
+                status_code=raw_response.status_code,
+                message=response_json.get("message", str(response_json)),
+            )
+
+        results = response_json.get("results")
+        if results is None:
+            raise DashScopeError(
+                status_code=raw_response.status_code,
+                message=f"No results in DashScope rerank response: {response_json}",
+            )
+
+        # qwen3-rerank returns:
+        #   {"index": int, "relevance_score": float}
+        # plus, when return_documents=true was sent:
+        #   "document": {"text": "..."}
+        # which already matches LiteLLM's RerankResponseDocument shape.
+        transformed_results: List[dict] = []
+        for r in results:
+            item: Dict[str, Any] = {
+                "index": r["index"],
+                "relevance_score": r["relevance_score"],
+            }
+            doc = r.get("document")
+            if isinstance(doc, dict):
+                item["document"] = doc
+            elif isinstance(doc, str):
+                # Defensive: spec says dict, but normalize string-shaped echoes.
+                item["document"] = {"text": doc}
+            transformed_results.append(item)
+
+        usage = response_json.get("usage") or {}
+        total_tokens = usage.get("total_tokens")
+        billed_units = RerankBilledUnits(total_tokens=total_tokens)
+        tokens = RerankTokens(input_tokens=total_tokens)
+        meta = RerankResponseMeta(billed_units=billed_units, tokens=tokens)
+
+        return RerankResponse(
+            id=response_json.get("id") or str(uuid.uuid4()),
+            results=transformed_results,  # type: ignore
+            meta=meta,
+        )
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: Union[dict, httpx.Headers],
+    ) -> BaseLLMException:
+        if isinstance(headers, dict):
+            headers = httpx.Headers(headers)
+        return DashScopeError(
+            status_code=status_code,
+            message=error_message,
+            headers=headers,
+        )

--- a/litellm/llms/gemini/chat/transformation.py
+++ b/litellm/llms/gemini/chat/transformation.py
@@ -1,5 +1,7 @@
 from typing import List, Optional, cast
 
+import litellm
+
 from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_generic_image_chunk_to_openai_image_obj,
     convert_to_anthropic_image_obj,
@@ -141,13 +143,20 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
                                 img_element["image_url"] = converted_image_url  # type: ignore
                     elif element.get("type") == "file":
                         file_element = cast(ChatCompletionFileObject, element)
-                        file_id = file_element["file"].get("file_id")
+                        _file_field = file_element.get("file")
+                        if _file_field is None:
+                            raise litellm.BadRequestError(
+                                message="Content block has type='file' but is missing the required 'file' field",
+                                model=model,
+                                llm_provider="gemini",
+                            )
+                        file_id = _file_field.get("file_id")
                         if file_id and ("http://" in file_id or "https://" in file_id):
                             # Convert HTTP/HTTPS file URL to base64 data
                             try:
                                 base64_data = convert_url_to_base64(file_id)
-                                file_element["file"]["file_data"] = base64_data  # type: ignore
-                                file_element["file"].pop("file_id", None)  # type: ignore
+                                _file_field["file_data"] = base64_data  # type: ignore
+                                _file_field.pop("file_id", None)  # type: ignore
                             except Exception:
                                 # If conversion fails, leave as is and let the API handle it
                                 pass

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -287,7 +287,13 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 content_item["image_url"] = new_image_url_obj
         elif content_item.get("type") == "file":
             content_item = cast(ChatCompletionFileObject, content_item)
-            file_obj = content_item["file"]
+            file_obj = content_item.get("file")
+            if file_obj is None:
+                raise litellm.BadRequestError(
+                    message="Content block has type='file' but is missing the required 'file' field",
+                    model=None,
+                    llm_provider="openai",
+                )
             new_file_obj = ChatCompletionFileObjectFile(
                 **{  # type: ignore
                     k: v

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -351,15 +351,28 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                             img_element = element
                             format: Optional[str] = None
                             media_resolution_enum: Optional[Dict[str, str]] = None
-                            if isinstance(img_element["image_url"], dict):
-                                image_url = img_element["image_url"]["url"]
-                                format = img_element["image_url"].get("format")
-                                detail = img_element["image_url"].get("detail")
+                            raw_image_url = img_element.get("image_url")
+                            if raw_image_url is None:
+                                raise litellm.BadRequestError(
+                                    message="Invalid message content: element type is 'image_url' but 'image_url' field is missing ",
+                                    model=model,
+                                    llm_provider="vertex_ai",
+                                )
+                            if isinstance(raw_image_url, dict):
+                                image_url = raw_image_url.get("url")
+                                if image_url is None:
+                                    raise litellm.BadRequestError(
+                                        message="Invalid message content: element type is 'image_url' but 'url' field is missing inside 'image_url' ",
+                                        model=model,
+                                        llm_provider="vertex_ai",
+                                    )
+                                format = raw_image_url.get("format")
+                                detail = raw_image_url.get("detail")
                                 media_resolution_enum = (
                                     _convert_detail_to_media_resolution_enum(detail)
                                 )
                             else:
-                                image_url = img_element["image_url"]
+                                image_url = raw_image_url
                             _part = _process_gemini_media(
                                 image_url=image_url,
                                 format=format,

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -407,11 +407,18 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                                 _parts.append(_part)
                         elif element["type"] == "file":
                             file_element = cast(ChatCompletionFileObject, element)
-                            file_id = file_element["file"].get("file_id")
-                            format = file_element["file"].get("format")
-                            file_data = file_element["file"].get("file_data")
-                            detail = file_element["file"].get("detail")
-                            video_metadata = file_element["file"].get("video_metadata")
+                            _file_field = file_element.get("file")
+                            if _file_field is None:
+                                raise litellm.BadRequestError(
+                                    message="Content block has type='file' but is missing the required 'file' field",
+                                    model=model,
+                                    llm_provider="vertex_ai",
+                                )
+                            file_id = _file_field.get("file_id")
+                            format = _file_field.get("format")
+                            file_data = _file_field.get("file_data")
+                            detail = _file_field.get("detail")
+                            video_metadata = _file_field.get("video_metadata")
                             passed_file = file_id or file_data
                             if passed_file is None:
                                 raise Exception(

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -3139,6 +3139,31 @@ class ModelResponseIterator:
         self.cumulative_tool_call_index: int = 0
         self.has_seen_tool_calls: bool = False
 
+    @staticmethod
+    def _check_streaming_error(chunk: dict) -> None:
+        """Detect embedded errors (e.g. 429 RESOURCE_EXHAUSTED) in streaming chunks and raise VertexAIError."""
+        if "error" not in chunk:
+            return
+        error_data = chunk["error"]
+        if not isinstance(error_data, dict):
+            raise VertexAIError(
+                status_code=500,
+                message=f"Unexpected error format in mid-stream chunk: {error_data}",
+            )
+        raw_code = error_data.get("code", 500)
+        if raw_code is None:
+            raw_code = 500
+        try:
+            error_code = int(raw_code)
+        except (TypeError, ValueError):
+            error_code = 500
+        error_message = error_data.get("message", "Unknown error")
+        error_status = error_data.get("status", "UNKNOWN")
+        raise VertexAIError(
+            status_code=error_code,
+            message=f"{error_status} - {error_message}",
+        )
+
     def _apply_stream_candidates(
         self,
         _candidates: List[Candidates],
@@ -3256,6 +3281,11 @@ class ModelResponseIterator:
     def chunk_parser(self, chunk: dict) -> Optional["ModelResponseStream"]:
         try:
             verbose_logger.debug(f"RAW GEMINI CHUNK: {chunk}")
+
+            # Detect mid-stream error chunks (e.g. 429 RESOURCE_EXHAUSTED).
+            # Vertex AI can return errors as HTTP 200 but with an "error" field in the SSE body.
+            self._check_streaming_error(chunk)
+
             from litellm.types.utils import ModelResponseStream
 
             processed_chunk = GenerateContentResponseBody(**chunk)  # type: ignore

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5720,6 +5720,33 @@ def embedding(  # noqa: PLR0915
                 aembedding=aembedding,
                 headers=headers,
             )
+        elif custom_llm_provider == "dashscope":
+            dashscope_key = (
+                api_key or litellm.api_key or get_secret_str("DASHSCOPE_API_KEY")
+            )
+            if dashscope_key is None:
+                raise ValueError(
+                    "Missing API key for DashScope. Set DASHSCOPE_API_KEY environment variable or pass api_key parameter."
+                )
+            if extra_headers is not None and isinstance(extra_headers, dict):
+                headers = extra_headers
+            else:
+                headers = {}
+            response = base_llm_http_handler.embedding(
+                model=model,
+                input=input,
+                timeout=timeout,
+                custom_llm_provider=custom_llm_provider,
+                logging_obj=logging,
+                api_base=api_base,
+                optional_params=optional_params,
+                litellm_params={},
+                model_response=EmbeddingResponse(),
+                api_key=dashscope_key,
+                client=client,
+                aembedding=aembedding,
+                headers=headers,
+            )
         elif custom_llm_provider == "ovhcloud":
             api_key = api_key or litellm.api_key or get_secret_str("OVHCLOUD_API_KEY")
             api_base = (

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8374,6 +8374,12 @@ class ProviderConfigManager:
             )
 
             return VolcEngineEmbeddingConfig()
+        elif litellm.LlmProviders.DASHSCOPE == provider:
+            from litellm.llms.dashscope.embed.transformation import (
+                DashScopeEmbeddingConfig,
+            )
+
+            return DashScopeEmbeddingConfig()
         elif litellm.LlmProviders.OVHCLOUD == provider:
             return litellm.OVHCloudEmbeddingConfig()
         elif litellm.LlmProviders.SNOWFLAKE == provider:
@@ -8453,6 +8459,12 @@ class ProviderConfigManager:
             return litellm.VoyageRerankConfig()
         elif litellm.LlmProviders.WATSONX == provider:
             return litellm.IBMWatsonXRerankConfig()
+        elif litellm.LlmProviders.DASHSCOPE == provider:
+            from litellm.llms.dashscope.rerank.transformation import (
+                DashScopeRerankConfig,
+            )
+
+            return DashScopeRerankConfig()
         return litellm.CohereRerankConfig()
 
     @staticmethod

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -35176,6 +35176,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,

--- a/tests/test_litellm/llms/dashscope/test_dashscope_embedding_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_embedding_transformation.py
@@ -1,0 +1,141 @@
+"""
+Unit tests for DashScope embedding transformation.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.dashscope.common_utils import DashScopeError
+from litellm.llms.dashscope.embed.transformation import (
+    DEFAULT_API_BASE,
+    DashScopeEmbeddingConfig,
+)
+from litellm.types.utils import EmbeddingResponse
+
+
+def test_validate_environment_and_url():
+    config = DashScopeEmbeddingConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="text-embedding-v4",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="sk-test",
+    )
+    assert headers["Authorization"] == "Bearer sk-test"
+
+    url = config.get_complete_url(
+        api_base=None,
+        api_key="sk-test",
+        model="text-embedding-v4",
+        optional_params={},
+        litellm_params={},
+    )
+    assert url == f"{DEFAULT_API_BASE}/embeddings"
+
+
+def test_transform_embedding_request():
+    config = DashScopeEmbeddingConfig()
+    data = config.transform_embedding_request(
+        model="text-embedding-v4",
+        input=["风急天高猿啸哀"],
+        optional_params={"dimensions": 1024, "encoding_format": "float"},
+        headers={},
+    )
+    assert data == {
+        "model": "text-embedding-v4",
+        "input": ["风急天高猿啸哀"],
+        "dimensions": 1024,
+        "encoding_format": "float",
+    }
+
+
+def test_transform_embedding_response_success():
+    config = DashScopeEmbeddingConfig()
+    payload = {
+        "data": [
+            {"embedding": [0.1, 0.2], "index": 0, "object": "embedding"},
+        ],
+        "model": "text-embedding-v4",
+        "object": "list",
+        "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        "id": "73591b79-xxxx",
+    }
+    raw = httpx.Response(
+        status_code=200,
+        content=json.dumps(payload).encode("utf-8"),
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    result = config.transform_embedding_response(
+        model="text-embedding-v4",
+        raw_response=raw,
+        model_response=EmbeddingResponse(),
+        logging_obj=MagicMock(),
+        api_key="sk-x",
+        request_data={"input": ["a"]},
+        optional_params={},
+        litellm_params={},
+    )
+    assert result.model == "text-embedding-v4"
+    assert len(result.data) == 1
+    assert result.usage.prompt_tokens == 5
+
+
+def test_transform_embedding_request_user_param():
+    config = DashScopeEmbeddingConfig()
+    data = config.transform_embedding_request(
+        model="text-embedding-v4",
+        input=["hello"],
+        optional_params={"user": "user-123"},
+        headers={},
+    )
+    assert data["user"] == "user-123"
+
+
+def test_map_openai_params_drops_unsupported_with_drop_params():
+    config = DashScopeEmbeddingConfig()
+    result = config.map_openai_params(
+        non_default_params={"dimensions": 512, "unknown_param": "value"},
+        optional_params={},
+        model="text-embedding-v4",
+        drop_params=True,
+    )
+    assert result == {"dimensions": 512}
+    assert "unknown_param" not in result
+
+
+def test_transform_embedding_response_error():
+    config = DashScopeEmbeddingConfig()
+    payload = {
+        "error": {
+            "message": "Incorrect API key provided.",
+            "type": "invalid_request_error",
+            "code": "invalid_api_key",
+        }
+    }
+    raw = httpx.Response(
+        status_code=401,
+        content=json.dumps(payload).encode("utf-8"),
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    with pytest.raises(DashScopeError) as exc:
+        config.transform_embedding_response(
+            model="text-embedding-v4",
+            raw_response=raw,
+            model_response=EmbeddingResponse(),
+            logging_obj=MagicMock(),
+            api_key="sk-bad",
+            request_data={"input": ["a"]},
+            optional_params={},
+            litellm_params={},
+        )
+    assert exc.value.status_code == 401
+    assert "Incorrect API key" in exc.value.message

--- a/tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py
@@ -1,0 +1,322 @@
+"""
+Unit tests for DashScope rerank transformation.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.dashscope.common_utils import DashScopeError
+from litellm.llms.dashscope.rerank.transformation import (
+    DEFAULT_RERANK_URL,
+    DashScopeRerankConfig,
+)
+from litellm.types.rerank import RerankResponse
+
+
+class TestDashScopeRerankURL:
+    def setup_method(self):
+        self.config = DashScopeRerankConfig()
+
+    def test_default_url(self):
+        url = self.config.get_complete_url(api_base=None, model="qwen3-rerank")
+        assert url == DEFAULT_RERANK_URL
+
+    def test_explicit_v1_base_appends_reranks(self):
+        url = self.config.get_complete_url(
+            api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            model="qwen3-rerank",
+        )
+        assert url == "https://dashscope.aliyuncs.com/compatible-mode/v1/reranks"
+
+    def test_intl_v1_base_appends_reranks(self):
+        url = self.config.get_complete_url(
+            api_base="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            model="qwen3-rerank",
+        )
+        assert url == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/reranks"
+
+    def test_already_complete_url_passthrough(self):
+        full = "https://dashscope.aliyuncs.com/compatible-api/v1/reranks"
+        assert self.config.get_complete_url(api_base=full, model="qwen3-rerank") == full
+
+    def test_trailing_slash_stripped(self):
+        full = "https://dashscope.aliyuncs.com/compatible-api/v1/reranks/"
+        assert self.config.get_complete_url(
+            api_base=full, model="qwen3-rerank"
+        ) == full.rstrip("/")
+
+    def test_custom_v1_base_appends_reranks(self):
+        url = self.config.get_complete_url(
+            api_base="https://my-proxy.example.com/v1", model="qwen3-rerank"
+        )
+        assert url == "https://my-proxy.example.com/v1/reranks"
+
+
+class TestDashScopeRerankRequest:
+    def setup_method(self):
+        self.config = DashScopeRerankConfig()
+
+    def test_validate_environment_with_explicit_key(self):
+        headers = self.config.validate_environment(
+            headers={}, model="qwen3-rerank", api_key="sk-test"
+        )
+        assert headers["Authorization"] == "Bearer sk-test"
+        assert headers["content-type"] == "application/json"
+
+    def test_validate_environment_missing_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="DASHSCOPE_API_KEY"):
+            self.config.validate_environment(
+                headers={}, model="qwen3-rerank", api_key=None
+            )
+
+    def test_validate_environment_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "env-key")
+        headers = self.config.validate_environment(
+            headers={}, model="qwen3-rerank", api_key=None
+        )
+        assert headers["Authorization"] == "Bearer env-key"
+
+    def test_supported_params(self):
+        assert self.config.get_supported_cohere_rerank_params("qwen3-rerank") == [
+            "query",
+            "documents",
+            "top_n",
+            "return_documents",
+        ]
+
+    def test_map_params_drops_unsupported(self):
+        # qwen3-rerank accepts query/documents/top_n/return_documents.
+        # rank_fields and max_*_per_doc are silently dropped.
+        params = self.config.map_cohere_rerank_params(
+            non_default_params={},
+            model="qwen3-rerank",
+            drop_params=False,
+            query="什么是文本排序模型",
+            documents=["d1", "d2"],
+            top_n=2,
+            rank_fields=["title"],
+            return_documents=True,
+            max_chunks_per_doc=5,
+            max_tokens_per_doc=100,
+        )
+        assert params == {
+            "query": "什么是文本排序模型",
+            "documents": ["d1", "d2"],
+            "top_n": 2,
+            "return_documents": True,
+        }
+
+    def test_transform_request_full(self):
+        body = self.config.transform_rerank_request(
+            model="qwen3-rerank",
+            optional_rerank_params={
+                "query": "如何制作美味的苹果派?",
+                "documents": ["a", "b"],
+                "top_n": 5,
+                "return_documents": True,
+            },
+            headers={},
+        )
+        assert body == {
+            "model": "qwen3-rerank",
+            "query": "如何制作美味的苹果派?",
+            "documents": ["a", "b"],
+            "top_n": 5,
+            "return_documents": True,
+        }
+
+    def test_transform_request_omits_unset_optional(self):
+        body = self.config.transform_rerank_request(
+            model="qwen3-rerank",
+            optional_rerank_params={"query": "q", "documents": ["a"]},
+            headers={},
+        )
+        assert "top_n" not in body
+        assert "return_documents" not in body
+
+    def test_transform_request_requires_query(self):
+        with pytest.raises(ValueError, match="query"):
+            self.config.transform_rerank_request(
+                model="qwen3-rerank",
+                optional_rerank_params={"documents": ["a"]},
+                headers={},
+            )
+
+    def test_transform_request_requires_documents(self):
+        with pytest.raises(ValueError, match="documents"):
+            self.config.transform_rerank_request(
+                model="qwen3-rerank",
+                optional_rerank_params={"query": "q"},
+                headers={},
+            )
+
+
+class TestDashScopeRerankResponse:
+    def setup_method(self):
+        self.config = DashScopeRerankConfig()
+        self.logging = MagicMock()
+
+    def _resp(self, body, status_code=200):
+        return httpx.Response(
+            status_code=status_code, content=json.dumps(body).encode()
+        )
+
+    def test_success_response(self):
+        body = {
+            "object": "list",
+            "results": [
+                {"index": 0, "relevance_score": 0.93},
+                {"index": 2, "relevance_score": 0.34},
+            ],
+            "model": "qwen3-rerank",
+            "id": "85ba5752",
+            "usage": {"total_tokens": 79},
+        }
+        out = self.config.transform_rerank_response(
+            model="qwen3-rerank",
+            raw_response=self._resp(body),
+            model_response=RerankResponse(),
+            logging_obj=self.logging,
+            api_key="sk",
+            request_data={"query": "q"},
+        )
+        assert out.id == "85ba5752"
+        assert out.results == [
+            {"index": 0, "relevance_score": 0.93},
+            {"index": 2, "relevance_score": 0.34},
+        ]
+        assert out.meta == {
+            "billed_units": {"total_tokens": 79},
+            "tokens": {"input_tokens": 79},
+        }
+
+    def test_response_with_return_documents_real_payload(self):
+        # Verbatim sample from a real qwen3-rerank call with return_documents=true.
+        body = {
+            "object": "list",
+            "results": [
+                {
+                    "document": {
+                        "text": "苹果派的制作步骤包括准备面团、切苹果、调制馅料、组装和烘烤。"
+                    },
+                    "index": 1,
+                    "relevance_score": 0.8304247466067356,
+                },
+                {
+                    "document": {
+                        "text": "制作苹果派时，预先煮软苹果可以缩短烘烤时间。"
+                    },
+                    "index": 3,
+                    "relevance_score": 0.7142660211908354,
+                },
+            ],
+            "model": "qwen3-rerank",
+            "id": "e191b077-97c4-9929-b121-c2fbd2c7b0af",
+            "usage": {"total_tokens": 192},
+        }
+        out = self.config.transform_rerank_response(
+            model="qwen3-rerank",
+            raw_response=self._resp(body),
+            model_response=RerankResponse(),
+            logging_obj=self.logging,
+            request_data={"query": "如何制作美味的苹果派?"},
+        )
+        assert out.id == "e191b077-97c4-9929-b121-c2fbd2c7b0af"
+        assert out.results == [
+            {
+                "index": 1,
+                "relevance_score": 0.8304247466067356,
+                "document": {
+                    "text": "苹果派的制作步骤包括准备面团、切苹果、调制馅料、组装和烘烤。"
+                },
+            },
+            {
+                "index": 3,
+                "relevance_score": 0.7142660211908354,
+                "document": {"text": "制作苹果派时，预先煮软苹果可以缩短烘烤时间。"},
+            },
+        ]
+        assert out.meta == {
+            "billed_units": {"total_tokens": 192},
+            "tokens": {"input_tokens": 192},
+        }
+
+    def test_response_string_document_normalized(self):
+        # Defensive path: if a future API revision returns a bare string,
+        # normalize to {"text": ...} so downstream code stays consistent.
+        body = {
+            "results": [{"index": 0, "relevance_score": 0.9, "document": "hello"}],
+            "model": "qwen3-rerank",
+            "usage": {"total_tokens": 5},
+        }
+        out = self.config.transform_rerank_response(
+            model="qwen3-rerank",
+            raw_response=self._resp(body),
+            model_response=RerankResponse(),
+            logging_obj=self.logging,
+        )
+        assert out.results[0]["document"] == {"text": "hello"}
+
+    def test_missing_id_generates_uuid(self):
+        body = {"results": [{"index": 0, "relevance_score": 0.5}], "usage": {}}
+        out = self.config.transform_rerank_response(
+            model="qwen3-rerank",
+            raw_response=self._resp(body),
+            model_response=RerankResponse(),
+            logging_obj=self.logging,
+        )
+        assert out.id is not None and len(out.id) > 0
+
+    def test_error_envelope_raises(self):
+        body = {
+            "code": "InvalidApiKey",
+            "message": "Invalid API-key provided.",
+            "request_id": "fb53",
+        }
+        with pytest.raises(DashScopeError) as exc_info:
+            self.config.transform_rerank_response(
+                model="qwen3-rerank",
+                raw_response=self._resp(body, status_code=401),
+                model_response=RerankResponse(),
+                logging_obj=self.logging,
+            )
+        assert "Invalid API-key provided." in str(exc_info.value)
+
+    def test_non_json_response_raises(self):
+        bad = httpx.Response(status_code=500, content=b"<html>bad gateway</html>")
+        with pytest.raises(DashScopeError):
+            self.config.transform_rerank_response(
+                model="qwen3-rerank",
+                raw_response=bad,
+                model_response=RerankResponse(),
+                logging_obj=self.logging,
+            )
+
+    def test_get_error_class(self):
+        err = self.config.get_error_class(
+            error_message="boom", status_code=500, headers={}
+        )
+        assert isinstance(err, DashScopeError)
+        assert err.status_code == 500
+
+
+class TestProviderConfigManagerDispatch:
+    def test_dashscope_returns_rerank_config(self):
+        import litellm
+        from litellm.utils import ProviderConfigManager
+
+        cfg = ProviderConfigManager.get_provider_rerank_config(
+            model="qwen3-rerank",
+            provider=litellm.LlmProviders.DASHSCOPE,
+            api_base=None,
+            present_version_params=[],
+        )
+        assert isinstance(cfg, DashScopeRerankConfig)

--- a/tests/test_litellm/llms/test_file_content_block.py
+++ b/tests/test_litellm/llms/test_file_content_block.py
@@ -1,0 +1,433 @@
+"""
+Tests for handling malformed or invalid 'file' content blocks (missing or null
+`file` sub-field, HTTP file_id URLs for Google AI Studio).
+
+Regression tests for:
+- litellm/llms/vertex_ai/gemini/transformation.py
+- litellm/llms/gemini/chat/transformation.py
+- litellm/litellm_core_utils/prompt_templates/common_utils.py
+  (migrate_file_to_image_url raises on missing `file`; file-id helpers skip non-OpenAI shapes)
+- litellm/litellm_core_utils/prompt_templates/factory.py (Bedrock + Anthropic)
+- litellm/llms/openai/chat/gpt_transformation.py
+"""
+
+import asyncio
+import copy
+from typing import List, cast
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    get_file_ids_from_messages,
+    migrate_file_to_image_url,
+    update_messages_with_model_file_ids,
+)
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    BedrockConverseMessagesProcessor,
+    anthropic_process_openai_file_message,
+)
+from litellm.llms.gemini.chat.transformation import GoogleAIStudioGeminiConfig
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.llms.vertex_ai.gemini.transformation import (
+    _gemini_convert_messages_with_history,
+)
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionFileObject,
+    OpenAIMessageContentListBlock,
+)
+
+_MALFORMED_MESSAGES_RAW = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hello"},
+            {"type": "file"},  # Missing required "file" sub-field
+        ],
+    }
+]
+
+_WELL_FORMED_MESSAGES_RAW = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "file",
+                "file": {"file_id": "file-abc123", "format": "pdf"},
+            },
+        ],
+    }
+]
+
+MALFORMED_FILE_OBJECT: ChatCompletionFileObject = cast(
+    ChatCompletionFileObject, {"type": "file"}
+)
+
+EXPLICIT_NULL_FILE_OBJECT: ChatCompletionFileObject = cast(
+    ChatCompletionFileObject,
+    {"type": "file", "file": None},
+)
+
+
+def _malformed() -> List[AllMessageValues]:
+    return copy.deepcopy(cast(List[AllMessageValues], _MALFORMED_MESSAGES_RAW))
+
+
+def _well_formed() -> List[AllMessageValues]:
+    return copy.deepcopy(cast(List[AllMessageValues], _WELL_FORMED_MESSAGES_RAW))
+
+
+def _explicit_null_file_in_content() -> List[AllMessageValues]:
+    return copy.deepcopy(
+        cast(
+            List[AllMessageValues],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                        {"type": "file", "file": None},
+                    ],
+                }
+            ],
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# vertex_ai/gemini/transformation.py
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_convert_messages_malformed_file_raises_bad_request():
+    """_gemini_convert_messages_with_history should raise BadRequestError (not KeyError)
+    when a content block has type='file' but no 'file' sub-field."""
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        _gemini_convert_messages_with_history(
+            messages=_malformed(),
+            model="gemini-2.0-flash",
+        )
+
+
+def test_gemini_convert_messages_explicit_null_file_field_raises_bad_request():
+    """Explicit JSON null for `file` must be rejected like a missing `file` key."""
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        _gemini_convert_messages_with_history(
+            messages=_explicit_null_file_in_content(),
+            model="gemini-2.0-flash",
+        )
+
+
+# ---------------------------------------------------------------------------
+# gemini/chat/transformation.py - GoogleAIStudioGeminiConfig
+# ---------------------------------------------------------------------------
+
+
+def test_google_ai_studio_transform_messages_malformed_file_raises_bad_request():
+    """GoogleAIStudioGeminiConfig._transform_messages should raise BadRequestError
+    when a content block has type='file' but no 'file' sub-field."""
+    config = GoogleAIStudioGeminiConfig()
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        config._transform_messages(messages=_malformed(), model="gemini-2.0-flash")
+
+
+def test_google_ai_studio_transform_messages_explicit_null_file_field_raises_bad_request():
+    """Explicit JSON null for `file` must be rejected like a missing `file` key."""
+    config = GoogleAIStudioGeminiConfig()
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        config._transform_messages(
+            messages=_explicit_null_file_in_content(), model="gemini-2.0-flash"
+        )
+
+
+def test_google_ai_studio_transform_messages_http_file_id_converts_to_base64(monkeypatch):
+    """Google AI Studio rejects raw HTTP(S) file URLs; _transform_messages should
+    fetch and replace them with base64 `file_data` before conversion."""
+    # Data URL shape so downstream Gemini media parsing accepts the inlined bytes
+    # (mirrors real `convert_url_to_base64` output from `_process_image_response`).
+    fake_file_data = "data:application/pdf;base64,aGVsbG8="
+
+    def _fake_convert_url_to_base64(url: str) -> str:
+        assert url == "https://example.com/doc.pdf"
+        return fake_file_data
+
+    monkeypatch.setattr(
+        "litellm.llms.gemini.chat.transformation.convert_url_to_base64",
+        _fake_convert_url_to_base64,
+    )
+    messages = cast(
+        List[AllMessageValues],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {
+                        "type": "file",
+                        "file": {
+                            "file_id": "https://example.com/doc.pdf",
+                            "format": "pdf",
+                        },
+                    },
+                ],
+            }
+        ],
+    )
+    config = GoogleAIStudioGeminiConfig()
+    config._transform_messages(messages=messages, model="gemini-2.0-flash")
+    content = messages[0].get("content")
+    assert isinstance(content, list)
+    file_block = next(c for c in content if isinstance(c, dict) and c.get("type") == "file")
+    file_field = file_block.get("file")
+    assert isinstance(file_field, dict)
+    assert file_field.get("file_data") == fake_file_data
+    assert "file_id" not in file_field
+
+
+def test_google_ai_studio_transform_messages_http_file_id_convert_failure_leaves_file_unchanged(
+    monkeypatch,
+):
+    """If convert_url_to_base64 fails, the Studio prep step must not mutate the block
+    (see try/except in GoogleAIStudioGeminiConfig._transform_messages)."""
+    https_id = "https://example.com/missing.pdf"
+
+    def _raise(_url: str) -> str:
+        raise litellm.ImageFetchError("simulated fetch failure")
+
+    monkeypatch.setattr(
+        "litellm.llms.gemini.chat.transformation.convert_url_to_base64",
+        _raise,
+    )
+    messages = cast(
+        List[AllMessageValues],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {
+                        "type": "file",
+                        "file": {
+                            "file_id": https_id,
+                            "format": "application/pdf",
+                        },
+                    },
+                ],
+            }
+        ],
+    )
+    config = GoogleAIStudioGeminiConfig()
+    config._transform_messages(messages=messages, model="gemini-2.0-flash")
+    content = messages[0].get("content")
+    assert isinstance(content, list)
+    file_block = next(c for c in content if isinstance(c, dict) and c.get("type") == "file")
+    file_field = file_block.get("file")
+    assert isinstance(file_field, dict)
+    assert file_field.get("file_id") == https_id
+    assert file_field.get("format") == "application/pdf"
+    assert "file_data" not in file_field
+
+
+# ---------------------------------------------------------------------------
+# common_utils.py - update_messages_with_model_file_ids
+# ---------------------------------------------------------------------------
+
+
+def test_update_messages_with_model_file_ids_malformed_skips_non_openai_file_block():
+    """Non-OpenAI file blocks (e.g. missing nested `file` dict) are skipped so callers
+    relying on LangChain v1 / provider-native shapes are not rejected here."""
+    messages = _malformed()
+    result = update_messages_with_model_file_ids(
+        messages=messages,
+        model_id="some-model",
+        model_file_id_mapping={},
+    )
+    assert result == messages
+    content = result[0].get("content")
+    assert isinstance(content, list)
+    file_block = next(c for c in content if isinstance(c, dict) and c.get("type") == "file")
+    assert "file" not in file_block
+
+
+def test_update_messages_with_model_file_ids_well_formed_updates():
+    """update_messages_with_model_file_ids should update file_id for well-formed blocks."""
+    mapping = {"file-abc123": {"some-model": "provider-file-xyz"}}
+    result = update_messages_with_model_file_ids(
+        messages=_well_formed(),
+        model_id="some-model",
+        model_file_id_mapping=mapping,
+    )
+    content = result[0].get("content")
+    assert isinstance(content, list)
+    file_block = next(c for c in content if c.get("type") == "file")
+    assert file_block.get("file", {}).get("file_id") == "provider-file-xyz"
+
+
+# ---------------------------------------------------------------------------
+# common_utils.py - get_file_ids_from_messages
+# ---------------------------------------------------------------------------
+
+
+def test_get_file_ids_from_messages_malformed_skips_non_openai_file_block():
+    """Blocks with type='file' but no OpenAI `file` sub-dict yield no extracted ids."""
+    assert get_file_ids_from_messages(messages=_malformed()) == []
+
+
+def test_get_file_ids_from_messages_well_formed_returns_ids():
+    """get_file_ids_from_messages should extract file_id from well-formed blocks."""
+    messages: List[AllMessageValues] = cast(
+        List[AllMessageValues],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "file", "file": {"file_id": "file-abc123", "format": "pdf"}},
+                ],
+            }
+        ],
+    )
+    result = get_file_ids_from_messages(messages=messages)
+    assert result == ["file-abc123"]
+
+
+# ---------------------------------------------------------------------------
+# factory.py - BedrockConverseMessagesProcessor (sync + async)
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_process_file_message_malformed_raises_bad_request():
+    """_process_file_message should raise BadRequestError (not KeyError)
+    when the file object is missing the 'file' sub-field."""
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        BedrockConverseMessagesProcessor._process_file_message(MALFORMED_FILE_OBJECT)
+
+
+def test_bedrock_process_file_message_explicit_null_file_field_raises_bad_request():
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        BedrockConverseMessagesProcessor._process_file_message(EXPLICIT_NULL_FILE_OBJECT)
+
+
+def test_bedrock_async_process_file_message_malformed_raises_bad_request():
+    """_async_process_file_message should raise BadRequestError (not KeyError)
+    when the file object is missing the 'file' sub-field."""
+
+    async def _run() -> None:
+        with pytest.raises(
+            litellm.BadRequestError, match="missing the required 'file' field"
+        ):
+            await BedrockConverseMessagesProcessor._async_process_file_message(
+                MALFORMED_FILE_OBJECT
+            )
+
+    asyncio.run(_run())
+
+
+def test_bedrock_async_process_file_message_explicit_null_file_field_raises_bad_request():
+    async def _run() -> None:
+        with pytest.raises(
+            litellm.BadRequestError, match="missing the required 'file' field"
+        ):
+            await BedrockConverseMessagesProcessor._async_process_file_message(
+                EXPLICIT_NULL_FILE_OBJECT
+            )
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# openai/chat/gpt_transformation.py
+# ---------------------------------------------------------------------------
+
+
+def test_openai_apply_common_transform_malformed_file_raises_bad_request():
+    """_apply_common_transform_content_item should raise BadRequestError (not KeyError)
+    when a content block has type='file' but no 'file' sub-field."""
+    config = OpenAIGPTConfig()
+    malformed_block: OpenAIMessageContentListBlock = cast(
+        OpenAIMessageContentListBlock, {"type": "file"}
+    )
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        config._apply_common_transform_content_item(malformed_block)
+
+
+def test_openai_apply_common_transform_explicit_null_file_field_raises_bad_request():
+    config = OpenAIGPTConfig()
+    explicit_null_block: OpenAIMessageContentListBlock = cast(
+        OpenAIMessageContentListBlock,
+        {"type": "file", "file": None},
+    )
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        config._apply_common_transform_content_item(explicit_null_block)
+
+
+def test_openai_apply_common_transform_well_formed_file_does_not_raise():
+    """_apply_common_transform_content_item should not raise for well-formed file blocks."""
+    config = OpenAIGPTConfig()
+    well_formed_block: OpenAIMessageContentListBlock = cast(
+        OpenAIMessageContentListBlock,
+        {"type": "file", "file": {"file_id": "file-abc123"}},
+    )
+    result = config._apply_common_transform_content_item(well_formed_block)
+    assert result.get("type") == "file"
+    file_field = cast(ChatCompletionFileObject, result).get("file", {})
+    assert file_field.get("file_id") == "file-abc123"
+
+
+# ---------------------------------------------------------------------------
+# factory.py - anthropic_process_openai_file_message
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_process_openai_file_message_malformed_raises_bad_request():
+    """anthropic_process_openai_file_message should raise BadRequestError (not KeyError)
+    when the file object is missing the 'file' sub-field."""
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        anthropic_process_openai_file_message(MALFORMED_FILE_OBJECT)
+
+
+def test_anthropic_process_openai_file_message_explicit_null_file_field_raises_bad_request():
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        anthropic_process_openai_file_message(EXPLICIT_NULL_FILE_OBJECT)
+
+
+def test_anthropic_process_openai_file_message_well_formed_file_id_does_not_raise():
+    """anthropic_process_openai_file_message should not raise for a well-formed file_id block."""
+    well_formed: ChatCompletionFileObject = cast(
+        ChatCompletionFileObject,
+        {"type": "file", "file": {"file_id": "file-abc123"}},
+    )
+    result = anthropic_process_openai_file_message(well_formed)
+    assert result.get("type") in ("document", "image", "container_upload")
+
+
+# ---------------------------------------------------------------------------
+# common_utils.py - migrate_file_to_image_url
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_file_to_image_url_malformed_raises_bad_request():
+    """migrate_file_to_image_url should raise BadRequestError (not KeyError)
+    when the file object is missing the 'file' sub-field."""
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        migrate_file_to_image_url(MALFORMED_FILE_OBJECT)
+
+
+def test_migrate_file_to_image_url_explicit_null_file_field_raises_bad_request():
+    with pytest.raises(litellm.BadRequestError, match="missing the required 'file' field"):
+        migrate_file_to_image_url(EXPLICIT_NULL_FILE_OBJECT)
+
+
+def test_migrate_file_to_image_url_well_formed_returns_image_url():
+    """migrate_file_to_image_url should return an image_url block for a well-formed file."""
+    well_formed: ChatCompletionFileObject = cast(
+        ChatCompletionFileObject,
+        {"type": "file", "file": {"file_id": "file-abc123", "format": "png"}},
+    )
+    result = migrate_file_to_image_url(well_formed)
+    assert result.get("type") == "image_url"
+    image_url = result.get("image_url", {})
+    assert isinstance(image_url, dict)
+    assert image_url.get("url") == "file-abc123"

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
@@ -1,0 +1,52 @@
+import pytest
+from typing import List, cast
+
+import litellm
+from litellm.llms.vertex_ai.gemini.transformation import (
+    _gemini_convert_messages_with_history,
+)
+from litellm.types.llms.openai import AllMessageValues
+
+
+def test_missing_image_url_field_raises_bad_request_error():
+    """When element type is 'image_url' but 'image_url' field is missing, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url"}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'image_url' field is missing" in str(exc_info.value)
+
+
+def test_missing_url_inside_image_url_dict_raises_bad_request_error():
+    """When image_url is a dict but 'url' key is absent, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": {"detail": "high"}}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'url' field is missing inside" in str(exc_info.value)
+
+
+def test_explicit_null_image_url_raises_bad_request_error():
+    """When image_url key is present but explicitly null, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": None}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'image_url' field is missing" in str(exc_info.value)
+
+
+def test_empty_dict_image_url_raises_bad_request_error():
+    """When image_url is an empty dict (no url), a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'url' field is missing inside" in str(exc_info.value)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -4290,3 +4290,444 @@ def test_transform_response_does_not_leak_body_on_parse_failure():
     msg = str(exc_info.value)
     assert "secret content" not in msg
     assert "Error converting to valid response block" in msg
+
+
+def test_chunk_parser_raises_on_429_error_chunk():
+    """Test chunk_parser raises VertexAIError on 429 RESOURCE_EXHAUSTED error chunk"""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {
+        "error": {
+            "code": 429,
+            "message": "Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.",
+            "status": "RESOURCE_EXHAUSTED",
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 429
+    assert "RESOURCE_EXHAUSTED" in exc_info.value.message
+    assert "Resource exhausted" in exc_info.value.message
+
+
+def test_chunk_parser_raises_on_500_error_chunk():
+    """Test chunk_parser raises VertexAIError on 500 INTERNAL error chunk"""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {
+        "error": {
+            "code": 500,
+            "message": "Internal error encountered.",
+            "status": "INTERNAL",
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "INTERNAL" in exc_info.value.message
+
+
+def test_chunk_parser_raises_on_error_chunk_with_minimal_fields():
+    """Test chunk_parser handles error chunks with missing optional fields"""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {
+        "error": {
+            "code": 429,
+            "message": "Resource exhausted.",
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 429
+
+
+def test_chunk_parser_normal_chunk_unaffected_by_error_check():
+    """Test that normal streaming chunks still work correctly after error check addition"""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    normal_chunk = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [{"text": "Hello"}],
+                },
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 6,
+        },
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    result = streaming_obj.chunk_parser(normal_chunk)
+    assert result is not None
+    assert len(result.choices) > 0
+    assert result.choices[0].delta.content == "Hello"
+
+
+def test_chunk_parser_raises_on_non_dict_error():
+    """Test chunk_parser raises VertexAIError when chunk['error'] is not a dict"""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {"error": "something went wrong"}
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "Unexpected error format" in exc_info.value.message
+
+
+def test_chunk_parser_raises_on_string_error_code():
+    """Test chunk_parser correctly converts string error code to int"""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    # code field is a string "429" rather than an int
+    error_chunk = {
+        "error": {
+            "code": "429",
+            "message": "Resource exhausted.",
+            "status": "RESOURCE_EXHAUSTED",
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 429
+    assert isinstance(exc_info.value.status_code, int)
+
+
+def test_chunk_parser_error_chunk_explicit_null_code_uses_500():
+    """JSON null for code must not call int(None); status defaults to 500."""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {
+        "error": {
+            "code": None,
+            "message": "Something went wrong.",
+            "status": "UNKNOWN",
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "Something went wrong" in exc_info.value.message
+
+
+def test_chunk_parser_error_chunk_non_numeric_code_defaults_to_500():
+    """Non-numeric code must not become ValueError -> RuntimeError in __next__."""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {
+        "error": {
+            "code": "NOT_A_NUMBER",
+            "message": "Malformed.",
+            "status": "INVALID",
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "Malformed" in exc_info.value.message
+
+
+def test_chunk_parser_error_chunk_empty_dict_defaults_to_500():
+    """Empty error object {} uses default code 500 and default message/status strings."""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {"error": {}}
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "UNKNOWN" in exc_info.value.message
+    assert "Unknown error" in exc_info.value.message
+
+
+def test_chunk_parser_error_chunk_non_dict_int_value():
+    """Non-dict error payloads (e.g. bare JSON number) must raise with status 500, not TypeError."""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {"error": 503}
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "Unexpected error format" in exc_info.value.message
+    assert "503" in exc_info.value.message
+
+
+def test_chunk_parser_error_chunk_non_dict_null_value():
+    """JSON null for error must hit the non-dict branch (same as int/string)."""
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    error_chunk = {"error": None}
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    with pytest.raises(VertexAIError) as exc_info:
+        streaming_obj.chunk_parser(error_chunk)
+
+    assert exc_info.value.status_code == 500
+    assert "Unexpected error format" in exc_info.value.message
+
+
+def test_mid_stream_429_error_raises_during_iteration():
+    """
+    Simulate a full streaming scenario: normal thinking chunks arrive first,
+    then a 429 RESOURCE_EXHAUSTED error chunk arrives mid-stream.
+    Verify that ModelResponseIterator raises VertexAIError during iteration.
+    """
+    import json
+    from unittest.mock import Mock
+
+    from litellm.llms.vertex_ai.common_utils import VertexAIError
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    # Simulate Vertex AI SSE stream: normal chunks followed by a 429 error chunk
+    normal_chunk_1 = json.dumps(
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "role": "model",
+                        "parts": [{"text": "Let me think about this...", "thought": True}],
+                    },
+                    "index": 0,
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15,
+            },
+            "modelVersion": "gemini-3.1-flash-image-preview",
+        }
+    )
+
+    normal_chunk_2 = json.dumps(
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "role": "model",
+                        "parts": [{"text": "I'll generate the image now.", "thought": True}],
+                    },
+                    "index": 0,
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 12,
+                "totalTokenCount": 22,
+            },
+        }
+    )
+
+    error_chunk = json.dumps(
+        {
+            "error": {
+                "code": 429,
+                "message": "Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.",
+                "status": "RESOURCE_EXHAUSTED",
+            }
+        }
+    )
+
+    # Build a mock SSE stream (lines returned by iter_lines)
+    sse_lines = iter([normal_chunk_1, normal_chunk_2, error_chunk])
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=sse_lines,
+        sync_stream=True,
+        logging_obj=logging_obj,
+    )
+
+    # Iterate the stream: first chunks should succeed, then 429 error should be raised
+    results = []
+    with pytest.raises(VertexAIError) as exc_info:
+        for chunk in streaming_obj:
+            if chunk is not None:
+                results.append(chunk)
+
+    # Verify: received normal chunks before the error
+    assert (
+        len(results) >= 1
+    ), "Should have received at least 1 normal chunk before the error"
+
+    # Verify: 429 error is properly raised
+    assert exc_info.value.status_code == 429
+    assert "RESOURCE_EXHAUSTED" in str(exc_info.value.message)


### PR DESCRIPTION
## Summary

Adds pricing for `zai/glm-5.1`, the latest GLM model from Z.AI, accessible via their Anthropic-compatible endpoint (`https://api.z.ai/api/anthropic`).

This model is currently missing from the pricing database, causing cost-tracking tools to report $0 for all token usage.

Only the provider-prefixed key is added, matching the existing `zai/glm-5` pattern (the glm-5 family has no bare keys).

## Pricing

From the official Z.AI pricing page:

| Token type | Price |
|---|---|
| Input | $1.40 / M tokens |
| Output | $4.40 / M tokens |
| Cache creation | $0.00 / M tokens (limited-time free) |
| Cache read | $0.26 / M tokens |

Source: https://docs.z.ai/guides/overview/pricing

## Related entries already in the database

- `zai/glm-5`
- `zai.glm-5`
- `openrouter/z-ai/glm-5`