### PR TITLE
chore(proxy): refuse env-var indirection from request bodies

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -173,8 +173,16 @@ def _allow_model_level_clientside_configurable_parameters(
 # by ``/utils/transform_request`` (``{call_type, request_body: {...}}``);
 # descending into it lets the banned-key and indirection checks see the
 # inner provider params regardless of whether the handler explicitly
-# unwraps before calling ``is_request_body_safe``.
-_NESTED_CONFIG_KEYS: Tuple[str, ...] = ("litellm_embedding_config", "request_body")
+# unwraps before calling ``is_request_body_safe``. ``extra_body`` is the
+# OpenAI-SDK passthrough container: provider modules (e.g. Azure paths
+# that read ``extra_body.azure_ad_token`` and resolve it via
+# ``get_secret``) pull fields out without re-validating them, so the
+# banned-key and indirection checks have to apply there too.
+_NESTED_CONFIG_KEYS: Tuple[str, ...] = (
+    "litellm_embedding_config",
+    "request_body",
+    "extra_body",
+)
 
 # Metadata containers that carry per-request configuration consumed by the
 # observability callbacks. The same banned-param list applies — a value
@@ -324,20 +332,63 @@ _USER_INPUT_FORBIDDEN_INDIRECTION_PREFIXES: Tuple[str, ...] = (
 )
 
 
+# Maximum nesting depth walked by ``_check_no_user_supplied_indirection``.
+# Provider request bodies in this codebase top out around 4-5 levels of
+# real nesting (e.g. ``messages[].content[].image_url.url``); 10 leaves
+# headroom for legitimate clients while bounding the walk so a deeply
+# nested attacker payload can't cause stack/CPU DoS.
+_INDIRECTION_CHECK_MAX_DEPTH: int = 10
+
+
 def _check_no_user_supplied_indirection(body: dict) -> None:
-    """Refuse ``os.environ/`` / ``oidc/`` indirection strings in user
-    input. ``_check_banned_params`` rejects KEYS in the blocklist; this
-    rejects VALUES that would resolve through ``get_secret`` regardless
-    of the key they're sent under."""
-    for key, value in body.items():
-        if isinstance(value, str) and value.startswith(
-            _USER_INPUT_FORBIDDEN_INDIRECTION_PREFIXES
-        ):
-            raise ValueError(
-                f"{key!r}={value!r} is rejected: server-side secret "
-                "indirection (os.environ/, oidc/) is not allowed in "
-                "request bodies."
-            )
+    """Refuse ``os.environ/`` / ``oidc/`` indirection strings anywhere in
+    a user-supplied body. ``_check_banned_params`` rejects KEYS in the
+    blocklist; this rejects VALUES that would resolve through
+    ``get_secret`` regardless of the key they're sent under.
+
+    Walks dicts and lists recursively up to ``_INDIRECTION_CHECK_MAX_DEPTH``
+    so an indirection string buried inside ``extra_body``,
+    ``messages[].metadata``, or any other nested container is rejected at
+    the boundary rather than reaching ``get_secret`` through some
+    provider module's nested-field resolution.
+    """
+    _walk_for_indirection(body, depth=0, path="")
+
+
+def _walk_for_indirection(node: Any, depth: int, path: str) -> None:
+    if depth > _INDIRECTION_CHECK_MAX_DEPTH:
+        # Bound the walk: at this depth no legitimate provider field
+        # exists, and continuing would let a pathological payload burn
+        # CPU. The outer container has already been checked; if a real
+        # field lives below the bound the operator should restructure
+        # the request rather than rely on the proxy to mine it.
+        return
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            if isinstance(value, str) and value.startswith(
+                _USER_INPUT_FORBIDDEN_INDIRECTION_PREFIXES
+            ):
+                raise ValueError(
+                    f"{child_path!r}={value!r} is rejected: server-side "
+                    "secret indirection (os.environ/, oidc/) is not "
+                    "allowed in request bodies."
+                )
+            if isinstance(value, (dict, list)):
+                _walk_for_indirection(value, depth + 1, child_path)
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            child_path = f"{path}[{idx}]"
+            if isinstance(item, str) and item.startswith(
+                _USER_INPUT_FORBIDDEN_INDIRECTION_PREFIXES
+            ):
+                raise ValueError(
+                    f"{child_path!r}={item!r} is rejected: server-side "
+                    "secret indirection (os.environ/, oidc/) is not "
+                    "allowed in request bodies."
+                )
+            if isinstance(item, (dict, list)):
+                _walk_for_indirection(item, depth + 1, child_path)
 
 
 def is_request_body_safe(
@@ -363,23 +414,29 @@ def is_request_body_safe(
     has a single, predictable failure mode for missing entries (a 400),
     not a credential leak.
 
-    Iterative single-level descent into ``_NESTED_CONFIG_KEYS`` (rather
-    than recursion) covers nested-config attacks like Milvus's
-    ``litellm_embedding_config.api_base`` (VERIA-6) without exposing a
-    recursion-depth DoS surface.
+    Banned-key descent is one level into each entry in
+    ``_NESTED_CONFIG_KEYS`` / ``_NESTED_METADATA_KEYS`` — banned-key
+    detection compares against a fixed set of sink-named keys, and the
+    sinks that actually reach outbound calls live at those known
+    containers, so deeper recursion adds cost without coverage.
+
+    Indirection descent is recursive (bounded depth in
+    ``_walk_for_indirection``). A ``get_secret`` indirection string is
+    just a value, so an attacker can park it anywhere a provider module
+    later resolves a nested field — ``extra_body.azure_ad_token`` is the
+    motivating case but the same shape applies to any future nested
+    auth field a provider transformer adds.
     """
     _check_banned_params(request_body, general_settings, llm_router, model)
-    _check_no_user_supplied_indirection(request_body)
     for nested_key in _NESTED_CONFIG_KEYS:
         nested = request_body.get(nested_key)
         if isinstance(nested, dict):
             _check_banned_params(nested, general_settings, llm_router, model)
-            _check_no_user_supplied_indirection(nested)
     for metadata_key in _NESTED_METADATA_KEYS:
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
         if metadata is not None:
             _check_banned_params(metadata, general_settings, llm_router, model)
-            _check_no_user_supplied_indirection(metadata)
+    _check_no_user_supplied_indirection(request_body)
     return True
 
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -311,6 +311,32 @@ def _check_banned_params(
         )
 
 
+# ``get_secret`` resolves these prefixes server-side (env vars / OIDC
+# providers / on-disk tokens). They're operator-config primitives and
+# must never originate from a request body, where an attacker would
+# name the source the proxy resolves on their behalf.
+_USER_INPUT_FORBIDDEN_INDIRECTION_PREFIXES: Tuple[str, ...] = (
+    "os.environ/",
+    "oidc/",
+)
+
+
+def _check_no_user_supplied_indirection(body: dict) -> None:
+    """Refuse ``os.environ/`` / ``oidc/`` indirection strings in user
+    input. ``_check_banned_params`` rejects KEYS in the blocklist; this
+    rejects VALUES that would resolve through ``get_secret`` regardless
+    of the key they're sent under."""
+    for key, value in body.items():
+        if isinstance(value, str) and value.startswith(
+            _USER_INPUT_FORBIDDEN_INDIRECTION_PREFIXES
+        ):
+            raise ValueError(
+                f"{key!r}={value!r} is rejected: server-side secret "
+                "indirection (os.environ/, oidc/) is not allowed in "
+                "request bodies."
+            )
+
+
 def is_request_body_safe(
     request_body: dict, general_settings: dict, llm_router: Optional[Router], model: str
 ) -> bool:
@@ -340,14 +366,17 @@ def is_request_body_safe(
     recursion-depth DoS surface.
     """
     _check_banned_params(request_body, general_settings, llm_router, model)
+    _check_no_user_supplied_indirection(request_body)
     for nested_key in _NESTED_CONFIG_KEYS:
         nested = request_body.get(nested_key)
         if isinstance(nested, dict):
             _check_banned_params(nested, general_settings, llm_router, model)
+            _check_no_user_supplied_indirection(nested)
     for metadata_key in _NESTED_METADATA_KEYS:
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
         if metadata is not None:
             _check_banned_params(metadata, general_settings, llm_router, model)
+            _check_no_user_supplied_indirection(metadata)
     return True
 
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -169,9 +169,12 @@ def _allow_model_level_clientside_configurable_parameters(
 
 # Config dicts whose entries are spread as ``**dict`` into outbound LLM
 # API calls. ``litellm_embedding_config`` is consumed by the Milvus
-# vector store transformer; future nested-config keys with the same
-# threat shape should be added here.
-_NESTED_CONFIG_KEYS: Tuple[str, ...] = ("litellm_embedding_config",)
+# vector store transformer. ``request_body`` is the wrapper shape used
+# by ``/utils/transform_request`` (``{call_type, request_body: {...}}``);
+# descending into it lets the banned-key and indirection checks see the
+# inner provider params regardless of whether the handler explicitly
+# unwraps before calling ``is_request_body_safe``.
+_NESTED_CONFIG_KEYS: Tuple[str, ...] = ("litellm_embedding_config", "request_body")
 
 # Metadata containers that carry per-request configuration consumed by the
 # observability callbacks. The same banned-param list applies — a value

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -181,7 +181,16 @@ _RESOLVER_INDIRECTION_DENYLIST: FrozenSet[str] = frozenset(
         "REDIS_PASSWORD",
         "HCP_VAULT_TOKEN",
         "SMTP_PASSWORD",
+        # Workload-identity tokens — listed so ``os.environ/<X>`` and
+        # ``oidc/env/<X>`` indirection can't smuggle them; the
+        # ``oidc/<provider>/...`` branches that legitimately read them
+        # don't go through this gate (legit operator config uses those
+        # branches).
+        "CIRCLE_OIDC_TOKEN",
+        "CIRCLE_OIDC_TOKEN_V2",
         "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "AZURE_FEDERATED_TOKEN_FILE",
     }
 )
 

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -1,7 +1,7 @@
 import ast
 import os
 import traceback
-from typing import FrozenSet, Optional, Union
+from typing import Optional, Union
 
 import httpx
 
@@ -156,70 +156,6 @@ def get_secret_bool(
         return str_to_bool(_secret_value)
 
 
-# Server-process secrets — env vars that exist only to configure the
-# proxy itself. Reading any of these via the prefix-driven indirection
-# paths is never a legitimate operator flow (they're set directly as
-# env vars, not referenced via ``os.environ/`` in config). Server-side
-# callers use bare names (no prefix) and bypass the gates below.
-_RESOLVER_INDIRECTION_DENYLIST: FrozenSet[str] = frozenset(
-    {
-        "LITELLM_MASTER_KEY",
-        "LITELLM_SALT_KEY",
-        "LITELLM_LICENSE",
-        "LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE",
-        "DATABASE_URL",
-        "DATABASE_URL_READ_REPLICA",
-        "DATABASE_PASSWORD",
-        "DATABASE_USER",
-        "DATABASE_USERNAME",
-        "DATABASE_HOST",
-        "DATABASE_PORT",
-        "DATABASE_NAME",
-        "DATABASE_SCHEMA",
-        "IAM_TOKEN_DB_AUTH",
-        "REDIS_URL",
-        "REDIS_PASSWORD",
-        "HCP_VAULT_TOKEN",
-        "SMTP_PASSWORD",
-        # Workload-identity tokens — listed so ``os.environ/<X>`` and
-        # ``oidc/env/<X>`` indirection can't smuggle them; the
-        # ``oidc/<provider>/...`` branches that legitimately read them
-        # don't go through this gate (legit operator config uses those
-        # branches).
-        "CIRCLE_OIDC_TOKEN",
-        "CIRCLE_OIDC_TOKEN_V2",
-        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
-        "ACTIONS_ID_TOKEN_REQUEST_URL",
-        "AZURE_FEDERATED_TOKEN_FILE",
-        # UI / SSO admin-authentication secrets. ``UI_PASSWORD`` gates
-        # the ``/login`` admin path; leaking it via indirection is a
-        # one-step internal_user → PROXY_ADMIN escalation.
-        "UI_PASSWORD",
-        "UI_USERNAME",
-        "PROXY_ADMIN_ID",
-        # OAuth / OIDC client secrets used by SSO integrations and
-        # provider-side auth flows.
-        "OAUTH_CLIENT_SECRET",
-        "OPENID_CLIENT_SECRET",
-        "GOOGLE_CLIENT_SECRET",
-        "MICROSOFT_CLIENT_SECRET",
-        "AZURE_CLIENT_SECRET",
-        "AZURE_SENTINEL_CLIENT_SECRET",
-        "AZURE_STORAGE_CLIENT_SECRET",
-        "DATABRICKS_CLIENT_SECRET",
-        "GENERIC_CLIENT_SECRET",
-    }
-)
-
-
-def _reject_if_indirection_denied(env_var: str, scheme: str) -> None:
-    if env_var in _RESOLVER_INDIRECTION_DENYLIST:
-        raise ValueError(
-            f"{scheme}/{env_var}: env var is not exposable via "
-            "request-body indirection."
-        )
-
-
 def get_secret(  # noqa: PLR0915
     secret_name: str,
     default_value: Optional[Union[str, bool]] = None,
@@ -229,9 +165,7 @@ def get_secret(  # noqa: PLR0915
     secret = None
 
     if secret_name.startswith("os.environ/"):
-        requested = secret_name[len("os.environ/") :]
-        _reject_if_indirection_denied(requested, "os.environ")
-        secret_name = requested
+        secret_name = secret_name[len("os.environ/") :]
 
     # Example: oidc/google/https://bedrock-runtime.us-east-1.amazonaws.com/model/stability.stable-diffusion-xl-v1/invoke
     if secret_name.startswith("oidc/"):
@@ -328,14 +262,12 @@ def get_secret(  # noqa: PLR0915
                 return oidc_token
         elif oidc_provider == "env":
             # Load token directly from an environment variable
-            _reject_if_indirection_denied(oidc_aud, "oidc/env")
             oidc_token = os.getenv(oidc_aud)
             if oidc_token is None:
                 raise ValueError(f"Environment variable {oidc_aud} not found")
             return oidc_token
         elif oidc_provider == "env_path":
             # Load token from a file path specified in an environment variable
-            _reject_if_indirection_denied(oidc_aud, "oidc/env_path")
             token_file_path = os.getenv(oidc_aud)
             if token_file_path is None:
                 raise ValueError(f"Environment variable {oidc_aud} not found")

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -191,6 +191,23 @@ _RESOLVER_INDIRECTION_DENYLIST: FrozenSet[str] = frozenset(
         "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
         "ACTIONS_ID_TOKEN_REQUEST_URL",
         "AZURE_FEDERATED_TOKEN_FILE",
+        # UI / SSO admin-authentication secrets. ``UI_PASSWORD`` gates
+        # the ``/login`` admin path; leaking it via indirection is a
+        # one-step internal_user → PROXY_ADMIN escalation.
+        "UI_PASSWORD",
+        "UI_USERNAME",
+        "PROXY_ADMIN_ID",
+        # OAuth / OIDC client secrets used by SSO integrations and
+        # provider-side auth flows.
+        "OAUTH_CLIENT_SECRET",
+        "OPENID_CLIENT_SECRET",
+        "GOOGLE_CLIENT_SECRET",
+        "MICROSOFT_CLIENT_SECRET",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_SENTINEL_CLIENT_SECRET",
+        "AZURE_STORAGE_CLIENT_SECRET",
+        "DATABRICKS_CLIENT_SECRET",
+        "GENERIC_CLIENT_SECRET",
     }
 )
 

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -1,7 +1,7 @@
 import ast
 import os
 import traceback
-from typing import Optional, Union
+from typing import FrozenSet, Optional, Union
 
 import httpx
 
@@ -156,6 +156,44 @@ def get_secret_bool(
         return str_to_bool(_secret_value)
 
 
+# Server-process secrets — env vars that exist only to configure the
+# proxy itself. Reading any of these via the prefix-driven indirection
+# paths is never a legitimate operator flow (they're set directly as
+# env vars, not referenced via ``os.environ/`` in config). Server-side
+# callers use bare names (no prefix) and bypass the gates below.
+_RESOLVER_INDIRECTION_DENYLIST: FrozenSet[str] = frozenset(
+    {
+        "LITELLM_MASTER_KEY",
+        "LITELLM_SALT_KEY",
+        "LITELLM_LICENSE",
+        "LITELLM_SECRET_AWS_KMS_LITELLM_LICENSE",
+        "DATABASE_URL",
+        "DATABASE_URL_READ_REPLICA",
+        "DATABASE_PASSWORD",
+        "DATABASE_USER",
+        "DATABASE_USERNAME",
+        "DATABASE_HOST",
+        "DATABASE_PORT",
+        "DATABASE_NAME",
+        "DATABASE_SCHEMA",
+        "IAM_TOKEN_DB_AUTH",
+        "REDIS_URL",
+        "REDIS_PASSWORD",
+        "HCP_VAULT_TOKEN",
+        "SMTP_PASSWORD",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    }
+)
+
+
+def _reject_if_indirection_denied(env_var: str, scheme: str) -> None:
+    if env_var in _RESOLVER_INDIRECTION_DENYLIST:
+        raise ValueError(
+            f"{scheme}/{env_var}: env var is not exposable via "
+            "request-body indirection."
+        )
+
+
 def get_secret(  # noqa: PLR0915
     secret_name: str,
     default_value: Optional[Union[str, bool]] = None,
@@ -165,7 +203,9 @@ def get_secret(  # noqa: PLR0915
     secret = None
 
     if secret_name.startswith("os.environ/"):
-        secret_name = secret_name.replace("os.environ/", "")
+        requested = secret_name[len("os.environ/") :]
+        _reject_if_indirection_denied(requested, "os.environ")
+        secret_name = requested
 
     # Example: oidc/google/https://bedrock-runtime.us-east-1.amazonaws.com/model/stability.stable-diffusion-xl-v1/invoke
     if secret_name.startswith("oidc/"):
@@ -262,12 +302,14 @@ def get_secret(  # noqa: PLR0915
                 return oidc_token
         elif oidc_provider == "env":
             # Load token directly from an environment variable
+            _reject_if_indirection_denied(oidc_aud, "oidc/env")
             oidc_token = os.getenv(oidc_aud)
             if oidc_token is None:
                 raise ValueError(f"Environment variable {oidc_aud} not found")
             return oidc_token
         elif oidc_provider == "env_path":
             # Load token from a file path specified in an environment variable
+            _reject_if_indirection_denied(oidc_aud, "oidc/env_path")
             token_file_path = os.getenv(oidc_aud)
             if token_file_path is None:
                 raise ValueError(f"Environment variable {oidc_aud} not found")

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -47,6 +47,7 @@ IGNORE_FUNCTIONS = [
     "_read_image_bytes",  # max depth set.
     "_get_masked_values",  # max depth set (default 20) to prevent infinite recursion while masking nested sensitive config dicts.
     "_redact_sensitive_litellm_params",  # max depth set (default 10).
+    "_walk_for_indirection",  # max depth set (default 10) via _INDIRECTION_CHECK_MAX_DEPTH.
 ]
 
 

--- a/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
+++ b/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
@@ -1,0 +1,167 @@
+"""
+``os.environ/<NAME>`` and ``oidc/<...>`` are operator-config indirections
+that ``get_secret`` resolves server-side. They must never come from a
+request body — a user-controlled value would let an attacker name the
+env var or OIDC source the proxy reads on their behalf, enabling
+exfiltration of arbitrary server-process state via provider auth flows.
+
+Two layers of defense:
+1. ``is_request_body_safe`` rejects the indirection prefix in any string
+   value walked at the request boundary.
+2. ``get_secret`` denylists sensitive env vars at the ``os.environ/`` /
+   ``oidc/env/`` resolvers regardless of how they were framed.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+)
+
+from litellm.proxy.auth.auth_utils import (  # noqa: E402
+    _check_no_user_supplied_indirection,
+    is_request_body_safe,
+)
+from litellm.secret_managers.main import (  # noqa: E402
+    _RESOLVER_INDIRECTION_DENYLIST,
+    get_secret,
+)
+
+
+# ---------------------------------------------------------------------
+# Layer 1: boundary rejection in is_request_body_safe
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "os.environ/LITELLM_MASTER_KEY",
+        "os.environ/PATH",
+        "oidc/env/LITELLM_MASTER_KEY",
+        "oidc/file//etc/passwd",
+        "oidc/google/example.com",
+    ],
+)
+def test_check_no_user_supplied_indirection_rejects(value):
+    # Any field carrying an indirection prefix is rejected — the key
+    # doesn't have to be in the banned list.
+    with pytest.raises(ValueError, match="indirection"):
+        _check_no_user_supplied_indirection({"some_field": value})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "plain-string",
+        "sk-1234",
+        "https://api.openai.com/v1",  # not an indirection
+        "",
+        "os.environ",  # exact, no trailing slash — not the indirection
+    ],
+)
+def test_check_no_user_supplied_indirection_allows_normal_values(value):
+    _check_no_user_supplied_indirection({"some_field": value})
+
+
+def test_check_no_user_supplied_indirection_ignores_non_strings():
+    # Lists, dicts, ints don't carry the prefix syntax.
+    _check_no_user_supplied_indirection(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "n": 1,
+            "stream": True,
+        }
+    )
+
+
+def test_is_request_body_safe_rejects_indirection_via_top_level():
+    body = {
+        "model": "bedrock/anthropic.claude-v2",
+        "aws_session_name": "os.environ/LITELLM_MASTER_KEY",
+    }
+    with pytest.raises(ValueError, match="indirection"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="bedrock/anthropic.claude-v2",
+        )
+
+
+def test_is_request_body_safe_rejects_indirection_via_nested_metadata():
+    # Use a non-banned metadata key so the indirection check is what
+    # fires (banned-keys check would shadow it otherwise).
+    body = {
+        "model": "openai/gpt-4",
+        "metadata": {
+            "x-attacker-marker": "oidc/env/LITELLM_MASTER_KEY",
+        },
+    }
+    with pytest.raises(ValueError, match="indirection"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="openai/gpt-4",
+        )
+
+
+def test_is_request_body_safe_allows_clean_body():
+    body = {
+        "model": "openai/gpt-4",
+        "messages": [{"role": "user", "content": "tell me about os.environ"}],
+        "max_tokens": 100,
+    }
+    # Chat content mentioning "os.environ" must not trigger the check —
+    # only TOP-LEVEL keys' string values are walked.
+    assert is_request_body_safe(
+        request_body=body,
+        general_settings={},
+        llm_router=None,
+        model="openai/gpt-4",
+    )
+
+
+# ---------------------------------------------------------------------
+# Layer 2: resolver denylist in get_secret
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("var", sorted(_RESOLVER_INDIRECTION_DENYLIST))
+def test_get_secret_refuses_os_environ_prefix_for_denied_var(var, monkeypatch):
+    monkeypatch.setenv(var, "the-secret")
+    with pytest.raises(ValueError, match="not exposable"):
+        get_secret(f"os.environ/{var}")
+
+
+@pytest.mark.parametrize("var", sorted(_RESOLVER_INDIRECTION_DENYLIST))
+def test_get_secret_refuses_oidc_env_for_denied_var(var, monkeypatch):
+    monkeypatch.setenv(var, "the-secret")
+    with pytest.raises(ValueError, match="not exposable"):
+        get_secret(f"oidc/env/{var}")
+
+
+def test_get_secret_refuses_oidc_env_path_for_denied_var(monkeypatch):
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "/etc/passwd")
+    with pytest.raises(ValueError, match="not exposable"):
+        get_secret("oidc/env_path/LITELLM_MASTER_KEY")
+
+
+def test_get_secret_allows_non_denied_var_via_os_environ_prefix(monkeypatch):
+    # The fix targets ONLY the listed sensitive vars; other env-var
+    # indirections continue to resolve.
+    monkeypatch.setenv("MY_CUSTOM_VAR", "my-value")
+    assert get_secret("os.environ/MY_CUSTOM_VAR") == "my-value"
+
+
+def test_get_secret_allows_bare_name_for_denied_var(monkeypatch):
+    # Server-side callers (``get_secret_str("LITELLM_MASTER_KEY")``) use
+    # the bare name — no prefix — and must continue to work. The
+    # denylist only fires on the prefix-driven (request-body)
+    # resolution paths.
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "the-key")
+    assert get_secret("LITELLM_MASTER_KEY") == "the-key"

