### PR TITLE
Fix/azure image edit sp auth

### DIFF
--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -3,8 +3,10 @@ from typing import Optional, cast
 import httpx
 
 import litellm
+from litellm.llms.azure.common_utils import BaseAzureLLM
 from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import _add_path_to_api_base
 
 
@@ -30,20 +32,17 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
         litellm_params: Optional[dict] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        api_key = (
-            api_key
-            or litellm.api_key
-            or litellm.azure_key
-            or get_secret_str("AZURE_OPENAI_API_KEY")
-            or get_secret_str("AZURE_API_KEY")
-        )
+        if litellm_params is None:
+            litellm_params = GenericLiteLLMParams()
+        elif isinstance(litellm_params, dict):
+            litellm_params = GenericLiteLLMParams(**litellm_params)
 
-        headers.update(
-            {
-                "Authorization": f"Bearer {api_key}",
-            }
+        if api_key and not litellm_params.api_key:
+            litellm_params.api_key = api_key
+
+        return BaseAzureLLM._base_validate_azure_environment(
+            headers=headers, litellm_params=litellm_params
         )
-        return headers
 
     def get_complete_url(
         self,

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -32,16 +32,11 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
         litellm_params: Optional[dict] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        if litellm_params is None:
-            litellm_params = GenericLiteLLMParams()
-        elif isinstance(litellm_params, dict):
-            litellm_params = GenericLiteLLMParams(**litellm_params)
-
-        if api_key and not litellm_params.api_key:
-            litellm_params.api_key = api_key
-
+        params = GenericLiteLLMParams(**(litellm_params or {}))
+        if api_key and not params.api_key:
+            params.api_key = api_key
         return BaseAzureLLM._base_validate_azure_environment(
-            headers=headers, litellm_params=litellm_params
+            headers=headers, litellm_params=params
         )
 
     def get_complete_url(

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -49,3 +49,43 @@ def test_azure_finalize_image_edit_strips_model_after_openai_transform():
     assert data_out.get("prompt") == prompt
     assert data_out.get("n") == 1
     assert len(files) >= 1
+
+
+def test_azure_image_edit_validate_environment_uses_api_key_header():
+    config = AzureImageEditConfig()
+    headers = {}
+
+    result = config.validate_environment(
+        headers=headers,
+        model="gpt-image-1",
+        api_key="azure-api-key",
+        litellm_params={},
+    )
+
+    assert result["api-key"] == "azure-api-key"
+    assert "Authorization" not in result
+
+
+def test_azure_image_edit_validate_environment_uses_azure_ad_token_provider(
+    monkeypatch,
+):
+    config = AzureImageEditConfig()
+    headers = {}
+    monkeypatch.setattr(
+        "litellm.llms.azure.common_utils.get_azure_ad_token",
+        lambda litellm_params: "azure-access-token",
+    )
+
+    result = config.validate_environment(
+        headers=headers,
+        model="gpt-image-1",
+        api_key=None,
+        litellm_params={
+            "tenant_id": "test-tenant-id",
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+        },
+    )
+
+    assert result["Authorization"] == "Bearer azure-access-token"
+    assert "api-key" not in result


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

Reproduced the failure by calling Azure image edit with Service Principal auth configured via `litellm_params`:

- `tenant_id`, `client_id`, and `client_secret` were supplied, while `api_key` was unset.
- `images/edits` requests previously built `Authorization: Bearer None` and failed with 401.
- The fix routes Azure image edit auth through `BaseAzureLLM._base_validate_azure_environment()`, allowing the shared Azure AD token fallback to apply.

Proof of fix:

- Added regression tests for API key auth and Azure AD token fallback in `tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py`.
- Verified the two Azure image edit auth paths locally with `uv run pytest tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py -q`.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Updated `litellm/llms/azure/image_edit/transformation.py` so `AzureImageEditConfig.validate_environment()` now reuses Azure common auth logic.
- Preserves API-key authentication and also correctly falls back to Azure AD token-based auth when `api_key` is not provided but `tenant_id`, `client_id`, and `client_secret` are present.
- Prevents the broken `Authorization: Bearer None` header in Azure image edit requests.

## Testing

- `uv run pytest tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py -q`
- `uv run black litellm/llms/azure/image_edit/transformation.py tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py`
- `uv run ruff check litellm/llms/azure/image_edit/transformation.py tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py`
