### PR TITLE
feat(proxy): add prefixed CLI env var fallbacks

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -453,14 +453,22 @@ class ProxyInitializationHelpers:
 
 @click.command()
 @click.option(
-    "--host", default="0.0.0.0", help="Host for the server to listen on.", envvar="HOST"
+    "--host",
+    default="0.0.0.0",
+    help="Host for the server to listen on.",
+    envvar=["LITELLM_HOST", "HOST"],
 )
-@click.option("--port", default=4000, help="Port to bind the server to.", envvar="PORT")
+@click.option(
+    "--port",
+    default=4000,
+    help="Port to bind the server to.",
+    envvar=["LITELLM_PORT", "PORT"],
+)
 @click.option(
     "--num_workers",
     default=DEFAULT_NUM_WORKERS_LITELLM_PROXY,
     help="Number of uvicorn / gunicorn workers to spin up. Default is 1 (from DEFAULT_NUM_WORKERS_LITELLM_PROXY)",
-    envvar="NUM_WORKERS",
+    envvar=["LITELLM_NUM_WORKERS", "NUM_WORKERS"],
 )
 @click.option("--api_base", default=None, help="API base URL.")
 @click.option(
@@ -487,7 +495,7 @@ class ProxyInitializationHelpers:
     is_flag=True,
     type=bool,
     help="To debug the input",
-    envvar="DEBUG",
+    envvar=["LITELLM_DEBUG", "DEBUG"],
 )
 @click.option(
     "--detailed_debug",
@@ -495,7 +503,7 @@ class ProxyInitializationHelpers:
     is_flag=True,
     type=bool,
     help="To view detailed debug logs",
-    envvar="DETAILED_DEBUG",
+    envvar=["LITELLM_DETAILED_DEBUG", "DETAILED_DEBUG"],
 )
 @click.option(
     "--use_queue",
@@ -605,14 +613,14 @@ class ProxyInitializationHelpers:
     default=None,
     type=str,
     help="Path to the SSL keyfile. Use this when you want to provide SSL certificate when starting proxy",
-    envvar="SSL_KEYFILE_PATH",
+    envvar=["LITELLM_SSL_KEYFILE_PATH", "SSL_KEYFILE_PATH"],
 )
 @click.option(
     "--ssl_certfile_path",
     default=None,
     type=str,
     help="Path to the SSL certfile. Use this when you want to provide SSL certificate when starting proxy",
-    envvar="SSL_CERTFILE_PATH",
+    envvar=["LITELLM_SSL_CERTFILE_PATH", "SSL_CERTFILE_PATH"],
 )
 @click.option(
     "--ciphers",
@@ -638,7 +646,7 @@ class ProxyInitializationHelpers:
     default=None,
     type=int,
     help="Set the uvicorn keepalive timeout in seconds (uvicorn timeout_keep_alive parameter)",
-    envvar="KEEPALIVE_TIMEOUT",
+    envvar=["LITELLM_KEEPALIVE_TIMEOUT", "KEEPALIVE_TIMEOUT"],
 )
 @click.option(
     "--timeout_worker_healthcheck",
@@ -649,21 +657,30 @@ class ProxyInitializationHelpers:
         "Requires uvicorn>=0.37.0. Only applies when running uvicorn directly with --num_workers>1; "
         "ignored under --run_gunicorn / --run_hypercorn."
     ),
-    envvar="TIMEOUT_WORKER_HEALTHCHECK",
+    envvar=[
+        "LITELLM_TIMEOUT_WORKER_HEALTHCHECK",
+        "TIMEOUT_WORKER_HEALTHCHECK",
+    ],
 )
 @click.option(
     "--max_requests_before_restart",
     default=None,
     type=int,
     help="Restart worker after this many requests (uvicorn: limit_max_requests, gunicorn: max_requests)",
-    envvar="MAX_REQUESTS_BEFORE_RESTART",
+    envvar=[
+        "LITELLM_MAX_REQUESTS_BEFORE_RESTART",
+        "MAX_REQUESTS_BEFORE_RESTART",
+    ],
 )
 @click.option(
     "--enforce_prisma_migration_check",
     is_flag=True,
     default=False,
     help="Exit with error if database migration fails on startup.",
-    envvar="ENFORCE_PRISMA_MIGRATION_CHECK",
+    envvar=[
+        "LITELLM_ENFORCE_PRISMA_MIGRATION_CHECK",
+        "ENFORCE_PRISMA_MIGRATION_CHECK",
+    ],
 )
 @click.option(
     "--use_v2_migration_resolver",

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -58,10 +58,6 @@ class LiteLLMCompletionTransformationHandler:
                 **kwargs,
             )
 
