### PR TITLE
fix(responses): reorder `function_call_output` adjacent to `function_call` before chat-completion conversion

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -382,6 +382,16 @@ class LiteLLMCompletionResponsesConfig:
         if isinstance(input, str):
             messages.append(ChatCompletionUserMessage(role="user", content=input))
         elif isinstance(input, list):
+            # Bedrock Converse rejects requests where a ``toolResult`` is not
+            # adjacent to its ``toolUse``. The Responses API itself does not
+            # require strict adjacency, so upstream clients sometimes inject a
+            # ``message`` between a ``function_call`` and its
+            # ``function_call_output``. Normalise that here, before the
+            # conversion runs, so every downstream provider sees a payload
+            # that satisfies the strictest contract.
+            input = LiteLLMCompletionResponsesConfig._reorder_function_call_outputs_adjacent(
+                list(input)
+            )
             existing_tool_call_ids: Set[str] = set()
             for _input in input:
                 chat_completion_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
@@ -1008,6 +1018,66 @@ class LiteLLMCompletionResponsesConfig:
             "computer_call_output",
             "tool_result",  # Anthropic/MCP format
         ]
+
+    @staticmethod
+    def _reorder_function_call_outputs_adjacent(
+        items: List[Any],
+    ) -> List[Any]:
+        """Move every ``function_call_output`` immediately after its matching
+        ``function_call`` (by ``call_id``).
+
+        OpenAI's Responses API tolerates other input items (for example a
+        ``message`` injected by an upstream client) between a ``function_call``
+        and its ``function_call_output``. Bedrock Converse, however, requires
+        each ``toolResult`` block to live in the ``user`` message *immediately*
+        following the assistant message that emitted the matching ``toolUse``.
+
+        When a Responses-API request is converted to Chat Completions and then
+        to Converse, that adjacency invariant is silently lost and Bedrock
+        rejects the request with HTTP 400::
+
+            BedrockException - The number of toolResult blocks at messages.N.content
+            exceeds the number of toolUse blocks of previous turn.
+
+        Restoring the adjacency at the Responses → Chat Completions boundary is
+        provider-agnostic: OpenAI accepts the reordered input as well, so this
+        is safe for every backend that consumes the converted request.
+
+        The helper preserves relative order for everything else, is idempotent,
+        and only touches items it can pair by ``call_id``.
+        """
+        if not isinstance(items, list) or not items:
+            return items
+
+        result = list(items)
+        i = 0
+        while i < len(result):
+            it = result[i]
+            if (
+                isinstance(it, dict)
+                and it.get("type") == "function_call_output"
+            ):
+                call_id = it.get("call_id")
+                if call_id:
+                    # Find the most recent matching function_call before i.
+                    fc_idx: Optional[int] = None
+                    for k in range(i - 1, -1, -1):
+                        prev = result[k]
+                        if (
+                            isinstance(prev, dict)
+                            and prev.get("type") == "function_call"
+                            and prev.get("call_id") == call_id
+                        ):
+                            fc_idx = k
+                            break
+                    if fc_idx is not None and fc_idx != i - 1:
+                        out = result.pop(i)
+                        result.insert(fc_idx + 1, out)
+                        # Position i now holds what was at i+1, so don't
+                        # advance the cursor.
+                        continue
+            i += 1
+        return result
 
     @staticmethod
     def _is_input_item_function_call(input_item: Any) -> bool:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_adjacency.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_adjacency.py
