### PR TITLE
fix(admin-ui): emit nested routes as <dir>/index.html so /ui/mcp/oauth/callback works

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -54,22 +54,10 @@ COPY . .
 # Set non-root flag for build time consistency
 ENV LITELLM_NON_ROOT=true
 
-# Stage the pre-built Admin UI from the checked-in Next.js static export.
-# _experimental/out/ is regenerated as part of the release runbook.
-# Restructure extensionless routes (foo.html -> foo/index.html) to match the layout
-# proxy_server.py expects, and drop a readiness marker.
 RUN mkdir -p /var/lib/litellm/ui /var/lib/litellm/assets && \
     cp -r /app/litellm/proxy/_experimental/out/. /var/lib/litellm/ui/ && \
     cp /app/litellm/proxy/logo.jpg /var/lib/litellm/assets/logo.jpg && \
-    ( cd /var/lib/litellm/ui && \
-      for html_file in *.html; do \
-        if [ "$html_file" != "index.html" ] && [ -f "$html_file" ]; then \
-          folder_name="${html_file%.html}" && \
-          mkdir -p "$folder_name" && \
-          mv "$html_file" "$folder_name/index.html"; \
-        fi; \
-      done && \
-      touch .litellm_ui_ready )
+    touch /var/lib/litellm/ui/.litellm_ui_ready
 
 RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
     if [ "$PROXY_EXTRAS_SOURCE" = "published" ]; then \

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -604,6 +604,49 @@ def test_ui_extensionless_route_requires_restructure(tmp_path):
     assert "login" in response.text
 
 
