### PR TITLE
fix(vertex): remove spurious vertexai SDK guard from VertexAIPartnerModels.count_tokens

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
@@ -293,22 +293,6 @@ class VertexAIPartnerModels(VertexBase):
             Dict containing token count information
         """
         try:
-            import vertexai
-        except Exception as e:
-            raise VertexAIError(
-                status_code=400,
-                message=f"""vertexai import failed please run `pip install -U "google-cloud-aiplatform>=1.38"`. Got error: {e}""",
-            )
-
-        if not (
-            hasattr(vertexai, "preview") or hasattr(vertexai.preview, "language_models")
-        ):
-            raise VertexAIError(
-                status_code=400,
-                message="""Upgrade vertex ai. Run `pip install "google-cloud-aiplatform>=1.38"`""",
-            )
-
-        try:
             from litellm.llms.vertex_ai.vertex_ai_partner_models.count_tokens.handler import (
                 VertexAIPartnerModelsTokenCounter,
             )


### PR DESCRIPTION
## Summary

`/v1/messages/count_tokens` for Vertex AI Claude models fails with HTTP 500 on any proxy deployment that does not have `google-cloud-aiplatform` (the Gemini SDK) installed, even though the actual token counting works fine without it.

**Root cause:** `VertexAIPartnerModels.count_tokens()` opens with an `import vertexai` guard copied from other methods in the class. The guard raises `VertexAIError` if the SDK is absent. But `count_tokens` never actually calls any `vertexai.*` API — it delegates immediately to `VertexAIPartnerModelsTokenCounter.handle_count_tokens_request()`, which uses plain HTTPS via `httpx` to hit Vertex's publisher-specific count-tokens endpoint.

**Before:**

```python
async def count_tokens(self, model, messages, ...):
    try:
        import vertexai         # raises if google-cloud-aiplatform not installed
    except Exception as e:
        raise VertexAIError(status_code=400, message=f"vertexai import failed ...")

    if not (hasattr(vertexai, "preview") or ...):
        raise VertexAIError(...)  # also never needed

    try:
        from litellm.llms.vertex_ai.vertex_ai_partner_models.count_tokens.handler import (
            VertexAIPartnerModelsTokenCounter,
        )
        result = await VertexAIPartnerModelsTokenCounter().handle_count_tokens_request(...)
```

**After:** Remove the `import vertexai` block entirely — the `VertexAIPartnerModelsTokenCounter` handles its own HTTP auth without the SDK.

## Impact

- All other Vertex AI Claude routes (`/v1/messages`, streaming, tool calls, vision) already work without `google-cloud-aiplatform` because they use the same HTTP path.
- `count_tokens` was the only exception, due to the copy-pasted guard.
- No behavioral change for deployments that do have `google-cloud-aiplatform` installed.

## Test plan

- [ ] `POST /v1/messages/count_tokens` for a `vertex_ai` Claude model returns token count without `google-cloud-aiplatform` installed
- [ ] `POST /v1/messages/count_tokens` continues to work when `google-cloud-aiplatform` is installed
- [ ] All existing Vertex AI tests pass

Fixes #28084