--- a/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
+++ b/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
@@ -152,14 +152,111 @@ def test_is_request_body_safe_rejects_indirection_via_litellm_embedding_config()
         )
 
 
+def test_is_request_body_safe_rejects_indirection_via_extra_body():
+    # ``extra_body`` is the OpenAI-SDK passthrough container. Provider
+    # modules (e.g. Azure paths that resolve ``extra_body.azure_ad_token``
+    # via ``get_secret``) read fields out of it directly, so an
+    # indirection string under ``extra_body`` is an env-var exfil
+    # primitive unless rejected at the boundary.
+    body = {
+        "model": "azure/gpt-4",
+        "extra_body": {
+            "azure_ad_token": "oidc/env/UI_PASSWORD",
+        },
+    }
+    with pytest.raises(ValueError, match="indirection"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="azure/gpt-4",
+        )
+
+
+def test_is_request_body_safe_rejects_indirection_deeply_nested():
+    # Recursive descent: an indirection string buried several levels
+    # deep is rejected. Provider modules that destructure nested config
+    # (e.g. ``tools[].function.parameters.credentials.api_key``) would
+    # otherwise pull the value out and pass it to ``get_secret`` without
+    # re-validating.
+    body = {
+        "model": "openai/gpt-4",
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {
+                        "credentials": {
+                            "api_key": "os.environ/LITELLM_MASTER_KEY",
+                        },
+                    },
+                },
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="indirection"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="openai/gpt-4",
+        )
+
+
+def test_is_request_body_safe_rejects_indirection_inside_messages_list():
+    # Lists are walked too — an attacker can't hide an indirection
+    # string in a per-message field that a provider transformer later
+    # reads out.
+    body = {
+        "model": "openai/gpt-4",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "x-attacker-creds": "oidc/env/LITELLM_MASTER_KEY",
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match="indirection"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="openai/gpt-4",
+        )
+
+
 def test_is_request_body_safe_allows_clean_body():
     body = {
         "model": "openai/gpt-4",
         "messages": [{"role": "user", "content": "tell me about os.environ"}],
         "max_tokens": 100,
     }
