### PR TITLE
Feat: Add Weighted-Routing Failover

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5701,7 +5701,17 @@ class Router:
             for d in all_deployments
             if (d.get("model_info") or {}).get("id") is not None
         }
-        remaining = all_ids - excluded
+        # Only consider deployments that are currently healthy (not in cooldown).
+        # Using all_ids here would cause a wasteful run_async_fallback invocation
+        # that fails with RouterRateLimitError whenever the "remaining" entries
+        # are all in cooldown — the inner async_get_healthy_deployments call
+        # would find an empty list and raise immediately.
+        cooldown_ids = set(
+            await _async_get_cooldown_deployments(
+                litellm_router_instance=self, parent_otel_span=None
+            )
+        )
+        remaining = (all_ids - cooldown_ids) - excluded
         if not remaining:
             return None
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5716,19 +5716,25 @@ class Router:
             "model": original_model_group,
             "_excluded_deployment_ids": list(excluded),
         }
-        input_kwargs.update(
-            {
-                "fallback_model_group": [entry],
-                "original_model_group": original_model_group,
-            }
-        )
+        # Build a local copy so the weighted-failover keys do not leak back to
+        # the caller's shared kwargs dict (any downstream fallback path reads
+        # the same dict and must not inherit our `_excluded_deployment_ids`
+        # entry).
+        failover_kwargs = {
+            **input_kwargs,
+            "fallback_model_group": [entry],
+            "original_model_group": original_model_group,
+        }
         try:
-            return await run_async_fallback(*args, **input_kwargs)
-        except openai.APIError:
-            # Expected model-level failure on the retried deployment (all litellm
-            # provider errors derive from openai.APIError). Defer to the regular
-            # fallback path. Programming errors (AttributeError, KeyError,
-            # TypeError, etc.) intentionally propagate so they remain visible.
+            return await run_async_fallback(*args, **failover_kwargs)
+        except (openai.APIError, RouterRateLimitError, RouterRateLimitErrorBasic):
+            # Expected model-level failure on the retried deployment. All
+            # litellm provider errors derive from openai.APIError; if every
+            # remaining deployment in the group is in cooldown the router
+            # raises RouterRateLimitError (a ValueError, not an APIError).
+            # In either case defer to the regular fallback path. Programming
+            # errors (AttributeError, KeyError, TypeError, etc.) intentionally
+            # propagate so they remain visible.
             return None
 
     async def async_function_with_fallbacks_common_utils(  # noqa: PLR0915

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -357,7 +357,7 @@ class Router:
             provider_budget_config (ProviderBudgetConfig): Provider budget configuration. Use this to set llm_provider budget limits. example $100/day to OpenAI, $100/day to Azure, etc. Defaults to None.
             deployment_affinity_ttl_seconds (int): TTL for user-key -> deployment affinity mapping. Defaults to 3600.
             ignore_invalid_deployments (bool): Ignores invalid deployments, and continues with other deployments. Default is to raise an error.
-            enable_weighted_failover (bool): When True and the routing strategy is "simple-shuffle", a retryable failure on one deployment causes the request to re-pick (weighted) across the other deployments in the same model group before any cross-group fallback runs. Bounded by `max_fallbacks`. Defaults to False.
+            enable_weighted_failover (bool): When True and the routing strategy is "simple-shuffle", a retryable failure on one deployment causes the request to re-pick (weighted) across the other deployments in the same model group before any cross-group fallback runs. Bounded by `max_fallbacks`. Async-only: currently honored by `router.acompletion()` and other async entrypoints. The sync `router.completion()` path falls back to the regular fallback flow. Defaults to False.
         Returns:
             Router: An instance of the litellm.Router class.
 
@@ -5721,7 +5721,11 @@ class Router:
         )
         try:
             return await run_async_fallback(*args, **input_kwargs)
