### PR TITLE
test(gemini): de-flake test_gemini_image_size_limit_exceeded

### DIFF
--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1594,13 +1594,46 @@ def test_gemini_31_flash_lite_reasoning_effort_minimal():
     ), "gemini-3.1-flash-lite-preview should use thinkingLevel, not thinkingBudget"
 
 
-def test_gemini_image_size_limit_exceeded():
+def test_gemini_image_size_limit_exceeded(monkeypatch):
     """
     Test that large images exceeding MAX_IMAGE_URL_DOWNLOAD_SIZE_MB are rejected.
 
     This validates that the 50MB default limit prevents downloading very large images
     that could cause memory issues and pod crashes.
+
+    The image fetch is mocked (mirroring the LargeImageClient pattern in
+    tests/test_litellm/litellm_core_utils/test_image_handling.py) so the test
+    deterministically exercises the size-limit rejection path without any
+    external network dependency.
     """
+    from httpx import Request, Response
+
+    from litellm.litellm_core_utils.prompt_templates import image_handling
+
+    class LargeImageClient:
+        """Returns a response whose Content-Length exceeds the 50MB limit."""
+
+        def get(self, url, follow_redirects=True):
+            size_bytes = int(100 * 1024 * 1024)  # 100MB > 50MB default limit
+            return Response(
+                status_code=200,
+                headers={
+                    "Content-Type": "image/jpeg",
+                    "Content-Length": str(size_bytes),
+                },
+                content=b"x" * size_bytes,
+                request=Request("GET", url),
+            )
+
+    # Bypass SSRF validation (which would resolve DNS / hit the network) and
+    # route straight to our mocked client.
+    monkeypatch.setattr(
+        image_handling,
+        "safe_get",
+        lambda client, url, **kw: client.get(url, follow_redirects=True),
+    )
+    monkeypatch.setattr(litellm, "module_level_client", LargeImageClient())
+
     messages = [
         {
             "role": "user",
@@ -1608,7 +1641,7 @@ def test_gemini_image_size_limit_exceeded():
                 {"type": "text", "text": "What is in this image?"},
                 {
                     "type": "image_url",
-                    "image_url": "https://upload.wikimedia.org/wikipedia/commons/5/51/Blue_Marble_2002.jpg",
+                    "image_url": "https://example.com/large-image.jpg",
                 },
             ],
         }

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1621,7 +1621,10 @@ def test_gemini_image_size_limit_exceeded(monkeypatch):
                     "Content-Type": "image/jpeg",
                     "Content-Length": str(size_bytes),
                 },
-                content=b"x" * size_bytes,
+                # Empty body: the Content-Length header check in
+                # _process_image_response rejects the image before the body
+                # is ever streamed, so there's no need to allocate 100MB.
+                content=b"",
                 request=Request("GET", url),
             )
 


### PR DESCRIPTION
## Summary

`tests/llm_translation/test_gemini.py::test_gemini_image_size_limit_exceeded` is flaky in CI. It downloaded a 50MB+ image from `upload.wikimedia.org` to assert the image exceeds `MAX_IMAGE_URL_DOWNLOAD_SIZE_MB`. Wikimedia intermittently rate-limited the runner (HTTP 429), so the code raised `ImageFetchError("Unable to fetch image ... Status code: 429")`. `pytest.raises(litellm.ImageFetchError)` still matched, but `assert "Image size" in error_message` failed.

## Fix

Remove the external-network dependency by mirroring the established `LargeImageClient` pattern in `tests/test_litellm/litellm_core_utils/test_image_handling.py`:

- Stub `litellm.module_level_client` with a client returning a response whose `Content-Length` reports 100MB (> 50MB default limit).
- Bypass SSRF validation (`image_handling.safe_get`) so no DNS resolution / network call occurs.
- Keep the `completion(model="gemini/...")` call so the gemini path's size-limit rejection is still exercised end-to-end.

The test now deterministically hits the size-limit path and is fully offline.

## Test plan

```
uv run pytest tests/llm_translation/test_gemini.py::test_gemini_image_size_limit_exceeded -v
```

Passes in 0.24s with no network access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that removes an external network dependency by mocking HTTP image download behavior; no production logic is modified.
> 
> **Overview**
> Makes `test_gemini_image_size_limit_exceeded` deterministic by removing the real Wikimedia download and instead monkeypatching image fetching to return a mocked `httpx.Response` with an oversized `Content-Length`.
> 
> The test now stubs `image_handling.safe_get` and `litellm.module_level_client` (via a local `LargeImageClient`) to force the size-limit rejection path offline, and updates the URL/assertions to validate the expected "exceeds maximum allowed size" error text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c537f70a3e9939856cd1954f941642e1c2a982a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->