### PR TITLE
fix(bedrock): forward Anthropic hosted-tools via additionalModelReque…

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5197,6 +5197,26 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
             tool_block_list.append(tool)  # type: ignore
             continue
 
+        # Defensive skip: Anthropic hosted-tools (memory_20250818, web_search_*, etc.)
+        # must be forwarded via additionalModelRequestFields.tools in the
+        # Converse transformer. If one slips through to _bedrock_tools_pt the
+        # generic transform below would emit a malformed toolSpec named
+        # `litellm_unnamed_tool_X` with an empty input schema, so we skip it
+        # here to fail safely instead. The Converse transformer is the
+        # canonical separation point.
+        if isinstance(tool, dict):
+            _hosted_prefixes = (
+                "memory",
+                "web_search",
+                "web_fetch",
+                "code_execution",
+            )
+            _hosted_type = tool.get("type")
+            if isinstance(_hosted_type, str) and any(
+                _hosted_type.startswith(p) for p in _hosted_prefixes
+            ):
+                continue
+
         # OpenAI function tools, or Anthropic Messages / Claude Code ({name, input_schema, type, ...})
         if isinstance(tool, dict) and "input_schema" in tool and "function" not in tool:
             parameters = copy.deepcopy(

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -33,6 +33,10 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 )
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
+from litellm.types.llms.anthropic import (
+    ANTHROPIC_BETA_HEADER_VALUES,
+    ANTHROPIC_HOSTED_TOOLS,
+)
 from litellm.types.llms.bedrock import *
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -82,6 +86,43 @@ BEDROCK_COMPUTER_USE_TOOLS = [
     "bash_",
     "text_editor_",
 ]
+
+# Anthropic hosted-tool type prefixes that must be forwarded via
+# `additionalModelRequestFields.tools` on Bedrock Converse instead of
+# being transformed into a Converse `toolSpec`. Bash/TextEditor are
+# already handled by the existing computer-use branch.
+BEDROCK_ANTHROPIC_HOSTED_TOOL_PREFIXES = (
+    ANTHROPIC_HOSTED_TOOLS.MEMORY.value,
+    ANTHROPIC_HOSTED_TOOLS.WEB_SEARCH.value,
+    ANTHROPIC_HOSTED_TOOLS.WEB_FETCH.value,
+    ANTHROPIC_HOSTED_TOOLS.CODE_EXECUTION.value,
+)
+
+# Map from a hosted-tool type-prefix to the beta header that the model
+# requires. AWS Bedrock forwards `additionalModelRequestFields.anthropic_beta`
+# to the underlying Anthropic model.
+BEDROCK_HOSTED_TOOL_BETA_HEADERS = {
+    ANTHROPIC_HOSTED_TOOLS.MEMORY.value: (
+        ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
+    ),
+    ANTHROPIC_HOSTED_TOOLS.WEB_FETCH.value: (
+        ANTHROPIC_BETA_HEADER_VALUES.WEB_FETCH_2025_09_10.value
+    ),
+    ANTHROPIC_HOSTED_TOOLS.WEB_SEARCH.value: (
+        ANTHROPIC_BETA_HEADER_VALUES.WEB_SEARCH_2025_03_05.value
+    ),
+}
+
+
+def _is_anthropic_hosted_tool(tool: dict) -> bool:
+    """Return True iff `tool["type"]` matches an Anthropic hosted-tool prefix."""
+    tool_type = tool.get("type") if isinstance(tool, dict) else None
+    if not isinstance(tool_type, str):
+        return False
+    return any(
+        tool_type.startswith(prefix)
+        for prefix in BEDROCK_ANTHROPIC_HOSTED_TOOL_PREFIXES
+    )
 
 # Beta header patterns that are not supported by Bedrock Converse API
 # These will be filtered out to prevent errors