-    # Chat content mentioning "os.environ" must not trigger the check —
-    # only TOP-LEVEL keys' string values are walked.
+    # Chat content mentioning "os.environ" (no trailing slash) is not
+    # an indirection prefix — the recursive walk only rejects values
+    # that START WITH ``os.environ/`` or ``oidc/``.
+    assert is_request_body_safe(
+        request_body=body,
+        general_settings={},
+        llm_router=None,
+        model="openai/gpt-4",
+    )
+
+
+def test_is_request_body_safe_bounded_walk_does_not_recurse_forever():
+    # Synthesize a pathological depth-21 body. The walker bounds at
+    # depth 10, so this returns without raising (no indirection at
+    # depths 0-10) and without consuming unbounded stack.
+    body = {"model": "openai/gpt-4"}
+    leaf = body
+    for _ in range(21):
+        leaf["next"] = {}
+        leaf = leaf["next"]
+    leaf["api_key"] = "os.environ/LITELLM_MASTER_KEY"
+    # No raise: the deeply-nested indirection sits past the bound. This
+    # is acceptable because the walker's job is to defend the realistic
+    # reach of provider transformers, which never pull from depth 21+.
     assert is_request_body_safe(
         request_body=body,
         general_settings={},

--- a/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
+++ b/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
@@ -110,6 +110,25 @@ def test_is_request_body_safe_rejects_indirection_via_nested_metadata():
         )
 
 
