### PR TITLE
fix(anthropic): don't force tool_choice on adaptive-thinking models

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1486,7 +1486,19 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     )
                     if _tool is None:
                         continue
-                    if not is_thinking_enabled:
+                    # Adaptive thinking models (Claude 4.7+) use
+                    # ``thinking.type == "adaptive"`` rather than
+                    # ``"enabled"``, so ``is_thinking_enabled`` (which only
+                    # matches ``"enabled"`` / ``reasoning_effort``) reports
+                    # False. Without this extra check we set a forced
+                    # ``tool_choice`` while ``thinking: adaptive`` is still on
+                    # the wire body, and Anthropic / Bedrock reject the
+                    # request with "Thinking may not be enabled when
+                    # tool_choice forces tool use".
+                    is_adaptive_thinking = self._is_adaptive_thinking_model(
+                        model
+                    )
+                    if not is_thinking_enabled and not is_adaptive_thinking:
                         _tool_choice = {
                             "name": RESPONSE_FORMAT_TOOL_NAME,
                             "type": "tool",

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1495,9 +1495,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     # the wire body, and Anthropic / Bedrock reject the
                     # request with "Thinking may not be enabled when
                     # tool_choice forces tool use".
-                    is_adaptive_thinking = self._is_adaptive_thinking_model(
-                        model
-                    )
+                    is_adaptive_thinking = self._is_adaptive_thinking_model(model)
                     if not is_thinking_enabled and not is_adaptive_thinking:
                         _tool_choice = {
                             "name": RESPONSE_FORMAT_TOOL_NAME,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1035,11 +1035,20 @@ class AmazonConverseConfig(BaseConfig):
                 optional_params=optional_params, tools=[_tool]
             )
 
+            # Adaptive-thinking models (Claude 4.7+) need the same carve-out
+            # as anthropic/chat/transformation.py: ``is_thinking_enabled``
+            # does not match ``thinking.type == "adaptive"``, so without
+            # this check we set a forced ``tool_choice`` while
+            # ``thinking: adaptive`` is still on the wire body and Bedrock
+            # rejects with "Thinking may not be enabled when tool_choice
+            # forces tool use".
+            is_adaptive_thinking = AnthropicConfig._is_adaptive_thinking_model(model)
             if (
                 litellm.utils.supports_tool_choice(
                     model=model, custom_llm_provider=self.custom_llm_provider
                 )
                 and not is_thinking_enabled
+                and not is_adaptive_thinking
             ):
                 optional_params["tool_choice"] = ToolChoiceValuesBlock(
                     tool=SpecificToolChoiceBlock(name=RESPONSE_FORMAT_TOOL_NAME)

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -1924,3 +1924,101 @@ def test_anthropic_streaming_completion_replay():
     assert chunk_count > 1, "expected multiple SSE chunks from streaming response"
     assert collected_text.strip(), collected_text
     assert finish_reason in {"stop", "length"}
+
+
+def test_adaptive_thinking_model_response_format_fallback_no_forced_tool_choice(
+    monkeypatch,
+):
+    """Adaptive-thinking models must not get a forced ``tool_choice`` when
+    response_format falls back to the synthetic-tool path.
+
+    ``thinking.type == "adaptive"`` is not matched by ``is_thinking_enabled``
+    (which only recognises ``"enabled"`` or ``reasoning_effort``), so the
+    ``if not is_thinking_enabled`` guard around the synthetic
+    ``RESPONSE_FORMAT_TOOL_NAME`` tool_choice would fire and pin the model to
+    that tool. Anthropic / Bedrock then reject the request with
+    "Thinking may not be enabled when tool_choice forces tool use".
+
+    We construct a model name outside the response-format whitelist so the
+    fallback branch is reached, and force ``_is_adaptive_thinking_model`` to
+    True via monkeypatch so the test does not depend on which models the
+    model_cost map happens to flag as adaptive.
+
+    See vercel/ai#14773 for the parallel symptom in another SDK.
+    """
+    config = litellm.AnthropicConfig()
+    monkeypatch.setattr(
+        litellm.AnthropicConfig,
+        "_is_adaptive_thinking_model",
+        staticmethod(lambda model: True),
+    )
+
+    mapped = config.map_openai_params(
+        non_default_params={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "integer"}},
+                        "required": ["answer"],
+                    },
+                    "name": "out",
+                },
+            },
+        },
+        optional_params={},
+        # Deliberately outside the hardcoded response_format whitelist so the
+        # synthetic-tool fallback branch is exercised.
+        model="some-future-adaptive-model",
+        drop_params=False,
+    )
+
+    assert "tool_choice" not in mapped, (
+        "Adaptive-thinking models must not have a forced tool_choice "
+        "synthesised on the response_format fallback path; got: "
+        f"{mapped.get('tool_choice')!r}"
+    )
+    # The tool itself is still added so the model can still emit JSON via
+    # the synthetic tool when it chooses to — only the *forcing* is removed.
+    assert mapped.get("json_mode") is True
+    assert any(
+        t.get("name") == "json_tool_call" for t in mapped.get("tools", [])
+    ), f"expected synthetic json_tool_call tool to be present, got tools={mapped.get('tools')}"
+
+
+def test_non_adaptive_model_response_format_fallback_still_forces_tool_choice():
+    """Regression guard: non-adaptive, non-thinking models keep the existing
+    forced ``tool_choice`` behaviour on the response_format fallback path.
+
+    This test exists to make sure the adaptive-thinking carve-out added in
+    the same change does not silently widen and stop forcing tool_choice
+    for the original (non-thinking) callers, which depend on it to make
+    the model actually invoke the synthetic JSON tool.
+    """
+    mapped = litellm.AnthropicConfig().map_openai_params(
+        non_default_params={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "integer"}},
+                        "required": ["answer"],
+                    },
+                    "name": "out",
+                },
+            },
+        },
+        optional_params={},
+        # claude-3-5-sonnet is not in the response_format output_format
+        # whitelist and is not flagged as adaptive in the model_cost map,
+        # so the fallback branch runs with the original behaviour.
+        model="claude-3-5-sonnet-20240620",
+        drop_params=False,
+    )
+
+    assert mapped.get("tool_choice") == {
+        "name": "json_tool_call",
+        "type": "tool",
+    }, f"expected forced json_tool_call tool_choice, got {mapped.get('tool_choice')!r}"

