### PR TITLE
fix(utils): import get_secret at runtime

### DIFF
--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -376,7 +376,6 @@ UTILS_MODULE_NAMES = (
     "HTTPHandler",
     "get_num_retries_from_retry_policy",
     "reset_retry_policy",
-    "get_secret",
     "get_coroutine_checker",
     "get_litellm_logging_class",
     "get_set_callbacks",
@@ -1284,7 +1283,6 @@ _UTILS_MODULE_IMPORT_MAP = {
         "litellm.router_utils.get_retry_from_policy",
         "reset_retry_policy",
     ),
-    "get_secret": ("litellm.secret_managers.main", "get_secret"),
     "get_coroutine_checker": (
         "litellm.litellm_core_utils.cached_imports",
         "get_coroutine_checker",

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -351,7 +351,6 @@ if TYPE_CHECKING:
         get_num_retries_from_retry_policy,
         reset_retry_policy,
     )
-    from litellm.secret_managers.main import get_secret
 
     # Type stubs for lazy-loaded config classes and types
     from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
@@ -383,6 +382,8 @@ if TYPE_CHECKING:
         ChatCompletionToolCallFunctionChunk,
     )
     from litellm.types.router import LiteLLM_Params
+
+from litellm.secret_managers.main import get_secret
 
 from litellm.llms.base_llm.chat.transformation import BaseConfig
 from litellm.llms.base_llm.completion.transformation import BaseTextCompletionConfig


### PR DESCRIPTION
NOTE: The PR that caused this regression had all the tests passing at the time of merging
<img width="629" height="453" alt="image" src="https://github.com/user-attachments/assets/043c8234-5950-42ae-97bf-72b654ce9440" />

## Summary
- Import `get_secret` at module runtime in `litellm/utils.py` instead of only under `TYPE_CHECKING`.
- Fixes `NameError: name 'get_secret' is not defined` on Azure paths in `get_optional_params` (and other call sites using `LOAD_GLOBAL`), which broke `test_user_config_two_region_failover` and any PR hitting that code path.

## Root cause
PEP 562 `__getattr__` does not apply to global name resolution inside functions in the same module; `get_secret` must live in the module dict at runtime.

## Test plan
- [x] `pytest tests/test_litellm/test_router_weighted_failover.py::test_user_config_two_region_failover -v`
- [x] `black --check` on `litellm/utils.py`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: fixes a runtime `NameError` by ensuring `get_secret` exists in `litellm.utils` module globals; only affects import wiring/lazy-import registry behavior.
> 
> **Overview**
> Fixes a runtime import bug where `get_secret` could be undefined inside `litellm/utils.py` functions by moving its import out of the `TYPE_CHECKING` block and into module runtime imports.
> 
> Updates the lazy-import registry (`_lazy_imports_registry.py`) to stop exposing `get_secret` via the `litellm.utils` lazy import path, aligning resolution with the new eager import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d29f481c1c76fe1b3e03c154e462d8790060190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->