### PR TITLE
fix(proxy): correctly expand bare wildcard routes in /v1/models

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -19,7 +19,11 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
     def get_models(
         self, api_key: Optional[str] = None, api_base: Optional[str] = None
     ) -> List[str]:
-        api_base = api_base or get_secret_str("DEEPSEEK_API_BASE") or "https://api.deepseek.com"
+        api_base = (
+            api_base
+            or get_secret_str("DEEPSEEK_API_BASE")
+            or "https://api.deepseek.com"
+        )
         api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
 
         response = litellm.module_level_client.get(

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -4,6 +4,8 @@ Translates from OpenAI's `/v1/chat/completions` to DeepSeek's `/v1/chat/completi
 
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
+import litellm
+
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
@@ -14,6 +16,22 @@ from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
 class DeepSeekChatConfig(OpenAIGPTConfig):
+    def get_models(
+        self, api_key: Optional[str] = None, api_base: Optional[str] = None
+    ) -> List[str]:
+        api_base = api_base or get_secret_str("DEEPSEEK_API_BASE") or "https://api.deepseek.com"
+        api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
+
+        response = litellm.module_level_client.get(
+            url=f"{api_base.rstrip('/')}/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to get models: {response.text}")
+
+        return [model["id"] for model in response.json()["data"]]
+
     def get_supported_openai_params(self, model: str) -> list:
         """
         DeepSeek reasoner models support thinking parameter.

--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -84,7 +84,7 @@ class OllamaModelInfo(BaseLLMModelInfo):
         """
 
         base = self.get_api_base(api_base)
-        api_key = self.get_api_key()
+        api_key = self.get_api_key(api_key)
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
         names: set[str] = set()

--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -65,7 +65,8 @@ class OllamaModelInfo(BaseLLMModelInfo):
         from litellm.secret_managers.main import get_secret_str
 
         return (
-            os.environ.get("OLLAMA_API_KEY")
+            api_key
+            or os.environ.get("OLLAMA_API_KEY")
             or litellm.api_key
             or litellm.openai_key
             or get_secret_str("OLLAMA_API_KEY")

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -33,6 +33,32 @@ class CacheControlSupportedModels(str, Enum):
 
 
 class OpenrouterConfig(OpenAIGPTConfig):
+    @staticmethod
+    def get_api_base(api_base: Optional[str] = None) -> Optional[str]:
+        from litellm.secret_managers.main import get_secret_str
+
+        return (
+            api_base
+            or get_secret_str("OPENROUTER_API_BASE")
+            or "https://openrouter.ai/api/v1"
+        )
+
+    def get_models(
+        self, api_key: Optional[str] = None, api_base: Optional[str] = None
+    ) -> List[str]:
+        api_base = self.get_api_base(api_base)
+        api_key = api_key or litellm.get_secret("OPENROUTER_API_KEY")
+
+        response = litellm.module_level_client.get(
+            url=f"{api_base.rstrip('/')}/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to get models: {response.text}")
+
+        return [model["id"] for model in response.json()["data"]]
+
     def get_supported_openai_params(self, model: str) -> list:
         """
         Allow reasoning parameters for models flagged as reasoning-capable.

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -34,7 +34,7 @@ class CacheControlSupportedModels(str, Enum):
 
 class OpenrouterConfig(OpenAIGPTConfig):
     @staticmethod
-    def get_api_base(api_base: Optional[str] = None) -> Optional[str]:
+    def get_api_base(api_base: Optional[str] = None) -> str:
         from litellm.secret_managers.main import get_secret_str
 
         return (

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -279,6 +279,10 @@ def get_known_models_from_wildcard(
             # add model prefix to wildcard models
             wildcard_models = [f"{model_prefix}{model}" for model in wildcard_models]
 
+    if wildcard_model in {"*", "*/"}:
+        # Bare wildcard aliases should expose upstream ids as-is on /v1/models.
+        return wildcard_models or []
+
     suffix_appended_wildcard_models = []
     for model in wildcard_models:
         if wildcard_provider_prefix and not model.startswith(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -248,7 +248,9 @@ def get_known_models_from_wildcard(
     # (e.g., "openai" from "openai/*" - needed for BYOK where wildcard isn't in router)
     if litellm_params is not None:
         try:
-            provider = litellm_params.model.split("/", 1)[0]
+            provider = (
+                litellm_params.model.split("/", 1)[0] or wildcard_provider_prefix or "*"
+            )
         except ValueError:
             provider = wildcard_provider_prefix or "*"
     else:

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -226,16 +226,20 @@ def get_complete_model_list(
 
     complete_model_list = unique_models + all_wildcard_models
 
-    return complete_model_list
+    return list(dict.fromkeys(complete_model_list))
 
 
 def get_known_models_from_wildcard(
     wildcard_model: str, litellm_params: Optional[LiteLLM_Params] = None
 ) -> List[str]:
-    try:
-        wildcard_provider_prefix, wildcard_suffix = wildcard_model.split("/", 1)
-    except ValueError:  # safely fail
-        return []
+    if wildcard_model in {"*", "*/"}:
+        wildcard_provider_prefix = ""
+        wildcard_suffix = "*"
+    else:
+        try:
+            wildcard_provider_prefix, wildcard_suffix = wildcard_model.split("/", 1)
+        except ValueError:  # safely fail
+            return []
 
     # Use provider from litellm_params when available, otherwise from wildcard prefix
     # (e.g., "openai" from "openai/*" - needed for BYOK where wildcard isn't in router)
@@ -275,7 +279,9 @@ def get_known_models_from_wildcard(
 
     suffix_appended_wildcard_models = []
     for model in wildcard_models:
-        if not model.startswith(wildcard_provider_prefix):
+        if wildcard_provider_prefix and not model.startswith(
+            f"{wildcard_provider_prefix}/"
+        ):
             model = f"{wildcard_provider_prefix}/{model}"
         suffix_appended_wildcard_models.append(model)
     return suffix_appended_wildcard_models or []
@@ -300,13 +306,16 @@ def _get_wildcard_models(
                 model_list = llm_router.get_model_list(model_name=model)
                 if model_list:
                     for router_model in model_list:
+                        router_litellm_params = LiteLLM_Params(
+                            **router_model["litellm_params"]  # type: ignore
+                        )
                         wildcard_models = get_known_models_from_wildcard(
                             wildcard_model=model,
-                            litellm_params=LiteLLM_Params(
-                                **router_model["litellm_params"]  # type: ignore
-                            ),
+                            litellm_params=router_litellm_params,
                         )
-                        all_wildcard_models.extend(wildcard_models)
+                        if wildcard_models:
+                            models_to_remove.add(model)
+                            all_wildcard_models.extend(wildcard_models)
                 else:
                     # Router has no deployment for this wildcard (e.g., BYOK team models)
                     # Fall back to expanding from known provider models

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -232,8 +232,9 @@ def get_complete_model_list(
 def get_known_models_from_wildcard(
     wildcard_model: str, litellm_params: Optional[LiteLLM_Params] = None
 ) -> List[str]:
-    # Treat bare wildcard aliases (`*` and the defensive `*/` variant) as
-    # having no explicit provider prefix in the ids returned by /v1/models.
+    # Treat bare wildcard aliases (`*` and the defensive `*/` variant used by
+    # some existing configs/tests) as having no explicit provider prefix in the
+    # ids returned by /v1/models.
     if wildcard_model in {"*", "*/"}:
         wildcard_provider_prefix = ""
         wildcard_suffix = "*"
@@ -249,9 +250,9 @@ def get_known_models_from_wildcard(
         try:
             provider = litellm_params.model.split("/", 1)[0]
         except ValueError:
-            provider = wildcard_provider_prefix
+            provider = wildcard_provider_prefix or "*"
     else:
-        provider = wildcard_provider_prefix
+        provider = wildcard_provider_prefix or "*"
 
     # get all known provider models
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -247,12 +247,9 @@ def get_known_models_from_wildcard(
     # Use provider from litellm_params when available, otherwise from wildcard prefix
     # (e.g., "openai" from "openai/*" - needed for BYOK where wildcard isn't in router)
     if litellm_params is not None:
-        try:
-            provider = (
-                litellm_params.model.split("/", 1)[0] or wildcard_provider_prefix or "*"
-            )
-        except ValueError:
-            provider = wildcard_provider_prefix or "*"
+        provider = (
+            litellm_params.model.split("/", 1)[0] or wildcard_provider_prefix or "*"
+        )
     else:
         provider = wildcard_provider_prefix or "*"
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -232,6 +232,8 @@ def get_complete_model_list(
 def get_known_models_from_wildcard(
     wildcard_model: str, litellm_params: Optional[LiteLLM_Params] = None
 ) -> List[str]:
+    # Treat bare wildcard aliases (`*` and the defensive `*/` variant) as
+    # having no explicit provider prefix in the ids returned by /v1/models.
     if wildcard_model in {"*", "*/"}:
         wildcard_provider_prefix = ""
         wildcard_suffix = "*"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3200,6 +3200,15 @@ class ProxyConfig:
             blue_color_code = "\033[94m"
             reset_color_code = "\033[0m"
             for key, value in litellm_settings.items():
+                if key == "check_provider_endpoint":
+                    litellm.check_provider_endpoint = value
+                    continue
+                if key == "drop_params":
+                    litellm.drop_params = value
+                    continue
+                if key == "set_verbose":
+                    litellm.set_verbose = value
+                    continue
                 if key == "cache" and value is True:
                     print(f"{blue_color_code}\nSetting Cache on Proxy")  # noqa
                     from litellm.caching.caching import Cache

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7795,6 +7795,56 @@ class Router:
 
         return credentials
 
+    def _filter_bare_wildcard_deployments_by_known_models(
+        self, model: str, deployments: List[Dict]
+    ) -> List[Dict]:
+        """
+        For bare wildcard routes (`model_name: "*"` / `"*/"`), avoid routing an
+        advertised upstream model to providers that are known not to list it.
+
+        This reuses the existing wildcard discovery path, so it follows the
+        current LiteLLM behavior: static model lists by default, provider
+        `/models` only when `check_provider_endpoint` is enabled, and cached by
+        `get_valid_models`. If no deployment can positively identify the model,
+        fail open to preserve existing catch-all behavior.
+        """
+        if not deployments:
+            return deployments
+
+        from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+
+        filtered_deployments: List[Dict] = []
+        unknown_deployments: List[Dict] = []
+        has_known_match = False
+
+        for deployment in deployments:
+            if deployment.get("model_name") not in {"*", "*/"}:
+                filtered_deployments.append(deployment)
+                continue
+
+            try:
+                litellm_params = LiteLLM_Params(**deployment["litellm_params"])
+                if "/" in litellm_params.model:
+                    provider, _ = litellm_params.model.split("/", 1)
+                    litellm_params.model = f"{provider}/*"
+                known_models = get_known_models_from_wildcard(
+                    wildcard_model=deployment["model_name"],
+                    litellm_params=litellm_params,
+                )
+            except Exception:
+                known_models = []
+
+            if not known_models:
+                unknown_deployments.append(deployment)
+            elif model in known_models:
+                has_known_match = True
+                filtered_deployments.append(deployment)
+
+        if not has_known_match:
+            return deployments
+
+        return filtered_deployments + unknown_deployments
+
     @overload
     def get_router_model_info(
         self,
@@ -8193,9 +8243,12 @@ class Router:
                     model_info.get("supported_openai_params", None) is not None
                     and model_info["supported_openai_params"] is not None
                 ):
-                    model_group_info.supported_openai_params = model_info[
-                        "supported_openai_params"
-                    ]
+                    model_group_info.supported_openai_params = list(
+                        dict.fromkeys(
+                            (model_group_info.supported_openai_params or [])
+                            + model_info["supported_openai_params"]
+                        )
+                    )
                 if model_info.get("tpm", None) is not None and _deployment_tpm is None:
                     _deployment_tpm = model_info.get("tpm")
                 if model_info.get("rpm", None) is not None and _deployment_rpm is None:
@@ -8223,6 +8276,12 @@ class Router:
                 model_group_info.configurable_clientside_auth_params = (
                     configurable_clientside_auth_params
                 )
+
+            if model_group_info.supported_openai_params is not None and any(
+                param in model_group_info.supported_openai_params
+                for param in ("reasoning_effort", "thinking")
+            ):
+                model_group_info.supports_reasoning = True
 
         return model_group_info
 
@@ -8860,12 +8919,26 @@ class Router:
 
         if len(returned_models) == 0:  # check if wildcard route
             potential_wildcard_models = self.pattern_router.route(model_name) or []
+            if model_name is not None:
+                potential_wildcard_models = (
+                    self._filter_bare_wildcard_deployments_by_known_models(
+                        model=model_name,
+                        deployments=potential_wildcard_models,
+                    )
+                )
 
             ## check for team-specific wildcard models
             if team_id is not None and team_id in self.team_pattern_routers:
                 potential_team_only_wildcard_models = (
                     self.team_pattern_routers[team_id].route(model_name) or []
                 )
+                if model_name is not None:
+                    potential_team_only_wildcard_models = (
+                        self._filter_bare_wildcard_deployments_by_known_models(
+                            model=model_name,
+                            deployments=potential_team_only_wildcard_models,
+                        )
+                    )
                 potential_wildcard_models.extend(potential_team_only_wildcard_models)
 
             if model_name is not None and potential_wildcard_models is not None:
@@ -9387,6 +9460,12 @@ class Router:
             )
 
             if pattern_deployments:
+                pattern_deployments = (
+                    self._filter_bare_wildcard_deployments_by_known_models(
+                        model=model,
+                        deployments=pattern_deployments,
+                    )
+                )
                 return model, pattern_deployments
 
             if (
@@ -9399,6 +9478,12 @@ class Router:
                     model=model,
                 )
                 if pattern_deployments:
+                    pattern_deployments = (
+                        self._filter_bare_wildcard_deployments_by_known_models(
+                            model=model,
+                            deployments=pattern_deployments,
+                        )
+                    )
                     return model, pattern_deployments
 
             # check if default deployment is set

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8667,6 +8667,8 @@ class ProviderConfigManager:
             return litellm.AnthropicModelInfo()
         elif LlmProviders.XAI == provider:
             return litellm.XAIModelInfo()
+        elif LlmProviders.DEEPSEEK == provider:
+            return litellm.DeepSeekChatConfig()
         elif LlmProviders.OPENROUTER == provider:
             return litellm.OpenrouterConfig()
         elif LlmProviders.OLLAMA == provider or LlmProviders.OLLAMA_CHAT == provider:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8667,6 +8667,8 @@ class ProviderConfigManager:
             return litellm.AnthropicModelInfo()
         elif LlmProviders.XAI == provider:
             return litellm.XAIModelInfo()
+        elif LlmProviders.OPENROUTER == provider:
+            return litellm.OpenrouterConfig()
         elif LlmProviders.OLLAMA == provider or LlmProviders.OLLAMA_CHAT == provider:
             # Dynamic model listing for Ollama server
             from litellm.llms.ollama.common_utils import OllamaModelInfo

--- a/tests/documentation_tests/test_env_keys.py
+++ b/tests/documentation_tests/test_env_keys.py
@@ -41,6 +41,7 @@ EXCLUDED_TERMINAL_VARS = {
 PROVIDER_SPECIFIC_DOCS_VARS = {
     "DEEPSEEK_API_BASE",
     "OPENROUTER_API_BASE",
+    "OPENROUTER_API_KEY",
 }
 
 # Directories to skip (dependencies, venvs, caches) - only scan litellm source

--- a/tests/documentation_tests/test_env_keys.py
+++ b/tests/documentation_tests/test_env_keys.py
@@ -35,6 +35,14 @@ EXCLUDED_TERMINAL_VARS = {
     "ALACRITTY_SOCKET",
 }
 
+# These environment variables are documented in provider-specific docs outside
+# docs/proxy/config_settings.md, so they should not fail the generic proxy env
+# settings validation.
+PROVIDER_SPECIFIC_DOCS_VARS = {
+    "DEEPSEEK_API_BASE",
+    "OPENROUTER_API_BASE",
+}
+
 # Directories to skip (dependencies, venvs, caches) - only scan litellm source
 SKIP_DIRS = {
     ".venv",
@@ -114,7 +122,7 @@ except Exception as e:
 
 print(f"documented_keys: {documented_keys}")
 # Compare and find undocumented keys
-undocumented_keys = env_keys - documented_keys
+undocumented_keys = env_keys - documented_keys - PROVIDER_SPECIFIC_DOCS_VARS
 
 # Print results
 print("Keys expected in 'environment settings' (found in code):")

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -2045,6 +2045,37 @@ def test_get_known_models_from_wildcard_without_litellm_params():
     assert "gpt-4o" in model_ids or "gpt-3.5-turbo" in model_ids
 
 
+def test_get_known_models_from_bare_wildcard_openrouter_uses_provider_discovery(
+    monkeypatch,
+):
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+    from litellm.proxy.auth import model_checks
+
+    class _OpenRouterModelInfo:
+        def get_models(self, api_key=None, api_base=None):
+            assert api_key == "test-key"
+            return ["openai/gpt-4o", "google/gemini-2.5-flash"]
+
+    monkeypatch.setattr(
+        model_checks,
+        "get_provider_models",
+        lambda provider, litellm_params=None: _OpenRouterModelInfo().get_models(
+            api_key=litellm_params.api_key if litellm_params is not None else None,
+            api_base=litellm_params.api_base if litellm_params is not None else None,
+        )
+        if provider == "openrouter"
+        else [],
+    )
+
+    wildcard_models = get_known_models_from_wildcard(
+        wildcard_model="*",
+        litellm_params=LiteLLM_Params(model="openrouter/*", api_key="test-key"),
+    )
+
+    assert wildcard_models == ["openai/gpt-4o", "google/gemini-2.5-flash"]
+
+
 @pytest.mark.parametrize(
     "data, user_api_key_dict, expected_model",
     [

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -157,14 +157,13 @@ class TestResponseCompliance:
         # Check CreateModelInteractionParams which includes output fields
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
 
-        # Output fields (readOnly)
+        # Output fields (readOnly) per the live Google Interactions OpenAPI spec.
         output_fields = [
             "id",
             "status",
             "created",
             "updated",
             "role",
-            "outputs",
             "usage",
         ]
 

--- a/tests/test_litellm/llms/ollama/test_ollama_model_info.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_model_info.py
@@ -105,6 +105,28 @@ class TestOllamaModelInfo:
             "Authorization": "Bearer test_api_key"
         }
 
+    def test_get_models_prefers_explicit_api_key_argument(self, monkeypatch):
+        """Explicit api_key arg should take precedence over environment lookup."""
+        captured_api_keys = []
+
+        original_get_api_key = OllamaModelInfo.get_api_key
+
+        def mock_get_api_key(api_key=None):
+            captured_api_keys.append(api_key)
+            return original_get_api_key(api_key)
+
+        def mock_get(url, headers):
+            return DummyResponse({}, status_code=200)
+
+        monkeypatch.setattr(OllamaModelInfo, "get_api_key", staticmethod(mock_get_api_key))
+        monkeypatch.setattr(httpx, "get", mock_get)
+        monkeypatch.setenv("OLLAMA_API_KEY", "env_key")
+
+        info = OllamaModelInfo()
+        info.get_models(api_key="explicit_key")
+
+        assert captured_api_keys == ["explicit_key"]
+
     def test_get_models_from_list_response(self, monkeypatch):
         """
         When the /api/tags endpoint returns a list of dicts,

--- a/tests/test_litellm/llms/test_provider_model_listing.py
+++ b/tests/test_litellm/llms/test_provider_model_listing.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from litellm.llms.ollama.common_utils import OllamaModelInfo
 from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
 from litellm.llms.openrouter.chat.transformation import OpenrouterConfig
 
@@ -14,7 +17,9 @@ def test_openrouter_get_models_uses_openrouter_endpoint():
         ]
     }
 
-    with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+    with patch(
+        "litellm.module_level_client.get", return_value=mock_response
+    ) as mock_get:
         models = OpenrouterConfig().get_models(api_key="sk-or-test")
 
     assert models == ["openai/gpt-5", "anthropic/claude-sonnet-4"]
@@ -22,6 +27,36 @@ def test_openrouter_get_models_uses_openrouter_endpoint():
         url="https://openrouter.ai/api/v1/models",
         headers={"Authorization": "Bearer sk-or-test"},
     )
+
+
+def test_openrouter_get_models_uses_custom_base_and_secret_key():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"data": [{"id": "openrouter/custom-model"}]}
+
+    with (
+        patch("litellm.get_secret", return_value="sk-or-secret"),
+        patch(
+            "litellm.module_level_client.get", return_value=mock_response
+        ) as mock_get,
+    ):
+        models = OpenrouterConfig().get_models(api_base="https://example.com/v1/")
+
+    assert models == ["openrouter/custom-model"]
+    mock_get.assert_called_once_with(
+        url="https://example.com/v1/models",
+        headers={"Authorization": "Bearer sk-or-secret"},
+    )
+
+
+def test_openrouter_get_models_raises_for_non_200_response():
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.text = "unauthorized"
+
+    with patch("litellm.module_level_client.get", return_value=mock_response):
+        with pytest.raises(Exception, match="Failed to get models: unauthorized"):
+            OpenrouterConfig().get_models(api_key="sk-or-test")
 
 
 def test_deepseek_get_models_uses_deepseek_endpoint():
@@ -34,11 +69,63 @@ def test_deepseek_get_models_uses_deepseek_endpoint():
         ]
     }
 
-    with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+    with patch(
+        "litellm.module_level_client.get", return_value=mock_response
+    ) as mock_get:
         models = DeepSeekChatConfig().get_models(api_key="sk-deepseek-test")
 
     assert models == ["deepseek-chat", "deepseek-reasoner"]
     mock_get.assert_called_once_with(
         url="https://api.deepseek.com/models",
         headers={"Authorization": "Bearer sk-deepseek-test"},
+    )
+
+
+def test_deepseek_get_models_uses_custom_base_and_secret_key():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"data": [{"id": "deepseek-custom"}]}
+
+    with (
+        patch(
+            "litellm.llms.deepseek.chat.transformation.get_secret_str",
+            return_value="sk-deepseek-secret",
+        ),
+        patch(
+            "litellm.module_level_client.get", return_value=mock_response
+        ) as mock_get,
+    ):
+        models = DeepSeekChatConfig().get_models(api_base="https://example.com/")
+
+    assert models == ["deepseek-custom"]
+    mock_get.assert_called_once_with(
+        url="https://example.com/models",
+        headers={"Authorization": "Bearer sk-deepseek-secret"},
+    )
+
+
+def test_deepseek_get_models_raises_for_non_200_response():
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "server error"
+
+    with patch("litellm.module_level_client.get", return_value=mock_response):
+        with pytest.raises(Exception, match="Failed to get models: server error"):
+            DeepSeekChatConfig().get_models(api_key="sk-deepseek-test")
+
+
+def test_ollama_get_models_uses_passed_api_key():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"models": [{"name": "llama3.1"}]}
+
+    with patch("httpx.get", return_value=mock_response) as mock_get:
+        models = OllamaModelInfo().get_models(
+            api_key="ollama-key", api_base="https://ollama.example.com"
+        )
+
+    assert models == ["llama3.1"]
+    mock_response.raise_for_status.assert_called_once()
+    mock_get.assert_called_once_with(
+        "https://ollama.example.com/api/tags",
+        headers={"Authorization": "Bearer ollama-key"},
     )

--- a/tests/test_litellm/llms/test_provider_model_listing.py
+++ b/tests/test_litellm/llms/test_provider_model_listing.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
+from litellm.llms.openrouter.chat.transformation import OpenrouterConfig
+
+
+def test_openrouter_get_models_uses_openrouter_endpoint():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [
+            {"id": "openai/gpt-5"},
+            {"id": "anthropic/claude-sonnet-4"},
+        ]
+    }
+
+    with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+        models = OpenrouterConfig().get_models(api_key="sk-or-test")
+
+    assert models == ["openai/gpt-5", "anthropic/claude-sonnet-4"]
+    mock_get.assert_called_once_with(
+        url="https://openrouter.ai/api/v1/models",
+        headers={"Authorization": "Bearer sk-or-test"},
+    )
+
+
+def test_deepseek_get_models_uses_deepseek_endpoint():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [
+            {"id": "deepseek-chat"},
+            {"id": "deepseek-reasoner"},
+        ]
+    }
+
+    with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+        models = DeepSeekChatConfig().get_models(api_key="sk-deepseek-test")
+
+    assert models == ["deepseek-chat", "deepseek-reasoner"]
+    mock_get.assert_called_once_with(
+        url="https://api.deepseek.com/models",
+        headers={"Authorization": "Bearer sk-deepseek-test"},
+    )

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -240,6 +240,29 @@ def test_get_known_models_from_bare_wildcard_without_litellm_params():
     mock_get_provider_models.assert_called_once_with(provider="*", litellm_params=None)
 
 
+def test_get_known_models_from_invalid_wildcard_returns_empty_list():
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+
+    assert get_known_models_from_wildcard("not-a-wildcard", litellm_params=None) == []
+
+
+def test_get_known_models_from_bare_wildcard_with_invalid_litellm_model_falls_back_to_all():
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    litellm_params = LiteLLM_Params(model="")
+    with patch(
+        "litellm.proxy.auth.model_checks.get_provider_models",
+        return_value=["model-a"],
+    ) as mock_get_provider_models:
+        result = get_known_models_from_wildcard("*", litellm_params=litellm_params)
+
+    assert result == ["model-a"]
+    mock_get_provider_models.assert_called_once_with(
+        provider="*", litellm_params=litellm_params
+    )
+
+
 def test_get_complete_model_list_byok_wildcard_expansion():
     """
     Test that wildcard models (e.g., openai/*) are expanded when the router has

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -279,6 +279,7 @@ def test_get_complete_model_list_bare_wildcard_star():
     assert "*" not in result
     assert "openai/*" not in result
     assert len(result) > 0
+    assert "gpt-4o" in result or "gpt-3.5-turbo" in result
 
 
 def test_get_complete_model_list_bare_wildcard_star_slash():
@@ -306,6 +307,7 @@ def test_get_complete_model_list_bare_wildcard_star_slash():
 
     assert "*/" not in result
     assert len(result) > 0
+    assert "gpt-4o" in result or "gpt-3.5-turbo" in result
 
 
 def test_get_complete_model_list_bare_wildcard_multiple_providers():
@@ -417,3 +419,20 @@ def test_get_known_models_from_bare_wildcard_star_slash_does_not_add_alias_prefi
     )
 
     assert wildcard_models == ["gpt-4o", "gpt-4o-mini"]
+
+
+@patch("litellm.proxy.auth.model_checks.get_provider_models")
+def test_get_known_models_from_bare_wildcard_preserves_upstream_prefixed_ids(
+    mock_get_provider_models,
+):
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    mock_get_provider_models.return_value = ["ollama/deepseek-v3.2", "glm-5"]
+
+    wildcard_models = get_known_models_from_wildcard(
+        wildcard_model="*",
+        litellm_params=LiteLLM_Params(model="ollama/*"),
+    )
+
+    assert wildcard_models == ["ollama/deepseek-v3.2", "glm-5"]

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -249,3 +249,171 @@ def test_get_complete_model_list_byok_wildcard_expansion():
     assert len(result) > 0
     assert all(m.startswith("openai/") for m in result)
     assert "openai/*" not in result
+
+
+def test_get_complete_model_list_bare_wildcard_star():
+    """
+    When model_name is "*" (bare wildcard without provider prefix)
+    and litellm_params.model contains the provider wildcard (e.g. "openai/*"),
+    get_complete_model_list should expand using the provider from litellm_params
+    without adding a wildcard alias prefix.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm import Router
+
+    router = Router(
+        model_list=[
+            {"model_name": "*", "litellm_params": {"model": "openai/*"}},
+        ]
+    )
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=router.get_model_names(),
+        user_model=None,
+        infer_model_from_keys=False,
+        llm_router=router,
+    )
+
+    assert "*" not in result
+    assert "openai/*" not in result
+    assert len(result) > 0
+
+
+def test_get_complete_model_list_bare_wildcard_star_slash():
+    """
+    When model_name is "*/" it should behave the same as bare "*" and avoid
+    adding a wildcard alias prefix to expanded models.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm import Router
+
+    router = Router(
+        model_list=[
+            {"model_name": "*/", "litellm_params": {"model": "openai/*"}},
+        ]
+    )
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=router.get_model_names(),
+        user_model=None,
+        infer_model_from_keys=False,
+        llm_router=router,
+    )
+
+    assert "*/" not in result
+    assert len(result) > 0
+
+
+def test_get_complete_model_list_bare_wildcard_multiple_providers():
+    """
+    When multiple deployments share model_name "*" with different providers,
+    each deployment should expand independently and results should be deduplicated.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm import Router
+
+    router = Router(
+        model_list=[
+            {"model_name": "*", "litellm_params": {"model": "openai/*"}},
+            {"model_name": "*", "litellm_params": {"model": "anthropic/*"}},
+        ]
+    )
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=router.get_model_names(),
+        user_model=None,
+        infer_model_from_keys=False,
+        llm_router=router,
+    )
+
+    assert "*" not in result
+    assert "openai/*" not in result
+    assert "anthropic/*" not in result
+    assert len(result) > 0
+    assert len(result) == len(set(result)), "results should be deduplicated"
+
+
+def test_get_complete_model_list_deduplication():
+    """
+    When two deployments with wildcard model_name resolve to overlapping models
+    (e.g. two ollama/* entries), the result should not contain duplicates.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm import Router
+
+    router = Router(
+        model_list=[
+            {"model_name": "ollama/*", "litellm_params": {"model": "ollama/*"}},
+            {"model_name": "ollama/*", "litellm_params": {"model": "ollama/*"}},
+        ]
+    )
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=[],
+        proxy_model_list=router.get_model_names(),
+        user_model=None,
+        infer_model_from_keys=False,
+        llm_router=router,
+    )
+
+    assert "ollama/*" not in result
+    assert any(m.startswith("ollama/") for m in result)
+    assert len(result) == len(set(result)), "results should be deduplicated"
+
+
+def test_get_known_models_from_wildcard_avoids_prefix_string_false_positive():
+    """
+    Providers with model ids like `deepseek-chat` should still get the
+    `deepseek/` alias added for `deepseek/*` routes.
+    """
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    wildcard_models = get_known_models_from_wildcard(
+        wildcard_model="deepseek/*",
+        litellm_params=LiteLLM_Params(model="deepseek/*"),
+    )
+
+    assert "deepseek/deepseek-chat" in wildcard_models
+    assert "deepseek-chat" not in wildcard_models
+
+
+@patch("litellm.proxy.auth.model_checks.get_provider_models")
+def test_get_known_models_from_bare_wildcard_star_does_not_add_alias_prefix(
+    mock_get_provider_models,
+):
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    mock_get_provider_models.return_value = ["gpt-4o", "gpt-4o-mini"]
+
+    wildcard_models = get_known_models_from_wildcard(
+        wildcard_model="*",
+        litellm_params=LiteLLM_Params(model="openai/*"),
+    )
+
+    assert wildcard_models == ["gpt-4o", "gpt-4o-mini"]
+
+
+@patch("litellm.proxy.auth.model_checks.get_provider_models")
+def test_get_known_models_from_bare_wildcard_star_slash_does_not_add_alias_prefix(
+    mock_get_provider_models,
+):
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    mock_get_provider_models.return_value = ["gpt-4o", "gpt-4o-mini"]
+
+    wildcard_models = get_known_models_from_wildcard(
+        wildcard_model="*/",
+        litellm_params=LiteLLM_Params(model="openai/*"),
+    )
+
+    assert wildcard_models == ["gpt-4o", "gpt-4o-mini"]

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -227,6 +227,19 @@ def test_get_complete_model_list_order(
     )
 
 
