### PR TITLE
fix(mcp): expose delegate_auth_to_upstream in MCP server list API

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3566,6 +3566,7 @@ class MCPServerManager:
             registration_url=server.registration_url,
             allow_all_keys=server.allow_all_keys,
             available_on_public_internet=server.available_on_public_internet,
+            delegate_auth_to_upstream=server.delegate_auth_to_upstream,
             is_byok=server.is_byok,
             byok_description=server.byok_description,
             byok_api_key_help_url=server.byok_api_key_help_url,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -1099,6 +1099,35 @@ class TestMCPDelegateAuthToUpstream:
             delegate_auth_to_upstream=delegate_auth_to_upstream,
         )
 
+    def test_build_mcp_server_table_preserves_delegate_auth_to_upstream(self):
+        """Registry → API list rows must expose delegate_auth_to_upstream for the UI."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+        manager = MCPServerManager()
+        delegated = MCPServer(
+            server_id="delegated-1",
+            name="delegated",
+            transport="http",
+            auth_type=MCPAuth.oauth2,
+            delegate_auth_to_upstream=True,
+            available_on_public_internet=True,
+        )
+        assert (
+            manager._build_mcp_server_table(delegated).delegate_auth_to_upstream is True
+        )
+
+        not_delegated = delegated.model_copy(
+            update={"delegate_auth_to_upstream": False}
+        )
+        assert (
+            manager._build_mcp_server_table(not_delegated).delegate_auth_to_upstream
+            is False
+        )
+
     async def test_delegate_skips_litellm_auth_with_no_authorization(self):
         """
         oauth2 + delegate_auth_to_upstream=True, no Authorization header at


### PR DESCRIPTION
## Summary
`_build_mcp_server_table` did not copy `delegate_auth_to_upstream` from the in-memory `MCPServer` into `LiteLLM_MCPServerTable`, so `GET /v1/mcp/server` always returned the Pydantic default `false` even when the DB and registry had `true`. The dashboard and any API consumer showed the flag off while runtime behavior stayed correct.

## Changes
- Map `delegate_auth_to_upstream` in `_build_mcp_server_table`.
- Add `test_build_mcp_server_table_preserves_delegate_auth_to_upstream`.
<img width="1127" height="711" alt="image" src="https://github.com/user-attachments/assets/a7bd8308-f6e9-4fe7-b887-4a03468cf6ed" />