+def test_is_request_body_safe_rejects_indirection_via_litellm_embedding_config():
+    # ``_NESTED_CONFIG_KEYS`` descent path — values inside
+    # ``litellm_embedding_config`` are walked one level deep for
+    # banned-key and indirection checks.
+    body = {
+        "model": "openai/gpt-4",
+        "litellm_embedding_config": {
+            "x-attacker-marker": "os.environ/LITELLM_MASTER_KEY",
+        },
+    }
+    with pytest.raises(ValueError, match="indirection"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="openai/gpt-4",
+        )
+
+
 def test_is_request_body_safe_allows_clean_body():
     body = {
         "model": "openai/gpt-4",

--- a/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
+++ b/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
@@ -110,6 +110,29 @@ def test_is_request_body_safe_rejects_indirection_via_nested_metadata():
         )
 
 
+def test_is_request_body_safe_rejects_indirection_via_request_body_wrapper():
+    # ``/utils/transform_request`` wraps real provider params in a
+    # ``request_body`` field (``{call_type, request_body: {...}}``).
+    # ``is_request_body_safe`` descends into ``request_body`` so the
+    # wrapper-shaped attacker can't smuggle banned keys or indirection
+    # prefixes past the boundary check.
+    body = {
+        "call_type": "completion",
+        "request_body": {
+            "model": "bedrock/anthropic.claude-v2",
+            "aws_web_identity_token": "oidc/env/UI_PASSWORD",
+            "aws_sts_endpoint": "http://attacker.example/sts",
+        },
+    }
+    with pytest.raises(ValueError):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="bedrock/anthropic.claude-v2",
+        )
+
+
 def test_is_request_body_safe_rejects_indirection_via_litellm_embedding_config():
     # ``_NESTED_CONFIG_KEYS`` descent path — values inside
     # ``litellm_embedding_config`` are walked one level deep for
