### PR TITLE
fix(bedrock/cohere): send embedding_types as JSON array, not string

### DIFF
--- a/litellm/llms/bedrock/embed/cohere_transformation.py
+++ b/litellm/llms/bedrock/embed/cohere_transformation.py
@@ -22,7 +22,7 @@ class BedrockCohereEmbeddingConfig:
     ) -> dict:
         for k, v in non_default_params.items():
             if k == "encoding_format":
-                optional_params["embedding_types"] = v
+                optional_params["embedding_types"] = v if isinstance(v, list) else [v]
             elif k == "dimensions":
                 optional_params["output_dimension"] = v
         return optional_params

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -957,3 +957,50 @@ def test_titan_image_embedding_cost_uses_per_image_rate():
         assert response.usage is not None
         assert response.usage.prompt_tokens_details is not None
         assert response.usage.prompt_tokens_details.image_count == 1
+
+
+@pytest.mark.parametrize(
+    "encoding_format,expected_embedding_types",
+    [
+        ("float", ["float"]),
+        ("base64", ["base64"]),
+        (["float", "int8"], ["float", "int8"]),
+    ],
+)
+def test_bedrock_cohere_embedding_types_wrapped_as_list(
+    encoding_format, expected_embedding_types
+):
+    """
+    Bedrock Cohere expects `embedding_types` as a JSON array, not a raw string.
+
+    Regression test for: Bedrock returns
+        Malformed input request: #/embedding_types: expected type: JSONArray, found: String
+    when `encoding_format` is passed as a string.
+    """
+    litellm.set_verbose = True
+    client = HTTPHandler()
+    model = "bedrock/cohere.embed-multilingual-v3"
+
+    with patch.object(client, "post") as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(cohere_embedding_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model=model,
+            input=test_input,
+            encoding_format=encoding_format,
+            client=client,
+            aws_region_name="us-east-1",
+            aws_bedrock_runtime_endpoint="https://bedrock-runtime.us-east-1.amazonaws.com",
+            api_key="test-bearer-token-12345",
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+
+        request_body = json.loads(mock_post.call_args.kwargs.get("data", "{}"))
+        assert "embedding_types" in request_body
+        assert request_body["embedding_types"] == expected_embedding_types
+        assert isinstance(request_body["embedding_types"], list)


### PR DESCRIPTION
## Relevant issues

Bedrock Cohere embeddings fail with `encoding_format` set:

```
Malformed input request: #/embedding_types: expected type: JSONArray, found: String
```

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Screenshots / Proof of Fix

Repro before fix:

```
curl -X POST http://localhost:4000/embeddings \
  -H "Content-Type: application/json" \
  -d '{"model": "cohere.embed-multilingual-v3", "input": "test sentence", "encoding_format": "float"}'
# -> Malformed input request: #/embedding_types: expected type: JSONArray, found: String
```

After fix, request body to Bedrock contains:

```json
{"embedding_types": ["float"], ...}
```

New unit tests verify the wire format for `encoding_format="float"`, `"base64"`, and `["float", "int8"]`:

```
tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py::test_bedrock_cohere_embedding_types_wrapped_as_list[float-expected_embedding_types0] PASSED
tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py::test_bedrock_cohere_embedding_types_wrapped_as_list[base64-expected_embedding_types1] PASSED
tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py::test_bedrock_cohere_embedding_types_wrapped_as_list[encoding_format2-expected_embedding_types2] PASSED
```

## Type

🐛 Bug Fix

## Changes

`litellm/llms/bedrock/embed/cohere_transformation.py` — wrap `encoding_format` in a list when mapping to `embedding_types`, matching the behavior of `CohereEmbeddingConfig` in `litellm/llms/cohere/embed/transformation.py`:

```python
optional_params["embedding_types"] = v if isinstance(v, list) else [v]
```