### PR TITLE
feat(prometheus): add user_email and user_alias to user budget metrics

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -416,6 +416,7 @@ custom_prometheus_metadata_labels: List[str] = []
 custom_prometheus_tags: List[str] = []
 prometheus_metrics_config: Optional[List] = None
 prometheus_emit_stream_label: bool = False
+prometheus_user_budget_label_include_email_alias: bool = False
 prometheus_end_user_metrics_max_series_per_metric: Optional[int] = 10000
 prometheus_end_user_metrics_ttl_seconds: Optional[float] = 3600.0
 prometheus_end_user_metrics_cleanup_interval_seconds: Optional[float] = 60.0

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3540,6 +3540,10 @@ class PrometheusLogger(CustomLogger):
             user_object.budget_reset_at = user_info.budget_reset_at
             if user_object.max_budget is None and user_info.max_budget is not None:
                 user_object.max_budget = user_info.max_budget
+            if user_info.user_email is not None:
+                user_object.user_email = user_info.user_email
+            if user_info.user_alias is not None:
+                user_object.user_alias = user_info.user_alias
 
         return user_object
 
@@ -3556,6 +3560,8 @@ class PrometheusLogger(CustomLogger):
         """
         enum_values = UserAPIKeyLabelValues(
             user=user.user_id,
+            user_email=user.user_email or "",
+            user_alias=user.user_alias or "",
         )
 
         _labels = prometheus_label_factory(

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -532,8 +532,6 @@ class PrometheusMetricLabels:
 
     litellm_remaining_user_budget_metric = [
         UserAPIKeyLabelNames.USER.value,
-        UserAPIKeyLabelNames.USER_EMAIL.value,
-        UserAPIKeyLabelNames.USER_ALIAS.value,
     ]
 
     litellm_user_max_budget_metric = litellm_remaining_user_budget_metric
@@ -724,6 +722,22 @@ class PrometheusMetricLabels:
             and UserAPIKeyLabelNames.STREAM.value not in default_labels
         ):
             custom_labels.append(UserAPIKeyLabelNames.STREAM.value)
+
+        _user_budget_metrics = {
+            "litellm_remaining_user_budget_metric",
+            "litellm_user_max_budget_metric",
+            "litellm_user_budget_remaining_hours_metric",
+        }
+        if (
+            label_name in _user_budget_metrics
+            and litellm.prometheus_user_budget_label_include_email_alias is True
+        ):
+            for label in [
+                UserAPIKeyLabelNames.USER_EMAIL.value,
+                UserAPIKeyLabelNames.USER_ALIAS.value,
+            ]:
+                if label not in default_labels and label not in custom_labels:
+                    custom_labels.append(label)
 
         if label_name in PrometheusMetricLabels._org_label_metrics:
             for label in [

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -160,6 +160,7 @@ class UserAPIKeyLabelNames(Enum):
     END_USER = "end_user"
     USER = "user"
     USER_EMAIL = "user_email"
+    USER_ALIAS = "user_alias"
     API_KEY_HASH = "hashed_api_key"
     API_KEY_ALIAS = "api_key_alias"
     TEAM = "team"
@@ -531,19 +532,13 @@ class PrometheusMetricLabels:
 
     litellm_remaining_user_budget_metric = [
         UserAPIKeyLabelNames.USER.value,
+        UserAPIKeyLabelNames.USER_EMAIL.value,
+        UserAPIKeyLabelNames.USER_ALIAS.value,
     ]
 
-    litellm_user_max_budget_metric = [
-        UserAPIKeyLabelNames.USER.value,
-    ]
+    litellm_user_max_budget_metric = litellm_remaining_user_budget_metric
 
-    litellm_user_budget_remaining_hours_metric = [
-        UserAPIKeyLabelNames.USER.value,
-    ]
-
-    litellm_user_budget_remaining_hours_metric = [
-        UserAPIKeyLabelNames.USER.value,
-    ]
+    litellm_user_budget_remaining_hours_metric = litellm_remaining_user_budget_metric
 
     litellm_remaining_api_key_requests_for_model = [
         UserAPIKeyLabelNames.API_KEY_HASH.value,
@@ -759,6 +754,7 @@ class UserAPIKeyLabelValues:
     end_user: Optional[str] = None
     user: Optional[str] = None
     user_email: Optional[str] = None
+    user_alias: Optional[str] = None
     hashed_api_key: Optional[str] = None
     api_key_alias: Optional[str] = None
     team: Optional[str] = None

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -610,22 +610,18 @@ def extract_user_budget_metrics(metrics_text: str, user_id: str) -> Dict[str, fl
     # Escape user_id for regex pattern matching
     escaped_user_id = re.escape(user_id)
 
-    # Get remaining budget
-    remaining_pattern = (
-        f'litellm_remaining_user_budget_metric{{user="{escaped_user_id}"}} ([0-9.]+)'
-    )
+    # Get remaining budget (user_email and user_alias may also be present as labels)
+    remaining_pattern = rf'litellm_remaining_user_budget_metric{{[^}}]*user="{escaped_user_id}"[^}}]*}} ([0-9.]+)'
     remaining_match = re.search(remaining_pattern, metrics_text)
     metrics["remaining"] = float(remaining_match.group(1)) if remaining_match else None
 
     # Get total budget
-    total_pattern = (
-        f'litellm_user_max_budget_metric{{user="{escaped_user_id}"}} ([0-9.]+)'
-    )
+    total_pattern = rf'litellm_user_max_budget_metric{{[^}}]*user="{escaped_user_id}"[^}}]*}} ([0-9.]+)'
     total_match = re.search(total_pattern, metrics_text)
     metrics["total"] = float(total_match.group(1)) if total_match else None
 
     # Get remaining hours
-    hours_pattern = f'litellm_user_budget_remaining_hours_metric{{user="{escaped_user_id}"}} ([0-9.]+)'
+    hours_pattern = rf'litellm_user_budget_remaining_hours_metric{{[^}}]*user="{escaped_user_id}"[^}}]*}} ([0-9.]+)'
     hours_match = re.search(hours_pattern, metrics_text)
     metrics["remaining_hours"] = float(hours_match.group(1)) if hours_match else None
 

--- a/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
@@ -460,6 +460,68 @@ async def test_assemble_user_object_does_not_override_metadata_max_budget(
     ), "max_budget from metadata must not be replaced by the DB value"
 
 
+async def test_assemble_user_object_populates_user_email_and_alias_from_db(
+    prometheus_logger,
+):
+    db_user = MagicMock()
+    db_user.max_budget = None
+    db_user.budget_reset_at = None
+    db_user.user_email = "alice@example.com"
+    db_user.user_alias = "Alice"
+
+    with patch("litellm.proxy.auth.auth_checks.get_user_object") as mock_get_user:
+        mock_get_user.return_value = db_user
+        user_object = await prometheus_logger._assemble_user_object(
+            user_id="user-abc-123",
+            spend=10.0,
+            max_budget=None,
+            response_cost=0.5,
+        )
+
+    assert user_object.user_email == "alice@example.com"
+    assert user_object.user_alias == "Alice"
+
+
+def test_set_user_budget_metrics_includes_user_email_and_alias_labels(
+    prometheus_logger,
+):
+    from litellm.proxy._types import LiteLLM_UserTable
+
+    user = LiteLLM_UserTable(
+        user_id="user-abc-123",
+        user_email="alice@example.com",
+        user_alias="Alice",
+        spend=25.0,
+        max_budget=100.0,
+        budget_reset_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+    )
+
+    prometheus_logger.litellm_remaining_user_budget_metric = MagicMock()
+    prometheus_logger.litellm_user_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_user_budget_remaining_hours_metric = MagicMock()
+
+    prometheus_logger._set_user_budget_metrics(user)
+
+    prometheus_logger.litellm_remaining_user_budget_metric.labels.assert_called_once_with(
+        user="user-abc-123",
+        user_email="alice@example.com",
+        user_alias="Alice",
+    )
+    prometheus_logger.litellm_remaining_user_budget_metric.labels().set.assert_called_once_with(
+        75.0
+    )
+    prometheus_logger.litellm_user_max_budget_metric.labels.assert_called_once_with(
+        user="user-abc-123",
+        user_email="alice@example.com",
+        user_alias="Alice",
+    )
+    prometheus_logger.litellm_user_budget_remaining_hours_metric.labels.assert_called_once_with(
+        user="user-abc-123",
+        user_email="alice@example.com",
+        user_alias="Alice",
+    )
+
+
 async def test_set_user_budget_metrics_after_api_request_no_inf_when_metadata_budget_none(
     prometheus_logger,
 ):

--- a/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
@@ -482,10 +482,14 @@ async def test_assemble_user_object_populates_user_email_and_alias_from_db(
     assert user_object.user_alias == "Alice"
 
 
-def test_set_user_budget_metrics_includes_user_email_and_alias_labels(
+def test_set_user_budget_metrics_default_no_email_alias_labels(
     prometheus_logger,
 ):
+    """By default (flag off), only user label is emitted."""
+    import litellm
     from litellm.proxy._types import LiteLLM_UserTable
+
+    litellm.prometheus_user_budget_label_include_email_alias = False
 
     user = LiteLLM_UserTable(
         user_id="user-abc-123",
@@ -504,22 +508,54 @@ def test_set_user_budget_metrics_includes_user_email_and_alias_labels(
 
     prometheus_logger.litellm_remaining_user_budget_metric.labels.assert_called_once_with(
         user="user-abc-123",
+    )
+
+
+def test_set_user_budget_metrics_includes_user_email_and_alias_labels_when_opted_in(
+    prometheus_logger,
+):
+    """When prometheus_user_budget_label_include_email_alias=True, email+alias labels appear."""
+    import litellm
+    from litellm.proxy._types import LiteLLM_UserTable
+
+    litellm.prometheus_user_budget_label_include_email_alias = True
+
+    user = LiteLLM_UserTable(
+        user_id="user-abc-123",
         user_email="alice@example.com",
         user_alias="Alice",
+        spend=25.0,
+        max_budget=100.0,
+        budget_reset_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
     )
-    prometheus_logger.litellm_remaining_user_budget_metric.labels().set.assert_called_once_with(
-        75.0
-    )
-    prometheus_logger.litellm_user_max_budget_metric.labels.assert_called_once_with(
-        user="user-abc-123",
-        user_email="alice@example.com",
-        user_alias="Alice",
-    )
-    prometheus_logger.litellm_user_budget_remaining_hours_metric.labels.assert_called_once_with(
-        user="user-abc-123",
-        user_email="alice@example.com",
-        user_alias="Alice",
-    )
+
+    prometheus_logger.litellm_remaining_user_budget_metric = MagicMock()
+    prometheus_logger.litellm_user_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_user_budget_remaining_hours_metric = MagicMock()
+
+    try:
+        prometheus_logger._set_user_budget_metrics(user)
+
+        prometheus_logger.litellm_remaining_user_budget_metric.labels.assert_called_once_with(
+            user="user-abc-123",
+            user_email="alice@example.com",
+            user_alias="Alice",
+        )
+        prometheus_logger.litellm_remaining_user_budget_metric.labels().set.assert_called_once_with(
+            75.0
+        )
+        prometheus_logger.litellm_user_max_budget_metric.labels.assert_called_once_with(
+            user="user-abc-123",
+            user_email="alice@example.com",
+            user_alias="Alice",
+        )
+        prometheus_logger.litellm_user_budget_remaining_hours_metric.labels.assert_called_once_with(
+            user="user-abc-123",
+            user_email="alice@example.com",
+            user_alias="Alice",
+        )
+    finally:
+        litellm.prometheus_user_budget_label_include_email_alias = False
 
 
 async def test_set_user_budget_metrics_after_api_request_no_inf_when_metadata_budget_none(


### PR DESCRIPTION
## Summary
- Add `user_email` and `user_alias` labels to user budget Prometheus metrics (`litellm_remaining_user_budget_metric`, `litellm_user_max_budget_metric`, `litellm_user_budget_remaining_hours_metric`)
- Populate email/alias from DB in `_assemble_user_object` when enriching user info after requests
- Aligns user budget metrics with team (`team` + `team_alias`) and API key (`hashed_api_key` + `api_key_alias`) budget metrics

## Test plan
- [x] `pytest tests/test_litellm/integrations/test_prometheus_user_team_metrics.py -q` (37 passed)
- [x] Manual: create user with `user_email`, make chat completion, verify `/metrics` shows `user_email` on budget gauges
<img width="1301" height="167" alt="image" src="https://github.com/user-attachments/assets/8a6469bf-8a0d-4d2d-ac24-bd9df8aa7567" />

FIxes LIT-3083

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional `user_email`/`user_alias` labels to Prometheus user-budget gauges, which can increase metric cardinality and impact existing dashboards/alerts if enabled. Default behavior remains unchanged via a new feature flag, reducing rollout risk.
> 
> **Overview**
> **Prometheus user budget metrics can now (optionally) include user identity labels beyond `user`.** This introduces a new global flag `prometheus_user_budget_label_include_email_alias` (default `False`) that, when enabled, appends `user_email` and `user_alias` labels to `litellm_remaining_user_budget_metric`, `litellm_user_max_budget_metric`, and `litellm_user_budget_remaining_hours_metric`.
> 
> The Prometheus logger now enriches the user object with `user_email`/`user_alias` fetched from the DB and passes these through label generation, with tests updated/added to cover both the default (no extra labels) and opted-in behavior and to make regex-based metric extraction resilient to extra labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae44431d3606253c343385045e2bebc9f3b88407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->