### PR TITLE
fix(mcp): log + respond to unsupported server→client requests instead of dropping silently

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -4,6 +4,7 @@ LiteLLM Proxy uses this MCP Client to connnect to other MCP servers.
 
 import asyncio
 import base64
+import logging
 from typing import (
     Any,
     Awaitable,
@@ -261,16 +262,27 @@ class _LiteLLMMCPClientSession(ClientSession):
             method = "elicitation/create"
 
         if method is not None:
-            params = getattr(request_root, "params", None)
             verbose_logger.warning(
                 "MCP upstream %s sent %s; the LiteLLM MCP Gateway does not "
                 "implement this capability yet. Responding with JSON-RPC "
-                "error %d. params=%r",
+                "error %d.",
                 self._litellm_server_url or "stdio",
                 method,
                 METHOD_NOT_FOUND,
-                params,
             )
+            # Params from sampling/createMessage can include the full
+            # conversation history and system prompt; params from
+            # elicitation/create can include sensitive instructions. Keep
+            # them at DEBUG level so they never land in production log
+            # aggregators unless operators explicitly opt in.
+            if verbose_logger.isEnabledFor(logging.DEBUG):
+                params = getattr(request_root, "params", None)
+                verbose_logger.debug(
+                    "MCP unsupported server->client request payload: "
+                    "method=%s params=%r",
+                    method,
+                    params,
+                )
             with responder:
                 await responder.respond(
                     _build_unsupported_method_error(method, self._litellm_server_url)

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -34,6 +34,10 @@ except ImportError:
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
 from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
+    METHOD_NOT_FOUND,
+    CreateMessageRequest,
+    ElicitRequest,
+    ErrorData,
     GetPromptRequestParams,
     GetPromptResult,
     Prompt,
@@ -192,6 +196,93 @@ class MCPSigV4Auth(httpx.Auth):
         yield request
 
 
+_UNSUPPORTED_METHODS_ISSUE_URL = "https://github.com/BerriAI/litellm/issues/23761"
+
+
+def _build_unsupported_method_error(method: str, server_url: str) -> ErrorData:
+    """
+    Build a JSON-RPC error for an unsupported server -> client method.
+
+    Per the MCP spec, when an upstream server sends a server -> client
+    request (e.g. `sampling/createMessage` or `elicitation/create`) and the
+    client does not implement that capability, the client must respond with
+    a JSON-RPC error so the server can fall back gracefully rather than
+    waiting on a response that will never arrive. The MCP Python SDK's
+    default callbacks already return a generic `INVALID_REQUEST` error in
+    this case; this helper returns a more descriptive error that identifies
+    LiteLLM as the responding peer and points operators at the tracking
+    issue.
+    """
+    return ErrorData(
+        code=METHOD_NOT_FOUND,
+        message=(
+            f"{method} is not supported by the LiteLLM MCP Gateway "
+            f"(upstream MCP server: {server_url or 'stdio'}). "
+            f"See {_UNSUPPORTED_METHODS_ISSUE_URL} for status."
+        ),
+    )
+
+
+class _LiteLLMMCPClientSession(ClientSession):
+    """
+    `mcp.ClientSession` subclass used by LiteLLM to handle server -> client
+    requests for methods the gateway does not yet implement.
+
+    Behaviour vs. the SDK default:
+      * Capabilities are unchanged — the gateway still does NOT declare
+        `sampling` or `elicitation` support during `initialize`, because the
+        SDK's identity check (`callback is not _default_*_callback`) is
+        bypassed: we override `_received_request` directly instead of
+        installing custom callbacks.
+      * Incoming `sampling/createMessage` and `elicitation/create` requests
+        are logged at WARNING level so operators can see when an upstream
+        server attempts to use these capabilities, instead of the silent
+        drop the previous code path produced at the LiteLLM logging layer.
+      * The JSON-RPC error sent back to the upstream server names LiteLLM
+        as the responding peer and uses `METHOD_NOT_FOUND` (-32601), which
+        matches "the method exists in the spec but this peer doesn't
+        implement it".
+    """
+
+    def __init__(self, *args: Any, server_url: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._litellm_server_url = server_url
+
+    async def _received_request(self, responder: Any) -> None:
+        # `responder.request` is a `types.ServerRequest` pydantic union.
+        # `.root` is the actual variant (CreateMessageRequest, ElicitRequest,
+        # etc.). We branch on isinstance to avoid coupling to private
+        # `match`/`case` shape in the SDK.
+        request_root = getattr(responder.request, "root", responder.request)
+        method: Optional[str] = None
+        if isinstance(request_root, CreateMessageRequest):
+            method = "sampling/createMessage"
+        elif isinstance(request_root, ElicitRequest):
+            method = "elicitation/create"
+
+        if method is not None:
+            params = getattr(request_root, "params", None)
+            verbose_logger.warning(
+                "MCP upstream %s sent %s; the LiteLLM MCP Gateway does not "
+                "implement this capability yet. Responding with JSON-RPC "
+                "error %d. params=%r",
+                self._litellm_server_url or "stdio",
+                method,
+                METHOD_NOT_FOUND,
+                params,
+            )
+            with responder:
+                await responder.respond(
+                    _build_unsupported_method_error(method, self._litellm_server_url)
+                )
+            return None
+
+        # Fall through to the SDK's default handling for every other
+        # server -> client request (`ping`, `roots/list`, task callbacks,
+        # etc.).
+        return await super()._received_request(responder)
+
+
 class MCPClient:
     """
     MCP Client supporting:
@@ -294,7 +385,22 @@ class MCPClient:
         transport = await transport_ctx.__aenter__()
         try:
             read_stream, write_stream = transport[0], transport[1]
-            session_ctx = ClientSession(read_stream, write_stream)
+            # Use a LiteLLM-specific `ClientSession` subclass that handles
+            # `sampling/createMessage` and `elicitation/create` requests from
+            # the upstream server: it logs a warning so the event is visible
+            # in proxy logs (previously LiteLLM was silent at the logging
+            # layer even though the SDK replied to the server with a generic
+            # `INVALID_REQUEST` error) and returns a more descriptive
+            # JSON-RPC error that names LiteLLM as the responding peer.
+            # `sampling` / `elicitation` capabilities are deliberately NOT
+            # declared during `initialize` — the override is done in
+            # `_received_request`, not via the SDK's callback hooks, so the
+            # SDK's identity check on the default callbacks still passes.
+            session_ctx = _LiteLLMMCPClientSession(
+                read_stream,
+                write_stream,
+                server_url=self.server_url,
+            )
             session = await session_ctx.__aenter__()
             try:
                 init_result = await session.initialize()

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -520,6 +520,57 @@ class TestUnsupportedServerToClientMethods:
         )
 
     @pytest.mark.asyncio
+    async def test_sampling_warning_log_does_not_contain_message_content(self, caplog):
+        """
+        Regression: WARNING-level logs must NOT include `sampling/createMessage`
+        params, which can contain conversation history, system prompts, or
+        other user-supplied content. Operators opt into the payload via DEBUG.
+        """
+        import logging
+
+        from mcp.types import (
+            CreateMessageRequest,
+            CreateMessageRequestParams,
+            SamplingMessage,
+            TextContent,
+        )
+
+        from litellm.experimental_mcp_client.client import (
+            _LiteLLMMCPClientSession,
+        )
+
+        session = _LiteLLMMCPClientSession.__new__(_LiteLLMMCPClientSession)
+        session._litellm_server_url = "https://upstream.example/mcp"
+
+        secret = "tenant-A-conversation-snippet-do-not-leak"
+        params = CreateMessageRequestParams(
+            messages=[
+                SamplingMessage(
+                    role="user",
+                    content=TextContent(type="text", text=secret),
+                )
+            ],
+            maxTokens=16,
+        )
+        responder = _FakeResponder(
+            CreateMessageRequest(method="sampling/createMessage", params=params)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+            await session._received_request(responder)
+
+        # No WARNING record may contain the user-supplied conversation text.
+        warnings_with_secret = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and secret in r.getMessage()
+        ]
+        assert warnings_with_secret == [], (
+            f"Sensitive sampling params leaked to WARNING log: "
+            f"{[r.getMessage() for r in warnings_with_secret]}"
+        )
+
+    @pytest.mark.asyncio
     async def test_other_server_requests_fall_through_to_default(self):
         """
         Server -> client methods that aren't sampling/elicitation must

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -48,7 +48,7 @@ class TestMCPClient:
 
     @pytest.mark.asyncio
     @patch("litellm.experimental_mcp_client.client.stdio_client")
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client._LiteLLMMCPClientSession")
     async def test_mcp_client_stdio_connect_success(
         self, mock_session, mock_stdio_client
     ):
@@ -107,7 +107,7 @@ class TestMCPClient:
 
         # Mock the session
         with patch(
-            "litellm.experimental_mcp_client.client.ClientSession"
+            "litellm.experimental_mcp_client.client._LiteLLMMCPClientSession"
         ) as mock_session:
             mock_session_instance = AsyncMock()
             mock_session_instance.initialize = AsyncMock()
@@ -155,7 +155,7 @@ class TestMCPClient:
 
         # Mock the session
         with patch(
-            "litellm.experimental_mcp_client.client.ClientSession"
+            "litellm.experimental_mcp_client.client._LiteLLMMCPClientSession"
         ) as mock_session:
             mock_session_instance = AsyncMock()
             mock_session_instance.initialize = AsyncMock()
@@ -209,7 +209,7 @@ class TestMCPClient:
 
         # Mock the session
         with patch(
-            "litellm.experimental_mcp_client.client.ClientSession"
+            "litellm.experimental_mcp_client.client._LiteLLMMCPClientSession"
         ) as mock_session:
             mock_session_instance = AsyncMock()
             mock_session_instance.initialize = AsyncMock()
@@ -330,7 +330,7 @@ class TestMCPClientInstructionsCapture:
         assert client._last_initialize_instructions is None
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client._LiteLLMMCPClientSession")
     async def test_captures_instructions_from_initialize(self, mock_session_cls):
         """Instructions from upstream initialize() are captured and stripped."""
         client = MCPClient(
@@ -359,7 +359,7 @@ class TestMCPClientInstructionsCapture:
         assert client._last_initialize_instructions == "upstream says hello"
 
     @pytest.mark.asyncio
-    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    @patch("litellm.experimental_mcp_client.client._LiteLLMMCPClientSession")
     async def test_none_instructions_stays_none(self, mock_session_cls):
         """When upstream returns no instructions the field stays None."""
         client = MCPClient(
@@ -386,6 +386,219 @@ class TestMCPClientInstructionsCapture:
 
         await client._execute_session_operation(transport_ctx, _op)
         assert client._last_initialize_instructions is None
+
+
+class TestUnsupportedServerToClientMethods:
+    """
+    Tests for `_LiteLLMMCPClientSession`, which handles upstream MCP server
+    requests for methods the LiteLLM MCP Gateway does not implement yet
+    (`sampling/createMessage`, `elicitation/create`).
+
+    Previously these requests were silently dropped at the LiteLLM logging
+    layer — the SDK auto-replied to the server with a generic error, but
+    operators saw nothing. The subclass logs a warning and replies with a
+    descriptive JSON-RPC `METHOD_NOT_FOUND` error so the upstream server can
+    fall back gracefully. See https://github.com/BerriAI/litellm/issues/23761.
+    """
+
+    def test_unsupported_method_error_includes_litellm_and_server(self):
+        from litellm.experimental_mcp_client.client import (
+            _build_unsupported_method_error,
+        )
+        from mcp.types import METHOD_NOT_FOUND
+
+        err = _build_unsupported_method_error(
+            "sampling/createMessage", "https://upstream.example/mcp"
+        )
+        assert err.code == METHOD_NOT_FOUND
+        assert "sampling/createMessage" in err.message
+        assert "LiteLLM MCP Gateway" in err.message
+        assert "https://upstream.example/mcp" in err.message
+
+    def test_unsupported_method_error_handles_empty_server_url(self):
+        from litellm.experimental_mcp_client.client import (
+            _build_unsupported_method_error,
+        )
+
+        err = _build_unsupported_method_error("elicitation/create", "")
+        assert "stdio" in err.message
+        assert "elicitation/create" in err.message
+
+    @pytest.mark.asyncio
+    async def test_sampling_request_logs_and_responds_with_method_not_found(
+        self, caplog
+    ):
+        import logging
+
+        from mcp.types import (
+            METHOD_NOT_FOUND,
+            CreateMessageRequest,
+            CreateMessageRequestParams,
+            ErrorData,
+            SamplingMessage,
+            TextContent,
+        )
+
+        from litellm.experimental_mcp_client.client import (
+            _LiteLLMMCPClientSession,
+        )
+
+        session = _LiteLLMMCPClientSession.__new__(_LiteLLMMCPClientSession)
+        session._litellm_server_url = "https://upstream.example/mcp"
+
+        params = CreateMessageRequestParams(
+            messages=[
+                SamplingMessage(
+                    role="user",
+                    content=TextContent(type="text", text="hi"),
+                )
+            ],
+            maxTokens=16,
+        )
+        responder = _FakeResponder(
+            CreateMessageRequest(method="sampling/createMessage", params=params)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+            await session._received_request(responder)
+
+        assert responder.responded_with is not None
+        assert isinstance(responder.responded_with, ErrorData)
+        assert responder.responded_with.code == METHOD_NOT_FOUND
+        assert "sampling/createMessage" in responder.responded_with.message
+        assert "https://upstream.example/mcp" in responder.responded_with.message
+        # A warning was logged with the server URL and the method name —
+        # the previous behaviour logged nothing at all.
+        assert any(
+            "sampling/createMessage" in record.getMessage()
+            and "https://upstream.example/mcp" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_elicitation_request_logs_and_responds_with_method_not_found(
+        self, caplog
+    ):
+        import logging
+
+        from mcp.types import (
+            METHOD_NOT_FOUND,
+            ElicitRequest,
+            ElicitRequestFormParams,
+            ErrorData,
+        )
+
+        from litellm.experimental_mcp_client.client import (
+            _LiteLLMMCPClientSession,
+        )
+
+        session = _LiteLLMMCPClientSession.__new__(_LiteLLMMCPClientSession)
+        session._litellm_server_url = ""  # stdio
+
+        params = ElicitRequestFormParams(
+            message="Confirm deletion?",
+            requestedSchema={
+                "type": "object",
+                "properties": {"confirm": {"type": "boolean"}},
+                "required": ["confirm"],
+            },
+        )
+        responder = _FakeResponder(
+            ElicitRequest(method="elicitation/create", params=params)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+            await session._received_request(responder)
+
+        assert isinstance(responder.responded_with, ErrorData)
+        assert responder.responded_with.code == METHOD_NOT_FOUND
+        assert "elicitation/create" in responder.responded_with.message
+        # stdio servers (no URL) are identified as "stdio" in the message.
+        assert "stdio" in responder.responded_with.message
+        assert any(
+            "elicitation/create" in record.getMessage() for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_other_server_requests_fall_through_to_default(self):
+        """
+        Server -> client methods that aren't sampling/elicitation must
+        still go to the SDK's default handler (e.g. ping/roots/list).
+        """
+        from litellm.experimental_mcp_client.client import (
+            _LiteLLMMCPClientSession,
+        )
+
+        session = _LiteLLMMCPClientSession.__new__(_LiteLLMMCPClientSession)
+        session._litellm_server_url = "https://upstream.example/mcp"
+
+        # Use a sentinel object that does not match CreateMessageRequest
+        # or ElicitRequest — it should fall through to super().
+        unrelated_root = object()
+        responder = _FakeResponder(unrelated_root)
+
+        with patch(
+            "mcp.ClientSession._received_request", new_callable=AsyncMock
+        ) as super_handler:
+            await session._received_request(responder)
+
+        super_handler.assert_awaited_once_with(responder)
+        # We didn't respond ourselves — the parent does.
+        assert responder.responded_with is None
+
+    def test_client_session_does_not_declare_unsupported_capabilities(self):
+        """
+        Guards against a future regression that wires custom callbacks into
+        the SDK — doing so would make the SDK declare `sampling` and
+        `elicitation` capabilities to the upstream server during `initialize`,
+        which we explicitly do NOT support yet.
+        """
+        from mcp.client.session import (
+            _default_elicitation_callback,
+            _default_sampling_callback,
+        )
+
+        from litellm.experimental_mcp_client.client import (
+            _LiteLLMMCPClientSession,
+        )
+
+        # We can't call __init__ without real streams, so just verify the
+        # subclass does not override the class-level callback identity.
+        # Both attributes are set in ClientSession.__init__; instead verify
+        # the subclass does not bind class-level overrides for them.
+        assert "_sampling_callback" not in vars(_LiteLLMMCPClientSession)
+        assert "_elicitation_callback" not in vars(_LiteLLMMCPClientSession)
+        # And the module-level defaults are importable — sanity check that
+        # the SDK API we depend on hasn't been removed under us.
+        assert _default_sampling_callback is not None
+        assert _default_elicitation_callback is not None
+
+
+class _FakeResponder:
+    """
+    Minimal stand-in for `mcp.shared.session.RequestResponder` used by the
+    `_received_request` tests above. It records the response value and
+    behaves as a no-op context manager.
+    """
+
+    def __init__(self, request_root: object) -> None:
+        self.request = MagicMock()
+        self.request.root = request_root
+        self.responded_with: object = None
+        self._completed = False
+        self._entered = False
+
+    def __enter__(self) -> "_FakeResponder":
+        self._entered = True
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._entered = False
+
+    async def respond(self, response: object) -> None:
+        assert self._entered, "RequestResponder must be used as a context manager"
+        self.responded_with = response
+        self._completed = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

Refs #23761.

## Problem

Per the MCP spec, when an upstream MCP server sends `sampling/createMessage` or `elicitation/create` to a client that doesn't implement those capabilities, the client must respond with a JSON-RPC error so the server can fall back gracefully. Today, when an upstream server sends one of these requests through the LiteLLM MCP Gateway, the operator sees nothing: the MCP Python SDK auto-replies to the server with a generic `INVALID_REQUEST` error, but LiteLLM logs nothing about the event, so it looks like a silent drop from the proxy's point of view.

This is the smallest, defensive fix for the bug described in the issue title. It is intentionally scoped narrower than the full Mode A/B implementation discussed in the issue body (#27109 is in flight for that and may go a different way); the goal here is just to make the current behaviour observable and spec-compliant in a way that won't conflict with whatever the full implementation ends up looking like.

## Change

`litellm/experimental_mcp_client/client.py`:

* Add `_LiteLLMMCPClientSession`, a thin `mcp.ClientSession` subclass that overrides `_received_request` for `CreateMessageRequest` / `ElicitRequest`:
  * logs a `WARNING` that names the upstream server URL and the method (so the event is now visible in proxy logs);
  * responds with a JSON-RPC error using `METHOD_NOT_FOUND` (`-32601`), with a message that identifies LiteLLM as the responding peer and points at the tracking issue;
  * falls through to the SDK default for every other server→client request (`ping`, `roots/list`, task callbacks, …).
* Use the subclass from `MCPClient._execute_session_operation` in place of the bare `ClientSession`.

`tests/test_litellm/experimental_mcp_client/test_mcp_client.py`:

* Update existing `@patch("...ClientSession")` references to patch the new subclass symbol (existing behaviour unchanged).
* Add `TestUnsupportedServerToClientMethods` covering:
  * the error message includes `LiteLLM MCP Gateway`, the method name, and the upstream server URL;
  * empty `server_url` (stdio) renders as `stdio` in the error message;
  * `sampling/createMessage` triggers a WARNING log and a `METHOD_NOT_FOUND` `ErrorData` response;
  * `elicitation/create` does the same for stdio servers;
  * unrelated server→client requests fall through to `super()._received_request`;
  * a regression guard that the subclass doesn't accidentally install custom sampling/elicitation callbacks (doing so would make the SDK declare these capabilities during `initialize`).

## Approach (Option A, smaller scope)

The override is in `_received_request` rather than via the SDK's `sampling_callback` / `elicitation_callback` hooks because the SDK's identity check on those callbacks (`callback is not _default_*_callback`) is also what gates capability declaration during `initialize`. Installing custom callbacks would make the SDK advertise `sampling` and `elicitation` support to upstream servers — which we explicitly don't implement yet, and which would actively encourage servers to send more of these requests.

## Why not the full Mode A/B implementation?

The issue describes a phased approach (sampling in Mode B → bidirectional relay in Mode A → elicitation in Mode B). That's a significantly larger change that touches the proxy server, the manager, and the gateway's session model. #27109 is already in flight along those lines but currently has merge conflicts and is awaiting maintainer direction.

This PR doesn't preclude any of those designs — it just upgrades the immediate behaviour from "silent at the LiteLLM layer" to "observable warning + spec-compliant JSON-RPC error", in a way that's independently useful and easy to extend later (the `_LiteLLMMCPClientSession` hook point is exactly where a real handler would slot in).

## Test plan

- [x] `pytest tests/test_litellm/experimental_mcp_client/` — 28 passed (13 existing + 6 new + 9 in `test_tools.py`).
- [x] Black formatting applied per `CLAUDE.md`.
- [x] Wider `pytest tests/test_litellm/proxy/_experimental/mcp_server/` run: 690 passed; 1 unrelated failure in `test_semantic_filter_basic_filtering` due to the optional `semantic_router` dep not being installed in my local venv — not touched by this PR.