### PR TITLE
fix(streaming): guard against empty choices in raise_on_model_repetition

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -269,6 +269,11 @@ class CustomStreamWrapper:
         if len(self.chunks) < 2:
             return
 
+        # Guard against chunks with empty choices (e.g. Gemini Flash metadata-only
+        # chunks during web_search streaming)
+        if not self.chunks[-1].choices or not self.chunks[-2].choices:
+            return
+
         last_content = self.chunks[-1].choices[0].delta.content
 
         if (


### PR DESCRIPTION
## Summary

Fixes #27928

Vertex AI Gemini Flash and Flash Lite models emit metadata-only streaming chunks with `choices=[]` when using `web_search_options`. The `raise_on_model_repetition()` method in `streaming_handler.py` unconditionally accesses `choices[0]` on the last two chunks, causing an `IndexError` that surfaces as `MidStreamFallbackError: list index out of range`.

## Changes

- `litellm/litellm_core_utils/streaming_handler.py`: Add a guard that returns early when either of the two most recent chunks has an empty `choices` list, preventing the `IndexError`.

## Root Cause

```python
# Line 272 - crashes when choices is empty
last_content = self.chunks[-1].choices[0].delta.content
# Line 282 - same issue
second_to_last_content = self.chunks[-2].choices[0].delta.content
```

Gemini Flash/Flash Lite emit metadata-only chunks during web search streaming that produce `ModelResponseStream(choices=[])`. The repetition detector tried to index into these empty lists.

## Test Plan

- Use `litellm.completion()` with `model="vertex_ai/gemini-2.0-flash"`, `stream=True`, and `web_search_options={}` 
- Before: crashes mid-stream with `MidStreamFallbackError`
- After: streaming completes successfully, empty-choices chunks are skipped by the repetition detector