### PR TITLE
docs: add DATABASE_URL gotcha to AGENTS.md Cloud instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,7 +264,7 @@ litellm_settings:
 uv run litellm --config config.yaml --port 4000
 ```
 
-The proxy takes ~15-20 seconds to fully start (it runs Prisma migrations on boot). Wait for `/health` to return before sending requests. Without a PostgreSQL `DATABASE_URL`, the proxy connects to a default Neon dev database embedded in the `litellm-proxy-extras` package.
+The proxy takes ~15-20 seconds to fully start (it runs Prisma migrations on boot). Wait for `/health/liveliness` to return `"I'm alive!"` before sending requests. Without a PostgreSQL `DATABASE_URL`, the proxy connects to a default Neon dev database embedded in the `litellm-proxy-extras` package. If a `DATABASE_URL` environment variable is set but points to an unreachable database (e.g. `localhost:5432` without a running PostgreSQL), unset it before starting: `unset DATABASE_URL`. Key management endpoints (`/key/generate`, etc.) require a working database connection.
 
 ### Running tests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

N/A - Environment setup improvement

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Added a clarification to `AGENTS.md` Cursor Cloud instructions about:
- The `DATABASE_URL` environment variable gotcha: if set but pointing to an unreachable database, the proxy fails to start. Document the `unset DATABASE_URL` workaround.
- Clarified the health check endpoint path (`/health/liveliness`) and expected response.
- Noted that key management endpoints require a working database connection.

## Screenshots / Proof of Fix

Environment setup verified with:
- Proxy server running on port 4000 with health check passing
- Model listing and info endpoints responding correctly
- Python unit tests: 2029 passed
- Ruff lint: all checks passed
- UI Vitest tests: 383 test files, 3844 tests all passed

[proxy_demo.log](https://cursor.com/agents/bc-1be1e9b0-9dcb-4fd4-9018-ce23678b2139/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproxy_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1be1e9b0-9dcb-4fd4-9018-ce23678b2139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1be1e9b0-9dcb-4fd4-9018-ce23678b2139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

