### PR TITLE
fix(deepseek): pass reasoning_effort value through to DeepSeek V4 API

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -2,13 +2,15 @@
 Translates from OpenAI's `/v1/chat/completions` to DeepSeek's `/v1/chat/completions`
 """
 
-from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, cast, overload
 
+import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
+from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -33,7 +35,8 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         Map OpenAI params to DeepSeek params.
 
         Handles `thinking` and `reasoning_effort` parameters for DeepSeek reasoner models.
-        DeepSeek only supports `{"type": "enabled"}` - no budget_tokens like Anthropic.
+        DeepSeek supports `{"type": "enabled"}` and `{"type": "disabled"}` for thinking,
+        and `reasoning_effort` values of `"high"` or `"max"` for V4 models.
 
         Reference: https://api-docs.deepseek.com/guides/thinking_mode
         """
@@ -47,20 +50,68 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         thinking_value = optional_params.pop("thinking", None)
         reasoning_effort = optional_params.pop("reasoning_effort", None)
 
-        # Handle thinking parameter - only accept {"type": "enabled"}
-        if thinking_value is not None:
-            if (
-                isinstance(thinking_value, dict)
-                and thinking_value.get("type") == "enabled"
+        # Handle thinking parameter - the latest version accepts both "enabled and "disabled" as dicts, so we check for that first
+        if thinking_value is not None:                                                                                                                                                                               
+            if (                                                                                                                                                                                                     
+                isinstance(thinking_value, dict)                                                                                                                                                                     
+                and thinking_value.get("type") in ("enabled", "disabled")
             ):
-                # DeepSeek only accepts {"type": "enabled"}, ignore budget_tokens
-                optional_params["thinking"] = {"type": "enabled"}
+                optional_params["thinking"] = {"type": thinking_value.get("type")}
 
         # Handle reasoning_effort - map to thinking enabled
-        elif reasoning_effort is not None and reasoning_effort != "none":
-            optional_params["thinking"] = {"type": "enabled"}
+
+        elif reasoning_effort is not None:
+            if reasoning_effort == "none":
+                # Only send thinking: disabled on V4 opt-in models.
+                # deepseek-reasoner/R1 have always-on thinking and reject {"type": "disabled"}.
+                if not supports_reasoning(model=model, custom_llm_provider="deepseek"):
+                    optional_params["thinking"] = {"type": "disabled"}
+            else:
+                # Normalize to DeepSeek's two supported values
+                normalized = "max" if reasoning_effort in ("max", "xhigh") else "high"
+                optional_params["thinking"] = {"type": "enabled"}
+                optional_params["reasoning_effort"] = normalized
 
         return optional_params
+
+    def _fill_reasoning_content(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
+        """
+        DeepSeek thinking mode requires `reasoning_content` to be passed back on
+        every assistant message in multi-turn conversations. If it is missing,
+        the API returns:
+          "The reasoning_content in the thinking mode must be passed back to the API."
+
+        For each assistant message that is missing `reasoning_content`:
+          1. Promote it from `provider_specific_fields["reasoning_content"]` if present
+             (LiteLLM stores provider-specific response fields there).
+          2. Otherwise inject a single space — the minimum value the API accepts.
+        """
+        result: List[AllMessageValues] = []
+        for msg in messages:
+            if msg.get("role") == "assistant" and not msg.get("reasoning_content"):
+                patched = dict(cast(dict, msg))
+                provider_fields = patched.get("provider_specific_fields") or {}
+                stored = provider_fields.get("reasoning_content")
+                if stored:
+                    patched["reasoning_content"] = stored
+                    cleaned = dict(provider_fields)
+                    cleaned.pop("reasoning_content", None)
+                    patched["provider_specific_fields"] = cleaned
+                else:
+                    litellm.verbose_logger.debug(
+                        "DeepSeek thinking mode: assistant message is missing "
+                        "`reasoning_content`. Injecting a placeholder to satisfy "
+                        "API validation. For best results, preserve "
+                        "`reasoning_content` from the original assistant response "
+                        "when building multi-turn conversation history."
+                    )
+                    patched["reasoning_content"] = " "
+                result.append(cast(AllMessageValues, patched))
+            else:
+                result.append(msg)
+        return result
 
     @overload
     def _transform_messages(
@@ -90,6 +141,66 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
             return super()._transform_messages(
                 messages=messages, model=model, is_async=False
             )
+
+    def _thinking_mode_active(self, model: str, optional_params: dict) -> bool:
+        """
+        Returns True only when thinking mode is actually active for this request:
+          - model supports reasoning (capability check)
+          - user explicitly passed thinking={"type": "enabled"} (opt-in check)
+        """
+        return (
+            supports_reasoning(model=model, custom_llm_provider="deepseek")
+            and (optional_params.get("thinking") or {}).get("type") == "enabled"
+        )
+
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        """
+        Ensures `reasoning_content` is forwarded on assistant messages for
+        multi-turn thinking-mode conversations (issue #28045).
+
+        Only runs when thinking mode is actually active - guarded by both
+        supports_reasoning() (model capability) and optional_params["thinking"]
+        (user explicitly enabled it), preventing spurious injection on models
+        like deepseek-v3.2 that support thinking as opt-in but not always-on.
+        """
+        if self._thinking_mode_active(model=model, optional_params=optional_params):
+            messages = self._fill_reasoning_content(messages)
+        return super().transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
+    async def async_transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        """
+        Async equivalent of transform_request — applies the same reasoning_content
+        fix for multi-turn thinking-mode conversations.
+        """
+        if self._thinking_mode_active(model=model, optional_params=optional_params):
+            messages = self._fill_reasoning_content(messages)
+        return await super().async_transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
 
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -70,7 +70,10 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
                 # Normalize to DeepSeek's two supported values
                 normalized = "max" if reasoning_effort in ("max", "xhigh") else "high"
                 optional_params["thinking"] = {"type": "enabled"}
-                optional_params["reasoning_effort"] = normalized
+                # Only forward reasoning_effort on V4 opt-in models.
+                # deepseek-reasoner/R1 have supports_reasoning=True but don't accept reasoning_effort field.
+                if not supports_reasoning(model=model, custom_llm_provider="deepseek"):
+                    optional_params["reasoning_effort"] = normalized
 
         return optional_params
 

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -52,14 +52,14 @@ class TestDeepSeekThinkingParams:
         assert "budget_tokens" not in result.get("thinking", {})
 
     def test_map_reasoning_effort_medium(self):
-        """Test that reasoning_effort='medium' normalizes to high."""
+        """Test that reasoning_effort='medium' normalizes to high for V4 models."""
         non_default_params = {"reasoning_effort": "medium"}
         optional_params = {}
 
         result = self.config.map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
-            model=self.model,
+            model="deepseek-v4-pro",
             drop_params=False,
         )
 
@@ -67,14 +67,14 @@ class TestDeepSeekThinkingParams:
         assert result["reasoning_effort"] == "high"
 
     def test_map_reasoning_effort_low(self):
-        """Test that reasoning_effort='low' normalizes to high."""
+        """Test that reasoning_effort='low' normalizes to high for V4 models."""
         non_default_params = {"reasoning_effort": "low"}
         optional_params = {}
 
         result = self.config.map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
-            model=self.model,
+            model="deepseek-v4-pro",
             drop_params=False,
         )
 
@@ -82,14 +82,14 @@ class TestDeepSeekThinkingParams:
         assert result["reasoning_effort"] == "high"
 
     def test_map_reasoning_effort_high(self):
-        """Test that reasoning_effort='high' passes through as high."""
+        """Test that reasoning_effort='high' passes through as high for V4 models."""
         non_default_params = {"reasoning_effort": "high"}
         optional_params = {}
 
         result = self.config.map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
-            model=self.model,
+            model="deepseek-v4-pro",
             drop_params=False,
         )
 