--- a/tests/llm_translation/test_bedrock_anthropic_regression.py
+++ b/tests/llm_translation/test_bedrock_anthropic_regression.py
@@ -539,3 +539,76 @@ class TestBedrockAnthropicCombinedRegressions:
                 for c in user_msg["content"]
             )
             assert has_cache_control
+
+
+def test_bedrock_converse_adaptive_thinking_response_format_no_forced_tool_choice(
+    monkeypatch,
+):
+    """Bedrock converse fallback path: same fix as PR #28114's anthropic-side
+    fix needs to apply here too.
+
+    AmazonConverseConfig._add_response_format_to_optional_params (the
+    response_format → synthetic-tool fallback) used to force tool_choice
+    when not is_thinking_enabled. Adaptive-thinking models (Claude 4.7+)
+    use ``thinking.type == "adaptive"`` and so are not matched by
+    is_thinking_enabled, leading to a forced tool_choice while thinking
+    is on the wire body — Bedrock returns:
+        Thinking may not be enabled when tool_choice forces tool use.
+
+    Reproduces the same bug in this provider as the anthropic-side
+    fallback. See PR #28114 description for full background.
+    """
+    import litellm
+    from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    # Force the helper True so the test does not depend on which models
+    # the model_cost map happens to flag adaptive.
+    monkeypatch.setattr(
+        AnthropicConfig,
+        "_is_adaptive_thinking_model",
+        staticmethod(lambda model: True),
+    )
+    # Make sure supports_tool_choice is True so the original guard doesn't
+    # short-circuit for the test model.
+    monkeypatch.setattr(
+        litellm.utils, "supports_tool_choice", lambda model, custom_llm_provider=None: True
+    )
+
+    config = AmazonConverseConfig()
+    response_format_value = {
+        "type": "json_schema",
+        "json_schema": {
+            "schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "integer"}},
+                "required": ["answer"],
+                "additionalProperties": False,
+            },
+            "name": "out",
+        },
+    }
+    optional_params = config._translate_response_format_param(
+        value=response_format_value,
+        # Use a model name that is not on the native-structured-output list
+        # so we hit the synthetic-tool fallback path.
+        model="some-future-adaptive-model",
+        optional_params={},
+        non_default_params={"response_format": response_format_value},
+        is_thinking_enabled=False,
+    )
+
+    assert "tool_choice" not in optional_params, (
+        "Adaptive-thinking models must not have a forced tool_choice "
+        "synthesised by the Bedrock response_format fallback path; got: "
+        f"{optional_params.get('tool_choice')!r}"
+    )
+    # The synthetic tool should still be present so the model can still
+    # emit JSON via it when it chooses to. ``_translate_response_format_param``
+    # runs early in the chain and tools are still in OpenAI shape at this
+    # point (function/parameters); they get converted to Bedrock toolSpec
+    # later in transform_request.
+    tools = optional_params.get("tools") or []
+    assert any(
+        t.get("function", {}).get("name") == "json_tool_call" for t in tools
+    ), f"expected synthetic json_tool_call tool, got tools={tools}"


