### PR TITLE
fix(streaming): preserve Gemini thought-only chunks in is_chunk_non_empty (#28000)

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -95,6 +95,27 @@ def print_verbose(print_statement):
         pass
 
 
+def _original_chunk_has_reasoning_content(response_obj: Dict[str, Any]) -> bool:
+    """Return True when the parsed upstream chunk carries reasoning_content.
+
+    `is_chunk_non_empty` only inspects the fresh `model_response` created at
+    the top of `chunk_creator`, so providers that surface reasoning_content via
+    `response_obj["original_chunk"]` (e.g. Gemini thinking parts under the
+    openai-compatible code path) need this fallback to avoid silent drops.
+    See https://github.com/BerriAI/litellm/issues/28000.
+    """
+    original_chunk = response_obj.get("original_chunk")
+    if original_chunk is None:
+        return False
+    choices = getattr(original_chunk, "choices", None) or []
+    if len(choices) == 0:
+        return False
+    delta = getattr(choices[0], "delta", None)
+    if delta is None:
+        return False
+    return getattr(delta, "reasoning_content", None) is not None
+
+
 class CustomStreamWrapper:
     def __init__(
         self,
@@ -818,6 +839,7 @@ class CustomStreamWrapper:
                 "reasoning_content" in model_response.choices[0].delta
                 and model_response.choices[0].delta.reasoning_content is not None
             )
+            or _original_chunk_has_reasoning_content(response_obj)
             or (model_response.choices[0].delta.provider_specific_fields is not None)
             or (
                 "provider_specific_fields" in model_response

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -226,6 +227,36 @@ def test_is_chunk_non_empty_ignores_original_chunk_without_reasoning(
             model_response=empty_model_response,
             response_obj={"original_chunk": original_chunk},
         )
+        is False
+    )
+
+
+def test_original_chunk_has_reasoning_content_defensive_branches():
+    """
+    Cover the defensive guards inside _original_chunk_has_reasoning_content so
+    every early-return path is exercised. Each branch must return False without
+    raising on the surrounding malformed input.
+    """
+    from litellm.litellm_core_utils.streaming_handler import (
+        _original_chunk_has_reasoning_content,
+    )
+
+    # 1. Missing original_chunk entirely.
+    assert _original_chunk_has_reasoning_content({}) is False
+
+    # 2. original_chunk present but no choices.
+    chunk_no_choices = ModelResponseStream(choices=[])
+    assert (
+        _original_chunk_has_reasoning_content({"original_chunk": chunk_no_choices})
+        is False
+    )
+
+    # 3. original_chunk with a choice whose delta is None. ModelResponseStream
+    # always materialises a Delta, so emulate the missing-delta case with a
+    # SimpleNamespace standing in for the choice.
+    chunk_no_delta = SimpleNamespace(choices=[SimpleNamespace(delta=None)])
+    assert (
+        _original_chunk_has_reasoning_content({"original_chunk": chunk_no_delta})
         is False
     )
 

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -158,6 +158,78 @@ def test_is_chunk_non_empty(initialized_custom_stream_wrapper: CustomStreamWrapp
     )
 
 
+def test_is_chunk_non_empty_with_original_chunk_reasoning_content(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/28000.
+
+    When Gemini emits a streaming chunk that carries only thinking content
+    (delta.content is None, delta.reasoning_content is set), the upstream
+    handler builds an `original_chunk` ModelResponseStream that holds the
+    reasoning_content, but `model_response` passed into is_chunk_non_empty
+    is a fresh empty object. The thought chunk must still be considered
+    non-empty so it propagates to the caller.
+    """
+    original_chunk = ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(
+                    content=None,
+                    reasoning_content="I need to add 2 and 2...",
+                ),
+                finish_reason=None,
+            )
+        ],
+    )
+    empty_model_response = ModelResponseStream(
+        choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)],
+    )
+
+    assert (
+        initialized_custom_stream_wrapper.is_chunk_non_empty(
+            completion_obj={"content": ""},
+            model_response=empty_model_response,
+            response_obj={"original_chunk": original_chunk},
+        )
+        is True
+    )
+
+
+def test_is_chunk_non_empty_ignores_original_chunk_without_reasoning(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    Companion to test_is_chunk_non_empty_with_original_chunk_reasoning_content.
+
+    An empty completion_obj plus an original_chunk that carries no
+    reasoning_content (and no other non-empty delta fields) must still be
+    treated as empty so existing pass-through behaviour is preserved.
+    """
+    original_chunk = ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content=None),
+                finish_reason=None,
+            )
+        ],
+    )
+    empty_model_response = ModelResponseStream(
+        choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)],
+    )
+
+    assert (
+        initialized_custom_stream_wrapper.is_chunk_non_empty(
+            completion_obj={"content": ""},
+            model_response=empty_model_response,
+            response_obj={"original_chunk": original_chunk},
+        )
+        is False
+    )
+
+
 def test_is_chunk_non_empty_with_annotations(
     initialized_custom_stream_wrapper: CustomStreamWrapper,
 ):
