### PR TITLE
fix(compliance): accept end_user_id as audit identity for Art. 12 / Art. 30

### DIFF
--- a/litellm/proxy/compliance_checks.py
+++ b/litellm/proxy/compliance_checks.py
@@ -91,8 +91,14 @@ class ComplianceChecker:
         )
 
     def _check_art_12_audit_complete(self) -> ComplianceCheckResult:
-        """Art. 12: Check if audit record is complete."""
-        has_user = bool(self.data.user_id)
+        """Art. 12: Check if audit record is complete.
+
+        EU AI Act Art. 12 requires traceability to the natural person being
+        processed. Either `user_id` (LiteLLM key owner) or `end_user_id`
+        (OpenAI-spec `user` field, identifies the data subject of the
+        request) is sufficient.
+        """
+        has_user = bool(self.data.user_id or self.data.end_user_id)
         has_model = bool(self.data.model)
         has_timestamp = bool(self.data.timestamp)
         has_guardrails = len(self.guardrails) > 0
@@ -100,7 +106,7 @@ class ComplianceChecker:
 
         missing = []
         if not has_user:
-            missing.append("user_id")
+            missing.append("user_id or end_user_id")
         if not has_model:
             missing.append("model")
         if not has_timestamp:
@@ -158,8 +164,14 @@ class ComplianceChecker:
         )
 
     def _check_art_30_audit_complete(self) -> ComplianceCheckResult:
-        """Art. 30: Check if audit record is complete."""
-        has_user = bool(self.data.user_id)
+        """Art. 30: Check if audit record is complete.
+
+        GDPR Art. 30 requires the categories of data subjects to be recorded.
+        Either `user_id` (LiteLLM key owner) or `end_user_id` (OpenAI-spec
+        `user` field, identifies the data subject of the request) is
+        sufficient.
+        """
+        has_user = bool(self.data.user_id or self.data.end_user_id)
         has_model = bool(self.data.model)
         has_timestamp = bool(self.data.timestamp)
         has_guardrails = len(self.guardrails) > 0
@@ -167,7 +179,7 @@ class ComplianceChecker:
 
         missing = []
         if not has_user:
-            missing.append("user_id")
+            missing.append("user_id or end_user_id")
         if not has_model:
             missing.append("model")
         if not has_timestamp:

--- a/litellm/types/proxy/compliance_endpoints.py
+++ b/litellm/types/proxy/compliance_endpoints.py
@@ -24,10 +24,17 @@ class ComplianceCheckRequest(BaseModel):
     """Request payload for compliance check endpoints.
 
     Mirrors the spend log fields needed for compliance evaluation.
+
+    `user_id` carries the LiteLLM key owner (spend_log.user, sourced from
+    `metadata.user_api_key_user_id`). `end_user_id` carries the OpenAI-spec
+    `user` field of the request body (spend_log.end_user). Either one is
+    sufficient to identify the data subject for EU AI Act Art. 12 and
+    GDPR Art. 30 audit completeness.
     """
 
     request_id: str
     user_id: Optional[str] = None
+    end_user_id: Optional[str] = None
     model: Optional[str] = None
     timestamp: Optional[str] = None
     guardrail_information: Optional[List[dict]] = None

--- a/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
@@ -457,6 +457,25 @@ class TestAuditIdentityFallback:
         results = {c.check_name: c.passed for c in checks}
         assert results["Audit record complete"] is True
 
