### PR TITLE
fix(mcp-oauth): PROXY_BASE_URL escape hatch + diagnostic logging for {"detail":"invalid_request"}

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -34,12 +34,18 @@ def get_request_base_url(request: Request) -> str:
     """
     Get the base URL for the request, considering X-Forwarded-* headers.
 
-    X-Forwarded-Proto / X-Forwarded-Host / X-Forwarded-Port are only honoured
-    when the request comes from a configured trusted proxy
-    (``use_x_forwarded_for`` enabled AND caller in ``mcp_trusted_proxy_ranges``).
-    Otherwise the request's literal ``base_url`` is returned, so an
-    untrusted caller cannot poison OAuth-discovery / redirect_uri values
-    by injecting headers.
+    Resolution order:
+      1. ``PROXY_BASE_URL`` env var — operator-declared canonical public
+         origin. Honoured unconditionally so deployments behind ingresses
+         that mangle ``X-Forwarded-*`` can skip the trust-gate gymnastics
+         entirely.
+      2. X-Forwarded-Proto / X-Forwarded-Host / X-Forwarded-Port — only
+         when the request comes from a configured trusted proxy
+         (``use_x_forwarded_for`` enabled AND caller in
+         ``mcp_trusted_proxy_ranges``). Otherwise an untrusted caller
+         could poison OAuth-discovery / redirect_uri values by injecting
+         headers.
+      3. The request's literal ``base_url``.
 
     Args:
         request: FastAPI Request object
@@ -47,6 +53,10 @@ def get_request_base_url(request: Request) -> str:
     Returns:
         The reconstructed base URL (e.g., "https://proxy.example.com")
     """
+    configured = os.environ.get("PROXY_BASE_URL", "").strip()
+    if configured:
+        return configured.rstrip("/")
+
     base_url = str(request.base_url).rstrip("/")
     parsed = urlparse(base_url)
 
@@ -284,4 +294,26 @@ def validate_trusted_redirect_uri(request: Request, redirect_uri: str) -> None:
             if _matches_trusted_origin_entry(redirect_netloc, entry):
                 return
 
+    # Diagnose: a bare 400 ``invalid_request`` is opaque to operators
+    # debugging an ingress / X-Forwarded-* mismatch. Surface the three
+    # inputs that drive the same-origin compare so a single log line is
+    # enough to tell the customer which knob is wrong.
+    verbose_logger.warning(
+        "MCP OAuth: rejecting redirect_uri %r as invalid_request. "
+        "Computed proxy base=%r (PROXY_BASE_URL=%r). "
+        "Inbound headers: X-Forwarded-Proto=%r X-Forwarded-Host=%r "
+        "X-Forwarded-Port=%r Host=%r. "
+        "Trusted-redirect-origins env=%r. "
+        "If this should be accepted, either align ingress X-Forwarded-* "
+        "with the browser URL, set PROXY_BASE_URL to your public origin, "
+        "or add the redirect_uri host to MCP_TRUSTED_REDIRECT_ORIGINS.",
+        redirect_uri,
+        proxy_base,
+        os.environ.get("PROXY_BASE_URL"),
+        request.headers.get("X-Forwarded-Proto"),
+        request.headers.get("X-Forwarded-Host"),
+        request.headers.get("X-Forwarded-Port"),
+        request.headers.get("Host"),
+        os.environ.get(_TRUSTED_REDIRECT_ORIGINS_ENV),
+    )
     raise HTTPException(status_code=400, detail="invalid_request")

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -30,15 +30,47 @@ _DEFAULT_PORTS = {"http": 80, "https": 443}
 _TRUSTED_REDIRECT_ORIGINS_ENV = "MCP_TRUSTED_REDIRECT_ORIGINS"
 
 
