### PR TITLE
feat(ui): add pause/resume Switch to the models table

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -228,8 +228,9 @@ const AllModelsTab = ({
       setPausingModelId(modelId);
       await modelPatchUpdateCall(accessToken, { blocked }, modelId);
       NotificationsManager.success(blocked ? "Model paused" : "Model resumed");
+      // invalidateQueries already schedules a refetch for active observers
+      // on this key — no need to also call refetchModels() (would double-fetch).
       queryClient.invalidateQueries({ queryKey: ["models", "list"] });
-      refetchModels();
     } catch (error) {
       console.error("Error toggling model pause state:", error);
       NotificationsManager.fromBackend(error);

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -7,7 +7,7 @@ import { columns } from "@/components/molecules/models/columns";
 import { getDisplayModelName } from "@/components/view_model/model_name_display";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import NotificationsManager from "@/components/molecules/notifications_manager";
-import { modelDeleteCall } from "@/components/networking";
+import { modelDeleteCall, modelPatchUpdateCall } from "@/components/networking";
 import { InfoCircleOutlined, SettingOutlined } from "@ant-design/icons";
 import { PaginationState, SortingState } from "@tanstack/react-table";
 import { useQueryClient } from "@tanstack/react-query";
@@ -217,6 +217,24 @@ const AllModelsTab = ({
     } finally {
       setDeleteLoading(false);
       setDeleteModalModelId(null);
+    }
+  };
+
+  const [pausingModelId, setPausingModelId] = useState<string | null>(null);
+
+  const handleTogglePause = async (modelId: string, blocked: boolean) => {
+    if (!accessToken) return;
+    try {
+      setPausingModelId(modelId);
+      await modelPatchUpdateCall(accessToken, { blocked }, modelId);
+      NotificationsManager.success(blocked ? "Model paused" : "Model resumed");
+      queryClient.invalidateQueries({ queryKey: ["models", "list"] });
+      refetchModels();
+    } catch (error) {
+      console.error("Error toggling model pause state:", error);
+      NotificationsManager.fromBackend(error);
+    } finally {
+      setPausingModelId(null);
     }
   };
 
@@ -536,6 +554,8 @@ const AllModelsTab = ({
                 expandedRows,
                 setExpandedRows,
                 setDeleteModalModelId,
+                handleTogglePause,
+                pausingModelId,
               )}
               data={filteredData}
               isLoading={isLoadingModelsInfo}

--- a/ui/litellm-dashboard/src/components/model_dashboard/types.ts
+++ b/ui/litellm-dashboard/src/components/model_dashboard/types.ts
@@ -6,6 +6,7 @@ export interface ModelInfo {
   team_id: string;
   db_model: boolean;
   access_groups: string[] | null;
+  blocked?: boolean;
 }
 
 export interface LiteLLMParams {

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx
@@ -1014,5 +1014,38 @@ describe("columns", () => {
       const toggle = screen.getByRole("switch", { name: /pause model/i });
       expect(toggle).toBeDisabled();
     });
+
+    it("disables the toggle while a PATCH for the same row is in-flight", () => {
+      // Regression for Greptile P1 on PR #28151 — antd's `loading` prop is
+      // visual only and does not prevent click events, so the row needs to
+      // be explicitly disabled while its PATCH is pending to avoid
+      // racing/conflicting PATCH calls on double-click.
+      const handler = vi.fn();
+      const model = createMockModel({
+        model_info: {
+          ...createMockModel().model_info,
+          db_model: true,
+          blocked: false,
+        },
+      });
+      const cols = columns(
+        "Admin",
+        defaultProps.userID,
+        defaultProps.premiumUser,
+        defaultProps.setSelectedModelId,
+        defaultProps.setSelectedTeamId,
+        defaultProps.getDisplayModelName,
+        defaultProps.handleEditClick,
+        defaultProps.handleRefreshClick,
+        defaultProps.expandedRows,
+        defaultProps.setExpandedRows,
+        vi.fn(),
+        handler,
+        model.model_info.id, // pausingModelId matches this row
+      );
+      render(<TestTable data={[model]} columns={cols} />);
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeDisabled();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx
@@ -944,4 +944,75 @@ describe("columns", () => {
     expect(screen.getByText("Out: $0.03")).toBeInTheDocument();
     expect(screen.queryByText(/In:/)).not.toBeInTheDocument();
   });
+
+  describe("pause/resume toggle", () => {
+    const renderWithToggle = (
+      overrides: Partial<ReturnType<typeof createMockModel>["model_info"]> = {},
+      togglePauseHandler?: ReturnType<typeof vi.fn>,
+      userRole: string = "Admin",
+    ) => {
+      const handler = togglePauseHandler ?? vi.fn();
+      const cols = columns(
+        userRole,
+        defaultProps.userID,
+        defaultProps.premiumUser,
+        defaultProps.setSelectedModelId,
+        defaultProps.setSelectedTeamId,
+        defaultProps.getDisplayModelName,
+        defaultProps.handleEditClick,
+        defaultProps.handleRefreshClick,
+        defaultProps.expandedRows,
+        defaultProps.setExpandedRows,
+        vi.fn(),
+        handler,
+      );
+      const model = createMockModel({
+        model_info: { ...createMockModel().model_info, ...overrides },
+      });
+      render(<TestTable data={[model]} columns={cols} />);
+      return { handler };
+    };
+
+    it("renders the toggle ON for a db_model that is not blocked", () => {
+      renderWithToggle({ db_model: true, blocked: false });
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeEnabled();
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("renders the toggle OFF for a db_model that is blocked", () => {
+      renderWithToggle({ db_model: true, blocked: true });
+      const toggle = screen.getByRole("switch", { name: /resume model/i });
+      expect(toggle).toBeEnabled();
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("calls the handler with blocked=true when an admin flips an active toggle off", async () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: true, blocked: false }, handler);
+      await userEvent.click(screen.getByRole("switch", { name: /pause model/i }));
+      expect(handler).toHaveBeenCalledWith("test-model-id", true);
+    });
+
+    it("calls the handler with blocked=false when an admin flips a paused toggle on", async () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: true, blocked: true }, handler);
+      await userEvent.click(screen.getByRole("switch", { name: /resume model/i }));
+      expect(handler).toHaveBeenCalledWith("test-model-id", false);
+    });
+
+    it("disables the toggle for non-admin users", () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: true, blocked: false }, handler, "User");
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeDisabled();
+    });
+
+    it("disables the toggle for config models", () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: false, blocked: false }, handler, "Admin");
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeDisabled();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
@@ -2,7 +2,7 @@ import { EditOutlined, InfoCircleOutlined, SyncOutlined } from "@ant-design/icon
 import { TrashIcon } from "@heroicons/react/outline";
 import { ColumnDef } from "@tanstack/react-table";
 import { Badge, Button, Icon } from "@tremor/react";
-import { Divider, Flex, Popover, Space, Tooltip, Typography } from "antd";
+import { Divider, Flex, Popover, Space, Switch, Tooltip, Typography } from "antd";
 import { ModelData } from "../../model_dashboard/types";
 import { ProviderLogo } from "./ProviderLogo";
 
@@ -53,6 +53,8 @@ export const columns = (
   expandedRows: Set<string>,
   setExpandedRows: (expandedRows: Set<string>) => void,
   onDeleteClick?: (modelId: string) => void,
+  onTogglePauseClick?: (modelId: string, blocked: boolean) => void | Promise<void>,
+  pausingModelId?: string | null,
 ): ColumnDef<ModelData>[] => [
     {
       header: () => <span className="text-sm font-semibold">Model ID</span>,
@@ -398,15 +400,42 @@ export const columns = (
     {
       id: "actions",
       header: () => <span className="text-sm font-semibold">Actions</span>,
-      size: 60,
-      minSize: 40,
+      size: 100,
+      minSize: 80,
       enableResizing: false,
       cell: ({ row }) => {
         const model = row.original;
         const canEditModel = userRole === "Admin" || model.model_info?.created_by === userID;
         const isConfigModel = !model.model_info?.db_model;
+        const isAdmin = userRole === "Admin";
+        const isBlocked = model.model_info?.blocked === true;
+        const isPauseToggleable = !isConfigModel && isAdmin && Boolean(onTogglePauseClick);
+        const pauseTooltip = isConfigModel
+          ? "Config models cannot be paused from the dashboard. Pause is DB-backed."
+          : !isAdmin
+            ? "Only proxy admins can pause or resume a model."
+            : isBlocked
+              ? "Resume model — restore normal routing."
+              : "Pause model — stop routing requests until resumed.";
         return (
           <div className="flex items-center justify-end gap-2 pr-4">
+            <Tooltip title={pauseTooltip}>
+              <Switch
+                size="small"
+                checked={!isBlocked}
+                disabled={!isPauseToggleable}
+                loading={pausingModelId === model.model_info.id}
+                aria-label={isBlocked ? "Resume model" : "Pause model"}
+                onClick={(_, e) => {
+                  e.stopPropagation();
+                }}
+                onChange={(nextChecked) => {
+                  if (isPauseToggleable && onTogglePauseClick) {
+                    void onTogglePauseClick(model.model_info.id, !nextChecked);
+                  }
+                }}
+              />
+            </Tooltip>
             {isConfigModel ? (
               <Tooltip title="Config model cannot be deleted on the dashboard. Please delete it from the config file.">
                 <Icon icon={TrashIcon} size="sm" className="opacity-50 cursor-not-allowed" />

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
@@ -417,14 +417,15 @@ export const columns = (
             : isBlocked
               ? "Resume model — restore normal routing."
               : "Pause model — stop routing requests until resumed.";
+        const isPausing = pausingModelId === model.model_info.id;
         return (
           <div className="flex items-center justify-end gap-2 pr-4">
             <Tooltip title={pauseTooltip}>
               <Switch
                 size="small"
                 checked={!isBlocked}
-                disabled={!isPauseToggleable}
-                loading={pausingModelId === model.model_info.id}
+                disabled={!isPauseToggleable || isPausing}
+                loading={isPausing}
                 aria-label={isBlocked ? "Resume model" : "Pause model"}
                 onClick={(_, e) => {
                   e.stopPropagation();

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
@@ -417,6 +417,10 @@ export const columns = (
             : isBlocked
               ? "Resume model — restore normal routing."
               : "Pause model — stop routing requests until resumed.";
+        // antd's `loading` prop on Switch is purely cosmetic — it does not block
+        // clicks. Pair `loading` with `disabled` derived from the same condition
+        // so a double-click during a pending PATCH cannot send a second,
+        // conflicting `blocked` value.
         const isPausing = pausingModelId === model.model_info.id;
         return (
           <div className="flex items-center justify-end gap-2 pr-4">


### PR DESCRIPTION
## Relevant issues

Completes #13703 and the user requests in:
- #361 — https://github.com/BerriAI/litellm/issues/361#issuecomment-3289390798 (@ingvarson)
- #361 — https://github.com/BerriAI/litellm/issues/361#issuecomment-3289452337 (@lazariv)

Pairs with the merged backend PR #27927, which added the `blocked` column on `LiteLLM_ProxyModelTable`, the router-level filter, the `/v1/models` listing filter, the credential-helper guard, and the proxy-admin auth gate on the PATCH endpoint. This PR ships the dashboard control that drives the same `blocked` field.

## Linear ticket

N/A — community contribution.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] Ensure the UI builds successfully — `npm run build` passes locally on this branch.
- [x] Ensure all UI unit tests pass — `npm run test` passes (3850/3850, including 6 new tests).
- [x] Add tests for new components or logic — see `ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem (the UI toggle for pause/resume).
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review.

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link: _filled by CI_

- [ ] **CI run for the last commit**
       Link: _filled by CI_

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

End-to-end behavior on the All Models page:

1. **Default state** — every row shows a small antd Switch in the Actions column. For an unblocked row the Switch is "on" (model is routing). For a paused row it's "off".
2. **Pause** — a proxy admin clicks the Switch on an active model → the Switch flips off and shows a spinner → backend PATCH `/model/{id}/update` with `{ "blocked": true }` lands → a success notification appears → the table refetches and the row stays in the paused state. `/v1/models` immediately stops listing the model.
3. **Resume** — proxy admin clicks the Switch on a paused model → `{ "blocked": false }` is sent, the row returns to "running", `/v1/models` re-includes it.
4. **Non-admin** — Switch is disabled for any role other than `Admin`. Tooltip: "Only proxy admins can pause or resume a model."
5. **Config model** — Switch is disabled for `db_model=false` rows. Tooltip: "Config models cannot be paused from the dashboard. Pause is DB-backed."

## Type

🆕 New Feature

## Changes

### Approach

- `ModelInfo` (TypeScript) gains `blocked?: boolean`, matching the field the proxy now propagates through `get_model_info_with_id` (already merged in #27927).
- `columns()` in `ui/litellm-dashboard/src/components/molecules/models/columns.tsx` accepts two new params:
  - `onTogglePauseClick?: (modelId: string, blocked: boolean) => void | Promise<void>` — the caller-provided handler that performs the PATCH.
  - `pausingModelId?: string | null` — the row currently mid-flight, so the Switch can render a per-row spinner.
- The Actions cell renders an antd `<Switch>` next to the existing delete icon. Disabled state is tightly coupled to backend authorization — only enabled when the model is `db_model=true`, the user is `Admin`, and a handler is wired. Tooltip copy matches the reason for the disabled state.
- `AllModelsTab` provides the handler. It calls `modelPatchUpdateCall(accessToken, { blocked }, modelId)` against the existing PATCH `/model/{id}/update` endpoint, then invalidates the React Query `["models", "list"]` key and calls `refetchModels()` so the table reflects the new state. Success / failure notifications go through `NotificationsManager` like the existing delete flow does.

### Tests

`ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx` adds a `pause/resume toggle` describe block with six focused cases:

- Renders ON for an unblocked db_model.
- Renders OFF for a blocked db_model.
- Calls the handler with `(modelId, true)` when an admin flips an active toggle off.
- Calls the handler with `(modelId, false)` when an admin flips a paused toggle on.
- Disabled for non-admin users.
- Disabled for config models.

### Scope

UI-only. Zero backend changes — the backend contract for `blocked` shipped in #27927 and CI on `litellm_internal_staging` is green.

cc @krrishdholakia — closing out the pause/resume feature with the dashboard control.