### PR TITLE
fix(router): scan all deployments for weight/rpm/tpm in simple-shuffle

### DIFF
--- a/litellm/router_strategy/simple_shuffle.py
+++ b/litellm/router_strategy/simple_shuffle.py
@@ -6,7 +6,7 @@ If weights are provided, it will return a deployment based on the weights.
 """
 
 import random
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_router_logger
 
@@ -18,6 +18,35 @@ else:
     LitellmRouter = Any
 
 
+# Order of precedence when more than one weighting field is declared across
+# the deployment list. ``weight`` is a generic relative-weight field and
+# should win over the rate-limit-derived weights so an operator who sets
+# ``weight: 100`` alongside an ``rpm:`` (used by other code paths for cap
+# enforcement) gets the explicit weighting they asked for.
+_WEIGHT_FIELDS_PRECEDENCE = ("weight", "rpm", "tpm")
+
+
+def _pick_weight_field(
+    healthy_deployments: List[Dict[str, Any]],
+) -> Optional[str]:
+    """
+    Return the first field in ``_WEIGHT_FIELDS_PRECEDENCE`` that *any*
+    deployment in the list declares, or ``None`` if none do.
+
+    The previous implementation only consulted ``healthy_deployments[0]``,
+    which silently fell through to uniform random whenever the first
+    deployment happened to be unweighted but later ones declared
+    ``rpm`` / ``tpm`` / ``weight``. That made deployment-level weighting
+    appear to "silently ignore" the field, depending on routing order.
+    """
+    for field in _WEIGHT_FIELDS_PRECEDENCE:
+        for deployment in healthy_deployments:
+            litellm_params = deployment.get("litellm_params") or {}
+            if litellm_params.get(field) is not None:
+                return field
+    return None
+
+
 def simple_shuffle(
     llm_router_instance: LitellmRouter,
     healthy_deployments: Union[List[Any], Dict[Any, Any]],
@@ -26,9 +55,18 @@ def simple_shuffle(
     """
     Returns a random deployment from the list of healthy deployments.
 
-    If weights are provided, it will return a deployment based on the weights.
+    If any deployment declares one of ``weight`` / ``rpm`` / ``tpm`` under
+    ``litellm_params``, a weighted random pick is performed using that
+    field as the relative weight (deployments that don't declare it get
+    weight ``0``). Field precedence: ``weight`` > ``rpm`` > ``tpm``.
 
-    If users pass `rpm` or `tpm`, we do a random weighted pick - based on `rpm`/`tpm`.
+    Note: ``rpm`` / ``tpm`` here are **static relative weights**, not
+    cap-enforced limits. Strategies like ``usage-based-routing-v2`` and
+    ``latency-based-routing`` enforce caps from cached usage; for cap
+    enforcement under simple-shuffle, enable
+    ``router_settings.enable_pre_call_checks`` (which filters
+    RPM-exhausted deployments out of ``healthy_deployments`` before the
+    shuffle) or use the proxy's key-level v3 TPM/RPM limiter.
 
     Args:
         llm_router_instance: LitellmRouter instance