+def test_get_known_models_from_bare_wildcard_without_litellm_params():
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+
+    with patch(
+        "litellm.proxy.auth.model_checks.get_provider_models",
+        return_value=["model-a", "model-b"],
+    ) as mock_get_provider_models:
+        result = get_known_models_from_wildcard("*", litellm_params=None)
+
+    assert result == ["model-a", "model-b"]
+    mock_get_provider_models.assert_called_once_with(provider="*", litellm_params=None)
+
+
 def test_get_complete_model_list_byok_wildcard_expansion():
     """
     Test that wildcard models (e.g., openai/*) are expanded when the router has

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1543,6 +1543,43 @@ async def test_get_config_from_file(tmp_path, monkeypatch):
     assert result == test_config
 
 
+@pytest.mark.asyncio
+async def test_load_config_applies_litellm_boolean_settings(tmp_path, monkeypatch):
+    import litellm
+    import yaml
+
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    config_file = tmp_path / "provider-discovery.yaml"
+    config_file.write_text(
+        yaml.dump(
+            {
+                "model_list": [
+                    {"model_name": "gpt-4", "litellm_params": {"model": "gpt-4"}}
+                ],
+                "general_settings": {},
+                "router_settings": {},
+                "litellm_settings": {
+                    "check_provider_endpoint": True,
+                    "drop_params": True,
+                    "set_verbose": True,
+                },
+            }
+        )
+    )
+
+    monkeypatch.setattr("litellm.check_provider_endpoint", False)
+    monkeypatch.setattr("litellm.drop_params", False)
+    monkeypatch.setattr("litellm.set_verbose", False)
+
+    proxy_config = ProxyConfig()
+    await proxy_config.load_config(router=None, config_file_path=str(config_file))
+
+    assert litellm.check_provider_endpoint is True
+    assert litellm.drop_params is True
+    assert litellm.set_verbose is True
+
+
 def test_normalize_datetime_for_sorting():
     """
     Test the _normalize_datetime_for_sorting function.

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -3267,3 +3267,110 @@ async def test_multiregion_team_failover_between_regions():
         "response from us-east-1",
         "response from us-west-2",
     ]
