### PR TITLE
Remove logger suppression function

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -266,22 +266,6 @@ verbose_proxy_logger.addHandler(handler)
 verbose_logger.addHandler(handler)
 
 
-def _suppress_loggers():
-    """Suppress noisy loggers at INFO level"""
-    # Suppress httpx request logging at INFO level
-    httpx_logger = logging.getLogger("httpx")
-    httpx_logger.setLevel(logging.WARNING)
-
-    # Suppress APScheduler logging at INFO level
-    apscheduler_executors_logger = logging.getLogger("apscheduler.executors.default")
-    apscheduler_executors_logger.setLevel(logging.WARNING)
-    apscheduler_scheduler_logger = logging.getLogger("apscheduler.scheduler")
-    apscheduler_scheduler_logger.setLevel(logging.WARNING)
-
-
-# Call the suppression function
-_suppress_loggers()
-
 ALL_LOGGERS = [
     logging.getLogger(),
     verbose_logger,


### PR DESCRIPTION
Removed the _suppress_loggers function and its call to suppress logging levels for httpx and APScheduler.

What is logged (or not) is defined by the application. A library should not override its decisions, via a simple import.

## Type

🐛 Bug Fix
