### PR TITLE
feat(search): add TinyFish (tinyfish.ai) as search provider

### DIFF
--- a/litellm/llms/tinyfish/search/__init__.py
+++ b/litellm/llms/tinyfish/search/__init__.py
@@ -1,0 +1,3 @@
+from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+__all__ = ["TinyfishSearchConfig"]

--- a/litellm/llms/tinyfish/search/transformation.py
+++ b/litellm/llms/tinyfish/search/transformation.py
@@ -1,0 +1,130 @@
+"""
+TinyFish Search API.
+Endpoint: GET https://api.search.tinyfish.ai
+Docs: https://docs.tinyfish.ai/search-api
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional, TypedDict, Union
+from urllib.parse import urlencode
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.search.transformation import (
+    BaseSearchConfig,
+    SearchResponse,
+    SearchResult,
+)
+from litellm.secret_managers.main import get_secret_str
+
+
+class _TinyfishSearchRequestRequired(TypedDict):
+    query: str
+
+
+class TinyfishSearchRequest(_TinyfishSearchRequestRequired, total=False):
+    location: str
+    language: str
+    page: int
+    include_thumbnail: str
+
+
+class TinyfishSearchConfig(BaseSearchConfig):
+    TINYFISH_API_BASE = "https://api.search.tinyfish.ai"
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "TinyFish"
+
+    def get_http_method(self) -> Literal["GET", "POST"]:
+        return "GET"
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> Dict:
+        api_key = api_key or get_secret_str("TINYFISH_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TINYFISH_API_KEY is not set. Set `TINYFISH_API_KEY` environment variable."
+            )
+        headers["X-API-Key"] = api_key
+        headers["Accept"] = "application/json"
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        optional_params: dict,
+        data: Optional[Union[Dict, List[Dict]]] = None,
+        **kwargs,
+    ) -> str:
+        api_base = (
+            api_base or get_secret_str("TINYFISH_API_BASE") or self.TINYFISH_API_BASE
+        )
+        if data and isinstance(data, dict) and "_tinyfish_params" in data:
+            query_string = urlencode(data["_tinyfish_params"], doseq=True)
+            return f"{api_base}?{query_string}"
+        return api_base
+
+    def transform_search_request(
+        self,
+        query: Union[str, List[str]],
+        optional_params: dict,
+        **kwargs,
+    ) -> Dict:
+        if isinstance(query, list):
+            query = " ".join(query)
+
+        request_data: TinyfishSearchRequest = {"query": query}
+
+        if "country" in optional_params:
+            request_data["location"] = optional_params["country"]
+
+        if "search_domain_filter" in optional_params:
+            domains = optional_params["search_domain_filter"]
+            if isinstance(domains, list) and len(domains) > 0:
+                request_data["query"] = self._append_domain_filters(
+                    request_data["query"], domains
+                )
+
+        result_data = dict(request_data)
+
+        for param, value in optional_params.items():
+            if (
+                param not in self.get_supported_perplexity_optional_params()
+                and param not in result_data
+            ):
+                result_data[param] = value
+
+        return {"_tinyfish_params": result_data}
+
+    @staticmethod
+    def _append_domain_filters(query: str, domains: List[str]) -> str:
+        domain_clauses = " OR ".join(f"site:{d}" for d in domains)
+        return f"({query}) ({domain_clauses})"
+
+    def transform_search_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: Optional[LiteLLMLoggingObj],
+        **kwargs,
+    ) -> SearchResponse:
+        response_json = raw_response.json()
+
+        results: List[SearchResult] = []
+        for item in response_json.get("results", []):
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    snippet=item.get("snippet", ""),
+                )
+            )
+
+        return SearchResponse(results=results, object="search")

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3368,6 +3368,7 @@ class SearchProviders(str, Enum):
     DUCKDUCKGO = "duckduckgo"
     SEARCHAPI = "searchapi"
     SERPER = "serper"
+    TINYFISH = "tinyfish"
 
 
 # Create a set of all search provider values for quick lookup

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9171,6 +9171,7 @@ class ProviderConfigManager:
         from litellm.llms.searxng.search.transformation import SearXNGSearchConfig
         from litellm.llms.serper.search.transformation import SerperSearchConfig
         from litellm.llms.tavily.search.transformation import TavilySearchConfig
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
 
         PROVIDER_TO_CONFIG_MAP = {
             SearchProviders.PERPLEXITY: PerplexitySearchConfig,
@@ -9186,6 +9187,7 @@ class ProviderConfigManager:
             SearchProviders.DUCKDUCKGO: DuckDuckGoSearchConfig,
             SearchProviders.SEARCHAPI: SearchAPIConfig,
             SearchProviders.SERPER: SerperSearchConfig,
+            SearchProviders.TINYFISH: TinyfishSearchConfig,
         }
         config_class = PROVIDER_TO_CONFIG_MAP.get(provider, None)
         if config_class is None:

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12771,6 +12771,14 @@
             "notes": "Serper Google Search API. Pricing: $1.00/1k queries (Starter), $0.75/1k (Standard), $0.50/1k (Scale), $0.30/1k (Ultimate)."
         }
     },
+    "tinyfish/search": {
+        "input_cost_per_query": 0.0,
+        "litellm_provider": "tinyfish",
+        "mode": "search",
+        "metadata": {
+            "notes": "TinyFish Search API. Search is included with subscription, no per-query cost."
+        }
+    },
     "elevenlabs/scribe_v1": {
         "input_cost_per_second": 6.11e-05,
         "litellm_provider": "elevenlabs",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2103,6 +2103,13 @@
         "search": true
       }
     },
+    "tinyfish": {
+      "display_name": "TinyFish (`tinyfish`)",
+      "url": "https://docs.litellm.ai/docs/search/tinyfish",
+      "endpoints": {
+        "search": true
+      }
+    },
     "triton": {
       "display_name": "Triton (`triton`)",
       "url": "https://docs.litellm.ai/docs/providers/triton-inference-server",

--- a/tests/code_coverage_tests/enforce_llms_folder_style.py
+++ b/tests/code_coverage_tests/enforce_llms_folder_style.py
@@ -19,6 +19,7 @@ SEARCH_PROVIDERS = [
     "duckduckgo",
     "searchapi",
     "serper",
+    "tinyfish",
 ]
 
 ALLOWED_FILES_IN_LLMS_FOLDER = [

--- a/tests/search_tests/test_tinyfish_search.py
+++ b/tests/search_tests/test_tinyfish_search.py
@@ -1,0 +1,189 @@
+"""
+Tests for TinyFish Search API integration.
+"""
+
+import os
+import pytest
+from urllib.parse import urlparse, parse_qs
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import litellm
+
+
+MOCK_TINYFISH_RESPONSE = {
+    "query": "web automation tools",
+    "results": [
+        {
+            "position": 1,
+            "site_name": "tinyfish.ai",
+            "title": "TinyFish — AI Web Automation",
+            "snippet": "Automate any website with natural language.",
+            "url": "https://tinyfish.ai",
+        },
+        {
+            "position": 2,
+            "site_name": "github.com",
+            "title": "Top Web Automation Tools",
+            "snippet": "A curated list of browser automation frameworks.",
+            "url": "https://github.com/example/web-automation",
+        },
+    ],
+    "total_results": 2,
+    "page": 0,
+}
+
+
+def _make_mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    return mock
+
+
+class TestTinyfishSearch:
+    @pytest.mark.asyncio
+    async def test_basic_search(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            response = await litellm.asearch(
+                query="web automation tools",
+                search_provider="tinyfish",
+            )
+
+            assert mock_get.call_count == 1
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            assert parsed_url.scheme == "https"
+            assert parsed_url.netloc == "api.search.tinyfish.ai"
+            assert parsed_url.path == ""
+
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["query"] == ["web automation tools"]
+
+            headers = call_args.kwargs.get("headers", {})
+            assert headers["X-API-Key"] == "sk-tinyfish-test"
+
+            assert hasattr(response, "results")
+            assert response.object == "search"
+            assert len(response.results) == 2
+
+            first = response.results[0]
+            assert first.title == "TinyFish — AI Web Automation"
+            assert first.url == "https://tinyfish.ai"
+            assert first.snippet == "Automate any website with natural language."
+
+    @pytest.mark.asyncio
+    async def test_country_maps_to_location(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="test",
+                search_provider="tinyfish",
+                country="US",
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["location"] == ["US"]
+
+    @pytest.mark.asyncio
+    async def test_domain_filter_injection(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="python tutorials",
+                search_provider="tinyfish",
+                search_domain_filter=["arxiv.org", "github.com"],
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            query_value = query_params["query"][0]
+            assert "site:arxiv.org" in query_value
+            assert "site:github.com" in query_value
+            assert "python tutorials" in query_value
+
+    @pytest.mark.asyncio
+    async def test_language_passthrough(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        mock_response = _make_mock_response(MOCK_TINYFISH_RESPONSE)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            await litellm.asearch(
+                query="test",
+                search_provider="tinyfish",
+                language="en",
+            )
+
+            call_args = mock_get.call_args
+            parsed_url = urlparse(call_args.kwargs["url"])
+            query_params = parse_qs(parsed_url.query)
+            assert query_params["language"] == ["en"]
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self):
+        os.environ["TINYFISH_API_KEY"] = "sk-tinyfish-test"
+
+        empty_response = {
+            "query": "xyznonexistent",
+            "results": [],
+            "total_results": 0,
+            "page": 0,
+        }
+        mock_response = _make_mock_response(empty_response)
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = mock_response
+
+            response = await litellm.asearch(
+                query="xyznonexistent",
+                search_provider="tinyfish",
+            )
+
+            assert response.object == "search"
+            assert len(response.results) == 0
+
+    def test_missing_api_key(self):
+        os.environ.pop("TINYFISH_API_KEY", None)
+
+        from litellm.llms.tinyfish.search.transformation import TinyfishSearchConfig
+
+        config = TinyfishSearchConfig()
+        with pytest.raises(ValueError, match="TINYFISH_API_KEY"):
+            config.validate_environment(headers={})


### PR DESCRIPTION
## Relevant issues

N/A - New feature addition

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/`](https://github.com/BerriAI/litellm/tree/main/tests) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

Add [TinyFish](https://tinyfish.ai) as a new search provider for the LiteLLM Search API.

TinyFish provides web search results via `GET https://api.search.tinyfish.ai` with `X-API-Key` header authentication. Supports unified params (`query`, `country` → `location`, `search_domain_filter` via `site:` operators) and TinyFish-specific passthrough params (`language`, `page`, `include_thumbnail`).

**New files:**
- `litellm/llms/tinyfish/search/` — Provider module with `TinyfishSearchConfig` (follows Brave pattern for GET-based providers)
- `tests/search_tests/test_tinyfish_search.py` — 6 mock tests covering basic search, country mapping, domain filter injection, language passthrough, empty results, and missing API key

**Modified files:**
- `litellm/types/utils.py` — Add `TINYFISH` to `SearchProviders` enum
- `litellm/utils.py` — Register in `get_provider_search_config()`
- `model_prices_and_context_window.json` — Add `tinyfish/search` entry (included with subscription, no per-query cost)
- `provider_endpoints_support.json` — Add TinyFish provider entry
- `tests/code_coverage_tests/enforce_llms_folder_style.py` — Add `tinyfish` to `SEARCH_PROVIDERS`

**Parameter mapping:**
| LiteLLM unified | TinyFish | Handling |
|----------------|----------|----------|
| `query` | `query` | Direct |
| `country` | `location` | Renamed |
| `search_domain_filter` | `query` | Injected as `site:` operators |
| `language` | `language` | Passthrough |
| `page` | `page` | Passthrough |

**Test coverage:**
- Mock tests validate request URL, headers, query params, country→location mapping, domain filter injection, language passthrough, empty results, and missing API key error
- Verified end-to-end with live TinyFish API

## Test plan

- [x] `uv run pytest tests/search_tests/test_tinyfish_search.py -v` — all 6 tests pass
- [x] Live end-to-end test with real TinyFish API key returns 10 results
- [x] `uv run black .` — formatting clean
- [x] `uv run ruff check` — no lint issues