### PR TITLE
fix(rate-limit): resolve router model_name aliases to real provider

### DIFF
--- a/litellm/proxy/hooks/rate_limiter_utils.py
+++ b/litellm/proxy/hooks/rate_limiter_utils.py
@@ -26,11 +26,21 @@ def resolve_llm_provider_for_rate_limit(
     ``litellm_proxy_failed_requests_metric`` show up with
     ``exception_class="RateLimitError"`` and no provider attribution.
 
-    Wrapped defensively: if ``model`` is missing, malformed, or
-    ``get_llm_provider`` raises (unknown alias, router-only model, etc.) we
-    fall back to ``("", "litellm_proxy")`` so we never break the request path
-    by piling a second exception on top of the rate-limit one we're trying to
-    raise.
+    Resolution order:
+
+    1. ``litellm.get_llm_provider(model)`` — covers raw provider/model
+       strings the SDK already understands (``"gpt-4o-mini"``,
+       ``"anthropic/claude-3-5-sonnet"``, ``"bedrock/..."`` etc.).
+    2. **Router alias fallback** — nearly every real proxy deployment
+       routes through a router ``model_name`` alias (e.g.
+       ``"tpm-locked"`` → ``litellm_params.model: openai/gpt-4o-mini``).
+       ``get_llm_provider`` doesn't know router aliases, so without this
+       step every alias call ended up labeled ``"litellm_proxy"``,
+       defeating the field's purpose for the most common case.
+    3. Defensive fallback to ``("", "litellm_proxy")`` — used only when
+       ``model`` is missing, malformed, or both lookups fail. We never let
+       a secondary exception escape and mask the rate-limit error we're
+       trying to surface.
     """
     if not model:
         return "", PROXY_LLM_PROVIDER_FALLBACK
@@ -43,6 +53,9 @@ def resolve_llm_provider_for_rate_limit(
             custom_llm_provider or PROXY_LLM_PROVIDER_FALLBACK,
         )
     except Exception as e:
+        alias_resolution = _resolve_provider_from_router_alias(model)
+        if alias_resolution is not None:
+            return alias_resolution
         verbose_proxy_logger.debug(
             "rate_limiter_utils.resolve_llm_provider_for_rate_limit: "
             "could not resolve provider for model=%s, falling back to %s. err=%s",
@@ -51,6 +64,55 @@ def resolve_llm_provider_for_rate_limit(
             str(e),
         )
         return model, PROXY_LLM_PROVIDER_FALLBACK
+
+
+def _resolve_provider_from_router_alias(
+    model: str,
+) -> Optional[Tuple[str, str]]:
+    """
+    Resolve a router ``model_name`` alias to ``(underlying_model, provider)``
+    by scanning the active router's ``model_list``.
+
+    Returns ``None`` if the router isn't initialized, the alias isn't
+    registered, the deployment has no usable ``litellm_params.model``, or
+    any underlying lookup raises. Callers fall through to the defensive
+    ``litellm_proxy`` fallback in that case — never raising secondary
+    exceptions out of the rate-limit raise path.
+    """
+    try:
+        from litellm.proxy.proxy_server import llm_router
+    except Exception:
+        return None
+    if llm_router is None:
+        return None
+    model_list = getattr(llm_router, "model_list", None)
+    if not model_list:
+        return None
+    for deployment in model_list:
+        if not isinstance(deployment, dict):
+            continue
+        if deployment.get("model_name") != model:
+            continue
+        params = deployment.get("litellm_params") or {}
+        underlying_model = params.get("model")
+        if not isinstance(underlying_model, str) or not underlying_model:
+            continue
+        try:
+            resolved_model, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                model=underlying_model,
+            )
+        except Exception:
+            continue
+        if not custom_llm_provider:
+            continue
+        # Prefer the underlying provider-qualified model so the failure
+        # callback / Prometheus label points at the actual deployment, not
+        # the alias.
+        return (
+            resolved_model or underlying_model,
+            custom_llm_provider,
+        )
+    return None
 
 
 def convert_priority_to_percent(

--- a/litellm/proxy/hooks/rate_limiter_utils.py
+++ b/litellm/proxy/hooks/rate_limiter_utils.py
@@ -85,34 +85,39 @@ def _resolve_provider_from_router_alias(
         return None
     if llm_router is None:
         return None
-    model_list = getattr(llm_router, "model_list", None)
-    if not model_list:
-        return None
-    for deployment in model_list:
-        if not isinstance(deployment, dict):
-            continue
-        if deployment.get("model_name") != model:
-            continue
-        params = deployment.get("litellm_params") or {}
-        underlying_model = params.get("model")
-        if not isinstance(underlying_model, str) or not underlying_model:
-            continue
-        try:
-            resolved_model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                model=underlying_model,
+    try:
+        model_list = getattr(llm_router, "model_list", None)
+        if not model_list:
+            return None
+        for deployment in model_list:
+            if not isinstance(deployment, dict):
+                continue
+            if deployment.get("model_name") != model:
+                continue
+            params = deployment.get("litellm_params")
+            if not isinstance(params, dict):
+                continue
+            underlying_model = params.get("model")
+            if not isinstance(underlying_model, str) or not underlying_model:
+                continue
+            try:
+                resolved_model, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                    model=underlying_model,
+                )
+            except Exception:
+                continue
+            if not custom_llm_provider:
+                continue
+            # Prefer the underlying provider-qualified model so the failure
+            # callback / Prometheus label points at the actual deployment, not
+            # the alias.
+            return (
+                resolved_model or underlying_model,
+                custom_llm_provider,
             )
-        except Exception:
-            continue
-        if not custom_llm_provider:
-            continue
-        # Prefer the underlying provider-qualified model so the failure
-        # callback / Prometheus label points at the actual deployment, not
-        # the alias.
-        return (
-            resolved_model or underlying_model,
-            custom_llm_provider,
-        )
-    return None
+        return None
+    except Exception:
+        return None
 
 
 def convert_priority_to_percent(

--- a/tests/test_litellm/proxy/hooks/test_proxy_rate_limit_provider_field.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_rate_limit_provider_field.py
@@ -153,14 +153,147 @@ class TestResolveLLMProviderForRateLimit:
     def test_get_llm_provider_raising_is_swallowed(self):
         # If get_llm_provider itself blows up (unexpected error), we still
         # fall back rather than letting the secondary exception escape.
+        # No router is registered in this test, so the alias-fallback path
+        # also yields None and we land at PROXY_LLM_PROVIDER_FALLBACK.
         with patch.object(
             litellm,
             "get_llm_provider",
             side_effect=RuntimeError("boom"),
         ):
-            resolved_model, provider = resolve_llm_provider_for_rate_limit("anything")
+            with patch(
+                "litellm.proxy.proxy_server.llm_router",
+                None,
+            ):
+                resolved_model, provider = resolve_llm_provider_for_rate_limit(
+                    "anything"
+                )
         assert provider == PROXY_LLM_PROVIDER_FALLBACK
         assert resolved_model == "anything"
+
+    def test_router_alias_resolves_to_underlying_provider(self):
+        """
+        Nearly every real LiteLLM proxy deployment uses router aliases:
+
+            model_list:
+              - model_name: tpm-locked
+                litellm_params:
+                  model: openai/gpt-4o-mini
+                  ...
+
+        ``litellm.get_llm_provider("tpm-locked")`` doesn't know about
+        router aliases and raises. Before this fix the resolver fell
+        through to ``"litellm_proxy"``, defeating the whole point of the
+        ``llm_provider`` field on the rate-limit error. The alias path
+        must look the deployment up in the router's ``model_list`` and
+        resolve from its ``litellm_params.model``.
+        """
+
+        class _FakeRouter:
+            model_list = [
+                {
+                    "model_name": "tpm-locked",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "fake",
+                    },
+                }
+            ]
+
+        with patch(
+            "litellm.proxy.proxy_server.llm_router",
+            _FakeRouter(),
+        ):
+            resolved_model, provider = resolve_llm_provider_for_rate_limit("tpm-locked")
+        assert provider == "openai", (
+            f"Router-alias path must resolve through litellm_params.model, "
+            f"not fall through to {PROXY_LLM_PROVIDER_FALLBACK!r}. Got "
+            f"provider={provider!r}, model={resolved_model!r}."
+        )
+        # The resolved model should point at the underlying deployment so
+        # downstream Prometheus labels / failure callbacks attribute the
+        # 429 to the real upstream, not the alias.
+        assert resolved_model == "gpt-4o-mini"
+
+    def test_router_alias_with_multiple_deployments_uses_first(self):
+        """
+        When an alias maps to multiple deployments (the load-balancing
+        case), the rate-limit error fired at the *alias* level is
+        deployment-agnostic — we have no way of knowing which one would
+        have been picked. Use the first deployment's underlying provider:
+        every deployment under one alias should agree on provider in any
+        sensible config, and 'first' is deterministic so the Prometheus
+        label is stable.
+        """
+
+        class _FakeRouter:
+            model_list = [
+                {
+                    "model_name": "claude-pool",
+                    "litellm_params": {"model": "anthropic/claude-3-5-sonnet"},
+                },
+                {
+                    "model_name": "claude-pool",
+                    "litellm_params": {"model": "anthropic/claude-3-5-haiku"},
+                },
+            ]
+
+        with patch(
+            "litellm.proxy.proxy_server.llm_router",
+            _FakeRouter(),
+        ):
+            _, provider = resolve_llm_provider_for_rate_limit("claude-pool")
+        assert provider == "anthropic"
+
+    def test_router_alias_unknown_falls_back(self):
+        """
+        Alias not in the router model_list — both lookups fail, so we
+        land at the defensive ``litellm_proxy`` fallback rather than
+        raising.
+        """
+
+        class _FakeRouter:
+            model_list = [
+                {
+                    "model_name": "tpm-locked",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                }
+            ]
+
+        with patch(
+            "litellm.proxy.proxy_server.llm_router",
+            _FakeRouter(),
+        ):
+            resolved_model, provider = resolve_llm_provider_for_rate_limit(
+                "not-an-alias"
+            )
+        assert provider == PROXY_LLM_PROVIDER_FALLBACK
+        assert resolved_model == "not-an-alias"
+
+    def test_router_alias_with_malformed_deployment_falls_back(self):
+        """
+        A deployment in the router model_list with no usable
+        ``litellm_params.model`` (or where ``get_llm_provider`` on the
+        underlying string also raises) must not crash the resolver —
+        fall through to the defensive fallback.
+        """
+
+        class _FakeRouter:
+            model_list = [
+                {"model_name": "broken", "litellm_params": {}},
+                {"model_name": "broken", "litellm_params": {"model": ""}},
+                {
+                    "model_name": "broken",
+                    "litellm_params": {"model": "nonsense-no-provider"},
+                },
+            ]
+
+        with patch(
+            "litellm.proxy.proxy_server.llm_router",
+            _FakeRouter(),
+        ):
+            resolved_model, provider = resolve_llm_provider_for_rate_limit("broken")
+        assert provider == PROXY_LLM_PROVIDER_FALLBACK
+        assert resolved_model == "broken"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/hooks/test_proxy_rate_limit_provider_field.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_rate_limit_provider_field.py
@@ -141,7 +141,10 @@ class TestResolveLLMProviderForRateLimit:
         # Must never raise — the resolver wraps `get_llm_provider` defensively
         # because raising here would mask the rate-limit error we're trying
         # to surface to the user.
-        resolved_model, provider = resolve_llm_provider_for_rate_limit(model)
+        # Pin llm_router to None so the alias-fallback path doesn't pick up
+        # a router left behind by another test in the session.
+        with patch("litellm.proxy.proxy_server.llm_router", None):
+            resolved_model, provider = resolve_llm_provider_for_rate_limit(model)
         assert provider == PROXY_LLM_PROVIDER_FALLBACK
         # Resolver returns the input model verbatim on the unknown branch so
         # the `.model` attribute is never silently swapped to a different one.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stacks on #27687

Stacked fix for PR [#27687 — feat: standardize rate limit errors with `category`, `rate_limit_type`, `model`, and `llm_provider` fields](https://github.com/BerriAI/litellm/pull/27687). Base is that PR's head branch; please merge it first (or rebase this one onto main after #27687 lands).

## Problem

For nearly every real LiteLLM proxy deployment the request `model` is a router `model_name` alias:

```yaml
model_list:
  - model_name: tpm-locked
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: ...
```

`litellm.get_llm_provider("tpm-locked")` doesn't know about router aliases — it raises. The resolver in #27687 then falls through to its defensive `litellm_proxy` fallback, so the `llm_provider` field on the raised `RateLimitError` ends up `"litellm_proxy"` instead of `"openai"` for the alias case.

That defeats the field's purpose for the most common config: customers running on the standard proxy pattern can't tell from the failure callback / Prometheus label whether OpenAI or Anthropic was about to be called, only that LiteLLM itself rate-limited.

End-to-end repro on PR #27687's branch: a v3 RPM cap hit on a `model: tpm-locked` request produced a callback payload with `category=litellm_rate_limit`, `rate_limit_type=requests` (both correct) but `llm_provider=litellm_proxy` (wrong).

## Fix

Add a router-alias fallback step to `resolve_llm_provider_for_rate_limit`. Resolution order is now:

1. `litellm.get_llm_provider(model)` — covers raw provider/model strings the SDK already understands.
2. **Router alias fallback** — scan `llm_router.model_list` for a deployment whose `model_name` matches the request model, then resolve from its `litellm_params.model`.
3. Defensive `("", "litellm_proxy")` fallback — only when both lookups fail.

Implementation details:

- New private helper `_resolve_provider_from_router_alias(model)` does the scan. Lazy-imports `llm_router` from `litellm.proxy.proxy_server` (same pattern as `auth_utils.py`, `parallel_request_limiter_v3.py`, `batch_rate_limiter.py`).
- Multiple deployments under one alias (load-balancing case) → first one wins. Every deployment under one alias should agree on provider in any sensible config, and "first" is deterministic so the Prometheus label stays stable.
- Defensive throughout: uninitialized router, malformed deployment, `litellm_params.model` that itself fails `get_llm_provider` — every branch falls through to the existing `litellm_proxy` fallback rather than letting a secondary exception escape and mask the rate-limit error we're trying to surface.
- No caller changes required (all 9+ call sites continue to pass just `model: str`).

## Tests

In `tests/test_litellm/proxy/hooks/test_proxy_rate_limit_provider_field.py::TestResolveLLMProviderForRateLimit`:

- `test_router_alias_resolves_to_underlying_provider` — alias `tpm-locked` → `openai/gpt-4o-mini` produces `provider=openai`, `model=gpt-4o-mini`. This is the headline regression test.
- `test_router_alias_with_multiple_deployments_uses_first` — load-balanced alias resolves deterministically.
- `test_router_alias_unknown_falls_back` — alias not in `model_list` lands at `litellm_proxy`.
- `test_router_alias_with_malformed_deployment_falls_back` — empty `litellm_params`, missing `model`, provider-less underlying string — all fall through cleanly.
- Existing `test_get_llm_provider_raising_is_swallowed` updated to also stub `litellm.proxy.proxy_server.llm_router = None` so it exercises the full "no resolution anywhere" path.

```
$ uv run pytest tests/test_litellm/proxy/hooks/test_proxy_rate_limit_provider_field.py -q
38 passed in 1.84s
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778738597799989?thread_ts=1778738597.799989&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-ceb8557c-646b-51ae-b6d3-e52268efceb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb8557c-646b-51ae-b6d3-e52268efceb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

