### PR TITLE
fix(bedrock-converse): drop blank-text fallback for empty thinking blocks

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4976,11 +4976,6 @@ class BedrockConverseMessagesProcessor:
                 else None
             )
             if reasoning_text and not reasoning_text.get("signature"):
-                # Fallback path for non-anthropic models that emit reasoning
-                # without a signature — convert to a plain text block. Skip
-                # whitespace-only text; Bedrock rejects blank ContentBlocks
-                # (e.g. Claude Code replays an empty thinking block when no
-                # extended thinking was produced).
                 reasoning_text_text = reasoning_text["text"]
                 if reasoning_text_text.strip():
                     assistants_part = BedrockContentBlock(text=reasoning_text_text)

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4976,9 +4976,15 @@ class BedrockConverseMessagesProcessor:
                 else None
             )
             if reasoning_text and not reasoning_text.get("signature"):
+                # Fallback path for non-anthropic models that emit reasoning
+                # without a signature — convert to a plain text block. Skip
+                # whitespace-only text; Bedrock rejects blank ContentBlocks
+                # (e.g. Claude Code replays an empty thinking block when no
+                # extended thinking was produced).
                 reasoning_text_text = reasoning_text["text"]
-                assistants_part = BedrockContentBlock(text=reasoning_text_text)
-                assistant_parts.append(assistants_part)
+                if reasoning_text_text.strip():
+                    assistants_part = BedrockContentBlock(text=reasoning_text_text)
+                    assistant_parts.append(assistants_part)
             else:
                 filtered_thinking_blocks.append(block)
         if len(filtered_thinking_blocks) > 0:

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -91,6 +91,81 @@ async def test_anthropic_bedrock_thinking_blocks_with_none_content():
     )
 
 
+def test_bedrock_converse_assistant_with_empty_thinking_block_and_tool_calls():
+    """
+    Regression: Claude Code (with extended thinking enabled) replays prior
+    assistant turns that include an empty thinking block alongside tool_use
+    blocks, e.g.
+
+        content=[
+            {"type": "text", "text": ""},
+            {"type": "thinking", "thinking": "", "signature": ""},
+            {"type": "tool_use", ...},
+        ]
+
+    After the Anthropic→OpenAI adapter, this becomes assistant message with
+    content="" and thinking_blocks=[{thinking:"", signature:""}] plus
+    tool_calls. The Bedrock Converse fallback for unsigned reasoning content
+    was emitting `BedrockContentBlock(text="")`, which Bedrock rejects with:
+
+        "The text field in the ContentBlock object at messages.X.content.0
+         is blank."
+
+    Verify no blank-text ContentBlocks are produced.
+    """
+    messages = [
+        {"role": "user", "content": "tell me about this repo"},
+        {
+            "role": "assistant",
+            "content": "",
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "", "signature": ""},
+            ],
+            "tool_calls": [
+                {
+                    "id": "tooluse_aC8Izm8kl5DqVkgLA4XqcH",
+                    "type": "function",
+                    "function": {"name": "Bash", "arguments": '{"command": "ls"}'},
+                },
+                {
+                    "id": "tooluse_31BEsgAjDwZxsUofwmdVPS",
+                    "type": "function",
+                    "function": {"name": "Bash", "arguments": '{"command": "pwd"}'},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tooluse_aC8Izm8kl5DqVkgLA4XqcH",
+            "content": "file1\nfile2",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tooluse_31BEsgAjDwZxsUofwmdVPS",
+            "content": "/repo",
+        },
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages=messages,
+        model="us.anthropic.claude-opus-4-7",
+        llm_provider="bedrock",
+    )
+
+    assistant_blocks = [m for m in result if m["role"] == "assistant"]
+    assert len(assistant_blocks) == 1
+    for block in assistant_blocks[0]["content"]:
+        if "text" in block:
+            assert block[
+                "text"
+            ].strip(), (
+                f"Bedrock Converse rejects blank-text ContentBlocks; got {block!r}"
+            )
+    # toolUse blocks must still be present
+    tool_use_blocks = [b for b in assistant_blocks[0]["content"] if "toolUse" in b]
+    assert len(tool_use_blocks) == 2
+
+
 def test_convert_to_azure_openai_messages():
     """Test coverting image_url to azure_openai spec"""
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

Resolves LIT-3050

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix
**Before fix:** 

<img width="1018" height="869" alt="image" src="https://github.com/user-attachments/assets/e7ad98c1-e622-4e8a-86b1-9d448f6f0cab" />


**After fix:**

<img width="653" height="691" alt="image" src="https://github.com/user-attachments/assets/e6e963d5-e97c-4f3a-a871-0f0f6d0d40ab" />


## Type

🐛 Bug Fix

## Changes

- `litellm/litellm_core_utils/prompt_templates/factory.py` — in `add_thinking_blocks_to_assistant_content`, skip appending the fallback text block when the reasoning text is empty/whitespace. Mirrors the existing empty-text guards at lines 5200 and 5228 of `_bedrock_converse_messages_pt`.
- `tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py` — add regression test `test_bedrock_converse_assistant_with_empty_thinking_block_and_tool_calls`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small guard change in Bedrock Converse message formatting to avoid emitting invalid empty `ContentBlock` text; behavior only changes for empty/whitespace reasoning text.
> 
> **Overview**
> Prevents the Bedrock Converse prompt adapter from generating `BedrockContentBlock(text="")` when converting unsigned reasoning/thinking content by skipping empty/whitespace-only reasoning text.
> 
> Adds a regression test covering an assistant turn with an empty thinking block plus `tool_calls`, asserting **no blank text blocks** are emitted while `toolUse` blocks remain present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51df273355a8ca041cb3fac97a85494f515217d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->