### PR TITLE
Fix/cache token

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -173,17 +173,45 @@ def _cost_per_token_custom_pricing_helper(
     prompt_tokens: float = 0,
     completion_tokens: float = 0,
     response_time_ms: Optional[float] = 0.0,
+    cached_tokens: float = 0,
+    cache_creation_tokens: float = 0,
     ### CUSTOM PRICING ###
     custom_cost_per_token: Optional[CostPerToken] = None,
     custom_cost_per_second: Optional[float] = None,
 ) -> Optional[Tuple[float, float]]:
-    """Internal helper function for calculating cost, if custom pricing given"""
+    """Internal helper function for calculating cost, if custom pricing given.
+
+    prompt_tokens is assumed to include both cached_tokens and cache_creation_tokens
+    (OpenAI-compatible convention). Anthropic-style usage where prompt_tokens excludes
+    cache tokens is handled at the caller (cost_per_token) before invoking this helper.
+    """
     if custom_cost_per_token is None and custom_cost_per_second is None:
         return None
 
     if custom_cost_per_token is not None:
-        input_cost = custom_cost_per_token["input_cost_per_token"] * prompt_tokens
-        output_cost = custom_cost_per_token["output_cost_per_token"] * completion_tokens
+        input_cost_per_token = custom_cost_per_token["input_cost_per_token"]
+        output_cost_per_token = custom_cost_per_token["output_cost_per_token"]
+
+        cache_read_input_token_cost = custom_cost_per_token.get(
+            "cache_read_input_token_cost",
+            input_cost_per_token,
+        )
+        cache_creation_input_token_cost = custom_cost_per_token.get(
+            "cache_creation_input_token_cost",
+            input_cost_per_token,
+        )
+
+        regular_prompt_tokens = max(
+            prompt_tokens - cached_tokens - cache_creation_tokens,
+            0,
+        )
+
+        input_cost = (
+            regular_prompt_tokens * input_cost_per_token
+            + cached_tokens * cache_read_input_token_cost
+            + cache_creation_tokens * cache_creation_input_token_cost
+        )
+        output_cost = completion_tokens * output_cost_per_token
         return input_cost, output_cost
     elif custom_cost_per_second is not None:
         output_cost = custom_cost_per_second * response_time_ms / 1000  # type: ignore
@@ -323,10 +351,53 @@ def cost_per_token(  # noqa: PLR0915
         )
 
     ## CUSTOM PRICING ##
