### PR TITLE
fix(bedrock): handle Application Inference Profile ARNs in passthrough logging

### DIFF
--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 from httpx import Response
 
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
 
@@ -202,9 +203,22 @@ class BedrockPassthroughConfig(
         if "invoke" in endpoint:
             invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(model)
             if invoke_provider is None:
-                raise ValueError(
-                    f"Invalid invoke provider: {invoke_provider}, for model: {model}"
+                # Application Inference Profile ARNs don't encode provider info in the ARN
+                # itself. Try to derive the provider from the original LiteLLM model name
+                # (e.g. "global.anthropic.claude-opus-4-7") stored in logging context.
+                fallback_model = litellm_logging_obj.model_call_details.get(
+                    "litellm_params", {}
+                ).get("model", "")
+                if fallback_model:
+                    invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(
+                        fallback_model
+                    )
+            if invoke_provider is None:
+                verbose_logger.warning(
+                    f"Could not determine Bedrock invoke provider for model: {model!r}. "
+                    "Skipping streaming response logging for this passthrough request."
                 )
+                return None
             obj = get_bedrock_event_stream_decoder(
                 invoke_provider=invoke_provider,
                 model=model,

--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -206,15 +206,17 @@ class BedrockPassthroughConfig(BaseAWSLLM, BedrockModelInfo, BedrockEventStreamD
                 # Application Inference Profile ARNs don't encode provider info in the ARN
                 # itself. Try to derive the provider from the original LiteLLM model name
                 # (e.g. "global.anthropic.claude-opus-4-7") stored in logging context.
-                fallback_model: Final = litellm_logging_obj.model_call_details.get("litellm_params", {}).get(
-                    "model", ""
-                )
+                fallback_model: Final = litellm_logging_obj.model_call_details.get(
+                    "litellm_params",
+                    {},  # mutable-ok: read-only empty fallback
+                ).get("model", "")
                 if fallback_model:
                     invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(fallback_model)
             if invoke_provider is None:
                 verbose_logger.warning(
-                    f"Could not determine Bedrock invoke provider for model: {model!r}. "
-                    "Skipping streaming response logging for this passthrough request."
+                    "Could not determine Bedrock invoke provider for model: %r. "
+                    "Skipping streaming response logging for this passthrough request.",
+                    model,
                 )
                 return None
             obj = get_bedrock_event_stream_decoder(

--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Final, Optional, cast
 
 from httpx import Response
 
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
 
@@ -200,9 +201,24 @@ class BedrockPassthroughConfig(BaseAWSLLM, BedrockModelInfo, BedrockEventStreamD
 
         all_translated_chunks: Final = []
         if "invoke" in endpoint:
-            invoke_provider: Final = AmazonInvokeConfig.get_bedrock_invoke_provider(model)
+            invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(model)
             if invoke_provider is None:
-                raise ValueError(f"Invalid invoke provider: {invoke_provider}, for model: {model}")
+                # Application Inference Profile ARNs don't encode provider info in the ARN
+                # itself. Try to derive the provider from the original LiteLLM model name
+                # (e.g. "global.anthropic.claude-opus-4-7") stored in logging context.
+                fallback_model: Final = litellm_logging_obj.model_call_details.get(
+                    "litellm_params", {}
+                ).get("model", "")
+                if fallback_model:
+                    invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(
+                        fallback_model
+                    )
+            if invoke_provider is None:
+                verbose_logger.warning(
+                    f"Could not determine Bedrock invoke provider for model: {model!r}. "
+                    "Skipping streaming response logging for this passthrough request."
+                )
+                return None
             obj = get_bedrock_event_stream_decoder(
                 invoke_provider=invoke_provider,
                 model=model,

--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -206,13 +206,11 @@ class BedrockPassthroughConfig(BaseAWSLLM, BedrockModelInfo, BedrockEventStreamD
                 # Application Inference Profile ARNs don't encode provider info in the ARN
                 # itself. Try to derive the provider from the original LiteLLM model name
                 # (e.g. "global.anthropic.claude-opus-4-7") stored in logging context.
-                fallback_model: Final = litellm_logging_obj.model_call_details.get(
-                    "litellm_params", {}
-                ).get("model", "")
+                fallback_model: Final = litellm_logging_obj.model_call_details.get("litellm_params", {}).get(
+                    "model", ""
+                )
                 if fallback_model:
-                    invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(
-                        fallback_model
-                    )
+                    invoke_provider = AmazonInvokeConfig.get_bedrock_invoke_provider(fallback_model)
             if invoke_provider is None:
                 verbose_logger.warning(
                     f"Could not determine Bedrock invoke provider for model: {model!r}. "

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -2769,6 +2769,13 @@ def test_bedrock_invoke_provider():
         )
         == "nova"
     )
+    # Application Inference Profile ARNs have no provider info in the ARN
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider(
+            "arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l"
+        )
+        is None
+    )
 
 
 def test_bedrock_description_param():

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -2763,6 +2763,13 @@ def test_bedrock_invoke_provider():
         )
         == "nova"
     )
+    # Application Inference Profile ARNs have no provider info in the ARN
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider(
+            "arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l"
+        )
+        is None
+    )
 
 
 def test_bedrock_description_param():

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -548,7 +548,14 @@ def test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracef
             endpoint="/model/some-model/invoke-with-response-stream",
         )
 
-    # With no chunks, the result is None (not an exception).
+        # The decoder must have been called — this proves the fallback resolved
+        # "global.anthropic.claude-opus-4-7" to "anthropic" and did not hit the
+        # early-exit None return that fires when provider resolution fails entirely.
+        mock_decoder.assert_called_once()
+        call_kwargs = mock_decoder.call_args.kwargs
+        assert call_kwargs["invoke_provider"] == "anthropic"
+
+    # With no chunks the assembled response is None, but no exception was raised.
     assert result is None
 
 

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -1,6 +1,7 @@
 import os
 import sys
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
@@ -505,3 +506,72 @@ def test_bedrock_passthrough_model_id_without_arn():
             f"https://bedrock-runtime.us-east-1.amazonaws.com/model/{model_id}/converse"
         )
         assert url_str == expected_url
+
+
+def test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracefully():
+    """
+    Application Inference Profile ARNs don't embed provider info, so
+    get_bedrock_invoke_provider returns None. The logging path must not raise;
+    it should fall back to the original litellm model name stored in
+    model_call_details, and if that also yields nothing it must return None
+    silently rather than crashing the background logging task.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/28105
+    """
+    config = BedrockPassthroughConfig()
+
+    profile_arn = "arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l"
+
+    # Simulate the litellm logging object that carries model_call_details.
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.model_call_details = {
+        "litellm_params": {"model": "global.anthropic.claude-opus-4-7"},
+    }
+
+    # Intercept the decoder so we don't need real botocore event-stream bytes.
+    # The import is done inside handle_logging_collected_chunks, so patch the source module.
+    with patch(
+        "litellm.llms.bedrock.chat.get_bedrock_event_stream_decoder"
+    ) as mock_decoder:
+        mock_chunk_obj = MagicMock()
+        mock_chunk_obj._chunk_parser.return_value = (
+            {}
+        )  # not a valid GenericStreamingChunk
+        mock_decoder.return_value = mock_chunk_obj
+
+        # Must not raise ValueError.
+        result = config.handle_logging_collected_chunks(
+            all_chunks=[],
+            litellm_logging_obj=mock_logging_obj,
+            model=profile_arn,
+            custom_llm_provider="bedrock",
+            endpoint="/model/some-model/invoke-with-response-stream",
+        )
+
+    # With no chunks, the result is None (not an exception).
+    assert result is None
+
+
+def test_handle_logging_collected_chunks_inference_profile_arn_no_fallback_returns_none():
+    """
+    When neither the ARN nor the original model name yields a known provider,
+    handle_logging_collected_chunks must return None instead of raising.
+    """
+    config = BedrockPassthroughConfig()
+
+    profile_arn = "arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l"
+
+    mock_logging_obj = MagicMock()
+    # Empty litellm_params — no usable fallback model name.
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+
+    # Must not raise ValueError.
+    result = config.handle_logging_collected_chunks(
+        all_chunks=[],
+        litellm_logging_obj=mock_logging_obj,
+        model=profile_arn,
+        custom_llm_provider="bedrock",
+        endpoint="/model/some-model/invoke-with-response-stream",
+    )
+
+    assert result is None

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-
 from litellm.llms.bedrock.passthrough.transformation import BedrockPassthroughConfig
 
 
@@ -524,13 +523,9 @@ def test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracef
 
     # Intercept the decoder so we don't need real botocore event-stream bytes.
     # The import is done inside handle_logging_collected_chunks, so patch the source module.
-    with patch(
-        "litellm.llms.bedrock.chat.get_bedrock_event_stream_decoder"
-    ) as mock_decoder:
+    with patch("litellm.llms.bedrock.chat.get_bedrock_event_stream_decoder") as mock_decoder:
         mock_chunk_obj = MagicMock()
-        mock_chunk_obj._chunk_parser.return_value = (
-            {}
-        )  # not a valid GenericStreamingChunk
+        mock_chunk_obj._chunk_parser.return_value = {}  # not a valid GenericStreamingChunk
         mock_decoder.return_value = mock_chunk_obj
 
         # Must not raise ValueError.

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 from litellm.llms.bedrock.passthrough.transformation import BedrockPassthroughConfig
@@ -500,3 +500,72 @@ def test_bedrock_passthrough_model_id_without_arn():
             f"https://bedrock-runtime.us-east-1.amazonaws.com/model/{model_id}/converse"
         )
         assert url_str == expected_url
