### PR TITLE
fix(fireworks_ai): strip `thinking_blocks` from chat messages before Fireworks API call

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -241,13 +241,9 @@ class FireworksAIConfig(OpenAIGPTConfig):
                                 disable_add_transform_inline_image_block=disable_add_transform_inline_image_block,
                             )
             filter_value_from_dict(cast(dict, message), "cache_control")
-            # Remove fields not permitted by FireworksAI that may cause:
-            # "Not permitted, field: 'messages[n].provider_specific_fields'"
             if isinstance(message, dict):
                 m = cast(dict, message)
                 m.pop("provider_specific_fields", None)
-                # Strict OpenAI schema: Anthropic/Claude Code replays include thinking_blocks;
-                # Fireworks rejects them ("Extra inputs are not permitted").
                 m.pop("thinking_blocks", None)
 
         return messages

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -241,6 +241,9 @@ class FireworksAIConfig(OpenAIGPTConfig):
                                 disable_add_transform_inline_image_block=disable_add_transform_inline_image_block,
                             )
             filter_value_from_dict(cast(dict, message), "cache_control")
+            # Remove fields not permitted by FireworksAI (additionalProperties: false
+            # on their ChatMessage schema) that may cause:
+            # "Extra inputs are not permitted, field: 'messages[n].<field>'"
             if isinstance(message, dict):
                 m = cast(dict, message)
                 m.pop("provider_specific_fields", None)

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -243,8 +243,12 @@ class FireworksAIConfig(OpenAIGPTConfig):
             filter_value_from_dict(cast(dict, message), "cache_control")
             # Remove fields not permitted by FireworksAI that may cause:
             # "Not permitted, field: 'messages[n].provider_specific_fields'"
-            if isinstance(message, dict) and "provider_specific_fields" in message:
-                cast(dict, message).pop("provider_specific_fields", None)
+            if isinstance(message, dict):
+                m = cast(dict, message)
+                m.pop("provider_specific_fields", None)
+                # Strict OpenAI schema: Anthropic/Claude Code replays include thinking_blocks;
+                # Fireworks rejects them ("Extra inputs are not permitted").
+                m.pop("thinking_blocks", None)
 
         return messages
 

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -232,3 +232,23 @@ def test_transform_messages_helper_removes_provider_specific_fields():
     )
     for msg in out:
         assert "provider_specific_fields" not in msg
+
+
+def test_transform_messages_helper_strips_thinking_blocks():
+    """Fireworks chat API rejects messages[].thinking_blocks (Claude Code / Anthropic replay)."""
+    config = FireworksAIConfig()
+    messages = [
+        {"role": "user", "content": "Translate a poem."},
+        {
+            "role": "assistant",
+            "content": "I can help.",
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "internal", "signature": ""}
+            ],
+        },
+    ]
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
+    )
+    assert "thinking_blocks" not in out[1]
+    assert out[1]["content"] == "I can help."

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -235,7 +235,7 @@ def test_transform_messages_helper_removes_provider_specific_fields():
 
 
 def test_transform_messages_helper_strips_thinking_blocks():
-    """Fireworks chat API rejects messages[].thinking_blocks (Claude Code / Anthropic replay)."""
+    """thinking_blocks must not be forwarded to Fireworks chat completions."""
     config = FireworksAIConfig()
     messages = [
         {"role": "user", "content": "Translate a poem."},


### PR DESCRIPTION

## Relevant issues

<!-- Link an issue if one exists, e.g. Fixes #NNNN -->

N/A — addresses Fireworks `invalid_request_error` when clients (e.g. Claude Code) replay Anthropic-shaped history with `messages[].thinking_blocks` on the OpenAI-compatible `/v1/chat/completions` path. `drop_params` does not apply to nested message fields.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(maintainer CI; local: targeted pytest below passed)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmosslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### Why

Fireworks `ChatMessage` in their OpenAPI uses **`additionalProperties: false`** and does not allow `messages[].thinking_blocks`. Clients that replay Anthropic-style history hit:

`invalid_request_error` — `Extra inputs are not permitted, field: 'messages[N].thinking_blocks'`

`drop_params` does not strip nested message keys.

### Unit test

```bash
cd berriai/litellm
python3 -m pytest tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py::test_transform_messages_helper_strips_thinking_blocks -q
```

---

### End-to-end: minimal proxy YAML

```yaml
model_list:
  - model_name: "fireworks_ai/*"
    litellm_params:
      model: "fireworks_ai/*"
      api_key: os.environ/FIREWORKS_API_KEY
```

---

### End-to-end: `curl` request

`thinking_blocks` on an assistant message is the failure mode; LiteLLM must strip it before calling Fireworks.

**Request**

```bash
curl -sS -D - http://127.0.0.1:4060/v1/chat/completions \
  -H "Authorization: Bearer sk-123" \
  -H "Content-Type: application/json" \
  -d '{
  "model": "fireworks_ai/accounts/fireworks/models/glm-5p1",
  "max_tokens": 32,
  "messages": [
    {"role": "user", "content": "Reply with exactly: OK"},
    {
      "role": "assistant",
      "content": "OK",
      "thinking_blocks": [
        {"type": "thinking", "thinking": "synthetic replay", "signature": ""}
      ]
    },
    {"role": "user", "content": "One more time: OK"}
  ]
}'
```

**Response** (HTTP `200`; real capture against Fireworks through LiteLLM on this branch; `id` / `created` will differ per call)

```http
HTTP/1.1 200 OK
```

```json
{
  "id": "chatcmpl-15ee7c1dfabe488ca3af59cab2565839",
  "created": 1778714554,
  "model": "fireworks_ai/accounts/fireworks/models/glm-5p1",
  "object": "chat.completion",
  "choices": [
    {
      "finish_reason": "length",
      "index": 0,
      "message": {
        "content": "1.  **Analyze the Input:** The user is asking me to reply \"OK\" one more time.\n2.  **Analyze the Constraints:**",
        "role": "assistant"
      }
    }
  ],
  "usage": {
    "completion_tokens": 32,
    "prompt_tokens": 19,
    "total_tokens": 51,
    "prompt_tokens_details": {
      "cached_tokens": 7
    }
  }
}
```

Same JSON body sent **directly** to Fireworks’ OpenAI-compatible `POST .../chat/completions` (bypassing LiteLLM) returns **`400`** with a body shaped like:

```json
{
  "error": {
    "object": "error",
    "type": "invalid_request_error",
    "code": "invalid_request_error",
    "message": "Extra inputs are not permitted, field: 'messages[1].thinking_blocks', value: [{'type': 'thinking', 'thinking': 'synthetic replay', 'signature': ''}]"
  }
}
```

## Type

🐛 Bug Fix

## Changes

- Strip `thinking_blocks` from message dicts in `litellm/llms/fireworks_ai/chat/transformation.py` (`_transform_messages_helper`).
- Add `test_transform_messages_helper_strips_thinking_blocks` in `tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only strips Fireworks-disallowed nested message keys before sending requests, reducing 400 invalid_request errors; behavior change is limited to dropping non-schema fields.
> 
> **Overview**
> Prevents Fireworks `/chat/completions` requests from failing schema validation by stripping additional disallowed per-message fields in `_transform_messages_helper`, expanding the existing cleanup to also drop `thinking_blocks` (and consistently removing `provider_specific_fields`).
> 
> Adds a unit test to ensure `thinking_blocks` are removed while message `content` is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38dbd9702c466ba377bc06b7ef67835d2681a74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->