-        except Exception:
+        except openai.APIError:
+            # Expected model-level failure on the retried deployment (all litellm
+            # provider errors derive from openai.APIError). Defer to the regular
+            # fallback path. Programming errors (AttributeError, KeyError,
+            # TypeError, etc.) intentionally propagate so they remain visible.
             return None
 
     async def async_function_with_fallbacks_common_utils(  # noqa: PLR0915

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5687,7 +5687,10 @@ class Router:
             return None
 
         metadata_variable_name = self._get_metadata_variable_name_from_kwargs(kwargs)
-        meta = kwargs.setdefault(metadata_variable_name, {}) or {}
+        meta = kwargs.get(metadata_variable_name)
+        if meta is None:
+            meta = {}
+            kwargs[metadata_variable_name] = meta
         if not isinstance(meta, dict):
             return None
         prev_excluded = set(meta.get("_failover_excluded_ids") or [])

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5672,7 +5672,7 @@ class Router:
         self,
         exception: Exception,
         original_model_group: str,
-        all_deployments: List[Dict],
+        all_deployments: List[DeploymentTypedDict],
         args: tuple,
         kwargs: dict,
         input_kwargs: dict,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -321,6 +321,7 @@ class Router:
         enable_health_check_routing: bool = False,
         health_check_staleness_threshold: Optional[int] = None,
         health_check_ignore_transient_errors: bool = False,
+        enable_weighted_failover: bool = False,
     ) -> None:
         """
         Initialize the Router class with the given parameters for caching, reliability, and routing strategy.
@@ -356,6 +357,7 @@ class Router:
             provider_budget_config (ProviderBudgetConfig): Provider budget configuration. Use this to set llm_provider budget limits. example $100/day to OpenAI, $100/day to Azure, etc. Defaults to None.
             deployment_affinity_ttl_seconds (int): TTL for user-key -> deployment affinity mapping. Defaults to 3600.
             ignore_invalid_deployments (bool): Ignores invalid deployments, and continues with other deployments. Default is to raise an error.
+            enable_weighted_failover (bool): When True and the routing strategy is "simple-shuffle", a retryable failure on one deployment causes the request to re-pick (weighted) across the other deployments in the same model group before any cross-group fallback runs. Bounded by `max_fallbacks`. Defaults to False.
         Returns:
             Router: An instance of the litellm.Router class.
 
@@ -524,6 +526,7 @@ class Router:
         )
         self.disable_cooldowns = disable_cooldowns
         self.enable_health_check_routing = enable_health_check_routing
+        self.enable_weighted_failover = enable_weighted_failover
         self.health_check_ignore_transient_errors = health_check_ignore_transient_errors
         _staleness = health_check_staleness_threshold or (
             DEFAULT_HEALTH_CHECK_INTERVAL * DEFAULT_HEALTH_CHECK_STALENESS_MULTIPLIER
@@ -1860,6 +1863,7 @@ class Router:
             # Set per-deployment num_retries on exception for retry logic
             if deployment is not None:
                 self._set_deployment_num_retries_on_exception(e, deployment)
+                self._set_failed_deployment_id_on_exception(e, deployment)
             raise e
 
     def _get_silent_experiment_kwargs(self, **kwargs) -> dict:
@@ -2525,6 +2529,7 @@ class Router:
             # Set per-deployment num_retries on exception for retry logic
             if deployment is not None:
                 self._set_deployment_num_retries_on_exception(e, deployment)
+                self._set_failed_deployment_id_on_exception(e, deployment)
             raise e
         except Exception as e:
             verbose_router_logger.info(
@@ -2535,6 +2540,7 @@ class Router:
             # Set per-deployment num_retries on exception for retry logic
             if deployment is not None:
                 self._set_deployment_num_retries_on_exception(e, deployment)
+                self._set_failed_deployment_id_on_exception(e, deployment)
             raise e
 
     def _update_kwargs_before_fallbacks(
@@ -2578,6 +2584,27 @@ class Router:
                 exception.num_retries = int(dep_num_retries)  # type: ignore  # Handle both int and str
             except (ValueError, TypeError):
                 pass  # Skip if value can't be converted to int
+
+    def _set_failed_deployment_id_on_exception(
+        self, exception: Exception, deployment: dict
+    ) -> None:
+        """
+        Stamp the failed deployment's `model_info.id` on the exception so the
+        fallback layer can exclude it from subsequent re-picks within the same
+        request (used by weighted-routing failover).
+
+        Idempotent: never overwrites an existing value, so the id of the
+        deployment that *first* failed in a chain is preserved if multiple
+        layers re-raise.
+        """
+        if getattr(exception, "failed_deployment_id", None):
+            return
+        deployment_id = (deployment.get("model_info") or {}).get("id")
+        if deployment_id:
+            try:
+                exception.failed_deployment_id = deployment_id  # type: ignore[attr-defined]
+            except Exception:
+                pass
 
     def _update_kwargs_with_default_litellm_params(
         self, kwargs: dict, metadata_variable_name: Optional[str] = "metadata"
@@ -5641,6 +5668,62 @@ class Router:
 
     #### [END] ASSISTANTS API ####
 
+    async def _maybe_run_weighted_failover(
+        self,
+        exception: Exception,
+        original_model_group: str,
+        all_deployments: List[Dict],
+        args: tuple,
+        kwargs: dict,
+        input_kwargs: dict,
+    ) -> Optional[Any]:
+        """Same-model-group retry after a failed deployment; returns None if not applicable."""
+        strategy, _ = self._get_routing_context(original_model_group)
+        if strategy != "simple-shuffle":
+            return None
+
+        failed_id: Optional[str] = getattr(exception, "failed_deployment_id", None)
+        if not failed_id:
+            return None
+
+        metadata_variable_name = self._get_metadata_variable_name_from_kwargs(kwargs)
+        meta = kwargs.setdefault(metadata_variable_name, {}) or {}
+        if not isinstance(meta, dict):
+            return None
+        prev_excluded = set(meta.get("_failover_excluded_ids") or [])
+        excluded = prev_excluded | {failed_id}
+
+        all_ids = {
+            (d.get("model_info") or {}).get("id")
+            for d in all_deployments
+            if (d.get("model_info") or {}).get("id") is not None
+        }
+        remaining = all_ids - excluded
+        if not remaining:
+            return None
+
+        verbose_router_logger.debug(
+            f"Weighted failover: exclude={excluded!r}, remaining={len(remaining)} "
+            f"for model_group={original_model_group!r}"
+        )
+
+        meta["_failover_excluded_ids"] = list(excluded)
+
+        entry = {
+            "model": original_model_group,
+            "_excluded_deployment_ids": list(excluded),
+        }
+        input_kwargs.update(
+            {
+                "fallback_model_group": [entry],
+                "original_model_group": original_model_group,
+            }
+        )
+        try:
+            return await run_async_fallback(*args, **input_kwargs)
+        except Exception:
+            return None
+
     async def async_function_with_fallbacks_common_utils(  # noqa: PLR0915
         self,
         e: Exception,
@@ -5741,6 +5824,23 @@ class Router:
                     *args,
                     **input_kwargs,
                 )
+                return response
+
+        # Weighted intra-group failover (simple-shuffle only); see _maybe_run_weighted_failover.
+        if (
+            self.enable_weighted_failover
+            and not _skip_order_fallback
+            and original_model_group is not None
+        ):
+            response = await self._maybe_run_weighted_failover(
+                exception=e,
+                original_model_group=original_model_group,
+                all_deployments=all_deployments,
+                args=args,
+                kwargs=kwargs,
+                input_kwargs=input_kwargs,
+            )
+            if response is not None:
                 return response
 
         try:
@@ -9344,6 +9444,7 @@ class Router:
             "model_group_retry_policy",
             "retry_policy",
             "model_group_alias",
+            "enable_weighted_failover",
         ]
 
         for var in vars_to_include:
@@ -9380,6 +9481,7 @@ class Router:
             "context_window_fallbacks",
             "model_group_retry_policy",
             "model_group_alias",
+            "enable_weighted_failover",
         ]
 
         _int_settings = [
@@ -10073,6 +10175,17 @@ class Router:
             cast(List[Dict], healthy_deployments), target_order=_target_order
         )
 
+        ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
+        ## this request via weighted-failover. Always honored, regardless of the
+        ## router-level flag, so a stale exclusion key on kwargs cannot escape.
+        _excluded_deployment_ids = (request_kwargs or {}).pop(
+            "_excluded_deployment_ids", None
+        )
+        healthy_deployments = litellm.utils._get_excluded_filtered_deployments(
+            cast(List[Dict], healthy_deployments),
+            excluded_deployment_ids=_excluded_deployment_ids,
+        )
+
         if len(healthy_deployments) == 0:
             exception = await async_raise_no_deployment_exception(
                 litellm_router_instance=self,
@@ -10462,6 +10575,17 @@ class Router:
         _target_order = (request_kwargs or {}).pop("_target_order", None)
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             healthy_deployments, target_order=_target_order
+        )
+
+        ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
+        ## this request via weighted-failover. See async counterpart in
+        ## async_get_healthy_deployments for details.
+        _excluded_deployment_ids = (request_kwargs or {}).pop(
+            "_excluded_deployment_ids", None
+        )
+        healthy_deployments = litellm.utils._get_excluded_filtered_deployments(
+            healthy_deployments,
+            excluded_deployment_ids=_excluded_deployment_ids,
         )
 
         if len(healthy_deployments) == 0:

--- a/litellm/router_strategy/simple_shuffle.py
+++ b/litellm/router_strategy/simple_shuffle.py
@@ -48,6 +48,15 @@ def simple_shuffle(
             ]
             verbose_router_logger.debug(f"\nweight {weights}")
             total_weight = sum(weights)
+            if total_weight <= 0:
+                # All remaining candidates have weight 0 (e.g. after a
+                # weighted-failover exclusion left only zero-weight backups).
+                # Fall back to uniform random instead of dividing by zero.
+                deployment = random.choice(healthy_deployments)
+                verbose_router_logger.info(
+                    f"get_available_deployment for model: {model}, total {weight_by}=0; uniform pick: {llm_router_instance.print_deployment(deployment) or deployment[0]}"
+                )
+                return deployment or deployment[0]
             weights = [weight / total_weight for weight in weights]
             verbose_router_logger.debug(f"\n weights {weights} by {weight_by}")
             # Perform weighted random pick

--- a/litellm/router_strategy/simple_shuffle.py
+++ b/litellm/router_strategy/simple_shuffle.py
@@ -49,14 +49,12 @@ def simple_shuffle(
             verbose_router_logger.debug(f"\nweight {weights}")
             total_weight = sum(weights)
             if total_weight <= 0:
-                # All remaining candidates have weight 0 (e.g. after a
-                # weighted-failover exclusion left only zero-weight backups).
-                # Fall back to uniform random instead of dividing by zero.
-                deployment = random.choice(healthy_deployments)
-                verbose_router_logger.info(
-                    f"get_available_deployment for model: {model}, total {weight_by}=0; uniform pick: {llm_router_instance.print_deployment(deployment) or deployment[0]}"
-                )
-                return deployment or deployment[0]
+                # All remaining candidates have weight 0 for this metric (e.g.
+                # after a weighted-failover exclusion left only zero-weight
+                # backups). Skip to the next metric (rpm/tpm) which may still
+                # provide a meaningful weighted pick; if none do, we fall
+                # through to the uniform random pick at the end.
+                continue
             weights = [weight / total_weight for weight in weights]
             verbose_router_logger.debug(f"\n weights {weights} by {weight_by}")
             # Perform weighted random pick

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4983,6 +4983,35 @@ def _get_order_filtered_deployments(
     return healthy_deployments
 
 
+def _get_excluded_filtered_deployments(
+    healthy_deployments: List[Dict],
+    excluded_deployment_ids: Optional[Iterable[str]] = None,
+) -> List:
+    """
+    Filter out deployments whose `model_info.id` appears in `excluded_deployment_ids`.
+
+    Used by weighted-routing failover so a single logical request can re-pick
+    across the remaining deployments in the same model group after one of them
+    has failed.
+
+    If the resulting list would be empty, the original list is returned unchanged
+    so the caller raises its usual no-deployments error rather than getting an
+    incorrect "all excluded" result.
+    """
+    if not excluded_deployment_ids:
+        return healthy_deployments
+
+    excluded_set = set(excluded_deployment_ids)
+    filtered = [
+        d
+        for d in healthy_deployments
+        if (d.get("model_info") or {}).get("id") not in excluded_set
+    ]
+    if not filtered:
+        return healthy_deployments
+    return filtered
+
+
 def _get_model_region(
     custom_llm_provider: str, litellm_params: LiteLLM_Params
 ) -> Optional[str]:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4994,22 +4994,20 @@ def _get_excluded_filtered_deployments(
     across the remaining deployments in the same model group after one of them
     has failed.
 
-    If the resulting list would be empty, the original list is returned unchanged
-    so the caller raises its usual no-deployments error rather than getting an
-    incorrect "all excluded" result.
+    If the filter would leave no deployments, an empty list is returned so the
+    caller raises its usual no-deployments error and the weighted-failover
+    helper falls through to the cross-group fallback path. Returning the
+    original unfiltered list here would re-include the just-failed deployment.
     """
     if not excluded_deployment_ids:
         return healthy_deployments
 
     excluded_set = set(excluded_deployment_ids)
