### PR TITLE
ci(mutmut): enable mutate_only_covered_lines to fit in CI budget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,6 +290,12 @@ tests_dir = [
 also_copy = [
     "litellm/",
 ]
+# Run the test suite once before mutation to gather line coverage, then skip
+# mutating lines no test exercises. Those mutants would survive regardless
+# (no test hits the line to kill them), so generating them wastes hours of CI.
+# The score now reads as "mutation score over covered code" — pair with a
+# line-coverage number when reporting.
+mutate_only_covered_lines = true
 # Disable rerun/parallel plugins for mutation runs:
 # - pytest-retry triggers an `INTERNALERROR: no option named 'filtered_exceptions'`
 #   when invoked via mutmut's in-process `pytest.main()` call.


### PR DESCRIPTION
## Summary

The manually-triggered mutation-test workflow timed out at the 350-minute job cap on its last run. Whole-folder mutation against `litellm/proxy/management_endpoints/` (~30 files, ~1.5 MB of source) was generating mutants for every line — including lines that no test covers, which would survive regardless and just burn CI minutes.

Setting `mutate_only_covered_lines = true` in `[tool.mutmut]` makes mutmut run the test suite once before the mutation loop, gather line coverage, and skip mutating uncovered lines. mutmut 3.x already does per-mutant test selection by function name automatically — no external coverage step needed.

The mutation score now reads as "score over covered code"; if reported, pair it with a line-coverage number so the two measurements stay legible.

## Test plan
- [ ] Re-trigger `mutation-test.yml` from the Actions tab and confirm it completes inside the 350-minute budget.
- [ ] If it still times out, follow up with a matrix shard or a larger runner — those are bigger workflow surgery and worth doing only against measured remaining headroom.