### PR TITLE
fix(streaming): handle empty choices array in streaming chunks

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -119,8 +119,19 @@ class ChunkProcessor:
         model = ChunkProcessor._get_model_from_chunks(chunks, first_chunk_model)
         system_fingerprint = chunk.get("system_fingerprint", None)
 
-        first_chunk_with_choices = next((c for c in chunks if c.get("choices")), chunk)
-        role = first_chunk_with_choices["choices"][0]["delta"]["role"]
+        first_chunk_with_choices = next(
+            (c for c in chunks if c.get("choices") and len(c["choices"]) > 0),
+            chunk,
+        )
+        if (
+            first_chunk_with_choices.get("choices")
+            and len(first_chunk_with_choices["choices"]) > 0
+        ):
+            role = (first_chunk_with_choices["choices"][0].get("delta") or {}).get(
+                "role", "assistant"
+            )
+        else:
+            role = "assistant"
         finish_reason = "stop"
         for chunk in chunks:
             if "choices" in chunk and len(chunk["choices"]) > 0:

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -269,6 +269,10 @@ class CustomStreamWrapper:
         if len(self.chunks) < 2:
             return
 
+        if not self.chunks[-1].choices or not self.chunks[-2].choices:
+            self._repeated_messages_count = 1
+            return
+
         last_content = self.chunks[-1].choices[0].delta.content
 
         if (

--- a/tests/test_litellm/litellm_core_utils/test_empty_choices_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_empty_choices_streaming.py
@@ -1,0 +1,158 @@
+"""
+Test that streaming handles empty choices arrays gracefully.
+
+Some providers send streaming chunks with empty choices arrays (choices: [])
+as initialization or ping chunks. LiteLLM should not crash when encountering
+these chunks.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
+from litellm.types.utils import (
+    Delta,
+    ModelResponseStream,
+    StreamingChoices,
+)
+
+
+@pytest.fixture
+def stream_wrapper() -> CustomStreamWrapper:
+    return CustomStreamWrapper(
+        completion_stream=None,
+        model="test-model",
+        logging_obj=MagicMock(),
+        custom_llm_provider="openai",
+    )
+
+
+class TestRaiseOnModelRepetitionEmptyChoices:
+    """Test raise_on_model_repetition handles chunks with empty choices."""
+
+    def test_empty_choices_on_last_chunk(self, stream_wrapper):
+        """Should not crash when the last chunk has empty choices."""
+        chunk_with_content = ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="hello", role="assistant"),
+                    finish_reason=None,
+                )
+            ]
+        )
+        chunk_empty_choices = ModelResponseStream(choices=[])
+
+        stream_wrapper.chunks = [chunk_with_content, chunk_empty_choices]
+        stream_wrapper.raise_on_model_repetition()
+
+    def test_empty_choices_on_second_to_last_chunk(self, stream_wrapper):
+        """Should not crash when the second-to-last chunk has empty choices."""
+        chunk_empty_choices = ModelResponseStream(choices=[])
+        chunk_with_content = ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="hello", role="assistant"),
+                    finish_reason=None,
+                )
+            ]
+        )
+
+        stream_wrapper.chunks = [chunk_empty_choices, chunk_with_content]
+        stream_wrapper.raise_on_model_repetition()
+
+    def test_both_chunks_empty_choices(self, stream_wrapper):
+        """Should not crash when both last chunks have empty choices."""
+        chunk1 = ModelResponseStream(choices=[])
+        chunk2 = ModelResponseStream(choices=[])
+
+        stream_wrapper.chunks = [chunk1, chunk2]
+        stream_wrapper.raise_on_model_repetition()
+
+    def test_normal_chunks_still_detect_repetition(self, stream_wrapper):
+        """Repetition detection still works for normal chunks with content."""
+        chunk1 = ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="repeated content here!", role="assistant"),
+                    finish_reason=None,
+                )
+            ]
+        )
+        chunk2 = ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="repeated content here!", role="assistant"),
+                    finish_reason=None,
+                )
+            ]
+        )
+
+        stream_wrapper.chunks = [chunk1, chunk2]
+        stream_wrapper.raise_on_model_repetition()
+        assert stream_wrapper._repeated_messages_count == 2
+
+
+class TestBuildBaseResponseEmptyChoices:
+    """Test build_base_response handles chunks with empty choices."""
+
+    def test_all_chunks_have_empty_choices(self):
+        """Should fallback to role='assistant' when no chunk has valid choices."""
+        chunks = [
+            {
+                "id": "1",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [],
+            },
+            {
+                "id": "2",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [],
+            },
+        ]
+
+        processor = ChunkProcessor(chunks=chunks, messages=None)
+        response = processor.build_base_response(chunks)
+        assert response["choices"][0]["message"]["role"] == "assistant"
+
+    def test_mixed_empty_and_valid_choices(self):
+        """Should find the first chunk with non-empty choices."""
+        chunks = [
+            {
+                "id": "1",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [],
+            },
+            {
+                "id": "2",
+                "object": "chat.completion.chunk",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "hi"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        ]
+
+        processor = ChunkProcessor(chunks=chunks, messages=None)
+        response = processor.build_base_response(chunks)
+        assert response["choices"][0]["message"]["role"] == "assistant"


### PR DESCRIPTION
## Summary

Some providers send streaming chunks with empty choices arrays as initialization or ping chunks. This causes IndexError crashes in two locations during streaming.

## Problem

When a streaming chunk arrives with an empty choices array:

1. **streaming_handler.py** - raise_on_model_repetition() accesses self.chunks[-1].choices[0].delta.content without verifying the choices array is non-empty.

2. **streaming_chunk_builder_utils.py** - build_base_response() uses a filter that passes chunks with empty choices lists, then choices[0] crashes. Additionally, the fallback chunk may also have empty choices.

Both crash with: IndexError: list index out of range

This affects any model/provider that sends empty-choices chunks during streaming (observed with OpenAI-compatible proxies forwarding various providers).

## Fix

1. **streaming_handler.py**: Added an early return in raise_on_model_repetition() when either of the last two chunks has an empty choices array. Repetition detection requires valid content in choices, so skipping these chunks is semantically correct.

2. **streaming_chunk_builder_utils.py**: Changed the filter to require len(choices) > 0 (not just key presence), and uses safe (x.get("delta") or {}).get("role", "assistant") pattern to handle both missing keys and null values.

## Testing

Added tests in tests/test_litellm/litellm_core_utils/test_empty_choices_streaming.py:

- TestRaiseOnModelRepetitionEmptyChoices: empty last chunk, empty second-to-last, both empty, and normal repetition detection still works
- TestBuildBaseResponseEmptyChoices: all chunks empty (fallback), mixed empty and valid chunks

---
Note: The 'Verify PR source branch' CI check references litellm_oss_branch as the target for external PRs, but that branch does not exist. Targeting main per CONTRIBUTING.md instructions.