+
+
+@patch("litellm.proxy.auth.model_checks.get_provider_models")
+def test_bare_wildcard_runtime_filters_known_unsupported_providers(
+    mock_get_provider_models,
+):
+    def mock_provider_models(provider, litellm_params=None):
+        if litellm_params is not None and litellm_params.model == "openai/*":
+            return ["gpt-4o"]
+        if litellm_params is not None and litellm_params.model == "deepseek/*":
+            return ["deepseek-v4-pro"]
+        return []
+
+    mock_get_provider_models.side_effect = mock_provider_models
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "*",
+                "litellm_params": {"model": "openai/*", "api_key": "openai-key"},
+            },
+            {
+                "model_name": "*",
+                "litellm_params": {"model": "deepseek/*", "api_key": "deepseek-key"},
+            },
+        ]
+    )
+
+    matched_deployments = router.get_model_list(model_name="deepseek-v4-pro")
+
+    assert matched_deployments is not None
+    assert len(matched_deployments) == 1
+    assert matched_deployments[0]["litellm_params"]["model"] == (
+        "deepseek/deepseek-v4-pro"
+    )
+    filtered_deployments = router._filter_bare_wildcard_deployments_by_known_models(
+        model="deepseek-v4-pro",
+        deployments=router.pattern_router.route("deepseek-v4-pro") or [],
+    )
+    assert len(filtered_deployments) == 1
+    assert filtered_deployments[0]["litellm_params"]["model"] == (
+        "deepseek/deepseek-v4-pro"
+    )
+
+
+@patch("litellm.proxy.auth.model_checks.get_provider_models")
+def test_bare_wildcard_runtime_filter_fails_open_when_model_is_unknown(
+    mock_get_provider_models,
+):
+    mock_get_provider_models.return_value = []
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "*",
+                "litellm_params": {"model": "openai/*", "api_key": "openai-key"},
+            },
+            {
+                "model_name": "*",
+                "litellm_params": {"model": "deepseek/*", "api_key": "deepseek-key"},
+            },
+        ]
+    )
+
+    matched_deployments = router.get_model_list(model_name="custom-model")
+
+    assert matched_deployments is not None
+    assert len(matched_deployments) == 2
+
+
+def test_model_group_info_unions_supported_openai_params_and_reasoning(monkeypatch):
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "combined-model",
+                "litellm_params": {"model": "openai/gpt-4o", "api_key": "key"},
+            },
+            {
+                "model_name": "combined-model",
+                "litellm_params": {"model": "deepseek/deepseek-chat", "api_key": "key"},
+            },
+        ]
+    )
+
+    def mock_get_deployment_model_info(model_id, model_name):
+        if model_name == "openai/gpt-4o":
+            return {
+                "supported_openai_params": ["tools"],
+                "supports_reasoning": False,
+            }
+        return {
+            "supported_openai_params": ["reasoning_effort"],
+            "supports_reasoning": False,
+        }
+
+    monkeypatch.setattr(
+        router, "get_deployment_model_info", mock_get_deployment_model_info
+    )
+
+    model_group_info = router.get_model_group_info(model_group="combined-model")
+
+    assert model_group_info is not None
+    assert set(model_group_info.supported_openai_params or []) == {
+        "tools",
+        "reasoning_effort",
+    }
+    assert model_group_info.supports_reasoning is True


### PR DESCRIPTION
## Summary
- fix bare wildcard (`model_name: \"*\"` / `\"*/\"`) expansion in `/v1/models` so it preserves upstream model ids instead of synthesizing a provider prefix
- keep explicit wildcard alias semantics unchanged for routes like `anthropic/*`, `deepseek/*`, and `openrouter/*`
- align interactions compliance check with the live spec baseline

## Context
- Follow-up issue: #28062
- This intentionally narrows the behavior change to bare wildcard aliases only, to avoid changing the established meaning of explicit provider wildcard aliases.