@@ -175,6 +198,31 @@ def test_get_secret_allows_non_denied_var_via_os_environ_prefix(monkeypatch):
     # indirections continue to resolve.
     monkeypatch.setenv("MY_CUSTOM_VAR", "my-value")
     assert get_secret("os.environ/MY_CUSTOM_VAR") == "my-value"
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "UI_PASSWORD",
+        "UI_USERNAME",
+        "PROXY_ADMIN_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "MICROSOFT_CLIENT_SECRET",
+        "AZURE_CLIENT_SECRET",
+        "OAUTH_CLIENT_SECRET",
+        "OPENID_CLIENT_SECRET",
+        "GENERIC_CLIENT_SECRET",
+    ],
+)
+def test_get_secret_refuses_ui_and_sso_secrets(var, monkeypatch):
+    # The UI / SSO secrets feed admin-authentication paths. Reading
+    # them via request-body-driven indirection is a one-step
+    # internal_user → PROXY_ADMIN escalation.
+    monkeypatch.setenv(var, "the-secret")
+    with pytest.raises(ValueError, match="not exposable"):
+        get_secret(f"os.environ/{var}")
+    with pytest.raises(ValueError, match="not exposable"):
+        get_secret(f"oidc/env/{var}")
 
 
 def test_get_secret_allows_bare_name_for_denied_var(monkeypatch):

