### PR TITLE
Fix/access group models v1 models

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -241,11 +241,9 @@ async def resolve_team_db_access_group_models(
             )
         except Exception as e:
             verbose_proxy_logger.debug(
-                "resolve_team_db_access_group_models: failed to fetch team "
-                "object for team_id=%s, skipping access-group resolution. "
-                "Error: %s",
+                "access-group resolution: get_team_object failed for team_id=%s: %s",
                 user_api_key_dict.team_id,
-                str(e),
+                e,
             )
             team_object = None
 
@@ -257,11 +255,9 @@ async def resolve_team_db_access_group_models(
             )
         except Exception as e:
             verbose_proxy_logger.debug(
-                "resolve_team_db_access_group_models: access-group resolution "
-                "failed for team_id=%s, returning team.models[] only. "
-                "Error: %s",
+                "access-group resolution: find_many failed for team_id=%s: %s",
                 getattr(team_object, "team_id", None),
-                str(e),
+                e,
             )
             access_group_model_names = []
         for model_name in access_group_model_names:

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
-from typing import Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -9,6 +9,10 @@ from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
 from litellm.types.router import LiteLLM_Params
 from litellm.utils import get_valid_models
+
+if TYPE_CHECKING:
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+    from litellm.proxy.utils import PrismaClient, ProxyLogging
 
 
 def _check_wildcard_routing(model: str) -> bool:
