### PR TITLE
docs: add one-line docstring to _disable_debugging

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -404,6 +404,7 @@ def _turn_on_debug():
 
 
 def _disable_debugging():
+    """Disable the package, router, and proxy verbose loggers."""
     verbose_logger.disabled = True
     verbose_router_logger.disabled = True
     verbose_proxy_logger.disabled = True


### PR DESCRIPTION
## Summary

Adds a one-line docstring to `_disable_debugging` in `litellm/_logging.py` so its intent is documented next to its sibling functions.

## Repro

`_disable_debugging` previously had no docstring while neighboring helpers in the same module are self-documenting by name only. This PR is documentation-only and has no behavioral change.

## Evidence

```
$ git diff
diff --git a/litellm/_logging.py b/litellm/_logging.py
index 5ddafd6..6b99f50 100644
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -404,6 +404,7 @@ def _turn_on_debug():


 def _disable_debugging():
+    """Disable the package, router, and proxy verbose loggers."""
     verbose_logger.disabled = True
     verbose_router_logger.disabled = True
     verbose_proxy_logger.disabled = True
```

## Tests

No tests added — this change is documentation-only and does not alter any runtime behavior. No existing tests are affected.
