### PR TITLE
fix(opentelemetry): JSON-serialize dict metadata fields for OTEL span attributes

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1107,8 +1107,13 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             "mcp_tool_call_metadata",
             "vector_store_request_metadata",
         ]:
-            if md.get(key) is not None:
-                common_attrs[f"metadata.{key}"] = str(md[key])
+            value = md.get(key)
+            if value is None:
+                continue
+            if isinstance(value, (dict, list)):
+                common_attrs[f"metadata.{key}"] = safe_dumps(value)
+            else:
+                common_attrs[f"metadata.{key}"] = str(value)
 
         # get hidden params
         hidden_params = getattr(std_log, "hidden_params", None) or (std_log or {}).get(


### PR DESCRIPTION
## Summary

Cherry-picks the OpenTelemetry metadata serialization fix from [#27457](https://github.com/BerriAI/litellm/pull/27457) / [#27451](https://github.com/BerriAI/litellm/pull/27451).

Dict and list metadata values (e.g. `spend_logs_metadata`, `applied_guardrails`, `mcp_tool_call_metadata`) are now serialized with `safe_dumps` instead of Python `str()`, producing valid JSON for downstream OTEL consumers.

## Test plan

- [x] Existing OTEL integration tests cover modified lines (per Codecov on original PR)
- [ ] CI green on `litellm_internal_staging`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to OpenTelemetry metric attribute formatting; main impact is altered serialization (Python `str()` -> JSON) for metadata values which could affect downstream parsing/expectations.
> 
> **Overview**
> **Fixes OpenTelemetry metric attribute serialization for structured metadata.**
> 
> When recording OTEL metrics, metadata values that are `dict`/`list` (e.g. guardrails/tool-call/vector-store metadata) are now encoded via `safe_dumps` instead of Python `str()`, while primitive values remain stringified. This produces valid JSON strings for downstream OTEL consumers and avoids emitting Python reprs as span/metric attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50efa4fa1e37e9d12c34555e796f2009d9290d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->