### PR TITLE
Fix documentation typos and README markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
         </a>
         </p>
     </p>
-<h4 align="center"><a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank">LiteLLM Proxy Server (AI Gateway)</a> | <a href="https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy" target="_blank"> Hosted Proxy</a> | <a href="https://litellm.ai/enterprise"target="_blank">Enterprise Tier</a> | <a href="https://www.litellm.ai/ai-gateway" target="_blank">Website</a></h4>
+<h4 align="center"><a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank">LiteLLM Proxy Server (AI Gateway)</a> | <a href="https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy" target="_blank"> Hosted Proxy</a> | <a href="https://litellm.ai/enterprise" target="_blank">Enterprise Tier</a> | <a href="https://www.litellm.ai/ai-gateway" target="_blank">Website</a></h4>
 <h4 align="center">
     <a href="https://pypi.org/project/litellm/" target="_blank">
         <img src="https://img.shields.io/pypi/v/litellm.svg" alt="PyPI Version">

--- a/tests/test_litellm/readme.md
+++ b/tests/test_litellm/readme.md
@@ -1,6 +1,6 @@
 # Testing for `litellm/` 
 
-This directory 1:1 maps the the `litellm/` directory, and can only contain mocked tests. 
+This directory 1:1 maps to the `litellm/` directory, and can only contain mocked tests. 
 
 The point of this is to:
 1. Increase test coverage of `litellm/`


### PR DESCRIPTION
This PR fixes two small documentation issues:

- Corrects a repeated-word typo in `tests/test_litellm/readme.md`
- Fixes a malformed HTML attribute in the main `README.md`

Verification:
- Reviewed both updated lines after the edit
- Pushed the branch `docs/fix-doc-typos`