@@ -97,14 +97,14 @@ class TestDeepSeekThinkingParams:
         assert result["reasoning_effort"] == "high"
 
     def test_map_reasoning_effort_max(self):
-        """Test that reasoning_effort='max' passes through as max."""
+        """Test that reasoning_effort='max' passes through as max for V4 models."""
         non_default_params = {"reasoning_effort": "max"}
         optional_params = {}
 
         result = self.config.map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
-            model=self.model,
+            model="deepseek-v4-pro",
             drop_params=False,
         )
 
@@ -112,19 +112,35 @@ class TestDeepSeekThinkingParams:
         assert result["reasoning_effort"] == "max"
 
     def test_map_reasoning_effort_xhigh_normalizes_to_max(self):
-        """Test that reasoning_effort='xhigh' normalizes to max."""
+        """Test that reasoning_effort='xhigh' normalizes to max for V4 models."""
         non_default_params = {"reasoning_effort": "xhigh"}
         optional_params = {}
 
         result = self.config.map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
-            model=self.model,
+            model="deepseek-v4-pro",
             drop_params=False,
         )
 
         assert result["thinking"] == {"type": "enabled"}
         assert result["reasoning_effort"] == "max"
+
+    def test_map_reasoning_effort_not_forwarded_for_reasoner(self):
+        """Test that reasoning_effort is not forwarded to deepseek-reasoner (R1 doesn't accept it)."""
+        non_default_params = {"reasoning_effort": "max"}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,  # deepseek-reasoner
+            drop_params=False,
+        )
+
+        # thinking should still be enabled but reasoning_effort must NOT be forwarded
+        assert result["thinking"] == {"type": "enabled"}
+        assert "reasoning_effort" not in result
 
     def test_map_reasoning_effort_none_is_noop_for_reasoner(self):
         """Test that reasoning_effort='none' is a no-op for deepseek-reasoner (always-on thinking)."""

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -52,7 +52,7 @@ class TestDeepSeekThinkingParams:
         assert "budget_tokens" not in result.get("thinking", {})
 
     def test_map_reasoning_effort_medium(self):
