### PR TITLE
fix: redact api key hash in rate limit errors

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1246,6 +1246,12 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     if matching_descriptor is not None
                     else "unknown"
                 )
+                is_sensitive_descriptor = (
+                    descriptor_key == "model_per_key" or "api_key" in descriptor_key
+                )
+                descriptor_display_value = (
+                    "REDACTED" if is_sensitive_descriptor else descriptor_value
+                )
 
                 now = self._get_current_time().timestamp()
                 reset_time = now + self.window_size
@@ -1258,7 +1264,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 current_limit = status["current_limit"]
 
                 detail = (
-                    f"Rate limit exceeded for {descriptor_key}: {descriptor_value}. "
+                    f"Rate limit exceeded for {descriptor_key}: {descriptor_display_value}. "
                     f"Limit type: {rate_limit_type}. "
                     f"Current limit: {current_limit}, Remaining: {remaining_display}. "
                     f"Limit resets at: {reset_time_formatted}"

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -847,6 +847,8 @@ async def test_tpm_api_key_rate_limits_v3():
         assert "retry-after" in e.headers
 
     assert error is not None, "An Exception must be thrown"
+    assert "Rate limit exceeded for model_per_key: REDACTED" in error.detail
+    assert _api_key_hash not in error.detail
     assert captured_descriptors is not None, "Rate limit descriptors should be captured"
 
     model_per_key_descriptor = None
@@ -942,6 +944,8 @@ async def test_rpm_api_key_rate_limits_v3():
         assert "retry-after" in e.headers
 
     assert error is not None, "An Exception must be thrown"
+    assert "Rate limit exceeded for model_per_key: REDACTED" in error.detail
+    assert _api_key_hash not in error.detail
     assert captured_descriptors is not None, "Rate limit descriptors should be captured"
 
     model_per_key_descriptor = None
@@ -1608,7 +1612,8 @@ async def test_multiple_rate_limits_per_descriptor():
 
     # Verify the exception details are correct and use the descriptor_key approach
     assert exc_info.value.status_code == 429
-    assert "Rate limit exceeded for api_key:" in exc_info.value.detail
+    assert "Rate limit exceeded for api_key: REDACTED" in exc_info.value.detail
+    assert _api_key_hash not in exc_info.value.detail
     assert "max_parallel_requests" in exc_info.value.detail
     assert "Current limit: 1" in exc_info.value.detail
     assert "Remaining: 0" in exc_info.value.detail  # max(0, -1) = 0


### PR DESCRIPTION
﻿## Summary
- Redact api_key descriptor values in user-facing rate limit error details.
- Keep non-sensitive descriptor values unchanged.
- Update the existing limiter test assertion so the token hash is not exposed.

Fixes #27884.

## To verify
- python -m ruff check litellm/proxy/hooks/parallel_request_limiter_v3.py
- python -m py_compile litellm/proxy/hooks/parallel_request_limiter_v3.py tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
- Direct _handle_rate_limit_error check for api_key redaction and non-sensitive descriptor preservation

## Notes
- The targeted pytest command is blocked in my local Windows environment by full proxy test fixture dependencies. After installing backoff, orjson, and boto3, collection still requires fastapi_sso through proxy_server startup.
