### PR TITLE
docs(budget_manager): add docstring to BudgetManager.reset_cost

### DIFF
--- a/litellm/budget_manager.py
+++ b/litellm/budget_manager.py
@@ -178,6 +178,18 @@ class BudgetManager:
         return list(self.user_dict.keys())
 
     def reset_cost(self, user):
+        """
+        Reset the tracked spend for a user back to zero.
+
+        Clears both the aggregate ``current_cost`` and the per-model
+        ``model_cost`` breakdown stored for the given user.
+
+        Args:
+            user: The user identifier whose cost should be reset.
+
+        Returns:
+            dict: ``{"user": <updated user record>}`` reflecting the reset state.
+        """
         self.user_dict[user]["current_cost"] = 0
         self.user_dict[user]["model_cost"] = {}
         return {"user": self.user_dict[user]}


### PR DESCRIPTION
## Summary

- Add a docstring to `BudgetManager.reset_cost` in `litellm/budget_manager.py` describing what it resets, its argument, and its return value.

## Why

Small documentation improvement to make the budget manager API easier to use without reading the implementation.

## Changes

- `litellm/budget_manager.py`: docstring-only addition to `reset_cost`. No behavior change.
