### PR TITLE
docs: add class docstring to _LoopWrapper

### DIFF
--- a/litellm/timeout.py
+++ b/litellm/timeout.py
@@ -90,6 +90,13 @@ def timeout(timeout_duration: float = 0.0, exception_to_raise=Timeout):
 
 
 class _LoopWrapper(Thread):
+    """Daemon thread that owns a dedicated asyncio event loop.
+
+    Used by the sync branch of :func:`timeout` to run a coroutine on a
+    background event loop so the calling thread can wait on it with a
+    timeout via :func:`asyncio.run_coroutine_threadsafe`.
+    """
+
     def __init__(self):
         super().__init__(daemon=True)
         self.loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Summary

Adds a class docstring to `_LoopWrapper` in `litellm/timeout.py` explaining that it is the daemon thread that owns the dedicated asyncio event loop used by the sync branch of the `timeout` decorator.

Docs-only change — no behavior change, no new dependencies.

## Tests

Not applicable — pure docstring addition, no executable code paths changed. `uv run black --check litellm/timeout.py` passes.
