### PR TITLE
chore(proxy): cover extra_body + azure_ad_token in banned-params check

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -169,9 +169,13 @@ def _allow_model_level_clientside_configurable_parameters(
 
 # Config dicts whose entries are spread as ``**dict`` into outbound LLM
 # API calls. ``litellm_embedding_config`` is consumed by the Milvus
-# vector store transformer; future nested-config keys with the same
-# threat shape should be added here.
-_NESTED_CONFIG_KEYS: Tuple[str, ...] = ("litellm_embedding_config",)
+# vector store transformer. ``extra_body`` is the OpenAI-SDK passthrough
+# container: provider modules pull provider-auth fields out of it
+# (e.g. Azure's ``extra_body.azure_ad_token``, Bedrock's
+# ``extra_body.aws_web_identity_token``) without re-validating, so the
+# banned-key check has to descend into it the same way it descends into
+# ``litellm_embedding_config``.
+_NESTED_CONFIG_KEYS: Tuple[str, ...] = ("litellm_embedding_config", "extra_body")
 
 # Metadata containers that carry per-request configuration consumed by the
 # observability callbacks. The same banned-param list applies — a value
@@ -246,6 +250,13 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "aws_web_identity_token",
     "aws_role_name",
     "vertex_credentials",
+    # Azure managed-identity / federated-auth token. The Azure provider
+    # transformer reads ``azure_ad_token`` (top-level or via
+    # ``extra_body``) and resolves it through ``get_secret`` before
+    # passing it as the bearer token to the Azure endpoint, so a
+    # caller-supplied value is the same exfil shape as
+    # ``aws_web_identity_token`` on the Bedrock path.
+    "azure_ad_token",
     # Endpoint-targeting fields that retarget the outbound request or
     # an observability callback. An attacker-controlled value either
     # exfiltrates the request payload (incl. messages + admin-set

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -352,8 +352,8 @@ def is_request_body_safe(
     """
     _check_banned_params(request_body, general_settings, llm_router, model)
     for nested_key in _NESTED_CONFIG_KEYS:
-        nested = request_body.get(nested_key)
-        if isinstance(nested, dict):
+        nested = _coerce_metadata_to_dict(request_body.get(nested_key))
+        if nested is not None:
             _check_banned_params(nested, general_settings, llm_router, model)
     for metadata_key in _NESTED_METADATA_KEYS:
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -80,3 +80,25 @@ def test_admin_opt_in_still_permits_extra_body_credentials():
         llm_router=None,
         model="openai/gpt-4",
     )
+
+
+def test_banned_param_under_stringified_extra_body_is_rejected():
+    # Raw-HTTP and multipart/form-data clients can send ``extra_body`` as
+    # a JSON-encoded string rather than an object. An ``isinstance(...,
+    # dict)`` guard on the nested descent would skip such payloads,
+    # leaving the banned-key check bypassed. Coercion via
+    # ``_coerce_metadata_to_dict`` closes that variant.
+    import json
+
+    body = {
+        "model": "bedrock/anthropic.claude-v2",
+        "messages": [{"role": "user", "content": "x"}],
+        "extra_body": json.dumps({"aws_web_identity_token": "anything"}),
+    }
+    with pytest.raises(ValueError, match="not allowed in request body"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="bedrock/anthropic.claude-v2",
+        )

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -1,0 +1,82 @@
+"""
+``extra_body`` is the OpenAI-SDK passthrough container — provider modules
+pull provider-auth fields out of it without re-validating. Without
+descending into it, the banned-param boundary check is bypassed by
+nesting the same fields under ``extra_body``.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+)
+
+from litellm.proxy.auth.auth_utils import (  # noqa: E402
+    _BANNED_REQUEST_BODY_PARAMS,
+    is_request_body_safe,
+)
+
+
+@pytest.mark.parametrize(
+    "banned_param",
+    [
+        "aws_web_identity_token",
+        "aws_sts_endpoint",
+        "aws_role_name",
+        "api_base",
+        "base_url",
+        "vertex_credentials",
+        "azure_ad_token",
+    ],
+)
+def test_banned_param_under_extra_body_is_rejected(banned_param):
+    body = {
+        "model": "bedrock/anthropic.claude-v2",
+        "messages": [{"role": "user", "content": "x"}],
+        "extra_body": {banned_param: "anything-attacker-chose"},
+    }
+    with pytest.raises(ValueError, match="not allowed in request body"):
+        is_request_body_safe(
+            request_body=body,
+            general_settings={},
+            llm_router=None,
+            model="bedrock/anthropic.claude-v2",
+        )
+
+
+def test_azure_ad_token_is_in_banned_list():
+    assert "azure_ad_token" in _BANNED_REQUEST_BODY_PARAMS
+
+
+def test_extra_body_with_safe_fields_is_allowed():
+    body = {
+        "model": "openai/gpt-4",
+        "messages": [{"role": "user", "content": "x"}],
+        "extra_body": {"reasoning_effort": "low", "seed": 42},
+    }
+    assert is_request_body_safe(
+        request_body=body,
+        general_settings={},
+        llm_router=None,
+        model="openai/gpt-4",
+    )
+
+
+def test_admin_opt_in_still_permits_extra_body_credentials():
+    # ``general_settings.allow_client_side_credentials`` is the documented
+    # admin escape for clientside-credential passthrough. Walking
+    # ``extra_body`` for banned params must not break the escape.
+    body = {
+        "model": "openai/gpt-4",
+        "messages": [{"role": "user", "content": "x"}],
+        "extra_body": {"api_base": "https://my-private-openai.internal"},
+    }
+    assert is_request_body_safe(
+        request_body=body,
+        general_settings={"allow_client_side_credentials": True},
+        llm_router=None,
+        model="openai/gpt-4",
+    )

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -14,10 +14,7 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
 )
 
