### PR TITLE
fix(http_handler): preserve upstream error for streaming request bodies

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -485,11 +485,20 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
             if k.lower() not in ("content-encoding", "content-length")
         }
 
+        # Streaming/multipart request bodies (e.g. file uploads) are not
+        # read-back-able — accessing `.content` raises httpx.RequestNotRead,
+        # which would replace the real upstream error with a confusing
+        # "Attempted to access streaming request content" message.
+        try:
+            request_content = original_error.request.content
+        except httpx.RequestNotRead:
+            request_content = b""
+
         masked_request = httpx.Request(
             method=original_error.request.method,
             url=masked_url,
             headers=original_error.request.headers,
-            content=original_error.request.content,
+            content=request_content,
         )
 
         super().__init__(

--- a/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
+++ b/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
@@ -135,6 +135,41 @@ class TestMaskedHTTPStatusError:
         # Content-Encoding must have been stripped from the rebuilt headers.
         assert "content-encoding" not in {k.lower() for k in masked.response.headers}
 
+    def test_handles_streaming_request_body(self):
+        """Multipart/streaming request bodies are not read-back-able; accessing
+        request.content raises httpx.RequestNotRead. MaskedHTTPStatusError must
+        not surface this as the user-facing error — it should fall back to an
+        empty body so the original upstream error is preserved.
+        """
+
+        def _gen():
+            yield b"chunk"
+
+        # Build a streaming request so .content raises RequestNotRead.
+        streaming_request = httpx.Request(
+            "POST",
+            "https://api.example.com/v1/images/edits?key=SECRET",
+            content=_gen(),
+        )
+        response = httpx.Response(
+            status_code=400,
+            content=b'{"error": "bad request"}',
+            request=streaming_request,
+        )
+        orig = httpx.HTTPStatusError(
+            "400 Bad Request", request=streaming_request, response=response
+        )
+
+        # Sanity check: confirm the streaming body really does raise on .content.
+        with pytest.raises(httpx.RequestNotRead):
+            _ = streaming_request.content
+
+        masked = MaskedHTTPStatusError(orig)
+
+        assert masked.status_code == 400
+        assert masked.response.content == b'{"error": "bad request"}'
+        assert "SECRET" not in str(masked.request.url)
+
 
 class TestSafeResponseHelpers:
     def test_safe_get_response_text_normal(self):


### PR DESCRIPTION
## Summary

Pipeline [#77387](https://app.circleci.com/pipelines/github/BerriAI/litellm/77387/workflows/7d02784e-92e7-4709-a6a5-ec0336e8b55c) failed mostly because the test OpenAI account has run out of quota (429 `insufficient_quota`) — that is an environment issue, not a code regression. While triaging the logs I found one real code bug that this PR fixes.

## The bug

In `image_gen_testing`, every OpenAI image-edit test failed with the same misleading error:

```
litellm.InternalServerError: OpenAIException - Attempted to access streaming
request content, without having called `read()`.
```

That is **not** the upstream error. OpenAI actually returned `400 Bad Request`, but our error-masking layer crashed while trying to rebuild the request:

```
File "litellm/llms/custom_httpx/http_handler.py", line 637, in post
    response.raise_for_status()
httpx.HTTPStatusError: Client error 400 Bad Request for url .../v1/images/edits

During handling of the above exception, another exception occurred:
...
httpx.RequestNotRead: Attempted to access streaming request content,
without having called `read()`.
```

The culprit is `MaskedHTTPStatusError.__init__`:

```python
masked_request = httpx.Request(
    method=original_error.request.method,
    url=masked_url,
    headers=original_error.request.headers,
    content=original_error.request.content,   # <-- raises for multipart/streaming bodies
)
```

For multipart file uploads (image edits, audio transcription, batch file uploads, etc.) the request body is a generator, so `httpx` raises `RequestNotRead` when you try to access `.content`. That new exception replaces the real upstream error and propagates all the way up, breaking exception mapping for every multipart endpoint.

## The fix

Wrap the access in a `try/except httpx.RequestNotRead` and fall back to `b""`, mirroring how `original_error.response.content` is already guarded a few lines above. The masked request only needs the URL/method/headers — the body is not used for anything user-visible. With this fix, the true upstream error (e.g. the 400 with its real message) surfaces instead.

## Test plan

- [x] New regression test `test_handles_streaming_request_body` in `tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py` builds a real streaming `httpx.Request`, confirms `.content` does raise `RequestNotRead`, then asserts `MaskedHTTPStatusError` constructs successfully and preserves the status code, response body, and URL masking.
- [x] Verified the new test fails without the fix and passes with it.
- [x] All 28 tests in the existing `test_credential_leak_prevention.py` still pass.

## Other CI failures (not addressed here)

The remaining failures across `llm_translation`, `local_testing_part1/2`, `logging`, `langfuse_logging`, `realtime_translation`, `e2e_openai_endpoints`, etc. are all `insufficient_quota` 429s from the shared OpenAI test key. One smaller test bug also exists in `tests/llm_translation/test_gpt4o_audio.py::test_audio_output_from_model` (the `except Exception` branch doesnt re-raise, so a hidden `UnboundLocalError` surfaces instead of the underlying API error) but its only test-side and out of scope for this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP error-wrapping logic used across providers; behavior only changes on error paths for streaming/multipart requests, but could affect how exceptions are surfaced and logged.
> 
> **Overview**
> Prevents `MaskedHTTPStatusError` from raising `httpx.RequestNotRead` when the original request body is streaming (e.g. multipart file uploads) by falling back to an empty request body while rebuilding the masked request.
> 
> Adds a regression test ensuring streaming request errors still preserve the upstream `status_code`/response body and continue to mask secrets in the request URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f34d1947b5b1d2eca581db46627e52ebe3a6f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->