### PR TITLE
fix(volcengine): translate reasoning_effort to thinking parameter

### DIFF
--- a/litellm/llms/volcengine/chat/transformation.py
+++ b/litellm/llms/volcengine/chat/transformation.py
@@ -66,6 +66,7 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
             "max_retries",
             "extra_headers",
             "thinking",
+            "reasoning_effort",
         ]  # works across all models
 
     def map_openai_params(
@@ -83,6 +84,26 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
             drop_params,
             replace_max_completion_tokens_with_max_tokens,
         )
+
+        # Translate OpenAI-spec `reasoning_effort` -> Volcengine native `thinking.type`.
+        # Explicit `thinking=` always wins over `reasoning_effort=` (precedence rule).
+        # Mapping rationale:
+        #   - "none" / "minimal" -> disabled (no chain-of-thought; matches GPT-5 minimal semantics)
+        #   - "low" / "medium" / "high" / "xhigh" -> enabled (model self-decides depth)
+        #   - "auto" -> auto (let the model choose)
+        reasoning_effort = optional_params.pop("reasoning_effort", None)
+        if (
+            reasoning_effort is not None
+            and "thinking" not in optional_params
+            and "thinking" not in non_default_params
+        ):
+            if reasoning_effort in ("none", "minimal"):
+                optional_params["thinking"] = {"type": "disabled"}
+            elif reasoning_effort in ("low", "medium", "high", "xhigh"):
+                optional_params["thinking"] = {"type": "enabled"}
+            elif reasoning_effort == "auto":
+                optional_params["thinking"] = {"type": "auto"}
+            # Unknown values: silently drop (super() already handles drop_params semantics)
 
         if "thinking" in optional_params:
             """

--- a/litellm/llms/volcengine/chat/transformation.py
+++ b/litellm/llms/volcengine/chat/transformation.py
@@ -1,5 +1,7 @@
 from typing import Optional, Union
 
+import litellm
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
 
 
@@ -103,7 +105,20 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
                 optional_params["thinking"] = {"type": "enabled"}
             elif reasoning_effort == "auto":
                 optional_params["thinking"] = {"type": "auto"}
-            # Unknown values: silently drop (super() already handles drop_params semantics)
+            else:
+                # Unknown reasoning_effort value: respect drop_params semantics.
+                # When drop_params=True (or litellm.drop_params=True): silently drop.
+                # Otherwise: raise so callers don't silently get default thinking behavior.
+                if not (drop_params or litellm.drop_params):
+                    raise UnsupportedParamsError(
+                        status_code=400,
+                        message=(
+                            f"VolcEngine does not support reasoning_effort="
+                            f"{reasoning_effort!r}. Supported values: 'none', "
+                            f"'minimal', 'low', 'medium', 'high', 'xhigh', 'auto'. "
+                            f"Pass drop_params=True to silently drop unknown values."
+                        ),
+                    )
 
         if "thinking" in optional_params:
             """

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -176,6 +176,34 @@ class TestVolcEngineConfig:
         )
         assert e2e["extra_body"]["thinking"] == {"type": "disabled"}
 
+    def test_reasoning_effort_unknown_value(self):
+        """Unknown reasoning_effort values must respect drop_params semantics."""
+        import pytest
+
+        from litellm.exceptions import UnsupportedParamsError
+
+        config = VolcEngineConfig()
+
+        # drop_params=False: raise on unknown value (not silently drop)
+        with pytest.raises(UnsupportedParamsError) as exc_info:
+            config.map_openai_params(
+                non_default_params={"reasoning_effort": "ultra"},
+                optional_params={},
+                model="doubao-seed-1.6",
+                drop_params=False,
+            )
+        assert "reasoning_effort" in str(exc_info.value)
+        assert "ultra" in str(exc_info.value)
+
+        # drop_params=True: silently drop unknown value, no thinking written
+        out = config.map_openai_params(
+            non_default_params={"reasoning_effort": "ultra"},
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=True,
+        )
+        assert out == {}
+
     def test_e2e_completion(self):
         from openai import OpenAI
 

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -109,6 +109,73 @@ class TestVolcEngineConfig:
         )
         assert result_no_thinking == {}
 
