### PR TITLE
fix(anthropic): ensure model is passed to AnthropicAdapter requests

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -213,7 +213,7 @@ class AnthropicAdapter:
     def translate_completion_output_params_streaming(
         self,
         completion_stream: Any,
-        model: str,
+        model: str = '',
         tool_name_mapping: Optional[Dict[str, str]] = None,
     ) -> Union[AsyncIterator[bytes], None]:
         """

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6274,7 +6274,8 @@ async def aadapter_completion(
         if isinstance(response, CustomStreamWrapper):
             translated_response = (
                 translation_obj.translate_completion_output_params_streaming(
-                    completion_stream=response
+                    completion_stream=response,
+                    model=kwargs.get("model", "")
                 )
             )
 
@@ -6325,7 +6326,8 @@ def adapter_completion(
     elif isinstance(response, CustomStreamWrapper) or inspect.isgenerator(response):
         translated_response = (
             translation_obj.translate_completion_output_params_streaming(
-                completion_stream=response
+                completion_stream=response,
+                model=kwargs.get("model", "")
             )
         )
 


### PR DESCRIPTION
This PR ensures `model` is always properly included in the request sent to AnthropicAdapter 

## Relevant issues
no

## Type
🐛 Bug Fix

## Changes
AnthropicAdapter was missing the `model` parameter when constructing internal request payloads. This caused failures when `model` was not explicitly passed by the caller.

This PR ensures `model` is always properly included in the request sent to Anthropic API.


## Tests
use unit test in tests/litellm/llms/anthropic/test_anthropic_schema_filter.py to cover missing model case.