### PR TITLE
fix: pass socket timeouts to Redis cluster clients

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -100,6 +100,8 @@ def _get_redis_cluster_kwargs(client=None):
         "azure_tenant_id",
         "azure_client_secret",
         "max_connections",
+        "socket_timeout",
+        "socket_connect_timeout",
     }
 
     return available_args

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,5 +1,4 @@
 import json
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -163,6 +162,13 @@ def test_max_connections_in_cluster_kwargs():
     assert (
         "max_connections" in kwargs
     ), "max_connections should be in available Redis cluster kwargs"
+
+
+def test_socket_timeouts_in_cluster_kwargs():
+    """Test that Redis cluster clients can receive socket timeout configuration"""
+    kwargs = _get_redis_cluster_kwargs()
+    assert "socket_timeout" in kwargs
+    assert "socket_connect_timeout" in kwargs
 
 
 def test_get_redis_async_client_with_connection_pool():


### PR DESCRIPTION
## Relevant issues

Fixes #27919

## Linear ticket

N/A - external contributor

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Regression test before fix:

```text
FAILED tests/test_litellm/test_redis.py::test_socket_timeouts_in_cluster_kwargs
AssertionError: assert 'socket_timeout' in {...}
```

Targeted tests after fix:

```text
uv run pytest tests/test_litellm/test_redis.py tests/test_litellm/caching/test_redis_cluster_cache.py -q
34 passed in 0.41s
```

Manual blackhole Redis verification after fix:

```text
RedisClusterException Redis Cluster cannot be connected. Please provide at least one reachable node: Timeout connecting to server
elapsed 1.055
```

Formatting/lint checks:

```text
uv run ruff check litellm/_redis.py tests/test_litellm/test_redis.py
All checks passed!

uv run black --check litellm/_redis.py tests/test_litellm/test_redis.py
2 files would be left unchanged.
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Pass `socket_timeout` and `socket_connect_timeout` through `_get_redis_cluster_kwargs()` so Redis cluster clients receive configured socket timeout settings.
- Add a regression test covering the Redis cluster kwarg allow-list.