+    def test_reasoning_effort_mapping(self):
+        """Translate OpenAI-spec reasoning_effort -> Volcengine thinking.type."""
+        config = VolcEngineConfig()
+
+        # reasoning_effort is now an advertised supported param
+        assert "reasoning_effort" in config.get_supported_openai_params(
+            model="doubao-seed-1.6"
+        )
+
+        # 'none' -> disabled (the original bug fix)
+        out = config.map_openai_params(
+            non_default_params={"reasoning_effort": "none"},
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=False,
+        )
+        assert out == {"extra_body": {"thinking": {"type": "disabled"}}}
+
+        # 'minimal' -> disabled (matches GPT-5 minimal semantics)
+        out = config.map_openai_params(
+            non_default_params={"reasoning_effort": "minimal"},
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=False,
+        )
+        assert out == {"extra_body": {"thinking": {"type": "disabled"}}}
+
+        # 'low' / 'medium' / 'high' / 'xhigh' -> enabled
+        for effort in ("low", "medium", "high", "xhigh"):
+            out = config.map_openai_params(
+                non_default_params={"reasoning_effort": effort},
+                optional_params={},
+                model="doubao-seed-1.6",
+                drop_params=False,
+            )
+            assert out == {"extra_body": {"thinking": {"type": "enabled"}}}, effort
+
+        # 'auto' -> auto
+        out = config.map_openai_params(
+            non_default_params={"reasoning_effort": "auto"},
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=False,
+        )
+        assert out == {"extra_body": {"thinking": {"type": "auto"}}}
+
+        # Explicit thinking= takes precedence over reasoning_effort=
+        out = config.map_openai_params(
+            non_default_params={
+                "reasoning_effort": "high",
+                "thinking": {"type": "disabled"},
+            },
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=False,
+        )
+        assert out == {"extra_body": {"thinking": {"type": "disabled"}}}
+
+        # End-to-end via get_optional_params
+        e2e = get_optional_params(
+            model="doubao-seed-1.6",
+            custom_llm_provider="volcengine",
+            reasoning_effort="none",
+            drop_params=False,
+        )
+        assert e2e["extra_body"]["thinking"] == {"type": "disabled"}
+
     def test_e2e_completion(self):
         from openai import OpenAI
 


### PR DESCRIPTION
## Title

fix(volcengine): translate `reasoning_effort` to `thinking` parameter (handle `'none'` → `disabled`)

## Relevant issues

Fixes the remaining gap from #13039. Builds on #13598 / #14569.

## Problem

After #14569, passing `extra_body={"thinking": {"type": "disabled"}}` correctly disables Doubao thinking. However, the standard OpenAI parameter `reasoning_effort='none'` is silently dropped:

`VolcEngineChatConfig.get_supported_openai_params` does not declare `reasoning_effort`, so the parent `OpenAIGPTConfig._map_openai_params` filters it out **before** reaching the VolcEngine thinking-translation block. The model receives a request with no thinking directive and falls back to its default (thinking ON), so `reasoning_content` is still produced.

### Reproduction (against `volcengine/doubao-seed-1-6-...`)

```python
r = completion(model="volcengine/...", reasoning_effort="none", messages=[...])
# BUG: r.choices[0].message.reasoning_content is NOT None
```

Workaround that works today:

```python
r = completion(model="volcengine/...", extra_body={"thinking": {"type": "disabled"}}, ...)
```

## Fix

- Add `reasoning_effort` to VolcEngine's `get_supported_openai_params`.
- In `map_openai_params`, translate `reasoning_effort` → Volcengine native `thinking.type`:
  - `none` / `minimal` → `disabled`
  - `low` / `medium` / `high` / `xhigh` → `enabled`
  - `auto` → `auto`
  - Explicit `thinking=` always overrides `reasoning_effort` (precedence rule).
- Reuses the existing validation / `extra_body` block from #14569 — no duplicate logic.

## Tests

Added `test_reasoning_effort_mapping` in `tests/test_litellm/llms/volcengine/test_volcengine.py` covering:
- Param exposure (in supported list)
- `none` / `minimal` → disabled
- `low` / `medium` / `high` / `xhigh` → enabled
- `auto` → auto
- Precedence: explicit `thinking=` over `reasoning_effort=`
- End-to-end via `get_optional_params`

Existing `test_thinking_parameter_handling` continues to pass unchanged.

## Type

🐛 Bug Fix