### PR TITLE
Convert 'thinking' parameter to 'reasoning_effort' for Claude models

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -151,8 +151,13 @@ class GithubCopilotConfig(OpenAIConfig):
         global ``openAIGPTConfig`` whose supported-params list does not include
         ``reasoning_effort`` for Claude models, so a deferred write would be dropped.
         """
-        thinking = non_default_params.pop("thinking", None)
-        existing_reasoning_effort = non_default_params.get("reasoning_effort")
+        if "claude" in model.lower():
+            thinking = non_default_params.pop("thinking", None)
+        else:
+            thinking = None
+        existing_reasoning_effort = non_default_params.get(
+            "reasoning_effort"
+        ) or optional_params.get("reasoning_effort")
         if (
             thinking is not None
             and isinstance(thinking, dict)
@@ -169,7 +174,7 @@ class GithubCopilotConfig(OpenAIConfig):
             else:
                 reasoning_effort = "minimal"
             optional_params["reasoning_effort"] = reasoning_effort
-        elif existing_reasoning_effort is not None:
+        elif non_default_params.get("reasoning_effort") is not None:
             optional_params["reasoning_effort"] = non_default_params.pop(
                 "reasoning_effort"
             )

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -130,6 +130,54 @@ class GithubCopilotConfig(OpenAIConfig):
 
         return base_params
 
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map OpenAI params to GitHub Copilot params.
+
+        GitHub Copilot uses an OpenAI-compatible API and does not understand the
+        Anthropic-native ``thinking`` parameter. When Claude Code calls the proxy's
+        ``/v1/messages`` endpoint with ``thinking`` and the request is routed to a
+        ``github_copilot/claude-*`` model, ``thinking`` must be converted to
+        ``reasoning_effort`` before being forwarded to the Copilot API.
+
+        ``reasoning_effort`` is written directly to ``optional_params`` rather than
+        deferred to the parent: ``OpenAIConfig.map_openai_params`` dispatches to the
+        global ``openAIGPTConfig`` whose supported-params list does not include
+        ``reasoning_effort`` for Claude models, so a deferred write would be dropped.
+        """
+        thinking = non_default_params.pop("thinking", None)
+        existing_reasoning_effort = non_default_params.get("reasoning_effort")
+        if (
+            thinking is not None
+            and isinstance(thinking, dict)
+            and thinking.get("type") == "enabled"
+            and existing_reasoning_effort is None
+        ):
+            budget_tokens = thinking.get("budget_tokens", 0)
+            if budget_tokens >= 10000:
+                reasoning_effort = "high"
+            elif budget_tokens >= 5000:
+                reasoning_effort = "medium"
+            elif budget_tokens >= 2000:
+                reasoning_effort = "low"
+            else:
+                reasoning_effort = "minimal"
+            optional_params["reasoning_effort"] = reasoning_effort
+        elif existing_reasoning_effort is not None:
+            optional_params["reasoning_effort"] = non_default_params.pop(
+                "reasoning_effort"
+            )
+
+        return super().map_openai_params(
+            non_default_params, optional_params, model, drop_params
+        )
+
     def _determine_initiator(self, messages: List[AllMessageValues]) -> str:
         """
         Determine if request is user or agent initiated based on message roles.

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -174,7 +174,10 @@ class GithubCopilotConfig(OpenAIConfig):
             else:
                 reasoning_effort = "minimal"
             optional_params["reasoning_effort"] = reasoning_effort
-        elif non_default_params.get("reasoning_effort") is not None:
+        elif (
+            "claude" in model.lower()
+            and non_default_params.get("reasoning_effort") is not None
+        ):
             optional_params["reasoning_effort"] = non_default_params.pop(
                 "reasoning_effort"
             )

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -164,7 +164,7 @@ class GithubCopilotConfig(OpenAIConfig):
             and thinking.get("type") == "enabled"
             and existing_reasoning_effort is None
         ):
-            budget_tokens = thinking.get("budget_tokens", 0)
+            budget_tokens = thinking.get("budget_tokens") or 0
             if budget_tokens >= 10000:
                 reasoning_effort = "high"
             elif budget_tokens >= 5000:

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -535,6 +535,34 @@ def test_map_openai_params_no_thinking_leaves_params_unchanged():
     assert optional_params.get("temperature") == 0.5
 
 
+def test_map_openai_params_thinking_does_not_overwrite_reasoning_effort_in_optional_params():
+    """``reasoning_effort`` already in ``optional_params`` must not be overwritten
+    by the ``thinking`` conversion."""
+    config = GithubCopilotConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 15000}},
+        optional_params={"reasoning_effort": "low"},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert optional_params["reasoning_effort"] == "low"
+
+
+def test_map_openai_params_thinking_not_popped_for_non_claude_model():
+    """For non-Claude models, ``thinking`` must not be silently discarded —
+    it should pass through to the parent's unsupported-param handling."""
+    config = GithubCopilotConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 15000}},
+        optional_params={},
+        model="gpt-4o",
+        drop_params=False,
+    )
+    assert "reasoning_effort" not in optional_params
+
+
 def test_copilot_vision_request_header_with_image():
     """Test that Copilot-Vision-Request header is added when messages contain images"""
     config = GithubCopilotConfig()

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -433,6 +433,108 @@ def test_get_supported_openai_params_case_insensitive():
     assert "reasoning_effort" not in supported_params_35
 
 
