### PR TITLE
test(reasoning_effort): add cross-provider wire-translation matrix

### DIFF
--- a/tests/llm_translation/reasoning_effort_matrix/conftest.py
+++ b/tests/llm_translation/reasoning_effort_matrix/conftest.py
@@ -1,0 +1,107 @@
+"""Self-contained matrix plumbing.
+
+This conftest adds ONLY:
+
+* a ``pytest_terminal_summary`` hook that, when any matrix cell fails,
+  reprints the result as the at-a-glance route x effort grid the manual QA
+  sweep produced (scattered xdist failures are otherwise unreadable);
+* a ``ci_record_enabled`` gate used to skip the live VCR-recorded
+  provider-acceptance test off-CI.
+
+It does NOT touch the shared ``tests/llm_translation/conftest.py`` VCR
+plumbing — pytest loads that parent conftest for this subdirectory
+automatically, so the live test still records/replays through Redis-VCR in
+CI with zero modification to existing files.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import Dict, Tuple
+
+_MATRIX_FILE = "test_reasoning_effort_wire_matrix.py"
+
+# (route, entrypoint, canonical, effort_label) -> "pass" | "fail" | "skip"
+_OUTCOMES: Dict[Tuple[str, str, str, str], str] = {}
+
+
+def ci_record_enabled() -> bool:
+    """True only where the live provider-acceptance call should run.
+
+    Mirrors the repo's VCR gate: a recorded/replayed call needs
+    ``CASSETTE_REDIS_URL`` (a CircleCI project secret). Off-CI it is unset,
+    so the live half stays dormant and the deterministic offline half is the
+    whole local signal. ``MATRIX_FORCE_LIVE=1`` is an explicit local override.
+    """
+    if os.environ.get("LITELLM_VCR_DISABLE") == "1":
+        return os.environ.get("MATRIX_FORCE_LIVE") == "1"
+    return bool(os.environ.get("CASSETTE_REDIS_URL")) or (
+        os.environ.get("MATRIX_FORCE_LIVE") == "1"
+    )
+
+
+def _parse_cell_id(nodeid: str):
+    if _MATRIX_FILE not in nodeid or "[" not in nodeid:
+        return None
+    param = nodeid.split("[", 1)[1].rsplit("]", 1)[0]
+    parts = param.split("__")
+    if len(parts) != 4:
+        return None
+    return tuple(parts)  # (route, entrypoint, canonical, effort_label)
+
+
+def pytest_runtest_logreport(report):
+    if report.when != "call" and not (report.when == "setup" and report.skipped):
+        return
+    cell = _parse_cell_id(report.nodeid)
+    if cell is None:
+        return
+    if report.failed:
+        _OUTCOMES[cell] = "fail"
+    elif report.skipped:
+        _OUTCOMES.setdefault(cell, "skip")
+    elif report.passed and report.when == "call":
+        _OUTCOMES.setdefault(cell, "pass")
+
+
+_MARK = {"pass": "✅", "fail": "❌", "skip": "·"}
+
+
+def pytest_terminal_summary(terminalreporter):
+    if not _OUTCOMES or not any(v == "fail" for v in _OUTCOMES.values()):
+        return
+
+    tw = terminalreporter
+    tw.write_sep("=", "reasoning_effort wire matrix — failure grid")
+
+    # group: (route, entrypoint) -> {canonical -> {effort_label -> mark}}
+    grids: Dict[Tuple[str, str], Dict[str, Dict[str, str]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+    efforts_seen: Dict[Tuple[str, str], list] = defaultdict(list)
+    for (route, entry, canonical, effort), outcome in _OUTCOMES.items():
+        grids[(route, entry)][canonical][effort] = _MARK.get(outcome, "?")
+        if effort not in efforts_seen[(route, entry)]:
+            efforts_seen[(route, entry)].append(effort)
+
+    for (route, entry), rows in sorted(grids.items()):
+        has_fail = any(m == "❌" for cols in rows.values() for m in cols.values())
+        if not has_fail:
+            continue
+        cols = efforts_seen[(route, entry)]
+        tw.write_line("")
+        tw.write_line(f"### {route} / {entry}")
+        header = "model".ljust(14) + " | " + " | ".join(c[:7].ljust(7) for c in cols)
+        tw.write_line(header)
+        tw.write_line("-" * len(header))
+        for canonical in sorted(rows):
+            line = (
+                canonical.ljust(14)
+                + " | "
+                + " | ".join(rows[canonical].get(c, " ").center(7) for c in cols)
+            )
+            tw.write_line(line)
+
+    tw.write_line("")
+    tw.write_line("Legend: ✅ pass  ❌ fail  · skipped(live/off-CI)")

--- a/tests/llm_translation/reasoning_effort_matrix/spec.py
+++ b/tests/llm_translation/reasoning_effort_matrix/spec.py
@@ -1,0 +1,584 @@
+"""Spec + adapters for the ``reasoning_effort`` wire-translation matrix.
+
+This module is the single source of truth the parametrized matrix test in
+``test_reasoning_effort_wire_matrix.py`` iterates over. It is deliberately
+*independent* of the production mapping code: the expected subtree per
+``(tier, effort)`` is hand-authored from the documented contract (see
+PRs #27039 / #27074), not derived from ``model_prices`` or the transformation
+modules. That independence is what lets the matrix catch data-layer bugs
+(e.g. a wrong capability flag) as well as code-layer ones.
+
+What each cell asserts:
+
+* **Wire cells** — LiteLLM must build a request whose reasoning subtree
+  (``thinking`` + ``output_config``) matches the expected value *and*
+  presence/absence exactly. Captured fully offline (no HTTP, no creds) via
+  the established per-provider transformation idiom.
+* **Client-400 cells** — LiteLLM must reject the request *before any wire
+  call* with a clean 400-class exception (``BadRequestError`` /
+  ``AnthropicError`` @400), never a bare ``ValueError`` (the #27074 bug).
+
+The provider-acceptance half (does Anthropic 200 the request we built) is a
+separate, CI-gated, VCR-recorded test — see the matrix test module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import litellm
+from litellm.llms.anthropic.common_utils import AnthropicError
+
+# --------------------------------------------------------------------------- #
+# Efforts
+# --------------------------------------------------------------------------- #
+
+# Sentinel: send NO ``reasoning_effort`` field at all (the "(omit)" sweep row).
+OMIT = "__omit__"
+
+# Ordered exactly as the QA sweep grid columns.
+EFFORTS: Tuple[str, ...] = (
+    OMIT,
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "disabled",
+    "invalid",
+    "",  # empty string — must be rejected, must NOT leak to the wire
+)
+
+
+def effort_label(effort: str) -> str:
+    """Stable, filesystem/pytest-id-safe label for an effort value."""
+    if effort == OMIT:
+        return "OMIT"
+    if effort == "":
+        return "EMPTY"
+    return effort
+
+
+# --------------------------------------------------------------------------- #
+# Tiers + model -> tier map (HAND-AUTHORED — independent of model_prices)
+# --------------------------------------------------------------------------- #
+
+ADAPTIVE_FULL = "adaptive_full"  # adaptive thinking; xhigh AND max accepted
+ADAPTIVE_MAX_ONLY = "adaptive_max_only"  # adaptive; max accepted, xhigh -> 400
+BUDGET = "budget"  # non-adaptive; thinking={enabled, budget_tokens}, no output_config
+
+TIERS: Tuple[str, ...] = (ADAPTIVE_FULL, ADAPTIVE_MAX_ONLY, BUDGET)
+
+# Canonical model key -> tier. The canonical key is the substring the
+# production ``_is_claude_4_x_model`` family checks key on.
+MODEL_TIER: Dict[str, str] = {
+    "opus-4-7": ADAPTIVE_FULL,
+    "opus-4-6": ADAPTIVE_MAX_ONLY,
+    "sonnet-4-6": ADAPTIVE_MAX_ONLY,
+    "opus-4-5": BUDGET,
+    "sonnet-4-5": BUDGET,
+    "haiku-4-5": BUDGET,
+}
+
+# Reasoning-capable Claude families intentionally NOT in the matrix yet.
+# The staleness canary fails loudly if model_prices grows a reasoning-capable
+# ``claude-*`` family absent from BOTH this allowlist and MODEL_TIER, forcing
+# a human to consciously add the model + its tier + verify its expected column.
+CANARY_ALLOWLIST: frozenset = frozenset(
+    {
+        "3-5-sonnet",
+        "3-5-haiku",
+        "3-7-sonnet",
+        "sonnet-4",  # claude-sonnet-4 (4.0)
+        "opus-4",  # claude-opus-4 (4.0)
+        "opus-4-1",
+        "4-sonnet",
+        "4-opus",
+    }
+)
+
+# --------------------------------------------------------------------------- #
+# Budget ladder (mirrors litellm/constants.py defaults — see HEAD-vs-sweep note)
+# --------------------------------------------------------------------------- #
+
+_BUDGET_TOKENS: Dict[str, int] = {
+    "minimal": 1024,  # floored at ANTHROPIC_MIN_THINKING_BUDGET_TOKENS (#27074)
+    "low": 1024,
+    "medium": 2048,
+    "high": 4096,
+    "xhigh": 8192,
+    "max": 16384,
+}
+
+# Effort -> output_config.effort value for adaptive models.
+_ADAPTIVE_EFFORT: Dict[str, str] = {
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "xhigh",
+    "max": "max",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Expected normalized subtree
+# --------------------------------------------------------------------------- #
+
+CLIENT_400 = "CLIENT_400"  # sentinel: must raise a clean 400 before the wire
+
+
+@dataclass(frozen=True)
+class Expected:
+    """Normalized expected reasoning subtree for one (tier, effort) cell.
+
+    ``thinking`` / ``output_config`` of ``None`` means the key MUST be absent
+    from the built request (presence/absence is asserted, not just value).
+    """
+
+    thinking: Optional[dict]
+    output_config: Optional[dict]
+
+
+def _expected(tier: str, effort: str) -> Union[Expected, str]:
+    # none / omit -> no thinking, no output_config (every tier)
+    if effort in (OMIT, "none"):
+        return Expected(thinking=None, output_config=None)
+
+    # Garbage -> clean client-side 400 (every tier). #27074 turned these from
+    # raw ValueError/500 into BadRequestError/AnthropicError@400.
+    if effort in ("disabled", "invalid", ""):
+        return CLIENT_400
+
+    if tier == BUDGET:
+        return Expected(
+            thinking={"type": "enabled", "budget_tokens": _BUDGET_TOKENS[effort]},
+            output_config=None,
+        )
+
+    # Adaptive tiers.
+    if effort == "xhigh" and tier == ADAPTIVE_MAX_ONLY:
+        # xhigh requires supports_xhigh_reasoning_effort with NO model-family
+        # fallback -> rejected client-side on opus-4-6 / sonnet-4-6.
+        return CLIENT_400
+
+    return Expected(
+        thinking={"type": "adaptive"},
+        output_config={"effort": _ADAPTIVE_EFFORT[effort]},
+    )
+
+
+# Materialized table: (tier, effort) -> Expected | CLIENT_400
+EXPECTED: Dict[Tuple[str, str], Union[Expected, str]] = {
+    (tier, effort): _expected(tier, effort) for tier in TIERS for effort in EFFORTS
+}
+
+
+# --------------------------------------------------------------------------- #
+# Normalized 400-class helper
+# --------------------------------------------------------------------------- #
+
+# Bare exceptions that, if raised, mean the request escaped as a generic 500
+# (the exact #27074 / #27039 regression). Never acceptable.
+_DIRTY_EXCEPTIONS = (ValueError, TypeError, AttributeError, KeyError)
+
+
+def is_clean_400(exc: BaseException) -> bool:
+    """True iff ``exc`` is a clean 400-class rejection (route-agnostic).
+
+    Accepts ``litellm.BadRequestError`` or ``AnthropicError`` with
+    ``status_code == 400``. Explicitly rejects bare Python exceptions, which
+    are exactly what the #27074 fix eliminated.
+    """
+    if isinstance(exc, _DIRTY_EXCEPTIONS) and not isinstance(
+        exc, litellm.exceptions.APIError
+    ):
+        return False
+    if isinstance(exc, litellm.exceptions.BadRequestError):
+        return True
+    if isinstance(exc, AnthropicError):
+        return getattr(exc, "status_code", None) in (400, "400")
+    # Some routes wrap as the generic litellm BadRequest subclass hierarchy.
+    return getattr(exc, "status_code", None) in (400, "400") and not isinstance(
+        exc, _DIRTY_EXCEPTIONS
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Route / entrypoint enumeration
+# --------------------------------------------------------------------------- #
+
+CHAT = "chat_completions"
+MESSAGES = "v1_messages"
+
+MESSAGES_ENTRYPOINT = "messages"
+
+
+@dataclass(frozen=True)
+class Route:
+    name: str
+    # entrypoint -> ordered list of (wire_model_id, canonical_tier_key)
+    models: Dict[str, List[Tuple[str, str]]]
+
+
+# Mirrors the QA-sweep proxy config (PR #27039 comment).
+_ANTHROPIC_MODELS = [
+    ("claude-opus-4-7", "opus-4-7"),
+    ("claude-opus-4-6", "opus-4-6"),
+    ("claude-opus-4-5", "opus-4-5"),
+    ("claude-sonnet-4-6", "sonnet-4-6"),
+    ("claude-sonnet-4-5", "sonnet-4-5"),
+    ("claude-haiku-4-5", "haiku-4-5"),
+]
+
+ROUTES: Tuple[Route, ...] = (
+    Route(
+        name="anthropic",
+        models={
+            CHAT: _ANTHROPIC_MODELS,
+            MESSAGES: [
+                ("claude-opus-4-7", "opus-4-7"),
+                ("claude-opus-4-6", "opus-4-6"),
+                ("claude-sonnet-4-6", "sonnet-4-6"),
+                ("claude-opus-4-5", "opus-4-5"),
+                ("claude-haiku-4-5", "haiku-4-5"),
+            ],
+        },
+    ),
+    Route(
+        name="bedrock_converse",
+        models={
+            CHAT: [
+                ("bedrock/converse/us.anthropic.claude-opus-4-7", "opus-4-7"),
+                ("bedrock/converse/us.anthropic.claude-opus-4-6-v1", "opus-4-6"),
+                (
+                    "bedrock/converse/us.anthropic.claude-opus-4-5-20251101-v1:0",
+                    "opus-4-5",
+                ),
+                ("bedrock/converse/us.anthropic.claude-sonnet-4-6", "sonnet-4-6"),
+                (
+                    "bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                    "sonnet-4-5",
+                ),
+            ],
+        },
+    ),
+    Route(
+        name="bedrock_invoke",
+        models={
+            CHAT: [
+                ("bedrock/invoke/us.anthropic.claude-opus-4-7", "opus-4-7"),
+                ("bedrock/invoke/us.anthropic.claude-opus-4-6-v1", "opus-4-6"),
+                ("bedrock/invoke/us.anthropic.claude-sonnet-4-6", "sonnet-4-6"),
+                (
+                    "bedrock/invoke/us.anthropic.claude-opus-4-5-20251101-v1:0",
+                    "opus-4-5",
+                ),
+            ],
+            MESSAGES: [
+                ("anthropic.claude-opus-4-7", "opus-4-7"),
+                ("anthropic.claude-opus-4-6", "opus-4-6"),
+                ("anthropic.claude-sonnet-4-6", "sonnet-4-6"),
+                ("anthropic.claude-opus-4-5", "opus-4-5"),
+            ],
+        },
+    ),
+    Route(
+        name="vertex_ai",
+        models={
+            CHAT: [
+                ("claude-opus-4-7", "opus-4-7"),
+                ("claude-opus-4-6", "opus-4-6"),
+                ("claude-sonnet-4-6", "sonnet-4-6"),
+                ("claude-haiku-4-5", "haiku-4-5"),
+            ],
+        },
+    ),
+    Route(
+        name="azure_ai",
+        models={
+            CHAT: [
+                ("claude-opus-4-7", "opus-4-7"),
+                ("claude-opus-4-6", "opus-4-6"),
+                ("claude-sonnet-4-6", "sonnet-4-6"),
+                ("claude-haiku-4-5", "haiku-4-5"),
+            ],
+        },
+    ),
+)
+
+ROUTES_BY_NAME: Dict[str, Route] = {r.name: r for r in ROUTES}
+
+
+# --------------------------------------------------------------------------- #
+# Per-route wire-request capture adapters (fully offline — no HTTP, no creds)
+# --------------------------------------------------------------------------- #
+
+
+def _completion_optional_params(config: Any, model: str, effort: str) -> dict:
+    """Run ``map_openai_params`` exactly as the proxy would for this effort."""
+    non_default: dict = {}
+    if effort != OMIT:
+        non_default["reasoning_effort"] = effort
+    return config.map_openai_params(
+        non_default_params=non_default,
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+
+def _normalize(thinking: Any, output_config: Any) -> Dict[str, Optional[dict]]:
+    return {
+        "thinking": thinking if isinstance(thinking, dict) else None,
+        "output_config": output_config if isinstance(output_config, dict) else None,
+    }
+
+
+_MESSAGES = [{"role": "user", "content": "What is 2+2?"}]
+
+
+def _capture_anthropic_chat(model: str, effort: str) -> Dict[str, Optional[dict]]:
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    config = AnthropicConfig()
+    op = _completion_optional_params(config, model, effort)
+    op.setdefault("max_tokens", 1024)
+    result = config.transform_request(
+        model=model,
+        messages=list(_MESSAGES),
+        optional_params=op,
+        litellm_params={},
+        headers={},
+    )
+    return _normalize(result.get("thinking"), result.get("output_config"))
+
+
+def _capture_bedrock_converse_chat(
+    model: str, effort: str
+) -> Dict[str, Optional[dict]]:
+    from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+    config = AmazonConverseConfig()
+    op = _completion_optional_params(config, model, effort)
+    op["maxTokens"] = 1024
+    result = config._transform_request(
+        model=model,
+        messages=list(_MESSAGES),
+        optional_params=op,
+        litellm_params={},
+        headers={},
+    )
+    additional = result.get("additionalModelRequestFields") or {}
+    # thinking value comes from the post-map params (what the PR test asserts);
+    # output_config placement is the #27074-item-1 wire regression.
+    return _normalize(op.get("thinking"), additional.get("output_config"))
+
+
+def _capture_bedrock_invoke_chat(model: str, effort: str) -> Dict[str, Optional[dict]]:
+    from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeConfig,
+    )
+
+    config = AmazonAnthropicClaudeConfig()
+    op = _completion_optional_params(config, model, effort)
+    op.setdefault("max_tokens", 1024)
+    result = config.transform_request(
+        model=model,
+        messages=list(_MESSAGES),
+        optional_params=op,
+        litellm_params={},
+        headers={},
+    )
+    return _normalize(result.get("thinking"), result.get("output_config"))
+
+
+def _capture_vertex_chat(model: str, effort: str) -> Dict[str, Optional[dict]]:
+    from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.transformation import (
+        VertexAIAnthropicConfig,
+    )
+
+    config = VertexAIAnthropicConfig()
+    op = _completion_optional_params(config, model, effort)
+    op.setdefault("max_tokens", 1024)
+    result = config.transform_request(
+        model=model,
+        messages=list(_MESSAGES),
+        optional_params=op,
+        litellm_params={},
+        headers={},
+    )
+    return _normalize(result.get("thinking"), result.get("output_config"))
+
+
+def _capture_azure_chat(model: str, effort: str) -> Dict[str, Optional[dict]]:
+    from litellm.llms.azure_ai.anthropic.transformation import AzureAnthropicConfig
+
+    config = AzureAnthropicConfig()
+    op = _completion_optional_params(config, model, effort)
+    op.setdefault("max_tokens", 1024)
+    result = config.transform_request(
+        model=model,
+        messages=list(_MESSAGES),
+        optional_params=op,
+        litellm_params={},
+        headers={},
+    )
+    return _normalize(result.get("thinking"), result.get("output_config"))
+
+
+def _messages_optional_params(effort: str) -> dict:
+    params: dict = {"max_tokens": 1024}
+    if effort != OMIT:
+        params["reasoning_effort"] = effort
+    return params
+
+
+def _capture_anthropic_messages(model: str, effort: str) -> Dict[str, Optional[dict]]:
+    from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+        AnthropicMessagesConfig,
+    )
+
+    config = AnthropicMessagesConfig()
+    result = config.transform_anthropic_messages_request(
+        model=model,
+        messages=list(_MESSAGES),
+        anthropic_messages_optional_request_params=_messages_optional_params(effort),
+        litellm_params={},
+        headers={},
+    )
+    return _normalize(result.get("thinking"), result.get("output_config"))
+
+
+def _capture_bedrock_invoke_messages(
+    model: str, effort: str
+) -> Dict[str, Optional[dict]]:
+    from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeMessagesConfig,
+    )
+    from litellm.types.router import GenericLiteLLMParams
+
+    config = AmazonAnthropicClaudeMessagesConfig()
+    result = config.transform_anthropic_messages_request(
+        model=model,
+        messages=list(_MESSAGES),
+        anthropic_messages_optional_request_params=_messages_optional_params(effort),
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    return _normalize(result.get("thinking"), result.get("output_config"))
+
+
+_CHAT_ADAPTERS: Dict[str, Callable[[str, str], Dict[str, Optional[dict]]]] = {
+    "anthropic": _capture_anthropic_chat,
+    "bedrock_converse": _capture_bedrock_converse_chat,
+    "bedrock_invoke": _capture_bedrock_invoke_chat,
+    "vertex_ai": _capture_vertex_chat,
+    "azure_ai": _capture_azure_chat,
+}
+
+_MESSAGES_ADAPTERS: Dict[str, Callable[[str, str], Dict[str, Optional[dict]]]] = {
+    "anthropic": _capture_anthropic_messages,
+    "bedrock_invoke": _capture_bedrock_invoke_messages,
+}
+
+
+def build_wire_request(
+    route: str, entrypoint: str, model: str, effort: str
+) -> Dict[str, Optional[dict]]:
+    """Capture the normalized reasoning subtree LiteLLM would put on the wire.
+
+    Fully offline. Propagates the production exception for client-rejected
+    efforts (the test classifies it via :func:`is_clean_400`).
+    """
+    adapters = _CHAT_ADAPTERS if entrypoint == CHAT else _MESSAGES_ADAPTERS
+    if route not in adapters:
+        raise KeyError(f"no {entrypoint} adapter for route {route!r}")
+    return adapters[route](model, effort)
+
+
+# --------------------------------------------------------------------------- #
+# Parametrization helpers
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Cell:
+    route: str
+    entrypoint: str
+    model: str
+    canonical: str
+    effort: str
+
+    @property
+    def tier(self) -> str:
+        return MODEL_TIER[self.canonical]
+
+    @property
+    def expected(self) -> Union[Expected, str]:
+        return EXPECTED[(self.tier, self.effort)]
+
+    @property
+    def id(self) -> str:
+        return f"{self.route}__{self.entrypoint}__{self.canonical}__{effort_label(self.effort)}"
+
+
+def all_cells() -> List[Cell]:
+    cells: List[Cell] = []
+    for route in ROUTES:
+        for entrypoint, models in route.models.items():
+            for wire_model, canonical in models:
+                for effort in EFFORTS:
+                    cells.append(
+                        Cell(
+                            route=route.name,
+                            entrypoint=entrypoint,
+                            model=wire_model,
+                            canonical=canonical,
+                            effort=effort,
+                        )
+                    )
+    return cells
+
+
+# --------------------------------------------------------------------------- #
+# Staleness canary data
+# --------------------------------------------------------------------------- #
+
+
+def _model_prices_path() -> str:
+    here = os.path.dirname(__file__)
+    # repo_root/model_prices_and_context_window.json
+    root = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    return os.path.join(root, "model_prices_and_context_window.json")
+
+
+def unmapped_reasoning_claude_families() -> List[str]:
+    """Reasoning-capable anthropic ``claude-*`` families absent from the matrix.
+
+    A non-empty result means a new model shipped that the matrix silently
+    under-covers — the canary test fails so a human adds it consciously.
+    """
+    with open(_model_prices_path()) as fh:
+        prices = json.load(fh)
+
+    known = set(MODEL_TIER) | set(CANARY_ALLOWLIST)
+    unmapped: set = set()
+    for name, meta in prices.items():
+        if not isinstance(meta, dict):
+            continue
+        if meta.get("litellm_provider") != "anthropic":
+            continue
+        if not meta.get("supports_reasoning"):
+            continue
+        if "claude" not in name:
+            continue
+        if any(token in name for token in known):
+            continue
+        unmapped.add(name)
+    return sorted(unmapped)

--- a/tests/llm_translation/reasoning_effort_matrix/test_reasoning_effort_wire_matrix.py
+++ b/tests/llm_translation/reasoning_effort_matrix/test_reasoning_effort_wire_matrix.py
@@ -1,0 +1,149 @@
+"""reasoning_effort wire-translation matrix.
+
+Automated successor to the manual 231-cell QA sweep behind #27039 / #27074.
+
+Two always-on, fully-offline oracles (the per-PR regression net):
+
+* ``test_wire_request`` — for every (route, entrypoint, model, effort) cell,
+  assert the reasoning subtree LiteLLM builds on the wire matches the
+  hand-authored spec *and* its presence/absence (catches silent strips), or
+  that a client-rejected effort raises a clean 400 (catches the
+  #27074 ValueError->BadRequest fix).
+
+* ``test_no_unmapped_reasoning_models`` — staleness canary; fails loudly when
+  model_prices grows a reasoning-capable Claude family the matrix doesn't
+  cover (the #27039 -> #27074 per-model recurrence).
+
+One CI-gated, VCR-recorded oracle (dormant off-CI):
+
+* ``test_provider_accepts_built_request`` — replays/records the real Anthropic
+  round-trip for wire cells and asserts Anthropic accepted the request
+  LiteLLM built. Skipped locally; the offline oracles are the local signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import litellm
+
+from .conftest import ci_record_enabled
+from .spec import (
+    CHAT,
+    CLIENT_400,
+    MESSAGES,
+    OMIT,
+    Cell,
+    Expected,
+    all_cells,
+    build_wire_request,
+    is_clean_400,
+    unmapped_reasoning_claude_families,
+)
+
+_CELLS = all_cells()
+_IDS = [c.id for c in _CELLS]
+
+
+@pytest.mark.parametrize("cell", _CELLS, ids=_IDS)
+def test_wire_request(cell: Cell):
+    """Offline: the wire subtree (or clean-400) matches the spec exactly."""
+    expected = cell.expected
+
+    if expected == CLIENT_400:
+        with pytest.raises(BaseException) as ei:  # noqa: PT011 - we classify below
+            build_wire_request(cell.route, cell.entrypoint, cell.model, cell.effort)
+        assert is_clean_400(ei.value), (
+            f"{cell.id}: expected a clean 400-class rejection before the wire, "
+            f"got {type(ei.value).__name__}: {ei.value!r}. "
+            f"A bare ValueError/500 here is the exact #27074 regression."
+        )
+        return
+
+    assert isinstance(expected, Expected)
+    built = build_wire_request(cell.route, cell.entrypoint, cell.model, cell.effort)
+
+    # Value AND presence/absence (None == key must be absent).
+    assert built["thinking"] == expected.thinking, (
+        f"{cell.id}: thinking mismatch — expected {expected.thinking!r}, "
+        f"built {built['thinking']!r}"
+    )
+    assert built["output_config"] == expected.output_config, (
+        f"{cell.id}: output_config mismatch — expected "
+        f"{expected.output_config!r}, built {built['output_config']!r}"
+    )
+
+
+def test_no_unmapped_reasoning_models():
+    """Staleness canary — see spec.unmapped_reasoning_claude_families."""
+    unmapped = unmapped_reasoning_claude_families()
+    assert not unmapped, (
+        "model_prices has reasoning-capable Claude families not covered by the "
+        f"matrix: {unmapped}. Add each to spec.MODEL_TIER with its tier (and "
+        "expected column), or to CANARY_ALLOWLIST if intentionally excluded."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CI-gated live provider-acceptance (VCR-recorded; dormant off-CI)
+# --------------------------------------------------------------------------- #
+
+_LIVE_TRANSIENT = (
+    litellm.ServiceUnavailableError,
+    litellm.Timeout,
+    litellm.RateLimitError,
+    litellm.InternalServerError,
+)
+
+# Scope the live half to the Anthropic-direct route: ANTHROPIC_API_KEY is the
+# one provider credential reliably present in the llm_translation CI job.
+# Bedrock/Vertex/Azure live coverage is a documented future extension.
+_LIVE_CELLS = [
+    c
+    for c in _CELLS
+    if c.route == "anthropic"
+    and not isinstance(c.expected, str)  # wire cells only (client-400 done offline)
+]
+_LIVE_IDS = [c.id for c in _LIVE_CELLS]
+
+
+@pytest.mark.skipif(
+    not ci_record_enabled(),
+    reason="live provider-acceptance is CI/VCR-only (set CASSETTE_REDIS_URL "
+    "or MATRIX_FORCE_LIVE=1)",
+)
+@pytest.mark.parametrize("cell", _LIVE_CELLS, ids=_LIVE_IDS)
+def test_provider_accepts_built_request(cell: Cell):
+    """CI: Anthropic must accept the request LiteLLM builds for this cell.
+
+    The recorded response is the proof oracle (b): a non-2xx here means
+    LiteLLM built a payload Anthropic rejects — a real regression, not flake.
+    Transient infra errors are skipped (repo convention).
+    """
+    kwargs = {
+        "model": f"anthropic/{cell.model}",
+        "messages": [{"role": "user", "content": "What is 2+2?"}],
+        "max_tokens": 16,
+    }
+    if cell.effort != OMIT:
+        kwargs["reasoning_effort"] = cell.effort
+
+    try:
+        if cell.entrypoint == CHAT:
+            resp = litellm.completion(**kwargs)
+        else:  # MESSAGES
+            resp = litellm.anthropic_messages(
+                model=kwargs["model"],
+                messages=kwargs["messages"],
+                max_tokens=kwargs["max_tokens"],
+                **({"reasoning_effort": cell.effort} if cell.effort != OMIT else {}),
+            )
+    except _LIVE_TRANSIENT as e:
+        pytest.skip(f"transient provider error: {type(e).__name__}: {e}")
+    except litellm.BadRequestError as e:
+        pytest.fail(
+            f"{cell.id}: Anthropic rejected the request LiteLLM built "
+            f"(400). LiteLLM mistranslated this cell. {e}"
+        )
+
+    assert resp is not None, f"{cell.id}: no response from Anthropic"


### PR DESCRIPTION
## Relevant issues

Follow-up regression coverage for the `reasoning_effort` mapping bug class behind #27039 (`reasoning_effort="none"` `NoneType` crash) and #27074 (`output_config.effort` strips + `ValueError`/500 on garbage effort). Automated successor to the manual 231-cell QA sweep on #27039.

## What this PR does

Adds a parametrized, fully-offline matrix under `tests/llm_translation/reasoning_effort_matrix/` covering **5 routes × Claude models × 11 effort values × 2 entrypoints** (`/chat/completions` and `/v1/messages`).

Two always-on offline oracles (the per-PR regression net, no network/creds):

- **Wire request** — asserts the reasoning subtree (`thinking` + `output_config`) LiteLLM builds matches a hand-authored `(tier × effort)` spec, by **value AND presence/absence** (catches silent strips). Client-rejected efforts must raise a clean **400-class** error (`BadRequestError` / `AnthropicError`@400), never a bare `ValueError`/500.
- **Staleness canary** — fails loudly when `model_prices` grows a reasoning-capable Claude family the matrix does not cover, so the per-model recurrence (#27039 → #27074) can't slip through silently.

One CI-gated oracle (dormant off-CI, no new CI config — runs in the existing `llm_translation` job via Redis-VCR):

- **Provider acceptance** — replays/records the real Anthropic round-trip and asserts Anthropic accepts the request LiteLLM built. Skipped locally; activates on `CASSETTE_REDIS_URL`.

Coverage is per-provider idiomatic: `map_openai_params` + `transform_request` for Anthropic / Bedrock Converse (incl. `additionalModelRequestFields` placement) / Bedrock Invoke / Vertex / Azure, and the `*MessagesConfig` transforms for the `/v1/messages` routes. The expected table is hand-authored and independent of `model_prices`/transformation code, so it catches data-layer bugs too. A self-contained `pytest_terminal_summary` hook reprints failures as the sweep's at-a-glance route × effort grid.

The model→tier collapse (`adaptive_full` = opus-4-7; `adaptive_max_only` = opus-4-6 / sonnet-4-6; `budget` = 4.5 family + haiku-4-5) is documented in `spec.py`.

## Testing

`tests/llm_translation/reasoning_effort_matrix/` — `353 passed, 84 skipped` offline (the 84 are the CI-gated live cells, correctly dormant off-CI). Failure-grid rendering verified by a forced-failure smoke run. `black` + `ruff` clean.

## Type

🧪 Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds new tests and pytest hooks; the main risk is added CI runtime/flakiness from the CI-gated live provider-acceptance test.
> 
> **Overview**
> Adds a new `reasoning_effort` wire-translation matrix test suite that parametrizes across multiple Anthropic routes/providers, Claude model tiers, and effort values to assert the exact `thinking`/`output_config` subtree sent on the wire or a *clean* client-side 400 for invalid efforts.
> 
> Introduces a staleness canary that fails if `model_prices_and_context_window.json` gains reasoning-capable Claude families not mapped in the matrix, plus a CI/VCR-gated live Anthropic round-trip acceptance check and a `pytest_terminal_summary` hook that reprints failures as an at-a-glance matrix grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ead9056dea5d28912b564bad1aac8005f59b327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->