### PR TITLE
fix: auto-normalize array of strings in message content to openai spec

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7941,6 +7941,16 @@ def validate_and_fix_openai_messages(messages: List):
         if message.get("tool_calls"):
             message["tool_calls"] = jsonify_tools(tools=message["tool_calls"])
 
+        content = message.get("content")
+        if isinstance(content, list):
+            normalized_content = []
+            for item in content:
+                if isinstance(item, str):
+                    normalized_content.append({"type": "text", "text": item})
+                else:
+                    normalized_content.append(item)
+            message["content"] = normalized_content
+
         convert_msg_to_dict = cast(AllMessageValues, convert_to_dict(message))
         cleaned_message = cleanup_none_field_in_message(message=convert_msg_to_dict)
         new_messages.append(cleaned_message)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4139,18 +4139,3 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
-
-
-def test_normalize_array_of_strings_in_content():
-    from litellm.utils import validate_and_fix_openai_messages
-
-    messages = [
-        {
-            "role": "user",
-            "content": ["what is the capital of France?"],
-        }
-    ]
-    result = validate_and_fix_openai_messages(messages=messages)
-    assert result[0]["content"] == [
-        {"type": "text", "text": "what is the capital of France?"},
-    ]

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -27,6 +27,7 @@ from litellm.utils import (
     get_llm_provider,
     get_optional_params_image_gen,
     is_cached_message,
+    validate_and_fix_openai_messages,
 )
 
 # Adds the parent directory to the system path
@@ -3277,6 +3278,37 @@ class TestIsCachedMessage:
         assert is_cached_message(message) is False
 
 
+def test_normalize_array_of_strings_in_content():
+    """String items in list content become OpenAI multimodal text parts; dict parts unchanged."""
+    only_strings = validate_and_fix_openai_messages(
+        [
+            {
+                "role": "user",
+                "content": ["what is the capital of France?"],
+            }
+        ]
+    )
+    assert only_strings[0]["content"] == [
+        {"type": "text", "text": "what is the capital of France?"}
+    ]
+
+    mixed = validate_and_fix_openai_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    "some text",
+                    {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+                ],
+            }
+        ]
+    )
+    assert mixed[0]["content"] == [
+        {"type": "text", "text": "some text"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+    ]
+
+
 @pytest.mark.asyncio
 class TestProxyLoggingBudgetAlerts:
     """Test budget_alerts method in ProxyLogging class."""
@@ -4107,3 +4139,18 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+def test_normalize_array_of_strings_in_content():
+    from litellm.utils import validate_and_fix_openai_messages
+
+    messages = [
+        {
+            "role": "user",
+            "content": ["what is the capital of France?"],
+        }
+    ]
+    result = validate_and_fix_openai_messages(messages=messages)
+    assert result[0]["content"] == [
+        {"type": "text", "text": "what is the capital of France?"},
+    ]


### PR DESCRIPTION
## Relevant issues

Fixes an observed issue where sending an array of strings in the `content` block (e.g., `["what is the capital of France?"]`) causes an internal `AttributeError: 'str' object has no attribute 'get'`. This previously bubbled up as a `500 Internal Server Error`, confusingly attaching the extracted `llm_provider` to the crash response.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Before:**
Sending an array of strings (e.g "content": ["what is the capital of France?"]) resulted in an internal crash that returned a 500 error containing internal proxy metadata:
```
{
  "error": {
    "message": "'str' object has no attribute 'get'",
    "type": "server_error",
    "param": null,
    "code": null,
    "llm_provider": "openai"
  }
}
```

**After:**
The array of strings is successfully caught and normalized into the strict OpenAI multi-modal dictionary spec before downstream processing, resulting in a successful 200 response:
`[{"type": "text", "text": "what is the capital of France?"}]`

*(Tests passing successfully locally)*

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Updated `validate_and_fix_openai_messages` in `litellm/utils.py` to auto-normalize array-of-strings `content` into standard OpenAI multi-modal dictionaries.
- Added a pytest function to ensure strings within arrays are properly converted while existing dictionaries are preserved.