+def test_map_openai_params_converts_thinking_to_reasoning_effort():
+    """
+    Test that Anthropic-native ``thinking`` is converted to ``reasoning_effort`` for
+    GitHub Copilot Claude models.
+
+    GitHub Copilot uses an OpenAI-compatible API and does not understand the
+    Anthropic ``thinking`` parameter. When Claude Code sends ``thinking`` via the
+    proxy's ``/v1/messages`` endpoint, litellm must translate it to
+    ``reasoning_effort`` before forwarding to Copilot.
+    """
+    config = GithubCopilotConfig()
+    model = "claude-sonnet-4-20250514"
+
+    # budget_tokens < 2000 -> "minimal"
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 1024}},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert optional_params["reasoning_effort"] == "minimal"
+
+    # 2000 <= budget_tokens < 5000 -> "low"
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 2000}},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert optional_params["reasoning_effort"] == "low"
+
+    # 5000 <= budget_tokens < 10000 -> "medium"
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 5000}},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert optional_params["reasoning_effort"] == "medium"
+
+    # budget_tokens >= 10000 -> "high"
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 15000}},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert optional_params["reasoning_effort"] == "high"
+
+
+def test_map_openai_params_thinking_does_not_overwrite_existing_reasoning_effort():
+    """Caller-supplied ``reasoning_effort`` must not be overwritten by the
+    ``thinking`` translation."""
+    config = GithubCopilotConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "thinking": {"type": "enabled", "budget_tokens": 15000},
+            "reasoning_effort": "low",
+        },
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert optional_params["reasoning_effort"] == "low"
+
+
+def test_map_openai_params_disabled_thinking_is_dropped():
+    """``thinking`` with ``type=disabled`` should be dropped without producing
+    ``reasoning_effort``."""
+    config = GithubCopilotConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "disabled"}},
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert "reasoning_effort" not in optional_params
+
+
+def test_map_openai_params_no_thinking_leaves_params_unchanged():
+    """A request without ``thinking`` should not gain a ``reasoning_effort`` value."""
+    config = GithubCopilotConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"temperature": 0.5},
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert "thinking" not in optional_params
+    assert "reasoning_effort" not in optional_params
+    assert optional_params.get("temperature") == 0.5
+
+
 def test_copilot_vision_request_header_with_image():
     """Test that Copilot-Vision-Request header is added when messages contain images"""
     config = GithubCopilotConfig()

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -563,6 +563,20 @@ def test_map_openai_params_thinking_not_popped_for_non_claude_model():
     assert "reasoning_effort" not in optional_params
 
 
+def test_map_openai_params_reasoning_effort_not_promoted_for_non_claude_model():
+    """For non-Claude models, ``reasoning_effort`` must not be force-promoted
+    to ``optional_params``; the parent's supported-params filtering must run."""
+    config = GithubCopilotConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model="gpt-4",
+        drop_params=True,
+    )
+    assert "reasoning_effort" not in optional_params
+
+
 def test_copilot_vision_request_header_with_image():
     """Test that Copilot-Vision-Request header is added when messages contain images"""
     config = GithubCopilotConfig()


### PR DESCRIPTION
…t' for Claude models

## Relevant issues

Fixes #25666

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:


- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
```
=============================== test session starts ===============================
platform win32 -- Python 3.12.11, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\tobio\PycharmProjects\litellm\.venv\Scripts\python.exe
codspeed: 4.3.0 (disabled, mode: walltime, callgraph: not supported, timer_resolution: 100.0ns)
cachedir: .pytest_cache
rootdir: C:\Users\tobio\PycharmProjects\litellm
configfile: pyproject.toml
plugins: anyio-4.13.0, ddtrace-2.19.0, langsmith-0.8.0, logfire-4.6.0, asyncio-1.3.0, codspeed-4.3.0, cov-5.0.0, mock-3.15.1, postgresql-7.0.2, recording-0.13.4, rerunfailures-15.1, retry-1.7.0, timeout-2.4.0, xdist-3.8.0, requests-mock-1.12.1, respx-0.22.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collected 19 items                                                                 

tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_completion_github_copilot_mock_response PASSED [  5%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_copilot_vision_request_header_text_only PASSED [ 10%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_copilot_vision_request_header_with_image PASSED [ 15%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_copilot_vision_request_header_with_type_image_url PASSED [ 21%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_get_supported_openai_params_case_insensitive PASSED [ 26%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_get_supported_openai_params_claude_model PASSED [ 31%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_github_copilot_config_get_openai_compatible_provider_info PASSED [ 36%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_map_openai_params_converts_thinking_to_reasoning_effort PASSED [ 42%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_map_openai_params_disabled_thinking_is_dropped PASSED [ 47%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_map_openai_params_no_thinking_leaves_params_unchanged PASSED [ 52%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_map_openai_params_thinking_does_not_overwrite_existing_reasoning_effort PASSED [ 57%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_transform_messages_disable_copilot_system_to_assistant PASSED [ 63%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_agent_request_with_assistant PASSED [ 68%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_agent_request_with_tool PASSED [ 73%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_empty_messages PASSED [ 78%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_mixed_messages_with_agent_roles PASSED [ 84%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_system_only_messages PASSED [ 89%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_user_only_messages PASSED [ 94%]
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py::test_x_initiator_header_user_request PASSED [100%]

=============================== 19 passed in 1.97s ================================

```

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Added map_openai_params override to GithubCopilotConfig in litellm/llms/github_copilot/chat/transformation.py
- When thinking (Anthropic-native) is passed for a github_copilot/claude-* model, it is now converted to reasoning_effort before the request is forwarded to the Copilot API
- Budget token thresholds: ≥10000→high, ≥5000→medium, ≥2000→low, <2000→minimal
- Existing reasoning_effort is never overwritten if already set
- Added 4 unit tests in tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py covering all conversion tiers and edge cases