### PR TITLE
fix: forward socket_timeout and socket_connect_timeout to RedisCluster

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -100,6 +100,8 @@ def _get_redis_cluster_kwargs(client=None):
         "azure_tenant_id",
         "azure_client_secret",
         "max_connections",
+        "socket_timeout",
+        "socket_connect_timeout",
     }
 
     return available_args


### PR DESCRIPTION
Closes #27919

---

`_get_redis_cluster_kwargs()` filters kwargs through an allow-list before passing them to `redis.RedisCluster()`. The allow-list was missing `socket_timeout` and `socket_connect_timeout`, so those values configured in `cache_params` or `router_settings.cache_kwargs` were silently dropped for Redis cluster clients.

This caused cluster connections to hang indefinitely on unreachable nodes (e.g. AWS ElastiCache Serverless / Valkey with cluster mode enabled), even when timeouts were explicitly configured.

The fix adds both kwargs to the explicit allow-list in `_get_redis_cluster_kwargs()`, matching the behavior already present in the non-cluster Redis path.

---

*This contribution was made with AI-agent assistance.*