+
+
+def test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracefully():
+    """
+    Application Inference Profile ARNs don't embed provider info, so
+    get_bedrock_invoke_provider returns None. The logging path must not raise;
+    it should fall back to the original litellm model name stored in
+    model_call_details, and if that also yields nothing it must return None
+    silently rather than crashing the background logging task.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/28105
+    """
+    config = BedrockPassthroughConfig()
+
+    profile_arn = "arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l"
+
+    # Simulate the litellm logging object that carries model_call_details.
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.model_call_details = {
+        "litellm_params": {"model": "global.anthropic.claude-opus-4-7"},
+    }
+
+    # Intercept the decoder so we don't need real botocore event-stream bytes.
+    # The import is done inside handle_logging_collected_chunks, so patch the source module.
+    with patch(
+        "litellm.llms.bedrock.chat.get_bedrock_event_stream_decoder"
+    ) as mock_decoder:
+        mock_chunk_obj = MagicMock()
+        mock_chunk_obj._chunk_parser.return_value = (
+            {}
+        )  # not a valid GenericStreamingChunk
+        mock_decoder.return_value = mock_chunk_obj
+
+        # Must not raise ValueError.
+        result = config.handle_logging_collected_chunks(
+            all_chunks=[],
+            litellm_logging_obj=mock_logging_obj,
+            model=profile_arn,
+            custom_llm_provider="bedrock",
+            endpoint="/model/some-model/invoke-with-response-stream",
+        )
+
+    # With no chunks, the result is None (not an exception).
+    assert result is None
+
+
+def test_handle_logging_collected_chunks_inference_profile_arn_no_fallback_returns_none():
+    """
+    When neither the ARN nor the original model name yields a known provider,
+    handle_logging_collected_chunks must return None instead of raising.
+    """
+    config = BedrockPassthroughConfig()
+
+    profile_arn = "arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l"
+
+    mock_logging_obj = MagicMock()
+    # Empty litellm_params — no usable fallback model name.
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+
+    # Must not raise ValueError.
+    result = config.handle_logging_collected_chunks(
+        all_chunks=[],
+        litellm_logging_obj=mock_logging_obj,
+        model=profile_arn,
+        custom_llm_provider="bedrock",
+        endpoint="/model/some-model/invoke-with-response-stream",
+    )
+
+    assert result is None

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -542,7 +542,14 @@ def test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracef
             endpoint="/model/some-model/invoke-with-response-stream",
         )
 
