### PR TITLE
fix(cost): align vertex_ai/gemini-embedding-2 GA source URL (followup #27848)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15576,7 +15576,7 @@
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supports_multimodal": true,
         "uses_embed_content": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15581,7 +15581,7 @@
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supports_multimodal": true,
         "uses_embed_content": true
     },


### PR DESCRIPTION
Address Greptile P2 concern on #27848: GA `vertex_ai/gemini-embedding-2` source URL still pointed to `ai.google.dev` while the preview entry was updated to the Vertex AI pricing page. Both share identical pricing values; sync source URL for consistency.

https://claude.ai/code/session_01W8jRwstnmduadGw8Z8egxe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: updates the `source` URL for `vertex_ai/gemini-embedding-2` pricing without altering any costs or limits.
> 
> **Overview**
> Updates the `source` link for the `vertex_ai/gemini-embedding-2` embedding model in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, pointing from the Gemini embeddings doc to the Vertex AI pricing page for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e5e6cd5a9398abd1bee4c21ac2de2f6ef06c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->