### PR TITLE
fix(exceptions): don't map upstream 400 to RateLimitError on substring match

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -53,8 +53,13 @@ class ExceptionCheckers:
 
         _error_str_lower = error_str.lower()
 
-        # Match "rate limit" (including variations like rate-limit / rate_limit)
-        if re.search(r"rate[\s_\-]*limit", _error_str_lower):
+        # Match "rate limit" (including variations like rate-limit / rate_limit).
+        # Anchored with a leading word boundary so substrings like
+        # ``_litellm_rate_limit_descriptors`` inside an unrelated upstream 400
+        # (e.g. "Unknown parameter: _litellm_rate_limit_descriptors") don't
+        # get misclassified as throttling. Without the boundary, the field
+        # name's embedded ``rate_limit`` matched and turned a 400 into a 429.
+        if re.search(r"\brate[\s_\-]*limit", _error_str_lower):
             return True
 
         #######################################
@@ -396,7 +401,20 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         + "Exception"
                     )
 
-                if ExceptionCheckers.is_error_str_rate_limit(error_str):
+                # A known 400 is unambiguous: the upstream rejected the
+                # request body, not the rate. Skipping the string heuristic
+                # in that case prevents an honest 400 ("Unknown parameter",
+                # "invalid_request_error", validation message) from being
+                # misclassified as a 429 just because its body happens to
+                # contain the substring ``rate_limit`` (e.g. a leaked field
+                # name) or a standalone ``429`` (e.g. a model id fragment).
+                _exception_status_code = getattr(
+                    original_exception, "status_code", None
+                )
+                if (
+                    _exception_status_code != 400
+                    and ExceptionCheckers.is_error_str_rate_limit(error_str)
+                ):
                     exception_mapping_worked = True
                     raise RateLimitError(
                         message=f"RateLimitError: {exception_provider} - {message}",

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -114,6 +114,144 @@ class TestExceptionCheckers:
         result = ExceptionCheckers.is_error_str_rate_limit(error_str)
         assert result is True
 
+    def test_is_error_str_rate_limit_ignores_field_name_substring(self):
+        """
+        Regression: an unrelated upstream 400 whose body happens to contain
+        ``rate_limit`` as a substring of an identifier (e.g. a field name
+        like ``_litellm_rate_limit_descriptors`` echoed back by OpenAI in an
+        "Unknown parameter" / "Unrecognized request arguments supplied"
+        error) must NOT be classified as a rate-limit signal.
+
+        Without a word boundary the regex ``rate[\\s_\\-]*limit`` matched
+        the embedded ``rate_limit`` and turned a 400 BadRequest into a 429
+        RateLimitError, hiding real proxy bugs (PR #27001 metadata leak)
+        behind a misleading ``throttling_error`` code.
+        """
+        for error_str in [
+            "Unknown parameter: '_litellm_rate_limit_descriptors'.",
+            "Unrecognized request arguments supplied: _litellm_rate_limit_descriptors, _litellm_tpm_reserved_tokens",
+            "my_rate_limit_field is not allowed",
+        ]:
+            assert (
+                ExceptionCheckers.is_error_str_rate_limit(error_str) is False
+            ), f"Field-name substring should not trigger rate-limit signal: {error_str!r}"
+
+    def test_is_error_str_rate_limit_still_matches_standalone_token(self):
+        """Both standalone forms still match — the tightening only affects
+        embedded substrings."""
+        for error_str in [
+            "Rate limit exceeded for tokens",
+            "rate_limit_exceeded: try again later",
+            "rate-limit-exceeded",
+            "You hit a rate limit",
+        ]:
+            assert (
+                ExceptionCheckers.is_error_str_rate_limit(error_str) is True
+            ), f"Standalone rate-limit phrase should match: {error_str!r}"
+
+
+class TestExceptionTypeStatusCodeGate:
+    """
+    Integration tests for the status-code gate on the OpenAI rate-limit
+    heuristic. Even if a 400 message happens to contain a substring that
+    trips the string heuristic, an explicit upstream 400 must map to
+    ``BadRequestError`` — never ``RateLimitError`` — because confusing the
+    two changes whether the client retries.
+    """
+
+    def _make_openai_400(self, message: str) -> Exception:
+        """Build something shaped like an upstream OpenAI 400."""
+        import httpx
+        import openai
+
+        request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+        response = httpx.Response(status_code=400, request=request)
+        err = openai.BadRequestError(
+            message=message,
+            response=response,
+            body={"message": message},
+        )
+        # openai.BadRequestError sets status_code via response, but assert
+        # the surface the mapper actually reads.
+        assert getattr(err, "status_code", None) == 400
+        return err
+
+    def test_openai_400_with_unknown_parameter_maps_to_bad_request(self):
+        """
+        PR #27001 regression: the v3 limiter leaked ``_litellm_*`` keys
+        into the upstream body and OpenAI rejected the request with::
+
+            400 Unknown parameter: '_litellm_rate_limit_descriptors'.
+
+        The exception mapper turned that 400 into a 429
+        ``RateLimitError`` / ``throttling_error`` because the message
+        substring matched ``rate[\\s_\\-]*limit``. That hid the real bug
+        and signalled "throttle and retry" to clients, which would loop
+        forever on a malformed request. Lock in the fix.
+        """
+        from litellm.exceptions import BadRequestError, RateLimitError
+
+        upstream = self._make_openai_400(
+            "Unknown parameter: '_litellm_rate_limit_descriptors'."
+        )
+
+        with pytest.raises(BadRequestError) as exc_info:
+            exception_type(
+                model="gpt-4o-mini",
+                original_exception=upstream,
+                custom_llm_provider="openai",
+                completion_kwargs={},
+                extra_kwargs={},
+            )
+        assert exc_info.value.status_code == 400
+        assert not isinstance(exc_info.value, RateLimitError)
+
+    def test_openai_400_with_unrecognized_arguments_maps_to_bad_request(self):
+        """Same regression, second OpenAI error wording observed in the wild."""
+        from litellm.exceptions import BadRequestError, RateLimitError
+
+        upstream = self._make_openai_400(
+            "Unrecognized request arguments supplied: "
+            "_litellm_rate_limit_descriptors, _litellm_tpm_reserved_model, "
+            "_litellm_tpm_reserved_scopes, _litellm_tpm_reserved_tokens."
+        )
+
+        with pytest.raises(BadRequestError) as exc_info:
+            exception_type(
+                model="gpt-4o-mini",
+                original_exception=upstream,
+                custom_llm_provider="openai",
+                completion_kwargs={},
+                extra_kwargs={},
+            )
+        assert exc_info.value.status_code == 400
+        assert not isinstance(exc_info.value, RateLimitError)
+
+    def test_openai_429_still_maps_to_rate_limit(self):
+        """The status-code gate must not regress the genuine 429 path."""
+        import httpx
+        import openai
+
+        from litellm.exceptions import RateLimitError
+
+        request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+        response = httpx.Response(status_code=429, request=request)
+        upstream = openai.RateLimitError(
+            message="Rate limit reached for requests",
+            response=response,
+            body={"message": "Rate limit reached for requests"},
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            exception_type(
+                model="gpt-4o-mini",
+                original_exception=upstream,
+                custom_llm_provider="openai",
+                completion_kwargs={},
+                extra_kwargs={},
+            )
+        assert exc_info.value.status_code == 429
+
     def test_is_azure_content_policy_violation_error_with_policy_violation_text(self):
         """Test detection of Azure content policy violation with explicit policy violation text"""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

OpenAI's `Unknown parameter: '<field>'` / `Unrecognized request arguments supplied: <field1>, <field2>` 400s, which echo the rejected field name back in the message, get misclassified as 429 `RateLimitError` whenever the field name contains `rate_limit` (or any `rate[\s_\-]*limit` substring) — e.g. `_litellm_rate_limit_descriptors`.

Concretely: while reproducing the v3 limiter leak (PR #27001 → PR #27913), OpenAI returned

```
{ "error": { "message": "Unknown parameter: '_litellm_rate_limit_descriptors'.", "code": "400" } }
```

and LiteLLM surfaced it to the client as

```
HTTP/1.1 429 Too Many Requests
{ "error": { "message": "litellm.RateLimitError: OpenAIException - Unknown parameter: '_litellm_rate_limit_descriptors'.", "type": "throttling_error", "code": "429" } }
```

That breaks two contracts:

1. **Retry semantics.** Clients see `429 throttling_error` and assume "back off and retry" — but the upstream rejected the body, retrying won't help. Loops forever on a malformed request.
2. **Debuggability.** It's the misclassification that hid the v3 leak: the 429 made it look like rate-limiting working as intended. The bug only surfaced after end-to-end provider testing.

## Root cause

In `litellm/litellm_core_utils/exception_mapping_utils.py`:

**Cause 1 — unanchored regex:** `ExceptionCheckers.is_error_str_rate_limit` uses `re.search(r"rate[\s_\-]*limit", _error_str_lower)`. No word boundary, so it matches `rate_limit` as a substring of any identifier. Real OpenAI 400 body fields named with `rate_limit` (or LiteLLM-internal field names like `_litellm_rate_limit_descriptors` leaked into the body) all trip the heuristic.

**Cause 2 — heuristic runs before status code:** Inside the OpenAI / OpenAI-compatible / Mistral branch of `exception_type`, `is_error_str_rate_limit` is called unconditionally — *before* the status-code branch that handles 400 → `BadRequestError`. So an explicit upstream 400 never gets a chance to map correctly when the string matches.

Anthropic's branch was already correct: it routes 400/413 to `BadRequestError` via status code, no string heuristic up front.

(Companion observation in PR #16482, which tightened `\b429\b` against `429` substrings — same shape of bug, different token.)

## Fix

**Anchor the regex** with a leading word boundary: `\brate[\s_\-]*limit`. Embedded identifiers like `_litellm_rate_limit_descriptors` no longer match (the preceding `_` is a word char so `\b` fails). Standalone phrases all still match: `Rate limit exceeded`, `rate_limit_exceeded`, `rate-limit-exceeded`, `You hit a rate limit`.

**Status-code gate at the mapping site:** when `getattr(original_exception, "status_code", None) == 400`, skip the string heuristic entirely. A 400 is unambiguous per RFC 9110 — the upstream rejected the body, not the rate. Don't second-guess it.

Both fixes are independent and complementary: the regex fix protects unknown-status-code paths (some upstream errors don't carry `status_code`), and the gate protects against any future heuristic that could mistake a 400 message for a 429.

## Tests

`tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py`:

- `test_is_error_str_rate_limit_ignores_field_name_substring` — three forms of the OpenAI 400 wire message all return False.
- `test_is_error_str_rate_limit_still_matches_standalone_token` — proves the tightening didn't regress legitimate detections.
- `TestExceptionTypeStatusCodeGate` — end-to-end mapper tests. Build a real `openai.BadRequestError` with status 400 and the wire messages we saw, run `exception_type`, assert the result is `litellm.BadRequestError` (not `RateLimitError`).
- `test_openai_429_still_maps_to_rate_limit` — confirms the genuine 429 path is untouched.

```
$ uv run pytest tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py -q
43 passed in 0.21s
```

## Related

Companion to #27913 (which fixes the underlying v3 limiter leak that this misclassification was hiding).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778738597799989?thread_ts=1778738597.799989&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-ceb8557c-646b-51ae-b6d3-e52268efceb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb8557c-646b-51ae-b6d3-e52268efceb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

