### PR TITLE
fix(bedrock): normalize invoke tool search tools for messages API

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -16,6 +16,7 @@ from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation
 )
 from litellm.llms.bedrock.common_utils import (
     get_anthropic_beta_from_headers,
+    normalize_bedrock_invoke_tool_search_tools,
     normalize_tool_input_schema_types_for_bedrock_invoke,
     remove_custom_field_from_tools,
 )
@@ -297,28 +298,12 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
     def _normalize_bedrock_tool_search_tools(self, optional_params: dict) -> dict:
         """
         Convert tool search entries to the format supported by the Bedrock Invoke API.
+
+        Delegates to ``normalize_bedrock_invoke_tool_search_tools`` so the
+        ``/v1/messages`` Bedrock handler can reuse the same normalization. See
+        that helper for the full rewrite/drop rules.
         """
-        tools = optional_params.get("tools")
-        if not tools or not isinstance(tools, list):
-            return optional_params
-
-        normalized_tools = []
-        for tool in tools:
-            tool_type = tool.get("type")
-            if tool_type == "tool_search_tool_bm25_20251119":
-                # Bedrock Invoke does not support the BM25 variant, so skip it.
-                continue
-            if tool_type == "tool_search_tool_regex_20251119":
-                normalized_tool = tool.copy()
-                normalized_tool["type"] = "tool_search_tool_regex"
-                normalized_tool["name"] = normalized_tool.get(
-                    "name", "tool_search_tool_regex"
-                )
-                normalized_tools.append(normalized_tool)
-                continue
-            normalized_tools.append(tool)
-
-        optional_params["tools"] = normalized_tools
+        normalize_bedrock_invoke_tool_search_tools(optional_params)
         return optional_params
 
     def transform_response(

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -153,6 +153,54 @@ def ensure_bedrock_anthropic_messages_tool_names(request_body: dict) -> None:
             tool["name"] = f"litellm_unnamed_tool_{i}"
 
 
+def normalize_bedrock_invoke_tool_search_tools(request_body: dict) -> None:
+    """
+    Bedrock Invoke does not accept Anthropic's dated tool-search server-side tool
+    types. Pydantic's tool-type discriminator rejects the request client-side with
+    ``Input tag 'tool_search_tool_regex_20251119' ... does not match any of the
+    expected tags`` before the call ever reaches Bedrock.
+
+    In-place normalization:
+
+    - ``tool_search_tool_regex_20251119`` is rewritten to the SDK-version-bare
+      ``tool_search_tool_regex`` (the canonical ``name`` Anthropic and Bedrock
+      both accept on the wire). ``name`` defaults to ``tool_search_tool_regex``
+      when missing.
+    - ``tool_search_tool_bm25_20251119`` is dropped entirely. Bedrock Invoke does
+      not support the BM25 variant of Anthropic tool-search.
+    - All other tool entries pass through unchanged.
+
+    Args:
+        request_body: The request dictionary to modify in-place.
+
+    Ref: https://github.com/BerriAI/litellm/issues/28083
+    """
+    tools = request_body.get("tools")
+    if not tools or not isinstance(tools, list):
+        return
+
+    normalized_tools: List[Any] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            normalized_tools.append(tool)
+            continue
+        tool_type = tool.get("type")
+        if tool_type == "tool_search_tool_bm25_20251119":
+            # Bedrock Invoke does not support the BM25 variant, so skip it.
+            continue
+        if tool_type == "tool_search_tool_regex_20251119":
+            normalized_tool = tool.copy()
+            normalized_tool["type"] = "tool_search_tool_regex"
+            normalized_tool["name"] = normalized_tool.get(
+                "name", "tool_search_tool_regex"
+            )
+            normalized_tools.append(normalized_tool)
+            continue
+        normalized_tools.append(tool)
+
+    request_body["tools"] = normalized_tools
+
+
 class AmazonBedrockGlobalConfig:
     def __init__(self):
         pass

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -35,6 +35,7 @@ from litellm.llms.bedrock.common_utils import (
     ensure_bedrock_anthropic_messages_tool_names,
     get_anthropic_beta_from_headers,
     is_claude_4_5_on_bedrock,
+    normalize_bedrock_invoke_tool_search_tools,
     normalize_tool_input_schema_types_for_bedrock_invoke,
     remove_custom_field_from_tools,
 )
@@ -563,6 +564,14 @@ class AmazonAnthropicClaudeMessagesConfig(
         # Ref: https://github.com/BerriAI/litellm/issues/22847
         remove_custom_field_from_tools(anthropic_messages_request)
         normalize_tool_input_schema_types_for_bedrock_invoke(anthropic_messages_request)
+        # Rewrite/drop Anthropic tool-search server-side tool types so Bedrock
+        # Invoke's Pydantic tool-type discriminator does not reject
+        # ``tool_search_tool_regex_20251119`` client-side. Runs before
+        # ``ensure_bedrock_anthropic_messages_tool_names`` so the canonical
+        # ``tool_search_tool_regex`` name default is preserved rather than
+        # masked by the unnamed-tool fallback.
+        # Ref: https://github.com/BerriAI/litellm/issues/28083
+        normalize_bedrock_invoke_tool_search_tools(anthropic_messages_request)
         ensure_bedrock_anthropic_messages_tool_names(anthropic_messages_request)
 
         # 6. AUTO-INJECT beta headers based on features used

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.abspath("../../../../../.."))
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.bedrock.common_utils import (
     ensure_bedrock_anthropic_messages_tool_names,
+    normalize_bedrock_invoke_tool_search_tools,
     normalize_tool_input_schema_types_for_bedrock_invoke,
     remove_custom_field_from_tools,
 )
@@ -358,6 +359,114 @@ def test_ensure_bedrock_anthropic_messages_tool_names():
     assert request["tools"][1]["name"] == "litellm_unnamed_tool_1"
     assert request["tools"][2]["name"] == "litellm_unnamed_tool_2"
     assert request["tools"][3]["name"] == "KeepMe"
+
+
+def test_normalize_bedrock_invoke_tool_search_tools():
+    """
+    Bedrock Invoke does not accept Anthropic's dated tool-search server-side tool
+    types. Normalization must:
+
+    - Rewrite ``tool_search_tool_regex_20251119`` to bare ``tool_search_tool_regex``
+      and default ``name`` when missing.
+    - Drop ``tool_search_tool_bm25_20251119`` (Bedrock does not support BM25).
+    - Preserve a custom ``name`` on the regex tool.
+    - Leave every other tool entry untouched.
+
+    Ref: https://github.com/BerriAI/litellm/issues/28083
+    """
+
+    # Mixed payload: BM25 (drop), regex with default name, regex with custom
+    # name, plus a regular function tool that must pass through.
+    request = {
+        "tools": [
+            {"type": "tool_search_tool_bm25_20251119"},
+            {"type": "tool_search_tool_regex_20251119"},
+            {
+                "type": "tool_search_tool_regex_20251119",
+                "name": "my_regex_search",
+            },
+            {
+                "name": "Read",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+        ]
+    }
+
+    normalize_bedrock_invoke_tool_search_tools(request)
+
+    assert len(request["tools"]) == 3, "BM25 tool should be dropped"
+    assert request["tools"][0]["type"] == "tool_search_tool_regex"
+    assert request["tools"][0]["name"] == "tool_search_tool_regex"
+    assert request["tools"][1]["type"] == "tool_search_tool_regex"
+    assert request["tools"][1]["name"] == "my_regex_search"
+    # Unrelated function tool passes through unchanged.
+    assert request["tools"][2] == {
+        "name": "Read",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+
+    # Empty / missing / non-list ``tools`` values must not raise.
+    empty = {"messages": [{"role": "user", "content": "hi"}]}
+    normalize_bedrock_invoke_tool_search_tools(empty)
+    assert "tools" not in empty
+
+    empty_list = {"tools": []}
+    normalize_bedrock_invoke_tool_search_tools(empty_list)
+    assert empty_list["tools"] == []
+
+    none_tools = {"tools": None}
+    normalize_bedrock_invoke_tool_search_tools(none_tools)
+    assert none_tools["tools"] is None
+
+    # Non-dict tool entries must pass through unchanged (no crash).
+    weird = {"tools": ["not-a-dict", 42]}
+    normalize_bedrock_invoke_tool_search_tools(weird)
+    assert weird["tools"] == ["not-a-dict", 42]
+
+
+def test_bedrock_invoke_messages_transform_normalizes_tool_search_regex():
+    """
+    Regression test for #28083: ``tool_search_tool_regex_20251119`` must be
+    rewritten to bare ``tool_search_tool_regex`` on the ``/v1/messages`` path
+    so Bedrock Invoke's Pydantic tool-type discriminator does not reject the
+    request client-side.
+
+    Before this fix the messages handler called every other tool-normalization
+    helper but skipped tool-search normalization, so any Anthropic tool-search
+    request via ``/v1/messages`` failed with ``Input tag
+    'tool_search_tool_regex_20251119' ... does not match any of the expected
+    tags``. The chat-completions handler already normalized correctly.
+    """
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    optional_params = {
+        "max_tokens": 128,
+        "stream": False,
+        "tools": [
+            {"type": "tool_search_tool_regex_20251119"},
+            {"type": "tool_search_tool_bm25_20251119"},
+        ],
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=[{"role": "user", "content": "Search for foo"}],
+        anthropic_messages_optional_request_params=copy.deepcopy(optional_params),
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    tool_types = [t["type"] for t in result["tools"]]
+    assert "tool_search_tool_regex_20251119" not in tool_types, (
+        "Bedrock Invoke would reject the dated `_20251119` regex type "
+        "client-side; it must be rewritten to bare `tool_search_tool_regex`."
+    )
+    assert (
+        "tool_search_tool_bm25_20251119" not in tool_types
+    ), "Bedrock Invoke does not support the BM25 variant; it must be dropped."
+    assert tool_types == ["tool_search_tool_regex"]
+    assert result["tools"][0]["name"] == "tool_search_tool_regex"
 
 
 def test_bedrock_invoke_messages_transform_adds_name_when_tool_missing_name():
@@ -917,9 +1026,7 @@ def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
     optional_params = {
         "max_tokens": 4096,
-        "context_management": {
-            "edits": [{"type": "compact_20260112"}]
-        },
+        "context_management": {"edits": [{"type": "compact_20260112"}]},
     }
 
     result = cfg.transform_anthropic_messages_request(
@@ -930,9 +1037,7 @@ def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
         headers={},
     )
 
-    assert result.get("context_management") == {
-        "edits": [{"type": "compact_20260112"}]
-    }
+    assert result.get("context_management") == {"edits": [{"type": "compact_20260112"}]}
     assert "compact-2026-01-12" in result.get("anthropic_beta", [])
     assert result["max_tokens"] == 4096
 
@@ -964,9 +1069,7 @@ def test_bedrock_messages_filters_unsupported_context_management_edits():
         headers={},
     )
 
-    assert result.get("context_management") == {
-        "edits": [{"type": "compact_20260112"}]
-    }
+    assert result.get("context_management") == {"edits": [{"type": "compact_20260112"}]}
     assert "compact-2026-01-12" in result.get("anthropic_beta", [])
 
 


### PR DESCRIPTION
## Summary

Fixes #28083.

LiteLLM has two independent Bedrock Invoke transform paths — one for `/v1/chat/completions` (`AmazonAnthropicClaudeConfig`) and one for `/v1/messages` (`AmazonAnthropicClaudeMessagesConfig`). The chat path already normalized Anthropic's dated tool-search server-side tool types (`tool_search_tool_regex_20251119`, `tool_search_tool_bm25_20251119`) before handing the payload to Anthropic's tool-type discriminator, but the messages path was missing the same normalization. As a result, any `/v1/messages` request that included a tool-search tool through a Bedrock-backed Claude alias failed client-side in LiteLLM's pre-flight validation with:

> Input tag 'tool_search_tool_regex_20251119' found using 'type' does not match any of the expected tags: 'bash_20241022', ..., 'web_search_20250305'

even though the same tool worked end-to-end on the chat-completions handler and on Anthropic-native / Azure / Bedrock Converse / Vertex AI.

This PR closes that gap.

## What changed

1. **New shared helper** `normalize_bedrock_invoke_tool_search_tools(request_body)` in `litellm/llms/bedrock/common_utils.py` (where the other Bedrock Invoke tool-normalization helpers live — `remove_custom_field_from_tools`, `normalize_tool_input_schema_types_for_bedrock_invoke`, `ensure_bedrock_anthropic_messages_tool_names`). It in-place:
   - Rewrites `tool_search_tool_regex_20251119` to the SDK-version-bare `tool_search_tool_regex` (the canonical name Anthropic and Bedrock both accept on the wire), defaulting `name` to `tool_search_tool_regex` when missing.
   - Drops `tool_search_tool_bm25_20251119` entirely — Bedrock Invoke does not support the BM25 variant.
   - Passes every other tool entry (including non-dict items) through unchanged.

2. **Chat path** (`litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py`): the existing private method `_normalize_bedrock_tool_search_tools` now delegates to the new helper. Method signature and return contract are preserved so any subclass / caller is unaffected (only one caller in the codebase today).

3. **Messages path** (`litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py`): the new helper is wired into `transform_anthropic_messages_request` alongside the other tool-normalization helpers — **this is the regression fix**.

4. **Tests**: a unit test for the helper plus an integration regression test that exercises `AmazonAnthropicClaudeMessagesConfig.transform_anthropic_messages_request` end-to-end with both `tool_search_tool_regex_20251119` and `tool_search_tool_bm25_20251119`. The integration test fails on `main` and passes after the fix.

## Why the helper runs *before* `ensure_bedrock_anthropic_messages_tool_names`

A `tool_search_tool_regex_20251119` payload that omits `name` is the wire-correct shape — Anthropic and Bedrock both default the name to `tool_search_tool_regex` on the server side. The helper preserves that contract by defaulting `name` to `tool_search_tool_regex` when missing.

`ensure_bedrock_anthropic_messages_tool_names` is a generic backfill that assigns `litellm_unnamed_tool_{i}` to any tool that arrives without a name. If it runs first, it shadows the tool-search default and the rewritten tool ends up named `litellm_unnamed_tool_0`, which doesn't round-trip back to a real tool-search invocation.

The new ordering is therefore: `remove_custom_field_from_tools` → `normalize_tool_input_schema_types_for_bedrock_invoke` → `normalize_bedrock_invoke_tool_search_tools` → `ensure_bedrock_anthropic_messages_tool_names`. This is captured in an inline comment and pinned by `test_bedrock_invoke_messages_transform_normalizes_tool_search_regex`, which asserts the final tool name is `tool_search_tool_regex`, not `litellm_unnamed_tool_0`. I caught this exact ordering bug by running the integration test mid-implementation — the test failed with `AssertionError: assert 'litellm_unnamed_tool_0' == 'tool_search_tool_regex'`, prompting the reorder.

## Tests run

All targeted tests pass on `origin/main`:

```
$ uv run pytest \
    tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_normalize_bedrock_invoke_tool_search_tools \
    tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_bedrock_invoke_messages_transform_normalizes_tool_search_regex \
    tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_remove_custom_field_from_tools \
    tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_normalize_tool_input_schema_types_for_bedrock_invoke \
    tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_ensure_bedrock_anthropic_messages_tool_names \
    tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_bedrock_invoke_messages_transform_adds_name_when_tool_missing_name \
    tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
============================== 14 passed in 0.78s ==============================
```

Formatting / lint on the changed files:

```
$ uv run black --check <four changed files>
All done! ✨ 🍰 ✨  4 files would be left unchanged.

$ uv run ruff check <three changed source files>
All checks passed!
```

## Note on pre-existing local failures

When running the **entire** `tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py` file with only `uv sync --group dev`, five tests fail with `ModuleNotFoundError: No module named 'orjson'` (they exercise SSE wrapper / streaming code paths that import `litellm.proxy.common_request_processing`). Similarly, `tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py` has five failures stemming from a `BEDROCK_RESPONSE_STREAM_SHAPE is None` assertion (a botocore data-files lookup unrelated to anything in this PR).

I verified each of these is pre-existing — they reproduce on a pristine checkout of `origin/main` before this branch's changes:

```
$ git stash
$ uv run pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_bedrock_sse_wrapper_encodes_dict_chunks
... ModuleNotFoundError: No module named 'orjson' ...
$ git stash pop
```

CONTRIBUTING.md hints at this: broader test suites or anything that touches proxy/PostgreSQL fixtures requires `make install-test-deps` (which I have not run locally, and which is not needed for the targeted Bedrock invoke transformation tests covered by this PR). I expect both buckets to pass in CI, which uses the full test environment.

## Type

🐛 Bug Fix

## Scope

- 4 files changed, +175 / −30. Most of the +/− is the new test cases (+121 / −0).
- Touches **only** the Bedrock Invoke tool-search code path. No behavior change for Bedrock Converse, non-Bedrock Anthropic, or the chat-completions Bedrock Invoke path (that path's only caller still receives the same in-place mutation contract as before).