### PR TITLE
feat: add retry_with_backoff() utility with exponential backoff utility for RateLimitError handling 

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1172,6 +1172,7 @@ _key_management_settings: KeyManagementSettings = KeyManagementSettings()
 # client must be imported immediately as it's used as a decorator at function definition time
 from .utils import client
 from .utils import retry_with_backoff, async_retry_with_backoff
+
 # Note: Most other utils imports are lazy-loaded via __getattr__ to avoid loading utils.py
 # (which imports tiktoken) at import time
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1171,7 +1171,7 @@ _key_management_settings: KeyManagementSettings = KeyManagementSettings()
 
 # client must be imported immediately as it's used as a decorator at function definition time
 from .utils import client
-
+from .utils import retry_with_backoff  
 # Note: Most other utils imports are lazy-loaded via __getattr__ to avoid loading utils.py
 # (which imports tiktoken) at import time
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1171,7 +1171,7 @@ _key_management_settings: KeyManagementSettings = KeyManagementSettings()
 
 # client must be imported immediately as it's used as a decorator at function definition time
 from .utils import client
-from .utils import retry_with_backoff  
+from .utils import retry_with_backoff, async_retry_with_backoff
 # Note: Most other utils imports are lazy-loaded via __getattr__ to avoid loading utils.py
 # (which imports tiktoken) at import time
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -51,6 +51,10 @@ from tokenizers import Tokenizer
 import litellm
 import litellm.litellm_core_utils
 
+
+from typing import Callable, Any, Tuple, Type
+
+
 # audio_utils.utils is lazy-loaded - only imported when needed for transcription calls
 import litellm.litellm_core_utils.json_validation_rule
 from litellm._internal_context import is_internal_call
