### PR TITLE
fix(responses): forward timeout on completion transformation path (Anthropic, Bedrock, Vertex)

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -58,10 +58,6 @@ class LiteLLMCompletionTransformationHandler:
                 **kwargs,
             )
 
-        completion_args = {}
-        completion_args.update(kwargs)
-        completion_args.update(litellm_completion_request)
-
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
         ] = litellm.completion(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1115,6 +1115,7 @@ def responses(
                 stream=stream,
                 extra_headers=extra_headers,
                 extra_body=extra_body,
+                timeout=timeout or request_timeout,
                 **kwargs,
             )
 

--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -158,3 +158,39 @@ async def test_async_response_api_handler_merges_trace_id_without_error():
             assert (
                 mock_acompletion.call_args.kwargs["litellm_trace_id"] == "session-trace"
             )
+
+
+@pytest.mark.asyncio
+async def test_aresponses_forwards_timeout_to_acompletion():
+    """Regression test: timeout passed to aresponses() must reach acompletion()
+    on the completion transformation path (Anthropic, Bedrock, Vertex etc.).
+
+    Previously, `timeout` was a named param of `responses()` but was NOT
+    forwarded to `litellm_completion_transformation_handler.response_api_handler`,
+    so it was silently dropped — `Router(timeout=N)` was a no-op for Anthropic
+    and similar providers, with calls falling back to the provider SDK default
+    (~600s for Anthropic).
+    """
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value = ModelResponse(
+            id="id",
+            created=0,
+            model="anthropic/claude-sonnet-4-5",
+            object="chat.completion",
+            choices=[],
+        )
+
+        await litellm.aresponses(
+            model="anthropic/claude-sonnet-4-5",
+            input="hello",
+            timeout=42,
+            api_key="sk-ant-fake",
+        )
+
+    assert mock_acompletion.call_count == 1
+    forwarded_timeout = mock_acompletion.call_args.kwargs.get("timeout")
+    assert forwarded_timeout == 42, (
+        f"timeout was not forwarded to acompletion (got {forwarded_timeout!r}); "
+        "this means Router(timeout=N) silently fails for providers on the "
+        "completion transformation path."
+    )


### PR DESCRIPTION
## What this fixes

`litellm.responses()` / `litellm.aresponses()` silently drops the `timeout` parameter on the **completion transformation path** (used by Anthropic, Vertex AI Claude, Bedrock, and any provider without a native `BaseResponsesAPIConfig`). The timeout works correctly on the **native Responses API path** (OpenAI, Azure).

Net effect: `Router(timeout=N)` is a no-op for Anthropic models — calls fall back to the Anthropic SDK default (~600s).

Filed as #28132.

## Root cause

`timeout` is declared as a named parameter of `responses()` — so it's removed from `**kwargs` by Python. The completion transformation path passed `**kwargs` to its handler, silently dropping the consumed value:

```python
# litellm/responses/main.py — completion transformation path (buggy)
if responses_api_provider_config is None or use_chat_completions_api is True:
    return litellm_completion_transformation_handler.response_api_handler(
        ...
        extra_body=extra_body,
        **kwargs,    # <-- timeout was consumed as a named param, NOT in kwargs
    )
```

The native path already forwards it explicitly (`timeout=timeout or request_timeout` on line 1169). This PR mirrors that pattern.

Same class of bug as #22544, which fixed `metadata` silently dropping on the same path.

## The fix

One line in `litellm/responses/main.py`:

```python
if responses_api_provider_config is None or use_chat_completions_api is True:
    return litellm_completion_transformation_handler.response_api_handler(
        ...
        extra_body=extra_body,
        timeout=timeout or request_timeout,   # <-- added
        **kwargs,
    )
```

The downstream handler already accepts `**kwargs` and forwards them to `litellm.completion()` / `litellm.acompletion()`, which respects `timeout` natively.

## Verification

### 1. Unit test (added in `tests/llm_responses_api_testing/test_anthropic_responses_api.py`)

`test_aresponses_forwards_timeout_to_acompletion` mocks `litellm.acompletion` and asserts that `timeout=42` passed to `litellm.aresponses()` reaches the underlying `acompletion` call.

Verified red→green:
- Without the fix: `AssertionError: timeout was not forwarded to acompletion (got None)`
- With the fix: PASSED

### 2. End-to-end repro with a slow HTTP server

A standalone repro spins up a local HTTP server that accepts the connection then sleeps 30s before responding. We call `litellm.aresponses(model="anthropic/...", timeout=3)` pointed at it.

| Scenario | Without fix | With fix |
|----------|-------------|----------|
| Anthropic non-streaming | hung 30.0s | timeout fired at 3.1s |
| Anthropic streaming | hung 30.1s | timeout fired at 3.0s |

Repro script (uses no real API key — `api_base` is overridden to local slow server):

<details>
<summary>Click to expand</summary>

```python
import asyncio
import time
import litellm

SLOW_PORT = 18299
SLOW_DELAY = 30
TIMEOUT = 3

_FAKE_RESPONSE = b'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"id":"msg_fake","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-6","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}'

async def _handle(reader, writer):
    try:
        while True:
            line = await asyncio.wait_for(reader.readline(), timeout=5)
            if line in (b"\r\n", b"", b"\n"):
                break
        await asyncio.sleep(SLOW_DELAY)
        writer.write(_FAKE_RESPONSE)
        await writer.drain()
    finally:
        writer.close()
        try: await writer.wait_closed()
        except: pass

async def main():
    server = await asyncio.start_server(_handle, "127.0.0.1", SLOW_PORT)
    try:
        for label, stream in [("non-streaming", False), ("streaming", True)]:
            t0 = time.monotonic()
            try:
                resp = await litellm.aresponses(
                    model="anthropic/claude-sonnet-4-6",
                    input=[{"role": "user", "content": "hi"}],
                    api_base=f"http://127.0.0.1:{SLOW_PORT}",
                    api_key="sk-ant-fake",
                    timeout=TIMEOUT,
                    stream=stream,
                    num_retries=0,
                )
                if stream and hasattr(resp, "__aiter__"):
                    async for _ in resp: pass
                print(f"{label}: HUNG {time.monotonic()-t0:.1f}s — timeout dropped")
            except Exception as e:
                print(f"{label}: timed out at {time.monotonic()-t0:.1f}s — {type(e).__name__}")
    finally:
        server.close()
        await server.wait_closed()

asyncio.run(main())
```

</details>

## Other named params at risk (same class)

While this PR targets `timeout`, the same wrong-pattern affects other parameters declared as named in `responses()` but not in `response_api_optional_params`. Easy follow-up — `extra_query` is the most notable.

| Parameter | Completion path | Native path |
|-----------|-----------------|-------------|
| `timeout` | dropped (this PR) | forwarded |
| `extra_query` | dropped | forwarded |
| `metadata` | fixed in #22544 | forwarded |

## Affected providers

Any provider routed via completion transformation (i.e. no native `BaseResponsesAPIConfig`):
- Anthropic (`anthropic/claude-*`)
- Vertex AI (`vertex_ai/claude-*`)
- Bedrock (`bedrock/anthropic.*`)
- Any other provider lacking native Responses API support

## Related

- Issue #28132 — full bug report
- PR #22544 — `metadata` fix (same bug class, same fix shape)
- PR #25591 — separate `timeout` fix path (`litellm_settings`-derived timeouts)
