### PR TITLE
fix(pricing): GPT-4o-Transcribe Pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3596,7 +3596,7 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-transcribe": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
@@ -3608,7 +3608,7 @@
         ]
     },
     "azure/gpt-4o-transcribe-diarize": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
@@ -8974,7 +8974,7 @@
         "supports_vision": true
     },
     "gpt-4o-transcribe-diarize": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,
@@ -19121,7 +19121,7 @@
         "supports_vision": true
     },
     "gpt-4o-transcribe": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3521,7 +3521,7 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-mini-transcribe": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
@@ -18991,7 +18991,7 @@
         "supports_vision": true
     },
     "gpt-4o-mini-transcribe": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,
@@ -38933,7 +38933,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-03-20": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,
@@ -38945,7 +38945,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-12-15": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3521,7 +3521,7 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-mini-transcribe": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
@@ -18996,7 +18996,7 @@
         "supports_vision": true
     },
     "gpt-4o-mini-transcribe": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,
@@ -38938,7 +38938,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-03-20": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,
@@ -38950,7 +38950,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-12-15": {
-        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3596,7 +3596,7 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-transcribe": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
@@ -3608,7 +3608,7 @@
         ]
     },
     "azure/gpt-4o-transcribe-diarize": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
@@ -8974,7 +8974,7 @@
         "supports_vision": true
     },
     "gpt-4o-transcribe-diarize": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,
@@ -19126,7 +19126,7 @@
         "supports_vision": true
     },
     "gpt-4o-transcribe": {
-        "input_cost_per_audio_token": 6e-06,
+        "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16000,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -235,7 +235,7 @@ def test_transcription_cost_uses_token_pricing():
         call_type="atranscription",
     )
 
-    expected_cost = (14 * 6e-06) + (45 * 1e-05)
+    expected_cost = (14 * 2.5e-06) + (45 * 1e-05)
     assert pytest.approx(cost, rel=1e-6) == expected_cost
 
 


### PR DESCRIPTION
## Relevant Issues:

Fixes incorrect pricing for GPT-4o-Transcribe and GPT-4o-Mini-Transcribe

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

According to OpenAI gpt-4o-transcribe pricing (audio tokens) is:
<img width="1165" height="637" alt="Screenshot 2026-05-13 at 3 34 33 PM" src="https://github.com/user-attachments/assets/49baa62b-19c4-480d-baf7-63a9cf8f40a6" />

https://developers.openai.com/api/docs/models/gpt-4o-transcribe

However in model_prices_and_context_window.json the pricing for gpt-4o-transcribe is as follows:
<img width="374" height="220" alt="Screenshot 2026-05-13 at 3 35 35 PM" src="https://github.com/user-attachments/assets/dad6ca33-7abc-4125-bd76-e1b32ffb94f7" />

The same pricing fix applies for GPT-4o-Mini-Transcribe

## Type

🐛 Bug Fix

## Changes

`model_prices_and_context_window.json`:
Fixed pricing for all GPT-4o-Transcribe references
input_cost_per_audio_token: 6e-06 → 2.5e-06

Fixed pricing for all GPT-4o-Mini-Transcribe references
input_cost_per_audio_token: 3e-06 → 1.25e-06

`model_prices_and_context_window_backup.json`:
Fixed pricing for all GPT-4o-Transcribe references
input_cost_per_audio_token: 6e-06 → 2.5e-06

Fixed pricing for all GPT-4o-Mini-Transcribe references
input_cost_per_audio_token: 3e-06 → 1.25e-06

`tests/test_litellm/test_cost_calculator.py`:
Fixed existing test for GPT-4o-Transcribe pricing to check for new values from this PR