-        completion_args = {}
-        completion_args.update(kwargs)
-        completion_args.update(litellm_completion_request)
-
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
         ] = litellm.completion(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1115,6 +1115,7 @@ def responses(
                 stream=stream,
                 extra_headers=extra_headers,
                 extra_body=extra_body,
+                timeout=timeout or request_timeout,
                 **kwargs,
             )
 

--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -158,3 +158,39 @@ async def test_async_response_api_handler_merges_trace_id_without_error():
             assert (
                 mock_acompletion.call_args.kwargs["litellm_trace_id"] == "session-trace"
             )
+
+
+@pytest.mark.asyncio
+async def test_aresponses_forwards_timeout_to_acompletion():
+    """Regression test: timeout passed to aresponses() must reach acompletion()
+    on the completion transformation path (Anthropic, Bedrock, Vertex etc.).
+
+    Previously, `timeout` was a named param of `responses()` but was NOT
+    forwarded to `litellm_completion_transformation_handler.response_api_handler`,
+    so it was silently dropped — `Router(timeout=N)` was a no-op for Anthropic
+    and similar providers, with calls falling back to the provider SDK default
+    (~600s for Anthropic).
+    """
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value = ModelResponse(
+            id="id",
+            created=0,
+            model="anthropic/claude-sonnet-4-5",
+            object="chat.completion",
+            choices=[],
+        )
+
+        await litellm.aresponses(
+            model="anthropic/claude-sonnet-4-5",
+            input="hello",
+            timeout=42,
+            api_key="sk-ant-fake",
+        )
+
+    assert mock_acompletion.call_count == 1
+    forwarded_timeout = mock_acompletion.call_args.kwargs.get("timeout")
+    assert forwarded_timeout == 42, (
+        f"timeout was not forwarded to acompletion (got {forwarded_timeout!r}); "
+        "this means Router(timeout=N) silently fails for providers on the "
+        "completion transformation path."
+    )

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -131,6 +131,40 @@ class TestProxyInitializationHelpers:
             )
             assert args["timeout_worker_healthcheck"] == 15
 
+
+    def test_run_server_prefers_litellm_prefixed_envvars(self):
+        from litellm.proxy.proxy_cli import run_server
+
+        expected_envvars = {
+            "host": ["LITELLM_HOST", "HOST"],
+            "port": ["LITELLM_PORT", "PORT"],
+            "num_workers": ["LITELLM_NUM_WORKERS", "NUM_WORKERS"],
+            "debug": ["LITELLM_DEBUG", "DEBUG"],
+            "detailed_debug": ["LITELLM_DETAILED_DEBUG", "DETAILED_DEBUG"],
+            "ssl_keyfile_path": ["LITELLM_SSL_KEYFILE_PATH", "SSL_KEYFILE_PATH"],
+            "ssl_certfile_path": ["LITELLM_SSL_CERTFILE_PATH", "SSL_CERTFILE_PATH"],
+            "keepalive_timeout": ["LITELLM_KEEPALIVE_TIMEOUT", "KEEPALIVE_TIMEOUT"],
+            "timeout_worker_healthcheck": [
+                "LITELLM_TIMEOUT_WORKER_HEALTHCHECK",
+                "TIMEOUT_WORKER_HEALTHCHECK",
+            ],
+            "max_requests_before_restart": [
+                "LITELLM_MAX_REQUESTS_BEFORE_RESTART",
+                "MAX_REQUESTS_BEFORE_RESTART",
+            ],
+            "enforce_prisma_migration_check": [
+                "LITELLM_ENFORCE_PRISMA_MIGRATION_CHECK",
+                "ENFORCE_PRISMA_MIGRATION_CHECK",
+            ],
+        }
+
+        envvars_by_option = {
+            param.name: param.envvar for param in run_server.params if param.name
+        }
+
+        for option_name, envvars in expected_envvars.items():
+            assert envvars_by_option[option_name] == envvars
+
     def test_get_reload_options_no_config(self):
         opts = ProxyInitializationHelpers._get_reload_options(None)
         assert opts == {"reload": True}

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -7,7 +7,7 @@ import { columns } from "@/components/molecules/models/columns";
 import { getDisplayModelName } from "@/components/view_model/model_name_display";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import NotificationsManager from "@/components/molecules/notifications_manager";
-import { modelDeleteCall } from "@/components/networking";
+import { modelDeleteCall, modelPatchUpdateCall } from "@/components/networking";
 import { InfoCircleOutlined, SettingOutlined } from "@ant-design/icons";
 import { PaginationState, SortingState } from "@tanstack/react-table";
 import { useQueryClient } from "@tanstack/react-query";
