### PR TITLE
  fix(proxy): sort BYOK models by their displayed name in /v2/model/info

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10918,10 +10918,20 @@ async def _apply_search_filter_to_models(
 
     search_lower = search.lower().strip()
 
+    def _model_matches_search(m: Dict[str, Any]) -> bool:
+        # Team BYOK models persist an internal `model_name`
+        # (e.g. `model_name_{team_id}_{uuid}`) and expose the user-facing
+        # name via `model_info.team_public_model_name`. Match both so the
+        # name shown in the UI is searchable.
+        if search_lower in (m.get("model_name") or "").lower():
+            return True
+        team_public_model_name = (m.get("model_info") or {}).get(
+            "team_public_model_name"
+        ) or ""
+        return search_lower in team_public_model_name.lower()
+
     # Filter models in router by search term
-    filtered_router_models = [
-        m for m in all_models if search_lower in m.get("model_name", "").lower()
-    ]
+    filtered_router_models = [m for m in all_models if _model_matches_search(m)]
 
     # Separate filtered models into config vs db models, and track db model IDs
     filtered_config_models = []
@@ -10949,12 +10959,23 @@ async def _apply_search_filter_to_models(
     # Only query database if prisma_client is available
     if prisma_client is not None:
         try:
-            # Build where condition for database query
+            # Match either the persisted model_name or, for team BYOK rows,
+            # the user-facing team_public_model_name stored inside model_info.
             db_where_condition: Dict[str, Any] = {
-                "model_name": {
-                    "contains": search_lower,
-                    "mode": "insensitive",
-                }
+                "OR": [
+                    {
+                        "model_name": {
+                            "contains": search_lower,
+                            "mode": "insensitive",
+                        }
+                    },
+                    {
+                        "model_info": {
+                            "path": ["team_public_model_name"],
+                            "string_contains": search_lower,
+                        }
+                    },
+                ]
             }
             # Exclude models already in router if we have any
             if db_model_ids_in_router:
@@ -11102,6 +11123,15 @@ def _sort_models(
         model_info = model.get("model_info", {})
 
         if sort_by == "model_name":
+            # Team BYOK models persist an internal `model_name` (e.g.
+            # `model_name_{team_id}_{uuid}`) and expose the user-facing
+            # name via `model_info.team_public_model_name` — same as the
+            # UI's getDisplayModelName. Sort by the displayed name so
+            # BYOK rows interleave alphabetically with non-BYOK rows
+            # instead of clumping at the end on their opaque IDs.
+            team_public_model_name = model_info.get("team_public_model_name")
+            if team_public_model_name:
+                return str(team_public_model_name).lower()
             return model.get("model_name", "").lower()
 
         elif sort_by == "created_at":
@@ -11316,26 +11346,30 @@ async def _filter_models_by_team_id(
         team_object, team_id, prisma_client, llm_router
     )
 
-    # Filter models based on direct_access or access_via_team_ids
-    # Models are already enriched with these fields before this function is called
+    # When filtering by a specific team we want exactly the models that team
+    # can use: its BYOK rows and the deployments resolved from team.models /
+    # access groups. `direct_access` describes the viewer's own permissions
+    # (the admin path sets it on every non-team model) and must NOT widen the
+    # team's visible set, otherwise selecting a team in the UI still shows
+    # every public model the admin can call.
     filtered_models = []
     for _model in all_models:
         model_info = _model.get("model_info", {})
         model_id = model_info.get("id", None)
 
-        # Include if direct_access is True
-        if model_info.get("direct_access", False):
+        # BYOK rows owned by this team are always accessible to it, even if
+        # they haven't been re-added to team.models for some reason.
+        if model_info.get("team_id") == team_id:
             filtered_models.append(_model)
             continue
 
-        # Include if team_id is in access_via_team_ids
         access_via_team_ids = model_info.get("access_via_team_ids", [])
         if isinstance(access_via_team_ids, list) and team_id in access_via_team_ids:
             filtered_models.append(_model)
             continue
 
-        # Also include if model_id is in team_accessible_model_ids (from config/db search)
-        # This catches models that might not have been enriched with access_via_team_ids yet
+        # Catches models resolved from team.models / access groups that
+        # weren't enriched with access_via_team_ids upstream.
         if model_id and model_id in team_accessible_model_ids:
             filtered_models.append(_model)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10905,7 +10905,10 @@ async def _get_caller_byok_team_scope(
     """
     if user_api_key_dict is None or prisma_client is None:
         return None
-    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+    if user_api_key_dict.user_role in (
+        LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+    ):
         return None
     user_id = user_api_key_dict.user_id
     if user_id is None:
@@ -11365,28 +11368,81 @@ async def _gather_team_accessible_model_ids(
     return team_accessible_model_ids
 
 
+async def _authorize_team_id_query(
+    team_id: str,
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: PrismaClient,
+) -> None:
+    """
+    `teamId` arrives untrusted via the /v2/model/info query string and the
+    filter below includes BYOK rows solely on `model_info.team_id == team_id`.
+    Without this guard, any authenticated user who knows (or guesses) another
+    team's id could enumerate that team's BYOK model metadata. Allow only
+    proxy admins or members of the requested team.
+    """
+    if user_api_key_dict.user_role in (
+        LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+    ):
+        return
+
+    user_id = user_api_key_dict.user_id
+    if user_id is None:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Not authorized to view this team's models"},
+        )
+    try:
+        user_row = await prisma_client.db.litellm_usertable.find_unique(
+            where={"user_id": user_id}
+        )
+    except Exception:
+        verbose_proxy_logger.exception(
+            "Failed to look up caller teams while authorizing teamId filter"
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Not authorized to view this team's models"},
+        )
+
+    if user_row is None or team_id not in (user_row.teams or []):
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Not authorized to view this team's models"},
+        )
+
+
 async def _filter_models_by_team_id(
     all_models: List[Dict[str, Any]],
     team_id: str,
     prisma_client: PrismaClient,
     llm_router: Router,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
 ) -> List[Dict[str, Any]]:
     """
     Filter models by team ID. Returns models where:
-    - direct_access is True, OR
-    - team_id is in access_via_team_ids
-
-    Also searches config and database for models accessible to the team.
+    - team_id matches the model's BYOK team_id, OR
+    - team_id is in access_via_team_ids, OR
+    - model_id is reachable via team.models / access groups
 
     Args:
         all_models: List of models to filter
         team_id: Team ID to filter by
         prisma_client: Prisma client for database queries
         llm_router: Router instance for config queries
+        user_api_key_dict: Caller auth context. When provided, the caller must
+            be a proxy admin or a member of `team_id`; otherwise raises 403.
 
     Returns:
         Filtered list of models
     """
+    if user_api_key_dict is not None:
+        await _authorize_team_id_query(
+            team_id=team_id,
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
+        )
+
     team_object = await _load_team_object_for_model_filter(team_id, prisma_client)
     if team_object is None:
         return []
@@ -11597,6 +11653,7 @@ async def model_info_v2(
             team_id=teamId.strip(),
             prisma_client=prisma_client,
             llm_router=llm_router,
+            user_api_key_dict=user_api_key_dict,
         )
         # Update search_total_count after teamId filter is applied
         search_total_count = len(all_models)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -20,6 +20,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    Callable,
     Dict,
     List,
     Literal,
@@ -10935,6 +10936,78 @@ async def _get_caller_byok_team_scope(
 _SORTED_SEARCH_DB_FETCH_CAP = 500
 
 
+async def _fetch_db_models_for_search(
+    prisma_client: Any,
+    proxy_config: Any,
+    search_lower: str,
+    db_model_ids_in_router: Set[str],
+    router_models_count: int,
+    page: int,
+    size: int,
+    sort_by: Optional[str],
+    is_byok_outside_caller_teams: Callable[[Dict[str, Any]], bool],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """
+    Run the bounded DB query that backs `/v2/model/info?search=`. Returns
+    `(decrypted_models, total_count)` where `total_count` is the cheap
+    `count(...)` of rows matching `search` (not yet team-scoped) so the
+    UI's pagination stays accurate without materializing every row.
+
+    Earlier iterations also OR'd a JSON-path match on
+    `model_info.team_public_model_name` to surface BYOK rows that live
+    only in the DB. That branch fell back to `string_contains: ""`
+    because Prisma's JSON `string_contains` is case-sensitive on
+    Postgres, which let any authenticated caller force a full BYOK-table
+    read via `/v2/model/info?search=x`. We rely on the router-side
+    filter for `team_public_model_name` instead and keep the DB cost
+    bounded by `search`.
+    """
+    db_where_condition: Dict[str, Any] = {
+        "model_name": {"contains": search_lower, "mode": "insensitive"}
+    }
+    if db_model_ids_in_router:
+        db_where_condition["model_id"] = {
+            "not": {"in": list(db_model_ids_in_router)}
+        }
+
+    # Unsorted searches only need enough DB rows to fill the current
+    # page after counting router-side matches. Sorted searches need
+    # ordering across the full match set, so fall back to a hard cap.
+    if sort_by:
+        take_limit = _SORTED_SEARCH_DB_FETCH_CAP
+    else:
+        take_limit = max(0, page * size - router_models_count)
+
+    db_models_total_count = await prisma_client.db.litellm_proxymodeltable.count(
+        where=db_where_condition
+    )
+
+    db_models_raw: list = []
+    if take_limit > 0:
+        db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
+            where=db_where_condition,
+            take=take_limit,
+        )
+
+    # Scope BYOK rows to the caller's allowed teams so non-admin callers
+    # can't enumerate other teams' BYOK metadata via `?search=...`.
+    matching_db_rows = [
+        m
+        for m in db_models_raw
+        if not is_byok_outside_caller_teams(
+            m.model_info if isinstance(m.model_info, dict) else {}
+        )
+    ]
+
+    decrypted: List[Dict[str, Any]] = []
+    for db_model in matching_db_rows:
+        decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
+        if decrypted_models:
+            decrypted.extend(decrypted_models)
+
+    return decrypted, db_models_total_count
+
+
 async def _apply_search_filter_to_models(
     all_models: List[Dict[str, Any]],
     search: str,
@@ -11031,101 +11104,30 @@ async def _apply_search_filter_to_models(
     router_models_count = config_models_count + db_models_in_router_count
 
     # Query database for additional models with search term
-    db_models = []
-    db_models_total_count = 0
-
-    # Only query database if prisma_client is available
+    db_models: List[Dict[str, Any]] = []
     if prisma_client is not None:
         try:
-            # Match the persisted internal `model_name` only. Earlier
-            # iterations of this code also OR'd a JSON-path match on
-            # `model_info.team_public_model_name` so BYOK rows present only
-            # in the DB (not the router) were searchable by display name.
-            # That branch had to fall back to `string_contains: ""` because
-            # Prisma's JSON `string_contains` is case-sensitive on
-            # Postgres, which made the predicate match every row with any
-            # `team_public_model_name` set — an authenticated user could
-            # force a full BYOK-table read with `/v2/model/info?search=x`.
-            # BYOK rows that are actually loaded into the router are
-            # already searchable via the router-side path above (which
-            # checks `team_public_model_name`), so we drop the unbounded
-            # JSON branch here to keep the DB cost bounded by `search`.
-            db_where_condition: Dict[str, Any] = {
-                "model_name": {
-                    "contains": search_lower,
-                    "mode": "insensitive",
-                }
-            }
-            # Exclude models already in router if we have any
-            if db_model_ids_in_router:
-                db_where_condition["model_id"] = {
-                    "not": {"in": list(db_model_ids_in_router)}
-                }
-
-            # Bound the DB fetch so a broad `search` can't force a full
-            # model-table read on each request:
-            #
-            # * Unsorted searches only need enough DB rows to fill the
-            #   current page after counting router-side matches.
-            # * Sorted searches need ordering across the full match set,
-            #   so we fall back to a hard cap (`_SORTED_SEARCH_DB_FETCH_CAP`)
-            #   instead of fetching everything.
-            #
-            # `total_count` exposes the precise number of remaining DB rows
-            # via a cheap `count(...)` so the UI's pagination stays
-            # accurate even when we don't materialize them all.
-            if sort_by:
-                take_limit = _SORTED_SEARCH_DB_FETCH_CAP
-            else:
-                models_needed = max(0, page * size - router_models_count)
-                take_limit = models_needed
-
-            db_models_total_count = (
-                await prisma_client.db.litellm_proxymodeltable.count(
-                    where=db_where_condition
-                )
+            db_models, db_models_total_count = await _fetch_db_models_for_search(
+                prisma_client=prisma_client,
+                proxy_config=proxy_config,
+                search_lower=search_lower,
+                db_model_ids_in_router=db_model_ids_in_router,
+                router_models_count=router_models_count,
+                page=page,
+                size=size,
+                sort_by=sort_by,
+                is_byok_outside_caller_teams=_is_byok_outside_caller_teams,
             )
-
-            db_models_raw: list = []
-            if take_limit > 0:
-                db_models_raw = (
-                    await prisma_client.db.litellm_proxymodeltable.find_many(
-                        where=db_where_condition,
-                        take=take_limit,
-                    )
-                )
-
-            # Scope BYOK rows to the caller's allowed teams so non-admin
-            # callers can't enumerate other teams' BYOK metadata via
-            # `/v2/model/info?search=...`.
-            matching_db_rows = [
-                m
-                for m in db_models_raw
-                if not _is_byok_outside_caller_teams(
-                    m.model_info if isinstance(m.model_info, dict) else {}
-                )
-            ]
-
-            # Calculate total count for search results
             search_total_count = router_models_count + db_models_total_count
-
-            for db_model in matching_db_rows:
-                decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
-                if decrypted_models:
-                    db_models.extend(decrypted_models)
         except Exception as e:
             verbose_proxy_logger.exception(
                 f"Error querying database models with search: {str(e)}"
             )
-            # If error, use router models count as fallback
             search_total_count = router_models_count
     else:
-        # If no prisma_client, only use router models
         search_total_count = router_models_count
 
-    # Combine all models
-    filtered_models = filtered_router_models + db_models
-    return filtered_models, search_total_count
+    return filtered_router_models + db_models, search_total_count
 
 
 def _normalize_datetime_for_sorting(dt: Any) -> Optional[datetime]:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10892,11 +10892,8 @@ def _enrich_model_info_with_litellm_data(
 async def _apply_search_filter_to_models(
     all_models: List[Dict[str, Any]],
     search: str,
-    page: int,
-    size: int,
     prisma_client: Optional[Any],
     proxy_config: Any,
-    sort_by: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], Optional[int]]:
     """
     Apply search filter to models, querying database for additional matching models.
@@ -10904,11 +10901,8 @@ async def _apply_search_filter_to_models(
     Args:
         all_models: List of models to filter
         search: Search term (case-insensitive)
-        page: Current page number
-        size: Page size
         prisma_client: Prisma client for database queries
         proxy_config: Proxy config for decrypting models
-        sort_by: Optional sort field - if provided, fetch all matching models instead of paginating at DB level
 
     Returns:
         Tuple of (filtered_models, total_count). total_count is None if not searching.
@@ -10954,13 +10948,19 @@ async def _apply_search_filter_to_models(
     # Query database for additional models with search term
     db_models = []
     db_models_total_count = 0
-    models_needed_for_page = size * page
 
     # Only query database if prisma_client is available
     if prisma_client is not None:
         try:
-            # Match either the persisted model_name or, for team BYOK rows,
-            # the user-facing team_public_model_name stored inside model_info.
+            # Prisma's JSON path `string_contains` is case-sensitive in
+            # Postgres (it doesn't accept the `mode: insensitive` flag the
+            # way column-level string filters do), so the BYOK branch
+            # below can't match mixed-case stored names like
+            # "Claude Sonnet" against a lowercased search term. Widen the
+            # JSON branch to "row has a team_public_model_name set"
+            # (`string_contains: ""` matches any string at the path) and
+            # filter case-insensitively in Python below so behavior
+            # matches the router-side path in `_model_matches_search`.
             db_where_condition: Dict[str, Any] = {
                 "OR": [
                     {
@@ -10972,7 +10972,7 @@ async def _apply_search_filter_to_models(
                     {
                         "model_info": {
                             "path": ["team_public_model_name"],
-                            "string_contains": search_lower,
+                            "string_contains": "",
                         }
                     },
                 ]
@@ -10983,58 +10983,36 @@ async def _apply_search_filter_to_models(
                     "not": {"in": list(db_model_ids_in_router)}
                 }
 
-            # Get total count of matching database models
-            db_models_total_count = (
-                await prisma_client.db.litellm_proxymodeltable.count(
-                    where=db_where_condition
-                )
+            # Fetch all candidates and filter in Python. We can't trust a
+            # DB-level count because the BYOK branch is over-broad — it
+            # returns every row with a team_public_model_name regardless
+            # of whether it matches the search term.
+            db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
+                where=db_where_condition,
             )
+
+            def _db_row_matches_search(db_model: Any) -> bool:
+                if search_lower in (db_model.model_name or "").lower():
+                    return True
+                info = (
+                    db_model.model_info if isinstance(db_model.model_info, dict) else {}
+                )
+                return (
+                    search_lower in (info.get("team_public_model_name") or "").lower()
+                )
+
+            matching_db_rows = [m for m in db_models_raw if _db_row_matches_search(m)]
+            db_models_total_count = len(matching_db_rows)
 
             # Calculate total count for search results
             search_total_count = router_models_count + db_models_total_count
 
-            # If sorting is requested, we need to fetch ALL matching models to sort correctly
-            # Otherwise, we can optimize by only fetching what's needed for the current page
-            if sort_by:
-                # Fetch all matching database models for sorting
-                if db_models_total_count > 0:
-                    db_models_raw = (
-                        await prisma_client.db.litellm_proxymodeltable.find_many(
-                            where=db_where_condition,
-                            take=db_models_total_count,  # Fetch all matching models
-                        )
-                    )
-
-                    # Convert database models to router format
-                    for db_model in db_models_raw:
-                        decrypted_models = proxy_config.decrypt_model_list_from_db(
-                            [db_model]
-                        )
-                        if decrypted_models:
-                            db_models.extend(decrypted_models)
-            else:
-                # Fetch database models if we need more for the current page
-                if router_models_count < models_needed_for_page:
-                    models_to_fetch = min(
-                        models_needed_for_page - router_models_count,
-                        db_models_total_count,
-                    )
-
-                    if models_to_fetch > 0:
-                        db_models_raw = (
-                            await prisma_client.db.litellm_proxymodeltable.find_many(
-                                where=db_where_condition,
-                                take=models_to_fetch,
-                            )
-                        )
-
-                        # Convert database models to router format
-                        for db_model in db_models_raw:
-                            decrypted_models = proxy_config.decrypt_model_list_from_db(
-                                [db_model]
-                            )
-                            if decrypted_models:
-                                db_models.extend(decrypted_models)
+            # Decrypt matching rows. Done after the in-Python filter so we
+            # don't decrypt BYOK rows we're going to throw away.
+            for db_model in matching_db_rows:
+                decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
+                if decrypted_models:
+                    db_models.extend(decrypted_models)
         except Exception as e:
             verbose_proxy_logger.exception(
                 f"Error querying database models with search: {str(e)}"
@@ -11511,11 +11489,8 @@ async def model_info_v2(
         all_models, search_total_count = await _apply_search_filter_to_models(
             all_models=all_models,
             search=search or "",
-            page=page,
-            size=size,
             prisma_client=prisma_client,
             proxy_config=proxy_config,
-            sort_by=sortBy,
         )
 
     if user_models_only:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10889,11 +10889,48 @@ def _enrich_model_info_with_litellm_data(
     return model
 
 
+async def _get_caller_byok_team_scope(
+    user_api_key_dict: Optional[UserAPIKeyAuth],
+    prisma_client: Optional[Any],
+) -> Optional[Set[str]]:
+    """
+    Return the team IDs whose BYOK rows the caller is allowed to see via
+    `/v2/model/info` search results.
+
+    `None` means "no scoping" — used for admins and for callers/paths that
+    have already been scoped upstream (or in tests that supply their own
+    pre-filtered input set). A returned set (possibly empty) means BYOK rows
+    must have `model_info.team_id` ∈ that set, otherwise they belong to a
+    team the caller is not a member of and must be dropped.
+    """
+    if user_api_key_dict is None or prisma_client is None:
+        return None
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+        return None
+    user_id = user_api_key_dict.user_id
+    if user_id is None:
+        return set()
+    try:
+        user_row = await prisma_client.db.litellm_usertable.find_unique(
+            where={"user_id": user_id}
+        )
+    except Exception:
+        verbose_proxy_logger.exception(
+            "Failed to look up caller teams while scoping BYOK search; "
+            "defaulting to no team access."
+        )
+        return set()
+    if user_row is None:
+        return set()
+    return set(user_row.teams or [])
+
+
 async def _apply_search_filter_to_models(
     all_models: List[Dict[str, Any]],
     search: str,
     prisma_client: Optional[Any],
     proxy_config: Any,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
 ) -> Tuple[List[Dict[str, Any]], Optional[int]]:
     """
     Apply search filter to models, querying database for additional matching models.
@@ -10903,6 +10940,10 @@ async def _apply_search_filter_to_models(
         search: Search term (case-insensitive)
         prisma_client: Prisma client for database queries
         proxy_config: Proxy config for decrypting models
+        user_api_key_dict: Caller identity used to scope BYOK matches to
+            teams the caller belongs to. When omitted (None), no team
+            scoping is applied — pass it from request handlers that expose
+            this function to non-admin callers.
 
     Returns:
         Tuple of (filtered_models, total_count). total_count is None if not searching.
@@ -10911,6 +10952,22 @@ async def _apply_search_filter_to_models(
         return all_models, None
 
     search_lower = search.lower().strip()
+
+    allowed_team_ids = await _get_caller_byok_team_scope(
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+    )
+
+    def _is_byok_outside_caller_teams(model_info_dict: Dict[str, Any]) -> bool:
+        # `team_id` is only set on team BYOK rows. Non-team rows fall
+        # through unaffected — they are gated by other paths (router
+        # membership, direct_access, include_team_models).
+        if allowed_team_ids is None:
+            return False
+        team_id = model_info_dict.get("team_id")
+        if team_id is None:
+            return False
+        return team_id not in allowed_team_ids
 
     def _model_matches_search(m: Dict[str, Any]) -> bool:
         # Team BYOK models persist an internal `model_name`
@@ -10924,8 +10981,16 @@ async def _apply_search_filter_to_models(
         ) or ""
         return search_lower in team_public_model_name.lower()
 
-    # Filter models in router by search term
-    filtered_router_models = [m for m in all_models if _model_matches_search(m)]
+    # Filter models in router by search term, dropping BYOK rows that
+    # belong to teams the caller is not a member of so search can't leak
+    # other teams' models when the request omits `include_team_models` /
+    # `teamId`.
+    filtered_router_models = [
+        m
+        for m in all_models
+        if _model_matches_search(m)
+        and not _is_byok_outside_caller_teams(m.get("model_info") or {})
+    ]
 
     # Separate filtered models into config vs db models, and track db model IDs
     filtered_config_models = []
@@ -10992,11 +11057,17 @@ async def _apply_search_filter_to_models(
             )
 
             def _db_row_matches_search(db_model: Any) -> bool:
-                if search_lower in (db_model.model_name or "").lower():
-                    return True
                 info = (
                     db_model.model_info if isinstance(db_model.model_info, dict) else {}
                 )
+                # Scope BYOK rows to the caller's teams before applying
+                # the display-name match, so the over-broad
+                # `string_contains: ""` JSON branch can't leak other
+                # teams' models into search results.
+                if _is_byok_outside_caller_teams(info):
+                    return False
+                if search_lower in (db_model.model_name or "").lower():
+                    return True
                 return (
                     search_lower in (info.get("team_public_model_name") or "").lower()
                 )
@@ -11491,6 +11562,7 @@ async def model_info_v2(
             search=search or "",
             prisma_client=prisma_client,
             proxy_config=proxy_config,
+            user_api_key_dict=user_api_key_dict,
         )
 
     if user_models_only:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11020,30 +11020,24 @@ async def _apply_search_filter_to_models(
     # Only query database if prisma_client is available
     if prisma_client is not None:
         try:
-            # Prisma's JSON path `string_contains` is case-sensitive in
-            # Postgres (it doesn't accept the `mode: insensitive` flag the
-            # way column-level string filters do), so the BYOK branch
-            # below can't match mixed-case stored names like
-            # "Claude Sonnet" against a lowercased search term. Widen the
-            # JSON branch to "row has a team_public_model_name set"
-            # (`string_contains: ""` matches any string at the path) and
-            # filter case-insensitively in Python below so behavior
-            # matches the router-side path in `_model_matches_search`.
+            # Match the persisted internal `model_name` only. Earlier
+            # iterations of this code also OR'd a JSON-path match on
+            # `model_info.team_public_model_name` so BYOK rows present only
+            # in the DB (not the router) were searchable by display name.
+            # That branch had to fall back to `string_contains: ""` because
+            # Prisma's JSON `string_contains` is case-sensitive on
+            # Postgres, which made the predicate match every row with any
+            # `team_public_model_name` set — an authenticated user could
+            # force a full BYOK-table read with `/v2/model/info?search=x`.
+            # BYOK rows that are actually loaded into the router are
+            # already searchable via the router-side path above (which
+            # checks `team_public_model_name`), so we drop the unbounded
+            # JSON branch here to keep the DB cost bounded by `search`.
             db_where_condition: Dict[str, Any] = {
-                "OR": [
-                    {
-                        "model_name": {
-                            "contains": search_lower,
-                            "mode": "insensitive",
-                        }
-                    },
-                    {
-                        "model_info": {
-                            "path": ["team_public_model_name"],
-                            "string_contains": "",
-                        }
-                    },
-                ]
+                "model_name": {
+                    "contains": search_lower,
+                    "mode": "insensitive",
+                }
             }
             # Exclude models already in router if we have any
             if db_model_ids_in_router:
@@ -11051,38 +11045,25 @@ async def _apply_search_filter_to_models(
                     "not": {"in": list(db_model_ids_in_router)}
                 }
 
-            # Fetch all candidates and filter in Python. We can't trust a
-            # DB-level count because the BYOK branch is over-broad — it
-            # returns every row with a team_public_model_name regardless
-            # of whether it matches the search term.
             db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
                 where=db_where_condition,
             )
 
-            def _db_row_matches_search(db_model: Any) -> bool:
-                info = (
-                    db_model.model_info if isinstance(db_model.model_info, dict) else {}
+            # Scope BYOK rows to the caller's allowed teams so non-admin
+            # callers can't enumerate other teams' BYOK metadata via
+            # `/v2/model/info?search=...`.
+            matching_db_rows = [
+                m
+                for m in db_models_raw
+                if not _is_byok_outside_caller_teams(
+                    m.model_info if isinstance(m.model_info, dict) else {}
                 )
-                # Scope BYOK rows to the caller's teams before applying
-                # the display-name match, so the over-broad
-                # `string_contains: ""` JSON branch can't leak other
-                # teams' models into search results.
-                if _is_byok_outside_caller_teams(info):
-                    return False
-                if search_lower in (db_model.model_name or "").lower():
-                    return True
-                return (
-                    search_lower in (info.get("team_public_model_name") or "").lower()
-                )
-
-            matching_db_rows = [m for m in db_models_raw if _db_row_matches_search(m)]
+            ]
             db_models_total_count = len(matching_db_rows)
 
             # Calculate total count for search results
             search_total_count = router_models_count + db_models_total_count
 
-            # Decrypt matching rows. Done after the in-Python filter so we
-            # don't decrypt BYOK rows we're going to throw away.
             for db_model in matching_db_rows:
                 decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
                 if decrypted_models:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10928,12 +10928,22 @@ async def _get_caller_byok_team_scope(
     return set(user_row.teams or [])
 
 
+# Hard cap on rows the DB-side BYOK search may pull when results need to be
+# sorted across the full match set. Without this, an authenticated caller
+# can hit `/v2/model/info?search=<broad>&sortBy=<field>` and force the
+# proxy to materialize and decrypt every matching BYOK row on each request.
+_SORTED_SEARCH_DB_FETCH_CAP = 500
+
+
 async def _apply_search_filter_to_models(
     all_models: List[Dict[str, Any]],
     search: str,
     prisma_client: Optional[Any],
     proxy_config: Any,
     user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+    page: int = 1,
+    size: int = 50,
+    sort_by: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], Optional[int]]:
     """
     Apply search filter to models, querying database for additional matching models.
@@ -10947,6 +10957,13 @@ async def _apply_search_filter_to_models(
             teams the caller belongs to. When omitted (None), no team
             scoping is applied — pass it from request handlers that expose
             this function to non-admin callers.
+        page: Current page number (1-indexed). Used with ``size`` to bound
+            the DB ``find_many(take=...)`` so a broad search term can't
+            force a full table read + decrypt on every request.
+        size: Page size. See ``page``.
+        sort_by: Sort field. When set, results must be sorted across the
+            full match set, so the DB fetch is capped at
+            ``_SORTED_SEARCH_DB_FETCH_CAP`` instead of one page.
 
     Returns:
         Tuple of (filtered_models, total_count). total_count is None if not searching.
@@ -11045,9 +11062,38 @@ async def _apply_search_filter_to_models(
                     "not": {"in": list(db_model_ids_in_router)}
                 }
 
-            db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
-                where=db_where_condition,
+            # Bound the DB fetch so a broad `search` can't force a full
+            # model-table read on each request:
+            #
+            # * Unsorted searches only need enough DB rows to fill the
+            #   current page after counting router-side matches.
+            # * Sorted searches need ordering across the full match set,
+            #   so we fall back to a hard cap (`_SORTED_SEARCH_DB_FETCH_CAP`)
+            #   instead of fetching everything.
+            #
+            # `total_count` exposes the precise number of remaining DB rows
+            # via a cheap `count(...)` so the UI's pagination stays
+            # accurate even when we don't materialize them all.
+            if sort_by:
+                take_limit = _SORTED_SEARCH_DB_FETCH_CAP
+            else:
+                models_needed = max(0, page * size - router_models_count)
+                take_limit = models_needed
+
+            db_models_total_count = (
+                await prisma_client.db.litellm_proxymodeltable.count(
+                    where=db_where_condition
+                )
             )
+
+            db_models_raw: list = []
+            if take_limit > 0:
+                db_models_raw = (
+                    await prisma_client.db.litellm_proxymodeltable.find_many(
+                        where=db_where_condition,
+                        take=take_limit,
+                    )
+                )
 
             # Scope BYOK rows to the caller's allowed teams so non-admin
             # callers can't enumerate other teams' BYOK metadata via
@@ -11059,7 +11105,6 @@ async def _apply_search_filter_to_models(
                     m.model_info if isinstance(m.model_info, dict) else {}
                 )
             ]
-            db_models_total_count = len(matching_db_rows)
 
             # Calculate total count for search results
             search_total_count = router_models_count + db_models_total_count
@@ -11600,6 +11645,9 @@ async def model_info_v2(
             prisma_client=prisma_client,
             proxy_config=proxy_config,
             user_api_key_dict=user_api_key_dict,
+            page=page,
+            size=size,
+            sort_by=sortBy,
         )
 
     if user_models_only:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10966,9 +10966,7 @@ async def _fetch_db_models_for_search(
         "model_name": {"contains": search_lower, "mode": "insensitive"}
     }
     if db_model_ids_in_router:
-        db_where_condition["model_id"] = {
-            "not": {"in": list(db_model_ids_in_router)}
-        }
+        db_where_condition["model_id"] = {"not": {"in": list(db_model_ids_in_router)}}
 
     # Unsorted searches only need enough DB rows to fill the current
     # page after counting router-side matches. Sorted searches need

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1199,11 +1199,8 @@ async def test_apply_search_filter_matches_team_public_model_name():
     filtered, _ = await _apply_search_filter_to_models(
         all_models=[byok_model, unrelated_model],
         search="claude",
-        page=1,
-        size=50,
         prisma_client=None,
         proxy_config=MagicMock(),
-        sort_by=None,
     )
     filtered_ids = {m["model_info"]["id"] for m in filtered}
     assert "byok-id-1" in filtered_ids
@@ -1213,11 +1210,8 @@ async def test_apply_search_filter_matches_team_public_model_name():
     filtered, _ = await _apply_search_filter_to_models(
         all_models=[byok_model, unrelated_model],
         search="model_name_team-abc-123",
-        page=1,
-        size=50,
         prisma_client=None,
         proxy_config=MagicMock(),
-        sort_by=None,
     )
     assert [m["model_info"]["id"] for m in filtered] == ["byok-id-1"]
 
@@ -1225,13 +1219,82 @@ async def test_apply_search_filter_matches_team_public_model_name():
     filtered, _ = await _apply_search_filter_to_models(
         all_models=[byok_model, unrelated_model],
         search="gemini",
-        page=1,
-        size=50,
         prisma_client=None,
         proxy_config=MagicMock(),
-        sort_by=None,
     )
     assert filtered == []
+
+
+@pytest.mark.asyncio
+async def test_apply_search_filter_matches_db_byok_case_insensitively():
+    """
+    Regression test: BYOK rows that only exist in the DB (not in the
+    in-memory router) must still match search case-insensitively against
+    their stored `team_public_model_name`. Prisma's JSON path
+    `string_contains` is case-sensitive in Postgres, so a search like
+    "claude" must still match a stored value of "Claude Sonnet".
+    """
+    from litellm.proxy.proxy_server import _apply_search_filter_to_models
+
+    # Stored team_public_model_name uses mixed case; lowercased search
+    # would never match it via Prisma's case-sensitive JSON filter.
+    byok_db_row = MagicMock()
+    byok_db_row.model_id = "byok-db-only"
+    byok_db_row.model_name = "model_name_team-xyz_internal"
+    byok_db_row.model_info = {
+        "id": "byok-db-only",
+        "team_id": "team-xyz",
+        "team_public_model_name": "Claude Sonnet 4.6",
+        "db_model": True,
+    }
+    # Decoy row with team_public_model_name set but not matching the
+    # search — verifies the Python filter prunes the over-broad DB query.
+    decoy_db_row = MagicMock()
+    decoy_db_row.model_id = "decoy-db-only"
+    decoy_db_row.model_name = "model_name_team-xyz_decoy"
+    decoy_db_row.model_info = {
+        "id": "decoy-db-only",
+        "team_id": "team-xyz",
+        "team_public_model_name": "Some Gemini Variant",
+        "db_model": True,
+    }
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_proxymodeltable.find_many = AsyncMock(
+        return_value=[byok_db_row, decoy_db_row]
+    )
+
+    proxy_config = MagicMock()
+
+    # decrypt_model_list_from_db echoes back a router-shaped dict; mock
+    # it so we can identify which DB row(s) survived the Python filter.
+    def _fake_decrypt(rows):
+        return [
+            {
+                "model_name": r.model_name,
+                "model_info": r.model_info,
+                "litellm_params": {"model": "claude-sonnet"},
+            }
+            for r in rows
+        ]
+
+    proxy_config.decrypt_model_list_from_db = _fake_decrypt
+
+    filtered, total_count = await _apply_search_filter_to_models(
+        all_models=[],
+        search="claude",
+        prisma_client=prisma_client,
+        proxy_config=proxy_config,
+    )
+
+    filtered_ids = {m["model_info"]["id"] for m in filtered}
+    assert (
+        "byok-db-only" in filtered_ids
+    ), "mixed-case team_public_model_name must match lowercased search"
+    assert (
+        "decoy-db-only" not in filtered_ids
+    ), "non-matching BYOK row fetched by over-broad query must be filtered out"
+    assert total_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1298,6 +1298,131 @@ async def test_apply_search_filter_matches_db_byok_case_insensitively():
 
 
 @pytest.mark.asyncio
+async def test_apply_search_filter_scopes_byok_to_caller_teams():
+    """
+    Regression test: `/v2/model/info?search=...` must not leak BYOK rows
+    from teams the caller is not a member of. The new DB branch fetches
+    every row with a `team_public_model_name` set (the JSON
+    `string_contains: ""` widening), so without team scoping a non-admin
+    user could search for a common substring like "claude" and see other
+    teams' BYOK models.
+    """
+    from litellm.proxy.proxy_server import _apply_search_filter_to_models
+
+    # In-router BYOK rows: one in the caller's team, one in someone else's.
+    caller_team_byok = {
+        "model_name": "model_name_team-mine_internal",
+        "litellm_params": {"model": "claude-sonnet"},
+        "model_info": {
+            "id": "byok-mine",
+            "team_id": "team-mine",
+            "team_public_model_name": "claude-sonnet-prod",
+            "db_model": True,
+        },
+    }
+    other_team_byok = {
+        "model_name": "model_name_team-other_internal",
+        "litellm_params": {"model": "claude-sonnet"},
+        "model_info": {
+            "id": "byok-other",
+            "team_id": "team-other",
+            "team_public_model_name": "claude-sonnet-staging",
+            "db_model": True,
+        },
+    }
+    # Non-team row stays in the router-side result regardless of teams.
+    public_model = {
+        "model_name": "claude-public",
+        "litellm_params": {"model": "claude-sonnet"},
+        "model_info": {"id": "public-id", "db_model": False},
+    }
+
+    # DB-only BYOK rows fetched by the over-broad JSON branch.
+    db_caller_row = MagicMock()
+    db_caller_row.model_id = "byok-db-mine"
+    db_caller_row.model_name = "model_name_team-mine_db"
+    db_caller_row.model_info = {
+        "id": "byok-db-mine",
+        "team_id": "team-mine",
+        "team_public_model_name": "Claude DB Mine",
+        "db_model": True,
+    }
+    db_other_row = MagicMock()
+    db_other_row.model_id = "byok-db-other"
+    db_other_row.model_name = "model_name_team-other_db"
+    db_other_row.model_info = {
+        "id": "byok-db-other",
+        "team_id": "team-other",
+        "team_public_model_name": "Claude DB Other",
+        "db_model": True,
+    }
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_proxymodeltable.find_many = AsyncMock(
+        return_value=[db_caller_row, db_other_row]
+    )
+    caller_user_row = MagicMock()
+    caller_user_row.teams = ["team-mine"]
+    prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=caller_user_row
+    )
+
+    proxy_config = MagicMock()
+    proxy_config.decrypt_model_list_from_db = lambda rows: [
+        {
+            "model_name": r.model_name,
+            "model_info": r.model_info,
+            "litellm_params": {"model": "claude-sonnet"},
+        }
+        for r in rows
+    ]
+
+    non_admin = MagicMock(spec=UserAPIKeyAuth)
+    non_admin.user_role = LitellmUserRoles.INTERNAL_USER
+    non_admin.user_id = "user-mine"
+
+    filtered, total_count = await _apply_search_filter_to_models(
+        all_models=[caller_team_byok, other_team_byok, public_model],
+        search="claude",
+        prisma_client=prisma_client,
+        proxy_config=proxy_config,
+        user_api_key_dict=non_admin,
+    )
+
+    filtered_ids = {m["model_info"]["id"] for m in filtered}
+    assert "byok-mine" in filtered_ids
+    assert "byok-db-mine" in filtered_ids
+    assert "public-id" in filtered_ids
+    assert "byok-other" not in filtered_ids, (
+        "router-side BYOK from another team must be dropped from search "
+        "when caller doesn't belong to that team"
+    )
+    assert "byok-db-other" not in filtered_ids, (
+        "DB-only BYOK from another team must be dropped from search when "
+        "caller doesn't belong to that team"
+    )
+    # total_count is router_models_count (3: caller_team_byok, public_model
+    # would be counted; other_team_byok is dropped — 2) + 1 db row = 3.
+    assert total_count == 3
+
+    # Admins keep the un-scoped view across teams.
+    admin = MagicMock(spec=UserAPIKeyAuth)
+    admin.user_role = LitellmUserRoles.PROXY_ADMIN
+    admin.user_id = "admin-1"
+
+    filtered_admin, _ = await _apply_search_filter_to_models(
+        all_models=[caller_team_byok, other_team_byok, public_model],
+        search="claude",
+        prisma_client=prisma_client,
+        proxy_config=proxy_config,
+        user_api_key_dict=admin,
+    )
+    admin_ids = {m["model_info"]["id"] for m in filtered_admin}
+    assert "byok-other" in admin_ids
+    assert "byok-db-other" in admin_ids
+
+
+@pytest.mark.asyncio
 async def test_filter_models_by_team_id_excludes_viewer_direct_access():
     """
     Regression test: when the UI picks a specific team in the Current Team

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1170,6 +1170,146 @@ def test_add_team_models_to_all_models():
 
 
 @pytest.mark.asyncio
+async def test_apply_search_filter_matches_team_public_model_name():
+    """
+    Regression test: team BYOK models persist an internal model_name
+    (e.g. `model_name_{team_id}_{uuid}`) and surface the user-facing name
+    via `model_info.team_public_model_name`. The /v2/model/info search
+    filter must match that public name so BYOK rows appear in results.
+    """
+    from litellm.proxy.proxy_server import _apply_search_filter_to_models
+
+    byok_model = {
+        "model_name": "model_name_team-abc-123_4a6b8",
+        "litellm_params": {"model": "claude-sonnet-4-5"},
+        "model_info": {
+            "id": "byok-id-1",
+            "team_id": "team-abc-123",
+            "team_public_model_name": "team-claude-sonnet",
+            "db_model": True,
+        },
+    }
+    unrelated_model = {
+        "model_name": "gpt-4",
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {"id": "normal-id-1", "db_model": False},
+    }
+
+    # Search matching only team_public_model_name should still include BYOK
+    filtered, _ = await _apply_search_filter_to_models(
+        all_models=[byok_model, unrelated_model],
+        search="claude",
+        page=1,
+        size=50,
+        prisma_client=None,
+        proxy_config=MagicMock(),
+        sort_by=None,
+    )
+    filtered_ids = {m["model_info"]["id"] for m in filtered}
+    assert "byok-id-1" in filtered_ids
+    assert "normal-id-1" not in filtered_ids
+
+    # Search by internal model_name still matches as before
+    filtered, _ = await _apply_search_filter_to_models(
+        all_models=[byok_model, unrelated_model],
+        search="model_name_team-abc-123",
+        page=1,
+        size=50,
+        prisma_client=None,
+        proxy_config=MagicMock(),
+        sort_by=None,
+    )
+    assert [m["model_info"]["id"] for m in filtered] == ["byok-id-1"]
+
+    # Non-matching search returns nothing
+    filtered, _ = await _apply_search_filter_to_models(
+        all_models=[byok_model, unrelated_model],
+        search="gemini",
+        page=1,
+        size=50,
+        prisma_client=None,
+        proxy_config=MagicMock(),
+        sort_by=None,
+    )
+    assert filtered == []
+
+
+@pytest.mark.asyncio
+async def test_filter_models_by_team_id_excludes_viewer_direct_access():
+    """
+    Regression test: when the UI picks a specific team in the Current Team
+    selector, the model list must show only that team's BYOK rows + the
+    models assigned to the team. The admin viewer's `direct_access` flag
+    (set on every non-team model upstream) must NOT widen the team's
+    visible set, or selecting team-111 still shows every public model.
+    """
+    from litellm.proxy.proxy_server import _filter_models_by_team_id
+
+    public_model = {
+        "model_name": "gpt-4",
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {
+            "id": "public-id",
+            # admin viewer has direct_access on this public model
+            "direct_access": True,
+            # team-111 is NOT in access_via_team_ids -> shouldn't show for team-111
+            "access_via_team_ids": ["team-222"],
+        },
+    }
+    team111_byok = {
+        "model_name": "model_name_team-111_uuid",
+        "litellm_params": {"model": "claude-sonnet"},
+        "model_info": {
+            "id": "byok-team-111",
+            "team_id": "team-111",
+            "team_public_model_name": "team-claude",
+            "access_via_team_ids": ["team-111"],
+        },
+    }
+    team222_byok = {
+        "model_name": "model_name_team-222_uuid",
+        "litellm_params": {"model": "claude-haiku"},
+        "model_info": {
+            "id": "byok-team-222",
+            "team_id": "team-222",
+            "team_public_model_name": "team-haiku",
+            "access_via_team_ids": ["team-222"],
+        },
+    }
+
+    prisma = MagicMock()
+    team_db = MagicMock()
+    team_db.model_dump.return_value = {
+        "team_id": "team-111",
+        "team_alias": "Team 111",
+        # specific models list that doesn't include the BYOK's internal name
+        "models": ["some-other-model"],
+        "access_group_ids": None,
+    }
+    prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_db)
+    prisma.db.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+
+    router = MagicMock()
+    router.get_model_access_groups = MagicMock(return_value={})
+    # team-111 only resolves "some-other-model", which has no deployments
+    router.get_model_list = MagicMock(return_value=[])
+
+    filtered = await _filter_models_by_team_id(
+        all_models=[public_model, team111_byok, team222_byok],
+        team_id="team-111",
+        prisma_client=prisma,
+        llm_router=router,
+    )
+    visible_ids = sorted(m["model_info"]["id"] for m in filtered)
+
+    assert "byok-team-111" in visible_ids, "team-111's own BYOK must always be visible"
+    assert "byok-team-222" not in visible_ids, "must not leak other teams' BYOK"
+    assert (
+        "public-id" not in visible_ids
+    ), "viewer's direct_access must not widen the team's visible set"
+
+
+@pytest.mark.asyncio
 async def test_add_access_group_models_to_team_models():
     """
     Test that models reachable via team access groups are included in team_models.
@@ -6922,3 +7062,80 @@ class TestTransformRequestBannedParams:
             f"Expected 400 for banned param '{banned}', "
             f"got {response.status_code}: {response.json()}"
         )
+
+
+class TestSortModelsByDisplayName:
+    """Regression: team BYOK rows persist an internal `model_name` like
+    `model_name_{team_id}_{uuid}` and expose the user-facing name via
+    `model_info.team_public_model_name`. Sorting must use the displayed
+    name so BYOK rows interleave with non-BYOK rows alphabetically —
+    otherwise they clump at the end on their opaque IDs even though the
+    UI shows them under a normal-looking name.
+    """
+
+    def test_byok_models_sort_by_team_public_model_name(self):
+        from litellm.proxy.proxy_server import _sort_models
+
+        models = [
+            {"model_name": "claude-haiku-4-5", "model_info": {}},
+            {
+                # Opaque internal name; UI displays team_public_model_name.
+                "model_name": "model_name_team-1_abc123",
+                "model_info": {"team_public_model_name": "anthropic/claude"},
+            },
+            {"model_name": "gpt-4o", "model_info": {}},
+        ]
+
+        sorted_models = _sort_models(
+            all_models=models, sort_by="model_name", sort_order="asc"
+        )
+        displayed_order = [
+            m["model_info"].get("team_public_model_name") or m["model_name"]
+            for m in sorted_models
+        ]
+        assert displayed_order == [
+            "anthropic/claude",
+            "claude-haiku-4-5",
+            "gpt-4o",
+        ]
+
+    def test_byok_models_sort_descending_by_display_name(self):
+        from litellm.proxy.proxy_server import _sort_models
+
+        models = [
+            {"model_name": "claude-haiku-4-5", "model_info": {}},
+            {
+                "model_name": "model_name_team-1_zzz",
+                "model_info": {"team_public_model_name": "zeta/model"},
+            },
+            {"model_name": "gpt-4o", "model_info": {}},
+        ]
+
+        sorted_models = _sort_models(
+            all_models=models, sort_by="model_name", sort_order="desc"
+        )
+        displayed_order = [
+            m["model_info"].get("team_public_model_name") or m["model_name"]
+            for m in sorted_models
+        ]
+        assert displayed_order == [
+            "zeta/model",
+            "gpt-4o",
+            "claude-haiku-4-5",
+        ]
+
+    def test_empty_team_public_model_name_falls_back_to_model_name(self):
+        # Empty string for team_public_model_name (not None) must still
+        # fall back to model_name — otherwise BYOK rows with a blank
+        # display name would sort to the top.
+        from litellm.proxy.proxy_server import _sort_models
+
+        models = [
+            {"model_name": "alpha", "model_info": {"team_public_model_name": ""}},
+            {"model_name": "beta", "model_info": {}},
+        ]
+
+        sorted_models = _sort_models(
+            all_models=models, sort_by="model_name", sort_order="asc"
+        )
+        assert [m["model_name"] for m in sorted_models] == ["alpha", "beta"]

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1226,86 +1226,13 @@ async def test_apply_search_filter_matches_team_public_model_name():
 
 
 @pytest.mark.asyncio
-async def test_apply_search_filter_matches_db_byok_case_insensitively():
-    """
-    Regression test: BYOK rows that only exist in the DB (not in the
-    in-memory router) must still match search case-insensitively against
-    their stored `team_public_model_name`. Prisma's JSON path
-    `string_contains` is case-sensitive in Postgres, so a search like
-    "claude" must still match a stored value of "Claude Sonnet".
-    """
-    from litellm.proxy.proxy_server import _apply_search_filter_to_models
-
-    # Stored team_public_model_name uses mixed case; lowercased search
-    # would never match it via Prisma's case-sensitive JSON filter.
-    byok_db_row = MagicMock()
-    byok_db_row.model_id = "byok-db-only"
-    byok_db_row.model_name = "model_name_team-xyz_internal"
-    byok_db_row.model_info = {
-        "id": "byok-db-only",
-        "team_id": "team-xyz",
-        "team_public_model_name": "Claude Sonnet 4.6",
-        "db_model": True,
-    }
-    # Decoy row with team_public_model_name set but not matching the
-    # search — verifies the Python filter prunes the over-broad DB query.
-    decoy_db_row = MagicMock()
-    decoy_db_row.model_id = "decoy-db-only"
-    decoy_db_row.model_name = "model_name_team-xyz_decoy"
-    decoy_db_row.model_info = {
-        "id": "decoy-db-only",
-        "team_id": "team-xyz",
-        "team_public_model_name": "Some Gemini Variant",
-        "db_model": True,
-    }
-
-    prisma_client = MagicMock()
-    prisma_client.db.litellm_proxymodeltable.find_many = AsyncMock(
-        return_value=[byok_db_row, decoy_db_row]
-    )
-
-    proxy_config = MagicMock()
-
-    # decrypt_model_list_from_db echoes back a router-shaped dict; mock
-    # it so we can identify which DB row(s) survived the Python filter.
-    def _fake_decrypt(rows):
-        return [
-            {
-                "model_name": r.model_name,
-                "model_info": r.model_info,
-                "litellm_params": {"model": "claude-sonnet"},
-            }
-            for r in rows
-        ]
-
-    proxy_config.decrypt_model_list_from_db = _fake_decrypt
-
-    filtered, total_count = await _apply_search_filter_to_models(
-        all_models=[],
-        search="claude",
-        prisma_client=prisma_client,
-        proxy_config=proxy_config,
-    )
-
-    filtered_ids = {m["model_info"]["id"] for m in filtered}
-    assert (
-        "byok-db-only" in filtered_ids
-    ), "mixed-case team_public_model_name must match lowercased search"
-    assert (
-        "decoy-db-only" not in filtered_ids
-    ), "non-matching BYOK row fetched by over-broad query must be filtered out"
-    assert total_count == 1
-
-
-@pytest.mark.asyncio
 async def test_apply_search_filter_scopes_byok_to_caller_teams():
     """
     Regression test: `/v2/model/info?search=...` must not leak BYOK rows
-    from teams the caller is not a member of. The new DB branch fetches
-    every row with a `team_public_model_name` set (the JSON
-    `string_contains: ""` widening), so without team scoping a non-admin
-    user could search for a common substring like "claude" and see other
-    teams' BYOK models.
+    from teams the caller is not a member of. Even with a bounded
+    `model_name`-contains DB query, a non-admin caller could otherwise
+    see other teams' BYOK rows that happen to match by internal name.
+    The post-fetch team scope drops those.
     """
     from litellm.proxy.proxy_server import _apply_search_filter_to_models
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1498,6 +1498,121 @@ async def test_filter_models_by_team_id_excludes_viewer_direct_access():
 
 
 @pytest.mark.asyncio
+async def test_filter_models_by_team_id_rejects_non_member():
+    """
+    Regression test: /v2/model/info?teamId=X includes BYOK rows solely on
+    `model_info.team_id == X`. Without an auth check, any authenticated user
+    could enumerate another team's BYOK metadata by guessing its id. Callers
+    that are neither proxy admins nor members of `team_id` must get 403.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import _filter_models_by_team_id
+
+    byok = {
+        "model_name": "model_name_team-111_uuid",
+        "litellm_params": {"model": "claude"},
+        "model_info": {"id": "byok-team-111", "team_id": "team-111"},
+    }
+
+    prisma = MagicMock()
+    # Caller is in team-222 only
+    user_row = MagicMock()
+    user_row.teams = ["team-222"]
+    prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=user_row)
+
+    caller = UserAPIKeyAuth(
+        user_id="alice",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-test",
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _filter_models_by_team_id(
+            all_models=[byok],
+            team_id="team-111",
+            prisma_client=prisma,
+            llm_router=MagicMock(),
+            user_api_key_dict=caller,
+        )
+    assert excinfo.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_filter_models_by_team_id_allows_team_member():
+    """
+    A caller who IS a member of `team_id` must be allowed to filter, and
+    should see that team's BYOK rows.
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import _filter_models_by_team_id
+
+    byok = {
+        "model_name": "model_name_team-111_uuid",
+        "litellm_params": {"model": "claude"},
+        "model_info": {"id": "byok-team-111", "team_id": "team-111"},
+    }
+
+    prisma = MagicMock()
+    user_row = MagicMock()
+    user_row.teams = ["team-111", "team-999"]
+    prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=user_row)
+    team_db = MagicMock()
+    team_db.model_dump.return_value = {
+        "team_id": "team-111",
+        "team_alias": "Team 111",
+        "models": [],
+        "access_group_ids": None,
+    }
+    prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_db)
+    prisma.db.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+
+    router = MagicMock()
+    router.get_model_access_groups = MagicMock(return_value={})
+    router.get_model_list = MagicMock(return_value=[byok])
+
+    caller = UserAPIKeyAuth(
+        user_id="bob",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-test",
+    )
+
+    result = await _filter_models_by_team_id(
+        all_models=[byok],
+        team_id="team-111",
+        prisma_client=prisma,
+        llm_router=router,
+        user_api_key_dict=caller,
+    )
+    assert [m["model_info"]["id"] for m in result] == ["byok-team-111"]
+
+
+@pytest.mark.asyncio
+async def test_caller_byok_team_scope_treats_view_only_admin_as_unscoped():
+    """
+    Regression test: `PROXY_ADMIN_VIEW_ONLY` is an admin role
+    ("can login, view all own keys, view all spend"). Search results for
+    this role must show BYOK rows across all teams, not be silently scoped
+    to the user-id's `teams` field — that path narrows results to whatever
+    teams the admin happens to be a member of, regressing pre-PR behavior.
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import _get_caller_byok_team_scope
+
+    caller = UserAPIKeyAuth(
+        user_id="view-admin",
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        api_key="sk-test",
+    )
+    scope = await _get_caller_byok_team_scope(
+        user_api_key_dict=caller,
+        prisma_client=MagicMock(),
+    )
+    assert scope is None, "PROXY_ADMIN_VIEW_ONLY must be unscoped, like PROXY_ADMIN"
+
+
+@pytest.mark.asyncio
 async def test_add_access_group_models_to_team_models():
     """
     Test that models reachable via team access groups are included in team_models.

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1285,6 +1285,7 @@ async def test_apply_search_filter_scopes_byok_to_caller_teams():
     }
 
     prisma_client = MagicMock()
+    prisma_client.db.litellm_proxymodeltable.count = AsyncMock(return_value=2)
     prisma_client.db.litellm_proxymodeltable.find_many = AsyncMock(
         return_value=[db_caller_row, db_other_row]
     )
@@ -1328,9 +1329,13 @@ async def test_apply_search_filter_scopes_byok_to_caller_teams():
         "DB-only BYOK from another team must be dropped from search when "
         "caller doesn't belong to that team"
     )
-    # total_count is router_models_count (3: caller_team_byok, public_model
-    # would be counted; other_team_byok is dropped — 2) + 1 db row = 3.
-    assert total_count == 3
+    # total_count is router_models_count (2: caller_team_byok + public_model,
+    # other_team_byok dropped router-side) + DB count (2 from the mocked
+    # `count()`). The DB count is the *unscoped* match count; non-admin
+    # team scoping applies only to the returned page so the count can be
+    # over-reported, but it must never under-report (callers can paginate
+    # within the bound).
+    assert total_count == 4
 
     # Admins keep the un-scoped view across teams.
     admin = MagicMock(spec=UserAPIKeyAuth)
@@ -1347,6 +1352,59 @@ async def test_apply_search_filter_scopes_byok_to_caller_teams():
     admin_ids = {m["model_info"]["id"] for m in filtered_admin}
     assert "byok-other" in admin_ids
     assert "byok-db-other" in admin_ids
+
+
+@pytest.mark.asyncio
+async def test_apply_search_filter_bounds_db_fetch_by_page_and_cap():
+    """
+    Regression test: a broad search term must not force a full BYOK-table
+    read + decrypt on each request.
+
+    * Unsorted searches: `find_many(take=N)` where N is just enough to
+      fill the current page after counting router-side matches.
+    * Sorted searches: `find_many(take=cap)` falls back to
+      `_SORTED_SEARCH_DB_FETCH_CAP` so ordering still works across a
+      large match set without scanning the whole table.
+    """
+    from litellm.proxy.proxy_server import (
+        _SORTED_SEARCH_DB_FETCH_CAP,
+        _apply_search_filter_to_models,
+    )
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_proxymodeltable.count = AsyncMock(return_value=10_000)
+    prisma_client.db.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+
+    proxy_config = MagicMock()
+    proxy_config.decrypt_model_list_from_db = lambda rows: []
+
+    # Unsorted: page=1, size=50, no router-side matches -> take must be 50.
+    await _apply_search_filter_to_models(
+        all_models=[],
+        search="model",
+        prisma_client=prisma_client,
+        proxy_config=proxy_config,
+        page=1,
+        size=50,
+        sort_by=None,
+    )
+    take = prisma_client.db.litellm_proxymodeltable.find_many.call_args.kwargs["take"]
+    assert take == 50, "unsorted search must take just one page's worth of rows"
+
+    # Sorted: still bounded, but by the hard cap rather than the page.
+    prisma_client.db.litellm_proxymodeltable.find_many.reset_mock()
+    await _apply_search_filter_to_models(
+        all_models=[],
+        search="model",
+        prisma_client=prisma_client,
+        proxy_config=proxy_config,
+        page=1,
+        size=50,
+        sort_by="model_name",
+    )
+    take = prisma_client.db.litellm_proxymodeltable.find_many.call_args.kwargs["take"]
+    assert take == _SORTED_SEARCH_DB_FETCH_CAP
+    assert take < 10_000, "sorted search must cap below the full match set"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes LIT-2860

Description

  The Model Management page calls /v2/model/info to list models. Team BYOK rows were
  broken in several ways: they didn't sort or search by the public name shown in the
  UI, the current-team filter still leaked unrelated models the admin had direct
  access to, and the teamId query parameter let any authenticated caller enumerate
  another team's BYOK metadata.

  This PR fixes those issues end-to-end, plus the DoS surface introduced by the
  search-fix patch along the way.

  Cause

  Team BYOK rows persist an internal model_name of the form
  model_name_{team_id}_{uuid} and store the user-facing name in
  model_info.team_public_model_name. The endpoint logic only operated on model_name,
  so:

  - Sort: sorting by name used the internal slug, producing UUID-ordered output
  instead of alphabetical-by-public-name.
  - Search: search_lower in model_name could never match the public name typed by the
  user, so BYOK rows silently dropped out of search results.
  - Current-team filter: _filter_models_by_team_id short-circuited on
  model_info.direct_access, which the upstream admin path sets on every non-team model
   — selecting a team in the UI still showed every public model the viewer could call.
  - teamId query param: included BYOK rows solely on model_info.team_id == team_id,
  with no caller authorization, so a guessable team id was enough to dump that team's
  BYOK metadata.
  - PROXY_ADMIN_VIEW_ONLY: _get_caller_byok_team_scope returned None (unscoped) only
  for PROXY_ADMIN; the view-only admin role fell through to a user-id team lookup and
  saw only their own teams' BYOK.
  - Unbounded DB fetch: the first search-fix patch OR'd a JSON-path string_contains: 
  "" predicate on model_info.team_public_model_name (Prisma's JSON string_contains is
  case-sensitive on Postgres, so the workaround widened to "row has any
  team_public_model_name set"). Any authenticated caller could force a full BYOK-table
   read with /v2/model/info?search=x.

  Fix

  litellm/proxy/proxy_server.py:

  - _apply_search_filter_to_models matches both model_name and
  model_info.team_public_model_name router-side; the DB-side query is a single bounded
   model_name contains <search> lookup (the over-broad JSON-path branch is gone). BYOK
   rows in the router (the typical case) stay searchable by public name.
  - _sort_models uses team_public_model_name when present, so name-sort produces UI
  order.
  - _filter_models_by_team_id keeps a model only when it's the team's own BYOK, the
  team is in access_via_team_ids, or the id is reachable via team.models / access
  groups. The viewer's direct_access flag no longer widens the result.
  - New _authorize_team_id_query requires the caller to be a proxy admin or a member
  of the requested team before applying the teamId filter; otherwise 403.
  - _get_caller_byok_team_scope treats PROXY_ADMIN and PROXY_ADMIN_VIEW_ONLY the same
  (both unscoped).

  Tests added/updated in tests/test_litellm/proxy/test_proxy_server.py cover: search
  by team_public_model_name, non-admin team scoping, teamId authorization (admin /
  member / non-member), view-only-admin unscoped behavior, and the team-id filter not
  leaking on direct_access.
  
  https://www.loom.com/share/5b064149b4d747f6b0012f57b3752d1b