@@ -1276,6 +1317,7 @@ class AmazonConverseConfig(BaseConfig):
         # from OpenAI-format tools that need transformation via _bedrock_tools_pt
         filtered_tools = []
         pre_formatted_tools: List[ToolBlock] = []
+        hosted_tools: list = []
         if original_tools:
             for tool in original_tools:
                 # Already-formatted Bedrock tools (e.g. systemTool for Nova grounding)
@@ -1288,6 +1330,13 @@ class AmazonConverseConfig(BaseConfig):
                     "tool_search_tool_bm25_20251119",
                 ):
                     # Tool search not supported in Converse API - skip it
+                    continue
+                # Anthropic hosted tools (memory_20250818, web_search_*, etc.)
+                # must be forwarded via additionalModelRequestFields.tools
+                # rather than the Converse toolConfig.tools structure, which
+                # only supports `toolSpec` blocks.
+                if _is_anthropic_hosted_tool(tool):
+                    hosted_tools.append(tool)
                     continue
                 filtered_tools.append(tool)
 
@@ -1371,6 +1420,22 @@ class AmazonConverseConfig(BaseConfig):
 
         # Append pre-formatted tools (systemTool etc.) after transformation
         bedrock_tools.extend(pre_formatted_tools)
+
+        # Forward Anthropic hosted-tools (memory, web_search, etc.) via
+        # additionalModelRequestFields.tools. Merge with any tools already
+        # placed there by the computer-use branch above.
+        if hosted_tools:
+            existing_additional_tools = additional_request_params.get("tools") or []
+            additional_request_params["tools"] = (
+                existing_additional_tools + hosted_tools
+            )
+            for hosted_tool in hosted_tools:
+                hosted_type = hosted_tool.get("type", "")
+                for prefix, beta_header in BEDROCK_HOSTED_TOOL_BETA_HEADERS.items():
+                    if hosted_type.startswith(prefix):
+                        if beta_header not in anthropic_beta_list:
+                            anthropic_beta_list.append(beta_header)
+                        break
 
         # Set anthropic_beta in additional_request_params if we have any beta features
         # ONLY apply to Anthropic/Claude models - other models (e.g., Qwen, Llama) don't support this field

