### PR TITLE
feat(otel): set http.response.status_code on the success SERVER span

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -736,6 +736,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             # Pre-request latency on the SERVER span (success path).
             self.set_preprocessing_duration_attribute(parent_span, kwargs)
 
+            # http.response.status_code on the SERVER span (success path).
+            # A successful proxy response is HTTP 200; the failure path sets
+            # this from the error code in _record_exception_on_span.
+            self.set_response_status_code_attribute(parent_span, 200)
+
             # 3. Guardrail span
             self._create_guardrail_span(kwargs=kwargs, context=ctx)
 
@@ -2956,6 +2961,25 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             self.safe_set_attribute(
                 span=span, key=HTTP_ROUTE_ATTRIBUTE, value=http_route
             )
+
+    def set_response_status_code_attribute(
+        self, span: Optional[Span], status_code: Optional[int]
+    ) -> None:
+        """
+        Set OTel-standard ``http.response.status_code`` (int) on the proxy
+        SERVER span. The failure path sets this from the error code in
+        ``_record_exception_on_span``; this is the success-path counterpart
+        so the attribute is present on every SERVER span regardless of
+        outcome (required by the HTTP semconv, and needed for error-ratio /
+        status-breakdown dashboards). No-op if span/value missing.
+        """
+        if span is None or status_code is None:
+            return
+        self.safe_set_attribute(
+            span=span,
+            key=HTTP_RESPONSE_STATUS_CODE_ATTRIBUTE,
+            value=int(status_code),
+        )
 
     def set_preprocessing_duration_attribute(
         self, span: Optional[Span], container: Any

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4808,6 +4808,41 @@ class TestOpenTelemetrySetProxyRequestRouteAttributes(unittest.TestCase):
         otel.set_proxy_request_route_attributes(None, url_path="/x", http_route="/x")
 
 
+class TestOpenTelemetrySetResponseStatusCodeAttribute(unittest.TestCase):
+    """http.response.status_code must land on the SERVER span on the
+    success path too (failure path sets it in _record_exception_on_span).
+    Without this the attribute is failure-only, so error-ratio /
+    status-breakdown dashboards have no 2xx bucket.
+    """
+
+    def _set(self, status_code):
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+
+        otel = OpenTelemetry()
+        span = tracer.start_span("Received Proxy Server Request")
+        otel.set_response_status_code_attribute(span, status_code)
+        span.end()
+        return exporter.get_finished_spans()[0]
+
+    def test_success_sets_int_200(self):
+        span = self._set(200)
+        # Exact OTel-standard name, stored as int (regression guard).
+        assert span.attributes["http.response.status_code"] == 200
+        assert isinstance(span.attributes["http.response.status_code"], int)
+
+    def test_none_status_code_omits_attribute(self):
+        span = self._set(None)
+        assert "http.response.status_code" not in span.attributes
+
+    def test_none_span_is_noop(self):
+        otel = OpenTelemetry()
+        # Mirrors the Langfuse-override path (create span returns None).
+        otel.set_response_status_code_attribute(None, 200)
+
+
 class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
     """litellm.preprocessing.duration_ms (proxy-receive -> first provider
     handoff) on the SERVER span. Read from container metadata so the


### PR DESCRIPTION
## Summary

The proxy SERVER span (`Received Proxy Server Request`) only carried `http.response.status_code` on **failures** (set in `_record_exception_on_span`); successful requests had no status-code attribute. This left error-ratio and status-breakdown dashboards with no 2xx denominator and made the span non-compliant with the OTel HTTP semantic conventions (the attribute is required whenever a response is sent, not error-only). This adds a `set_response_status_code_attribute` helper and calls it from `async_post_call_success_hook` with `200`, symmetric with the failure path and with the route / preprocessing-duration attributes that already land on the success SERVER span. Follow-up to #28040.

## Screenshot 

<img width="1587" height="543" alt="Screenshot 2026-05-16 at 3 05 07 PM" src="https://github.com/user-attachments/assets/eeed4f0d-cd1f-4e52-b1f8-b719c2a25939" />
<img width="854" height="241" alt="Screenshot 2026-05-16 at 3 05 34 PM" src="https://github.com/user-attachments/assets/5026b24c-97f9-45f2-b161-5caf70862bf4" />


## Test plan
- [x] `tests/test_litellm/integrations/test_opentelemetry.py::TestOpenTelemetrySetResponseStatusCodeAttribute` — int-200 on success, None status code omits the attribute, None span is a no-op
- [x] `make test-unit` slice: 18 tests in the OTel attribute suite (route / preprocessing / server-span / new) pass; Black clean
- [x] Manual: Jaeger all-in-one + proxy with `callbacks: ["otel"]`; `mock-success` 200 request → `Received Proxy Server Request` span carries `http.response.status_code=200` alongside `http.route`, `url.path`, `litellm.preprocessing.duration_ms`