### PR TITLE
chore(github_copilot): refresh model catalog from upstream /models API

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17901,22 +17901,9 @@
     },
     "github_copilot/claude-haiku-4.5": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-opus-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions"
@@ -17924,7 +17911,22 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true,
-        "supports_minimal_reasoning_effort": true
+        "supports_reasoning": true
+    },
+    "github_copilot/claude-opus-4.5": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_minimal_reasoning_effort": true,
+        "supports_reasoning": true
     },
     "github_copilot/claude-opus-4.6-fast": {
         "litellm_provider": "github_copilot",
@@ -17938,6 +17940,22 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true
+    },
+    "github_copilot/claude-opus-4.7": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/messages"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true
     },
     "github_copilot/claude-opus-41": {
         "litellm_provider": "github_copilot",
@@ -17965,16 +17983,33 @@
     },
     "github_copilot/claude-sonnet-4.5": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/claude-sonnet-4.6": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/messages"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true
     },
     "github_copilot/gemini-2.5-pro": {
         "litellm_provider": "github_copilot",
@@ -17984,7 +18019,25 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3-flash-preview": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true
     },
     "github_copilot/gemini-3-pro-preview": {
         "litellm_provider": "github_copilot",
@@ -17996,13 +18049,30 @@
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
+    "github_copilot/gemini-3.1-pro-preview": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true
+    },
     "github_copilot/gpt-3.5-turbo": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 16384,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-3.5-turbo-0613": {
         "litellm_provider": "github_copilot",
@@ -18010,7 +18080,10 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4": {
         "litellm_provider": "github_copilot",
@@ -18018,7 +18091,22 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
+    },
+    "github_copilot/gpt-4-0125-preview": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true
     },
     "github_copilot/gpt-4-0613": {
         "litellm_provider": "github_copilot",
@@ -18026,16 +18114,22 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4-o-preview": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true
+        "supports_parallel_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4.1": {
         "litellm_provider": "github_copilot",
@@ -18046,7 +18140,10 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4.1-2025-04-14": {
         "litellm_provider": "github_copilot",
@@ -18057,68 +18154,89 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-41-copilot": {
         "litellm_provider": "github_copilot",
-        "mode": "completion"
+        "mode": "chat"
     },
     "github_copilot/gpt-4o": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4o-2024-05-13": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4o-2024-08-06": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-2024-11-20": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
+    },
+    "github_copilot/gpt-4o-2024-11-20": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4o-mini": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true
+        "supports_parallel_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-4o-mini-2024-07-18": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true
+        "supports_parallel_function_calling": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ]
     },
     "github_copilot/gpt-5": {
         "litellm_provider": "github_copilot",
@@ -18137,14 +18255,19 @@
     },
     "github_copilot/gpt-5-mini": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
+        "max_input_tokens": 264000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5.1": {
         "litellm_provider": "github_copilot",
@@ -18177,7 +18300,7 @@
     },
     "github_copilot/gpt-5.2": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
+        "max_input_tokens": 264000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
@@ -18188,11 +18311,27 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gpt-5.2-codex": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5.3-codex": {
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
+        "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
@@ -18202,25 +18341,96 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gpt-5.4": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gpt-5.4-mini": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gpt-5.5": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/oswe-vscode-prime": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 264000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_vision": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true
     },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
-        "mode": "embedding"
+        "mode": "embedding",
+        "supported_endpoints": [
+            "/v1/embeddings"
+        ]
     },
     "github_copilot/text-embedding-3-small-inference": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
-        "mode": "embedding"
+        "mode": "embedding",
+        "supported_endpoints": [
+            "/v1/embeddings"
+        ]
     },
     "github_copilot/text-embedding-ada-002": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
-        "mode": "embedding"
+        "mode": "embedding",
+        "supported_endpoints": [
+            "/v1/embeddings"
+        ]
     },
     "chatgpt/gpt-5.4": {
         "litellm_provider": "chatgpt",


### PR DESCRIPTION
## Relevant issues

- Refs #25666 — adds `supports_reasoning: true` to applicable models so callers can detect capability programmatically instead of hardcoding model-name lists

## Linear ticket

n/a

## Pre-Submission checklist

- [x] Metadata only — no runtime code paths changed; existing tests unaffected
- [x] `make test-unit` passes
- [x] PR scope is isolated to `github_copilot/*` entries
- [ ] Greptile review pending

## CI (LiteLLM team)

- [ ] **Branch creation CI run** — _link_:
- [ ] **CI run for the last commit** — _link_:
- [ ] **Merge / cherry-pick CI run** — _link_:

## Screenshots / Proof of Fix

Catalog values are aligned with what `GET https://api.individual.githubcopilot.com/models` actually returns. Examples:

| field | model | before | after | source |
| --- | --- | --- | --- | --- |
| max_input_tokens | gpt-4o-mini | 64000 | 128000 | `capabilities.limits.max_context_window_tokens` |
| max_input_tokens | gpt-5-mini | 128000 | 264000 | same |
| max_input_tokens | gpt-5.3-codex | 128000 | 400000 | same |
| max_input_tokens | claude-haiku-4.5 | 128000 | 200000 | same |
| supports_reasoning | claude-haiku-4.5 | (missing) | true | `capabilities.supports.max_thinking_budget` |
| supports_response_schema | gpt-5-mini | (missing) | true | `capabilities.supports.structured_outputs` |
| supported_endpoints | gpt-5.3-codex | (missing) | `["/v1/responses"]` | `model.supported_endpoints` |
| mode | gpt-5.4-mini | (missing → "chat") | `"responses"` | derived: only `/responses` supported, no `/chat/completions` |

10 new model entries added: `claude-opus-4.7`, `claude-sonnet-4.6`, `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gpt-4-0125-preview`, `gpt-5.2-codex`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `oswe-vscode-prime`.

## Type

🧹 Refactoring (catalog data only)

## Changes

- `litellm/model_prices_and_context_window_backup.json` only
- diff stat: 253 insertions(+), 43 deletions(-) — strictly within `github_copilot/*` entries; other providers untouched
- For each existing entry: preserved pricing fields (`input_cost_per_token`, `cache_*`, etc.); only updated/added fields derivable from `/models`
- **One mode change worth flagging**: `github_copilot/gpt-41-copilot` went `completion → chat` because Copilot reports `capabilities.type = "chat"`. If `completion` was deliberate for that entry, happy to revert in a follow-up commit.

Targeting `litellm_internal_staging` (project default branch).