-        """Test that reasoning_effort='medium' maps to thinking enabled."""
+        """Test that reasoning_effort='medium' normalizes to high."""
         non_default_params = {"reasoning_effort": "medium"}
         optional_params = {}
 
@@ -64,9 +64,10 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "high"
 
     def test_map_reasoning_effort_low(self):
-        """Test that reasoning_effort='low' maps to thinking enabled."""
+        """Test that reasoning_effort='low' normalizes to high."""
         non_default_params = {"reasoning_effort": "low"}
         optional_params = {}
 
@@ -78,9 +79,10 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "high"
 
     def test_map_reasoning_effort_high(self):
-        """Test that reasoning_effort='high' maps to thinking enabled."""
+        """Test that reasoning_effort='high' passes through as high."""
         non_default_params = {"reasoning_effort": "high"}
         optional_params = {}
 
@@ -92,10 +94,11 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "high"
 
-    def test_map_reasoning_effort_none_does_not_enable_thinking(self):
-        """Test that reasoning_effort='none' does not enable thinking."""
-        non_default_params = {"reasoning_effort": "none"}
+    def test_map_reasoning_effort_max(self):
+        """Test that reasoning_effort='max' passes through as max."""
+        non_default_params = {"reasoning_effort": "max"}
         optional_params = {}
 
         result = self.config.map_openai_params(
@@ -105,7 +108,54 @@ class TestDeepSeekThinkingParams:
             drop_params=False,
         )
 
+        assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "max"
+
+    def test_map_reasoning_effort_xhigh_normalizes_to_max(self):
+        """Test that reasoning_effort='xhigh' normalizes to max."""
+        non_default_params = {"reasoning_effort": "xhigh"}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "max"
+
+    def test_map_reasoning_effort_none_is_noop_for_reasoner(self):
+        """Test that reasoning_effort='none' is a no-op for deepseek-reasoner (always-on thinking)."""
+        non_default_params = {"reasoning_effort": "none"}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,  # deepseek-reasoner
+            drop_params=False,
+        )
+
+        # deepseek-reasoner has always-on thinking, API rejects {"type": "disabled"}
         assert "thinking" not in result