@@ -38,27 +76,33 @@ def simple_shuffle(
     Returns:
         Dict: A single healthy deployment
     """
-
-    ############## Check if 'weight' or 'rpm' or 'tpm' param set for a weighted pick #################
-    for weight_by in ["weight", "rpm", "tpm"]:
-        weight = healthy_deployments[0].get("litellm_params").get(weight_by, None)
-        if weight is not None:
-            weights = [
-                m["litellm_params"].get(weight_by, 0) for m in healthy_deployments
+    weight_field = _pick_weight_field(healthy_deployments)
+    if weight_field is not None:
+        weights = [
+            (m.get("litellm_params") or {}).get(weight_field, 0)
+            for m in healthy_deployments
+        ]
+        verbose_router_logger.debug(f"\nweight {weights}")
+        total_weight = sum(weights)
+        # Defensive: if every deployment declared the field as 0 (or
+        # negative — pathological config), total_weight == 0 and the
+        # divide-by-zero below would crash. Fall through to uniform random
+        # instead. Same goes for any non-finite total.
+        if total_weight > 0:
+            normalized = [w / total_weight for w in weights]
+            verbose_router_logger.debug(f"\n weights {normalized} by {weight_field}")
+            selected_index = random.choices(range(len(normalized)), weights=normalized)[
+                0
             ]
-            verbose_router_logger.debug(f"\nweight {weights}")
-            total_weight = sum(weights)
-            weights = [weight / total_weight for weight in weights]
-            verbose_router_logger.debug(f"\n weights {weights} by {weight_by}")
-            # Perform weighted random pick
-            selected_index = random.choices(range(len(weights)), weights=weights)[0]
             verbose_router_logger.debug(f"\n selected index, {selected_index}")
             deployment = healthy_deployments[selected_index]
             verbose_router_logger.info(
-                f"get_available_deployment for model: {model}, Selected deployment: {llm_router_instance.print_deployment(deployment) or deployment[0]} for model: {model}"
+                f"get_available_deployment for model: {model}, Selected deployment: "
+                f"{llm_router_instance.print_deployment(deployment) or deployment[0]} "
+                f"for model: {model}"
             )
             return deployment or deployment[0]
 
-    ############## No RPM/TPM passed, we do a random pick #################
+    ############## No usable weights, we do a random pick #################
     item = random.choice(healthy_deployments)
     return item or item[0]

--- a/tests/test_litellm/router_strategy/test_simple_shuffle.py
+++ b/tests/test_litellm/router_strategy/test_simple_shuffle.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for the simple-shuffle routing strategy weighting logic.
+"""
+
+from collections import Counter
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.router_strategy.simple_shuffle import _pick_weight_field, simple_shuffle
+
+
+def _deployment(name: str, **litellm_params: Any) -> Dict[str, Any]:
+    return {
+        "model_name": name,
+        "litellm_params": {"model": f"openai/{name}", **litellm_params},
+    }
+
+
+class TestPickWeightField:
+    def test_returns_none_when_no_deployment_declares_anything(self):
+        deployments = [_deployment("a"), _deployment("b")]
+        assert _pick_weight_field(deployments) is None
+
+    def test_returns_weight_when_declared_on_first(self):
+        deployments = [_deployment("a", weight=10), _deployment("b")]
+        assert _pick_weight_field(deployments) == "weight"
+
+    def test_returns_weight_when_declared_only_on_later_deployments(self):
+        """
+        Regression for the silent-fallthrough bug: previously the code
+        consulted only ``healthy_deployments[0]`` to decide whether to do
+        a weighted pick. A config like::
+
+            - model_name: gpt-4o-mini
+              litellm_params: { model: openai/gpt-4o-mini }            # no weight
+            - model_name: gpt-4o-mini
+              litellm_params: { model: openai/gpt-4o-mini, rpm: 1000 } # weighted
+
+        would silently fall back to uniform random because the *first*
+        entry had no ``rpm``. Users perceived this as 'deployment-level
+        ``rpm:`` is ignored under simple-shuffle' — actually it was just
+        ordering-sensitive. Fix: scan all deployments.
+        """
+        deployments = [
+            _deployment("a"),
+            _deployment("b", rpm=1000),
+            _deployment("c", rpm=500),
+        ]
+        assert _pick_weight_field(deployments) == "rpm"
+
+    def test_precedence_weight_over_rpm_over_tpm(self):
+        # ``weight`` declared anywhere should win over rpm/tpm.
+        deployments = [_deployment("a", tpm=1000), _deployment("b", weight=5)]
+        assert _pick_weight_field(deployments) == "weight"
+
+        # ``rpm`` should win over ``tpm`` if no ``weight`` declared.
+        deployments = [_deployment("a", tpm=1000), _deployment("b", rpm=5)]
+        assert _pick_weight_field(deployments) == "rpm"
+
+    def test_handles_missing_litellm_params(self):
+        deployments: List[Dict[str, Any]] = [{"model_name": "broken"}]
+        assert _pick_weight_field(deployments) is None
+
+
+def _run_shuffle(deployments: List[Dict[str, Any]], n: int = 5000) -> Counter:
+    router = MagicMock()
+    router.print_deployment = lambda d: d.get("model_name", "?")
+    picks: Counter = Counter()
+    for _ in range(n):
+        picked = simple_shuffle(
+            llm_router_instance=router,
+            healthy_deployments=deployments,
+            model="model",
+        )
+        picks[picked["model_name"]] += 1
+    return picks
+
+
+class TestSimpleShuffle:
+    def test_uniform_random_when_no_weights(self):
+        deployments = [_deployment("a"), _deployment("b"), _deployment("c")]
+        picks = _run_shuffle(deployments, n=6000)
+        # Each deployment should be picked ~33% of the time. Generous
+        # tolerance to keep the test non-flaky.
+        for name in ("a", "b", "c"):
+            assert (
+                1500 < picks[name] < 2500
+            ), f"Expected ~2000 picks for {name}, got {picks[name]}"
+
+    def test_rpm_on_later_deployment_is_respected(self):
+        """
+        End-to-end regression for the silent-fallthrough bug. With the old
+        code (which only checked deployments[0]) this distribution would
+        be uniform across a/b/c. With the fix the weights become
+        [0, 1000, 500] -> b gets ~2/3, c gets ~1/3, a gets 0.
+        """
+        deployments = [
+            _deployment("a"),
+            _deployment("b", rpm=1000),
+            _deployment("c", rpm=500),
+        ]
+        picks = _run_shuffle(deployments, n=6000)
+        assert picks["a"] == 0, "Deployment with no rpm should get weight 0"
+        # b should be ~2/3 of picks, c ~1/3.
+        assert 3500 < picks["b"] < 4500
+        assert 1500 < picks["c"] < 2500
+
+    def test_zero_total_weight_falls_through_to_uniform_random(self):
+        """
+        Defensive: if every deployment declares the weight field as 0
+        (pathological config) we used to divide by zero. Now we fall
+        through to uniform random instead of crashing.
+        """
+        deployments = [
+            _deployment("a", weight=0),
+            _deployment("b", weight=0),
+            _deployment("c", weight=0),
+        ]
+        picks = _run_shuffle(deployments, n=3000)
+        # No crash + every deployment is reachable.
+        assert sum(picks.values()) == 3000
+        for name in ("a", "b", "c"):
+            assert picks[name] > 0
+
+    def test_single_deployment_always_picked(self):
+        deployments = [_deployment("only")]
+        picks = _run_shuffle(deployments, n=100)
+        assert picks["only"] == 100
+
+    def test_weight_field_wins_over_rpm(self):
+        """
+        Precedence regression: ``weight`` should always win over ``rpm``
+        when both are declared somewhere, so an operator using ``weight``
+        for explicit routing isn't accidentally overridden by ``rpm``
+        that's set for cap-enforcement purposes elsewhere.
+        """
+        deployments = [
+            _deployment("a", weight=9, rpm=1),
+            _deployment("b", weight=1, rpm=9),
+        ]
+        picks = _run_shuffle(deployments, n=6000)
+        # ``weight``-driven: a should dominate.
+        assert (
+            picks["a"] > picks["b"] * 4
+        ), f"weight should win over rpm, got picks={dict(picks)}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`simple_shuffle` only consults `healthy_deployments[0]` when deciding whether to do a weighted random pick. A config like:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      # ^ no weight/rpm/tpm declared
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      rpm: 1000
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      rpm: 500
```

silently falls back to **uniform random across all three** because the first entry has no `rpm`. Users perceive this as "deployment-level `rpm:` (or `tpm:` / `weight:`) is silently ignored under `simple-shuffle`" — the actual behavior is ordering-sensitive: if the first deployment happens to declare the weight field, everything works; if not, the rest are silently disregarded.

This was reported as part of a broader audit of v3 rate limit semantics (sibling to #27913, #27914, #27915). It is the only one of those audit findings that's a pre-existing router bug rather than a v3-limiter or exception-mapper issue.

## Fix

Extract `_pick_weight_field(healthy_deployments)` which scans **every** deployment for the precedence-ordered weight fields (`weight` > `rpm` > `tpm`) and returns the first one declared by any of them. Deployments that don't declare the chosen field continue to get weight `0` (preserves the existing semantics for in-list-but-unweighted entries).

Also: defensive divide-by-zero guard when `total_weight == 0` (every deployment declared the field as 0 — pathological config). Falls through to uniform random instead of crashing.

Docstring updated to be explicit that `rpm` and `tpm` here are **static relative weights**, not cap-enforced limits, and to point users at `router_settings.enable_pre_call_checks` (router-level RPM cap filter, gated on `messages is not None`) or the proxy's key-level v3 TPM/RPM limiter for actual cap enforcement under simple-shuffle.

## Scope notes

This PR does **not** change the documented semantics of `rpm`/`tpm` under simple-shuffle (still relative weights). Adding actual cap enforcement to simple-shuffle would change load-balancing behavior for every user on that strategy and is out of scope here — leaving it for a follow-up.

## Tests

`tests/test_litellm/router_strategy/test_simple_shuffle.py` — 10 new unit tests:

`TestPickWeightField`:

- `test_returns_none_when_no_deployment_declares_anything`
- `test_returns_weight_when_declared_on_first`
- `test_returns_weight_when_declared_only_on_later_deployments` — **the headline regression test**
- `test_precedence_weight_over_rpm_over_tpm` — covers two precedence pairs
- `test_handles_missing_litellm_params` — defensive

`TestSimpleShuffle` (statistical assertions over 6,000 picks):

- `test_uniform_random_when_no_weights`
- `test_rpm_on_later_deployment_is_respected` — end-to-end regression for silent-fallthrough
- `test_zero_total_weight_falls_through_to_uniform_random` — divide-by-zero defense
- `test_single_deployment_always_picked`
- `test_weight_field_wins_over_rpm` — precedence under simple_shuffle (not just helper)

```
$ uv run pytest tests/test_litellm/router_strategy/test_simple_shuffle.py -q
10 passed in 0.17s
```

## Related

Companion PRs from the same audit:

- #27913 — fix(rate-limit): stop v3 limiter from leaking internal stash to provider body
- #27914 — fix(rate-limit): resolve router model_name aliases to real provider (stacked on #27687)
- #27915 — fix(exceptions): don't map upstream 400 to RateLimitError on substring match
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1778738597799989?thread_ts=1778738597.799989&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-ceb8557c-646b-51ae-b6d3-e52268efceb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb8557c-646b-51ae-b6d3-e52268efceb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