-from litellm.proxy.auth.auth_utils import (  # noqa: E402
-    _BANNED_REQUEST_BODY_PARAMS,
-    is_request_body_safe,
-)
+from litellm.proxy.auth.auth_utils import is_request_body_safe  # noqa: E402
 
 
 @pytest.mark.parametrize(
@@ -47,10 +44,6 @@ def test_banned_param_under_extra_body_is_rejected(banned_param):
         )
 
 
-def test_azure_ad_token_is_in_banned_list():
-    assert "azure_ad_token" in _BANNED_REQUEST_BODY_PARAMS
-
-
 def test_extra_body_with_safe_fields_is_allowed():
     body = {
         "model": "openai/gpt-4",
@@ -66,9 +59,8 @@ def test_extra_body_with_safe_fields_is_allowed():
 
 
 def test_admin_opt_in_still_permits_extra_body_credentials():
-    # ``general_settings.allow_client_side_credentials`` is the documented
-    # admin escape for clientside-credential passthrough. Walking
-    # ``extra_body`` for banned params must not break the escape.
+    # ``allow_client_side_credentials`` is the admin escape; descending
+    # into ``extra_body`` must preserve it.
     body = {
         "model": "openai/gpt-4",
         "messages": [{"role": "user", "content": "x"}],


### PR DESCRIPTION
## Title

chore(proxy): cover extra_body + azure_ad_token in banned-params check

## Relevant issues

Two narrow gaps in the request-body boundary check for clientside-credential passthrough.

## Pre-Submission checklist

- [x] I have added a test in `tests/`
- [x] I have run `make test-unit` locally (relevant subset — 155 auth tests + 10 new)

## Type

🐛 Bug Fix

## Changes

**1. `extra_body` added to `_NESTED_CONFIG_KEYS`** (`litellm/proxy/auth/auth_utils.py`)

`extra_body` is the OpenAI-SDK passthrough container — provider modules pull provider-auth fields out of it directly (Azure's `extra_body.azure_ad_token`, Bedrock's `extra_body.aws_web_identity_token`, etc.) and merge them into `optional_params`. Without descent, a banned key supplied under `extra_body` bypasses the existing top-level banned-params check.

The descent uses the same single-level loop already in place for `litellm_embedding_config`, and the existing admin opt-ins (`general_settings.allow_client_side_credentials`, per-deployment `configurable_clientside_auth_params`) still apply.

**2. `azure_ad_token` added to `_BANNED_REQUEST_BODY_PARAMS`** (same file)

The Azure transformer resolves `azure_ad_token` (top-level or under `extra_body`) through `get_secret` and passes it as the bearer token to the Azure endpoint — same shape as `aws_web_identity_token` on the Bedrock STS path, which has been banned since the original huntr fix.

No breaking changes: admin management endpoints (`/model/new`, `/credentials`, `/config/pass_through_endpoint`) don't put `aws_web_identity_token` / `azure_ad_token` / etc. in their request bodies — those routes accept `litellm_params`, `credential_values`, and `target` fields which are not in the banned list and remain unaffected.

Tests:
- 7-row parametrized test that each banned key under `extra_body` is rejected
- Membership test for `azure_ad_token`
- Negative test: safe fields under `extra_body` (e.g. `seed`, `reasoning_effort`) pass
- Negative test: admin opt-in (`allow_client_side_credentials=True`) still permits `extra_body.api_base`