### PR TITLE
docs: add one-line docstring to GCPIAMCredentialProvider.get_credentials

### DIFF
--- a/litellm/_redis_credential_provider.py
+++ b/litellm/_redis_credential_provider.py
@@ -96,6 +96,7 @@ class GCPIAMCredentialProvider(CredentialProvider):
         self._gcp_service_account = gcp_service_account
 
     def get_credentials(self) -> Tuple[str]:
+        """Return a single-element tuple containing a cached GCP IAM token."""
         token = _get_cached_gcp_iam_token(self._gcp_service_account)
         return (token,)
 


### PR DESCRIPTION
## Summary

Adds a single-line docstring to `GCPIAMCredentialProvider.get_credentials` so the public method documents what it returns. No behavior change.

## Tests

Docstring-only change; no runtime behavior touched, so no test added.