### PR TITLE
fix: use >= in _team_max_budget_check (matches all other budget checks)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3694,7 +3694,7 @@ async def _team_max_budget_check(
             fallback_spend=team_object.spend or 0.0,
         )
 
-        if math.isfinite(team_object.max_budget) and spend > team_object.max_budget:
+        if math.isfinite(team_object.max_budget) and spend >= team_object.max_budget:
             if valid_token:
                 call_info = CallInfo(
                     token=valid_token.token,


### PR DESCRIPTION
## Summary

`_team_max_budget_check` used strict `>` comparison while every other budget enforcement check in `auth_checks.py` uses `>=`. This means a team at exactly its budget limit is not blocked on the next request.

**The bug:**

```python
# line ~2870 — was
if math.isfinite(team_object.max_budget) and spend > team_object.max_budget:

# fixed
if math.isfinite(team_object.max_budget) and spend >= team_object.max_budget:
```

**Inconsistency table before this fix:**

| Check | Operator |
|---|---|
| `_virtual_key_max_budget_check` | `>=` |
| team member budget check | `>=` |
| org budget check (`_org_max_budget_check`) | `>=` |
| tag budget check | `>` (separate issue) |
| **`_team_max_budget_check`** | **`>` ← was wrong** |

**Observable impact:**

- A team with `max_budget=10.0` and `spend=10.0` passes the check (`10.0 > 10.0` is `False`) and the next request is allowed through.
- Setting `max_budget=0` as a hard "no spend" block does nothing for teams (`0 > 0` is `False`), but correctly blocks keys (`0 >= 0` is `True`).

## Changes

Single character change in `litellm/proxy/auth/auth_checks.py`.

## Test plan

- [ ] Existing budget tests pass
- [ ] A team with `spend == max_budget` is blocked on next request
- [ ] A team with `spend < max_budget` is still allowed through
- [ ] `max_budget=0` correctly blocks teams

Fixes #28020
