### PR TITLE
feat(chart): add support for autoscaling behavior in HPA

### DIFF
--- a/deploy/charts/litellm-helm/templates/hpa.yaml
+++ b/deploy/charts/litellm-helm/templates/hpa.yaml
@@ -12,6 +12,10 @@ spec:
     name: {{ include "litellm.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource

--- a/deploy/charts/litellm-helm/tests/hpa_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/hpa_tests.yaml
@@ -1,0 +1,36 @@
+suite: "hpa with behavior"
+templates:
+  - hpa.yaml
+tests:
+  - it: "renders behavior when set"
+    set:
+      autoscaling.enabled: true
+      autoscaling.behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 60
+          policies:
+            - type: Pods
+              value: 2
+              periodSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: 90
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 60
+    asserts:
+      - isKind: { of: HorizontalPodAutoscaler }
+      - equal: { path: spec.behavior.scaleUp.stabilizationWindowSeconds, value: 60 }
+      - equal: { path: spec.behavior.scaleDown.stabilizationWindowSeconds, value: 90 }
+
+---
+suite: "hpa without behavior"
+templates:
+  - hpa.yaml
+tests:
+  - it: "does not render behavior when not set"
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isKind: { of: HorizontalPodAutoscaler }
+      - isNull: { path: spec.behavior }

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -184,6 +184,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # behavior: {}
 
 # Autoscaling with keda is mutually exclusive with hpa
 keda:


### PR DESCRIPTION
## Relevant issues

https://github.com/BerriAI/litellm/issues/27988

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Helm unit tests passing (11 suites, 56 tests, including 2 new HPA tests):

<img width="1148" height="411" alt="Screenshot 2026-05-15 alle 12 21 53" src="https://github.com/user-attachments/assets/2b107725-ea8c-43cb-8e45-44344a95bcba" />

Validated manually on a production GKE cluster: adding `behavior` with stabilization windows eliminates HPA oscillation caused by CPU spikes during pod bootstrap and migration jobs.

## Type

🆕 New Feature

## Changes

The `litellm-helm` HPA template uses `autoscaling/v2` but does not expose the `behavior` field. Without it, there is no way to configure stabilization windows or scaling policies, causing continuous replica oscillation on workloads with high memory baseline or transient CPU spikes at startup.
- `templates/hpa.yaml`: add optional `behavior` passthrough from values
- `values.yaml`: add commented `behavior: {}` default under `autoscaling`
- `tests/hpa_tests.yaml`: 2 test suites (behavior set / not set)