### PR TITLE
fix(proxy): expose db status on public /health/readiness

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1548,15 +1548,21 @@ def _allow_public_health_readiness_details() -> bool:
     return general_settings.get("allow_public_health_readiness_details") is True
 
 
-async def _set_public_readiness_status(response: Response) -> None:
+async def _resolve_public_readiness_db(response: Response) -> str:
+    """
+    Return the db status string for the public probe and flip the response to
+    503 when a configured DB is unreachable. Mirrors the legacy values:
+    "Not connected" (no DB configured), "connected", "disconnected".
+    """
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
-        return
+        return "Not connected"
 
     db_health_status = await _db_health_readiness_check()
     if db_health_status["status"] != "connected":
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return db_health_status["status"]
 
 
 @router.get(
@@ -1565,15 +1571,17 @@ async def _set_public_readiness_status(response: Response) -> None:
 )
 async def health_readiness(response: Response):
     """
-    Public readiness probe. Keep this low-detail for unauthenticated load
-    balancers by default. Admins can opt into the legacy detailed public
-    payload with general_settings.allow_public_health_readiness_details.
+    Public readiness probe. Returns a low-detail payload safe to expose to
+    unauthenticated load balancers — `status` plus `db` so orchestrators and
+    external probes can distinguish "healthy" from "DB unreachable" without a
+    credential. Admins can opt into the legacy detailed payload with
+    general_settings.allow_public_health_readiness_details.
     """
     if _allow_public_health_readiness_details():
         return await _get_health_readiness_details(response=response)
 
-    await _set_public_readiness_status(response=response)
-    return {"status": "healthy"}
+    db_status = await _resolve_public_readiness_db(response=response)
+    return {"status": "healthy", "db": db_status}
 
 
 @router.get(

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -844,9 +844,14 @@ def test_health_readiness(proxy_client):
         duration_ms < 500
     ), f"Health check took {duration_ms:.2f}ms, expected < 500ms for readiness endpoint"
 
-    # Assert response contains only low-detail public probe fields
+    # Assert response contains only low-detail public probe fields. `db` is
+    # included so unauthenticated probes can distinguish "DB unreachable"
+    # from a fully-healthy worker; its value depends on whether the test env
+    # exposes DATABASE_URL.
     response_data = response.json()
-    assert response_data == {"status": "healthy"}
+    assert set(response_data.keys()) == {"status", "db"}
+    assert response_data["status"] == "healthy"
+    assert response_data["db"] in {"connected", "disconnected", "Not connected"}
     print(f"Response time: {duration_ms:.2f}ms")
 
 
@@ -1750,7 +1755,7 @@ async def test_health_readiness_returns_503_when_db_disconnected():
         result = await health_readiness(response=response)
 
     assert response.status_code == 503
-    assert result == {"status": "healthy"}
+    assert result == {"status": "healthy", "db": "disconnected"}
 
 
 @pytest.mark.asyncio
@@ -1773,7 +1778,7 @@ async def test_health_readiness_returns_200_when_db_connected():
         result = await health_readiness(response=response)
 
     assert response.status_code == 200
-    assert result == {"status": "healthy"}
+    assert result == {"status": "healthy", "db": "connected"}
 
 
 @pytest.mark.asyncio
@@ -1792,7 +1797,7 @@ async def test_health_readiness_returns_200_when_no_db_configured():
         result = await health_readiness(response=response)
 
     assert response.status_code == 200
-    assert result == {"status": "healthy"}
+    assert result == {"status": "healthy", "db": "Not connected"}
 
 
 def test_clean_endpoint_data_strips_credentials_keeps_routing_fields():


### PR DESCRIPTION
## Summary

- Adds `db` back to the unauthenticated `/health/readiness` payload so external probes can distinguish a healthy worker from a DB-unreachable one without auth.
- The recon-sensitive fields (`litellm_version`, `success_callbacks`, `cache`, `log_level`, `is_detailed_debug`, `use_aiohttp_transport`) stay behind `/health/readiness/details`.
- Values match the legacy contract: `"connected"`, `"disconnected"`, `"Not connected"`. The 503-on-disconnect behavior is unchanged.

## Why

#26912 reduced the public probe to `{"status": "healthy"}`. Cloud alerting and external readiness probes that consumed `body.db == "connected"` started misreading 503s as healthy (the HTTP code still flipped, but body-driven probes ignored that). Re-exposing `db` restores the contract those probes depend on without re-leaking the version / callback / cache surface that #26912 was protecting.

## Test plan

- [x] `pytest tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_readiness_returns_503_when_db_disconnected` — body now `{"status": "healthy", "db": "disconnected"}`, status 503
- [x] `pytest tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_readiness_returns_200_when_db_connected` — body now `{"status": "healthy", "db": "connected"}`, status 200
- [x] `pytest tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py::test_health_readiness_returns_200_when_no_db_configured` — body now `{"status": "healthy", "db": "Not connected"}`, status 200
- [x] `pytest .../test_health_readiness_details_returns_diagnostic_fields` — `/details` still gates `litellm_version`, `success_callbacks`, `cache`
- [x] `pytest .../test_health_readiness_allows_explicit_legacy_public_details` — opt-in flag still serves the full payload