### PR DESCRIPTION
## Summary

Adaptive-thinking models (Claude 4.7+) declare `thinking.type == "adaptive"` rather than `"enabled"`, so `is_thinking_enabled()` (which only matches `"enabled"` or `reasoning_effort`) reports `False` for them.

On the `response_format` → synthetic-tool fallback path in `litellm/llms/anthropic/chat/transformation.py`, the `if not is_thinking_enabled:` guard then sets:

```python
optional_params["tool_choice"] = {"name": "json_tool_call", "type": "tool"}
```

while `optional_params["thinking"] = {"type": "adaptive"}` is still on the wire body. Anthropic / Bedrock reject the request with:

```
Thinking may not be enabled when tool_choice forces tool use.
```

This PR adds a carve-out for adaptive-thinking models using the existing `AnthropicConfig._is_adaptive_thinking_model()` helper so the forced `tool_choice` is skipped. The synthetic JSON tool itself is still added and `json_mode` is still set, so the response side is unchanged — the model can still emit JSON via the tool when it chooses to.

## Reachability

This branch is unreachable for the in-tree Claude 4.6 / 4.7 models today because they all match the `response_format` output_format whitelist a few lines earlier in `map_openai_params`. The fix bites users who push those models off the native `output_format` path:

- yaml override of `supports_response_schema` / `supports_native_structured_output` to coerce the fallback path (e.g. when an upstream backend like AWS Bedrock has not yet whitelisted `outputConfig.textFormat` for a given Anthropic model)
- future adaptive-thinking models that aren't yet on the hardcoded whitelist
- third-party adapters that translate Responses-API requests into LiteLLM completions

A parallel symptom in another SDK is documented at [vercel/ai#14773](https://github.com/vercel/ai/issues/14773), where Vercel AI SDK's `@ai-sdk/amazon-bedrock` hardcodes `supportsNativeStructuredOutput: true` for every Anthropic-on-Bedrock model and runs into the same wall.

## Behaviour change

| scenario | before | after |
|---|---|---|
| adaptive-thinking model + `response_format` on fallback path | sets forced `tool_choice` → 400 from Anthropic / Bedrock | no `tool_choice`; synthetic tool + `json_mode` still added |
| non-adaptive, non-thinking model + `response_format` on fallback path | sets forced `tool_choice` (so the model invokes the synthetic JSON tool) | unchanged |
| `is_thinking_enabled` (i.e. `thinking.type == "enabled"` or `reasoning_effort` set) + `response_format` on fallback path | no forced `tool_choice` (existing behaviour) | unchanged |

## Tests

`tests/llm_translation/test_anthropic_completion.py`:

- `test_adaptive_thinking_model_response_format_fallback_no_forced_tool_choice` — pins the new behaviour, monkeypatches `_is_adaptive_thinking_model` to True so it doesn't depend on which models the model_cost map happens to flag as adaptive
- `test_non_adaptive_model_response_format_fallback_still_forces_tool_choice` — guards against silently widening the carve-out to non-adaptive models, which would break callers that rely on the forced `tool_choice` to actually invoke the synthetic JSON tool

Both tests pass on the patched source. Run locally with:

```
pytest tests/llm_translation/test_anthropic_completion.py::test_adaptive_thinking_model_response_format_fallback_no_forced_tool_choice tests/llm_translation/test_anthropic_completion.py::test_non_adaptive_model_response_format_fallback_still_forces_tool_choice -v
```

## Test plan

- [x] Reproduced the failure end-to-end on `bedrock/global.anthropic.claude-opus-4-7` with `thinking.type=adaptive` + a Responses-API `text.format` request flowing through the fallback path; observed the `Thinking may not be enabled when tool_choice forces tool use` 400 from Bedrock.
- [x] Verified the patch removes `tool_choice` from `optional_params` while preserving the synthetic `json_tool_call` tool and `json_mode`.
- [x] Two new unit tests added and passing.
- [x] CLA — happy to sign at https://cla-assistant.io/BerriAI/litellm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)