### PR TITLE
fix(bedrock): strip `client_metadata` from `filter_internal_params`

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -426,11 +426,26 @@ def filter_internal_params(
     if not isinstance(data, dict):
         return data
 
-    # Known internal parameters that should never be sent to provider APIs
+    # Known internal parameters that should never be sent to provider APIs.
+    #
+    # ``client_metadata`` is sent by some clients (e.g. OpenAI Codex CLI,
+    # Claude Code) to attach run-level metadata. Most providers ignore
+    # unknown fields, but Bedrock Converse with custom *application
+    # inference profiles* rejects it because the underlying inference
+    # profile validates ``additionalModelRequestFields`` strictly:
+    #
+    #     The model returned the following errors: client_metadata: Extra
+    #     inputs are not permitted
+    #
+    # ``drop_params`` does not cover this because ``client_metadata`` is
+    # not a known OpenAI parameter, so it survives as part of
+    # ``additional_request_params`` and ends up in the Converse payload.
+    # Filter it here so every provider path sees the same sanitization.
     internal_params = {
         "skip_mcp_handler",
         "mcp_handler_context",
         "_skip_mcp_handler",
+        "client_metadata",
     }
 
     # Add any additional internal params if provided

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -4,6 +4,7 @@ import pytest
 
 from litellm.litellm_core_utils.core_helpers import (
     _FINISH_REASON_MAP,
+    filter_internal_params,
     map_finish_reason,
     reconstruct_model_name,
     redact_nested_match_and_regex_keys,
@@ -201,3 +202,64 @@ class TestRedactNestedMatchAndRegexKeys:
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
         assert redact_nested_match_and_regex_keys("plain") == "plain"
+
+
+def test_filter_internal_params_strips_client_metadata():
+    """``client_metadata`` must never leak into provider payloads.
+
+    Bedrock Converse with custom application inference profiles rejects any
+    field in ``additionalModelRequestFields`` that the inference profile
+    does not whitelist. Some clients (OpenAI Codex CLI, Claude Code, ...)
+    send a ``client_metadata`` field for run-level telemetry; ``drop_params``
+    does not cover it because it is not a known OpenAI param. Filtering it
+    here means every provider path sees the same sanitization.
+    """
+
+    data = {
+        "model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "messages": [{"role": "user", "content": "hi"}],
+        "client_metadata": {"user_id": "u-123", "session_id": "s-456"},
+        "temperature": 0.2,
+    }
+
+    filtered = filter_internal_params(data)
+
+    assert "client_metadata" not in filtered
+    # Other parameters must be preserved untouched.
+    assert filtered["model"] == data["model"]
+    assert filtered["messages"] == data["messages"]
+    assert filtered["temperature"] == data["temperature"]
+
+
+def test_filter_internal_params_still_strips_known_internal_params():
+    """Regression guard: previously known internal params keep being filtered."""
+
+    data = {
+        "skip_mcp_handler": True,
+        "_skip_mcp_handler": True,
+        "mcp_handler_context": {"foo": "bar"},
+        "client_metadata": {"user_id": "u-1"},
+        "temperature": 0.1,
+    }
+
+    filtered = filter_internal_params(data)
+
+    assert filtered == {"temperature": 0.1}
+
+
+def test_filter_internal_params_supports_additional_internal_params():
+    """The ``additional_internal_params`` extension point must keep working."""
+
+    data = {
+        "client_metadata": {"user_id": "u-1"},
+        "extra_secret": "shhh",
+        "temperature": 0.1,
+    }
+
+    filtered = filter_internal_params(
+        data, additional_internal_params={"extra_secret"}
+    )
+
+    assert "client_metadata" not in filtered
+    assert "extra_secret" not in filtered
+    assert filtered == {"temperature": 0.1}


### PR DESCRIPTION
## Summary

Bedrock Converse with custom **application inference profiles** rejects any field in `additionalModelRequestFields` that the underlying inference profile does not whitelist. Some clients (OpenAI Codex CLI, Claude Code, others adopting OpenAI's Responses API conventions) send a top-level `client_metadata` field for run-level telemetry. LiteLLM forwards it via `additional_request_params`, and the Converse call fails with HTTP 400:

```
The model returned the following errors: client_metadata: Extra inputs are not permitted
```

`drop_params=true` does not cover this case because `client_metadata` is **not a known OpenAI parameter**, so it survives the OpenAI-side filtering and reaches the provider transformation untouched.

## Fix

Add `client_metadata` to the central `filter_internal_params` set in `litellm/litellm_core_utils/core_helpers.py`. Every provider path that already calls this helper (Bedrock Converse, the fallback router via `fallback_utils`, etc.) now filters it once, instead of needing per-provider patches.

The relevant call site is `litellm/llms/bedrock/chat/converse_transformation.py` around line 1263:

```python
additional_request_params = filter_internal_params(additional_request_params)
```

so this fix flows naturally into the Bedrock Converse path without any other change.

## Tests

Three regression tests in `tests/test_litellm/litellm_core_utils/test_core_helpers.py`:

- `client_metadata` is removed from a representative Bedrock-style payload while every other field (model, messages, temperature, …) is preserved.
- The previously known internal markers (`skip_mcp_handler`, `_skip_mcp_handler`, `mcp_handler_context`) are still filtered alongside `client_metadata` in the same call.
- The `additional_internal_params` extension point keeps working when `client_metadata` is part of the default set.

## Repro

Any Responses-API client that sends `client_metadata`, routed against a Bedrock model that uses an application inference profile (custom ARN). Codex CLI's default `client_metadata: {"user_id": ..., "session_id": ...}` payload triggers it consistently before this patch and stops triggering it after.
