### PR TITLE
fix(proxy): prefer local cost overrides for litellm proxy

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1753,7 +1753,14 @@ def response_cost_calculator(
                     provider_response_cost = get_response_cost_from_hidden_params(
                         response_object._hidden_params
                     )
-                    if provider_response_cost is not None:
+                    use_local_proxy_pricing = custom_pricing is True and (
+                        custom_llm_provider == "litellm_proxy"
+                        or str(model or "").startswith("litellm_proxy/")
+                    )
+                    if (
+                        provider_response_cost is not None
+                        and not use_local_proxy_pricing
+                    ):
                         return provider_response_cost
 
             response_cost = completion_cost(

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -67,6 +67,41 @@ def test_cost_calculator_with_response_cost_in_additional_headers():
     assert result == 1000
 
 
+def test_litellm_proxy_custom_pricing_overrides_upstream_response_cost(monkeypatch):
+    model = "hosted_vllm/glm-4.7-fp8"
+    response = ModelResponse(
+        model=model,
+        choices=[],
+        usage=Usage(prompt_tokens=100, completion_tokens=25, total_tokens=125),
+    )
+    response._hidden_params["additional_headers"] = {
+        "llm_provider-x-litellm-response-cost": "9.99"
+    }
+    monkeypatch.setattr(
+        litellm,
+        "model_cost",
+        {
+            f"litellm_proxy/{model}": {
+                "litellm_provider": "litellm_proxy",
+                "mode": "chat",
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+            }
+        },
+    )
+
+    result = response_cost_calculator(
+        response_object=response,
+        model=model,
+        custom_llm_provider="litellm_proxy",
+        call_type="completion",
+        optional_params={},
+        custom_pricing=True,
+    )
+
+    assert result == 0.0
+
+
 def test_baseten_model_api_pricing_entries():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")


### PR DESCRIPTION
## Summary
- let `litellm_proxy` calls with `custom_pricing=True` ignore the upstream proxy response-cost header
- fall back to the existing local cost calculation so model_info / router overrides can win
- add a regression test for a zero-cost local override on a chained proxy call

Fixes #27656.

## To verify
- `python -m py_compile litellm/cost_calculator.py tests/test_litellm/test_cost_calculator.py`
- `python -m pytest tests/test_litellm/test_cost_calculator.py -k "response_cost_in_additional_headers or litellm_proxy_custom_pricing" -q --basetemp .tmp\pytest`
- `python -m ruff check litellm/cost_calculator.py`
- `git diff --check`