+def test_admin_ui_export_serves_nested_extensionless_routes():
+    out_dir = (
+        Path(litellm.__file__).parent / "proxy" / "_experimental" / "out"
+    )
+    assert out_dir.is_dir(), f"missing UI export at {out_dir}"
+
+    nested_html_offenders = [
+        path.relative_to(out_dir).as_posix()
+        for path in out_dir.rglob("*.html")
+        if path.parent != out_dir
+        and path.name != "index.html"
+        and "_next" not in path.parts
+        and "litellm-asset-prefix" not in path.parts
+    ]
+    assert not nested_html_offenders, (
+        "Nested routes must be named index.html. Offenders: "
+        f"{nested_html_offenders}"
+    )
+
+    callback_index = out_dir / "mcp" / "oauth" / "callback" / "index.html"
+    assert callback_index.is_file(), (
+        f"MCP OAuth callback page must exist at {callback_index}; "
+        "without it /ui/mcp/oauth/callback 404s after Linear redirects back."
+    )
+
+    fastapi_app = FastAPI()
+    fastapi_app.mount(
+        "/ui", StaticFiles(directory=str(out_dir), html=True), name="ui"
+    )
+    client = TestClient(fastapi_app)
+
+    redirect = client.get(
+        "/ui/mcp/oauth/callback?code=abc&state=xyz",
+        follow_redirects=False,
+    )
+    assert redirect.status_code == 307
+    assert redirect.headers["location"].endswith("/ui/mcp/oauth/callback/?code=abc&state=xyz")
+
+    landed = client.get("/ui/mcp/oauth/callback?code=abc&state=xyz")
+    assert landed.status_code == 200
+    assert "<html" in landed.text.lower()
+
+
 def test_restructure_always_happens(monkeypatch):
     """
     Test that restructuring logic always executes regardless of LITELLM_NON_ROOT setting.

--- a/ui/litellm-dashboard/next.config.mjs
+++ b/ui/litellm-dashboard/next.config.mjs
@@ -14,6 +14,7 @@ const nextConfig = {
   },
   basePath: "",
   assetPrefix: "/litellm-asset-prefix",
+  trailingSlash: true,
   turbopack: {
     // Must be absolute; "." is no longer allowed
     root: __dirname,


### PR DESCRIPTION
## Relevant issues

Stacked on top of #28112 (the regenerated static export artifact). Merge that one first so this PR collapses cleanly into `litellm_internal_staging`.

After clicking Approve on the Linear MCP OAuth consent screen, the browser is redirected back to `http://<proxy>/ui/mcp/oauth/callback?code=...&state=...` and the proxy returns `{"detail":"Not Found"}`, so the handshake never completes.

Root cause is the packaged Next.js static export. With the default `next.config.mjs`, every route is emitted as `<name>.html` at the parent level, with a sibling directory (e.g. `mcp/oauth/callback/`) containing only Next.js metadata `.txt` files and no `index.html`. FastAPI's `StaticFiles(html=True)` mount at `/ui` follows Starlette's rule of serving `<dir>/index.html` for directory paths; it does not fall back to `<path>.html` for extensionless requests, so a request for `/ui/mcp/oauth/callback` lands on the empty `callback/` directory and 404s.

`docker/Dockerfile.non_root` tried to compensate at image-build time by walking the export and moving `*.html` into `<name>/index.html`, but the loop uses a shell glob (`for html_file in *.html`) which does not recurse. The fix only touched top-level files; nested routes like `mcp/oauth/callback.html` were left untouched. The marker `.litellm_ui_ready` was still dropped, so the Python-side runtime restructure step in `proxy_server.py` was skipped at startup.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run; Link:
- [ ] CI run for the last commit; Link:
- [ ] Merge / cherry-pick CI run; Links:

## Screenshots / Proof of Fix

Pulled the latest rc image, then ran the proxy with the rebuilt `_experimental/out/` mounted into the runtime UI path that the non-root image expects:

```bash
ENV_TMP=$(mktemp) && \
sed -E 's/^([A-Z_][A-Z0-9_]*)[[:space:]]*=[[:space:]]*"?([^"]*)"?$/\1=\2/' .env > "$ENV_TMP" && \
docker run -d --name litellm-rc \
  -p 4000:4000 --env-file "$ENV_TMP" \
  -e GOOGLE_APPLICATION_CREDENTIALS=/app/unused.json \
  -v $PWD/litellm/proxy/dev_config.yaml:/app/config.yaml:ro \
  -v $PWD/litellm/proxy/dump_failure.py:/app/dump_failure.py:ro \
  -v $PWD/litellm/proxy/_experimental/out:/var/lib/litellm/ui:ro \
  -w /app \
  ghcr.io/berriai/litellm-non_root:v1.85.0-rc.2 \
  --config /app/config.yaml --detailed_debug
```

Static routing for the URL Linear actually redirects to, plus a handful of other UI routes for regression coverage:

```text
$ for p in /ui/mcp/oauth/callback /ui/mcp/oauth/callback/ /ui/login /ui/models-and-endpoints /ui/ /ui/skills /ui/teams /ui/virtual-keys; do
    code=$(curl -s -o /dev/null -w "%{http_code}" -L "http://localhost:4000${p}");
    echo "$code  $p";
  done
200  /ui/mcp/oauth/callback
200  /ui/mcp/oauth/callback/
200  /ui/login
200  /ui/models-and-endpoints
200  /ui/
200  /ui/skills
200  /ui/teams
200  /ui/virtual-keys
```

Live LLM round-trip against a real provider through the upgraded image:

```text
$ curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"claude","messages":[{"role":"user","content":"reply with the single word OK"}]}' \
    | jq -r '.choices[0].message.content'
OK
```

End-to-end browser flow to repro the original bug and confirm the fix:

1. Go to http://localhost:4000/ui/, sign in as admin / sk-1234.
2. Open http://localhost:4000/ui/tools/mcp-servers/ and add a Linear MCP server with OAuth enabled.
3. Click Connect; the proxy redirects to Linear's consent screen.
4. Click Approve. Linear posts back to `http://localhost:4000/ui/mcp/oauth/callback?code=...&state=...`. Before this PR that URL returned `{"detail":"Not Found"}`; after the PR it 307s to `/ui/mcp/oauth/callback/` and the dashboard finishes the token exchange.

## Type

Bug Fix

## Changes

`ui/litellm-dashboard/next.config.mjs` now sets `trailingSlash: true`, so the static export emits every nested route as `<dir>/index.html` natively instead of `<dir>.html`. The matching regeneration of `litellm/proxy/_experimental/out/` lives in the stacked artifact PR #28112.

`docker/Dockerfile.non_root` drops the broken shell-glob restructure loop. It only saw top-level `*.html` files and never reached `mcp/oauth/callback.html`, so it added no value once the export is already in the desired layout. The `.litellm_ui_ready` readiness marker is still written so the proxy startup path keeps skipping the redundant Python restructure step.

A regression test in `tests/test_litellm/proxy/test_proxy_server.py` mounts the actual bundled export through `StaticFiles` and asserts that `/ui/mcp/oauth/callback?code=...&state=...` 307s to `/ui/mcp/oauth/callback/?code=...&state=...` and the followed redirect returns HTML. It also asserts that no nested route in the export ships as a stray `<name>.html`, which is what catches future regressions of either `trailingSlash` being removed or someone moving back to a recursion-broken restructure step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Admin UI static export layout and Docker image build steps, which could break existing UI routing if the exported artifact or proxy assumptions diverge.
> 
> **Overview**
> Fixes Admin UI routing for extensionless nested paths by enabling `trailingSlash` in the Next.js static export so routes are emitted as `<dir>/index.html` (e.g., `mcp/oauth/callback/index.html`).
> 
> Simplifies the non-root Docker build by removing the non-recursive HTML “restructure” loop and only writing the `.litellm_ui_ready` marker after copying the prebuilt UI.
> 
> Adds a regression test that validates the bundled export contains no nested non-`index.html` pages and that `/ui/mcp/oauth/callback?…` redirects and serves HTML via `StaticFiles(html=True)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc35578864dec61c912137d4e2bee04db162a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->