--- a/tests/test_litellm/llms/bedrock/test_bedrock_hosted_tools.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_hosted_tools.py
@@ -1,0 +1,205 @@
+"""
+Tests for Anthropic hosted-tool support on AWS Bedrock Converse.
+
+Hosted tools (memory_20250818, web_search_*, web_fetch_*, code_execution_*)
+must be forwarded via `additionalModelRequestFields.tools` rather than being
+mapped into Converse `toolConfig.tools`, because the Converse `toolSpec`
+schema does not represent them and would otherwise emit a malformed tool
+named `litellm_unnamed_tool_X`.
+"""
+
+from litellm.llms.bedrock.chat.converse_transformation import (
+    BEDROCK_ANTHROPIC_HOSTED_TOOL_PREFIXES,
+    BEDROCK_HOSTED_TOOL_BETA_HEADERS,
+    AmazonConverseConfig,
+    _is_anthropic_hosted_tool,
+)
+
+
+CLAUDE_MODEL = "anthropic.claude-sonnet-4-6-20250929-v1:0"
+
+
+class TestIsAnthropicHostedTool:
+    """Unit tests for the hosted-tool predicate."""
+
+    def test_memory_tool_type_recognised(self):
+        assert _is_anthropic_hosted_tool(
+            {"type": "memory_20250818", "name": "memory"}
+        )
+
+    def test_web_search_tool_type_recognised(self):
+        assert _is_anthropic_hosted_tool(
+            {"type": "web_search_20250305", "name": "web_search"}
+        )
+
+    def test_function_tool_not_hosted(self):
+        assert not _is_anthropic_hosted_tool(
+            {"type": "function", "function": {"name": "foo", "parameters": {}}}
+        )
+
+    def test_missing_type_not_hosted(self):
+        assert not _is_anthropic_hosted_tool({"name": "memory"})
+
+    def test_non_dict_not_hosted(self):
+        assert not _is_anthropic_hosted_tool("memory_20250818")  # type: ignore[arg-type]
+
+
+class TestMemoryToolForwardedViaAdditionalModelRequestFields:
+    """The memory tool must end up in additionalModelRequestFields, not toolConfig."""
+
+    def test_memory_tool_not_in_tool_config(self):
+        config = AmazonConverseConfig()
+        tools = [{"type": "memory_20250818", "name": "memory"}]
+
+        result = config._transform_request_helper(
+            model=CLAUDE_MODEL,
+            system_content_blocks=[],
+            optional_params={"tools": tools},
+            messages=[{"role": "user", "content": "Hi"}],
+            headers={},
+        )
+
+        # toolConfig should not contain a phantom litellm_unnamed_tool entry
+        tool_config = result.get("toolConfig")
+        if tool_config is not None:
+            for tool_block in tool_config.get("tools", []):
+                spec = tool_block.get("toolSpec", {})
+                assert not spec.get("name", "").startswith(
+                    "litellm_unnamed_tool"
+                ), "memory tool should not be transformed into a generic toolSpec"
+
+    def test_memory_tool_in_additional_model_request_fields(self):
+        config = AmazonConverseConfig()
+        tools = [{"type": "memory_20250818", "name": "memory"}]
+
+        result = config._transform_request_helper(
+            model=CLAUDE_MODEL,
+            system_content_blocks=[],
+            optional_params={"tools": tools},
+            messages=[{"role": "user", "content": "Hi"}],
+            headers={},
+        )
+
+        additional = result["additionalModelRequestFields"]
+        assert "tools" in additional
+        assert {"type": "memory_20250818", "name": "memory"} in additional["tools"]
+
+    def test_memory_tool_beta_header_injected(self):
+        config = AmazonConverseConfig()
+        tools = [{"type": "memory_20250818", "name": "memory"}]
+
+        result = config._transform_request_helper(
+            model=CLAUDE_MODEL,
+            system_content_blocks=[],
+            optional_params={"tools": tools},
+            messages=[{"role": "user", "content": "Hi"}],
+            headers={},
+        )
+
+        additional = result["additionalModelRequestFields"]
+        assert "anthropic_beta" in additional
+        assert "context-management-2025-06-27" in additional["anthropic_beta"]
+
+
+class TestFunctionToolNoRegression:
+    """Plain function tools must still be transformed into toolConfig.tools."""
+
+    def test_function_tool_emits_tool_spec(self):
+        config = AmazonConverseConfig()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                        },
+                        "required": ["city"],
+                    },
+                },
+            }
+        ]
+
+        result = config._transform_request_helper(
+            model=CLAUDE_MODEL,
+            system_content_blocks=[],
+            optional_params={"tools": tools},
+            messages=[{"role": "user", "content": "Hi"}],
+            headers={},
+        )
+
+        tool_config = result.get("toolConfig")
+        assert tool_config is not None
+        names = [
+            block["toolSpec"]["name"]
+            for block in tool_config["tools"]
+            if "toolSpec" in block
+        ]
+        assert "get_weather" in names
+        # additionalModelRequestFields should not contain a tools array
+        # for plain function tools
+        assert "tools" not in result["additionalModelRequestFields"]
+
+
+class TestMixedTools:
+    """Memory + function tool together: both routed correctly, no cross-talk."""
+
+    def test_memory_and_function_tool_split(self):
+        config = AmazonConverseConfig()
+        tools = [
+            {"type": "memory_20250818", "name": "memory"},
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            },
+        ]
+
+        result = config._transform_request_helper(
+            model=CLAUDE_MODEL,
+            system_content_blocks=[],
+            optional_params={"tools": tools},
+            messages=[{"role": "user", "content": "Hi"}],
+            headers={},
+        )
+
+        # function tool -> toolConfig
+        tool_config = result["toolConfig"]
+        spec_names = [
+            block["toolSpec"]["name"]
+            for block in tool_config["tools"]
+            if "toolSpec" in block
+        ]
+        assert "get_weather" in spec_names
+        assert not any(n.startswith("litellm_unnamed_tool") for n in spec_names)
+
+        # memory tool -> additionalModelRequestFields
+        additional = result["additionalModelRequestFields"]
+        assert any(
+            t.get("type") == "memory_20250818" for t in additional["tools"]
+        )
+        # memory beta header propagated
+        assert "context-management-2025-06-27" in additional["anthropic_beta"]
+
+
+class TestConstantsExposed:
+    """Sanity check that the new public constants are wired up correctly."""
+
+    def test_memory_prefix_in_hosted_tool_list(self):
+        assert "memory" in BEDROCK_ANTHROPIC_HOSTED_TOOL_PREFIXES
+
+    def test_memory_beta_header_mapping(self):
+        assert (
+            BEDROCK_HOSTED_TOOL_BETA_HEADERS["memory"]
+            == "context-management-2025-06-27"
+        )