@@ -217,6 +217,25 @@ const AllModelsTab = ({
     } finally {
       setDeleteLoading(false);
       setDeleteModalModelId(null);
+    }
+  };
+
+  const [pausingModelId, setPausingModelId] = useState<string | null>(null);
+
+  const handleTogglePause = async (modelId: string, blocked: boolean) => {
+    if (!accessToken) return;
+    try {
+      setPausingModelId(modelId);
+      await modelPatchUpdateCall(accessToken, { blocked }, modelId);
+      NotificationsManager.success(blocked ? "Model paused" : "Model resumed");
+      // invalidateQueries already schedules a refetch for active observers
+      // on this key — no need to also call refetchModels() (would double-fetch).
+      queryClient.invalidateQueries({ queryKey: ["models", "list"] });
+    } catch (error) {
+      console.error("Error toggling model pause state:", error);
+      NotificationsManager.fromBackend(error);
+    } finally {
+      setPausingModelId(null);
     }
   };
 
@@ -536,6 +555,8 @@ const AllModelsTab = ({
                 expandedRows,
                 setExpandedRows,
                 setDeleteModalModelId,
+                handleTogglePause,
+                pausingModelId,
               )}
               data={filteredData}
               isLoading={isLoadingModelsInfo}

--- a/ui/litellm-dashboard/src/components/model_dashboard/types.ts
+++ b/ui/litellm-dashboard/src/components/model_dashboard/types.ts
@@ -6,6 +6,7 @@ export interface ModelInfo {
   team_id: string;
   db_model: boolean;
   access_groups: string[] | null;
+  blocked?: boolean;
 }
 
 export interface LiteLLMParams {

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.test.tsx
@@ -944,4 +944,108 @@ describe("columns", () => {
     expect(screen.getByText("Out: $0.03")).toBeInTheDocument();
     expect(screen.queryByText(/In:/)).not.toBeInTheDocument();
   });
+
+  describe("pause/resume toggle", () => {
+    const renderWithToggle = (
+      overrides: Partial<ReturnType<typeof createMockModel>["model_info"]> = {},
+      togglePauseHandler?: ReturnType<typeof vi.fn>,
+      userRole: string = "Admin",
+    ) => {
+      const handler = togglePauseHandler ?? vi.fn();
+      const cols = columns(
+        userRole,
+        defaultProps.userID,
+        defaultProps.premiumUser,
+        defaultProps.setSelectedModelId,
+        defaultProps.setSelectedTeamId,
+        defaultProps.getDisplayModelName,
+        defaultProps.handleEditClick,
+        defaultProps.handleRefreshClick,
+        defaultProps.expandedRows,
+        defaultProps.setExpandedRows,
+        vi.fn(),
+        handler,
+      );
+      const model = createMockModel({
+        model_info: { ...createMockModel().model_info, ...overrides },
+      });
+      render(<TestTable data={[model]} columns={cols} />);
+      return { handler };
+    };
+
+    it("renders the toggle ON for a db_model that is not blocked", () => {
+      renderWithToggle({ db_model: true, blocked: false });
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeEnabled();
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("renders the toggle OFF for a db_model that is blocked", () => {
+      renderWithToggle({ db_model: true, blocked: true });
+      const toggle = screen.getByRole("switch", { name: /resume model/i });
+      expect(toggle).toBeEnabled();
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("calls the handler with blocked=true when an admin flips an active toggle off", async () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: true, blocked: false }, handler);
+      await userEvent.click(screen.getByRole("switch", { name: /pause model/i }));
+      expect(handler).toHaveBeenCalledWith("test-model-id", true);
+    });
+
+    it("calls the handler with blocked=false when an admin flips a paused toggle on", async () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: true, blocked: true }, handler);
+      await userEvent.click(screen.getByRole("switch", { name: /resume model/i }));
+      expect(handler).toHaveBeenCalledWith("test-model-id", false);
+    });
+
+    it("disables the toggle for non-admin users", () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: true, blocked: false }, handler, "User");
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeDisabled();
+    });
+
+    it("disables the toggle for config models", () => {
+      const handler = vi.fn();
+      renderWithToggle({ db_model: false, blocked: false }, handler, "Admin");
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeDisabled();
+    });
+
+    it("disables the toggle while a PATCH for the same row is in-flight", () => {
+      // Regression for Greptile P1 on PR #28151 — antd's `loading` prop is
+      // visual only and does not prevent click events, so the row needs to
+      // be explicitly disabled while its PATCH is pending to avoid
+      // racing/conflicting PATCH calls on double-click.
+      const handler = vi.fn();
+      const model = createMockModel({
+        model_info: {
+          ...createMockModel().model_info,
+          db_model: true,
+          blocked: false,
+        },
+      });
+      const cols = columns(
+        "Admin",
+        defaultProps.userID,
+        defaultProps.premiumUser,
+        defaultProps.setSelectedModelId,
+        defaultProps.setSelectedTeamId,
+        defaultProps.getDisplayModelName,
+        defaultProps.handleEditClick,
+        defaultProps.handleRefreshClick,
+        defaultProps.expandedRows,
+        defaultProps.setExpandedRows,
+        vi.fn(),
+        handler,
+        model.model_info.id, // pausingModelId matches this row
+      );
+      render(<TestTable data={[model]} columns={cols} />);
+      const toggle = screen.getByRole("switch", { name: /pause model/i });
+      expect(toggle).toBeDisabled();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
@@ -2,7 +2,7 @@ import { EditOutlined, InfoCircleOutlined, SyncOutlined } from "@ant-design/icon
 import { TrashIcon } from "@heroicons/react/outline";
 import { ColumnDef } from "@tanstack/react-table";
 import { Badge, Button, Icon } from "@tremor/react";
-import { Divider, Flex, Popover, Space, Tooltip, Typography } from "antd";
+import { Divider, Flex, Popover, Space, Switch, Tooltip, Typography } from "antd";
 import { ModelData } from "../../model_dashboard/types";
 import { ProviderLogo } from "./ProviderLogo";
 
@@ -53,6 +53,8 @@ export const columns = (
   expandedRows: Set<string>,
   setExpandedRows: (expandedRows: Set<string>) => void,
   onDeleteClick?: (modelId: string) => void,
+  onTogglePauseClick?: (modelId: string, blocked: boolean) => void | Promise<void>,
+  pausingModelId?: string | null,
 ): ColumnDef<ModelData>[] => [
     {
       header: () => <span className="text-sm font-semibold">Model ID</span>,
@@ -398,15 +400,47 @@ export const columns = (
     {
       id: "actions",
       header: () => <span className="text-sm font-semibold">Actions</span>,
-      size: 60,
-      minSize: 40,
+      size: 100,
+      minSize: 80,
       enableResizing: false,
       cell: ({ row }) => {
         const model = row.original;
         const canEditModel = userRole === "Admin" || model.model_info?.created_by === userID;
         const isConfigModel = !model.model_info?.db_model;
+        const isAdmin = userRole === "Admin";
+        const isBlocked = model.model_info?.blocked === true;
+        const isPauseToggleable = !isConfigModel && isAdmin && Boolean(onTogglePauseClick);
+        const pauseTooltip = isConfigModel
+          ? "Config models cannot be paused from the dashboard. Pause is DB-backed."
+          : !isAdmin
+            ? "Only proxy admins can pause or resume a model."
+            : isBlocked
+              ? "Resume model — restore normal routing."
+              : "Pause model — stop routing requests until resumed.";
+        // antd's `loading` prop on Switch is purely cosmetic — it does not block
+        // clicks. Pair `loading` with `disabled` derived from the same condition
+        // so a double-click during a pending PATCH cannot send a second,
+        // conflicting `blocked` value.
+        const isPausing = pausingModelId === model.model_info.id;
         return (
           <div className="flex items-center justify-end gap-2 pr-4">
+            <Tooltip title={pauseTooltip}>
+              <Switch
+                size="small"
+                checked={!isBlocked}
+                disabled={!isPauseToggleable || isPausing}
+                loading={isPausing}
+                aria-label={isBlocked ? "Resume model" : "Pause model"}
+                onClick={(_, e) => {
+                  e.stopPropagation();
+                }}
+                onChange={(nextChecked) => {
+                  if (isPauseToggleable && onTogglePauseClick) {
+                    void onTogglePauseClick(model.model_info.id, !nextChecked);
+                  }
+                }}
+              />
+            </Tooltip>
             {isConfigModel ? (
               <Tooltip title="Config model cannot be deleted on the dashboard. Please delete it from the config file.">
                 <Icon icon={TrashIcon} size="sm" className="opacity-50 cursor-not-allowed" />


### PR DESCRIPTION
## Summary
- add `LITELLM_*` aliases for the env-backed proxy CLI options
- keep the existing unprefixed names as fallbacks so current deployments keep working
- cover the env var ordering in `test_proxy_cli.py`

## Notes
`TIMEOUT_WORKER_HEALTHCHECK` was added after the issue was filed, so this updates the full current set of env-backed proxy flags rather than only the original ten.

## Testing
- `uv run --extra proxy --extra extra_proxy pytest tests/test_litellm/proxy/test_proxy_cli.py::TestProxyInitializationHelpers::test_run_server_prefers_litellm_prefixed_envvars -q`
- `uv run --extra proxy --extra extra_proxy pytest tests/test_litellm/proxy/test_proxy_cli.py -q` *(32 passed, 1 unrelated failure because `hypercorn` is not installed in this local env)*

Closes #27791
