### PR TITLE
build(deps): pin openai==2.33.0 in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4298,7 +4298,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.36.0"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4310,9 +4310,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pins `openai` back to **2.33.0** in `uv.lock` (single file, 3 lines: version + sdist hash + wheel hash). Within the existing `pyproject.toml` range `openai>=2.20.0,<3.0.0` — no constraint change.

## Why

`openai` 2.34.0 began rejecting an **explicitly-passed empty-string** `api_key` at client construction — `openai.OpenAI(api_key="")` now raises `OpenAIError` before any request is made, instead of accepting it and only failing on a real call.

`tests/local_testing/test_exceptions.py::test_exception_with_headers` (and `test_exception_bubbling_up`, the Perplexity exception test) deliberately construct the client with `api_key=""` because the network call is mocked — the key value was never meant to matter. When `uv.lock` floated `openai` 2.33.0 → 2.36.0 (a side effect of #27557 regenerating the lock; nothing required 2.36), these tests started failing at construction time with `Missing credentials ... OPENAI_API_KEY`.

Resolver dry-run confirmed nothing in the dependency graph needs >2.33 — only the `openai` line moved across all 399 packages.

## Scope / longer-term

Temporary stopgap to unblock CI. The durable fix is a one-line test change (pass a dummy non-empty key, since the request is mocked), which would let the pin be re-relaxed. Tracked for follow-up.

## Test plan

- `uv sync --frozen` now installs `openai==2.33.0`
- `tests/local_testing/test_exceptions.py::test_exception_with_headers` and related cases construct the client and pass without test-code changes