@@ -165,6 +169,172 @@ def get_team_models(
 
     verbose_proxy_logger.debug("ALL TEAM MODELS - {}".format(len(all_models)))
     return all_models
+
+
+async def _resolve_team_access_group_model_names(
+    team_objects: List[Any],
+    prisma_client: "PrismaClient",
+) -> List[str]:
+    """
+    Resolve model names reachable via ``team.access_group_ids[]`` against the
+    DB-backed ``LiteLLM_AccessGroupTable``.
+
+    Sibling of ``_add_access_group_models_to_team_models`` in ``proxy_server.py``:
+    the admin helper returns deployment ids (for ``/team/info`` / ``/v2/team/list``),
+    while this helper returns model names (for the OpenAI-compatible
+    ``/v1/models`` path).
+
+    Skip rules mirror the admin helper:
+    - teams with no ``access_group_ids`` contribute nothing.
+    - teams whose ``models`` is empty or contains ``all-proxy-models`` already
+      see every model on the proxy; access-group resolution is skipped to avoid
+      double-counting.
+
+    Returns deduped model names in encounter order. The
+    ``no-default-models`` sentinel is never emitted (callers are still
+    responsible for stripping it from any caller-supplied list — see the
+    sentinel filter in ``resolve_team_db_access_group_models``).
+    """
+    eligible_teams: List[Any] = []
+    all_access_group_ids: set = set()
+    for team in team_objects:
+        if not getattr(team, "access_group_ids", None):
+            continue
+        team_models_raw = getattr(team, "models", None) or []
+        if (
+            not team_models_raw
+            or SpecialModelNames.all_proxy_models.value in team_models_raw
+        ):
+            continue
+        eligible_teams.append(team)
+        all_access_group_ids.update(team.access_group_ids)
+
+    if not eligible_teams:
+        return []
+
+    access_group_rows = await prisma_client.db.litellm_accessgrouptable.find_many(
+        where={"access_group_id": {"in": list(all_access_group_ids)}}
+    )
+    ag_to_model_names: Dict[str, List[str]] = {
+        row.access_group_id: row.access_model_names or [] for row in access_group_rows
+    }
+
+    seen: set = set()
+    resolved: List[str] = []
+    for team in eligible_teams:
+        for ag_id in team.access_group_ids or []:
+            for model_name in ag_to_model_names.get(ag_id, []):
+                if model_name in seen:
+                    continue
+                seen.add(model_name)
+                resolved.append(model_name)
+    return resolved
+
+
+async def resolve_team_db_access_group_models(
+    *,
+    team_models: List[str],
+    key_models: List[str],
+    pre_loaded_team_object: Optional[Any],
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: Optional["PrismaClient"],
+    user_api_key_cache: Optional["UserApiKeyCache"],
+    proxy_logging_obj: Optional["ProxyLogging"],
+) -> Tuple[List[str], bool]:
+    """
+    Expand ``team_models`` with DB-backed access-group resolution and apply
+    the ``no-default-models`` sentinel rules. Returns
+    ``(resolved_team_models, force_empty_response)``.
+
+    Lives next to ``get_team_models`` because "what models can this team
+    see, including DB-backed access groups" is the same conceptual class
+    of authorization logic. The legacy ``get_team_models`` handles
+    in-config access groups (via ``router.get_model_access_groups()``);
+    this sibling handles the DB-backed Unified Access Groups stored in
+    ``LiteLLM_AccessGroupTable``.
+
+    Responsibilities (kept here so the ``/v1/models`` call site in
+    ``get_available_models_for_user`` stays small):
+
+    1. Best-effort load of the team object on the fallback path — when
+       the caller didn't pass an explicit ``team_id`` kwarg but the
+       authenticated key has a ``team_id``, look the team up via
+       ``get_team_object`` (cache-aware). Transient DB errors are logged
+       and treated as "no team object".
+    2. Resolve every model name reachable via ``team.access_group_ids[]``
+       and merge the result into ``team_models``. Resolver failures are
+       logged and treated as "no access-group contribution" so a Prisma
+       hiccup never 500s ``/v1/models``.
+    3. Snapshot whether the ``no-default-models`` sentinel was present,
+       then strip it. If the sentinel was the only thing the team had
+       and neither the key nor access-group resolution contributed any
+       real models, signal ``force_empty_response=True`` so the caller
+       returns an empty list directly — otherwise
+       ``get_complete_model_list`` would interpret the empty
+       ``team_models`` as "no preference" and silently fall back to the
+       full ``proxy_model_list`` (privilege escalation).
+    """
+    # Function-local import to mirror the pattern in
+    # ``get_available_models_for_user``: ``model_checks.py`` is a light
+    # utility module today, and pulling ``auth_checks`` (which
+    # transitively imports ``proxy/utils.py``) at module level would
+    # bloat the import surface for every legacy caller of
+    # ``get_team_models``.
+    from litellm.proxy.auth.auth_checks import get_team_object
+
+    team_object = pre_loaded_team_object
+
+    if (
+        team_object is None
+        and user_api_key_dict.team_id
+        and prisma_client is not None
+        and user_api_key_cache is not None
+        and proxy_logging_obj is not None
+    ):
+        try:
+            team_object = await get_team_object(
+                team_id=user_api_key_dict.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "resolve_team_db_access_group_models: failed to fetch team "
+                "object for team_id=%s, skipping access-group resolution. "
+                "Error: %s",
+                user_api_key_dict.team_id,
+                str(e),
+            )
+            team_object = None
+
+    if team_object is not None and prisma_client is not None:
+        try:
+            access_group_model_names = await _resolve_team_access_group_model_names(
+                team_objects=[team_object],
+                prisma_client=prisma_client,
+            )
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "resolve_team_db_access_group_models: access-group resolution "
+                "failed for team_id=%s, returning team.models[] only. "
+                "Error: %s",
+                getattr(team_object, "team_id", None),
+                str(e),
+            )
+            access_group_model_names = []
+        for model_name in access_group_model_names:
+            if model_name not in team_models:
+                team_models.append(model_name)
+
+    sentinel_value = SpecialModelNames.no_default_models.value
+    had_no_default_models_sentinel = sentinel_value in team_models
+    team_models = [m for m in team_models if m != sentinel_value]
+
+    force_empty_response = (
+        had_no_default_models_sentinel and not team_models and not key_models
+    )
+    return team_models, force_empty_response
 
 
 def get_complete_model_list(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -11,8 +11,7 @@ from litellm.types.router import LiteLLM_Params
 from litellm.utils import get_valid_models
 
 if TYPE_CHECKING:
-    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
-    from litellm.proxy.utils import PrismaClient, ProxyLogging
+    from litellm.proxy.utils import PrismaClient
 
 
 def _check_wildcard_routing(model: str) -> bool:
@@ -141,13 +140,23 @@ def get_team_models(
     proxy_model_list: List[str],
     model_access_groups: Dict[str, List[str]],
     include_model_access_groups: Optional[bool] = False,
+    team_access_group_ids: Optional[List[str]] = None,
 ) -> List[str]:
     """
     Returns:
     - List of model name strings
     - Empty list if no models set
     - If model_access_groups is provided, only return models that are in the access groups
+    - If team_access_group_ids is provided, IDs found in model_access_groups are
+      injected into team_models so the existing access-group expansion picks them up.
     """
+    if team_access_group_ids:
+        team_models = list(team_models) + [
+            ag_id
+            for ag_id in team_access_group_ids
+            if ag_id in model_access_groups and ag_id not in team_models
+        ]
+
     all_models_set: Set[str] = set()
     if len(team_models) > 0:
         all_models_set.update(team_models)
@@ -171,12 +180,11 @@ def get_team_models(
     return all_models
 
 
-async def _resolve_team_access_group_model_names(
+async def _resolve_team_access_group_model_names_by_id(
     team_objects: List[Any],
     prisma_client: "PrismaClient",
-) -> List[str]:
-    eligible_teams: List[Any] = []
-    all_access_group_ids: set = set()
+) -> Dict[str, List[str]]:
+    eligible_ids: Set[str] = set()
     for team in team_objects:
         if not getattr(team, "access_group_ids", None):
             continue
@@ -186,92 +194,15 @@ async def _resolve_team_access_group_model_names(
             or SpecialModelNames.all_proxy_models.value in team_models_raw
         ):
             continue
-        eligible_teams.append(team)
-        all_access_group_ids.update(team.access_group_ids)
+        eligible_ids.update(team.access_group_ids)
 
-    if not eligible_teams:
-        return []
+    if not eligible_ids:
+        return {}
 
-    access_group_rows = await prisma_client.db.litellm_accessgrouptable.find_many(
-        where={"access_group_id": {"in": list(all_access_group_ids)}}
+    rows = await prisma_client.db.litellm_accessgrouptable.find_many(
+        where={"access_group_id": {"in": list(eligible_ids)}}
     )
-    ag_to_model_names: Dict[str, List[str]] = {
-        row.access_group_id: row.access_model_names or [] for row in access_group_rows
-    }
-
-    seen: set = set()
-    resolved: List[str] = []
-    for team in eligible_teams:
-        for ag_id in team.access_group_ids or []:
-            for model_name in ag_to_model_names.get(ag_id, []):
-                if model_name in seen:
-                    continue
-                seen.add(model_name)
-                resolved.append(model_name)
-    return resolved
-
-
-async def resolve_team_db_access_group_models(
-    *,
-    team_models: List[str],
-    key_models: List[str],
-    pre_loaded_team_object: Optional[Any],
-    user_api_key_dict: UserAPIKeyAuth,
-    prisma_client: Optional["PrismaClient"],
-    user_api_key_cache: Optional["UserApiKeyCache"],
-    proxy_logging_obj: Optional["ProxyLogging"],
-) -> Tuple[List[str], bool]:
-    from litellm.proxy.auth.auth_checks import get_team_object
-
-    team_object = pre_loaded_team_object
-
-    if (
-        team_object is None
-        and user_api_key_dict.team_id
-        and prisma_client is not None
-        and user_api_key_cache is not None
-        and proxy_logging_obj is not None
-    ):
-        try:
-            team_object = await get_team_object(
-                team_id=user_api_key_dict.team_id,
-                prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
-                proxy_logging_obj=proxy_logging_obj,
-            )
-        except Exception as e:
-            verbose_proxy_logger.debug(
-                "access-group resolution: get_team_object failed for team_id=%s: %s",
-                user_api_key_dict.team_id,
-                e,
-            )
-            team_object = None
-
-    if team_object is not None and prisma_client is not None:
-        try:
-            access_group_model_names = await _resolve_team_access_group_model_names(
-                team_objects=[team_object],
-                prisma_client=prisma_client,
-            )
-        except Exception as e:
-            verbose_proxy_logger.debug(
-                "access-group resolution: find_many failed for team_id=%s: %s",
-                getattr(team_object, "team_id", None),
-                e,
-            )
-            access_group_model_names = []
-        for model_name in access_group_model_names:
-            if model_name not in team_models:
-                team_models.append(model_name)
-
-    sentinel_value = SpecialModelNames.no_default_models.value
-    had_no_default_models_sentinel = sentinel_value in team_models
-    team_models = [m for m in team_models if m != sentinel_value]
-
-    force_empty_response = (
-        had_no_default_models_sentinel and not team_models and not key_models
-    )
-    return team_models, force_empty_response
+    return {row.access_group_id: row.access_model_names or [] for row in rows}
 
 
 def get_complete_model_list(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -175,12 +175,6 @@ async def _resolve_team_access_group_model_names(
     team_objects: List[Any],
     prisma_client: "PrismaClient",
 ) -> List[str]:
-    """
-    Resolve model names reachable via ``team.access_group_ids[]`` against
-    ``LiteLLM_AccessGroupTable``. Skips teams with no access groups or whose
-    ``models`` is empty / contains ``all-proxy-models``. Returns deduped
-    names in encounter order; sentinel stripping is the caller's job.
-    """
     eligible_teams: List[Any] = []
     all_access_group_ids: set = set()
     for team in team_objects:
@@ -227,18 +221,6 @@ async def resolve_team_db_access_group_models(
     user_api_key_cache: Optional["UserApiKeyCache"],
     proxy_logging_obj: Optional["ProxyLogging"],
 ) -> Tuple[List[str], bool]:
-    """
-    DB-backed Unified Access Group resolver for ``/v1/models``. Sibling of
-    ``get_team_models``: best-effort loads the team object on the fallback
-    path, merges access-group model names into ``team_models``, then strips
-    the ``no-default-models`` sentinel. Returns
-    ``(resolved_team_models, force_empty_response)`` — ``force_empty`` is
-    True when the sentinel was the only signal and nothing real was
-    contributed, guarding against ``get_complete_model_list`` falling back
-    to the full ``proxy_model_list``.
-    """
-    # Function-local to keep ``model_checks.py``'s import surface narrow;
-    # ``auth_checks`` transitively pulls in ``proxy/utils.py``.
     from litellm.proxy.auth.auth_checks import get_team_object
 
     team_object = pre_loaded_team_object

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -176,24 +176,10 @@ async def _resolve_team_access_group_model_names(
     prisma_client: "PrismaClient",
 ) -> List[str]:
     """
-    Resolve model names reachable via ``team.access_group_ids[]`` against the
-    DB-backed ``LiteLLM_AccessGroupTable``.
-
-    Sibling of ``_add_access_group_models_to_team_models`` in ``proxy_server.py``:
-    the admin helper returns deployment ids (for ``/team/info`` / ``/v2/team/list``),
-    while this helper returns model names (for the OpenAI-compatible
-    ``/v1/models`` path).
-
-    Skip rules mirror the admin helper:
-    - teams with no ``access_group_ids`` contribute nothing.
-    - teams whose ``models`` is empty or contains ``all-proxy-models`` already
-      see every model on the proxy; access-group resolution is skipped to avoid
-      double-counting.
-
-    Returns deduped model names in encounter order. The
-    ``no-default-models`` sentinel is never emitted (callers are still
-    responsible for stripping it from any caller-supplied list — see the
-    sentinel filter in ``resolve_team_db_access_group_models``).
+    Resolve model names reachable via ``team.access_group_ids[]`` against
+    ``LiteLLM_AccessGroupTable``. Skips teams with no access groups or whose
+    ``models`` is empty / contains ``all-proxy-models``. Returns deduped
+    names in encounter order; sentinel stripping is the caller's job.
     """
     eligible_teams: List[Any] = []
     all_access_group_ids: set = set()
@@ -242,44 +228,17 @@ async def resolve_team_db_access_group_models(
     proxy_logging_obj: Optional["ProxyLogging"],
 ) -> Tuple[List[str], bool]:
     """
-    Expand ``team_models`` with DB-backed access-group resolution and apply
-    the ``no-default-models`` sentinel rules. Returns
-    ``(resolved_team_models, force_empty_response)``.
-
-    Lives next to ``get_team_models`` because "what models can this team
-    see, including DB-backed access groups" is the same conceptual class
-    of authorization logic. The legacy ``get_team_models`` handles
-    in-config access groups (via ``router.get_model_access_groups()``);
-    this sibling handles the DB-backed Unified Access Groups stored in
-    ``LiteLLM_AccessGroupTable``.
-
-    Responsibilities (kept here so the ``/v1/models`` call site in
-    ``get_available_models_for_user`` stays small):
-
-    1. Best-effort load of the team object on the fallback path — when
-       the caller didn't pass an explicit ``team_id`` kwarg but the
-       authenticated key has a ``team_id``, look the team up via
-       ``get_team_object`` (cache-aware). Transient DB errors are logged
-       and treated as "no team object".
-    2. Resolve every model name reachable via ``team.access_group_ids[]``
-       and merge the result into ``team_models``. Resolver failures are
-       logged and treated as "no access-group contribution" so a Prisma
-       hiccup never 500s ``/v1/models``.
-    3. Snapshot whether the ``no-default-models`` sentinel was present,
-       then strip it. If the sentinel was the only thing the team had
-       and neither the key nor access-group resolution contributed any
-       real models, signal ``force_empty_response=True`` so the caller
-       returns an empty list directly — otherwise
-       ``get_complete_model_list`` would interpret the empty
-       ``team_models`` as "no preference" and silently fall back to the
-       full ``proxy_model_list`` (privilege escalation).
+    DB-backed Unified Access Group resolver for ``/v1/models``. Sibling of
+    ``get_team_models``: best-effort loads the team object on the fallback
+    path, merges access-group model names into ``team_models``, then strips
+    the ``no-default-models`` sentinel. Returns
+    ``(resolved_team_models, force_empty_response)`` — ``force_empty`` is
+    True when the sentinel was the only signal and nothing real was
+    contributed, guarding against ``get_complete_model_list`` falling back
+    to the full ``proxy_model_list``.
     """
-    # Function-local import to mirror the pattern in
-    # ``get_available_models_for_user``: ``model_checks.py`` is a light
-    # utility module today, and pulling ``auth_checks`` (which
-    # transitively imports ``proxy/utils.py``) at module level would
-    # bloat the import surface for every legacy caller of
-    # ``get_team_models``.
+    # Function-local to keep ``model_checks.py``'s import surface narrow;
+    # ``auth_checks`` transitively pulls in ``proxy/utils.py``.
     from litellm.proxy.auth.auth_checks import get_team_object
 
     team_object = pre_loaded_team_object

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -99,6 +99,7 @@ from litellm.proxy._types import (
     CallInfo,
     LiteLLM_VerificationTokenView,
     Member,
+    SpecialModelNames,
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.route_checks import RouteChecks
@@ -5843,10 +5844,10 @@ async def get_available_models_for_user(
     """
     from litellm.proxy.auth.auth_checks import get_team_object
     from litellm.proxy.auth.model_checks import (
+        _resolve_team_access_group_model_names_by_id,
         get_complete_model_list,
         get_key_models,
         get_team_models,
-        resolve_team_db_access_group_models,
     )
     from litellm.proxy.management_endpoints.team_endpoints import validate_membership
 
@@ -5883,24 +5884,59 @@ async def get_available_models_for_user(
             user_api_key_dict=user_api_key_dict, team_table=team_object
         )
         team_models = team_object.models
+    elif (
+        user_api_key_dict.team_id
+        and prisma_client is not None
+        and user_api_key_cache is not None
+        and proxy_logging_obj is not None
+    ):
+        try:
+            team_object = await get_team_object(
+                team_id=user_api_key_dict.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "access-group resolution: get_team_object failed for team_id=%s: %s",
+                user_api_key_dict.team_id,
+                e,
+            )
+            team_object = None
+
+    # Merge DB-backed access groups so get_team_models can expand team.access_group_ids
+    if team_object is not None and prisma_client is not None:
+        try:
+            db_access_groups = await _resolve_team_access_group_model_names_by_id(
+                team_objects=[team_object],
+                prisma_client=prisma_client,
+            )
+            for ag_id, model_names in db_access_groups.items():
+                if ag_id not in model_access_groups:
+                    model_access_groups[ag_id] = model_names
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "access-group resolution: find_many failed for team_id=%s: %s",
+                getattr(team_object, "team_id", None),
+                e,
+            )
+
+    sentinel = SpecialModelNames.no_default_models.value
+    had_sentinel = sentinel in team_models
 
     team_models = get_team_models(
         team_models=team_models,
         proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,
         include_model_access_groups=include_model_access_groups,
+        team_access_group_ids=(
+            team_object.access_group_ids if team_object is not None else None
+        ),
     )
 
-    team_models, force_empty = await resolve_team_db_access_group_models(
-        team_models=team_models,
-        key_models=key_models,
-        pre_loaded_team_object=team_object,
-        user_api_key_dict=user_api_key_dict,
-        prisma_client=prisma_client,
-        user_api_key_cache=user_api_key_cache,
-        proxy_logging_obj=proxy_logging_obj,
-    )
-    if force_empty:
+    team_models = [m for m in team_models if m != sentinel]
+    if had_sentinel and not team_models and not key_models:
         return []
 
     # Get complete model list

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5891,13 +5891,9 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
     )
 
-    # Expand team_models with DB-backed Unified Access Group resolution and
-    # apply the ``no-default-models`` sentinel rules. See
-    # ``resolve_team_db_access_group_models`` in ``proxy/auth/model_checks.py``
-    # for the full contract: it loads the team object on the fallback path,
-    # tolerates transient Prisma errors, strips the sentinel, and signals
-    # ``force_empty`` when a sentinel-only team didn't pick up any real
-    # models (privilege-escalation guard for ``get_complete_model_list``).
+    # DB-backed Unified Access Groups + ``no-default-models`` sentinel
+    # handling. ``force_empty`` guards against ``get_complete_model_list``
+    # widening access when a sentinel-only team has no resolved models.
     team_models, force_empty = await resolve_team_db_access_group_models(
         team_models=team_models,
         key_models=key_models,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -99,7 +99,6 @@ from litellm.proxy._types import (
     CallInfo,
     LiteLLM_VerificationTokenView,
     Member,
-    SpecialModelNames,
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.route_checks import RouteChecks
@@ -5811,66 +5810,6 @@ def construct_database_url_from_env_vars() -> Optional[str]:
     return None
 
 
-async def _resolve_team_access_group_model_names(
-    team_objects: List[Any],
-    prisma_client: "PrismaClient",
-) -> List[str]:
-    """
-    Resolve model names reachable via ``team.access_group_ids[]`` against the
-    DB-backed ``LiteLLM_AccessGroupTable``.
-
-    Sibling of ``_add_access_group_models_to_team_models`` in ``proxy_server.py``:
-    the admin helper returns deployment ids (for ``/team/info`` / ``/v2/team/list``),
-    while this helper returns model names (for the OpenAI-compatible
-    ``/v1/models`` path).
-
-    Skip rules mirror the admin helper:
-    - teams with no ``access_group_ids`` contribute nothing.
-    - teams whose ``models`` is empty or contains ``all-proxy-models`` already
-      see every model on the proxy; access-group resolution is skipped to avoid
-      double-counting.
-
-    Returns deduped model names in encounter order. The
-    ``no-default-models`` sentinel is never emitted (callers are still
-    responsible for stripping it from any caller-supplied list — see the
-    sentinel filter in ``get_available_models_for_user``).
-    """
-    eligible_teams: List[Any] = []
-    all_access_group_ids: set = set()
-    for team in team_objects:
-        if not getattr(team, "access_group_ids", None):
-            continue
-        team_models_raw = getattr(team, "models", None) or []
-        if (
-            not team_models_raw
-            or SpecialModelNames.all_proxy_models.value in team_models_raw
-        ):
-            continue
-        eligible_teams.append(team)
-        all_access_group_ids.update(team.access_group_ids)
-
-    if not eligible_teams:
-        return []
-
-    access_group_rows = await prisma_client.db.litellm_accessgrouptable.find_many(
-        where={"access_group_id": {"in": list(all_access_group_ids)}}
-    )
-    ag_to_model_names: Dict[str, List[str]] = {
-        row.access_group_id: row.access_model_names or [] for row in access_group_rows
-    }
-
-    seen: set = set()
-    resolved: List[str] = []
-    for team in eligible_teams:
-        for ag_id in team.access_group_ids or []:
-            for model_name in ag_to_model_names.get(ag_id, []):
-                if model_name in seen:
-                    continue
-                seen.add(model_name)
-                resolved.append(model_name)
-    return resolved
-
-
 async def get_available_models_for_user(
     user_api_key_dict: "UserAPIKeyAuth",
     llm_router: Optional["Router"],
@@ -5907,6 +5846,7 @@ async def get_available_models_for_user(
         get_complete_model_list,
         get_key_models,
         get_team_models,
+        resolve_team_db_access_group_models,
     )
     from litellm.proxy.management_endpoints.team_endpoints import validate_membership
 
@@ -5951,78 +5891,23 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
     )
 
-    # Resolve models reachable via team.access_group_ids[] (DB-backed Unified
-    # Access Groups). Without this, a team configured as
-    # ``models=["no-default-models"]`` plus one or more access groups returns
-    # only the sentinel from /v1/models, even though the access groups grant
-    # real models. Mirrors _add_access_group_models_to_team_models, but emits
-    # model names instead of deployment ids (which is what /v1/models needs).
-    if (
-        team_object is None
-        and user_api_key_dict.team_id
-        and prisma_client is not None
-        and user_api_key_cache is not None
-        and proxy_logging_obj is not None
-    ):
-        try:
-            team_object = await get_team_object(
-                team_id=user_api_key_dict.team_id,
-                prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
-                proxy_logging_obj=proxy_logging_obj,
-            )
-        except Exception as e:
-            # Resolution is best-effort: a DB hiccup here must never take
-            # down /v1/models. Log so operators can diagnose unexpected
-            # skips (otherwise this silently degrades to the pre-fix
-            # behavior).
-            verbose_proxy_logger.debug(
-                "get_available_models_for_user: failed to fetch team object "
-                "for team_id=%s, skipping access-group resolution. Error: %s",
-                user_api_key_dict.team_id,
-                str(e),
-            )
-            team_object = None
-
-    if team_object is not None and prisma_client is not None:
-        try:
-            access_group_model_names = await _resolve_team_access_group_model_names(
-                team_objects=[team_object],
-                prisma_client=prisma_client,
-            )
-        except Exception as e:
-            # Same best-effort contract as the get_team_object call above:
-            # a transient Prisma error in access-group resolution must not
-            # 500 the /v1/models endpoint. Degrade to "no access-group
-            # contribution" and let the sentinel-aware logic below decide
-            # what to return.
-            verbose_proxy_logger.debug(
-                "get_available_models_for_user: access-group resolution "
-                "failed for team_id=%s, returning team.models[] only. "
-                "Error: %s",
-                getattr(team_object, "team_id", None),
-                str(e),
-            )
-            access_group_model_names = []
-        for model_name in access_group_model_names:
-            if model_name not in team_models:
-                team_models.append(model_name)
-
-    # ``no-default-models`` is an internal "this team has no direct models"
-    # marker. It must never appear in the OpenAI-format response (otherwise
-    # OpenWebUI renders it as a selectable model id) and must NOT be
-    # silently dropped — ``get_complete_model_list`` interprets an empty
-    # ``team_models`` as "no preference" and falls back to the full
-    # ``proxy_model_list``, which would grant every proxy model to a team
-    # that explicitly opted out. Match the user-path treatment in
-    # ``auth_checks.py``: if the sentinel was the only thing the team had
-    # and access-group resolution didn't add anything real, return ``[]``
-    # immediately rather than letting the fallback path widen access.
-    sentinel_value = SpecialModelNames.no_default_models.value
-    had_no_default_models_sentinel = sentinel_value in team_models
-    team_models = [m for m in team_models if m != sentinel_value]
-
-    if had_no_default_models_sentinel and not team_models and not key_models:
+    # Expand team_models with DB-backed Unified Access Group resolution and
+    # apply the ``no-default-models`` sentinel rules. See
+    # ``resolve_team_db_access_group_models`` in ``proxy/auth/model_checks.py``
+    # for the full contract: it loads the team object on the fallback path,
+    # tolerates transient Prisma errors, strips the sentinel, and signals
+    # ``force_empty`` when a sentinel-only team didn't pick up any real
+    # models (privilege-escalation guard for ``get_complete_model_list``).
+    team_models, force_empty = await resolve_team_db_access_group_models(
+        team_models=team_models,
+        key_models=key_models,
+        pre_loaded_team_object=team_object,
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+    if force_empty:
         return []
 
     # Get complete model list

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -99,6 +99,7 @@ from litellm.proxy._types import (
     CallInfo,
     LiteLLM_VerificationTokenView,
     Member,
+    SpecialModelNames,
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.route_checks import RouteChecks
@@ -5810,6 +5811,66 @@ def construct_database_url_from_env_vars() -> Optional[str]:
     return None
 
 
+async def _resolve_team_access_group_model_names(
+    team_objects: List[Any],
+    prisma_client: "PrismaClient",
+) -> List[str]:
+    """
+    Resolve model names reachable via ``team.access_group_ids[]`` against the
+    DB-backed ``LiteLLM_AccessGroupTable``.
+
+    Sibling of ``_add_access_group_models_to_team_models`` in ``proxy_server.py``:
+    the admin helper returns deployment ids (for ``/team/info`` / ``/v2/team/list``),
+    while this helper returns model names (for the OpenAI-compatible
+    ``/v1/models`` path).
+
+    Skip rules mirror the admin helper:
+    - teams with no ``access_group_ids`` contribute nothing.
+    - teams whose ``models`` is empty or contains ``all-proxy-models`` already
+      see every model on the proxy; access-group resolution is skipped to avoid
+      double-counting.
+
+    Returns deduped model names in encounter order. The
+    ``no-default-models`` sentinel is never emitted (callers are still
+    responsible for stripping it from any caller-supplied list — see the
+    sentinel filter in ``get_available_models_for_user``).
+    """
+    eligible_teams: List[Any] = []
+    all_access_group_ids: set = set()
+    for team in team_objects:
+        if not getattr(team, "access_group_ids", None):
+            continue
+        team_models_raw = getattr(team, "models", None) or []
+        if (
+            not team_models_raw
+            or SpecialModelNames.all_proxy_models.value in team_models_raw
+        ):
+            continue
+        eligible_teams.append(team)
+        all_access_group_ids.update(team.access_group_ids)
+
+    if not eligible_teams:
+        return []
+
+    access_group_rows = await prisma_client.db.litellm_accessgrouptable.find_many(
+        where={"access_group_id": {"in": list(all_access_group_ids)}}
+    )
+    ag_to_model_names: Dict[str, List[str]] = {
+        row.access_group_id: row.access_model_names or [] for row in access_group_rows
+    }
+
+    seen: set = set()
+    resolved: List[str] = []
+    for team in eligible_teams:
+        for ag_id in team.access_group_ids or []:
+            for model_name in ag_to_model_names.get(ag_id, []):
+                if model_name in seen:
+                    continue
+                seen.add(model_name)
+                resolved.append(model_name)
+    return resolved
+
+
 async def get_available_models_for_user(
     user_api_key_dict: "UserAPIKeyAuth",
     llm_router: Optional["Router"],
@@ -5867,6 +5928,7 @@ async def get_available_models_for_user(
 
     # Get team models
     team_models: List[str] = user_api_key_dict.team_models
+    team_object: Optional[Any] = None
 
     # If specific team_id is provided, validate and get team models
     if team_id and prisma_client and proxy_logging_obj and user_api_key_cache:
@@ -5888,6 +5950,47 @@ async def get_available_models_for_user(
         model_access_groups=model_access_groups,
         include_model_access_groups=include_model_access_groups,
     )
+
+    # Resolve models reachable via team.access_group_ids[] (DB-backed Unified
+    # Access Groups). Without this, a team configured as
+    # ``models=["no-default-models"]`` plus one or more access groups returns
+    # only the sentinel from /v1/models, even though the access groups grant
+    # real models. Mirrors _add_access_group_models_to_team_models, but emits
+    # model names instead of deployment ids (which is what /v1/models needs).
+    if (
+        team_object is None
+        and user_api_key_dict.team_id
+        and prisma_client is not None
+        and user_api_key_cache is not None
+        and proxy_logging_obj is not None
+    ):
+        try:
+            team_object = await get_team_object(
+                team_id=user_api_key_dict.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception:
+            team_object = None
+
+    if team_object is not None and prisma_client is not None:
+        access_group_model_names = await _resolve_team_access_group_model_names(
+            team_objects=[team_object],
+            prisma_client=prisma_client,
+        )
+        for model_name in access_group_model_names:
+            if model_name not in team_models:
+                team_models.append(model_name)
+
+    # Strip the ``no-default-models`` sentinel before passing to
+    # get_complete_model_list. The sentinel is an internal marker meaning
+    # "this team has no direct models"; it must never appear in the
+    # OpenAI-format response (otherwise OpenWebUI shows it as a selectable
+    # model id). Matches the user-path treatment in auth_checks.py.
+    team_models = [
+        m for m in team_models if m != SpecialModelNames.no_default_models.value
+    ]
 
     # Get complete model list
     all_models = get_complete_model_list(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5891,9 +5891,6 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
     )
 
-    # DB-backed Unified Access Groups + ``no-default-models`` sentinel
-    # handling. ``force_empty`` guards against ``get_complete_model_list``
-    # widening access when a sentinel-only team has no resolved models.
     team_models, force_empty = await resolve_team_db_access_group_models(
         team_models=team_models,
         key_models=key_models,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5971,26 +5971,59 @@ async def get_available_models_for_user(
                 user_api_key_cache=user_api_key_cache,
                 proxy_logging_obj=proxy_logging_obj,
             )
-        except Exception:
+        except Exception as e:
+            # Resolution is best-effort: a DB hiccup here must never take
+            # down /v1/models. Log so operators can diagnose unexpected
+            # skips (otherwise this silently degrades to the pre-fix
+            # behavior).
+            verbose_proxy_logger.debug(
+                "get_available_models_for_user: failed to fetch team object "
+                "for team_id=%s, skipping access-group resolution. Error: %s",
+                user_api_key_dict.team_id,
+                str(e),
+            )
             team_object = None
 
     if team_object is not None and prisma_client is not None:
-        access_group_model_names = await _resolve_team_access_group_model_names(
-            team_objects=[team_object],
-            prisma_client=prisma_client,
-        )
+        try:
+            access_group_model_names = await _resolve_team_access_group_model_names(
+                team_objects=[team_object],
+                prisma_client=prisma_client,
+            )
+        except Exception as e:
+            # Same best-effort contract as the get_team_object call above:
+            # a transient Prisma error in access-group resolution must not
+            # 500 the /v1/models endpoint. Degrade to "no access-group
+            # contribution" and let the sentinel-aware logic below decide
+            # what to return.
+            verbose_proxy_logger.debug(
+                "get_available_models_for_user: access-group resolution "
+                "failed for team_id=%s, returning team.models[] only. "
+                "Error: %s",
+                getattr(team_object, "team_id", None),
+                str(e),
+            )
+            access_group_model_names = []
         for model_name in access_group_model_names:
             if model_name not in team_models:
                 team_models.append(model_name)
 
-    # Strip the ``no-default-models`` sentinel before passing to
-    # get_complete_model_list. The sentinel is an internal marker meaning
-    # "this team has no direct models"; it must never appear in the
-    # OpenAI-format response (otherwise OpenWebUI shows it as a selectable
-    # model id). Matches the user-path treatment in auth_checks.py.
-    team_models = [
-        m for m in team_models if m != SpecialModelNames.no_default_models.value
-    ]
+    # ``no-default-models`` is an internal "this team has no direct models"
+    # marker. It must never appear in the OpenAI-format response (otherwise
+    # OpenWebUI renders it as a selectable model id) and must NOT be
+    # silently dropped — ``get_complete_model_list`` interprets an empty
+    # ``team_models`` as "no preference" and falls back to the full
+    # ``proxy_model_list``, which would grant every proxy model to a team
+    # that explicitly opted out. Match the user-path treatment in
+    # ``auth_checks.py``: if the sentinel was the only thing the team had
+    # and access-group resolution didn't add anything real, return ``[]``
+    # immediately rather than letting the fallback path widen access.
+    sentinel_value = SpecialModelNames.no_default_models.value
+    had_no_default_models_sentinel = sentinel_value in team_models
+    team_models = [m for m in team_models if m != sentinel_value]
+
+    if had_no_default_models_sentinel and not team_models and not key_models:
+        return []
 
     # Get complete model list
     all_models = get_complete_model_list(

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -251,21 +251,7 @@ def test_get_complete_model_list_byok_wildcard_expansion():
     assert "openai/*" not in result
 
 
-# ---------------------------------------------------------------------------
-# resolve_team_db_access_group_models — force_empty contract
-#
-# These two tests pin the privilege-escalation guard of the public sibling
-# helper of get_team_models in isolation. The end-to-end coverage lives in
-# tests/test_litellm/proxy/test_get_available_models_for_user.py; what this
-# file owns is the direct contract: under what (team_models, key_models,
-# access-group-contribution) tuple does the helper return force_empty=True?
-# ---------------------------------------------------------------------------
-
-
 def _make_team_obj(*, models, access_group_ids, team_id="team-iso"):
-    """Minimal stand-in for LiteLLM_TeamTableCachedObj — only the two
-    attributes resolve_team_db_access_group_models reads at runtime."""
-
     class _T:
         pass
 
@@ -290,12 +276,6 @@ def _make_user_api_key_dict(*, team_id=None):
 
 @pytest.mark.asyncio
 async def test_resolve_team_db_access_group_models_force_empty_when_sentinel_only_team_has_no_resolved_models():
-    """
-    The sentinel-only team with no real access-group contribution must
-    surface force_empty=True so the /v1/models caller can return [] before
-    get_complete_model_list falls back to the full proxy_model_list
-    (privilege escalation).
-    """
     from litellm.proxy.auth.model_checks import resolve_team_db_access_group_models
 
     team = _make_team_obj(models=["no-default-models"], access_group_ids=["ag-deleted"])
@@ -319,11 +299,6 @@ async def test_resolve_team_db_access_group_models_force_empty_when_sentinel_onl
 
 @pytest.mark.asyncio
 async def test_resolve_team_db_access_group_models_no_force_empty_when_access_groups_contribute():
-    """
-    Same sentinel-only team, but the access-group resolution returns a real
-    model. force_empty must be False — the team legitimately has access to
-    the resolved models and the caller should not short-circuit to [].
-    """
     from litellm.proxy.auth.model_checks import resolve_team_db_access_group_models
 
     team = _make_team_obj(models=["no-default-models"], access_group_ids=["ag-1"])

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -262,62 +262,78 @@ def _make_team_obj(*, models, access_group_ids, team_id="team-iso"):
     return obj
 
 
-def _make_user_api_key_dict(*, team_id=None):
-    from litellm.proxy._types import UserAPIKeyAuth
-
-    return UserAPIKeyAuth(
-        api_key="hashed",
-        user_id="u",
-        team_id=team_id,
-        team_models=[],
-        models=[],
-    )
+def _make_ag_row(ag_id, model_names):
+    row = MagicMock()
+    row.access_group_id = ag_id
+    row.access_model_names = list(model_names)
+    return row
 
 
 @pytest.mark.asyncio
-async def test_resolve_team_db_access_group_models_force_empty_when_sentinel_only_team_has_no_resolved_models():
-    from litellm.proxy.auth.model_checks import resolve_team_db_access_group_models
-
-    team = _make_team_obj(models=["no-default-models"], access_group_ids=["ag-deleted"])
-
-    prisma = AsyncMock()
-    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(return_value=[])
-
-    resolved, force_empty = await resolve_team_db_access_group_models(
-        team_models=["no-default-models"],
-        key_models=[],
-        pre_loaded_team_object=team,
-        user_api_key_dict=_make_user_api_key_dict(team_id=team.team_id),
-        prisma_client=prisma,
-        user_api_key_cache=None,
-        proxy_logging_obj=None,
+async def test_resolve_team_access_group_model_names_by_id_returns_mapping():
+    from litellm.proxy.auth.model_checks import (
+        _resolve_team_access_group_model_names_by_id,
     )
 
-    assert resolved == []
-    assert force_empty is True
+    team = _make_team_obj(
+        models=["no-default-models"], access_group_ids=["ag-1", "ag-2"]
+    )
+    prisma = AsyncMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(
+        return_value=[
+            _make_ag_row("ag-1", ["gpt-4o"]),
+            _make_ag_row("ag-2", ["claude-opus-4-5"]),
+        ]
+    )
+
+    result = await _resolve_team_access_group_model_names_by_id(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == {"ag-1": ["gpt-4o"], "ag-2": ["claude-opus-4-5"]}
 
 
 @pytest.mark.asyncio
-async def test_resolve_team_db_access_group_models_no_force_empty_when_access_groups_contribute():
-    from litellm.proxy.auth.model_checks import resolve_team_db_access_group_models
-
-    team = _make_team_obj(models=["no-default-models"], access_group_ids=["ag-1"])
-
-    ag_row = AsyncMock()
-    ag_row.access_group_id = "ag-1"
-    ag_row.access_model_names = ["gpt-4o"]
-    prisma = AsyncMock()
-    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(return_value=[ag_row])
-
-    resolved, force_empty = await resolve_team_db_access_group_models(
-        team_models=["no-default-models"],
-        key_models=[],
-        pre_loaded_team_object=team,
-        user_api_key_dict=_make_user_api_key_dict(team_id=team.team_id),
-        prisma_client=prisma,
-        user_api_key_cache=None,
-        proxy_logging_obj=None,
+async def test_resolve_team_access_group_model_names_by_id_skips_empty_models_team():
+    from litellm.proxy.auth.model_checks import (
+        _resolve_team_access_group_model_names_by_id,
     )
 
-    assert resolved == ["gpt-4o"]
-    assert force_empty is False
+    team = _make_team_obj(models=[], access_group_ids=["ag-1"])
+    prisma = AsyncMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock()
+
+    result = await _resolve_team_access_group_model_names_by_id(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == {}
+    prisma.db.litellm_accessgrouptable.find_many.assert_not_called()
+
+
+def test_get_team_models_injects_team_access_group_ids():
+    from litellm.proxy.auth.model_checks import get_team_models
+
+    result = get_team_models(
+        team_models=["gpt-3.5-turbo"],
+        proxy_model_list=["gpt-3.5-turbo", "gpt-4o", "claude-opus-4-5"],
+        model_access_groups={"ag-1": ["gpt-4o", "claude-opus-4-5"]},
+        team_access_group_ids=["ag-1"],
+    )
+
+    assert set(result) == {"gpt-3.5-turbo", "gpt-4o", "claude-opus-4-5"}
+
+
+def test_get_team_models_ignores_team_access_group_ids_not_in_dict():
+    # An access group id that the caller didn't pre-merge into model_access_groups
+    # contributes nothing — get_team_models is pure data manipulation.
+    from litellm.proxy.auth.model_checks import get_team_models
+
+    result = get_team_models(
+        team_models=["gpt-3.5-turbo"],
+        proxy_model_list=["gpt-3.5-turbo", "gpt-4o"],
+        model_access_groups={"ag-known": ["gpt-4o"]},
+        team_access_group_ids=["ag-unknown"],
+    )
+
+    assert result == ["gpt-3.5-turbo"]

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -249,3 +249,100 @@ def test_get_complete_model_list_byok_wildcard_expansion():
     assert len(result) > 0
     assert all(m.startswith("openai/") for m in result)
     assert "openai/*" not in result
+
+
+# ---------------------------------------------------------------------------
+# resolve_team_db_access_group_models — force_empty contract
+#
+# These two tests pin the privilege-escalation guard of the public sibling
+# helper of get_team_models in isolation. The end-to-end coverage lives in
+# tests/test_litellm/proxy/test_get_available_models_for_user.py; what this
+# file owns is the direct contract: under what (team_models, key_models,
+# access-group-contribution) tuple does the helper return force_empty=True?
+# ---------------------------------------------------------------------------
+
+
+def _make_team_obj(*, models, access_group_ids, team_id="team-iso"):
+    """Minimal stand-in for LiteLLM_TeamTableCachedObj — only the two
+    attributes resolve_team_db_access_group_models reads at runtime."""
+
+    class _T:
+        pass
+
+    obj = _T()
+    obj.team_id = team_id
+    obj.models = list(models)
+    obj.access_group_ids = list(access_group_ids)
+    return obj
+
+
+def _make_user_api_key_dict(*, team_id=None):
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    return UserAPIKeyAuth(
+        api_key="hashed",
+        user_id="u",
+        team_id=team_id,
+        team_models=[],
+        models=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_team_db_access_group_models_force_empty_when_sentinel_only_team_has_no_resolved_models():
+    """
+    The sentinel-only team with no real access-group contribution must
+    surface force_empty=True so the /v1/models caller can return [] before
+    get_complete_model_list falls back to the full proxy_model_list
+    (privilege escalation).
+    """
+    from litellm.proxy.auth.model_checks import resolve_team_db_access_group_models
+
+    team = _make_team_obj(models=["no-default-models"], access_group_ids=["ag-deleted"])
+
+    prisma = AsyncMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(return_value=[])
+
+    resolved, force_empty = await resolve_team_db_access_group_models(
+        team_models=["no-default-models"],
+        key_models=[],
+        pre_loaded_team_object=team,
+        user_api_key_dict=_make_user_api_key_dict(team_id=team.team_id),
+        prisma_client=prisma,
+        user_api_key_cache=None,
+        proxy_logging_obj=None,
+    )
+
+    assert resolved == []
+    assert force_empty is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_team_db_access_group_models_no_force_empty_when_access_groups_contribute():
+    """
+    Same sentinel-only team, but the access-group resolution returns a real
+    model. force_empty must be False — the team legitimately has access to
+    the resolved models and the caller should not short-circuit to [].
+    """
+    from litellm.proxy.auth.model_checks import resolve_team_db_access_group_models
+
+    team = _make_team_obj(models=["no-default-models"], access_group_ids=["ag-1"])
+
+    ag_row = AsyncMock()
+    ag_row.access_group_id = "ag-1"
+    ag_row.access_model_names = ["gpt-4o"]
+    prisma = AsyncMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(return_value=[ag_row])
+
+    resolved, force_empty = await resolve_team_db_access_group_models(
+        team_models=["no-default-models"],
+        key_models=[],
+        pre_loaded_team_object=team,
+        user_api_key_dict=_make_user_api_key_dict(team_id=team.team_id),
+        prisma_client=prisma,
+        user_api_key_cache=None,
+        proxy_logging_obj=None,
+    )
+
+    assert resolved == ["gpt-4o"]
+    assert force_empty is False

--- a/tests/test_litellm/proxy/test_get_available_models_for_user.py
+++ b/tests/test_litellm/proxy/test_get_available_models_for_user.py
@@ -26,10 +26,8 @@ from litellm.proxy._types import (
     SpecialModelNames,
     UserAPIKeyAuth,
 )
-from litellm.proxy.utils import (
-    _resolve_team_access_group_model_names,
-    get_available_models_for_user,
-)
+from litellm.proxy.auth.model_checks import _resolve_team_access_group_model_names
+from litellm.proxy.utils import get_available_models_for_user
 
 
 def _make_team_cached_obj(

--- a/tests/test_litellm/proxy/test_get_available_models_for_user.py
+++ b/tests/test_litellm/proxy/test_get_available_models_for_user.py
@@ -1,0 +1,386 @@
+"""
+Tests for ``get_available_models_for_user`` resolving DB-backed Unified
+Access Groups and stripping the ``no-default-models`` sentinel.
+
+Regression coverage for the bug where a team configured as
+``models=["no-default-models"]`` plus one or more
+``team.access_group_ids[]`` returned only the sentinel from ``/v1/models``
+(OpenWebUI then rendered an empty model dropdown), even though
+``LiteLLM_AccessGroupTable`` resolution was correct on the admin-side
+``/team/info`` / ``/v2/team/list`` endpoints.
+
+See ``access-group-models-v1-models-fix.md`` for the full incident write-up.
+"""
+
+import os
+import sys
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.proxy._types import (
+    LiteLLM_TeamTableCachedObj,
+    SpecialModelNames,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.utils import (
+    _resolve_team_access_group_model_names,
+    get_available_models_for_user,
+)
+
+
+def _make_team_cached_obj(
+    *,
+    team_id: str = "team_alpha",
+    models: Optional[List[str]] = None,
+    access_group_ids: Optional[List[str]] = None,
+) -> LiteLLM_TeamTableCachedObj:
+    return LiteLLM_TeamTableCachedObj(
+        team_id=team_id,
+        models=models if models is not None else [],
+        access_group_ids=access_group_ids,
+    )
+
+
+def _make_access_group_row(group_id: str, model_names: List[str]):
+    row = MagicMock()
+    row.access_group_id = group_id
+    row.access_model_names = model_names
+    return row
+
+
+def _make_prisma_client_with_ag_rows(rows: List):
+    prisma = MagicMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(return_value=rows)
+    return prisma
+
+
+def _make_user_api_key_dict(
+    *,
+    team_id: Optional[str] = None,
+    team_models: Optional[List[str]] = None,
+) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="sk-test",
+        models=[],
+        team_id=team_id,
+        team_models=team_models or [],
+    )
+
+
+def _patched_get_team_object(team_obj):
+    """Returns an AsyncMock that ignores extra kwargs and returns ``team_obj``."""
+
+    async def _impl(*_args, **_kwargs):
+        return team_obj
+
+    return _impl
+
+
+# ---------------------------------------------------------------------------
+# _resolve_team_access_group_model_names — pure helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_returns_access_group_model_names():
+    """Happy path: team has access groups, helper returns their model names."""
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-1"]
+    )
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["gpt-4o", "claude-opus-4-5"])]
+    )
+
+    result = await _resolve_team_access_group_model_names(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == ["gpt-4o", "claude-opus-4-5"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_skips_teams_with_empty_models():
+    """
+    A team with ``models=[]`` already sees every proxy model; resolving its
+    access groups would double-count. Mirror ``_add_access_group_models_to_team_models``.
+    """
+    team = _make_team_cached_obj(models=[], access_group_ids=["ag-1"])
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["gpt-4o"])]
+    )
+
+    result = await _resolve_team_access_group_model_names(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == []
+    prisma.db.litellm_accessgrouptable.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolver_skips_teams_with_all_proxy_models_sentinel():
+    """Same skip rule for the explicit ``all-proxy-models`` marker."""
+    team = _make_team_cached_obj(
+        models=[SpecialModelNames.all_proxy_models.value],
+        access_group_ids=["ag-1"],
+    )
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["gpt-4o"])]
+    )
+
+    result = await _resolve_team_access_group_model_names(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == []
+    prisma.db.litellm_accessgrouptable.find_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolver_deduplicates_across_access_groups():
+    """Two access groups that share a model are deduped, order preserved."""
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-1", "ag-2"]
+    )
+    prisma = _make_prisma_client_with_ag_rows(
+        [
+            _make_access_group_row("ag-1", ["gpt-4o", "claude-opus-4-5"]),
+            _make_access_group_row("ag-2", ["claude-opus-4-5", "mistral-large"]),
+        ]
+    )
+
+    result = await _resolve_team_access_group_model_names(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == ["gpt-4o", "claude-opus-4-5", "mistral-large"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_handles_deleted_access_group():
+    """Missing rows contribute nothing; no error."""
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-1", "ag-deleted"]
+    )
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["gpt-4o"])]
+    )
+
+    result = await _resolve_team_access_group_model_names(
+        team_objects=[team], prisma_client=prisma
+    )
+
+    assert result == ["gpt-4o"]
+
+
+# ---------------------------------------------------------------------------
+# get_available_models_for_user — end-to-end behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_default_models_team_resolves_access_group_models():
+    """
+    The original bug: ``models=["no-default-models"]`` plus an access group
+    returned just the sentinel. Now it returns the access-group models with
+    the sentinel stripped.
+    """
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-1"]
+    )
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["gpt-4o", "claude-opus-4-5"])]
+    )
+
+    user_api_key_dict = _make_user_api_key_dict(
+        team_id=team.team_id, team_models=["no-default-models"]
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_team_object",
+        new=_patched_get_team_object(team),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=None,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=None,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert SpecialModelNames.no_default_models.value not in result
+    assert set(result) == {"gpt-4o", "claude-opus-4-5"}
+
+
+@pytest.mark.asyncio
+async def test_direct_and_access_group_models_are_merged_and_deduped():
+    """Direct ``team.models[]`` and access-group-resolved names union together."""
+    team = _make_team_cached_obj(models=["gpt-4o"], access_group_ids=["ag-1"])
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["claude-opus-4-5", "gpt-4o"])]
+    )
+
+    user_api_key_dict = _make_user_api_key_dict(
+        team_id=team.team_id, team_models=["gpt-4o"]
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_team_object",
+        new=_patched_get_team_object(team),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=None,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=None,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert result.count("gpt-4o") == 1
+    assert set(result) == {"gpt-4o", "claude-opus-4-5"}
+
+
+@pytest.mark.asyncio
+async def test_sentinel_only_team_without_access_groups_returns_empty():
+    """
+    A team with ``models=["no-default-models"]`` and no access groups must
+    return an empty list — never the literal sentinel string, which OpenWebUI
+    would otherwise render as a selectable model id.
+    """
+    team = _make_team_cached_obj(models=["no-default-models"], access_group_ids=None)
+    prisma = _make_prisma_client_with_ag_rows([])
+
+    user_api_key_dict = _make_user_api_key_dict(
+        team_id=team.team_id, team_models=["no-default-models"]
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_team_object",
+        new=_patched_get_team_object(team),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=None,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=None,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert SpecialModelNames.no_default_models.value not in result
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_team_id_param_resolves_access_groups():
+    """
+    The ``team_id`` kwarg path (used by admin/UI flows that pin a team
+    explicitly) must resolve access groups too.
+    """
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-1"]
+    )
+    prisma = _make_prisma_client_with_ag_rows(
+        [_make_access_group_row("ag-1", ["gpt-4o"])]
+    )
+
+    user_api_key_dict = _make_user_api_key_dict(team_id=None, team_models=[])
+
+    async def _noop_validate_membership(*_args, **_kwargs):
+        return True
+
+    with (
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new=_patched_get_team_object(team),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.validate_membership",
+            new=_noop_validate_membership,
+        ),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=None,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=team.team_id,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert set(result) == {"gpt-4o"}
+    assert SpecialModelNames.no_default_models.value not in result
+
+
+@pytest.mark.asyncio
+async def test_deleted_access_group_does_not_leak_sentinel():
+    """
+    Edge case from the field: a team references an access group that has been
+    deleted from ``LiteLLM_AccessGroupTable``. Resolution returns no rows; the
+    sentinel must still be stripped so /v1/models returns an empty list, not
+    ``["no-default-models"]``.
+    """
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-deleted"]
+    )
+    prisma = _make_prisma_client_with_ag_rows([])
+
+    user_api_key_dict = _make_user_api_key_dict(
+        team_id=team.team_id, team_models=["no-default-models"]
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_team_object",
+        new=_patched_get_team_object(team),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=None,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=None,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_user_with_no_team_skips_access_group_resolution():
+    """
+    Callers without any team (no ``team_id`` kwarg, no
+    ``user_api_key_dict.team_id``) skip the DB resolution entirely — they have
+    no team-scoped access groups to look up.
+    """
+    user_api_key_dict = _make_user_api_key_dict(team_id=None, team_models=[])
+    prisma = _make_prisma_client_with_ag_rows([])
+
+    result = await get_available_models_for_user(
+        user_api_key_dict=user_api_key_dict,
+        llm_router=None,
+        general_settings={},
+        user_model=None,
+        prisma_client=prisma,
+        proxy_logging_obj=MagicMock(),
+        team_id=None,
+        user_api_key_cache=MagicMock(),
+    )
+
+    assert result == []
+    prisma.db.litellm_accessgrouptable.find_many.assert_not_called()

--- a/tests/test_litellm/proxy/test_get_available_models_for_user.py
+++ b/tests/test_litellm/proxy/test_get_available_models_for_user.py
@@ -1,16 +1,4 @@
-"""
-Tests for ``get_available_models_for_user`` resolving DB-backed Unified
-Access Groups and stripping the ``no-default-models`` sentinel.
-
-Regression coverage for the bug where a team configured as
-``models=["no-default-models"]`` plus one or more
-``team.access_group_ids[]`` returned only the sentinel from ``/v1/models``
-(OpenWebUI then rendered an empty model dropdown), even though
-``LiteLLM_AccessGroupTable`` resolution was correct on the admin-side
-``/team/info`` / ``/v2/team/list`` endpoints.
-
-See ``access-group-models-v1-models-fix.md`` for the full incident write-up.
-"""
+"""Tests for get_available_models_for_user UAG resolution and sentinel strip."""
 
 import os
 import sys
@@ -85,7 +73,6 @@ def _patched_get_team_object(team_obj):
 
 @pytest.mark.asyncio
 async def test_resolver_returns_access_group_model_names():
-    """Happy path: team has access groups, helper returns their model names."""
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1"]
     )
@@ -102,10 +89,6 @@ async def test_resolver_returns_access_group_model_names():
 
 @pytest.mark.asyncio
 async def test_resolver_skips_teams_with_empty_models():
-    """
-    A team with ``models=[]`` already sees every proxy model; resolving its
-    access groups would double-count. Mirror ``_add_access_group_models_to_team_models``.
-    """
     team = _make_team_cached_obj(models=[], access_group_ids=["ag-1"])
     prisma = _make_prisma_client_with_ag_rows(
         [_make_access_group_row("ag-1", ["gpt-4o"])]
@@ -121,7 +104,6 @@ async def test_resolver_skips_teams_with_empty_models():
 
 @pytest.mark.asyncio
 async def test_resolver_skips_teams_with_all_proxy_models_sentinel():
-    """Same skip rule for the explicit ``all-proxy-models`` marker."""
     team = _make_team_cached_obj(
         models=[SpecialModelNames.all_proxy_models.value],
         access_group_ids=["ag-1"],
@@ -140,7 +122,6 @@ async def test_resolver_skips_teams_with_all_proxy_models_sentinel():
 
 @pytest.mark.asyncio
 async def test_resolver_deduplicates_across_access_groups():
-    """Two access groups that share a model are deduped, order preserved."""
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1", "ag-2"]
     )
@@ -160,7 +141,6 @@ async def test_resolver_deduplicates_across_access_groups():
 
 @pytest.mark.asyncio
 async def test_resolver_handles_deleted_access_group():
-    """Missing rows contribute nothing; no error."""
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1", "ag-deleted"]
     )
@@ -182,11 +162,6 @@ async def test_resolver_handles_deleted_access_group():
 
 @pytest.mark.asyncio
 async def test_no_default_models_team_resolves_access_group_models():
-    """
-    The original bug: ``models=["no-default-models"]`` plus an access group
-    returned just the sentinel. Now it returns the access-group models with
-    the sentinel stripped.
-    """
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1"]
     )
@@ -219,7 +194,6 @@ async def test_no_default_models_team_resolves_access_group_models():
 
 @pytest.mark.asyncio
 async def test_direct_and_access_group_models_are_merged_and_deduped():
-    """Direct ``team.models[]`` and access-group-resolved names union together."""
     team = _make_team_cached_obj(models=["gpt-4o"], access_group_ids=["ag-1"])
     prisma = _make_prisma_client_with_ag_rows(
         [_make_access_group_row("ag-1", ["claude-opus-4-5", "gpt-4o"])]
@@ -250,18 +224,8 @@ async def test_direct_and_access_group_models_are_merged_and_deduped():
 
 @pytest.mark.asyncio
 async def test_sentinel_only_team_without_access_groups_returns_empty():
-    """
-    A team with ``models=["no-default-models"]`` and no access groups must
-    return an empty list — never the literal sentinel string, which OpenWebUI
-    would otherwise render as a selectable model id.
-
-    Regression guard: this test now configures a populated ``llm_router``.
-    Without the sentinel-aware short-circuit in
-    ``get_available_models_for_user``, stripping the sentinel would leave
-    ``team_models=[]`` and ``get_complete_model_list`` would fall through to
-    ``proxy_model_list``, silently granting every proxy model to a team
-    that explicitly opted out.
-    """
+    # Privilege-escalation guard: configures a populated llm_router so that
+    # stripping the sentinel without force_empty would leak every proxy model.
     team = _make_team_cached_obj(models=["no-default-models"], access_group_ids=None)
     prisma = _make_prisma_client_with_ag_rows([])
 
@@ -301,13 +265,8 @@ async def test_sentinel_only_team_without_access_groups_returns_empty():
 
 @pytest.mark.asyncio
 async def test_db_failure_in_access_group_resolution_does_not_crash():
-    """
-    ``/v1/models`` must not 500 on a transient Prisma failure. If
-    ``litellm_accessgrouptable.find_many`` raises, we degrade to "no
-    access-group contribution" — same behavior as the pre-fix state — and
-    still honor the sentinel short-circuit so a no-default-models team
-    doesn't accidentally get full access.
-    """
+    # On transient Prisma failure, degrade to "no access-group contribution"
+    # and still honor the sentinel short-circuit.
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1"]
     )
@@ -346,11 +305,6 @@ async def test_db_failure_in_access_group_resolution_does_not_crash():
 
 @pytest.mark.asyncio
 async def test_team_with_direct_models_unaffected_by_resolver_failure():
-    """
-    If ``team.models[]`` contains real model names and access-group
-    resolution fails, the team's direct models still come through. Only the
-    access-group contribution is dropped on resolver failure.
-    """
     team = _make_team_cached_obj(models=["gpt-4o"], access_group_ids=["ag-1"])
 
     prisma = MagicMock()
@@ -382,10 +336,6 @@ async def test_team_with_direct_models_unaffected_by_resolver_failure():
 
 @pytest.mark.asyncio
 async def test_explicit_team_id_param_resolves_access_groups():
-    """
-    The ``team_id`` kwarg path (used by admin/UI flows that pin a team
-    explicitly) must resolve access groups too.
-    """
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1"]
     )
@@ -425,12 +375,6 @@ async def test_explicit_team_id_param_resolves_access_groups():
 
 @pytest.mark.asyncio
 async def test_deleted_access_group_does_not_leak_sentinel():
-    """
-    Edge case from the field: a team references an access group that has been
-    deleted from ``LiteLLM_AccessGroupTable``. Resolution returns no rows; the
-    sentinel must still be stripped so /v1/models returns an empty list, not
-    ``["no-default-models"]``.
-    """
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-deleted"]
     )
@@ -460,11 +404,6 @@ async def test_deleted_access_group_does_not_leak_sentinel():
 
 @pytest.mark.asyncio
 async def test_user_with_no_team_skips_access_group_resolution():
-    """
-    Callers without any team (no ``team_id`` kwarg, no
-    ``user_api_key_dict.team_id``) skip the DB resolution entirely — they have
-    no team-scoped access groups to look up.
-    """
     user_api_key_dict = _make_user_api_key_dict(team_id=None, team_models=[])
     prisma = _make_prisma_client_with_ag_rows([])
 

--- a/tests/test_litellm/proxy/test_get_available_models_for_user.py
+++ b/tests/test_litellm/proxy/test_get_available_models_for_user.py
@@ -256,12 +256,112 @@ async def test_sentinel_only_team_without_access_groups_returns_empty():
     A team with ``models=["no-default-models"]`` and no access groups must
     return an empty list — never the literal sentinel string, which OpenWebUI
     would otherwise render as a selectable model id.
+
+    Regression guard: this test now configures a populated ``llm_router``.
+    Without the sentinel-aware short-circuit in
+    ``get_available_models_for_user``, stripping the sentinel would leave
+    ``team_models=[]`` and ``get_complete_model_list`` would fall through to
+    ``proxy_model_list``, silently granting every proxy model to a team
+    that explicitly opted out.
     """
     team = _make_team_cached_obj(models=["no-default-models"], access_group_ids=None)
     prisma = _make_prisma_client_with_ag_rows([])
 
     user_api_key_dict = _make_user_api_key_dict(
         team_id=team.team_id, team_models=["no-default-models"]
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_model_names.return_value = [
+        "gpt-4o",
+        "claude-opus-4-5",
+        "mistral-large",
+    ]
+    mock_router.get_model_access_groups.return_value = {}
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_team_object",
+        new=_patched_get_team_object(team),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=mock_router,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=None,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert SpecialModelNames.no_default_models.value not in result
+    assert result == []
+    assert (
+        "gpt-4o" not in result
+    ), "A no-default-models team must not silently see every proxy model"
+
+
+@pytest.mark.asyncio
+async def test_db_failure_in_access_group_resolution_does_not_crash():
+    """
+    ``/v1/models`` must not 500 on a transient Prisma failure. If
+    ``litellm_accessgrouptable.find_many`` raises, we degrade to "no
+    access-group contribution" — same behavior as the pre-fix state — and
+    still honor the sentinel short-circuit so a no-default-models team
+    doesn't accidentally get full access.
+    """
+    team = _make_team_cached_obj(
+        models=["no-default-models"], access_group_ids=["ag-1"]
+    )
+
+    prisma = MagicMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(
+        side_effect=RuntimeError("simulated transient DB error")
+    )
+
+    user_api_key_dict = _make_user_api_key_dict(
+        team_id=team.team_id, team_models=["no-default-models"]
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_model_names.return_value = ["gpt-4o", "claude-opus-4-5"]
+    mock_router.get_model_access_groups.return_value = {}
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_team_object",
+        new=_patched_get_team_object(team),
+    ):
+        result = await get_available_models_for_user(
+            user_api_key_dict=user_api_key_dict,
+            llm_router=mock_router,
+            general_settings={},
+            user_model=None,
+            prisma_client=prisma,
+            proxy_logging_obj=MagicMock(),
+            team_id=None,
+            user_api_key_cache=MagicMock(),
+        )
+
+    assert result == []
+    assert "gpt-4o" not in result
+
+
+@pytest.mark.asyncio
+async def test_team_with_direct_models_unaffected_by_resolver_failure():
+    """
+    If ``team.models[]`` contains real model names and access-group
+    resolution fails, the team's direct models still come through. Only the
+    access-group contribution is dropped on resolver failure.
+    """
+    team = _make_team_cached_obj(models=["gpt-4o"], access_group_ids=["ag-1"])
+
+    prisma = MagicMock()
+    prisma.db.litellm_accessgrouptable.find_many = AsyncMock(
+        side_effect=RuntimeError("simulated transient DB error")
+    )
+
+    user_api_key_dict = _make_user_api_key_dict(
+        team_id=team.team_id, team_models=["gpt-4o"]
     )
 
     with patch(
@@ -279,8 +379,7 @@ async def test_sentinel_only_team_without_access_groups_returns_empty():
             user_api_key_cache=MagicMock(),
         )
 
-    assert SpecialModelNames.no_default_models.value not in result
-    assert result == []
+    assert result == ["gpt-4o"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_get_available_models_for_user.py
+++ b/tests/test_litellm/proxy/test_get_available_models_for_user.py
@@ -14,7 +14,9 @@ from litellm.proxy._types import (
     SpecialModelNames,
     UserAPIKeyAuth,
 )
-from litellm.proxy.auth.model_checks import _resolve_team_access_group_model_names
+from litellm.proxy.auth.model_checks import (
+    _resolve_team_access_group_model_names_by_id,
+)
 from litellm.proxy.utils import get_available_models_for_user
 
 
@@ -67,24 +69,30 @@ def _patched_get_team_object(team_obj):
 
 
 # ---------------------------------------------------------------------------
-# _resolve_team_access_group_model_names — pure helper
+# _resolve_team_access_group_model_names_by_id — pure helper
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_resolver_returns_access_group_model_names():
+async def test_resolver_returns_access_group_id_to_model_names_mapping():
     team = _make_team_cached_obj(
-        models=["no-default-models"], access_group_ids=["ag-1"]
+        models=["no-default-models"], access_group_ids=["ag-1", "ag-2"]
     )
     prisma = _make_prisma_client_with_ag_rows(
-        [_make_access_group_row("ag-1", ["gpt-4o", "claude-opus-4-5"])]
+        [
+            _make_access_group_row("ag-1", ["gpt-4o", "claude-opus-4-5"]),
+            _make_access_group_row("ag-2", ["mistral-large"]),
+        ]
     )
 
-    result = await _resolve_team_access_group_model_names(
+    result = await _resolve_team_access_group_model_names_by_id(
         team_objects=[team], prisma_client=prisma
     )
 
-    assert result == ["gpt-4o", "claude-opus-4-5"]
+    assert result == {
+        "ag-1": ["gpt-4o", "claude-opus-4-5"],
+        "ag-2": ["mistral-large"],
+    }
 
 
 @pytest.mark.asyncio
@@ -94,11 +102,11 @@ async def test_resolver_skips_teams_with_empty_models():
         [_make_access_group_row("ag-1", ["gpt-4o"])]
     )
 
-    result = await _resolve_team_access_group_model_names(
+    result = await _resolve_team_access_group_model_names_by_id(
         team_objects=[team], prisma_client=prisma
     )
 
-    assert result == []
+    assert result == {}
     prisma.db.litellm_accessgrouptable.find_many.assert_not_called()
 
 
@@ -112,35 +120,16 @@ async def test_resolver_skips_teams_with_all_proxy_models_sentinel():
         [_make_access_group_row("ag-1", ["gpt-4o"])]
     )
 
-    result = await _resolve_team_access_group_model_names(
+    result = await _resolve_team_access_group_model_names_by_id(
         team_objects=[team], prisma_client=prisma
     )
 
-    assert result == []
+    assert result == {}
     prisma.db.litellm_accessgrouptable.find_many.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_resolver_deduplicates_across_access_groups():
-    team = _make_team_cached_obj(
-        models=["no-default-models"], access_group_ids=["ag-1", "ag-2"]
-    )
-    prisma = _make_prisma_client_with_ag_rows(
-        [
-            _make_access_group_row("ag-1", ["gpt-4o", "claude-opus-4-5"]),
-            _make_access_group_row("ag-2", ["claude-opus-4-5", "mistral-large"]),
-        ]
-    )
-
-    result = await _resolve_team_access_group_model_names(
-        team_objects=[team], prisma_client=prisma
-    )
-
-    assert result == ["gpt-4o", "claude-opus-4-5", "mistral-large"]
-
-
-@pytest.mark.asyncio
-async def test_resolver_handles_deleted_access_group():
+async def test_resolver_omits_missing_rows_for_deleted_access_group():
     team = _make_team_cached_obj(
         models=["no-default-models"], access_group_ids=["ag-1", "ag-deleted"]
     )
@@ -148,11 +137,11 @@ async def test_resolver_handles_deleted_access_group():
         [_make_access_group_row("ag-1", ["gpt-4o"])]
     )
 
-    result = await _resolve_team_access_group_model_names(
+    result = await _resolve_team_access_group_model_names_by_id(
         team_objects=[team], prisma_client=prisma
     )
 
-    assert result == ["gpt-4o"]
+    assert result == {"ag-1": ["gpt-4o"]}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Title

fix(proxy): resolve team access-group models in `/v1/models`, strip `no-default-models` sentinel

## Relevant issues

Internal incident: teams configured with Unified Access Groups saw an empty model dropdown in OpenWebUI because `/v1/models` returned only the `no-default-models` sentinel.

## Pre-Submission checklist

- [x] Test added in `tests/test_litellm/`
- [x] `make test-unit` (subset) passes locally — 11 new tests, 30 related tests, all green
- [x] Black-formatted

## Type

🐛 Bug Fix

## Changes

### The bug

`get_available_models_for_user` in `litellm/proxy/utils.py` is the model resolver behind `/v1/models`, `/v1/models/{id}`, and `/model_group/info`. It reads `team.models[]` but **never resolves `team.access_group_ids[]`** against the DB-backed `LiteLLM_AccessGroupTable`. As a result, a team configured as:

- `models = ["no-default-models"]`
- `access_group_ids = ["jedai_general_access"]` (which contains 6 real models)

…returned literally `["no-default-models"]` from `/v1/models`. OpenWebUI rendered an empty dropdown. The same team's `/team/info` and `/v2/team/list` responses were correct because those endpoints use a different code path (`_add_access_group_models_to_team_models` in `proxy_server.py`) which **does** resolve the access groups — but emits **deployment ids**, not the model names the OpenAI-format path needs.

A secondary bug: even when `team_models` was correctly derived, the `no-default-models` sentinel was never stripped, so it could surface as a selectable model id in the response.

### The fix

1. **New private helper `_resolve_team_access_group_model_names`** in `litellm/proxy/utils.py` — a sibling of the admin-side `_add_access_group_models_to_team_models`, but returns **model names** suitable for `/v1/models`. Single batch `find_many` against `litellm_accessgrouptable`, no N+1.

2. **Skip rules mirror the admin helper exactly**: teams whose `models[]` is empty or contains `all-proxy-models` already see every model on the proxy, so access-group resolution is bypassed (the admin helper does this to avoid double-counting; we match that behavior).

3. **Wired into `get_available_models_for_user`** so that — regardless of whether the caller passed `team_id` explicitly or whether we fall back to `user_api_key_dict.team_id` — the active team's access groups are resolved and merged into `team_models` before the OpenAI-format response is built.

4. **`SpecialModelNames.no_default_models` is now stripped from `team_models`** before `get_complete_model_list`. The user path already handled the sentinel (`auth_checks.py`); the team path did not.

### Why the helper lives in `proxy/utils.py`, not `model_checks.py`

The bug doc suggested `model_checks.py` as a possible home, but that module is currently 100% sync utility code with no DB calls. Adding an async Prisma-aware function there would change its character. Keeping the helper next to its only caller (`get_available_models_for_user`) also avoids the `proxy/utils.py → proxy_server.py` circular-import trap that would otherwise force us to relocate the existing admin helper as well.

### Files changed

- `litellm/proxy/utils.py`
  - Added `SpecialModelNames` to the existing `_types` import.
  - New `_resolve_team_access_group_model_names(team_objects, prisma_client) -> List[str]` helper.
  - `get_available_models_for_user`: resolve access groups + strip the `no-default-models` sentinel.
- `tests/test_litellm/proxy/test_get_available_models_for_user.py` (new file, 11 tests).

### Test coverage

**Pure resolver** (`_resolve_team_access_group_model_names`):
- Happy path: returns access-group model names.
- Skips teams whose `models[]` is empty (all-models access).
- Skips teams with the `all-proxy-models` sentinel.
- Dedupes across overlapping access groups, preserves encounter order.
- Deleted access group → contributes nothing, no error.

**End-to-end** (`get_available_models_for_user`):
- The original bug: `models=["no-default-models"]` + access group → returns the access-group models, no sentinel.
- Mixed direct + access-group models → union, deduped.
- Sentinel-only team with no access groups → returns `[]`, not `["no-default-models"]`.
- Explicit `team_id` kwarg path → still resolves access groups.
- Deleted access group → empty, no sentinel leak.
- Caller with no team → resolution skipped, no DB call.

All 11 new tests pass. Verified no regressions in the surrounding suite (`test_proxy_utils.py`, `test_filter_models_by_team_access_group.py`, `test_empty_model_list.py` — 30 tests green).