@@ -2036,23 +2108,19 @@ async def test_azure_streaming_role_preserved_with_include_usage(sync_mode: bool
             chunks.append(chunk)
 
     # The prompt_filter chunk should be forwarded with choices=[]
-    assert len(chunks[0].choices) == 0, (
-        f"Expected prompt_filter chunk with choices=[], got {len(chunks[0].choices)} choices"
-    )
+    assert (
+        len(chunks[0].choices) == 0
+    ), f"Expected prompt_filter chunk with choices=[], got {len(chunks[0].choices)} choices"
 
     # At least one chunk must have role='assistant' in its delta
     has_role = any(
-        len(c.choices) > 0
-        and getattr(c.choices[0].delta, "role", None) == "assistant"
+        len(c.choices) > 0 and getattr(c.choices[0].delta, "role", None) == "assistant"
         for c in chunks
     )
     assert has_role, (
         "No chunk contained role='assistant' in delta (issue #24221). "
         "Chunk deltas: "
-        + str([
-            c.choices[0].delta if c.choices else "no choices"
-            for c in chunks
-        ])
+        + str([c.choices[0].delta if c.choices else "no choices" for c in chunks])
     )
 
 


### PR DESCRIPTION
## Relevant issues

Fixes #28000.

## Linear ticket

N/A

## Summary

When Gemini streams with `reasoning_effort`/thinking enabled, the openai-compatible chunk path produces chunks where `delta.content` is `None` and `delta.reasoning_content` is set on the parsed `original_chunk`. `is_chunk_non_empty` only inspects the fresh `model_response` created at the top of `chunk_creator`, so it never sees the reasoning_content and reports the chunk as empty. The chunk is then dropped before reaching the caller and `delta.reasoning_content` is always `None` on the consumer side.

Once the chunk is recognised as non-empty, `return_processed_chunk_logic` already rebuilds `choices` from `original_chunk.model_dump()`, so no other change is needed.

Root cause identified by @ThibaultCoudertSephora in #28000.

## Change

- Adds a module-level helper `_original_chunk_has_reasoning_content(response_obj)` and calls it from `is_chunk_non_empty` next to the existing reasoning_content branch. Extracted as a helper per the CLAUDE.md guidance on named helpers for non-trivial chained access.
- The helper only returns `True` when `response_obj[\"original_chunk\"].choices[0].delta.reasoning_content` is not `None`, so chunks that legitimately have an empty delta still propagate as empty.

## Tests

- `test_is_chunk_non_empty_with_original_chunk_reasoning_content` — regression test: empty `model_response`, `response_obj` carrying an `original_chunk` whose delta has `reasoning_content`. Fails on `main` (`assert False is True`), passes with the fix.
- `test_is_chunk_non_empty_ignores_original_chunk_without_reasoning` — negative case: empty `model_response`, `original_chunk` with no `reasoning_content`. Still treated as empty so existing pass-through behaviour is preserved.

Both tests live next to the existing `test_is_chunk_non_empty` cases in `tests/test_litellm/litellm_core_utils/test_streaming_handler.py`.

## Pre-Submission checklist

- [x] I have added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory.
- [x] My PR passes the relevant unit tests locally (`uv run pytest tests/test_litellm/litellm_core_utils/test_streaming_handler.py` — 67 passing, 2 pre-existing failures unrelated to this change: `test_gemini_legacy_vertex_*` fail on `main` with `ModuleNotFoundError: No module named 'proto'`).
- [x] My PR's scope is isolated — single helper + single call site + 2 unit tests.
- [x] I have requested a Greptile review and received a Confidence Score of at least 4/5 — will request after opening.

## Type

🐛 Bug Fix

## Changes

- `litellm/litellm_core_utils/streaming_handler.py`: add `_original_chunk_has_reasoning_content` helper; call it inside `is_chunk_non_empty` so chunks whose reasoning_content lives on `original_chunk` are not dropped.
- `tests/test_litellm/litellm_core_utils/test_streaming_handler.py`: add 2 unit tests covering positive and negative paths.