+# One-shot flag for the malformed-``PROXY_BASE_URL`` warning so the
+# proxy logs the misconfig once at first use instead of on every request.
+_warned_invalid_proxy_base_url: Optional[str] = None
+
+
+def _resolve_proxy_base_url_env() -> Optional[str]:
+    """Return ``PROXY_BASE_URL`` if it parses as an http(s) URL with a
+    netloc; otherwise log a one-shot warning naming the bad value and
+    return ``None`` so the caller falls back to the request-derived
+    origin. A bare hostname like ``litellm.example.com`` would otherwise
+    sail through ``urlparse`` with empty scheme + netloc, silently
+    breaking every same-origin compare and leaving the operator staring
+    at the same opaque 400 the env var was meant to fix.
+    """
+    global _warned_invalid_proxy_base_url
+    configured = os.environ.get("PROXY_BASE_URL", "").strip()
+    if not configured:
+        return None
+    parsed = urlparse(configured)
+    if parsed.scheme in ("http", "https") and parsed.netloc:
+        return configured.rstrip("/")
+    if _warned_invalid_proxy_base_url != configured:
+        verbose_logger.warning(
+            "PROXY_BASE_URL=%r is not a valid http(s) URL (missing scheme "
+            "or host) and will be ignored for MCP OAuth origin resolution. "
+            "Set it to a full URL like https://litellm.example.com.",
+            configured,
+        )
+        _warned_invalid_proxy_base_url = configured
+    return None
+
+
 def get_request_base_url(request: Request) -> str:
     """
     Get the base URL for the request, considering X-Forwarded-* headers.
 
     Resolution order:
       1. ``PROXY_BASE_URL`` env var — operator-declared canonical public
-         origin. Honoured unconditionally so deployments behind ingresses
-         that mangle ``X-Forwarded-*`` can skip the trust-gate gymnastics
-         entirely.
+         origin. Honoured unconditionally when it parses as a full
+         http(s) URL; a malformed value (e.g. missing scheme) is logged
+         once and ignored so the proxy still serves traffic.
       2. X-Forwarded-Proto / X-Forwarded-Host / X-Forwarded-Port — only
          when the request comes from a configured trusted proxy
          (``use_x_forwarded_for`` enabled AND caller in
@@ -53,9 +85,9 @@ def get_request_base_url(request: Request) -> str:
     Returns:
         The reconstructed base URL (e.g., "https://proxy.example.com")
     """
-    configured = os.environ.get("PROXY_BASE_URL", "").strip()
+    configured = _resolve_proxy_base_url_env()
     if configured:
-        return configured.rstrip("/")
+        return configured
 
     base_url = str(request.base_url).rstrip("/")
     parsed = urlparse(base_url)

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -30,29 +30,16 @@ _DEFAULT_PORTS = {"http": 80, "https": 443}
 _TRUSTED_REDIRECT_ORIGINS_ENV = "MCP_TRUSTED_REDIRECT_ORIGINS"
 
 
-# One-shot flag for the malformed-``PROXY_BASE_URL`` warning so the
-# proxy logs the misconfig once at first use instead of on every request.
 _warned_invalid_proxy_base_url: Optional[str] = None
 
 
 def _resolve_proxy_base_url_env() -> Optional[str]:
-    """Return ``PROXY_BASE_URL`` if it parses as an http(s) URL with a
-    netloc; otherwise log a one-shot warning naming the bad value and
-    return ``None`` so the caller falls back to the request-derived
-    origin. A bare hostname like ``litellm.example.com`` would otherwise
-    sail through ``urlparse`` with empty scheme + netloc, silently
-    breaking every same-origin compare and leaving the operator staring
-    at the same opaque 400 the env var was meant to fix.
-    """
     global _warned_invalid_proxy_base_url
     configured = os.environ.get("PROXY_BASE_URL", "").strip()
     if not configured:
         return None
     parsed = urlparse(configured)
     if parsed.scheme in ("http", "https") and parsed.netloc:
-        # Normalize by dropping query/params/fragment so callers doing
-        # f"{base_url}/callback" don't end up with the path glued onto a
-        # query string or fragment. Mirrors the X-Forwarded-* path below.
         normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
         return normalized.rstrip("/")
     if _warned_invalid_proxy_base_url != configured:
@@ -70,24 +57,11 @@ def get_request_base_url(request: Request) -> str:
     """
     Get the base URL for the request, considering X-Forwarded-* headers.
 
-    Resolution order:
-      1. ``PROXY_BASE_URL`` env var — operator-declared canonical public
-         origin. Honoured unconditionally when it parses as a full
-         http(s) URL; a malformed value (e.g. missing scheme) is logged
-         once and ignored so the proxy still serves traffic.
-      2. X-Forwarded-Proto / X-Forwarded-Host / X-Forwarded-Port — only
-         when the request comes from a configured trusted proxy
-         (``use_x_forwarded_for`` enabled AND caller in
-         ``mcp_trusted_proxy_ranges``). Otherwise an untrusted caller
-         could poison OAuth-discovery / redirect_uri values by injecting
-         headers.
-      3. The request's literal ``base_url``.
-
-    Args:
-        request: FastAPI Request object
-
-    Returns:
-        The reconstructed base URL (e.g., "https://proxy.example.com")
+    Resolution order: ``PROXY_BASE_URL`` env var, then X-Forwarded-* when
+    the caller is a trusted proxy (``use_x_forwarded_for`` enabled AND
+    caller in ``mcp_trusted_proxy_ranges``), otherwise the request's
+    literal ``base_url``. Untrusted callers cannot poison OAuth-discovery
+    / redirect_uri values by injecting headers.
     """
     configured = _resolve_proxy_base_url_env()
     if configured:
@@ -330,10 +304,6 @@ def validate_trusted_redirect_uri(request: Request, redirect_uri: str) -> None:
             if _matches_trusted_origin_entry(redirect_netloc, entry):
                 return
 
