### PR TITLE
fix(proxy): use >= in _team_max_budget_check for consistency with other budget checks

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3650,7 +3650,7 @@ async def _team_max_budget_check(
             fallback_spend=team_object.spend or 0.0,
         )
 
-        if spend > team_object.max_budget:
+        if spend >= team_object.max_budget:
             if valid_token:
                 call_info = CallInfo(
                     token=valid_token.token,


### PR DESCRIPTION
## Summary
- Changes `_team_max_budget_check` comparison from `>` to `>=` to match all other budget enforcement checks

## Root Cause
Team budget used `spend > max_budget` (strict greater-than) while key budget, key budget windows, and org budget all use `spend >= max_budget`. This inconsistency meant that when a team's spend exactly equaled `max_budget`, the request was incorrectly allowed through.

## Test plan
- [ ] Team with spend == max_budget is now correctly blocked
- [ ] Team with spend < max_budget still allowed
- [ ] Key budget behavior unchanged (already uses >=)
- [ ] Existing proxy auth tests pass

Closes #28020

🤖 Generated with [Claude Code](https://claude.com/claude-code)