### PR TITLE
fix(router): use .get() for 'hidden' and 'model' keys in dict-style model_group_alias entries

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8697,10 +8697,10 @@ class Router:
             if isinstance(item, str):
                 _router_model_group = item
             elif isinstance(item, dict):
-                if item["hidden"] is True:
+                if item.get("hidden") is True:
                     return None
                 else:
-                    _router_model_group = item["model"]
+                    _router_model_group = item.get("model", "")
             else:
                 return None
 
@@ -9299,10 +9299,10 @@ class Router:
                 _router_model_name: str = model_value
             elif isinstance(model_value, dict):
                 _model_value = RouterModelGroupAliasItem(**model_value)  # type: ignore
-                if _model_value["hidden"] is True:
+                if _model_value.get("hidden") is True:
                     continue
                 else:
-                    _router_model_name = _model_value["model"]
+                    _router_model_name = _model_value.get("model", "")
             else:
                 continue
 

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -977,6 +977,56 @@ def test_update_settings(model_list):
     assert router.allowed_fails == 20
 
 
+def test_get_model_group_info_alias_dict_without_hidden_key(model_list):
+    """Regression test: get_model_group_info must not raise KeyError when a
+    dict-style model_group_alias entry omits the 'hidden' key.
+
+    RouterModelGroupAliasItem declares 'hidden: bool' as a TypedDict field, but
+    TypedDict is a type-hint only — Python does NOT inject default values at
+    runtime.  Any user who writes:
+
+        model_group_alias:
+          "gpt-4-alias": {"model": "gpt-3.5-turbo"}
+
+    gets a plain dict without 'hidden', causing item["hidden"] to raise
+    KeyError on every request (via set_response_headers -> get_model_group_info).
+    """
+    alias_model_list = list(model_list) + [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {"model": "openai/gpt-3.5-turbo", "api_key": "sk-fake"},
+        }
+    ]
+    router = Router(
+        model_list=alias_model_list,
+        model_group_alias={
+            "gpt-4-alias": {"model": "gpt-3.5-turbo"},
+        },
+    )
+
+    # Must not raise KeyError — 'hidden' key is absent from the alias dict
+    result = router.get_model_group_info(model_group="gpt-4-alias")
+    assert result is not None
+
+    # Alias with hidden=True must still return None
+    router2 = Router(
+        model_list=alias_model_list,
+        model_group_alias={
+            "secret-alias": {"model": "gpt-3.5-turbo", "hidden": True},
+        },
+    )
+    assert router2.get_model_group_info(model_group="secret-alias") is None
+
+    # Alias with hidden=False (explicit) must return info
+    router3 = Router(
+        model_list=alias_model_list,
+        model_group_alias={
+            "visible-alias": {"model": "gpt-3.5-turbo", "hidden": False},
+        },
+    )
+    assert router3.get_model_group_info(model_group="visible-alias") is not None
+
+
 def test_common_checks_available_deployment(model_list):
     """Test if the 'common_checks_available_deployment' function is working correctly"""
     router = Router(model_list=model_list)

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1026,6 +1026,9 @@ def test_get_model_group_info_alias_dict_without_hidden_key(model_list):
     )
     assert router3.get_model_group_info(model_group="visible-alias") is not None
 
+    model_list_result = router.get_model_list()
+    assert model_list_result is not None
+
 
 def test_common_checks_available_deployment(model_list):
     """Test if the 'common_checks_available_deployment' function is working correctly"""

--- a/tests/test_litellm/router_utils/test_router_utils_common_utils.py
+++ b/tests/test_litellm/router_utils/test_router_utils_common_utils.py
@@ -516,3 +516,38 @@ class TestAddModelFileIdMappings:
     def test_should_return_empty_mapping_when_given_empty_list(self):
         result = add_model_file_id_mappings([], [])
         assert result == {}
+
+
+def test_get_model_group_info_alias_dict_without_hidden_key():
+    """Regression test: get_model_group_info must not raise KeyError when a
+    dict-style model_group_alias entry omits the 'hidden' key.
+
+    RouterModelGroupAliasItem declares 'hidden: bool' as a TypedDict field but
+    TypedDict is a type-hint only — Python does not inject default values at
+    runtime. Any config entry like {"model": "gpt-3.5-turbo"} without 'hidden'
+    triggers a KeyError on every request via set_response_headers.
+    """
+    model_list = [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {"model": "openai/gpt-3.5-turbo", "api_key": "sk-fake"},
+        }
+    ]
+
+    # Dict alias without 'hidden' key — must not raise KeyError
+    router = Router(
+        model_list=model_list,
+        model_group_alias={"gpt-4-alias": {"model": "gpt-3.5-turbo"}},
+    )
+    result = router.get_model_group_info(model_group="gpt-4-alias")
+    assert result is not None
+
+    # Dict alias with hidden=True must return None
+    router2 = Router(
+        model_list=model_list,
+        model_group_alias={"secret-alias": {"model": "gpt-3.5-turbo", "hidden": True}},
+    )
+    assert router2.get_model_group_info(model_group="secret-alias") is None
+
+    # get_model_list must also not raise KeyError (second affected call site)
+    assert router.get_model_list() is not None


### PR DESCRIPTION
## Relevant issues
Fixes #28123

## Pre-Submission checklist
- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Screenshots / Proof of Fix
Before fix:
KeyError: 'hidden'
  File "litellm/router.py", line 8700, in get_model_group_info
    if item["hidden"] is True:

After fix:
get_model_group_info() returns model info correctly when 'hidden' key is absent.
Regression test passes: test_get_model_group_info_alias_without_hidden_key ✅

## Type
🐛 Bug Fix

## Changes
RouterModelGroupAliasItem is a TypedDict — type-hint only, not enforced at
runtime. Any dict-style alias entry without a 'hidden' key caused a KeyError
on every request since get_model_group_info() is called on every router
completion via set_response_headers.

Fixed by switching item["hidden"] to item.get("hidden") and item["model"]
to item.get("model", "") in both call sites in router.py.

Added regression test covering three cases: missing hidden key, hidden=True,
and hidden=False.