-    # Diagnose: a bare 400 ``invalid_request`` is opaque to operators
-    # debugging an ingress / X-Forwarded-* mismatch. Surface the three
-    # inputs that drive the same-origin compare so a single log line is
-    # enough to tell the customer which knob is wrong.
     verbose_logger.warning(
         "MCP OAuth: rejecting redirect_uri %r as invalid_request. "
         "Computed proxy base=%r (PROXY_BASE_URL=%r). "

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -50,7 +50,11 @@ def _resolve_proxy_base_url_env() -> Optional[str]:
         return None
     parsed = urlparse(configured)
     if parsed.scheme in ("http", "https") and parsed.netloc:
-        return configured.rstrip("/")
+        # Normalize by dropping query/params/fragment so callers doing
+        # f"{base_url}/callback" don't end up with the path glued onto a
+        # query string or fragment. Mirrors the X-Forwarded-* path below.
+        normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+        return normalized.rstrip("/")
     if _warned_invalid_proxy_base_url != configured:
         verbose_logger.warning(
             "PROXY_BASE_URL=%r is not a valid http(s) URL (missing scheme "

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1374,6 +1374,121 @@ def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
     assert "X-Forwarded-Host" in msg
 
 
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "litellm.example.com",  # no scheme — bare hostname
+        "litellm.example.com/",
+        "://litellm.example.com",  # scheme-relative-ish, still no scheme
+        "ftp://litellm.example.com",  # wrong scheme
+        "https://",  # scheme but no netloc
+        "not a url at all",
+    ],
+)
+def test_get_request_base_url_rejects_malformed_proxy_base_url(
+    bad_value, monkeypatch, caplog
+):
+    """A scheme-less or otherwise malformed ``PROXY_BASE_URL`` must NOT
+    silently win the resolution order — that would leave every same-origin
+    compare in ``validate_trusted_redirect_uri`` failing (empty scheme,
+    empty netloc) and the operator staring at the same opaque 400 the
+    env var was meant to fix. Verify the helper falls through to the
+    request's literal base_url and emits a one-shot diagnostic.
+    """
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server import oauth_utils
+        from litellm.proxy._experimental.mcp_server.oauth_utils import (
+            get_request_base_url,
+        )
+    except ImportError:
+        pytest.skip("MCP oauth_utils not available")
+
+    # Reset one-shot flag so each parametrize iteration logs.
+    oauth_utils._warned_invalid_proxy_base_url = None
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://litellm-internal:4000/"
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers.get = lambda name, default=None: default
+
+    monkeypatch.setenv("PROXY_BASE_URL", bad_value)
+
+    import logging
+
+    with (
+        caplog.at_level(logging.WARNING, logger="LiteLLM"),
+        patch("litellm.proxy.proxy_server.general_settings", {}, create=True),
+    ):
+        result = get_request_base_url(mock_request)
+
+    assert result == "http://litellm-internal:4000", (
+        f"malformed PROXY_BASE_URL={bad_value!r} should be ignored, " f"got {result!r}"
+    )
+    matching = [
+        r
+        for r in caplog.records
+        if "PROXY_BASE_URL" in r.getMessage() and "ignored" in r.getMessage()
+    ]
+    assert len(matching) == 1, (
+        "expected one diagnostic for malformed PROXY_BASE_URL, got "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+    assert (
+        repr(bad_value) in matching[0].getMessage()
+        or bad_value in matching[0].getMessage()
+    )
+
+
+def test_get_request_base_url_malformed_proxy_base_url_warning_is_one_shot(
+    monkeypatch, caplog
+):
+    """Two requests in a row with the same bad ``PROXY_BASE_URL`` must
+    log the warning exactly once — the proxy can take thousands of
+    requests per minute and we don't want one misconfig to drown the
+    log stream.
+    """
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server import oauth_utils
+        from litellm.proxy._experimental.mcp_server.oauth_utils import (
+            get_request_base_url,
+        )
+    except ImportError:
+        pytest.skip("MCP oauth_utils not available")
+
+    oauth_utils._warned_invalid_proxy_base_url = None
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://litellm-internal:4000/"
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers.get = lambda name, default=None: default
+
+    monkeypatch.setenv("PROXY_BASE_URL", "litellm.example.com")
+
+    import logging
+
+    with (
+        caplog.at_level(logging.WARNING, logger="LiteLLM"),
+        patch("litellm.proxy.proxy_server.general_settings", {}, create=True),
+    ):
+        for _ in range(5):
+            get_request_base_url(mock_request)
+
+    matching = [
+        r
+        for r in caplog.records
+        if "PROXY_BASE_URL" in r.getMessage() and "ignored" in r.getMessage()
+    ]
+    assert (
+        len(matching) == 1
+    ), f"expected exactly one warning across 5 calls, got {len(matching)}"
+
+
 # -------------------------------------------------------------------
 # Tests for scopes_supported when mcp_server.scopes is None
 # -------------------------------------------------------------------

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1279,14 +1279,6 @@ def test_xff_misconfig_warning_emitted_once(caplog):
 
 
 def test_get_request_base_url_honors_proxy_base_url_env(monkeypatch):
-    """When ``PROXY_BASE_URL`` is set, ``get_request_base_url`` must return
-    it verbatim regardless of inbound ``X-Forwarded-*`` or the trust gate.
-
-    This is the escape hatch for deployments behind ingresses that mangle
-    X-Forwarded-* — operators can declare the canonical public origin once
-    and the same-origin check in ``validate_trusted_redirect_uri`` will
-    compare against it.
-    """
     try:
         from fastapi import Request
 
@@ -1302,15 +1294,12 @@ def test_get_request_base_url_honors_proxy_base_url_env(monkeypatch):
     mock_request.client.host = "10.0.0.7"
     headers = {
         "X-Forwarded-Proto": "https",
-        "X-Forwarded-Host": "litellm-internal:4000",  # ingress lies
+        "X-Forwarded-Host": "litellm-internal:4000",
         "X-Forwarded-Port": "9999",
     }
     mock_request.headers.get = lambda name, default=None: headers.get(name, default)
 
     monkeypatch.setenv("PROXY_BASE_URL", "https://litellm.example.com")
-
-    # Trailing slash on the env value must be stripped; trust gate
-    # outcome doesn't matter because PROXY_BASE_URL takes precedence.
     assert get_request_base_url(mock_request) == "https://litellm.example.com"
 
     monkeypatch.setenv("PROXY_BASE_URL", "https://litellm.example.com/")
@@ -1320,11 +1309,6 @@ def test_get_request_base_url_honors_proxy_base_url_env(monkeypatch):
 def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
     caplog, monkeypatch
 ):
-    """A bare ``{"detail":"invalid_request"}`` is undiagnosable for the
-    operator. Verify the rejection path emits a WARN log carrying the
-    redirect_uri, computed proxy base, and the X-Forwarded-* headers so
-    a single log line tells the customer which knob is wrong.
-    """
     try:
         from fastapi import HTTPException, Request
 
@@ -1340,7 +1324,7 @@ def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
     mock_request = MagicMock(spec=Request)
     mock_request.base_url = "http://litellm-internal:4000/"
     mock_request.client = MagicMock()
-    mock_request.client.host = "203.0.113.5"  # not in any trusted range
+    mock_request.client.host = "203.0.113.5"
     headers = {
         "X-Forwarded-Proto": "https",
         "X-Forwarded-Host": "litellm.example.com",
@@ -1370,31 +1354,24 @@ def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
     )
     msg = matching[0].getMessage()
     assert "https://litellm.example.com/ui/mcp/oauth/callback" in msg
