### PR TITLE
Ishaan - May 13th Staging LiteLLM

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1299,9 +1299,18 @@ class LiteLLMAnthropicMessagesAdapter:
                         else truncated_name
                     )
 
+                    # Strip Gemini thought-signature suffix from id (mirrors streaming
+                    # path below); base64 chars (+ / =) violate Anthropic's
+                    # `^[a-zA-Z0-9_-]+$` tool_use.id pattern when replayed.
+                    raw_id = tool_call.id or ""
+                    base_id = (
+                        raw_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0]
+                        if THOUGHT_SIGNATURE_SEPARATOR in raw_id
+                        else raw_id
+                    )
                     tool_use_block = AnthropicResponseContentBlockToolUse(
                         type="tool_use",
-                        id=tool_call.id,
+                        id=base_id,
                         name=original_name,
                         input=parse_tool_call_arguments(
                             tool_call.function.arguments,

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -3,8 +3,10 @@ from typing import Optional, cast
 import httpx
 
 import litellm
+from litellm.llms.azure.common_utils import BaseAzureLLM
 from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import _add_path_to_api_base
 
 
@@ -30,20 +32,42 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
         litellm_params: Optional[dict] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        api_key = (
-            api_key
-            or litellm.api_key
-            or litellm.azure_key
-            or get_secret_str("AZURE_OPENAI_API_KEY")
-            or get_secret_str("AZURE_API_KEY")
-        )
+        """
+        Validate Azure environment and set up authentication headers.
 
-        headers.update(
-            {
-                "Authorization": f"Bearer {api_key}",
-            }
+        Delegates to ``BaseAzureLLM._base_validate_azure_environment`` so the
+        Azure image-edit route uses the same auth resolution as every other
+        Azure provider (videos, vector_stores, responses, containers, ...):
+
+        - prefers the Azure-style ``api-key`` header when an API key is available
+        - falls back to ``Authorization: Bearer <azure_ad_token>`` only when AAD
+          auth is configured
+
+        The previous implementation unconditionally set
+        ``Authorization: Bearer <api_key>``, which is correct for OpenAI direct
+        but not for Azure OpenAI / API Management gateways that expect the
+        ``api-key`` header. Subscription-key-based deployments (e.g., behind
+        Azure APIM) responded with ``401 "Access denied due to missing
+        subscription key"``.
+
+        API-key precedence (matches ``AzureVideosConfig``):
+
+        - ``litellm_params["api_key"]`` is the source of truth.
+        - The positional ``api_key`` kwarg only fills in when
+          ``litellm_params["api_key"]`` is empty.
+        - This is a deliberate change from the old ``or`` chain (where the
+          positional ``api_key`` argument won) so behavior matches every other
+          Azure ``validate_environment`` implementation. In production the only
+          caller (``llm_http_handler.image_edit``) sources both values from
+          the same ``litellm_params.api_key``, so the precedence only matters
+          for direct callers of this method.
+        """
+        params = GenericLiteLLMParams(**(litellm_params or {}))
+        if api_key is not None and params.api_key is None:
+            params.api_key = api_key
+        return BaseAzureLLM._base_validate_azure_environment(
+            headers=headers, litellm_params=params
         )
-        return headers
 
     def get_complete_url(
         self,

--- a/litellm/proxy/example_config_yaml/websearch_interception_config.yaml
+++ b/litellm/proxy/example_config_yaml/websearch_interception_config.yaml
@@ -10,7 +10,7 @@ search_tools:
       search_provider: "perplexity"
 
 litellm_settings:
-  success_callback: ["websearch_interception"]
+  callbacks: ["websearch_interception"]
   websearch_interception_params:
     enabled_providers: ["bedrock"]
     search_tool_name: "my-perplexity-search"

--- a/tests/image_gen_tests/test_image_edits.py
+++ b/tests/image_gen_tests/test_image_edits.py
@@ -314,10 +314,13 @@ async def test_azure_image_edit_litellm_sdk():
         # Check headers
         headers = call_args.kwargs.get("headers", {})
         print("Request headers:", headers)
-        assert "Authorization" in headers, "Authorization header should be present"
-        assert headers["Authorization"].startswith(
-            "Bearer "
-        ), "Authorization should be Bearer token"
+        assert (
+            "api-key" in headers
+        ), "Azure image edit must use the api-key header, not Authorization: Bearer"
+        assert headers["api-key"] == test_api_key
+        assert (
+            "Authorization" not in headers
+        ), "Azure image edit must not send an Authorization header when an api_key is provided"
 
         print("result from image edit", result)
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -430,6 +430,46 @@ def test_translate_openai_content_to_anthropic_text_and_tool_calls():
     assert result[1]["input"] == {"location": "Boston"}
 
 
+def test_translate_openai_content_to_anthropic_strips_gemini_thought_from_tool_call_id():
+    """
+    Non-streaming path must strip the Gemini thought-signature suffix from
+    tool_call.id, same as the streaming path. The base64 signature contains
+    `+ / =` which violate Anthropic's `^[a-zA-Z0-9_-]+$` tool_use.id pattern
+    and 400 when the history is replayed to an Anthropic-native provider.
+    """
+    base = "call_3e9417b7925e49aca9a71dc1885e"
+    sig = "CiIBDDnWx+/a=="
+    combined = f"{base}{THOUGHT_SIGNATURE_SEPARATOR}{sig}"
+    openai_choices = [
+        Choices(
+            message=Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionAssistantToolCall(
+                        id=combined,
+                        type="function",
+                        function=Function(
+                            name="get_weather",
+                            arguments='{"location": "Boston"}',
+                        ),
+                    )
+                ],
+            )
+        )
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter._translate_openai_content_to_anthropic(choices=openai_choices)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "tool_use"
+    assert result[0]["id"] == base
+    assert THOUGHT_SIGNATURE_SEPARATOR not in result[0]["id"]
+    assert result[0]["name"] == "get_weather"
+    assert result[0]["input"] == {"location": "Boston"}
+
+
 def test_translate_openai_response_to_anthropic_text_and_tool_calls():
     """`translate_openai_response_to_anthropic` should surface assistant text even when tools fire."""
     openai_response = ModelResponse(
@@ -2327,7 +2367,8 @@ class TestAnthropicStreamWrapperToolArgs:
 
     def _find_tool_deltas(self, events):
         return [
-            e for e in events
+            e
+            for e in events
             if isinstance(e, dict)
             and e.get("type") == "content_block_delta"
             and isinstance(e.get("delta"), dict)
@@ -2373,7 +2414,6 @@ class TestAnthropicStreamWrapperToolArgs:
         combined = "".join(d["delta"]["partial_json"] for d in tool_deltas)
         parsed = json.loads(combined)
         assert parsed == {"city": "Tokyo"}
-
 
 
 def test_translate_anthropic_tool_choice_none():

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -1,5 +1,94 @@
+from unittest.mock import patch
+
 from litellm.llms.azure.image_edit.transformation import AzureImageEditConfig
 from litellm.types.router import GenericLiteLLMParams
+
+
+def test_validate_environment_uses_api_key_header_for_subscription_key():
+    """
+    Azure OpenAI / API Management gateways authenticate via the ``api-key``
+    header. Using ``Authorization: Bearer <subscription-key>`` is the OpenAI
+    direct convention and is rejected by Azure with
+    ``401 "Access denied due to missing subscription key"``.
+
+    Regression guard for the previous unconditional Bearer header.
+    """
+    config = AzureImageEditConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="gpt-image-1",
+        api_key="my-azure-subscription-key",
+        litellm_params={},
+    )
+    assert headers.get("api-key") == "my-azure-subscription-key"
+    assert "Authorization" not in headers
+
+
+def test_validate_environment_prefers_litellm_params_api_key():
+    config = AzureImageEditConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="gpt-image-1",
+        api_key=None,
+        litellm_params={"api_key": "from-params"},
+    )
+    assert headers.get("api-key") == "from-params"
+    assert "Authorization" not in headers
+
+
+def test_validate_environment_litellm_params_api_key_beats_positional_arg():
+    """
+    Precedence pin: when both ``api_key`` (positional) and
+    ``litellm_params["api_key"]`` are set with different values, the
+    ``litellm_params`` value wins.
+
+    This matches the convention used by every other Azure
+    ``validate_environment`` (videos, vector_stores, responses, ...), where
+    ``litellm_params.api_key`` is the source of truth and the positional
+    kwarg only fills in when ``litellm_params`` lacks a key. In production
+    the only caller (``llm_http_handler.image_edit``) sources both values
+    from the same ``litellm_params.api_key``, so this only matters for
+    direct callers.
+    """
+    config = AzureImageEditConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="gpt-image-1",
+        api_key="from-positional",
+        litellm_params={"api_key": "from-params"},
+    )
+    assert headers.get("api-key") == "from-params"
+    assert "Authorization" not in headers
+
+
+def test_validate_environment_falls_back_to_aad_bearer_when_no_api_key():
+    """
+    When neither ``api_key`` nor any AZURE_*_API_KEY env var is available, the
+    base helper resolves an AAD token and falls back to
+    ``Authorization: Bearer <token>``. This mirrors the behavior of every
+    other Azure provider class (videos, vector_stores, responses, ...).
+    """
+    config = AzureImageEditConfig()
+    with (
+        patch(
+            "litellm.llms.azure.common_utils.get_azure_ad_token",
+            return_value="fake-aad-token",
+        ),
+        patch(
+            "litellm.llms.azure.common_utils.get_secret_str",
+            return_value=None,
+        ),
+        patch("litellm.api_key", None),
+        patch("litellm.azure_key", None),
+    ):
+        headers = config.validate_environment(
+            headers={},
+            model="gpt-image-1",
+            api_key=None,
+            litellm_params={},
+        )
+    assert headers.get("Authorization") == "Bearer fake-aad-token"
+    assert "api-key" not in headers
 
 
 def test_azure_deployment_image_edit_form_data_strips_model():


### PR DESCRIPTION
… path; example websearch config (#27873)

- adapters/transformation.py: mirror the streaming path and strip the `__thought__<b64>` suffix off `tool_call.id` before building the AnthropicResponseContentBlockToolUse. Base64's `+ / =` characters violate Anthropic's `^[a-zA-Z0-9_-]+$` tool_use.id pattern, so when a conversation that flowed through Gemini is later replayed to an Anthropic-native provider (Bedrock or Anthropic API) the request 400s.
- example_config_yaml/websearch_interception_config.yaml: register the interceptor under `callbacks:` not `success_callback:`. `success_callback` does not run pre-request hooks, so the tool-conversion step never fires on `/v1/messages` and the raw `web_search_20250305` tool is forwarded to Bedrock, which 400s.
- adds a unit test pinning the non-streaming strip behavior and the surviving `^[a-zA-Z0-9_-]+$` shape of the resulting id.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request/response transformation logic for Anthropic pass-through and Azure image edits; could break interoperability if downstream systems relied on previous `Authorization: Bearer <api_key>` behavior or on unmodified tool call ids.
> 
> **Overview**
> Fixes Anthropic `/v1/messages` pass-through translation to **strip Gemini `__thought__<b64>` suffixes from non-streaming `tool_call.id`** so returned `tool_use.id` matches Anthropic’s allowed character set (preventing 400s when replaying history to Anthropic/Bedrock).
> 
> Updates Azure image-edit `validate_environment` to **reuse `BaseAzureLLM._base_validate_azure_environment`**, switching to the Azure `api-key` header when an API key is present (with consistent precedence for `litellm_params.api_key`) and only using `Authorization: Bearer` for AAD-token auth; tests and the example `websearch_interception_config.yaml` are updated accordingly (`callbacks` replaces `success_callback`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65950e785cc4dbfe6686a0fa135fe7bd0771627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->