### PR TITLE
fix(ollama): extract thinking field from /api/generate non-streaming response

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -370,7 +370,12 @@ class OllamaConfig(BaseConfig):
             response_text = response_json.get("response", "")
             content = None
             reasoning_content = None
-            if response_text is not None and isinstance(response_text, str):
+            # Check for top-level "thinking" field (Ollama returns this for
+            # reasoning models like Qwen3/DeepSeek-R1 via /api/generate)
+            if "thinking" in response_json:
+                reasoning_content = response_json["thinking"]
+                content = response_text
+            elif response_text is not None and isinstance(response_text, str):
                 reasoning_content, content = _parse_content_for_reasoning(response_text)
             else:
                 content = response_text  # type: ignore


### PR DESCRIPTION
## Summary

Fixes #27956

Ollama's `/api/generate` endpoint returns a top-level `"thinking"` field for reasoning models (Qwen3, DeepSeek-R1), but the non-streaming `transform_response()` in `OllamaConfig` only parsed `<think>` XML tags from the `"response"` text via `_parse_content_for_reasoning()`. This caused `reasoning_content` to always be `null` when using the generate endpoint with reasoning models.

The fix checks for the `"thinking"` field first, matching the pattern already used in:
- The `/api/chat` path (`OllamaChatConfig.transform_response()`)
- The streaming iterator (`OllamaTextCompletionResponseIterator.chunk_parser()`)

## Changes

- `litellm/llms/ollama/completion/transformation.py`: Check for top-level `"thinking"` key in the response JSON before falling back to `_parse_content_for_reasoning()` tag parsing.

## Test Plan

```python
# With a reasoning model like qwen3:8b via Ollama /api/generate
import litellm

response = litellm.text_completion(
    model="ollama/qwen3:8b",
    prompt="What is 2+2? Think step by step."
)
# Before: response.choices[0].message.reasoning_content is None
# After: response.choices[0].message.reasoning_content contains the thinking output
```