### PR TITLE
fix: preserve strict schema properties

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3630,14 +3630,18 @@ def _remove_strict_from_schema(schema):
     """
     Relevant Issues: https://github.com/BerriAI/litellm/issues/6136, https://github.com/BerriAI/litellm/issues/6088
     """
+    schema_map_keys = {"properties", "patternProperties", "$defs", "definitions"}
     if isinstance(schema, dict):
         # Remove the 'additionalProperties' key if it exists and is set to False
         if "strict" in schema:
             del schema["strict"]
 
-        # Recursively process all dictionary values
         for key, value in schema.items():
-            _remove_strict_from_schema(value)
+            if key in schema_map_keys and isinstance(value, dict):
+                for prop_schema in value.values():
+                    _remove_strict_from_schema(prop_schema)
+            else:
+                _remove_strict_from_schema(value)
 
     elif isinstance(schema, list):
         # Recursively process all items in the list

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -49,6 +49,35 @@ def reset_mock_cache():
     _model_cache.flush_cache()
 
 
+def test_remove_strict_from_schema_preserves_property_named_strict():
+    from litellm.utils import _remove_strict_from_schema
+
+    schema = {
+        "type": "object",
+        "strict": True,
+        "properties": {
+            "strict": {"type": "boolean"},
+            "field": {"type": "string", "strict": True},
+        },
+        "patternProperties": {
+            "strict": {"type": "number", "strict": True},
+        },
+        "$defs": {
+            "strict": {"type": "object", "strict": True},
+        },
+        "required": ["strict", "field"],
+    }
+
+    result = _remove_strict_from_schema(schema)
+
+    assert "strict" not in result
+    assert result["properties"]["strict"] == {"type": "boolean"}
+    assert result["properties"]["field"] == {"type": "string"}
+    assert result["patternProperties"]["strict"] == {"type": "number"}
+    assert result["$defs"]["strict"] == {"type": "object"}
+    assert result["required"] == ["strict", "field"]
+
+
 # Test 1: Check trimming of normal message
 def test_basic_trimming():
     litellm._turn_on_debug()


### PR DESCRIPTION
## Summary
- keep user-defined properties named `strict` when sanitizing JSON schemas
- still remove schema-level `strict` keywords before provider requests
- add a regression test that preserves `required: ["strict", ...]`

Fixes #27853.

## To verify
- `python -m py_compile litellm/utils.py tests/litellm_utils_tests/test_utils.py`
- `python -m pytest tests/litellm_utils_tests/test_utils.py::test_remove_strict_from_schema_preserves_property_named_strict -q --basetemp .tmp\pytest`
- `python -m ruff check litellm/utils.py`
- `git diff --check`