+        assert "reasoning_effort" not in result
+
+    def test_map_reasoning_effort_none_disables_thinking_for_v4(self):
+        """Test that reasoning_effort='none' sends thinking disabled for V4 opt-in models."""
+        non_default_params = {"reasoning_effort": "none"}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model="deepseek-v4-pro",
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in result
 
     def test_map_reasoning_effort_null_does_not_enable_thinking(self):
         """Test that reasoning_effort=None does not enable thinking."""
@@ -166,3 +216,32 @@ class TestDeepSeekThinkingParams:
         )
 
         assert "thinking" not in result
+
+    def test_map_thinking_disabled(self):
+        """Test that thinking={"type": "disabled"} is passed through correctly."""
+        non_default_params = {"thinking": {"type": "disabled"}}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+
+    def test_map_thinking_disabled_with_budget_tokens_strips_budget(self):
+        """Test that budget_tokens is stripped even when thinking is disabled."""
+        non_default_params = {"thinking": {"type": "disabled", "budget_tokens": 0}}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+        assert "budget_tokens" not in result.get("thinking", {})


### PR DESCRIPTION
## What's the problem?

Fixes #27439

DeepSeek V4 Pro and V4 Flash support graded reasoning effort via `reasoning_effort` - either `"high"` or `"max"`. The old code in `map_openai_params` was always collapsing any non-none value to `thinking: {"type": "enabled"}` and throwing away the actual effort level. So `reasoning_effort="max"` and `reasoning_effort="high"` both hit the DeepSeek API the same way, with no way for users to actually request max reasoning.

Two previous PRs (#27445, #27829) tried to fix this but both stalled - #27445 targeted main (wrong branch) and #27829 still didn't forward the value (Greptile flagged it as P1).

## What changed?

In `DeepSeekChatConfig.map_openai_params()` in `litellm/llms/deepseek/chat/transformation.py`:

- `reasoning_effort="low"/"medium"/"high"` normalizes to `"high"` and sends both `thinking: {"type": "enabled"}` and `reasoning_effort: "high"`
- `reasoning_effort="max"` or `"xhigh"` normalizes to `"max"` and sends both `thinking: {"type": "enabled"}` and `reasoning_effort: "max"`
- `reasoning_effort="none"` sends `thinking: {"type": "disabled"}` for V4 opt-in models only. `deepseek-reasoner`/R1 have always-on thinking and reject disabled, so it stays a no-op for them (guarded via `supports_reasoning()`)
- `thinking={"type": "disabled"}` direct passthrough now works too, previously only `"enabled"` was accepted

Per DeepSeek V4 docs, both `thinking` and `reasoning_effort` need to appear together in the request for effort control to work.

Note: `_fill_reasoning_content`, `_thinking_mode_active`, `transform_request`, and `async_transform_request` also show up in this diff - these are from PR #28080 (already merged) and appear here due to base branch lag on `shin_agent_oss_staging_05_17_2026`.

Reference: https://api-docs.deepseek.com/guides/thinking_mode

## Testing

Updated `tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py` - 16 tests, all passing locally:
- `low/medium/high` normalizes to `"high"` with thinking enabled
- `max` passes through as `"max"` with thinking enabled
- `xhigh` normalizes to `"max"` with thinking enabled
- `none` is a no-op for `deepseek-reasoner` (always-on thinking)
- `none` sends thinking disabled for V4 opt-in models like `deepseek-v4-pro`
- `thinking={"type": "disabled"}` direct passthrough works
- budget_tokens stripped for both enabled and disabled cases

## Checklist

- [x] Changes are isolated to the DeepSeek transformation layer
- [x] Tests cover the full normalization mapping
- [x] All 16 tests pass locally
- [x] CLA already signed (merged PR #28080 previously)