### PR TITLE
fix: handle missing "text" field in Anthropic content_block_start to avoid KeyError

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -820,7 +820,7 @@ class ModelResponseIterator:
                     "type"
                 ]
                 if content_block_start["content_block"]["type"] == "text":
-                    text = content_block_start["content_block"]["text"]
+                    text = content_block_start["content_block"].get("text", "")
                 elif (
                     content_block_start["content_block"]["type"] == "tool_use"
                     or content_block_start["content_block"]["type"] == "server_tool_use"


### PR DESCRIPTION
Closing — duplicate of #28116 which already covers this fix. Thanks!