+    def test_gdpr_audit_complete_with_only_user_id(self):
+        """Existing GDPR semantics preserved: user_id alone is still sufficient."""
+        data = ComplianceCheckRequest(
+            request_id="req-406",
+            user_id="key-owner-1",
+            end_user_id=None,
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_detection",
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checks = ComplianceChecker(data).check_gdpr()
+        results = {c.check_name: c.passed for c in checks}
+        assert results["Audit record complete"] is True
+
     def test_eu_ai_act_audit_incomplete_when_both_user_fields_missing(self):
         """Both user_id and end_user_id absent → NON-COMPLIANT."""
         data = ComplianceCheckRequest(

--- a/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
@@ -385,3 +385,109 @@ class TestGdprCompliant:
         )
         checks = ComplianceChecker(data).check_gdpr()
         assert all(c.passed for c in checks)
+
+
+# ---------------------------------------------------------------------------
+# Audit identity fallback: end_user_id alone is sufficient
+# ---------------------------------------------------------------------------
+
+
+class TestAuditIdentityFallback:
+    """`user_id` (key owner) absent but `end_user_id` (OpenAI-spec user) present.
+
+    The OpenAI-spec `user` field on the request body identifies the natural
+    person being processed — exactly what EU AI Act Art. 12 and GDPR Art. 30
+    require for audit completeness. A request that carries `end_user_id`
+    must pass the audit check even when `user_id` is absent (common when the
+    upstream caller uses a team-shared virtual key whose `user_api_key_user_id`
+    is null).
+    """
+
+    _BASE_GUARDRAILS = [
+        {
+            "guardrail_name": "prohibited_practices",
+            "guardrail_status": "success",
+        }
+    ]
+
+    def test_eu_ai_act_audit_complete_with_only_end_user_id(self):
+        """EU AI Act Art. 12 must pass when only end_user_id is populated."""
+        data = ComplianceCheckRequest(
+            request_id="req-401",
+            user_id=None,
+            end_user_id="end-user-42",
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=self._BASE_GUARDRAILS,
+        )
+        checks = ComplianceChecker(data).check_eu_ai_act()
+        results = {c.check_name: c.passed for c in checks}
+        assert results["Audit record complete"] is True
+
+    def test_gdpr_audit_complete_with_only_end_user_id(self):
+        """GDPR Art. 30 must pass when only end_user_id is populated."""
+        data = ComplianceCheckRequest(
+            request_id="req-402",
+            user_id=None,
+            end_user_id="end-user-42",
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_detection",
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checks = ComplianceChecker(data).check_gdpr()
+        results = {c.check_name: c.passed for c in checks}
+        assert results["Audit record complete"] is True
+
+    def test_eu_ai_act_audit_complete_with_only_user_id(self):
+        """Existing semantics preserved: user_id alone is still sufficient."""
+        data = ComplianceCheckRequest(
+            request_id="req-403",
+            user_id="key-owner-1",
+            end_user_id=None,
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=self._BASE_GUARDRAILS,
+        )
+        checks = ComplianceChecker(data).check_eu_ai_act()
+        results = {c.check_name: c.passed for c in checks}
+        assert results["Audit record complete"] is True
+
+    def test_eu_ai_act_audit_incomplete_when_both_user_fields_missing(self):
+        """Both user_id and end_user_id absent → NON-COMPLIANT."""
+        data = ComplianceCheckRequest(
+            request_id="req-404",
+            user_id=None,
+            end_user_id=None,
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=self._BASE_GUARDRAILS,
+        )
+        checks = ComplianceChecker(data).check_eu_ai_act()
+        audit_check = next(c for c in checks if c.check_name == "Audit record complete")
+        assert audit_check.passed is False
+        assert "user_id or end_user_id" in audit_check.detail
+
+    def test_gdpr_audit_incomplete_when_both_user_fields_missing(self):
+        """Both user_id and end_user_id absent → NON-COMPLIANT on GDPR."""
+        data = ComplianceCheckRequest(
+            request_id="req-405",
+            user_id=None,
+            end_user_id=None,
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_detection",
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checks = ComplianceChecker(data).check_gdpr()
+        audit_check = next(c for c in checks if c.check_name == "Audit record complete")
+        assert audit_check.passed is False
+        assert "user_id or end_user_id" in audit_check.detail

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -9646,6 +9646,7 @@ export interface ComplianceResponse {
 export interface ComplianceCheckRequest {
   request_id: string;
   user_id?: string;
+  end_user_id?: string;
   model?: string;
   timestamp?: string;
   guardrail_information?: Record<string, any>[];

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/CompliancePanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/CompliancePanel.tsx
@@ -12,6 +12,7 @@ interface CompliancePanelProps {
   logEntry: {
     request_id: string;
     user?: string;
+    end_user?: string;
     model?: string;
     startTime?: string;
     metadata?: Record<string, any>;
@@ -149,6 +150,7 @@ const CompliancePanel: React.FC<CompliancePanelProps> = ({ accessToken, logEntry
     const payload: ComplianceCheckRequest = {
       request_id: logEntry.request_id,
       user_id: logEntry.user,
+      end_user_id: logEntry.end_user,
       model: logEntry.model,
       timestamp: logEntry.startTime,
       guardrail_information: logEntry.metadata?.guardrail_information,

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -63,6 +63,7 @@ interface GuardrailViewerProps {
   logEntry?: {
     request_id: string;
     user?: string;
+    end_user?: string;
     model?: string;
     startTime?: string;
     metadata?: Record<string, any>;

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -186,6 +186,7 @@ export function LogDetailContent({ logEntry, isLoadingDetails = false, accessTok
             logEntry={{
               request_id: logEntry.request_id,
               user: logEntry.user,
+              end_user: logEntry.end_user,
               model: logEntry.model,
               startTime: logEntry.startTime,
               metadata: logEntry.metadata,


### PR DESCRIPTION
## Relevant issues

Not previously reported. Diagnosed while validating EU AI Act audit exports against a team-shared virtual key.

## Pre-Submission checklist

- [x] Added testing in `tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py` — new class `TestAuditIdentityFallback` with 5 cases covering: `end_user_id` alone, `user_id` alone (existing semantics preserved), both absent (EU AI Act + GDPR).
- [ ] `make test-unit` — to be validated in CI. Logic verified locally in isolation (5/5 passing) before opening this draft.
- [x] Scope isolated to a single problem: audit identity completeness in `_check_art_12_audit_complete` and `_check_art_30_audit_complete`.
- [x] CLA — to be signed before requesting review.
- [ ] @greptileai review — will request after CI is green.

## Problem

`_check_art_12_audit_complete` and `_check_art_30_audit_complete` require `self.data.user_id`. The UI populates that field from `logEntry.user`, which `LogDetailsDrawer/LogDetailContent.tsx` reads from `SpendLogs.user`. That column is sourced from `metadata.user_api_key_user_id` (the LiteLLM owner of the virtual key) in `litellm/proxy/spend_tracking/spend_tracking_utils.py` (line ~426). It is `null` whenever a team-shared virtual key is used — the common pattern for multi-tenant app callers that authenticate to the proxy with one logical key per team or environment.

Meanwhile `SpendLogs.end_user` carries the OpenAI-spec `user` field of the request body, sourced from `end_user_id` via `get_end_user_id_for_cost_tracking`. That field identifies the natural person being processed — which is exactly what EU AI Act Art. 12 (traceability) and GDPR Art. 30 (categories of data subjects) require for audit completeness.

Today, a request from a service that authenticates with a team-shared virtual key but correctly propagates `user` in the body (per the OpenAI spec) reports as `NON-COMPLIANT` on the dashboard, with `Missing: user_id`, even though the request is fully audit-traceable.

## Fix

Accept either field. `_check_art_12_audit_complete` and `_check_art_30_audit_complete` now pass when `user_id` or `end_user_id` is present. The frontend (`CompliancePanel.tsx`, plumbed through `GuardrailViewer.tsx` and `LogDetailContent.tsx`) forwards `end_user_id: logEntry.end_user` alongside the existing `user_id: logEntry.user`. `ComplianceCheckRequest` gains `end_user_id: Optional[str] = None`.

The failure message becomes `Missing: user_id or end_user_id` so the dashboard hint reflects the new semantics.

Behaviour when only `user_id` is populated is preserved — existing test coverage for that path is unchanged and still asserts `Audit record complete: True`.

## Type

Bug fix
