### PR TITLE
fix(openrouter): classify 400 context-window errors as ContextWindowExceededError

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2324,6 +2324,16 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     exception_mapping_worked = True
                     if original_exception.status_code == 400:
                         exception_mapping_worked = True
+                        if ExceptionCheckers.is_error_str_context_window_exceeded(
+                            error_str
+                        ):
+                            raise ContextWindowExceededError(
+                                message=f"ContextWindowExceededError: {exception_provider} - {error_str}",
+                                llm_provider=custom_llm_provider,
+                                model=model,
+                                response=getattr(original_exception, "response", None),
+                                litellm_debug_info=extra_information,
+                            )
                         raise BadRequestError(
                             message=f"{exception_provider} - {error_str}",
                             llm_provider=custom_llm_provider,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -301,6 +301,54 @@ def test_vertex_ai_rate_limit_error_mapping(error_message, should_raise_rate_lim
             )
 
 
+# Test cases for OpenRouter ContextWindowExceededError mapping
+# Regression for https://github.com/BerriAI/litellm/issues/28063
+openrouter_context_window_test_cases = [
+    ("This model's maximum context length is 4096 tokens.", True),
+    ("input length and max_tokens exceed context limit", True),
+    ("Input is longer than the model's context length", True),
+    ("Invalid model parameter", False),  # Negative case
+]
+
+
+class _OpenRouterUpstreamError(Exception):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@pytest.mark.parametrize(
+    "error_message, should_raise_context_window", openrouter_context_window_test_cases
+)
+def test_openrouter_context_window_error_mapping(
+    error_message, should_raise_context_window
+):
+    """
+    Tests that the exception_type function correctly maps OpenRouter's
+    400 context window exceeded errors to litellm.ContextWindowExceededError.
+    """
+    model = "openrouter/anthropic/claude-3.5-sonnet"
+    custom_llm_provider = "openrouter"
+    original_exception = _OpenRouterUpstreamError(error_message, status_code=400)
+
+    if should_raise_context_window:
+        with pytest.raises(litellm.ContextWindowExceededError) as excinfo:
+            exception_type(
+                model=model,
+                original_exception=original_exception,
+                custom_llm_provider=custom_llm_provider,
+            )
+        assert isinstance(excinfo.value, litellm.ContextWindowExceededError)
+    else:
+        with pytest.raises(litellm.BadRequestError) as excinfo:
+            exception_type(
+                model=model,
+                original_exception=original_exception,
+                custom_llm_provider=custom_llm_provider,
+            )
+        assert not isinstance(excinfo.value, litellm.ContextWindowExceededError)
+
+
 class TestExtractAndRaiseLitellmException:
     """Tests for extract_and_raise_litellm_exception function"""
 


### PR DESCRIPTION
OpenRouter passes upstream provider context-window errors through with status 400 (e.g. OpenAI's "this model's maximum context length is X tokens", Anthropic's "input length and max_tokens exceed context limit"). Every other branch in `exception_mapping_utils.py` runs the error string through `ExceptionCheckers.is_error_str_context_window_exceeded` first and raises `ContextWindowExceededError` on match — see lines ~398 and ~1314. The OpenRouter 400 branch was raising plain `BadRequestError` unconditionally.

Downstream SDKs with context-window recovery (auto-compaction, sliding window, larger-context fallback) never fire on OpenRouter routes as a result.

Patch is the same `is_error_str_context_window_exceeded` check the other providers use, before the `BadRequestError`. 4 new parametrized test cases in `test_exception_mapping_utils.py` covering the three canonical phrases plus one generic 400 negative. All 42 tests in the file pass.

Closes #28063.