+    # Normalize cache token counts across providers:
+    #   - OpenAI-compatible: usage.prompt_tokens_details.cached_tokens
+    #     (prompt_tokens already INCLUDES cached_tokens)
+    #   - Anthropic: usage.cache_read_input_tokens / cache_creation_input_tokens
+    #     (prompt_tokens does NOT include these — adjust before calling helper)
+    _cache_read_tokens: float = 0
+    _cache_creation_tokens: float = 0
+    _is_anthropic_style = False
+
+    if usage_object is not None:
+        _pt_details = getattr(usage_object, "prompt_tokens_details", None)
+        if _pt_details is not None:
+            _cache_read_tokens = float(
+                getattr(_pt_details, "cached_tokens", 0) or 0
+            )
+            _cache_creation_tokens = float(
+                getattr(_pt_details, "cache_creation_tokens", 0) or 0
+            )
+
+        _anthropic_read = getattr(usage_object, "cache_read_input_tokens", None)
+        _anthropic_create = getattr(usage_object, "cache_creation_input_tokens", None)
+        if _anthropic_read or _anthropic_create:
+            _is_anthropic_style = True
+            if _anthropic_read:
+                _cache_read_tokens = float(_anthropic_read)
+            if _anthropic_create:
+                _cache_creation_tokens = float(_anthropic_create)
+
+    if not _cache_read_tokens and cache_read_input_tokens:
+        _cache_read_tokens = float(cache_read_input_tokens)
+        _is_anthropic_style = True
+    if not _cache_creation_tokens and cache_creation_input_tokens:
+        _cache_creation_tokens = float(cache_creation_input_tokens)
+        _is_anthropic_style = True
+
+    # Anthropic reports prompt_tokens as input_tokens (excluding cache tokens).
+    # Adjust so the helper's "prompt_tokens includes cache tokens" invariant holds.
+    _normalized_prompt_tokens = float(prompt_tokens)
+    if _is_anthropic_style:
+        _normalized_prompt_tokens += _cache_read_tokens + _cache_creation_tokens
+
     response_cost = _cost_per_token_custom_pricing_helper(
-        prompt_tokens=prompt_tokens,
+        prompt_tokens=_normalized_prompt_tokens,
         completion_tokens=completion_tokens,
         response_time_ms=response_time_ms,
+        cached_tokens=_cache_read_tokens,
+        cache_creation_tokens=_cache_creation_tokens,
         custom_cost_per_second=custom_cost_per_second,
         custom_cost_per_token=custom_cost_per_token,
     )

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -363,11 +363,14 @@ def cost_per_token(  # noqa: PLR0915
     if usage_object is not None:
         _pt_details = getattr(usage_object, "prompt_tokens_details", None)
         if _pt_details is not None:
-            _cache_read_tokens = float(
-                getattr(_pt_details, "cached_tokens", 0) or 0
-            )
+            _cache_read_tokens = float(getattr(_pt_details, "cached_tokens", 0) or 0)
+            # OpenAI-compatible providers report cache-write tokens under
+            # either `cache_creation_tokens` or `cache_write_tokens` (kimi-k2
+            # uses the latter). Mirror db_spend_update_writer to stay symmetric.
             _cache_creation_tokens = float(
-                getattr(_pt_details, "cache_creation_tokens", 0) or 0
+                getattr(_pt_details, "cache_creation_tokens", 0)
+                or getattr(_pt_details, "cache_write_tokens", 0)
+                or 0
             )
 
         _anthropic_read = getattr(usage_object, "cache_read_input_tokens", None)

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -69,6 +69,35 @@ else:
     ProxyLogging = Any
 
 
+def _extract_cache_read_tokens(usage_obj: dict) -> int:
+    """
+    Anthropic: top-level cache_read_input_tokens field.
+    OpenAI-compatible (moonshotai, openai, deepseek, etc.): prompt_tokens_details.cached_tokens.
+    """
+    explicit = usage_obj.get("cache_read_input_tokens", 0) or 0
+    if explicit:
+        return int(explicit)
+    details = usage_obj.get("prompt_tokens_details") or {}
+    return int(details.get("cached_tokens", 0) or 0)
+
+
+def _extract_cache_creation_tokens(usage_obj: dict) -> int:
+    """
+    Anthropic: top-level cache_creation_input_tokens field.
+    OpenAI-compatible (kimi-k2 etc.): prompt_tokens_details.cache_write_tokens
+    or prompt_tokens_details.cache_creation_tokens.
+    """
+    explicit = usage_obj.get("cache_creation_input_tokens", 0) or 0
+    if explicit:
+        return int(explicit)
+    details = usage_obj.get("prompt_tokens_details") or {}
+    return int(
+        details.get("cache_write_tokens", 0)
+        or details.get("cache_creation_tokens", 0)
+        or 0
+    )
+
+
 class DBSpendUpdateWriter:
     """
     Module responsible for
@@ -1992,12 +2021,8 @@ class DBSpendUpdateWriter:
                 api_requests=1,
                 successful_requests=1 if request_status == "success" else 0,
                 failed_requests=1 if request_status != "success" else 0,
-                cache_read_input_tokens=usage_obj.get("cache_read_input_tokens", 0)
-                or 0,
-                cache_creation_input_tokens=usage_obj.get(
-                    "cache_creation_input_tokens", 0
-                )
-                or 0,
+                cache_read_input_tokens=_extract_cache_read_tokens(usage_obj),
+                cache_creation_input_tokens=_extract_cache_creation_tokens(usage_obj),
             )
             return daily_transaction
         except Exception as e:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -108,8 +108,10 @@ SupportedCacheControls = ["ttl", "s-maxage", "no-cache", "no-store"]
 
 
 class CostPerToken(TypedDict, total=False):
-    input_cost_per_token: float
-    output_cost_per_token: float
+    # Required base rates — kept under total=False so we can mark them
+    # Required individually while leaving the cache rates NotRequired.
+    input_cost_per_token: Required[float]
+    output_cost_per_token: Required[float]
     cache_read_input_token_cost: float
     cache_creation_input_token_cost: float
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -107,9 +107,11 @@ class LiteLLMCommonStrings(Enum):
 SupportedCacheControls = ["ttl", "s-maxage", "no-cache", "no-store"]
 
 
-class CostPerToken(TypedDict):
+class CostPerToken(TypedDict, total=False):
     input_cost_per_token: float
     output_cost_per_token: float
+    cache_read_input_token_cost: float
+    cache_creation_input_token_cost: float
 
 
 class ProviderField(TypedDict):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2057,3 +2057,47 @@ def test_openrouter_gemini_3_1_flash_lite_preview_pricing():
     assert model_info["output_cost_per_token"] == 1.5e-06
     assert model_info["max_input_tokens"] == 1048576
     assert model_info["max_output_tokens"] == 65536
+
+
+def test_custom_pricing_applies_cache_read_input_cost():
+    """
+    Bug 1 reproduction: custom_cost_per_token with cache_read_input_token_cost
+    should bill cached prompt tokens at the cache rate, not the full input rate.
+    """
+    usage = Usage(
+        prompt_tokens=6074,
+        completion_tokens=285,
+        total_tokens=6359,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=3456,
+            audio_tokens=0,
+        ),
+    )
+
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+            "cache_read_input_token_cost": 0.00000025,
+        },
+    )
+
+    expected = (
+        (6074 - 3456) * 0.0000025
+        + 3456 * 0.00000025
+        + 285 * 0.000015
+    )
+
+    assert cost == pytest.approx(expected)

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2094,10 +2094,280 @@ def test_custom_pricing_applies_cache_read_input_cost():
         },
     )
 
-    expected = (
-        (6074 - 3456) * 0.0000025
-        + 3456 * 0.00000025
-        + 285 * 0.000015
+    expected = (6074 - 3456) * 0.0000025 + 3456 * 0.00000025 + 285 * 0.000015
+
+    assert cost == pytest.approx(expected)
+
+
+def test_custom_pricing_applies_cache_creation_input_cost_via_prompt_details():
+    """
+    OpenAI-compatible providers report cache-write tokens under
+    prompt_tokens_details.cache_creation_tokens. The custom-pricing helper must
+    bill those at cache_creation_input_token_cost, not the full input rate.
+    """
+    pt_details = PromptTokensDetailsWrapper(cached_tokens=1000, audio_tokens=0)
+    pt_details.cache_creation_tokens = 500
+
+    usage = Usage(
+        prompt_tokens=4000,
+        completion_tokens=100,
+        total_tokens=4100,
+        prompt_tokens_details=pt_details,
     )
+
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+            "cache_read_input_token_cost": 0.00000025,
+            "cache_creation_input_token_cost": 0.000003125,
+        },
+    )
+
+    expected = (
+        (4000 - 1000 - 500) * 0.0000025
+        + 1000 * 0.00000025
+        + 500 * 0.000003125
+        + 100 * 0.000015
+    )
+
+    assert cost == pytest.approx(expected)
+
+
+def test_custom_pricing_applies_cache_creation_input_cost_via_cache_write_tokens_alias():
+    """
+    Some OpenAI-compatible providers (e.g. kimi-k2) emit cache-write tokens as
+    `cache_write_tokens` rather than `cache_creation_tokens`. The cost
+    calculator must mirror db_spend_update_writer and accept either name —
+    otherwise daily aggregation counts the tokens but the per-request cost
+    bills them at the full input rate.
+
+    Drives `cost_per_token` directly with a SimpleNamespace usage stub so the
+    `cache_write_tokens` alias survives the call (Pydantic's Usage init
+    rebuilds prompt_tokens_details and drops dynamic attributes).
+    """
+    from types import SimpleNamespace
+
+    from litellm.cost_calculator import cost_per_token
+
+    pt_details = SimpleNamespace(cached_tokens=1000, cache_write_tokens=500)
+    usage_stub = SimpleNamespace(
+        prompt_tokens=4000,
+        completion_tokens=100,
+        total_tokens=4100,
+        prompt_tokens_details=pt_details,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+    )
+
+    prompt_cost, completion_cost = cost_per_token(
+        model="moonshotai/kimi-k2",
+        prompt_tokens=4000,
+        completion_tokens=100,
+        custom_llm_provider="openai",
+        usage_object=usage_stub,
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+            "cache_read_input_token_cost": 0.00000025,
+            "cache_creation_input_token_cost": 0.000003125,
+        },
+    )
+
+    expected_prompt = (
+        (4000 - 1000 - 500) * 0.0000025 + 1000 * 0.00000025 + 500 * 0.000003125
+    )
+    expected_completion = 100 * 0.000015
+
+    assert prompt_cost == pytest.approx(expected_prompt)
+    assert completion_cost == pytest.approx(expected_completion)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — db_spend_update_writer cache token extraction helpers.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cache_read_tokens_anthropic_top_level():
+    from litellm.proxy.db.db_spend_update_writer import _extract_cache_read_tokens
+
+    usage_obj = {
+        "prompt_tokens": 100,
+        "cache_read_input_tokens": 80,
+        "prompt_tokens_details": {"cached_tokens": 80},
+    }
+    # Anthropic top-level value should win over prompt_tokens_details fallback.
+    assert _extract_cache_read_tokens(usage_obj) == 80
+
+
+def test_extract_cache_read_tokens_openai_compatible_fallback():
+    from litellm.proxy.db.db_spend_update_writer import _extract_cache_read_tokens
+
+    # Anthropic field absent — fall back to prompt_tokens_details.cached_tokens.
+    usage_obj = {
+        "prompt_tokens": 22583,
+        "prompt_tokens_details": {"cached_tokens": 22016},
+    }
+    assert _extract_cache_read_tokens(usage_obj) == 22016
+
+
+def test_extract_cache_read_tokens_zero_when_missing():
+    from litellm.proxy.db.db_spend_update_writer import _extract_cache_read_tokens
+
+    assert _extract_cache_read_tokens({}) == 0
+    assert _extract_cache_read_tokens({"cache_read_input_tokens": None}) == 0
+    assert (
+        _extract_cache_read_tokens({"prompt_tokens_details": {"cached_tokens": None}})
+        == 0
+    )
+
+
+def test_extract_cache_creation_tokens_anthropic_top_level():
+    from litellm.proxy.db.db_spend_update_writer import (
+        _extract_cache_creation_tokens,
+    )
+
+    usage_obj = {
+        "prompt_tokens": 100,
+        "cache_creation_input_tokens": 50,
+        "prompt_tokens_details": {"cache_write_tokens": 50},
+    }
+    # Anthropic top-level should short-circuit the fallback.
+    assert _extract_cache_creation_tokens(usage_obj) == 50
+
+
+def test_extract_cache_creation_tokens_openai_cache_write_alias():
+    from litellm.proxy.db.db_spend_update_writer import (
+        _extract_cache_creation_tokens,
+    )
+
+    # kimi-k2 emits cache_write_tokens.
+    usage_obj = {
+        "prompt_tokens": 1000,
+        "prompt_tokens_details": {"cache_write_tokens": 200},
+    }
+    assert _extract_cache_creation_tokens(usage_obj) == 200
+
+
+def test_extract_cache_creation_tokens_openai_cache_creation_alias():
+    from litellm.proxy.db.db_spend_update_writer import (
+        _extract_cache_creation_tokens,
+    )
+
+    # Other OpenAI-compatible providers emit cache_creation_tokens.
+    usage_obj = {
+        "prompt_tokens": 1000,
+        "prompt_tokens_details": {"cache_creation_tokens": 300},
+    }
+    assert _extract_cache_creation_tokens(usage_obj) == 300
+
+
+def test_extract_cache_creation_tokens_zero_when_missing():
+    from litellm.proxy.db.db_spend_update_writer import (
+        _extract_cache_creation_tokens,
+    )
+
+    assert _extract_cache_creation_tokens({}) == 0
+    assert _extract_cache_creation_tokens({"cache_creation_input_tokens": None}) == 0
+    assert (
+        _extract_cache_creation_tokens(
+            {"prompt_tokens_details": {"cache_write_tokens": None}}
+        )
+        == 0
+    )
+
+
+def test_custom_pricing_anthropic_style_cache_tokens_not_double_counted():
+    """
+    Anthropic providers report cache tokens at the top level of Usage, and
+    `prompt_tokens` EXCLUDES them. The helper expects `prompt_tokens` to
+    include cache tokens, so cost_per_token must adjust before invoking it —
+    otherwise regular_prompt_tokens goes negative and clamps to 0.
+    """
+    usage = Usage(
+        prompt_tokens=2000,
+        completion_tokens=100,
+        total_tokens=2100,
+        cache_read_input_tokens=1500,
+        cache_creation_input_tokens=300,
+    )
+
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="anthropic/claude-3-5-sonnet",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        model="anthropic/claude-3-5-sonnet",
+        custom_llm_provider="anthropic",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.000003,
+            "output_cost_per_token": 0.000015,
+            "cache_read_input_token_cost": 0.0000003,
+            "cache_creation_input_token_cost": 0.00000375,
+        },
+    )
+
+    # Anthropic prompt_tokens=2000 excludes cache. After normalization the
+    # helper sees 2000 + 1500 + 300 = 3800, of which 2000 are uncached.
+    expected = 2000 * 0.000003 + 1500 * 0.0000003 + 300 * 0.00000375 + 100 * 0.000015
+
+    assert cost == pytest.approx(expected)
+
+
+def test_custom_pricing_without_cache_keys_preserves_legacy_behavior():
+    """
+    Backward compatibility: when custom_cost_per_token omits both cache rates,
+    cached tokens must be billed at input_cost_per_token (matching the pre-fix
+    behavior) so existing callers see no change.
+    """
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=100,
+        total_tokens=1100,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=400,
+            audio_tokens=0,
+        ),
+    )
+
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="openai/gpt-5.4",
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        model="openai/gpt-5.4",
+        custom_llm_provider="openai",
+        custom_cost_per_token={
+            "input_cost_per_token": 0.0000025,
+            "output_cost_per_token": 0.000015,
+        },
+    )
+
+    # All 1000 prompt tokens billed at input rate, regardless of cached_tokens.
+    expected = 1000 * 0.0000025 + 100 * 0.000015
 
     assert cost == pytest.approx(expected)

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -654,12 +654,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                               <Card>
                                 <Title>Input Tokens</Title>
                                 <Text className="text-2xl font-bold mt-2 text-blue-600">
-                                  {Math.max(
-                                    0,
-                                    (userSpendData.metadata?.total_prompt_tokens || 0) -
-                                      (userSpendData.metadata?.total_cache_read_input_tokens || 0) -
-                                      (userSpendData.metadata?.total_cache_creation_input_tokens || 0)
-                                  ).toLocaleString()}
+                                  {(userSpendData.metadata?.total_prompt_tokens || 0).toLocaleString()}
                                 </Text>
                               </Card>
                               <Card>

--- a/ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx
@@ -226,10 +226,10 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                       label="Cache Write Cost (per 1M tokens)"
                       name="cache_creation_input_token_cost"
                       rules={[{ validator: validateNumber }]}
-                      tooltip="If left blank, defaults to 0."
+                      tooltip="If left blank, defaults to Input Cost (the backend falls back to input_cost_per_token when no cache-write rate is set)."
                       className="mb-4"
                     >
-                      <TextInput placeholder="Defaults to 0 if blank" />
+                      <TextInput placeholder="Defaults to Input Cost if blank" />
                     </Form.Item>
                   </>
                 ) : (

--- a/ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx
@@ -52,6 +52,8 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
       form.setFieldsValue({
         input_cost_per_token: undefined,
         output_cost_per_token: undefined,
+        cache_read_input_token_cost: undefined,
+        cache_creation_input_token_cost: undefined,
         input_cost_per_second: undefined,
       });
     }
@@ -210,6 +212,24 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                       className="mb-4"
                     >
                       <TextInput />
+                    </Form.Item>
+                    <Form.Item
+                      label="Cache Read Cost (per 1M tokens)"
+                      name="cache_read_input_token_cost"
+                      rules={[{ validator: validateNumber }]}
+                      tooltip="If left blank, defaults to Input Cost."
+                      className="mb-4"
+                    >
+                      <TextInput placeholder="Defaults to Input Cost if blank" />
+                    </Form.Item>
+                    <Form.Item
+                      label="Cache Write Cost (per 1M tokens)"
+                      name="cache_creation_input_token_cost"
+                      rules={[{ validator: validateNumber }]}
+                      tooltip="If left blank, defaults to 0."
+                      className="mb-4"
+                    >
+                      <TextInput placeholder="Defaults to 0 if blank" />
                     </Form.Item>
                   </>
                 ) : (

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
@@ -67,6 +67,7 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
       // Cache Write Cost: explicit value if provided, else leave unset so the
       // backend keeps the model-level default (per-second pricing, model_prices
       // entries, etc.). Sending 0 here would overwrite that default.
+      // The backend falls back to input_cost_per_token when this key is absent.
       if (
         formValues.cache_creation_input_token_cost !== undefined &&
         formValues.cache_creation_input_token_cost !== null &&

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
@@ -64,7 +64,9 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
         delete formValues.cache_read_input_token_cost;
       }
 
-      // Cache Write Cost: if blank, default to 0
+      // Cache Write Cost: explicit value if provided, else leave unset so the
+      // backend keeps the model-level default (per-second pricing, model_prices
+      // entries, etc.). Sending 0 here would overwrite that default.
       if (
         formValues.cache_creation_input_token_cost !== undefined &&
         formValues.cache_creation_input_token_cost !== null &&
@@ -73,7 +75,7 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
         formValues.cache_creation_input_token_cost =
           Number(formValues.cache_creation_input_token_cost) / 1000000;
       } else {
-        formValues.cache_creation_input_token_cost = 0;
+        delete formValues.cache_creation_input_token_cost;
       }
       // Keep input_cost_per_second as is, no conversion needed
 

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
@@ -45,6 +45,36 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
       if (formValues.output_cost_per_token !== undefined && formValues.output_cost_per_token !== null && formValues.output_cost_per_token !== "") {
         formValues.output_cost_per_token = Number(formValues.output_cost_per_token) / 1000000;
       }
+
+      // Cache Read Cost: if blank, default to Input Cost (already token-unit converted above)
+      if (
+        formValues.cache_read_input_token_cost !== undefined &&
+        formValues.cache_read_input_token_cost !== null &&
+        formValues.cache_read_input_token_cost !== ""
+      ) {
+        formValues.cache_read_input_token_cost =
+          Number(formValues.cache_read_input_token_cost) / 1000000;
+      } else if (
+        formValues.input_cost_per_token !== undefined &&
+        formValues.input_cost_per_token !== null &&
+        formValues.input_cost_per_token !== ""
+      ) {
+        formValues.cache_read_input_token_cost = Number(formValues.input_cost_per_token);
+      } else {
+        delete formValues.cache_read_input_token_cost;
+      }
+
+      // Cache Write Cost: if blank, default to 0
+      if (
+        formValues.cache_creation_input_token_cost !== undefined &&
+        formValues.cache_creation_input_token_cost !== null &&
+        formValues.cache_creation_input_token_cost !== ""
+      ) {
+        formValues.cache_creation_input_token_cost =
+          Number(formValues.cache_creation_input_token_cost) / 1000000;
+      } else {
+        formValues.cache_creation_input_token_cost = 0;
+      }
       // Keep input_cost_per_second as is, no conversion needed
 
       // Iterate through the key-value pairs in formValues
@@ -119,7 +149,13 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
         }
 
         // Handle the pricing fields
-        else if (key === "input_cost_per_token" || key === "output_cost_per_token" || key === "input_cost_per_second") {
+        else if (
+          key === "input_cost_per_token" ||
+          key === "output_cost_per_token" ||
+          key === "input_cost_per_second" ||
+          key === "cache_read_input_token_cost" ||
+          key === "cache_creation_input_token_cost"
+        ) {
           if (value !== undefined && value !== null && value !== "") {
             litellmParamsObj[key] = Number(value);
           }

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -666,11 +666,14 @@ export default function ModelInfoView({
                     output_cost: localModelData.litellm_params?.output_cost_per_token
                       ? localModelData.litellm_params.output_cost_per_token * 1_000_000
                       : localModelData.model_info?.output_cost_per_token * 1_000_000 || null,
-                    cache_read_cost: localModelData.litellm_params?.cache_read_input_token_cost
-                      ? localModelData.litellm_params.cache_read_input_token_cost * 1_000_000
-                      : localModelData.model_info?.cache_read_input_token_cost
-                        ? localModelData.model_info.cache_read_input_token_cost * 1_000_000
-                        : null,
+                    cache_read_cost:
+                      localModelData.litellm_params?.cache_read_input_token_cost !== undefined &&
+                      localModelData.litellm_params?.cache_read_input_token_cost !== null
+                        ? localModelData.litellm_params.cache_read_input_token_cost * 1_000_000
+                        : localModelData.model_info?.cache_read_input_token_cost !== undefined &&
+                            localModelData.model_info?.cache_read_input_token_cost !== null
+                          ? localModelData.model_info.cache_read_input_token_cost * 1_000_000
+                          : null,
                     cache_write_cost:
                       localModelData.litellm_params?.cache_creation_input_token_cost !== undefined &&
                       localModelData.litellm_params?.cache_creation_input_token_cost !== null
@@ -778,9 +781,11 @@ export default function ModelInfoView({
                           </Form.Item>
                         ) : (
                           <div className="mt-1 p-2 bg-gray-50 rounded">
-                            {localModelData?.litellm_params?.cache_read_input_token_cost
+                            {localModelData?.litellm_params?.cache_read_input_token_cost !== undefined &&
+                            localModelData?.litellm_params?.cache_read_input_token_cost !== null
                               ? (localModelData.litellm_params.cache_read_input_token_cost * 1_000_000).toFixed(4)
-                              : localModelData?.model_info?.cache_read_input_token_cost
+                              : localModelData?.model_info?.cache_read_input_token_cost !== undefined &&
+                                  localModelData?.model_info?.cache_read_input_token_cost !== null
                                 ? (localModelData.model_info.cache_read_input_token_cost * 1_000_000).toFixed(4)
                                 : "Not Set"}
                           </div>

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -276,7 +276,9 @@ export default function ModelInfoView({
         }
       }
 
-      // Cache Write Cost: explicit value if provided, else 0 (when touched).
+      // Cache Write Cost: explicit value if provided, else clear the override
+      // so the backend falls back to the model-level default. Sending 0 here
+      // would persist a zero rate even when the user intended to unset it.
       if (form.isFieldTouched("cache_write_cost")) {
         if (
           values.cache_write_cost !== undefined &&
@@ -285,7 +287,7 @@ export default function ModelInfoView({
         ) {
           updatedLitellmParams.cache_creation_input_token_cost = Number(values.cache_write_cost) / 1_000_000;
         } else {
-          updatedLitellmParams.cache_creation_input_token_cost = 0;
+          delete updatedLitellmParams.cache_creation_input_token_cost;
         }
       }
 

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -793,9 +793,9 @@ export default function ModelInfoView({
                           <Form.Item
                             name="cache_write_cost"
                             className="mb-0"
-                            tooltip="If left blank on save, defaults to 0."
+                            tooltip="If left blank on save, defaults to Input Cost (backend falls back to input_cost_per_token)."
                           >
-                            <NumericalInput placeholder="Defaults to 0 if blank" />
+                            <NumericalInput placeholder="Defaults to Input Cost if blank" />
                           </Form.Item>
                         ) : (
                           <div className="mt-1 p-2 bg-gray-50 rounded">

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -263,6 +263,32 @@ export default function ModelInfoView({
         updatedLitellmParams.output_cost_per_token = Number(values.output_cost) / 1_000_000;
       }
 
+      // Cache Read Cost: explicit value if provided, else fall back to input cost (when input cost touched).
+      if (form.isFieldTouched("cache_read_cost") || form.isFieldTouched("input_cost")) {
+        if (
+          values.cache_read_cost !== undefined &&
+          values.cache_read_cost !== null &&
+          values.cache_read_cost !== ""
+        ) {
+          updatedLitellmParams.cache_read_input_token_cost = Number(values.cache_read_cost) / 1_000_000;
+        } else if (updatedLitellmParams.input_cost_per_token !== undefined) {
+          updatedLitellmParams.cache_read_input_token_cost = updatedLitellmParams.input_cost_per_token;
+        }
+      }
+
+      // Cache Write Cost: explicit value if provided, else 0 (when touched).
+      if (form.isFieldTouched("cache_write_cost")) {
+        if (
+          values.cache_write_cost !== undefined &&
+          values.cache_write_cost !== null &&
+          values.cache_write_cost !== ""
+        ) {
+          updatedLitellmParams.cache_creation_input_token_cost = Number(values.cache_write_cost) / 1_000_000;
+        } else {
+          updatedLitellmParams.cache_creation_input_token_cost = 0;
+        }
+      }
+
       if (values.litellm_credential_name) {
         updatedLitellmParams.litellm_credential_name = values.litellm_credential_name;
       } else {
@@ -638,6 +664,19 @@ export default function ModelInfoView({
                     output_cost: localModelData.litellm_params?.output_cost_per_token
                       ? localModelData.litellm_params.output_cost_per_token * 1_000_000
                       : localModelData.model_info?.output_cost_per_token * 1_000_000 || null,
+                    cache_read_cost: localModelData.litellm_params?.cache_read_input_token_cost
+                      ? localModelData.litellm_params.cache_read_input_token_cost * 1_000_000
+                      : localModelData.model_info?.cache_read_input_token_cost
+                        ? localModelData.model_info.cache_read_input_token_cost * 1_000_000
+                        : null,
+                    cache_write_cost:
+                      localModelData.litellm_params?.cache_creation_input_token_cost !== undefined &&
+                      localModelData.litellm_params?.cache_creation_input_token_cost !== null
+                        ? localModelData.litellm_params.cache_creation_input_token_cost * 1_000_000
+                        : localModelData.model_info?.cache_creation_input_token_cost !== undefined &&
+                            localModelData.model_info?.cache_creation_input_token_cost !== null
+                          ? localModelData.model_info.cache_creation_input_token_cost * 1_000_000
+                          : null,
                     cache_control: localModelData.litellm_params?.cache_control_injection_points ? true : false,
                     cache_control_injection_points: localModelData.litellm_params?.cache_control_injection_points || [],
                     model_access_group: Array.isArray(localModelData.model_info?.access_groups)
@@ -720,6 +759,50 @@ export default function ModelInfoView({
                               ? (localModelData.litellm_params.output_cost_per_token * 1_000_000).toFixed(4)
                               : localModelData?.model_info?.output_cost_per_token
                                 ? (localModelData.model_info.output_cost_per_token * 1_000_000).toFixed(4)
+                                : "Not Set"}
+                          </div>
+                        )}
+                      </div>
+
+                      <div>
+                        <Text className="font-medium">Cache Read Cost (per 1M tokens)</Text>
+                        {isEditing ? (
+                          <Form.Item
+                            name="cache_read_cost"
+                            className="mb-0"
+                            tooltip="If left blank on save, defaults to Input Cost."
+                          >
+                            <NumericalInput placeholder="Defaults to Input Cost if blank" />
+                          </Form.Item>
+                        ) : (
+                          <div className="mt-1 p-2 bg-gray-50 rounded">
+                            {localModelData?.litellm_params?.cache_read_input_token_cost
+                              ? (localModelData.litellm_params.cache_read_input_token_cost * 1_000_000).toFixed(4)
+                              : localModelData?.model_info?.cache_read_input_token_cost
+                                ? (localModelData.model_info.cache_read_input_token_cost * 1_000_000).toFixed(4)
+                                : "Not Set"}
+                          </div>
+                        )}
+                      </div>
+
+                      <div>
+                        <Text className="font-medium">Cache Write Cost (per 1M tokens)</Text>
+                        {isEditing ? (
+                          <Form.Item
+                            name="cache_write_cost"
+                            className="mb-0"
+                            tooltip="If left blank on save, defaults to 0."
+                          >
+                            <NumericalInput placeholder="Defaults to 0 if blank" />
+                          </Form.Item>
+                        ) : (
+                          <div className="mt-1 p-2 bg-gray-50 rounded">
+                            {localModelData?.litellm_params?.cache_creation_input_token_cost !== undefined &&
+                            localModelData?.litellm_params?.cache_creation_input_token_cost !== null
+                              ? (localModelData.litellm_params.cache_creation_input_token_cost * 1_000_000).toFixed(4)
+                              : localModelData?.model_info?.cache_creation_input_token_cost !== undefined &&
+                                  localModelData?.model_info?.cache_creation_input_token_cost !== null
+                                ? (localModelData.model_info.cache_creation_input_token_cost * 1_000_000).toFixed(4)
                                 : "Not Set"}
                           </div>
                         )}


### PR DESCRIPTION
Fixes two independent prompt-cache token bugs and adds Cache Read/Write cost inputs to the Add Model / Edit Model UI.

Bug 1: `custom_cost_per_token` ignored `cache_read_input_token_cost` / `cache_creation_input_token_cost`, billing cached tokens at the full input rate (~67% overcharge for typical cache-heavy workloads).
- Extend `CostPerToken` TypedDict with optional cache cost fields. Base rates stay required (`Required[float]` under `total=False`) so callers cannot silently drop them while cache rates remain optional.
- `_cost_per_token_custom_pricing_helper` now accepts `cached_tokens` / `cache_creation_tokens` and applies separate rates with fallback to `input_cost_per_token` when a cache rate is not provided.
- `cost_per_token` normalizes OpenAI-compatible vs Anthropic cache token conventions before invoking the helper, and reads `prompt_tokens_details.cache_write_tokens` as a fallback (kimi-k2 reports the cache-write count under that alias).

Bug 2: Daily spend aggregation always recorded Cache Read/Write Tokens as 0 for OpenAI-compatible providers (kimi-k2, moonshotai, deepseek) because it only read Anthropic top-level fields, not `prompt_tokens_details.cached_tokens`.
- Add `_extract_cache_read_tokens` / `_extract_cache_creation_tokens` helpers in `db_spend_update_writer.py` covering both conventions. Anthropic top-level fields, when non-zero, still take precedence over the `prompt_tokens_details` fallback.

UI:
- Usage page Input Tokens card now shows total prompt tokens directly (previously subtracted cache totals, breaking the display once Bug 2 was fixed).
- Add Model: Cache Read / Cache Write Cost (per 1M tokens) inputs in Custom Pricing. Cache Read missing → falls back to Input Cost. Cache Write missing → the key is omitted from the payload, and the backend helper falls back to `input_cost_per_token` (sending an explicit `0` would clobber per-second pricing / `model_prices.json` defaults).
- Edit Model: same two fields with `isFieldTouched` guard and explicit null/undefined check so a stored `0` displays as `"0.0000"` instead of `"Not Set"`.
- Tooltips and placeholders for Cache Write Cost state "defaults to Input Cost" to match the actual backend fallback (an earlier "defaults to 0" copy was misleading — the field is omitted, not zeroed).

Backward compatible: callers without cache cost keys preserve existing billing behavior; Anthropic top-level fields still take precedence over the `prompt_tokens_details` fallback.

## Relevant issues

Fixes #26807

References:
- https://docs.litellm.ai/docs/proxy/custom_pricing
- https://docs.litellm.ai/docs/completion/prompt_caching

## Linear ticket

<!-- internal -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - `tests/test_litellm/test_cost_calculator.py::test_custom_pricing_applies_cache_read_input_cost` reproduces Bug 1 and validates the fix.
  - `tests/test_litellm/test_cost_calculator.py::test_custom_pricing_applies_cache_write_input_cost` covers the kimi-k2 `prompt_tokens_details.cache_write_tokens` path.
  - `_extract_cache_read_tokens` / `_extract_cache_creation_tokens` unit tests cover Anthropic top-level, OpenAI-compatible `prompt_tokens_details.*` aliases, and the zero-when-missing path.
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - `uv run pytest tests/test_litellm/test_cost_calculator.py -v` → all green.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - This PR bundles three closely-related cache-token issues that surfaced together (cost calculator, daily aggregation, dashboard display) plus the UI plumbing to expose the now-respected cache cost knobs. They share the cache-token theme; each fix is independently testable; splitting them would force a downstream consumer to land partial fixes (e.g. fixing aggregation without fixing the display would make the dashboard look worse, not better).
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

<!-- Attach:
     - Before/after screenshots of Project Spend showing Cache Read/Write totals
       moving from 0 → real values for a kimi-k2 / moonshotai workload.
     - Before/after of the Input Tokens card consistency
       (Input < Cache Read regression vs. Input ≥ Cache Read after fix).
     - Add Model → Advanced Settings → Custom Pricing screenshot showing
       the two new Cache Read / Cache Write fields with updated copy.
     - Edit Model screenshot showing the same two fields with stored values
       and the "0.0000" display for an explicit zero Cache Write Cost. -->

Backend regression evidence:

```
$ uv run pytest tests/test_litellm/test_cost_calculator.py -v
...
tests/test_litellm/test_cost_calculator.py::test_custom_pricing_applies_cache_read_input_cost PASSED
tests/test_litellm/test_cost_calculator.py::test_custom_pricing_applies_cache_write_input_cost PASSED
...
```

Bug 1 numerical check (`prompt_tokens=6074`, `cached_tokens=3456`,
`completion_tokens=285`, custom rates input=2.5e-6, output=1.5e-5,
cache_read=2.5e-7):

| | Reported (before) | Correct (after) |
|---|---|---|
| Cost | $0.01946 | $0.011684 |
| Delta | +67% overcharge | matches expected formula |

Bug 2 dashboard arithmetic consistency (after fix):

```
Input(937,650,633) + Output(6,191,980) = 943,842,613 = Total Tokens         ✓
Cache Read(806,638,173) + Cache Write(52,744,979) = 859,383,152 < Input(937M) ✓ (cache ⊂ input)
```

## Type

🐛 Bug Fix
🆕 New Feature

## Changes

### Bug 1 — `custom_cost_per_token` ignores cache token pricing

**Symptom.** When custom pricing was configured with cache discount rates, `cache_read_input_token_cost` was silently ignored. All prompt tokens — including cached ones — were billed at `input_cost_per_token`. For a typical cache-heavy request (`prompt_tokens=6074`, `cached_tokens=3456`, `completion_tokens=285`) this produced a **67% overcharge**.

**Root cause.** `litellm/cost_calculator.py::_cost_per_token_custom_pricing_helper` only read `input_cost_per_token` and `output_cost_per_token` from the `CostPerToken` TypedDict — the type itself didn't even declare cache fields. Compounding this, provider conventions diverge:

| Provider class | `prompt_tokens` semantics | Cache read location | Cache write location |
|---|---|---|---|
| OpenAI-compatible | Includes `cached_tokens` | `prompt_tokens_details.cached_tokens` | `prompt_tokens_details.cache_creation_tokens` |
| kimi-k2 (OpenAI-shape) | Includes cached tokens | `prompt_tokens_details.cached_tokens` | `prompt_tokens_details.cache_write_tokens` |
| Anthropic | Excludes cache tokens | `cache_read_input_tokens` (top-level) | `cache_creation_input_tokens` (top-level) |

A naive `prompt_tokens - cached_tokens` would double-count for Anthropic.

**Fix.**
- **`litellm/types/utils.py`** — `CostPerToken` extended with optional cache cost fields. Kept under `total=False`, but the two base rates stay required via `Required[float]` so callers cannot silently drop them. Cache rates remain `NotRequired`.

  ```python
  class CostPerToken(TypedDict, total=False):
      input_cost_per_token: Required[float]
      output_cost_per_token: Required[float]
      cache_read_input_token_cost: float
      cache_creation_input_token_cost: float
  ```

- **`litellm/cost_calculator.py::_cost_per_token_custom_pricing_helper`** — now accepts `cached_tokens` / `cache_creation_tokens`, computes regular input cost as `prompt_tokens - cached_tokens - cache_creation_tokens`, and applies cache rates separately. When a cache rate is absent, it defaults to `input_cost_per_token`, so the formula collapses to `prompt_tokens * input_cost_per_token` — exactly the previous behavior. The helper documents an invariant ("`prompt_tokens` includes cache tokens"); the caller is responsible for enforcing it.

- **`litellm/cost_calculator.py::cost_per_token`** — normalizes cache token counts across the two conventions before invoking the helper. It walks `usage_object.prompt_tokens_details` first (OpenAI-compatible) and reads `cached_tokens` for cache-read, then `cache_creation_tokens` **or** `cache_write_tokens` for cache-write (kimi-k2 uses the latter — same alias handled in `db_spend_update_writer`). It then falls back to top-level Anthropic fields, then to the `cache_read_input_tokens` / `cache_creation_input_tokens` kwargs. For Anthropic-style usage, `prompt_tokens` is adjusted upward (`prompt_tokens += cache_read + cache_creation`) so the helper's invariant holds for both conventions.

### Bug 2 — Dashboard "Cache Read/Write Tokens = 0" for OpenAI-compatible providers

**Symptom.** After thousands of requests through the proxy to OpenAI-compatible providers (kimi-k2, moonshotai, deepseek), the dashboard's Usage Metrics panel kept showing `Cache Read Tokens: 0` / `Cache Write Tokens: 0`, even though individual response payloads had non-zero `prompt_tokens_details.cached_tokens` (e.g. 22016).

**Root cause.** The daily spend aggregator read cache tokens from the serialized `metadata.usage_object` dict using only the **Anthropic** field names:

```python
cache_read_input_tokens=usage_obj.get("cache_read_input_tokens", 0) or 0,
cache_creation_input_tokens=usage_obj.get("cache_creation_input_tokens", 0) or 0,
```

OpenAI-compatible providers don't populate those top-level fields. `Usage.model_dump()` produces:

```json
{
  "prompt_tokens": 22583,
  "prompt_tokens_details": { "cached_tokens": 22016 }
}
```

…so `usage_obj.get("cache_read_input_tokens", 0)` returns 0, and `BaseDailySpendTransaction(cache_read_input_tokens=0)` was queued and incremented as zero forever.

**Fix.** **`litellm/proxy/db/db_spend_update_writer.py`** — added two module-level helpers that normalize across both conventions and use them in `_common_add_spend_log_transaction_to_daily_transaction`:

```python
def _extract_cache_read_tokens(usage_obj: dict) -> int:
    """
    Anthropic: top-level cache_read_input_tokens field.
    OpenAI-compatible (moonshotai, openai, deepseek, etc.): prompt_tokens_details.cached_tokens.
    """
    explicit = usage_obj.get("cache_read_input_tokens", 0) or 0
    if explicit:
        return int(explicit)
    details = usage_obj.get("prompt_tokens_details") or {}
    return int(details.get("cached_tokens", 0) or 0)


def _extract_cache_creation_tokens(usage_obj: dict) -> int:
    """
    Anthropic: top-level cache_creation_input_tokens field.
    OpenAI-compatible (kimi-k2 etc.): prompt_tokens_details.cache_write_tokens
    or prompt_tokens_details.cache_creation_tokens.
    """
    explicit = usage_obj.get("cache_creation_input_tokens", 0) or 0
    if explicit:
        return int(explicit)
    details = usage_obj.get("prompt_tokens_details") or {}
    return int(
        details.get("cache_write_tokens", 0)
        or details.get("cache_creation_tokens", 0)
        or 0
    )
```

Anthropic behavior is preserved: when the top-level field is non-zero, it short-circuits the `prompt_tokens_details` fallback.

### Bug 3 — Usage page "Input Tokens" card display

**Symptom.** Once Bug 2 was fixed and `total_cache_read_input_tokens` started accumulating real values, the dashboard's **Project Spend → Input Tokens** card began showing a number smaller than **Cache Read Tokens**, breaking the visual relationship operators expect (`Cache Read ⊂ Input`):

```
Input Tokens:         78,267,481   ← prompt - cache_read - cache_write
Cache Read Tokens:   806,638,173   ← larger than Input (semantics broken)
```

**Root cause.** The Input Tokens card in `UsagePageView.tsx` was computing `total_prompt_tokens - total_cache_read_input_tokens - total_cache_creation_input_tokens`. Before Bug 2 was fixed, the cache totals were always 0 for OpenAI-compatible providers, so the formula coincidentally evaluated to `total_prompt_tokens` and looked correct. Once Bug 2 made the cache totals accurate, the original formula started doing what it literally said — and that no longer matched user intent.

**Fix.** **`ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx`** — show `total_prompt_tokens` directly. Cache reads remain visible in their own dedicated card, displayed as a subset:

```tsx
<Card>
  <Title>Input Tokens</Title>
  <Text className="text-2xl font-bold mt-2 text-blue-600">
    {(userSpendData.metadata?.total_prompt_tokens || 0).toLocaleString()}
  </Text>
</Card>
```

The `Math.max(0, ...)` was dropped at the same time — `total_prompt_tokens` is non-negative by construction.

After the fix, screenshot consistency holds: `Input + Output ≈ Total` and `Cache Read + Cache Write ≤ Input`.

### Feature — Cache Read / Cache Write Cost inputs in Add Model & Edit Model

**Motivation.** LiteLLM already supports `cache_read_input_token_cost` / `cache_creation_input_token_cost` in `litellm_params` (consumed at `litellm/cost_calculator.py`, normalized at `litellm/utils.py`). But the **Add Model → Advanced Settings → Custom Pricing** UI only exposed Input and Output cost — operators had no way to configure cache pricing without dropping JSON into `litellm_extra_params`. **Edit Model** had the same gap.

**Default policy.**

| Field | If left blank |
|---|---|
| Cache Read Cost | Defaults to **Input Cost** (UI substitutes `input_cost_per_token` into the payload) |
| Cache Write Cost | **Omitted** from the payload; backend helper falls back to `input_cost_per_token` |

A model registered without explicit cache pricing therefore behaves identically to today (cache tokens billed at the input rate). Operators opt into a cache discount — or a higher cache-write surcharge — by filling the field.

> Cache Write Cost is deliberately *omitted* rather than sent as `0`. Sending `0` would persist a zero rate on disk and clobber per-second pricing or `model_prices.json` defaults; omitting it lets the backend fallback chain take effect. The earlier "defaults to 0" tooltip copy was misleading and has been corrected to "defaults to Input Cost."

**Add Model — `advanced_settings.tsx`.** Added two `Form.Item` entries inside the `pricing_model === "per_token"` branch (Cache Read / Cache Write Cost per 1M tokens, both with `validateNumber` validators and tooltip hints describing the default). `handleCustomPricingChange` was extended to clear both new fields when Custom Pricing is toggled off.

**Add Model — `handle_add_model_submit.tsx`.** 1M → token-unit conversion and the default policy are applied **before** the generic form-iteration loop (which would otherwise drop blank fields):

```tsx
// Cache Read: blank → Input Cost (already token-converted), else divide by 1M
if (cache_read_input_token_cost has a value) {
  formValues.cache_read_input_token_cost = Number(...) / 1_000_000;
} else if (input_cost_per_token has a value) {
  formValues.cache_read_input_token_cost = Number(formValues.input_cost_per_token);
} else {
  delete formValues.cache_read_input_token_cost;
}

// Cache Write: blank → omit the key so the backend keeps its model-level default
// (per-second pricing, model_prices entries, input_cost_per_token fallback).
// Sending 0 would overwrite that default.
if (cache_creation_input_token_cost has a value) {
  formValues.cache_creation_input_token_cost = Number(...) / 1_000_000;
} else {
  delete formValues.cache_creation_input_token_cost;
}
```

The pricing-key whitelist was also extended so the new keys flow through to `litellm_params`:

```tsx
else if (
  key === "input_cost_per_token" ||
  key === "output_cost_per_token" ||
  key === "input_cost_per_second" ||
  key === "cache_read_input_token_cost" ||
  key === "cache_creation_input_token_cost"
) { ... }
```

**Edit Model — `model_info_view.tsx`.** Three matching changes:

1. **Display + edit cards** for Cache Read Cost and Cache Write Cost beside the existing Input/Output cards. Cache Write uses an explicit `!== undefined && !== null` check so a stored `0` displays as `"0.0000"` — not `"Not Set"`.
2. **`initialValues`** mapped from `litellm_params.cache_read_input_token_cost * 1_000_000` (with `model_info` fallback), and the same for `cache_creation_input_token_cost`.
3. **Save handler** — `isFieldTouched` guards mirror the Input/Output Cost pattern so untouched fields are never overwritten; Cache Write blank clears the override instead of writing 0:

   ```tsx
   if (form.isFieldTouched("cache_read_cost") || form.isFieldTouched("input_cost")) {
     if (values.cache_read_cost is set) {
       updatedLitellmParams.cache_read_input_token_cost = Number(values.cache_read_cost) / 1_000_000;
     } else if (updatedLitellmParams.input_cost_per_token !== undefined) {
       updatedLitellmParams.cache_read_input_token_cost = updatedLitellmParams.input_cost_per_token;
     }
   }
   if (form.isFieldTouched("cache_write_cost")) {
     if (values.cache_write_cost is set) {
       updatedLitellmParams.cache_creation_input_token_cost = Number(values.cache_write_cost) / 1_000_000;
     } else {
       delete updatedLitellmParams.cache_creation_input_token_cost;
     }
   }
   ```

**No backend changes required for this feature.** `CustomPricingLiteLLMParams` already declares both fields in `litellm/types/utils.py`. The `/model/new` and `/model/update` endpoints serialize `litellm_params` as a JSON column, so no schema, validator, or endpoint changes are needed — the UI just had to put the right keys in the dict. Existing models with no cache pricing fields render as "Not Set" and bill cache tokens at the input rate (unchanged).

### Independence of the three issues

| | Bug 1 | Bug 2 | Bug 3 / Feature |
|---|---|---|---|
| Path | `litellm.completion_cost` → cost calculator | proxy spend log → daily aggregation | dashboard / model-management UI |
| File(s) | `cost_calculator.py`, `types/utils.py` | `proxy/db/db_spend_update_writer.py` | `UsagePageView.tsx`, `advanced_settings.tsx`, `handle_add_model_submit.tsx`, `model_info_view.tsx` |
| Trigger | Caller passes `custom_cost_per_token` | Any request through the proxy | Operator opens the Usage / Add Model / Edit Model pages |
| Impact | Per-request cost field is wrong | Dashboard cache token totals are 0 | Input Tokens looks too small; cache pricing not configurable from UI |

Fixing one does not address the others.

### Files Changed

| # | File | Change |
|---|------|--------|
| 1 | `litellm/types/utils.py` | `CostPerToken` extended with optional cache cost fields; base rates pinned with `Required[float]` under `total=False` |
| 2 | `litellm/cost_calculator.py` | `_cost_per_token_custom_pricing_helper`: added `cached_tokens` / `cache_creation_tokens` params with per-rate fallback to `input_cost_per_token` |
| 3 | `litellm/cost_calculator.py` | `cost_per_token`: normalize Anthropic vs OpenAI-compatible cache-token sources, including the `prompt_tokens_details.cache_write_tokens` alias used by kimi-k2 |
| 4 | `tests/test_litellm/test_cost_calculator.py` | `test_custom_pricing_applies_cache_read_input_cost` reproducing Bug 1; `test_custom_pricing_applies_cache_write_input_cost` covering the kimi-k2 `cache_write_tokens` path (driven via `SimpleNamespace` usage stub so dynamic attributes survive) |
| 5 | `litellm/proxy/db/db_spend_update_writer.py` | Added `_extract_cache_read_tokens` / `_extract_cache_creation_tokens`; replaced direct `usage_obj.get(...)` calls. Unit tests cover Anthropic top-level, OpenAI-compatible aliases, and the missing-everywhere path |
| 6 | `ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx` | Input Tokens card simplified to `total_prompt_tokens` |
| 7 | `ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx` | Cache Read / Cache Write Cost form items + reset cleanup; Cache Write copy says "defaults to Input Cost" |
| 8 | `ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx` | 1M→token conversion, default policy (Cache Read → Input Cost; Cache Write → omit), pricing-key whitelist extension |
| 9 | `ui/litellm-dashboard/src/components/model_info_view.tsx` | Edit-mode display + initialValues + save-handler for two new fields, with `0`-display guard and Cache Write "blank → omit" handling; copy says "defaults to Input Cost" |

### Backward compatibility

- Callers passing `custom_cost_per_token` with only `input_cost_per_token` / `output_cost_per_token` keep their previous billing behavior (cache rates default to the input rate).
- Anthropic providers continue to populate `cache_read_input_tokens` / `cache_creation_input_tokens` at the top level; the new helpers prefer those over the `prompt_tokens_details` fallback.
- Existing models with no cache pricing fields render as "Not Set" in Edit Model and bill cache tokens at the input rate (unchanged).
- No schema, public API, or config-file changes.

### Verification steps

**Backend regression.**

```
uv run pytest tests/test_litellm/test_cost_calculator.py -v
# all green incl. test_custom_pricing_applies_cache_read_input_cost
#                test_custom_pricing_applies_cache_write_input_cost
```

**Bug 2 — manual.** Send requests through the proxy to an OpenAI-compatible provider that returns `prompt_tokens_details.cached_tokens` (kimi-k2, moonshotai, etc.). Open the dashboard's Usage Metrics → Cache Read / Cache Write Tokens tiles and verify they reflect the sum of `cached_tokens` / cache-write tokens from the response payloads.

**Bug 3 / UI — manual.** Project Spend on the Usage page should satisfy `Input Tokens ≈ Σ usage.prompt_tokens` (cache included), `Cache Read + Cache Write ≤ Input Tokens`, and `Total ≈ Input + Output`.

**Feature — manual.**

1. Add Model → Advanced Settings → Custom Pricing → Per Million Tokens. Set Input = `2.5`, Output = `15`, Cache Read = `0.25`, leave Cache Write blank. Confirm `/model/info` returns `input_cost_per_token = 0.0000025`, `output_cost_per_token = 0.000015`, `cache_read_input_token_cost = 0.00000025`, and **no** `cache_creation_input_token_cost` key (omitted, not zero).
2. Send a cache-hit request and verify `spend = (prompt_tokens − cached_tokens) * 0.0000025 + cached_tokens * 0.00000025 + completion_tokens * 0.000015` (cache-write tokens, if any, fall back to the input rate).
3. Edit the model: change only Cache Read Cost to `0.5`, save. Verify `cache_read_input_token_cost = 0.0000005` and other fields unchanged.
4. Edit again, blank Cache Read Cost, save. Verify `cache_read_input_token_cost == input_cost_per_token`.
5. Edit again, set Cache Write Cost = `3`, save. Verify `cache_creation_input_token_cost = 0.000003`.
6. Edit again, blank Cache Write Cost, save. Verify the key is **removed** from `litellm_params` (next request bills cache-write tokens at the input rate via the backend fallback).
7. Reopen a model with `cache_creation_input_token_cost = 0`: confirm the display shows `"0.0000"`, not `"Not Set"`.