-    assert "litellm-internal:4000" in msg  # computed proxy base
+    assert "litellm-internal:4000" in msg
     assert "X-Forwarded-Host" in msg
 
 
 @pytest.mark.parametrize(
     "bad_value",
     [
-        "litellm.example.com",  # no scheme — bare hostname
+        "litellm.example.com",
         "litellm.example.com/",
-        "://litellm.example.com",  # scheme-relative-ish, still no scheme
-        "ftp://litellm.example.com",  # wrong scheme
-        "https://",  # scheme but no netloc
+        "://litellm.example.com",
+        "ftp://litellm.example.com",
+        "https://",
         "not a url at all",
     ],
 )
 def test_get_request_base_url_rejects_malformed_proxy_base_url(
     bad_value, monkeypatch, caplog
 ):
-    """A scheme-less or otherwise malformed ``PROXY_BASE_URL`` must NOT
-    silently win the resolution order — that would leave every same-origin
-    compare in ``validate_trusted_redirect_uri`` failing (empty scheme,
-    empty netloc) and the operator staring at the same opaque 400 the
-    env var was meant to fix. Verify the helper falls through to the
-    request's literal base_url and emits a one-shot diagnostic.
-    """
     try:
         from fastapi import Request
 
@@ -1405,7 +1382,6 @@ def test_get_request_base_url_rejects_malformed_proxy_base_url(
     except ImportError:
         pytest.skip("MCP oauth_utils not available")
 
-    # Reset one-shot flag so each parametrize iteration logs.
     oauth_utils._warned_invalid_proxy_base_url = None
 
     mock_request = MagicMock(spec=Request)
@@ -1445,11 +1421,6 @@ def test_get_request_base_url_rejects_malformed_proxy_base_url(
 def test_get_request_base_url_malformed_proxy_base_url_warning_is_one_shot(
     monkeypatch, caplog
 ):
-    """Two requests in a row with the same bad ``PROXY_BASE_URL`` must
-    log the warning exactly once — the proxy can take thousands of
-    requests per minute and we don't want one misconfig to drown the
-    log stream.
-    """
     try:
         from fastapi import Request
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1352,7 +1352,7 @@ def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
     import logging
 
     with (
-        caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"),
+        caplog.at_level(logging.WARNING, logger="LiteLLM"),
         patch("litellm.proxy.proxy_server.general_settings", {}, create=True),
     ):
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1278,6 +1278,102 @@ def test_xff_misconfig_warning_emitted_once(caplog):
     ), f"expected exactly one warning, got {len(matching)}: {[r.getMessage() for r in matching]}"
 
 
+def test_get_request_base_url_honors_proxy_base_url_env(monkeypatch):
+    """When ``PROXY_BASE_URL`` is set, ``get_request_base_url`` must return
+    it verbatim regardless of inbound ``X-Forwarded-*`` or the trust gate.
+
+    This is the escape hatch for deployments behind ingresses that mangle
+    X-Forwarded-* — operators can declare the canonical public origin once
+    and the same-origin check in ``validate_trusted_redirect_uri`` will
+    compare against it.
+    """
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.oauth_utils import (
+            get_request_base_url,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://litellm-internal:4000/"
+    mock_request.client = MagicMock()
+    mock_request.client.host = "10.0.0.7"
+    headers = {
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "litellm-internal:4000",  # ingress lies
+        "X-Forwarded-Port": "9999",
+    }
+    mock_request.headers.get = lambda name, default=None: headers.get(name, default)
+
+    monkeypatch.setenv("PROXY_BASE_URL", "https://litellm.example.com")
+
+    # Trailing slash on the env value must be stripped; trust gate
+    # outcome doesn't matter because PROXY_BASE_URL takes precedence.
+    assert get_request_base_url(mock_request) == "https://litellm.example.com"
+
+    monkeypatch.setenv("PROXY_BASE_URL", "https://litellm.example.com/")
+    assert get_request_base_url(mock_request) == "https://litellm.example.com"
+
+
+def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
+    caplog, monkeypatch
+):
+    """A bare ``{"detail":"invalid_request"}`` is undiagnosable for the
+    operator. Verify the rejection path emits a WARN log carrying the
+    redirect_uri, computed proxy base, and the X-Forwarded-* headers so
+    a single log line tells the customer which knob is wrong.
+    """
+    try:
+        from fastapi import HTTPException, Request
+
+        from litellm.proxy._experimental.mcp_server.oauth_utils import (
+            validate_trusted_redirect_uri,
+        )
+    except ImportError:
+        pytest.skip("MCP oauth_utils not available")
+
+    monkeypatch.delenv("PROXY_BASE_URL", raising=False)
+    monkeypatch.delenv("MCP_TRUSTED_REDIRECT_ORIGINS", raising=False)
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "http://litellm-internal:4000/"
+    mock_request.client = MagicMock()
+    mock_request.client.host = "203.0.113.5"  # not in any trusted range
+    headers = {
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "litellm.example.com",
+        "X-Forwarded-Port": "443",
+        "Host": "litellm-internal:4000",
+    }
+    mock_request.headers.get = lambda name, default=None: headers.get(name, default)
+
+    import logging
+
+    with (
+        caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"),
+        patch("litellm.proxy.proxy_server.general_settings", {}, create=True),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_trusted_redirect_uri(
+                mock_request,
+                "https://litellm.example.com/ui/mcp/oauth/callback",
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "invalid_request"
+
+    matching = [r for r in caplog.records if "rejecting redirect_uri" in r.getMessage()]
+    assert len(matching) == 1, (
+        "expected exactly one diagnostic warning, got "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+    msg = matching[0].getMessage()
+    assert "https://litellm.example.com/ui/mcp/oauth/callback" in msg
+    assert "litellm-internal:4000" in msg  # computed proxy base
+    assert "X-Forwarded-Host" in msg
+
+
 # -------------------------------------------------------------------
 # Tests for scopes_supported when mcp_server.scopes is None
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Customers hitting `{"detail":"invalid_request"}` on the MCP `/authorize` endpoint had no way to recover when their ingress mangles `X-Forwarded-*` headers (the same-origin check in `validate_trusted_redirect_uri` compares the browser-supplied `redirect_uri` against `get_request_base_url`, which is reconstructed from those headers).

This PR adds two contained, defensive changes — it does **not** weaken the existing validator:

- **`PROXY_BASE_URL` escape hatch** — `get_request_base_url` honours the existing `PROXY_BASE_URL` env var as the canonical public origin when set, bypassing the `X-Forwarded-*` trust gate entirely. Operators who know their public URL can set it once instead of debugging ingress header rewrites.
- **Diagnostic logging** — the rejection path in `validate_trusted_redirect_uri` now emits a WARN log carrying the `redirect_uri`, computed proxy base, `PROXY_BASE_URL`, the `X-Forwarded-*` / `Host` headers seen, and the trusted-origins allowlist. A bare 400 was undiagnosable; this turns it into a one-line root-cause.

The loopback + same-origin + ops-allowlist validator is unchanged. The same-origin compare already uses the existing `_strip_default_port` normalization.

## Test plan

- [x] New unit test: `test_get_request_base_url_honors_proxy_base_url_env` — verifies env value is returned verbatim (with trailing slash stripped) regardless of inbound `X-Forwarded-*` or trust gate state.
- [x] New unit test: `test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection` — verifies WARN log fires with redirect_uri, computed base, and X-Forwarded-Host on rejection.
- [x] `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py` — all 63 tests pass.

## Runbook (before / after)

Reproduce the bug against `litellm_internal_staging`, then deploy this branch with `PROXY_BASE_URL` set and confirm the OAuth flow succeeds — see chat reply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth redirect/origin resolution used in authorization flows; misconfiguration could change computed public base URL and affect redirect validation/links, though validation rules themselves are unchanged.
> 
> **Overview**
> Adds a `PROXY_BASE_URL` override to MCP OAuth origin resolution so `get_request_base_url()` can return an operator-configured public base URL (with validation + one-shot warning when malformed) instead of relying on `X-Forwarded-*` headers.
> 
> Enhances `validate_trusted_redirect_uri()` to emit a detailed WARN log when rejecting a `redirect_uri`, including the computed base, relevant headers, and trusted-origins allowlist to make `invalid_request` failures diagnosable. Updates tests to cover env override behavior, malformed env handling, one-shot warning, and the new diagnostic log on rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683bce805d743f339710aca773f844d36f64e4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->