-    filtered = [
+    return [
         d
         for d in healthy_deployments
         if (d.get("model_info") or {}).get("id") not in excluded_set
     ]
-    if not filtered:
-        return healthy_deployments
-    return filtered
 
 
 def _get_model_region(

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -9,6 +9,7 @@ cross-group fallback runs.
 
 from collections import Counter
 from typing import Optional
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -573,3 +574,198 @@ async def test_user_config_two_region_failover():
     # failover because eastus2 was picked first).
     assert successes["northcentralus"] == 20
     assert successes["eastus2"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for healthy-deployment-only check in _maybe_run_weighted_failover
+# (Issue: weighted failover checked all deployments, not just healthy ones)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_weighted_failover_skips_when_remaining_all_in_cooldown(
+    monkeypatch,
+):
+    """When every non-excluded deployment is in cooldown, _maybe_run_weighted_failover
+    must return None immediately without invoking run_async_fallback.
+
+    Previously the check was against all_deployments (including cooldown ones), so
+    run_async_fallback would be called unnecessarily and would raise RouterRateLimitError.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "B"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "C"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        enable_weighted_failover=True,
+    )
+
+    # A just failed; B and C are both in cooldown.
+    exc = Exception("A down")
+    exc.failed_deployment_id = "A"
+
+    run_async_fallback_called = False
+
+    async def _should_not_be_called(*args, **kwargs):
+        nonlocal run_async_fallback_called
+        run_async_fallback_called = True
+        return "should not reach here"
+
+    monkeypatch.setattr("litellm.router.run_async_fallback", _should_not_be_called)
+
+    # Patch cooldown so B and C appear in cooldown.
+    with patch(
+        "litellm.router._async_get_cooldown_deployments",
+        new=AsyncMock(return_value=["B", "C"]),
+    ):
+        result = await router._maybe_run_weighted_failover(
+            exception=exc,
+            original_model_group="test-model",
+            all_deployments=[_make_dep("A"), _make_dep("B"), _make_dep("C")],
+            args=(),
+            kwargs={"metadata": {}},
+            input_kwargs={},
+        )
+
+    assert (
+        result is None
+    ), "Should return None when all remaining deployments are in cooldown"
+    assert (
+        not run_async_fallback_called
+    ), "run_async_fallback must NOT be called when no healthy deployments remain"
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_weighted_failover_proceeds_when_one_healthy_remains(
+    monkeypatch,
+):
+    """When at least one non-excluded deployment is healthy (not in cooldown),
+    _maybe_run_weighted_failover should still invoke run_async_fallback normally.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "B"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "C"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        enable_weighted_failover=True,
+    )
+
+    # A just failed; B is in cooldown; C is healthy.
+    exc = Exception("A down")
+    exc.failed_deployment_id = "A"
+
+    run_async_fallback_called = False
+
+    async def _stub_run_async_fallback(*args, **kwargs):
+        nonlocal run_async_fallback_called
+        run_async_fallback_called = True
+        return "ok from C"
+
+    monkeypatch.setattr("litellm.router.run_async_fallback", _stub_run_async_fallback)
+
+    with patch(
+        "litellm.router._async_get_cooldown_deployments",
+        new=AsyncMock(return_value=["B"]),
+    ):
+        result = await router._maybe_run_weighted_failover(
+            exception=exc,
+            original_model_group="test-model",
+            all_deployments=[_make_dep("A"), _make_dep("B"), _make_dep("C")],
+            args=(),
+            kwargs={"metadata": {}},
+            input_kwargs={},
+        )
+
+    assert result == "ok from C"
+    assert (
+        run_async_fallback_called
+    ), "run_async_fallback must be called when a healthy deployment remains"
+
+
+@pytest.mark.asyncio
+async def test_failover_falls_through_to_external_fallback_when_remaining_in_cooldown():
+    """End-to-end: when the only non-failed deployments are in cooldown,
+    weighted failover must fall through to the configured cross-group fallback.
+
+    Without the fix the _maybe_run_weighted_failover would invoke run_async_fallback
+    unnecessarily (because it counted cooldown deployments as "remaining"), get back
+    RouterRateLimitError, return None, and reach the same fallback path — but only
+    incidentally. With the fix the early-exit path is taken directly.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("A down"),
+                    "weight": 1_000_000,  # always picked first
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("B down"),
+                    "weight": 1,
+                },
+                "model_info": {"id": "B"},
+            },
+            {
+                "model_name": "fallback-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from fallback",
+                },
+                "model_info": {"id": "fallback"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+        fallbacks=[{"test-model": ["fallback-model"]}],
+    )
+
+    # Put B in cooldown so weighted failover can't use it after A fails.
+    with patch(
+        "litellm.router._async_get_cooldown_deployments",
+        new=AsyncMock(return_value=["B"]),
+    ):
+        response = await router.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert response._hidden_params["model_id"] == "fallback"

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -375,21 +375,25 @@ async def test_weights_respected_when_all_healthy():
     )
 
     counts: Counter = Counter()
-    for _ in range(400):
+    for _ in range(1000):
         resp = await router.acompletion(
             model="test-model",
             messages=[{"role": "user", "content": "hi"}],
         )
         counts[resp._hidden_params["model_id"]] += 1
 
-    # Expect ~80/20 split. Loose bound to keep test stable.
+    # Expect ~80/20 split. Loose bounds to keep the test stable under CI load.
     assert counts["A"] > counts["B"] * 2  # A should heavily dominate
-    assert counts["B"] > 20  # but B should still get some traffic
+    assert counts["B"] > 50  # but B should still get a meaningful share
 
 
 @pytest.mark.asyncio
 async def test_failover_skipped_for_non_simple_shuffle():
-    """Other routing strategies are not yet covered by weighted failover."""
+    """Weighted failover is only wired up for `simple-shuffle`. With another
+    strategy, a failure on the picked deployment must NOT silently retry the
+    other deployment in the same group. Both deployments fail here to keep the
+    test deterministic regardless of which one the strategy picks first.
+    """
     router = Router(
         model_list=[
             {
@@ -405,8 +409,8 @@ async def test_failover_skipped_for_non_simple_shuffle():
                 "model_name": "test-model",
                 "litellm_params": {
                     "model": "gpt-4o",
-                    "api_key": "good",
-                    "mock_response": "ok from B",
+                    "api_key": "bad",
+                    "mock_response": Exception("B down"),
                 },
                 "model_info": {"id": "B"},
             },

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -76,6 +76,58 @@ class TestGetExcludedFilteredDeployments:
 
 
 # ---------------------------------------------------------------------------
+# Router helpers (router_code_coverage.py requires these names in a *router* test file)
+# ---------------------------------------------------------------------------
+
+
+def test_set_failed_deployment_id_on_exception():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key"},
+                "model_info": {"id": "dep-a"},
+            }
+        ],
+    )
+    exc = Exception("fail")
+    dep = _make_dep("dep-a")
+    router._set_failed_deployment_id_on_exception(exc, dep)
+    assert getattr(exc, "failed_deployment_id", None) == "dep-a"
+    router._set_failed_deployment_id_on_exception(exc, _make_dep("dep-b"))
+    assert exc.failed_deployment_id == "dep-a"
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_weighted_failover_returns_none_without_failed_id():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key", "weight": 1},
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key", "weight": 1},
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        enable_weighted_failover=True,
+    )
+    result = await router._maybe_run_weighted_failover(
+        exception=Exception("fail"),
+        original_model_group="test-model",
+        all_deployments=[_make_dep("A"), _make_dep("B")],
+        args=(),
+        kwargs={"metadata": {}},
+        input_kwargs={},
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Integration tests for weighted-failover end-to-end via Router
 # ---------------------------------------------------------------------------
 

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -49,15 +49,16 @@ class TestGetExcludedFilteredDeployments:
         ids = sorted(d["model_info"]["id"] for d in result)
         assert ids == ["a", "c"]
 
-    def test_all_excluded_returns_original(self):
-        # Safety: empty filtered list would otherwise mask the real
-        # no-deployments error. The helper returns the original list so the
-        # caller raises its usual error.
+    def test_all_excluded_returns_empty(self):
+        # When every healthy deployment has been excluded, the helper must
+        # return an empty list so the caller raises its usual no-deployments
+        # error. Returning the original list here would re-include the
+        # just-failed deployment and let weighted failover re-pick it.
         deps = [_make_dep("a"), _make_dep("b")]
         result = _get_excluded_filtered_deployments(
             deps, excluded_deployment_ids=["a", "b"]
         )
-        assert len(result) == 2
+        assert result == []
 
     def test_excluded_set_with_unknown_ids(self):
         deps = [_make_dep("a"), _make_dep("b")]

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -1,0 +1,473 @@
+"""
+Tests for weighted-routing failover (router_settings.enable_weighted_failover).
+
+When enabled and the routing strategy is "simple-shuffle", a retryable failure
+on one deployment causes the request to re-pick a different deployment in the
+SAME model group (weighted across the remaining deployments) before any
+cross-group fallback runs.
+"""
+
+from collections import Counter
+from typing import Optional
+
+import pytest
+
+from litellm import Router
+from litellm.utils import _get_excluded_filtered_deployments
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _get_excluded_filtered_deployments
+# ---------------------------------------------------------------------------
+
+
+def _make_dep(dep_id: str, weight: Optional[int] = None) -> dict:
+    params: dict = {"model": "gpt-4o", "api_key": "key"}
+    if weight is not None:
+        params["weight"] = weight
+    return {
+        "model_name": "test-model",
+        "litellm_params": params,
+        "model_info": {"id": dep_id},
+    }
+
+
+class TestGetExcludedFilteredDeployments:
+    def test_no_excluded_returns_all(self):
+        deps = [_make_dep("a"), _make_dep("b")]
+        result = _get_excluded_filtered_deployments(deps, excluded_deployment_ids=None)
+        assert len(result) == 2
+
+    def test_empty_excluded_returns_all(self):
+        deps = [_make_dep("a"), _make_dep("b")]
+        result = _get_excluded_filtered_deployments(deps, excluded_deployment_ids=[])
+        assert len(result) == 2
+
+    def test_drops_excluded(self):
+        deps = [_make_dep("a"), _make_dep("b"), _make_dep("c")]
+        result = _get_excluded_filtered_deployments(deps, excluded_deployment_ids=["b"])
+        ids = sorted(d["model_info"]["id"] for d in result)
+        assert ids == ["a", "c"]
+
+    def test_all_excluded_returns_original(self):
+        # Safety: empty filtered list would otherwise mask the real
+        # no-deployments error. The helper returns the original list so the
+        # caller raises its usual error.
+        deps = [_make_dep("a"), _make_dep("b")]
+        result = _get_excluded_filtered_deployments(
+            deps, excluded_deployment_ids=["a", "b"]
+        )
+        assert len(result) == 2
+
+    def test_excluded_set_with_unknown_ids(self):
+        deps = [_make_dep("a"), _make_dep("b")]
+        result = _get_excluded_filtered_deployments(
+            deps, excluded_deployment_ids=["zzz"]
+        )
+        assert len(result) == 2
+
+    def test_handles_missing_model_info(self):
+        deps = [
+            {"model_name": "x", "litellm_params": {"model": "gpt-4o"}},  # no model_info
+            _make_dep("b"),
+        ]
+        result = _get_excluded_filtered_deployments(deps, excluded_deployment_ids=["b"])
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for weighted-failover end-to-end via Router
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_failover_when_flag_off():
+    """Default behavior: a failure on the picked deployment surfaces to caller."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("region-A failed"),
+                    "weight": 1,
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from B",
+                    "weight": 0,  # weight=0 so A is always picked
+                },
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        # enable_weighted_failover defaults to False
+    )
+
+    with pytest.raises(Exception):
+        await router.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_failover_lands_on_other_deployment_when_flag_on():
+    """Flag on: when A fails, request must succeed via B in the same call."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("region-A down"),
+                    "weight": 1,  # always picked first (B has weight 0)
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from B",
+                    "weight": 0,
+                },
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+    )
+
+    response = await router.acompletion(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert response._hidden_params["model_id"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_failover_chain_three_deployments():
+    """A and B fail, request succeeds on C."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("A down"),
+                    "weight": 1_000_000,  # A always picked first
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("B down"),
+                    "weight": 1,  # picked when A is excluded
+                },
+                "model_info": {"id": "B"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from C",
+                    "weight": 0,
+                },
+                "model_info": {"id": "C"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+    )
+
+    response = await router.acompletion(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert response._hidden_params["model_id"] == "C"
+
+
+@pytest.mark.asyncio
+async def test_failover_exhausted_raises_original_error_class():
+    """When ALL deployments fail, the request raises (does not hang)."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("A down"),
+                    "weight": 1,
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("B down"),
+                    "weight": 1,
+                },
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+    )
+
+    with pytest.raises(Exception):
+        await router.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_failover_falls_through_to_external_fallback():
+    """When all deployments in the group fail, external fallback still runs."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("A down"),
+                    "weight": 1,
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("B down"),
+                    "weight": 1,
+                },
+                "model_info": {"id": "B"},
+            },
+            {
+                "model_name": "fallback-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from fallback",
+                },
+                "model_info": {"id": "fallback"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+        fallbacks=[{"test-model": ["fallback-model"]}],
+    )
+
+    response = await router.acompletion(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert response._hidden_params["model_id"] == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_weights_respected_when_all_healthy():
+    """With both regions healthy, the picker should still honor configured
+    weights — failover must not change the steady-state load shape."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "from A",
+                    "weight": 80,
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "from B",
+                    "weight": 20,
+                },
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+    )
+
+    counts: Counter = Counter()
+    for _ in range(400):
+        resp = await router.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        counts[resp._hidden_params["model_id"]] += 1
+
+    # Expect ~80/20 split. Loose bound to keep test stable.
+    assert counts["A"] > counts["B"] * 2  # A should heavily dominate
+    assert counts["B"] > 20  # but B should still get some traffic
+
+
+@pytest.mark.asyncio
+async def test_failover_skipped_for_non_simple_shuffle():
+    """Other routing strategies are not yet covered by weighted failover."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("A down"),
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from B",
+                },
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="latency-based-routing",
+        num_retries=0,
+        enable_weighted_failover=True,
+    )
+
+    with pytest.raises(Exception):
+        await router.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_failover_skipped_for_context_window_error():
+    """ContextWindowExceededError must NOT trigger weighted failover —
+    it has its own dedicated fallback path. Uses the router's built-in
+    `mock_testing_context_fallbacks` to deterministically raise the right
+    exception class.
+    """
+    import litellm
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from A",
+                    "weight": 1,
+                },
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "ok from B",
+                    "weight": 1,
+                },
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        num_retries=0,
+        enable_weighted_failover=True,
+    )
+
+    with pytest.raises(litellm.ContextWindowExceededError):
+        await router.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_testing_context_fallbacks=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_config_two_region_failover():
+    """Mirrors the user's actual proxy_server_config.yaml shape: two Azure
+    regions weighted 50/50, num_retries=0. With the flag on, a failure in
+    one region is recovered by the other in the same request."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.4-mini",
+                "litellm_params": {
+                    "model": "azure/deployment-eastus2",
+                    "api_key": "bad",
+                    "api_base": "https://eastus2.example",
+                    "mock_response": Exception("eastus2 5xx"),
+                    "weight": 50,
+                },
+                "model_info": {"id": "eastus2"},
+            },
+            {
+                "model_name": "gpt-5.4-mini",
+                "litellm_params": {
+                    "model": "azure/deployment-northcentralus",
+                    "api_key": "good",
+                    "api_base": "https://northcentralus.example",
+                    "mock_response": "ok from northcentralus",
+                    "weight": 50,
+                },
+                "model_info": {"id": "northcentralus"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        cooldown_time=120,
+        num_retries=0,
+        enable_pre_call_checks=True,
+        disable_cooldowns=False,
+        allowed_fails=5,
+        enable_weighted_failover=True,
+    )
+
+    # Force eastus2 to be picked first by leaving its weight intact and
+    # asserting we always end up on northcentralus when eastus2 errors.
+    # Run several requests and ensure we never see an unhandled failure.
+    successes = Counter()
+    for _ in range(20):
+        resp = await router.acompletion(
+            model="gpt-5.4-mini",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        successes[resp._hidden_params["model_id"]] += 1
+
+    # With one region permanently failing, every request must land on the
+    # other region (either directly because it was picked first, or via
+    # failover because eastus2 was picked first).
+    assert successes["northcentralus"] == 20
+    assert successes["eastus2"] == 0

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -127,6 +127,51 @@ async def test_maybe_run_weighted_failover_returns_none_without_failed_id():
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_maybe_run_weighted_failover_persists_excluded_ids_to_kwargs(monkeypatch):
+    """Regression: writing to the metadata dict returned by `setdefault` must
+    update the dict in `kwargs` itself so the next hop sees prior exclusions.
+    Previously `setdefault(..., {}) or {}` returned a disconnected dict on the
+    first hop, dropping `_failover_excluded_ids` writes.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "A"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "k", "weight": 1},
+                "model_info": {"id": "B"},
+            },
+        ],
+        routing_strategy="simple-shuffle",
+        enable_weighted_failover=True,
+    )
+
+    async def _stub_run_async_fallback(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("litellm.router.run_async_fallback", _stub_run_async_fallback)
+
+    exc = Exception("fail")
+    exc.failed_deployment_id = "A"
+    kwargs: dict = {"metadata": {}}
+    await router._maybe_run_weighted_failover(
+        exception=exc,
+        original_model_group="test-model",
+        all_deployments=[_make_dep("A"), _make_dep("B")],
+        args=(),
+        kwargs=kwargs,
+        input_kwargs={},
+    )
+    # The dict inside kwargs must reflect the write — proves `meta` was the
+    # same object as kwargs["metadata"] (no disconnected copy).
+    assert kwargs["metadata"].get("_failover_excluded_ids") == ["A"]
+
+
 # ---------------------------------------------------------------------------
 # Integration tests for weighted-failover end-to-end via Router
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

On failure, retry the same model group on a different deployment (e.g. another Azure region), while the initial pick still respects configured weights. Behind a router-level flag.



## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

<img width="1018" height="245" alt="image" src="https://github.com/user-attachments/assets/df26cad6-f7e9-4106-9ab5-507c98617355" />
Run 2 had one wrong deployment
<img width="846" height="232" alt="image" src="https://github.com/user-attachments/assets/f7fafbaa-4427-4608-b1e1-7eaee8c3e3ce" />
<img width="846" height="232" alt="image" src="https://github.com/user-attachments/assets/bb18d46f-3be3-44cb-9758-c7909616a4fe" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new async-only failover behavior in the router’s core fallback path, which can change which deployments receive traffic on retryable errors (though gated behind `enable_weighted_failover`). Main risk is unexpected retry/selection behavior or edge cases around cooldown/exclusion handling.
> 
> **Overview**
> Adds an optional `enable_weighted_failover` router setting that, for `simple-shuffle` only, retries a failed request on another deployment **within the same model group** (weighted across remaining healthy deployments) before attempting cross-model fallbacks.
> 
> Implements per-request exclusion by stamping `failed_deployment_id` onto exceptions, filtering healthy deployments via new `_get_excluded_filtered_deployments`, and hardening `simple_shuffle` to avoid division-by-zero when all candidate weights are zero. Includes a comprehensive new test suite covering exclusion logic, cooldown interactions, strategy gating, and end-to-end async failover behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f507494d03bc16237179eb7489d0fcc6267978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->