### PR TITLE
chore: backport #27908 to litellm_1.84.0rc2

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.71"
+version = "0.4.72"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.71"
+version = "0.4.72"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ proxy = [
     "azure-identity==1.25.2",
     "azure-storage-blob==12.28.0",
     "mcp==1.26.0",
-    "litellm-proxy-extras==0.4.71",
+    "litellm-proxy-extras==0.4.72",
     "litellm-enterprise==0.1.40",
     "RestrictedPython==8.1",
     "rich==13.9.4",

--- a/uv.lock
+++ b/uv.lock
@@ -3420,7 +3420,7 @@ source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.71"
+version = "0.4.72"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
Backport of [#27908](https://github.com/BerriAI/litellm/pull/27908) onto `litellm_1.84.0rc2`.

Bumps `litellm-proxy-extras` 0.4.71 → 0.4.72 and refreshes `uv.lock`.

Cherry-picked commits:
- `0aa439d9` bump: version 0.4.71 → 0.4.72
- `e838a400` uv lock