-    # With no chunks, the result is None (not an exception).
+        # The decoder must have been called — this proves the fallback resolved
+        # "global.anthropic.claude-opus-4-7" to "anthropic" and did not hit the
+        # early-exit None return that fires when provider resolution fails entirely.
+        mock_decoder.assert_called_once()
+        call_kwargs = mock_decoder.call_args.kwargs
+        assert call_kwargs["invoke_provider"] == "anthropic"
+
+    # With no chunks the assembled response is None, but no exception was raised.
     assert result is None
 
 

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -523,7 +523,9 @@ def test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracef
 
     # Intercept the decoder so we don't need real botocore event-stream bytes.
     # The import is done inside handle_logging_collected_chunks, so patch the source module.
-    with patch("litellm.llms.bedrock.chat.get_bedrock_event_stream_decoder") as mock_decoder:
+    with patch(  # test-quality-ok: the behavior under test is which invoke_provider this factory receives
+        "litellm.llms.bedrock.chat.get_bedrock_event_stream_decoder"
+    ) as mock_decoder:
         mock_chunk_obj = MagicMock()
         mock_chunk_obj._chunk_parser.return_value = {}  # not a valid GenericStreamingChunk
         mock_decoder.return_value = mock_chunk_obj


### PR DESCRIPTION
## Summary

Fixes #28105

When using Bedrock pass-through with an **Application Inference Profile ARN** (e.g. `arn:aws:bedrock:ap-northeast-2:123456789012:application-inference-profile/czu0ezc2tq2l`), the background logging task crashed with:

```
ValueError: Invalid invoke provider: None, for model: arn:aws:bedrock:ap-northeast-2:...
```

This caused `success_callback` (s3_v2, langfuse, etc.) to never fire, even though the actual LLM request returned 200.

**Root cause:** `get_bedrock_invoke_provider` returns `None` for Application Inference Profile ARNs because the ARN contains no provider name — only an opaque profile ID. The logging path in `handle_logging_collected_chunks` then raised a `ValueError` unconditionally.

**Fix:**
- When `invoke_provider` is `None`, fall back to calling `get_bedrock_invoke_provider` on the original LiteLLM model name stored in `litellm_logging_obj.model_call_details["litellm_params"]["model"]` (e.g. `global.anthropic.claude-opus-4-7` → `anthropic`)
- If that also yields nothing, log a warning and return `None` gracefully instead of raising — so the logging task does not crash

## Test plan

- [x] `test_handle_logging_collected_chunks_inference_profile_arn_falls_back_gracefully` — verifies the fallback to original model name works and no exception is raised
- [x] `test_handle_logging_collected_chunks_inference_profile_arn_no_fallback_returns_none` — verifies graceful `None` return when no fallback is available
- [x] Assertion added to existing `test_bedrock_invoke_provider` confirming Application Inference Profile ARNs correctly return `None` from `get_bedrock_invoke_provider`
- [x] All 16 tests in `test_bedrock_passthrough_transformation.py` pass