### PR TITLE
fix(bedrock): recalculate total_tokens after cache-token inflation in _transform_usage

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1714,7 +1714,6 @@ class AmazonConverseConfig(BaseConfig):
     ) -> Usage:
         input_tokens = usage["inputTokens"]
         output_tokens = usage["outputTokens"]
-        total_tokens = usage["totalTokens"]
         cache_creation_input_tokens: int = 0
         cache_read_input_tokens: int = 0
 
@@ -1725,6 +1724,14 @@ class AmazonConverseConfig(BaseConfig):
         if "cacheWriteInputTokens" in usage:
             cache_creation_input_tokens = usage["cacheWriteInputTokens"]
             input_tokens += cache_creation_input_tokens
+
+        # Recalculate total_tokens AFTER inflating input_tokens with cache tokens,
+        # so that total_tokens == prompt_tokens + completion_tokens.
+        # Bedrock's native "totalTokens" only covers inputTokens + outputTokens
+        # (i.e. non-cached tokens), so it would be too low whenever cache tokens
+        # are present.  Mirroring what the Anthropic transformation already does
+        # (see litellm/llms/anthropic/chat/transformation.py).
+        total_tokens = input_tokens + output_tokens
 
         prompt_tokens_details = PromptTokensDetailsWrapper(
             cached_tokens=cache_read_input_tokens,

--- a/tests/test_bedrock_cache_total_tokens.py
+++ b/tests/test_bedrock_cache_total_tokens.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for the Bedrock _transform_usage total_tokens fix.
+
+Verifies that total_tokens is recalculated AFTER cache-token inflation so that
+    total_tokens == prompt_tokens + completion_tokens
+always holds, regardless of whether cacheReadInputTokens or cacheWriteInputTokens
+are present in the Bedrock usage payload.
+"""
+import pytest
+from unittest.mock import MagicMock
+from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+
+def _make_transform():
+    """Return a bound _transform_usage method with minimal mock dependencies."""
+    config = AmazonConverseConfig()
+    return config._transform_usage
+
+
+class TestBedrockTransformUsageTotalTokens:
+    """total_tokens must equal prompt_tokens + completion_tokens after cache-token inflation."""
+
+    def test_no_cache_tokens_baseline(self):
+        """Without cache tokens, total_tokens should equal inputTokens + outputTokens."""
+        transform = _make_transform()
+        usage = transform({
+            "inputTokens": 100,
+            "outputTokens": 50,
+            "totalTokens": 150,
+        })
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 50
+        assert usage.total_tokens == 150
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+
+    def test_cache_read_tokens_total_includes_cache(self):
+        """Cache-read tokens added to input_tokens must be reflected in total_tokens.
+
+        Before the fix, total_tokens was 150 (from Bedrock's totalTokens which excluded
+        cache tokens). After the fix it must be 180 = 130 prompt + 50 completion.
+        """
+        transform = _make_transform()
+        usage = transform({
+            "inputTokens": 100,
+            "cacheReadInputTokens": 30,
+            "outputTokens": 50,
+            "totalTokens": 150,  # Bedrock's native value — intentionally stale
+        })
+        assert usage.prompt_tokens == 130           # 100 + 30 cache-read
+        assert usage.completion_tokens == 50
+        assert usage.total_tokens == 180            # was 150 before the fix
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+
+    def test_cache_write_tokens_total_includes_cache(self):
+        """Cache-write tokens added to input_tokens must be reflected in total_tokens."""
+        transform = _make_transform()
+        usage = transform({
+            "inputTokens": 100,
+            "cacheWriteInputTokens": 20,
+            "outputTokens": 50,
+            "totalTokens": 150,
+        })
+        assert usage.prompt_tokens == 120           # 100 + 20 cache-write
+        assert usage.completion_tokens == 50
+        assert usage.total_tokens == 170            # was 150 before the fix
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+
+    def test_both_cache_read_and_write_tokens(self):
+        """Both cache-read and cache-write tokens must both roll up into total_tokens."""
+        transform = _make_transform()
+        usage = transform({
+            "inputTokens": 100,
+            "cacheReadInputTokens": 30,
+            "cacheWriteInputTokens": 20,
+            "outputTokens": 50,
+            "totalTokens": 150,
+        })
+        assert usage.prompt_tokens == 150           # 100 + 30 + 20
+        assert usage.completion_tokens == 50
+        assert usage.total_tokens == 200            # was 150 before the fix
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+
+    def test_prompt_tokens_details_preserved(self):
+        """Cache fields must be accessible via prompt_tokens_details as well."""
+        transform = _make_transform()
+        usage = transform({
+            "inputTokens": 100,
+            "cacheReadInputTokens": 30,
+            "cacheWriteInputTokens": 20,
+            "outputTokens": 50,
+            "totalTokens": 150,
+        })
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 30
+
+    def test_zero_tokens_edge_case(self):
+        """Zero-token payload must not raise and must satisfy the invariant."""
+        transform = _make_transform()
+        usage = transform({
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "totalTokens": 0,
+        })
+        assert usage.prompt_tokens == 0
+        assert usage.completion_tokens == 0
+        assert usage.total_tokens == 0
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens


### PR DESCRIPTION
## Summary

Fixes a bug in `AmazonConverseConfig._transform_usage` where `total_tokens` was read from Bedrock's raw `totalTokens` field **before** cache-token inflation, causing `total_tokens` to be understated whenever `cacheReadInputTokens` or `cacheWriteInputTokens` are present.

## Root cause

`_transform_usage` inflates `input_tokens` by adding cache tokens:

```python
if "cacheReadInputTokens" in usage:
    cache_read_input_tokens = usage["cacheReadInputTokens"]
    input_tokens += cache_read_input_tokens      # input_tokens grows here
if "cacheWriteInputTokens" in usage:
    cache_creation_input_tokens = usage["cacheWriteInputTokens"]
    input_tokens += cache_creation_input_tokens  # and here
```

But `total_tokens` was set **before** this block:

```python
total_tokens = usage["totalTokens"]  # ← BUG: snapshot taken before inflation
```

Bedrock's native `totalTokens` = `inputTokens + outputTokens` (non-cached only), so it misses the cache tokens that were just added to `input_tokens`. This violates the invariant `total_tokens == prompt_tokens + completion_tokens` that the rest of litellm relies on.

## Concrete example

| Field | Before fix | After fix |
|---|---|---|
| Bedrock `inputTokens` | 100 | 100 |
| Bedrock `cacheReadInputTokens` | 30 | 30 |
| Bedrock `outputTokens` | 50 | 50 |
| `usage.prompt_tokens` | 130 | 130 |
| `usage.completion_tokens` | 50 | 50 |
| `usage.total_tokens` | **150 ← WRONG** | **180 ← correct** |

## Fix

Removed the early `total_tokens = usage["totalTokens"]` assignment and added a recalculation **after** the inflation block:

```python
# Recalculate total_tokens AFTER inflating input_tokens with cache tokens,
# so that total_tokens == prompt_tokens + completion_tokens.
# Bedrock's native "totalTokens" only covers inputTokens + outputTokens
# (i.e. non-cached tokens), so it would be too low whenever cache tokens
# are present.  Mirroring what the Anthropic transformation already does
# (see litellm/llms/anthropic/chat/transformation.py).
total_tokens = input_tokens + output_tokens
```

This matches the pattern already used in `litellm/llms/anthropic/chat/transformation.py` (line ~2242).

## Impact

- Affects any Bedrock request that uses prompt caching (Claude 3.x on Bedrock).
- `total_tokens` reported in `response.usage` and passed to callbacks/logging integrations is too low, causing incorrect cost tracking, analytics dashboards, and rate-limit accounting.
- Cost calculation itself is unaffected (uses `prompt_tokens`/`completion_tokens` separately).