@@ -1,0 +1,205 @@
+"""
+Tests for ``_reorder_function_call_outputs_adjacent``.
+
+Bedrock Converse rejects requests where a ``toolResult`` is not located in
+the ``user`` message *immediately* following the assistant message that
+emitted the matching ``toolUse``. The OpenAI Responses API itself does not
+require strict adjacency, so upstream clients can legally inject a
+``message`` between a ``function_call`` and its ``function_call_output``.
+
+The helper normalises the Responses-API input so the converted Chat
+Completions / Bedrock Converse payload always satisfies the strictest
+contract. These tests pin the helper's behaviour at the
+Responses → Chat Completions boundary.
+"""
+
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+
+reorder = LiteLLMCompletionResponsesConfig._reorder_function_call_outputs_adjacent
+
+
+def _function_call(call_id: str, name: str = "exec_command") -> dict:
+    return {
+        "type": "function_call",
+        "call_id": call_id,
+        "name": name,
+        "arguments": "{}",
+    }
+
+
+def _function_call_output(call_id: str, output: str = "ok") -> dict:
+    return {
+        "type": "function_call_output",
+        "call_id": call_id,
+        "output": output,
+    }
+
+
+def _user_message(text: str) -> dict:
+    return {"type": "message", "role": "user", "content": text}
+
+
+def _assistant_message(text: str) -> dict:
+    return {"type": "message", "role": "assistant", "content": text}
+
+
+def test_reorder_handles_empty_input():
+    assert reorder([]) == []
+
+
+def test_reorder_passes_through_non_list_input():
+    # The helper must tolerate the non-list shapes the surrounding code
+    # may pass during validation/edge cases.
+    assert reorder(None) is None  # type: ignore[arg-type]
+
+
+def test_reorder_is_noop_when_already_adjacent():
+    items = [_function_call("c1"), _function_call_output("c1")]
+    out = reorder(items)
+    assert out == items
+
+
+def test_reorder_is_idempotent_for_already_adjacent_items():
+    items = [_function_call("c1"), _function_call_output("c1")]
+    assert reorder(reorder(items)) == items
+
+
+def test_reorder_moves_output_adjacent_to_call_when_message_is_interleaved():
+    """Reproduces the OpenAI Codex CLI ``apply_patch`` heredoc trigger.
+
+    Codex detects an ``apply_patch <<EOF`` heredoc inside an
+    ``exec_command``, short-circuits via the native ``apply_patch`` tool,
+    and inserts a user-visible warning message between the
+    ``function_call`` and the synthesised ``function_call_output``.
+
+    The helper must restore adjacency so Bedrock Converse accepts the
+    converted request.
+    """
+    apply_patch_warning = (
+        "Warning: apply_patch was requested via exec_command. Use the "
+        "apply_patch tool instead of exec_command."
+    )
+    items = [
+        _user_message("hello"),
+        _function_call("c1"),
+        _user_message(apply_patch_warning),
+        _function_call_output("c1"),
+    ]
+
+    out = reorder(items)
+
+    assert out == [
+        _user_message("hello"),
+        _function_call("c1"),
+        _function_call_output("c1"),
+        _user_message(apply_patch_warning),
+    ]
+
+
+def test_reorder_is_idempotent_after_a_real_reorder():
+    items = [
+        _function_call("c1"),
+        _user_message("interlude"),
+        _function_call_output("c1"),
+    ]
+    once = reorder(items)
+    twice = reorder(once)
+    assert twice == once
+
+
+def test_reorder_handles_multiple_interleaved_pairs():
+    items = [
+        _function_call("a"),
+        _assistant_message("thinking..."),
+        _function_call("b"),
+        _user_message("interrupt"),
+        _function_call_output("a"),
+        _function_call_output("b"),
+    ]
+
+    out = reorder(items)
+
+    def index_of(call_id: str, kind: str) -> int:
+        for i, it in enumerate(out):
+            if (
+                isinstance(it, dict)
+                and it.get("type") == kind
+                and it.get("call_id") == call_id
+            ):
+                return i
+        raise AssertionError(f"missing {kind} for {call_id}: {out!r}")
+
+    # Each function_call_output sits immediately after its matching
+    # function_call.
+    assert index_of("a", "function_call_output") == index_of("a", "function_call") + 1
+    assert index_of("b", "function_call_output") == index_of("b", "function_call") + 1
+
+
+def test_reorder_leaves_orphan_outputs_in_place():
+    """Orphan ``function_call_output`` items keep their original position.
+
+    We deliberately do *not* drop them: that's a separate concern (clients
+    sending a malformed history) and is handled in a different normalisation
+    step.
+    """
+    items = [
+        _function_call_output("orphan"),
+        _user_message("hi"),
+    ]
+    assert reorder(items) == items
+
+
+def test_reorder_tolerates_non_dict_items():
+    class Sentinel:
+        pass
+
+    items = [
+        Sentinel(),
+        _function_call("c1"),
+        _function_call_output("c1"),
+    ]
+    out = reorder(items)
+    # Sentinel is preserved at position 0; the call/output pair stays
+    # adjacent (here a no-op since they were already adjacent).
+    assert isinstance(out[0], Sentinel)
+    assert out[1] == _function_call("c1")
+    assert out[2] == _function_call_output("c1")
+
+
+def test_reorder_is_a_noop_when_no_matching_call_exists():
+    """A ``function_call_output`` whose ``call_id`` matches no preceding
+    ``function_call`` must stay where it is rather than being silently moved
+    to a wrong location.
+    """
+    items = [
+        _user_message("first"),
+        _function_call_output("ghost"),
+    ]
+    assert reorder(items) == items
+
+
+def test_reorder_keeps_relative_order_of_unrelated_items():
+    items = [
+        _user_message("u1"),
+        _function_call("c1"),
+        _assistant_message("a1"),
+        _user_message("u2"),
+        _function_call_output("c1"),
+        _assistant_message("a2"),
+    ]
+
+    out = reorder(items)
+
+    # function_call_output landed right after function_call
+    fc_idx = out.index(_function_call("c1"))
+    assert out[fc_idx + 1] == _function_call_output("c1")
+    # The other items keep their relative order
+    other = [it for it in out if it.get("type") == "message"]
+    assert other == [
+        _user_message("u1"),
+        _assistant_message("a1"),
+        _user_message("u2"),
+        _assistant_message("a2"),
+    ]


