### PR TITLE
fix(anthropic/stream): tolerate missing 'text' on content_block_start (#28067)

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -820,7 +820,13 @@ class ModelResponseIterator:
                     "type"
                 ]
                 if content_block_start["content_block"]["type"] == "text":
-                    text = content_block_start["content_block"]["text"]
+                    # Anthropic Messages streaming spec: the initial text on a
+                    # content_block_start text block is conventionally "" and the
+                    # real content arrives via subsequent content_block_delta
+                    # chunks. Some Anthropic-compatible upstreams omit the field
+                    # entirely rather than sending "", so default to "" to avoid
+                    # aborting the stream with KeyError.
+                    text = content_block_start["content_block"].get("text", "")
                 elif (
                     content_block_start["content_block"]["type"] == "tool_use"
                     or content_block_start["content_block"]["type"] == "server_tool_use"

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -262,6 +262,25 @@ def test_anthropic_tool_streaming():
             assert tool_use["index"] == correct_tool_index
 
 
+def test_anthropic_content_block_start_text_missing_field():
+    """
+    Regression for #28067: some Anthropic-compatible upstreams omit the
+    optional `text` field on a content_block_start text block. The actual
+    content arrives via subsequent content_block_delta chunks, so the parser
+    must tolerate the missing field instead of raising KeyError and aborting
+    the stream.
+    """
+    response_iter = ModelResponseIterator([], False)
+    chunk = {
+        "type": "content_block_start",
+        "index": 0,
+        # 'text' field intentionally omitted (observed in the wild)
+        "content_block": {"type": "text"},
+    }
+    # Should not raise.
+    response_iter.chunk_parser(chunk=chunk)
+
+
 def test_process_anthropic_headers_empty():
     result = process_anthropic_headers({})
     assert result == {}, "Expected empty dictionary for no input"


### PR DESCRIPTION
## Summary

Fixes #28067.

`ModelResponseIterator.chunk_parser()` in the Anthropic chat handler raised `KeyError: 'text'` whenever an upstream emitted a `content_block_start` text block without the optional `text` field, aborting the stream with `MidStreamFallbackError` and cooling down the model group.

The Anthropic Messages streaming spec describes the initial `text` on `content_block_start` as conventionally `""` ([docs](https://docs.anthropic.com/en/api/messages-streaming#content-block-events)) — the real content arrives via subsequent `content_block_delta` chunks regardless. Some Anthropic-compatible reverse-proxy providers ship the field unset rather than empty (observed against `api-cc.freemodel.dev` proxying `claude-haiku-4-5`).

The fix uses `.get("text", "")` so the parser keeps the local `text = ""` default and lets the deltas accumulate normally.

## Changes

- `litellm/llms/anthropic/chat/handler.py`: defensive `.get("text", "")` at the `content_block_start` text branch.
- `tests/llm_translation/test_anthropic_completion.py`: regression test feeding a `text`-less `content_block_start` chunk directly into `chunk_parser`.

## Test plan

- [x] `pytest tests/llm_translation/test_anthropic_completion.py::test_anthropic_content_block_start_text_missing_field`
- [x] Existing `test_anthropic_tool_streaming` still passes (uses a `tool_use` block — touches a different branch)

---

*AI-assisted, human reviewed.*
