### PR TITLE
fix: handle image_url=None in token_counter to prevent ValueError crash

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -585,7 +585,8 @@ def _count_image_tokens(
     Count tokens for an image_url content block.
 
     Args:
-        image_url: The image URL data - can be a string URL or dict with 'url' and 'detail'
+        image_url: The image URL data - can be a string URL or dict with 'url' and 'detail'.
+            None is treated as an unknown image and returns the default token count.
         use_default_image_token_count: Whether to use default image token counts
 
     Returns:
@@ -594,6 +595,8 @@ def _count_image_tokens(
     Raises:
         ValueError: If image_url is invalid type or detail value is invalid
     """
+    if image_url is None:
+        return DEFAULT_IMAGE_TOKEN_COUNT
     if isinstance(image_url, dict):
         detail = image_url.get("detail", "auto")
         if detail not in ["low", "high", "auto"]:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -908,6 +908,38 @@ def test_token_counter_with_image_url():
         ), f"Expected detail validation error, got: {e}"
 
 
+def test_token_counter_image_url_none():
+    """
+    Regression test: token_counter must not raise ValueError when a content
+    block has {"type": "image_url", "image_url": None}.
+
+    Previously _count_image_tokens() reached its final else-branch and raised:
+        ValueError: Invalid image_url type: NoneType. Expected str or dict with 'url' field.
+
+    After the fix, None is treated as an unknown image and the default token
+    count (DEFAULT_IMAGE_TOKEN_COUNT = 250) is returned so callers are not
+    disrupted by a None value in an otherwise valid message list.
+    """
+    from litellm.constants import DEFAULT_IMAGE_TOKEN_COUNT
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "image_url", "image_url": None},
+            ],
+        }
+    ]
+
+    tokens = token_counter(model="gpt-4-vision-preview", messages=messages)
+    assert tokens > 0, f"Expected positive token count, got {tokens}"
+    assert tokens >= DEFAULT_IMAGE_TOKEN_COUNT, (
+        f"Expected at least DEFAULT_IMAGE_TOKEN_COUNT={DEFAULT_IMAGE_TOKEN_COUNT} "
+        f"tokens due to the None image_url fallback, got {tokens}"
+    )
+
+
 def test_token_counter_with_thinking_content():
     """
     Test that _count_content_list() correctly handles Claude's extended thinking content blocks.


### PR DESCRIPTION
## Relevant issues
Fixes #28119

## Pre-Submission checklist
- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Screenshots / Proof of Fix
Before fix:
ValueError: Error getting number of tokens from content list:
  Invalid image_url type: NoneType. Expected str or dict with 'url' field.,
  default_token_count=None

After fix:
token_counter returns a positive token count using DEFAULT_IMAGE_TOKEN_COUNT (250).
Regression test passes: test_token_counter_image_url_none ✅

## Type
🐛 Bug Fix

## Changes
Added a None guard at the top of _count_image_tokens() in
litellm/litellm_core_utils/token_counter.py.
When image_url is None, returns DEFAULT_IMAGE_TOKEN_COUNT instead of
crashing with ValueError. Added regression test to cover this case.