### PR TITLE
test(proxy): isolate run_server CLI tests from prisma DB-setup path

### DIFF
--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -538,7 +538,13 @@ class TestProxyInitializationHelpers:
 
     @patch("uvicorn.run")
     @patch("builtins.print")
-    def test_keepalive_timeout_flag(self, mock_print, mock_uvicorn_run):
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch(
+        "litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False
+    )
+    def test_keepalive_timeout_flag(
+        self, mock_should_update, mock_setup_db, mock_print, mock_uvicorn_run
+    ):
         """Test that the keepalive_timeout flag is properly passed to uvicorn"""
         from click.testing import CliRunner
 
@@ -551,7 +557,18 @@ class TestProxyInitializationHelpers:
         mock_key_mgmt = MagicMock()
         mock_save_worker_config = MagicMock()
 
+        # Strip DATABASE_URL/DIRECT_URL so run_server doesn't enter the prisma
+        # DB-setup block (un-timeout'd `subprocess.run(["prisma"])` +
+        # migrate-deploy retry loop) — same isolation every other run_server
+        # test in this file uses.
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+
         with (
+            patch.dict(os.environ, clean_env, clear=True),
             patch.dict(
                 "sys.modules",
                 {
@@ -596,7 +613,13 @@ class TestProxyInitializationHelpers:
 
     @patch("uvicorn.run")
     @patch("builtins.print")
-    def test_timeout_worker_healthcheck_flag(self, mock_print, mock_uvicorn_run):
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch(
+        "litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False
+    )
+    def test_timeout_worker_healthcheck_flag(
+        self, mock_should_update, mock_setup_db, mock_print, mock_uvicorn_run
+    ):
         """Test that the --timeout_worker_healthcheck flag is threaded through to the uvicorn init helper."""
         from click.testing import CliRunner
 
@@ -609,7 +632,18 @@ class TestProxyInitializationHelpers:
         mock_key_mgmt = MagicMock()
         mock_save_worker_config = MagicMock()
 
+        # Strip DATABASE_URL/DIRECT_URL so run_server doesn't enter the prisma
+        # DB-setup block (un-timeout'd `subprocess.run(["prisma"])` +
+        # migrate-deploy retry loop) — same isolation every other run_server
+        # test in this file uses.
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+
         with (
+            patch.dict(os.environ, clean_env, clear=True),
             patch.dict(
                 "sys.modules",
                 {


### PR DESCRIPTION
## Summary

`test_keepalive_timeout_flag` and `test_timeout_worker_healthcheck_flag` in `tests/test_litellm/proxy/test_proxy_cli.py` were the only `run_server` tests in that file that neither stripped `DATABASE_URL`/`DIRECT_URL` from the environment nor mocked the prisma DB-setup path.

When a `DATABASE_URL` is present (CI env / cross-test leak within an xdist worker), `run_server --local` enters the DB-setup block and blocks in:

- the un-timeout'd `subprocess.run(["prisma"], capture_output=True)` at `litellm/proxy/proxy_cli.py:987`, then
- the `ProxyExtrasDBManager` `prisma migrate deploy` retry loops (4 × `timeout=60` + backoff, repeated)

On the CI runner (no reachable Postgres) this is ~370s per test. Because `--dist=loadscope` pins both tests (same module) to one xdist worker, the `Unit Tests: Proxy Infrastructure` job spends ~12.5 min on that single worker while the other finishes in ~3 min — the run appears stuck at 99% and crosses the 20-minute job timeout.

The fix applies the same isolation every other `run_server` test in this file already uses: mock `PrismaManager.setup_database` + `should_update_prisma_schema`, and strip `DATABASE_URL`/`DIRECT_URL` via `patch.dict(os.environ, clean_env, clear=True)`. Tests-only change; no production code touched.

## Test plan

Reproduced and verified locally (`tests/test_litellm/proxy/test_proxy_cli.py`, full module):

| | before | after |
|---|---|---|
| Full module (32 tests) | 31.7s | 2.9s |
| `test_keepalive_timeout_flag` | 21.7s | <0.01s |
| `test_timeout_worker_healthcheck_flag` | 6.8s | <0.01s |
| Either test with `DATABASE_URL` set | 36.9s | 0.01s |

The two tests fall off the slow-durations list entirely and behave like the other 30 `run_server` siblings. Assertions (uvicorn arg threading) are unchanged and still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests now explicitly avoid the Prisma DB-setup path when `DATABASE_URL`/`DIRECT_URL` are present, reducing CI flakiness/timeouts; production behavior is unchanged. Risk is low since changes are limited to test isolation/mocking.
> 
> **Overview**
> Makes `test_keepalive_timeout_flag` and `test_timeout_worker_healthcheck_flag` consistent with other `run_server` CLI tests by **preventing accidental entry into the Prisma DB-setup path**.
> 
> Both tests now (1) patch `PrismaManager.setup_database` and `should_update_prisma_schema` and (2) run under a sanitized env (`patch.dict(..., clear=True)`) that strips `DATABASE_URL`/`DIRECT_URL`, keeping assertions focused on uvicorn arg threading without triggering slow DB/migration subprocess work in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebb6061f86a21b933749fa89d097c05daa8a4da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->