@@ -9722,3 +9726,81 @@ def __getattr__(name: str) -> Any:
         return handler_func(name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+
+# ─────────────────────────────────────────────
+# Retry with Exponential Backoff Utility
+# Handles RateLimitError and ServiceUnavailableError
+# automatically with jitter to avoid thundering herd
+# ─────────────────────────────────────────────
+
+def retry_with_backoff(
+   fn: Callable,
+   max_retries: int = 3,
+   base_delay: float = 1.0,
+   max_delay: float = 60.0,
+   backoff_factor: float = 2.0,
+   retry_on: Optional[Tuple[Type[Exception], ...]] = None,
+) -> Any:
+   """
+   Retries a callable with exponential backoff and jitter.
+
+   Args:
+       fn:             The callable to retry (e.g. lambda: litellm.completion(...))
+       max_retries:    Maximum number of retry attempts (default: 3)
+       base_delay:     Initial delay in seconds (default: 1.0)
+       max_delay:      Maximum delay cap in seconds (default: 60.0)
+       backoff_factor: Multiplier per retry (default: 2.0)
+       retry_on:       Tuple of exception types to retry on.
+                       Defaults to (RateLimitError, ServiceUnavailableError)
+
+   Returns:
+       The return value of fn() on success.
+
+   Raises:
+       The last exception if all retries are exhausted.
+
+   Example:
+       import litellm
+       from litellm.utils import retry_with_backoff
+
+       response = retry_with_backoff(
+           lambda: litellm.completion(
+               model="gpt-4o",
+               messages=[{"role": "user", "content": "Hello"}]
+           ),
+           max_retries=5,
+           base_delay=2.0,
+       )
+   """
+
+   if retry_on is None:
+       retry_on = (RateLimitError, ServiceUnavailableError)
+
+   last_exception = None
+
+   for attempt in range(max_retries + 1):
+       try:
+           return fn()
+
+       except retry_on as e:
+           last_exception = e
+
+           if attempt == max_retries:
+               # Exhausted all retries
+               raise last_exception
+
+           # Exponential backoff with full jitter
+           delay = min(
+               base_delay * (backoff_factor ** attempt) + random.uniform(0, 1),
+               max_delay,
+           )
+
+           verbose_logger.warning(
+               f"[LiteLLM] Attempt {attempt + 1}/{max_retries} failed "
+               f"({type(e).__name__}). Retrying in {delay:.2f}s..."
+           )
+           time.sleep(delay)
+
+   raise last_exception

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -51,9 +51,6 @@ from tokenizers import Tokenizer
 import litellm
 import litellm.litellm_core_utils
 
-
-from typing import Callable, Any, Tuple, Type
-
 # audio_utils.utils is lazy-loaded - only imported when needed for transcription calls
 import litellm.litellm_core_utils.json_validation_rule
 from litellm._internal_context import is_internal_call

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9744,7 +9744,9 @@ def retry_with_backoff(
    retry_on: Optional[Tuple[Type[Exception], ...]] = None,
 ) -> Any:
    """
-   Retries a callable with exponential backoff and jitter.
+   Retries a synchronous callable with exponential backoff and jitter.
+
+   For async callables, use async_retry_with_backoff instead.
 
    Args:
        fn:             The callable to retry (e.g. lambda: litellm.completion(...))
@@ -9759,6 +9761,7 @@ def retry_with_backoff(
        The return value of fn() on success.
 
    Raises:
+       TypeError: If fn is a coroutine function (use async_retry_with_backoff).
        The last exception if all retries are exhausted.
 
    Example:
@@ -9774,22 +9777,33 @@ def retry_with_backoff(
            base_delay=2.0,
        )
    """
+   if inspect.iscoroutinefunction(fn):
+       raise TypeError(
+           "retry_with_backoff does not support async callables. "
+           "Use async_retry_with_backoff instead."
+       )
 
    if retry_on is None:
        retry_on = (RateLimitError, ServiceUnavailableError)
 
-   last_exception = None
+   last_exception: Optional[Exception] = None
 
    for attempt in range(max_retries + 1):
        try:
-           return fn()
+           result = fn()
+           if inspect.iscoroutine(result):
+               result.close()
+               raise TypeError(
+                   "retry_with_backoff received a coroutine from fn(). "
+                   "Use async_retry_with_backoff for async callables."
+               )
+           return result
 
        except retry_on as e:
            last_exception = e
 
            if attempt == max_retries:
-               # Exhausted all retries
-               raise last_exception
+               raise
 
            # Exponential backoff with full jitter
            delay = min(
@@ -9798,9 +9812,81 @@ def retry_with_backoff(
            )
 
            verbose_logger.warning(
-               f"[LiteLLM] Attempt {attempt + 1}/{max_retries} failed "
+               f"[LiteLLM] Attempt {attempt + 1}/{max_retries + 1} failed "
                f"({type(e).__name__}). Retrying in {delay:.2f}s..."
            )
            time.sleep(delay)
 
-   raise last_exception
+   raise last_exception  # pragma: no cover
+
+
+async def async_retry_with_backoff(
+   fn: Callable,
+   max_retries: int = 3,
+   base_delay: float = 1.0,
+   max_delay: float = 60.0,
+   backoff_factor: float = 2.0,
+   retry_on: Optional[Tuple[Type[Exception], ...]] = None,
+) -> Any:
+   """
+   Retries an async callable with exponential backoff and jitter.
+
+   Args:
+       fn:             The async callable to retry (e.g. lambda: litellm.acompletion(...))
+       max_retries:    Maximum number of retry attempts (default: 3)
+       base_delay:     Initial delay in seconds (default: 1.0)
+       max_delay:      Maximum delay cap in seconds (default: 60.0)
+       backoff_factor: Multiplier per retry (default: 2.0)
+       retry_on:       Tuple of exception types to retry on.
+                       Defaults to (RateLimitError, ServiceUnavailableError)
+
+   Returns:
+       The return value of await fn() on success.
+
+   Raises:
+       The last exception if all retries are exhausted.
+
+   Example:
+       import litellm
+       from litellm.utils import async_retry_with_backoff
+
+       response = await async_retry_with_backoff(
+           lambda: litellm.acompletion(
+               model="gpt-4o",
+               messages=[{"role": "user", "content": "Hello"}]
+           ),
+           max_retries=5,
+           base_delay=2.0,
+       )
+   """
+   if retry_on is None:
+       retry_on = (RateLimitError, ServiceUnavailableError)
+
+   last_exception: Optional[Exception] = None
+
+   for attempt in range(max_retries + 1):
+       try:
+           result = fn()
+           if inspect.iscoroutine(result):
+               result = await result
+           return result
+
+       except retry_on as e:
+           last_exception = e
+
+           if attempt == max_retries:
+               raise
+
+           # Exponential backoff with full jitter
+           delay = min(
+               base_delay * (backoff_factor ** attempt) + random.uniform(0, 1),
+               max_delay,
+           )
+
+           verbose_logger.warning(
+               f"[LiteLLM] Attempt {attempt + 1}/{max_retries + 1} failed "
+               f"({type(e).__name__}). Retrying in {delay:.2f}s..."
+           )
+           await asyncio.sleep(delay)
+
+   raise last_exception  # pragma: no cover

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -54,7 +54,6 @@ import litellm.litellm_core_utils
 
 from typing import Callable, Any, Tuple, Type
 
-
 # audio_utils.utils is lazy-loaded - only imported when needed for transcription calls
 import litellm.litellm_core_utils.json_validation_rule
 from litellm._internal_context import is_internal_call
@@ -9728,165 +9727,165 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-
 # ─────────────────────────────────────────────
 # Retry with Exponential Backoff Utility
 # Handles RateLimitError and ServiceUnavailableError
 # automatically with jitter to avoid thundering herd
 # ─────────────────────────────────────────────
 
+
 def retry_with_backoff(
-   fn: Callable,
-   max_retries: int = 3,
-   base_delay: float = 1.0,
-   max_delay: float = 60.0,
-   backoff_factor: float = 2.0,
-   retry_on: Optional[Tuple[Type[Exception], ...]] = None,
+    fn: Callable,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    backoff_factor: float = 2.0,
+    retry_on: Optional[Tuple[Type[Exception], ...]] = None,
 ) -> Any:
-   """
-   Retries a synchronous callable with exponential backoff and jitter.
+    """
+    Retries a synchronous callable with exponential backoff and jitter.
 
-   For async callables, use async_retry_with_backoff instead.
+    For async callables, use async_retry_with_backoff instead.
 
-   Args:
-       fn:             The callable to retry (e.g. lambda: litellm.completion(...))
-       max_retries:    Maximum number of retry attempts (default: 3)
-       base_delay:     Initial delay in seconds (default: 1.0)
-       max_delay:      Maximum delay cap in seconds (default: 60.0)
-       backoff_factor: Multiplier per retry (default: 2.0)
-       retry_on:       Tuple of exception types to retry on.
-                       Defaults to (RateLimitError, ServiceUnavailableError)
+    Args:
+        fn:             The callable to retry (e.g. lambda: litellm.completion(...))
+        max_retries:    Maximum number of retry attempts (default: 3)
+        base_delay:     Initial delay in seconds (default: 1.0)
+        max_delay:      Maximum delay cap in seconds (default: 60.0)
+        backoff_factor: Multiplier per retry (default: 2.0)
+        retry_on:       Tuple of exception types to retry on.
+                        Defaults to (RateLimitError, ServiceUnavailableError)
 
-   Returns:
-       The return value of fn() on success.
+    Returns:
+        The return value of fn() on success.
 
-   Raises:
-       TypeError: If fn is a coroutine function (use async_retry_with_backoff).
-       The last exception if all retries are exhausted.
+    Raises:
+        TypeError: If fn is a coroutine function (use async_retry_with_backoff).
+        The last exception if all retries are exhausted.
 
-   Example:
-       import litellm
-       from litellm.utils import retry_with_backoff
+    Example:
+        import litellm
+        from litellm.utils import retry_with_backoff
 
-       response = retry_with_backoff(
-           lambda: litellm.completion(
-               model="gpt-4o",
-               messages=[{"role": "user", "content": "Hello"}]
-           ),
-           max_retries=5,
-           base_delay=2.0,
-       )
-   """
-   if inspect.iscoroutinefunction(fn):
-       raise TypeError(
-           "retry_with_backoff does not support async callables. "
-           "Use async_retry_with_backoff instead."
-       )
+        response = retry_with_backoff(
+            lambda: litellm.completion(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "Hello"}]
+            ),
+            max_retries=5,
+            base_delay=2.0,
+        )
+    """
+    if inspect.iscoroutinefunction(fn):
+        raise TypeError(
+            "retry_with_backoff does not support async callables. "
+            "Use async_retry_with_backoff instead."
+        )
 
-   if retry_on is None:
-       retry_on = (RateLimitError, ServiceUnavailableError)
+    if retry_on is None:
+        retry_on = (RateLimitError, ServiceUnavailableError)
 
-   last_exception: Optional[Exception] = None
+    last_exception: Optional[Exception] = None
 
-   for attempt in range(max_retries + 1):
-       try:
-           result = fn()
-           if inspect.iscoroutine(result):
-               result.close()
-               raise TypeError(
-                   "retry_with_backoff received a coroutine from fn(). "
-                   "Use async_retry_with_backoff for async callables."
-               )
-           return result
+    for attempt in range(max_retries + 1):
+        try:
+            result = fn()
+            if inspect.iscoroutine(result):
+                result.close()
+                raise TypeError(
+                    "retry_with_backoff received a coroutine from fn(). "
+                    "Use async_retry_with_backoff for async callables."
+                )
+            return result
 
-       except retry_on as e:
-           last_exception = e
+        except retry_on as e:
+            last_exception = e
 
-           if attempt == max_retries:
-               raise
+            if attempt == max_retries:
+                raise
 
-           # Exponential backoff with full jitter
-           delay = min(
-               base_delay * (backoff_factor ** attempt) + random.uniform(0, 1),
-               max_delay,
-           )
+            # Exponential backoff with full jitter
+            delay = min(
+                base_delay * (backoff_factor**attempt) + random.uniform(0, 1),
+                max_delay,
+            )
 
-           verbose_logger.warning(
-               f"[LiteLLM] Attempt {attempt + 1}/{max_retries + 1} failed "
-               f"({type(e).__name__}). Retrying in {delay:.2f}s..."
-           )
-           time.sleep(delay)
+            verbose_logger.warning(
+                f"[LiteLLM] Attempt {attempt + 1}/{max_retries + 1} failed "
+                f"({type(e).__name__}). Retrying in {delay:.2f}s..."
+            )
+            time.sleep(delay)
 
-   raise last_exception  # pragma: no cover
+    raise last_exception  # pragma: no cover
 
 
 async def async_retry_with_backoff(
-   fn: Callable,
-   max_retries: int = 3,
-   base_delay: float = 1.0,
-   max_delay: float = 60.0,
-   backoff_factor: float = 2.0,
-   retry_on: Optional[Tuple[Type[Exception], ...]] = None,
+    fn: Callable,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    backoff_factor: float = 2.0,
+    retry_on: Optional[Tuple[Type[Exception], ...]] = None,
 ) -> Any:
-   """
-   Retries an async callable with exponential backoff and jitter.
+    """
+    Retries an async callable with exponential backoff and jitter.
 
-   Args:
-       fn:             The async callable to retry (e.g. lambda: litellm.acompletion(...))
-       max_retries:    Maximum number of retry attempts (default: 3)
-       base_delay:     Initial delay in seconds (default: 1.0)
-       max_delay:      Maximum delay cap in seconds (default: 60.0)
-       backoff_factor: Multiplier per retry (default: 2.0)
-       retry_on:       Tuple of exception types to retry on.
-                       Defaults to (RateLimitError, ServiceUnavailableError)
+    Args:
+        fn:             The async callable to retry (e.g. lambda: litellm.acompletion(...))
+        max_retries:    Maximum number of retry attempts (default: 3)
+        base_delay:     Initial delay in seconds (default: 1.0)
+        max_delay:      Maximum delay cap in seconds (default: 60.0)
+        backoff_factor: Multiplier per retry (default: 2.0)
+        retry_on:       Tuple of exception types to retry on.
+                        Defaults to (RateLimitError, ServiceUnavailableError)
 
-   Returns:
-       The return value of await fn() on success.
+    Returns:
+        The return value of await fn() on success.
 
-   Raises:
-       The last exception if all retries are exhausted.
+    Raises:
+        The last exception if all retries are exhausted.
 
-   Example:
-       import litellm
-       from litellm.utils import async_retry_with_backoff
+    Example:
+        import litellm
+        from litellm.utils import async_retry_with_backoff
 
-       response = await async_retry_with_backoff(
-           lambda: litellm.acompletion(
-               model="gpt-4o",
-               messages=[{"role": "user", "content": "Hello"}]
-           ),
-           max_retries=5,
-           base_delay=2.0,
-       )
-   """
-   if retry_on is None:
-       retry_on = (RateLimitError, ServiceUnavailableError)
+        response = await async_retry_with_backoff(
+            lambda: litellm.acompletion(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "Hello"}]
+            ),
+            max_retries=5,
+            base_delay=2.0,
+        )
+    """
+    if retry_on is None:
+        retry_on = (RateLimitError, ServiceUnavailableError)
 
-   last_exception: Optional[Exception] = None
+    last_exception: Optional[Exception] = None
 
-   for attempt in range(max_retries + 1):
-       try:
-           result = fn()
-           if inspect.iscoroutine(result):
-               result = await result
-           return result
+    for attempt in range(max_retries + 1):
+        try:
+            result = fn()
+            if inspect.iscoroutine(result):
+                result = await result
+            return result
 
-       except retry_on as e:
-           last_exception = e
+        except retry_on as e:
+            last_exception = e
 
-           if attempt == max_retries:
-               raise
+            if attempt == max_retries:
+                raise
 
-           # Exponential backoff with full jitter
-           delay = min(
-               base_delay * (backoff_factor ** attempt) + random.uniform(0, 1),
-               max_delay,
-           )
+            # Exponential backoff with full jitter
+            delay = min(
+                base_delay * (backoff_factor**attempt) + random.uniform(0, 1),
+                max_delay,
+            )
 
-           verbose_logger.warning(
-               f"[LiteLLM] Attempt {attempt + 1}/{max_retries + 1} failed "
-               f"({type(e).__name__}). Retrying in {delay:.2f}s..."
-           )
-           await asyncio.sleep(delay)
+            verbose_logger.warning(
+                f"[LiteLLM] Attempt {attempt + 1}/{max_retries + 1} failed "
+                f"({type(e).__name__}). Retrying in {delay:.2f}s..."
+            )
+            await asyncio.sleep(delay)
 
-   raise last_exception  # pragma: no cover
+    raise last_exception  # pragma: no cover

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4107,3 +4107,83 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+# ── Tests for retry_with_backoff ──────────────────────
+from litellm.utils import retry_with_backoff
+from litellm.exceptions import RateLimitError
+
+
+class TestRetryWithBackoff:
+    """Tests for the retry_with_backoff utility function."""
+
+    def test_retry_succeeds_on_first_try(self):
+        """Should return immediately with no retries."""
+        result = retry_with_backoff(lambda: "success")
+        assert result == "success"
+
+    def test_retry_succeeds_after_failures(self):
+        """Should retry and succeed after initial failures."""
+        attempts = {"count": 0}
+
+        def flaky_fn():
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise RateLimitError(
+                    message="rate limited",
+                    model="gpt-4o",
+                    llm_provider="openai",
+                )
+            return "recovered"
+
+        result = retry_with_backoff(flaky_fn, max_retries=3, base_delay=0.01)
+        assert result == "recovered"
+        assert attempts["count"] == 3
+
+    def test_retry_raises_after_max_retries(self):
+        """Should raise the exception after exhausting retries."""
+
+        def always_fails():
+            raise RateLimitError(
+                message="always rate limited",
+                model="gpt-4o",
+                llm_provider="openai",
+            )
+
+        with pytest.raises(RateLimitError):
+            retry_with_backoff(always_fails, max_retries=2, base_delay=0.01)
+
+    def test_retry_custom_exception(self):
+        """Should only retry on specified exception types."""
+
+        def raises_value_error():
+            raise ValueError("not a rate limit")
+
+        with pytest.raises(ValueError):
+            retry_with_backoff(
+                raises_value_error,
+                max_retries=3,
+                base_delay=0.01,
+                retry_on=(RateLimitError,),  # ValueError not included
+            )
+
+    def test_retry_respects_max_delay(self):
+        """Delay should never exceed max_delay."""
+        import time
+
+        attempts = {"count": 0, "start": time.time()}
+
+        def fails_twice():
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise RateLimitError("rate limited", "gpt-4o", "openai")
+            return "done"
+
+        retry_with_backoff(
+            fails_twice,
+            max_retries=3,
+            base_delay=0.01,
+            max_delay=0.05,
+        )
+        elapsed = time.time() - attempts["start"]
+        assert elapsed < 1.0  # Should be fast with tiny delays

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4110,7 +4110,7 @@ class TestValidateAndFixThinkingParam:
 
 
 # ── Tests for retry_with_backoff ──────────────────────
-from litellm.utils import retry_with_backoff
+from litellm.utils import retry_with_backoff, async_retry_with_backoff
 from litellm.exceptions import RateLimitError
 
 
@@ -4187,3 +4187,78 @@ class TestRetryWithBackoff:
         )
         elapsed = time.time() - attempts["start"]
         assert elapsed < 1.0  # Should be fast with tiny delays
+
+    def test_retry_rejects_async_callable(self):
+        """Should raise TypeError if fn is a coroutine function."""
+
+        async def async_fn():
+            return "async result"
+
+        with pytest.raises(TypeError, match="does not support async"):
+            retry_with_backoff(async_fn)
+
+    def test_retry_rejects_lambda_returning_coroutine(self):
+        """Should raise TypeError if fn() returns a coroutine."""
+
+        async def async_fn():
+            return "async result"
+
+        with pytest.raises(TypeError, match="received a coroutine"):
+            retry_with_backoff(lambda: async_fn())
+
+
+class TestAsyncRetryWithBackoff:
+    """Tests for the async_retry_with_backoff utility function."""
+
+    @pytest.mark.asyncio
+    async def test_async_retry_succeeds_on_first_try(self):
+        """Should return immediately with no retries."""
+
+        async def async_fn():
+            return "async success"
+
+        result = await async_retry_with_backoff(lambda: async_fn())
+        assert result == "async success"
+
+    @pytest.mark.asyncio
+    async def test_async_retry_succeeds_after_failures(self):
+        """Should retry and succeed after initial failures."""
+        attempts = {"count": 0}
+
+        async def flaky_async():
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise RateLimitError(
+                    message="rate limited",
+                    model="gpt-4o",
+                    llm_provider="openai",
+                )
+            return "recovered"
+
+        result = await async_retry_with_backoff(
+            lambda: flaky_async(), max_retries=3, base_delay=0.01
+        )
+        assert result == "recovered"
+        assert attempts["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_async_retry_raises_after_max_retries(self):
+        """Should raise the exception after exhausting retries."""
+
+        async def always_fails():
+            raise RateLimitError(
+                message="always rate limited",
+                model="gpt-4o",
+                llm_provider="openai",
+            )
+
+        with pytest.raises(RateLimitError):
+            await async_retry_with_backoff(
+                lambda: always_fails(), max_retries=2, base_delay=0.01
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_retry_works_with_sync_fn(self):
+        """Should also work with a synchronous callable."""
+        result = await async_retry_with_backoff(lambda: "sync result")
+        assert result == "sync result"


### PR DESCRIPTION

What

Adds a retry_with_backoff() utility function to handle transient LLM API errors (RateLimitError, ServiceUnavailableError) with exponential backoff and random jitter.

Why
Currently users must implement retry logic manually on every LiteLLM integration. This is a repeated pattern that belongs in the SDK itself. Closes the gap for production use cases where rate limits are common across providers like OpenAI, Anthropic, and VertexAI.

## Relevant issues

Fixes #7358

## Linear ticket
N/A

## Pre-Submission checklist

	- I have Added testing in the tests/test_litellm/ directory, Adding at least 1 test is a hard requirement - see details
	- My PR passes all unit tests on make test-unit
	- My PR’s scope is as isolated as possible, it only solves 1 specific problem
	- I have requested a Greptile review by commenting @greptileai and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
<img width="1361" height="316" alt="image" src="https://github.com/user-attachments/assets/e1272158-6ec6-4f9c-a1b6-99f7a3b5a778" />


## Type

🆕 New Feature

## Changes

	- Added retry_with_backoff() function to litellm/utils.py with exponential backoff, jitter, configurable max delay, and custom exception support
	- Exported via litellm/__init__.py so users can call litellm.retry_with_backoff() directly
	- Added 5 unit tests in tests/test_litellm/test_utils.py covering: first-try success, partial failure recovery, max retries exhaustion, custom exception types, and max delay cap