### PR DESCRIPTION
## Problem

After #16115 the Anthropic direct path correctly forwards hosted tools (memory_20250818, web_search_*, web_fetch_*, code_execution_*) and auto-injects the matching beta header. The **Bedrock Converse** path does not — hosted tools fall through to `_bedrock_tools_pt` and are emitted as a generic empty toolSpec named `litellm_unnamed_tool_X`, which Bedrock dutifully returns as a phantom tool_use the model can never satisfy.

Reproduction (LiteLLM 1.83.14, real Bedrock call, debug enabled):

```python
import litellm
litellm._turn_on_debug()
litellm.acompletion(
    model='bedrock/eu.anthropic.claude-sonnet-4-6',
    messages=[{'role':'user','content':'remember my name is Maze'}],
    tools=[{'type':'memory_20250818','name':'memory'}],
    aws_region_name='eu-central-1',
    max_tokens=200,
)
```

Outgoing payload — note empty `additionalModelRequestFields`, unnamed tool:

```json
{
  "toolConfig": {"tools": [{"toolSpec": {
    "inputSchema":{"json":{"type":"object","properties":{},"required":[]}},
    "name":"litellm_unnamed_tool_0",
    "description":"litellm_unnamed_tool_0"
  }}]},
  "additionalModelRequestFields": {}
}
```

## Fix

Route hosted tools into `additionalModelRequestFields.tools` (raw Anthropic format) and auto-inject the matching beta header into `additionalModelRequestFields.anthropic_beta`. This mirrors the existing computer-use branch and the Anthropic direct path. A defensive guard in `_bedrock_tools_pt` skips hosted tools so they cannot regress into the generic transform later.

Beta header mapping:
- `memory_*` → `context-management-2025-06-27`
- `web_fetch_*` → `web-fetch-2025-09-10`
- `web_search_*` → `web-search-2025-03-05`

## After

Same input, with the patch applied:

```json
{
  "additionalModelRequestFields": {
    "tools": [{"type": "memory_20250818", "name": "memory"}],
    "anthropic_beta": ["context-management-2025-06-27"]
  }
}
```

End-to-end verified against real Bedrock — Sonnet now invokes `memory.view` followed by `memory.create` on its own initiative.

## Tests

- 12 new tests in `tests/test_litellm/llms/bedrock/test_bedrock_hosted_tools.py` covering the predicate, payload routing, beta-header injection, function-tool no-regression and mixed-tool routing.
- Existing `test_anthropic_beta_support.py` and `test_converse_transformation.py` suites still green (110 tests).

## Notes

- Bash/text_editor remain on the existing computer-use branch — no change.
- The patch merges hosted-tools with any tools already placed in `additionalModelRequestFields` by the computer-use branch, so the two features coexist cleanly.