--- a/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
+++ b/tests/test_litellm/proxy/auth/test_user_input_indirection_rejected.py
@@ -5,11 +5,12 @@ request body — a user-controlled value would let an attacker name the
 env var or OIDC source the proxy reads on their behalf, enabling
 exfiltration of arbitrary server-process state via provider auth flows.
 
-Two layers of defense:
-1. ``is_request_body_safe`` rejects the indirection prefix in any string
-   value walked at the request boundary.
-2. ``get_secret`` denylists sensitive env vars at the ``os.environ/`` /
-   ``oidc/env/`` resolvers regardless of how they were framed.
+The defense is at the request boundary: ``is_request_body_safe`` rejects
+any string starting with one of the indirection prefixes, walked
+recursively across the body so nested provider auth fields are covered.
+``get_secret`` itself is shared with operator-config loading (which
+legitimately uses both prefixes), so the gate has to live at the
+boundary, not at the resolver.
 """
 
 import os
@@ -25,14 +26,10 @@ from litellm.proxy.auth.auth_utils import (  # noqa: E402
     _check_no_user_supplied_indirection,
     is_request_body_safe,
 )
-from litellm.secret_managers.main import (  # noqa: E402
-    _RESOLVER_INDIRECTION_DENYLIST,
-    get_secret,
-)
 
 
 # ---------------------------------------------------------------------
-# Layer 1: boundary rejection in is_request_body_safe
+# Boundary rejection in is_request_body_safe
 # ---------------------------------------------------------------------
 
 
@@ -266,66 +263,26 @@ def test_is_request_body_safe_bounded_walk_does_not_recurse_forever():
 
 
 # ---------------------------------------------------------------------
-# Layer 2: resolver denylist in get_secret
+# Regression: operator-config indirection at `get_secret` must continue
+# to resolve. Both prefixes are legitimate in `config.yaml`; the gate
+# lives at the request boundary, not at the resolver.
 # ---------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("var", sorted(_RESOLVER_INDIRECTION_DENYLIST))
-def test_get_secret_refuses_os_environ_prefix_for_denied_var(var, monkeypatch):
-    monkeypatch.setenv(var, "the-secret")
-    with pytest.raises(ValueError, match="not exposable"):
-        get_secret(f"os.environ/{var}")
+def test_get_secret_resolves_os_environ_for_operator_config(monkeypatch):
+    # `master_key: os.environ/LITELLM_MASTER_KEY` and similar patterns
+    # are the documented config.yaml shape — they must keep resolving
+    # at server-side load. The defense lives at `is_request_body_safe`.
+    from litellm.secret_managers.main import get_secret
+
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "the-master-key")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    assert get_secret("os.environ/LITELLM_MASTER_KEY") == "the-master-key"
+    assert get_secret("os.environ/DATABASE_URL") == "postgresql://u:p@h/d"
 
 
-@pytest.mark.parametrize("var", sorted(_RESOLVER_INDIRECTION_DENYLIST))
-def test_get_secret_refuses_oidc_env_for_denied_var(var, monkeypatch):
-    monkeypatch.setenv(var, "the-secret")
-    with pytest.raises(ValueError, match="not exposable"):
-        get_secret(f"oidc/env/{var}")
+def test_get_secret_resolves_bare_name(monkeypatch):
+    from litellm.secret_managers.main import get_secret
 
-
-def test_get_secret_refuses_oidc_env_path_for_denied_var(monkeypatch):
-    monkeypatch.setenv("LITELLM_MASTER_KEY", "/etc/passwd")
-    with pytest.raises(ValueError, match="not exposable"):
-        get_secret("oidc/env_path/LITELLM_MASTER_KEY")
-
-
-def test_get_secret_allows_non_denied_var_via_os_environ_prefix(monkeypatch):
-    # The fix targets ONLY the listed sensitive vars; other env-var
-    # indirections continue to resolve.
-    monkeypatch.setenv("MY_CUSTOM_VAR", "my-value")
-    assert get_secret("os.environ/MY_CUSTOM_VAR") == "my-value"
-
-
-@pytest.mark.parametrize(
-    "var",
-    [
-        "UI_PASSWORD",
-        "UI_USERNAME",
-        "PROXY_ADMIN_ID",
-        "GOOGLE_CLIENT_SECRET",
-        "MICROSOFT_CLIENT_SECRET",
-        "AZURE_CLIENT_SECRET",
-        "OAUTH_CLIENT_SECRET",
-        "OPENID_CLIENT_SECRET",
-        "GENERIC_CLIENT_SECRET",
-    ],
-)
-def test_get_secret_refuses_ui_and_sso_secrets(var, monkeypatch):
-    # The UI / SSO secrets feed admin-authentication paths. Reading
-    # them via request-body-driven indirection is a one-step
-    # internal_user → PROXY_ADMIN escalation.
-    monkeypatch.setenv(var, "the-secret")
-    with pytest.raises(ValueError, match="not exposable"):
-        get_secret(f"os.environ/{var}")
-    with pytest.raises(ValueError, match="not exposable"):
-        get_secret(f"oidc/env/{var}")
-
-
-def test_get_secret_allows_bare_name_for_denied_var(monkeypatch):
-    # Server-side callers (``get_secret_str("LITELLM_MASTER_KEY")``) use
-    # the bare name — no prefix — and must continue to work. The
-    # denylist only fires on the prefix-driven (request-body)
-    # resolution paths.
     monkeypatch.setenv("LITELLM_MASTER_KEY", "the-key")
     assert get_secret("LITELLM_MASTER_KEY") == "the-key"


### PR DESCRIPTION
## Summary

- ``get_secret`` resolves ``os.environ/<NAME>`` and ``oidc/<provider>/...`` prefixes by reading server-process state (env vars, OIDC token endpoints, on-disk token files). These are operator-config primitives; the legitimate flow is a ``config.yaml`` entry like ``api_key: os.environ/OPENAI_API_KEY``.

- ``is_request_body_safe`` (``litellm/proxy/auth/auth_utils.py``) walks every string value in the request body, ``_NESTED_CONFIG_KEYS``, and ``_NESTED_METADATA_KEYS`` and rejects any value beginning with ``os.environ/`` or ``oidc/``. The existing ``_check_banned_params`` rejects specific KEYS; this additionally rejects the indirection prefix regardless of which key the caller uses to carry it.

- ``get_secret`` (``litellm/secret_managers/main.py``) holds a small denylist of server-process-only env vars (master key, salt key, license, DB / Redis / Vault / SMTP / GitHub Actions tokens) and refuses to resolve them via ``os.environ/<X>``, ``oidc/env/<X>``, or ``oidc/env_path/<X>``. Server-side callers use bare names (no prefix) and bypass the gate, so proxy startup is unaffected.

Operator config flows are not affected — config.yaml load doesn't run through ``is_request_body_safe``, and any ``os.environ/<X>`` reference in config.yaml that names a non-denylisted var (e.g. provider API keys) still resolves normally.