### PR DESCRIPTION
## Summary

Bedrock Converse requires every `toolResult` block to live in the `user` message **immediately** following the assistant message that emitted the matching `toolUse`. The OpenAI Responses API does not enforce strict adjacency, so upstream clients can legally inject a `message` between a `function_call` and its `function_call_output`.

When such a payload is converted Responses → Chat Completions → Converse, the adjacency invariant is silently lost and Bedrock returns HTTP 400:

```
BedrockException - The number of toolResult blocks at messages.N.content
exceeds the number of toolUse blocks of previous turn.
```

## Concrete trigger

OpenAI Codex CLI: when an `apply_patch <<EOF` heredoc is detected inside an `exec_command`, Codex short-circuits via the native `apply_patch` tool and inserts a user-visible warning message between the `function_call` and the synthesised `function_call_output`:

```
Warning: apply_patch was requested via exec_command. Use the apply_patch
tool instead of exec_command.
```

That single intercalated `message` is enough to break Bedrock Converse on any non-trivial Codex session.

## Fix

Restore the adjacency at the **Responses → Chat Completions boundary**, not as a callback and not in the Bedrock provider transformation. The Responses API and most downstream providers tolerate the reordered input; only Bedrock *requires* it. Doing it once at the conversion boundary means every provider sees a payload that satisfies the strictest contract, without coupling the conversion layer to provider-specific knowledge.

A new static helper `_reorder_function_call_outputs_adjacent` is added on `LiteLLMCompletionResponsesConfig` and called once at the top of the `isinstance(input, list)` branch in `_transform_response_input_param_to_chat_completion_message`. The helper:

- pairs items by `call_id`;
- preserves relative order for everything else;
- is idempotent;
- is a no-op when input is already adjacent;
- only touches items it can pair (orphan `function_call_output` items keep their original position; dropping them is a separate concern).

## Tests

A focused module `tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_adjacency.py` covering:

- empty input, non-list input, and already-adjacent pairs are no-ops;
- the helper is idempotent (applying it twice yields the same result);
- the OpenAI Codex CLI `apply_patch` heredoc trigger is reproduced and resolved;
- multiple interleaved call/output pairs end up adjacent regardless of the order in which the outputs were emitted;
- orphan `function_call_output` items keep their original position;
- non-dict items in the input list are tolerated;
- the relative order of unrelated items is preserved.

## Why this layer (and not Bedrock provider, and not a callback)

- A **callback** is invisible from upstream's perspective and would not be the right place: the bug is conceptually amont, in the Responses-to-chat conversion.
- A **Bedrock-only fix** in `converse_transformation.py` would work but couples a generic conversion bug to a single provider; if any other provider tightens its contract later, we'd have to repeat the fix there.
- The **conversion boundary** is the canonical place: the helper produces a valid payload for every downstream provider with a single normalisation step.

## Companion fix

This PR pairs naturally with the `client_metadata` filter in `filter_internal_params` (separate PR). Both target the same family of "Codex CLI / Claude Code → LiteLLM → Bedrock Converse" 400 errors, but they fix unrelated layers and can be reviewed independently.
