### PR TITLE
vcr-cache: zstd compression, CircleCI L1 cache, S3/R2 backend, header trims

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,47 @@ commands:
           paths:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
+  restore_vcr_l1_cache:
+    description: |
+      Restore the local-disk VCR L1 cassette cache (read-through layer in
+      front of Redis/R2). Most cassette reads on a re-run never reach the
+      remote store, which is what cuts Redis Cloud bandwidth.
+      Cache key includes the parallelism node index so each xdist shard
+      restores its own slice; falls back to the same shard on `main`,
+      and finally to the index-0 shard so freshly-spawned shards still
+      get a warm starting point.
+    parameters:
+      cache_dir:
+        type: string
+        default: ".vcr-l1-cache"
+    steps:
+      - restore_cache:
+          keys:
+            - vcr-l1-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ .Branch }}-{{ .Revision }}
+            - vcr-l1-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ .Branch }}-
+            - vcr-l1-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-main-
+            - vcr-l1-v1-{{ .Environment.CIRCLE_JOB }}-0-main-
+      - run:
+          name: "Configure VCR L1 cache directory"
+          command: |
+            mkdir -p "<< parameters.cache_dir >>"
+            echo "export CASSETTE_LOCAL_CACHE_DIR=$(pwd)/<< parameters.cache_dir >>" >> "$BASH_ENV"
+  save_vcr_l1_cache:
+    description: |
+      Persist the local-disk VCR L1 cassette cache so the next run on the
+      same branch (or the next run on `main`) starts warm. `when: always`
+      because cassettes for tests that *did* pass are still worth keeping
+      even if other tests in the same job failed.
+    parameters:
+      cache_dir:
+        type: string
+        default: ".vcr-l1-cache"
+    steps:
+      - save_cache:
+          paths:
+            - << parameters.cache_dir >>
+          key: vcr-l1-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ .Branch }}-{{ .Revision }}
+          when: always
 
 jobs:
   # Add Windows testing job
@@ -215,6 +256,7 @@ jobs:
             ./docker/entrypoint.sh
             set -e
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests (Part 1 - A-M)
           command: |
@@ -237,6 +279,7 @@ jobs:
                 --timeout=300 \
                 --timeout_method=thread"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -280,6 +323,7 @@ jobs:
             ./docker/entrypoint.sh
             set -e
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests (Part 2 - N-Z)
           command: |
@@ -302,6 +346,7 @@ jobs:
                 --timeout=300 \
                 --timeout_method=thread"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -347,6 +392,7 @@ jobs:
             set -e
 
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -361,6 +407,7 @@ jobs:
                 -k \"langfuse\""
           no_output_timeout: 15m
       # Store test results
+      - save_vcr_l1_cache
       - store_test_results:
           path: test-results
   auth_ui_unit_tests:
@@ -452,6 +499,7 @@ jobs:
           key: v1-uv-cache-{{ checksum "uv.lock" }}
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -469,6 +517,7 @@ jobs:
                 --timeout=300 --timeout_method=thread"
           no_output_timeout: 15m
       # Store test results
+      - save_vcr_l1_cache
       - store_test_results:
           path: test-results
 
@@ -495,6 +544,7 @@ jobs:
           key: v1-uv-cache-{{ checksum "uv.lock" }}
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -509,6 +559,7 @@ jobs:
                 --durations=5 \
                 -n 4"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -538,6 +589,7 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -552,6 +604,7 @@ jobs:
                 -k \"assistants\""
           no_output_timeout: 15m
       # Store test results
+      - save_vcr_l1_cache
       - store_test_results:
           path: test-results
   llm_translation_testing:
@@ -576,6 +629,7 @@ jobs:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -598,6 +652,7 @@ jobs:
           no_output_timeout: 15m
 
       # Store test results
+      - save_vcr_l1_cache
       - store_test_results:
           path: test-results
   realtime_translation_testing:
@@ -614,6 +669,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run realtime tests
           command: |
@@ -631,6 +687,7 @@ jobs:
                 -n 4 \
                 --timeout=120 --timeout_method=thread"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -700,6 +757,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -716,6 +774,7 @@ jobs:
                 -n 2 \
                 --timeout=120 --timeout_method=thread"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -745,6 +804,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -759,6 +819,7 @@ jobs:
                 --durations=5 \
                 --retries 3 --retry-delay 5"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -796,6 +857,7 @@ jobs:
             - ~/.cache/uv
           key: v1-uv-cache-{{ checksum "uv.lock" }}
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -811,6 +873,7 @@ jobs:
           no_output_timeout: 15m
 
       # Store test results
+      - save_vcr_l1_cache
       - store_test_results:
           path: test-results
   ocr_testing:
@@ -827,6 +890,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -841,6 +905,7 @@ jobs:
                 --durations=5 \
                 -n 4"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -869,6 +934,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -883,6 +949,7 @@ jobs:
                 --durations=5 \
                 -n 4"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -985,6 +1052,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -999,6 +1067,7 @@ jobs:
                 --durations=5 \
                 -n 2"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -1028,6 +1097,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -1042,6 +1112,7 @@ jobs:
                 --durations=5 \
                 -n 4"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -1071,6 +1142,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -1085,6 +1157,7 @@ jobs:
                 -n 4"
           no_output_timeout: 15m
       # Store test results
+      - save_vcr_l1_cache
       - store_test_results:
           path: test-results
   logging_testing:
@@ -1102,6 +1175,7 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -1118,6 +1192,7 @@ jobs:
                 --durations=5 \
                 --timeout=120 --timeout_method=thread"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |
@@ -1146,6 +1221,7 @@ jobs:
           command: |
             uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
+      - restore_vcr_l1_cache
       - run:
           name: Run tests
           command: |
@@ -1159,6 +1235,7 @@ jobs:
                 --junitxml=test-results/junit.xml \
                 --durations=5"
           no_output_timeout: 15m
+      - save_vcr_l1_cache
       - run:
           name: Rename the coverage files
           command: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,14 @@ dev = [
     "pytest-timeout==2.4.0",
     "vcrpy==8.1.1",
     "pytest-recording==0.13.4",
+    # Compresses the VCR cassette payloads stored in the test cache
+    # backends. Default-on, with magic-byte sniffing on read so legacy
+    # uncompressed cassettes still load.
+    "zstandard==0.25.0",
+    # Optional cassette backend (S3 / Cloudflare R2). The persister
+    # imports this lazily so it is only required when CASSETTE_S3_BUCKET
+    # is set; pinning it in dev keeps test environments reproducible.
+    "boto3==1.43.1",
 ]
 proxy-dev = [
     "prisma==0.11.0",

--- a/tests/_flush_vcr_cache.py
+++ b/tests/_flush_vcr_cache.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 
-import redis
+from tests._vcr_redis_persister import (
+    CASSETTE_LOCAL_CACHE_DIR_ENV,
+    CASSETTE_REDIS_URL_ENV,
+    CASSETTE_S3_BUCKET_ENV,
+    CASSETTE_S3_ENDPOINT_ENV,
+    CASSETTE_S3_REGION_ENV,
+    REDIS_KEY_PREFIX,
+    _local_cache_dir_from_env,
+    _maybe_build_redis_client,
+    _redis_url_from_env,
+    _s3_bucket_from_env,
+)
 
-from tests._vcr_redis_persister import CASSETTE_REDIS_URL_ENV, _redis_url_from_env
-
-PREFIX = "litellm:vcr:cassette:"
+PREFIX = REDIS_KEY_PREFIX
 SCAN_BATCH = 500
 
 
-def _client() -> redis.Redis:
-    url = _redis_url_from_env()
-    if not url:
-        sys.exit(f"Set {CASSETTE_REDIS_URL_ENV} to flush the VCR cache")
-    return redis.Redis.from_url(
-        url,
-        socket_timeout=5,
-        socket_connect_timeout=5,
-        decode_responses=False,
-    )
-
-
-def main() -> None:
-    client = _client()
+def _flush_redis() -> int:
+    client = _maybe_build_redis_client()
+    if client is None:
+        return 0
     deleted = 0
     pipeline = client.pipeline(transaction=False)
     pending = 0
@@ -37,7 +37,64 @@ def main() -> None:
             pending = 0
     if pending:
         deleted += sum(pipeline.execute())
-    print(f"Deleted {deleted} VCR cassette key(s) under {PREFIX!r}")
+    print(f"Deleted {deleted} VCR cassette key(s) from Redis under {PREFIX!r}")
+    return deleted
+
+
+def _flush_s3() -> int:
+    bucket = _s3_bucket_from_env()
+    if not bucket:
+        return 0
+    try:
+        import boto3
+        from botocore.config import Config
+    except ImportError as exc:
+        sys.exit(f"boto3 is required to flush the S3 cassette cache: {exc}")
+    client = boto3.client(
+        "s3",
+        endpoint_url=os.environ.get(CASSETTE_S3_ENDPOINT_ENV) or None,
+        region_name=os.environ.get(CASSETTE_S3_REGION_ENV) or "auto",
+        config=Config(s3={"addressing_style": "path"}),
+    )
+    paginator = client.get_paginator("list_objects_v2")
+    deleted = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=PREFIX):
+        contents = page.get("Contents") or []
+        if not contents:
+            continue
+        objects = [{"Key": obj["Key"]} for obj in contents]
+        # delete_objects accepts up to 1000 keys per request.
+        for i in range(0, len(objects), 1000):
+            chunk = objects[i : i + 1000]
+            resp = client.delete_objects(Bucket=bucket, Delete={"Objects": chunk})
+            deleted += len(resp.get("Deleted", []))
+    print(f"Deleted {deleted} VCR cassette object(s) from S3 bucket {bucket!r}")
+    return deleted
+
+
+def _flush_local() -> int:
+    cache_dir = _local_cache_dir_from_env()
+    if not cache_dir or not os.path.isdir(cache_dir):
+        return 0
+    count = 0
+    for root, _dirs, files in os.walk(cache_dir):
+        count += len(files)
+    shutil.rmtree(cache_dir, ignore_errors=True)
+    print(f"Deleted {count} VCR cassette file(s) from local cache {cache_dir!r}")
+    return count
+
+
+def main() -> None:
+    if not (
+        _redis_url_from_env() or _s3_bucket_from_env() or _local_cache_dir_from_env()
+    ):
+        sys.exit(
+            f"Set {CASSETTE_REDIS_URL_ENV}, {CASSETTE_S3_BUCKET_ENV}, or "
+            f"{CASSETTE_LOCAL_CACHE_DIR_ENV} to flush a VCR cache."
+        )
+    _flush_redis()
+    _flush_s3()
+    _flush_local()
 
 
 if __name__ == "__main__":

--- a/tests/_vcr_conftest_common.py
+++ b/tests/_vcr_conftest_common.py
@@ -24,7 +24,7 @@ from tests._vcr_redis_persister import (
     cassette_cache_capacity_snapshot,
     cassette_cache_health,
     filter_non_2xx_response,
-    make_redis_persister,
+    make_persister,
     mark_test_outcome_for_cassette,
     patch_vcrpy_aiohttp_record_path,
 )
@@ -122,7 +122,11 @@ FILTERED_REQUEST_HEADERS = (
     "authorization",
     "x-api-key",
     "anthropic-api-key",
-    "anthropic-version",
+    # ``anthropic-version`` is intentionally NOT filtered: it isn't a
+    # secret, it's tiny (~30 bytes), and a few tests parametrize over
+    # different beta versions — keeping it in the cassette lets the
+    # safe_body matcher distinguish those parametrizations rather than
+    # collapsing them onto one shared episode.
     "openai-api-key",
     "azure-api-key",
     "api-key",
@@ -136,16 +140,60 @@ FILTERED_REQUEST_HEADERS = (
     "x-goog-user-project",
 )
 
+# Explicit names always stripped from cassette responses. Provider-specific
+# noise (request ids, server-side trace ids, etc.) which no test asserts on.
 FILTERED_RESPONSE_HEADERS = (
     "set-cookie",
     "x-request-id",
     "request-id",
     "cf-ray",
+    "cf-cache-status",
+    "cf-mitigated",
     "anthropic-organization-id",
     "openai-organization",
+    "openai-processing-ms",
+    "openai-version",
     "x-amzn-requestid",
     "x-amzn-trace-id",
+    "x-amzn-remapped-content-length",
+    "x-amzn-remapped-host",
     "date",
+    "expires",
+    "age",
+    "via",
+    "server",
+    "alt-svc",
+    "strict-transport-security",
+    "nel",
+    "report-to",
+    "reporting-endpoints",
+    "vary",
+    "x-content-type-options",
+    "x-frame-options",
+    "x-xss-protection",
+    "referrer-policy",
+    "permissions-policy",
+)
+
+# Prefix-based blocklist for whole header families that show up in 10+
+# variants per response and that no test asserts on. Trims significantly
+# more bytes per cassette than the explicit list could without an
+# unmaintainable enumeration. Each prefix is matched case-insensitively.
+FILTERED_RESPONSE_HEADER_PREFIXES = (
+    "x-amz-",  # AWS/Bedrock metadata: x-amz-id-2, x-amz-server-side-encryption, etc.
+    "x-amzn-",
+    "x-google-",
+    "x-vertex-",
+    "x-goog-",
+    "x-envoy-",
+    "x-cloud-trace-",
+    "x-firefox-",
+    "x-ms-",  # Azure response metadata.
+    "anthropic-ratelimit-",  # 7+ verbose rate-limit headers per response.
+    "openai-ratelimit-",
+    "x-ratelimit-",
+    "x-stainless-",
+    "cf-",
 )
 
 # Tiny placeholder used to replace base64 image payloads in cassettes.
@@ -192,7 +240,10 @@ def _scrub_response(response):
     headers = response.get("headers") or {}
     if isinstance(headers, dict):
         for header in list(headers):
-            if header.lower() in FILTERED_RESPONSE_HEADERS:
+            lower = header.lower()
+            if lower in FILTERED_RESPONSE_HEADERS or any(
+                lower.startswith(prefix) for prefix in FILTERED_RESPONSE_HEADER_PREFIXES
+            ):
                 headers.pop(header, None)
     return response
 
@@ -672,7 +723,9 @@ def vcr_config_dict() -> dict:
 def vcr_disabled() -> bool:
     if os.environ.get("LITELLM_VCR_DISABLE") == "1":
         return True
-    return not os.environ.get("CASSETTE_REDIS_URL")
+    return not (
+        os.environ.get("CASSETTE_REDIS_URL") or os.environ.get("CASSETTE_S3_BUCKET")
+    )
 
 
 _atexit_banner_registered = False
@@ -722,7 +775,7 @@ def register_persister_if_enabled(vcr) -> None:
     """Call from ``pytest_recording_configure(config, vcr)`` in each conftest."""
     if vcr_disabled():
         return
-    vcr.register_persister(make_redis_persister())
+    vcr.register_persister(make_persister())
     vcr.register_matcher(SAFE_BODY_MATCHER_NAME, _safe_body_matcher)
     vcr.register_matcher(KEY_FINGERPRINT_MATCHER_NAME, _key_fingerprint_matcher)
     patch_vcrpy_aiohttp_record_path()

--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
+import tempfile
+import time
 import warnings
-from typing import Any, Optional
+from typing import Any, Optional, Protocol
 
 from vcr.persisters.filesystem import CassetteNotFoundError
 from vcr.serialize import deserialize, serialize
@@ -11,8 +14,22 @@ from vcr.serialize import deserialize, serialize
 CASSETTE_TTL_SECONDS = 24 * 60 * 60
 REDIS_KEY_PREFIX = "litellm:vcr:cassette:"
 CASSETTE_REDIS_URL_ENV = "CASSETTE_REDIS_URL"
+CASSETTE_S3_BUCKET_ENV = "CASSETTE_S3_BUCKET"
+CASSETTE_S3_ENDPOINT_ENV = "CASSETTE_S3_ENDPOINT"
+CASSETTE_S3_REGION_ENV = "CASSETTE_S3_REGION"
+CASSETTE_LOCAL_CACHE_DIR_ENV = "CASSETTE_LOCAL_CACHE_DIR"
+CASSETTE_DISABLE_COMPRESSION_ENV = "CASSETTE_DISABLE_COMPRESSION"
 VCR_VERBOSE_ENV = "LITELLM_VCR_VERBOSE"
 MAX_EPISODES_PER_CASSETTE = 50
+
+# zstd standard frame magic. We rely on this to discriminate at load time
+# between legacy uncompressed YAML (which never starts with these four
+# bytes — YAML cassettes always begin with "!!python/object" or
+# "interactions:") and freshly compressed payloads. That keeps the
+# rollout backward compatible with any cassettes already cached as raw
+# YAML when this code first ships.
+_ZSTD_FRAME_MAGIC = b"\x28\xb5\x2f\xfd"
+_ZSTD_COMPRESSION_LEVEL = 10
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -21,7 +38,7 @@ _passed_by_cassette_key: dict[str, bool] = {}
 
 
 class VCRCassetteCacheWarning(UserWarning):
-    """Emitted when the cassette Redis cache fails to load or save.
+    """Emitted when the cassette cache fails to load or save.
 
     Surfaced in pytest's session-end warnings summary so failures are
     visible in CI logs even when the underlying tests pass.
@@ -65,10 +82,15 @@ def cassette_cache_capacity_snapshot(client: Optional[Any] = None) -> Optional[d
     Returns ``None`` if Redis is unreachable, the server didn't report
     ``maxmemory``, or ``maxmemory`` is 0 (uncapped). Best-effort: any
     exception turns into ``None`` so this never breaks a test session.
+
+    Only meaningful for the Redis backend; the S3/R2 backend has no
+    fixed capacity ceiling so this returns ``None`` there too.
     """
     try:
         if client is None:
-            client = _build_default_client()
+            client = _maybe_build_redis_client()
+            if client is None:
+                return None
         info = client.info(section="memory")
     except Exception:  # pragma: no cover - best-effort probe
         return None
@@ -93,6 +115,11 @@ def mark_test_outcome_for_cassette(cassette_path: str, passed: bool) -> None:
 
 
 def redis_key_for(cassette_path: str) -> str:
+    """Return the canonical cassette key used by every backend.
+
+    The name is preserved for backward compatibility — see
+    :func:`cassette_key_for` for the alias used by new call sites.
+    """
     abs_path = os.path.abspath(str(cassette_path))
     try:
         rel = os.path.relpath(abs_path, start=_REPO_ROOT)
@@ -104,24 +131,95 @@ def redis_key_for(cassette_path: str) -> str:
     return f"{REDIS_KEY_PREFIX}{rel}"
 
 
+cassette_key_for = redis_key_for
+
+
 def _redis_url_from_env() -> Optional[str]:
     return os.environ.get(CASSETTE_REDIS_URL_ENV) or None
 
 
-def _build_default_client():
-    import redis
-    from redis.backoff import ExponentialBackoff
-    from redis.exceptions import ConnectionError as RedisConnectionError
-    from redis.exceptions import TimeoutError as RedisTimeoutError
-    from redis.retry import Retry
+def _s3_bucket_from_env() -> Optional[str]:
+    return os.environ.get(CASSETTE_S3_BUCKET_ENV) or None
 
+
+def _local_cache_dir_from_env() -> Optional[str]:
+    return os.environ.get(CASSETTE_LOCAL_CACHE_DIR_ENV) or None
+
+
+def _compression_disabled() -> bool:
+    return os.environ.get(CASSETTE_DISABLE_COMPRESSION_ENV) == "1"
+
+
+# ---------------------------------------------------------------------------
+# Compression: zstd with magic-byte sniffing for legacy cassettes.
+# ---------------------------------------------------------------------------
+
+
+def _compress(payload: bytes) -> bytes:
+    """Compress ``payload`` with zstd. Idempotent on already-compressed input.
+
+    YAML cassettes are extremely repetitive (JSON-in-string bodies, SSE
+    chunk headers, repeated header keys) and routinely shrink 6-12x.
+    The compressed bytes start with the zstd frame magic, which the
+    YAML serializer never emits, so :func:`_decompress` can sniff the
+    format on load without a separate metadata key.
+    """
+    if payload.startswith(_ZSTD_FRAME_MAGIC):
+        return payload
+    if _compression_disabled():
+        return payload
+    try:
+        import zstandard  # type: ignore[import-not-found]
+    except ImportError:  # pragma: no cover - dev dependency
+        return payload
+    return zstandard.ZstdCompressor(level=_ZSTD_COMPRESSION_LEVEL).compress(payload)
+
+
+def _decompress(payload: bytes) -> bytes:
+    """Decompress zstd-framed payloads; pass legacy bytes through unchanged.
+
+    The frame-magic check means we can roll this out without flushing
+    the existing Redis cache: payloads written before this change start
+    with ``"!!python/object"`` (or ``"interactions:"``) — neither of
+    which collides with ``b"\\x28\\xb5\\x2f\\xfd"`` — and load as-is.
+    """
+    if not payload.startswith(_ZSTD_FRAME_MAGIC):
+        return payload
+    try:
+        import zstandard  # type: ignore[import-not-found]
+    except ImportError:  # pragma: no cover - dev dependency
+        raise
+    return zstandard.ZstdDecompressor().decompress(payload)
+
+
+# ---------------------------------------------------------------------------
+# Backends: Redis (legacy) and S3/R2 (zero-egress alternative).
+# ---------------------------------------------------------------------------
+
+
+class CassetteBackend(Protocol):
+    """Pluggable cassette store. Implementations only deal in raw bytes."""
+
+    name: str
+    save_error_types: tuple
+
+    def get(self, key: str) -> Optional[bytes]: ...
+
+    def set(self, key: str, payload: bytes, ttl_seconds: int) -> None: ...
+
+
+def _maybe_build_redis_client() -> Optional[Any]:
     url = _redis_url_from_env()
     if not url:
-        raise RuntimeError(
-            f"Set {CASSETTE_REDIS_URL_ENV} to enable the VCR persister. "
-            "Cassette Redis is intentionally separate from the application "
-            "Redis (REDIS_URL/REDIS_HOST) to avoid being flushed by tests."
-        )
+        return None
+    try:
+        import redis
+        from redis.backoff import ExponentialBackoff
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+        from redis.retry import Retry
+    except ImportError:  # pragma: no cover - redis is a hard test dep
+        return None
     return redis.Redis.from_url(
         url,
         socket_timeout=5,
@@ -132,26 +230,300 @@ def _build_default_client():
     )
 
 
-def make_redis_persister(
-    client: Optional[Any] = None,
+def _build_default_client():
+    """Backward-compat shim used by the legacy ``make_redis_persister``."""
+    client = _maybe_build_redis_client()
+    if client is None:
+        raise RuntimeError(
+            f"Set {CASSETTE_REDIS_URL_ENV} to enable the VCR persister. "
+            "Cassette Redis is intentionally separate from the application "
+            "Redis (REDIS_URL/REDIS_HOST) to avoid being flushed by tests."
+        )
+    return client
+
+
+class _RedisBackend:
+    name = "redis"
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        try:
+            from redis.exceptions import RedisError
+        except ImportError:  # pragma: no cover - redis is a hard test dep
+            RedisError = Exception  # type: ignore[assignment,misc]
+        self.save_error_types = (RedisError,)
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self._client.get(key)
+
+    def set(self, key: str, payload: bytes, ttl_seconds: int) -> None:
+        self._client.set(key, payload, ex=ttl_seconds)
+
+    def info_memory(self):
+        return self._client.info(section="memory")
+
+
+class _S3Backend:
+    """S3-compatible object store backend. Works with AWS S3, Cloudflare
+    R2, Backblaze B2, MinIO, etc.
+
+    TTL is enforced on read by checking the object's ``LastModified``
+    timestamp; objects older than ``ttl_seconds`` are treated as cache
+    misses so the test re-records and re-uploads. Bucket lifecycle
+    rules should be configured separately to actually evict the bytes
+    (otherwise reads succeed-but-treat-as-miss until the lifecycle
+    sweep runs). With Cloudflare R2, this pattern means storage stays
+    near-zero cost, no egress fees on cassette reads, and the soft
+    TTL semantics match the original Redis persister.
+    """
+
+    name = "s3"
+
+    def __init__(self, client: Any, bucket: str) -> None:
+        self._client = client
+        self._bucket = bucket
+        try:
+            from botocore.exceptions import ClientError
+        except ImportError:  # pragma: no cover - boto3 is a dev dep
+            ClientError = Exception  # type: ignore[assignment,misc]
+        self._client_error = ClientError
+        self.save_error_types = (ClientError, OSError)
+
+    def get(self, key: str) -> Optional[bytes]:
+        try:
+            obj = self._client.get_object(Bucket=self._bucket, Key=key)
+        except self._client_error as exc:
+            code = self._error_code(exc)
+            if code in {"NoSuchKey", "404", "NotFound"}:
+                return None
+            raise
+        last_modified = obj.get("LastModified")
+        if last_modified is not None:
+            try:
+                age = time.time() - last_modified.timestamp()
+            except (AttributeError, TypeError):  # pragma: no cover - defensive
+                age = 0.0
+            if age > CASSETTE_TTL_SECONDS:
+                return None
+        body = obj["Body"].read()
+        return body if isinstance(body, (bytes, bytearray)) else bytes(body)
+
+    def set(self, key: str, payload: bytes, ttl_seconds: int) -> None:
+        # ttl_seconds is unused on the write path — the bucket's
+        # lifecycle policy plus the read-side age check enforce TTL.
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=payload)
+
+    @staticmethod
+    def _error_code(exc: BaseException) -> str:
+        response = getattr(exc, "response", None)
+        if isinstance(response, dict):
+            err = response.get("Error", {})
+            if isinstance(err, dict):
+                return str(err.get("Code", "")) or ""
+        return ""
+
+
+def _maybe_build_s3_backend() -> Optional[_S3Backend]:
+    bucket = _s3_bucket_from_env()
+    if not bucket:
+        return None
+    try:
+        import boto3  # type: ignore[import-not-found]
+        from botocore.config import Config  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - dev dependency
+        warnings.warn(
+            f"{CASSETTE_S3_BUCKET_ENV} is set but boto3 is not installed: {exc}",
+            VCRCassetteCacheWarning,
+            stacklevel=2,
+        )
+        return None
+    endpoint = os.environ.get(CASSETTE_S3_ENDPOINT_ENV) or None
+    region = os.environ.get(CASSETTE_S3_REGION_ENV) or "auto"
+    config = Config(
+        retries={"max_attempts": 3, "mode": "standard"},
+        connect_timeout=5,
+        read_timeout=10,
+        # R2 requires path-style addressing; AWS S3 accepts it too.
+        s3={"addressing_style": "path"},
+    )
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        region_name=region,
+        config=config,
+    )
+    return _S3Backend(client=client, bucket=bucket)
+
+
+# ---------------------------------------------------------------------------
+# Local-disk L1 cache. Wraps any backend and is read-through / write-through.
+# CircleCI's `restore_cache` / `save_cache` mounts the directory across runs
+# so most replays never touch the remote backend at all.
+# ---------------------------------------------------------------------------
+
+
+class _LocalDiskL1Cache:
+    name = "disk-l1"
+
+    def __init__(
+        self,
+        base_dir: str,
+        inner: CassetteBackend,
+        ttl_seconds: int = CASSETTE_TTL_SECONDS,
+    ) -> None:
+        self._base = os.path.abspath(base_dir)
+        self._inner = inner
+        self._ttl = ttl_seconds
+        os.makedirs(self._base, exist_ok=True)
+        # Inherit the inner backend's exception classification so the
+        # persister's best-effort ``except`` block still catches remote
+        # failures even when L1 is in front.
+        self.save_error_types = tuple(
+            set(getattr(inner, "save_error_types", (Exception,))) | {OSError}
+        )
+
+    def _path_for(self, key: str) -> str:
+        # Hash the full key to avoid filesystem-illegal characters and
+        # path-length issues on Windows / shallow filesystems. Two-byte
+        # shard prefix keeps any single directory under ~256 entries on
+        # average — friendly to ``ls`` and to CircleCI cache restore.
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return os.path.join(self._base, digest[:2], digest)
+
+    def get(self, key: str) -> Optional[bytes]:
+        path = self._path_for(key)
+        try:
+            stat = os.stat(path)
+        except FileNotFoundError:
+            return self._fall_through(key, path)
+        except OSError as exc:
+            _log.debug("L1 stat failed for %s: %s", path, exc)
+            return self._fall_through(key, path)
+        if (time.time() - stat.st_mtime) > self._ttl:
+            return self._fall_through(key, path)
+        try:
+            with open(path, "rb") as f:
+                return f.read()
+        except OSError as exc:
+            _log.debug("L1 read failed for %s: %s", path, exc)
+            return self._fall_through(key, path)
+
+    def _fall_through(self, key: str, path: str) -> Optional[bytes]:
+        data = self._inner.get(key)
+        if data is not None:
+            self._write_through(path, data)
+        return data
+
+    def set(self, key: str, payload: bytes, ttl_seconds: int) -> None:
+        # Write to the remote first — the local copy is only useful if
+        # the same payload is accessible to other shards via the remote
+        # store. If the remote write fails, the persister's outer
+        # ``except`` clause handles it; we still update L1 so the
+        # current process at least has a consistent local view.
+        try:
+            self._inner.set(key, payload, ttl_seconds)
+        finally:
+            self._write_through(self._path_for(key), payload)
+
+    def info_memory(self):
+        # Forward the capacity probe through to the remote backend so
+        # the existing health banner keeps reporting Redis usage.
+        inner_probe = getattr(self._inner, "info_memory", None)
+        if callable(inner_probe):
+            return inner_probe()
+        return {}
+
+    @staticmethod
+    def _write_through(path: str, payload: bytes) -> None:
+        directory = os.path.dirname(path)
+        try:
+            os.makedirs(directory, exist_ok=True)
+            # Atomic-ish write: tmp + rename so a crashed CI run never
+            # leaves a half-written file that the next run misreads as
+            # a cache hit. tempfile.mkstemp is on the same filesystem
+            # so rename is atomic.
+            fd, tmp = tempfile.mkstemp(prefix=".vcrtmp", dir=directory)
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    f.write(payload)
+                os.replace(tmp, path)
+            except OSError:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError as exc:
+            _log.debug("L1 write-through failed for %s: %s", path, exc)
+
+
+def _select_remote_backend() -> CassetteBackend:
+    """Pick a remote backend based on env vars. S3 takes precedence
+    because it's the cheaper option once configured.
+    """
+    s3_backend = _maybe_build_s3_backend()
+    if s3_backend is not None:
+        return s3_backend
+    redis_client = _maybe_build_redis_client()
+    if redis_client is not None:
+        return _RedisBackend(client=redis_client)
+    raise RuntimeError(
+        f"No cassette backend configured. Set {CASSETTE_S3_BUCKET_ENV} for "
+        f"S3/R2 or {CASSETTE_REDIS_URL_ENV} for Redis. The cassette store is "
+        "intentionally separate from the application's Redis "
+        "(REDIS_URL/REDIS_HOST) to avoid being flushed by tests."
+    )
+
+
+def _maybe_layer_l1(backend: CassetteBackend) -> CassetteBackend:
+    cache_dir = _local_cache_dir_from_env()
+    if not cache_dir:
+        return backend
+    try:
+        return _LocalDiskL1Cache(cache_dir, backend)
+    except OSError as exc:
+        warnings.warn(
+            f"Failed to initialize VCR L1 cache at {cache_dir!r}: {exc}",
+            VCRCassetteCacheWarning,
+            stacklevel=2,
+        )
+        return backend
+
+
+# ---------------------------------------------------------------------------
+# Persister factory.
+# ---------------------------------------------------------------------------
+
+
+def make_persister(
+    backend: Optional[CassetteBackend] = None,
     ttl_seconds: int = CASSETTE_TTL_SECONDS,
 ):
-    redis_client = client if client is not None else _build_default_client()
+    """Build a vcrpy persister wired to the configured backend.
 
-    try:
-        from redis.exceptions import RedisError
-    except ImportError:  # pragma: no cover - redis is a hard test dep
-        RedisError = Exception  # type: ignore[assignment,misc]
+    Selection rules:
 
-    class _RedisPersister:
+    1. If an explicit ``backend`` is passed, use it (mainly for tests).
+    2. If ``CASSETTE_S3_BUCKET`` is set, use the S3/R2 backend.
+    3. Otherwise fall back to the Redis backend.
+    4. If ``CASSETTE_LOCAL_CACHE_DIR`` is set, layer a local-disk L1
+       cache in front of the chosen backend.
+    """
+    if backend is None:
+        backend = _select_remote_backend()
+    backend = _maybe_layer_l1(backend)
+    save_error_types = tuple(getattr(backend, "save_error_types", (Exception,)))
+
+    class _Persister:
         @staticmethod
         def load_cassette(cassette_path, serializer):
+            key = redis_key_for(cassette_path)
             try:
-                data = redis_client.get(redis_key_for(cassette_path))
-            except RedisError as exc:
+                data = backend.get(key)
+            except save_error_types as exc:
                 _record_cache_failure("load", exc)
                 msg = (
-                    f"VCR redis load failed for {cassette_path}; treating "
+                    f"VCR cache load failed for {cassette_path}; treating "
                     f"as cache miss: {type(exc).__name__}: {exc}"
                 )
                 _log.warning(msg)
@@ -159,8 +531,19 @@ def make_redis_persister(
                 raise CassetteNotFoundError() from exc
             if data is None:
                 raise CassetteNotFoundError()
-            if isinstance(data, bytes):
-                data = data.decode("utf-8")
+            try:
+                data = _decompress(data)
+            except Exception as exc:  # pragma: no cover - defensive
+                _record_cache_failure("load", exc)
+                msg = (
+                    f"VCR cache decompress failed for {cassette_path}; "
+                    f"treating as miss: {type(exc).__name__}: {exc}"
+                )
+                _log.warning(msg)
+                warnings.warn(msg, VCRCassetteCacheWarning, stacklevel=2)
+                raise CassetteNotFoundError() from exc
+            if isinstance(data, (bytes, bytearray)):
+                data = bytes(data).decode("utf-8")
             return deserialize(data, serializer)
 
         @staticmethod
@@ -170,7 +553,7 @@ def make_redis_persister(
             episode_count = len(cassette_dict.get("requests", []) or [])
             if episode_count > MAX_EPISODES_PER_CASSETTE:
                 _log.warning(
-                    "VCR redis save refused for %s; cassette has %d episodes "
+                    "VCR cache save refused for %s; cassette has %d episodes "
                     "(> MAX_EPISODES_PER_CASSETTE=%d). The test likely produces "
                     "non-deterministic request bodies (e.g. uuid) and is "
                     "appending instead of replaying. Opt it out with the "
@@ -182,32 +565,51 @@ def make_redis_persister(
                 return
             if not passed:
                 _log.info(
-                    "VCR redis save skipped for %s; test did not pass — "
+                    "VCR cache save skipped for %s; test did not pass — "
                     "leaving any prior cassette intact",
                     cassette_path,
                 )
                 return
             data = serialize(cassette_dict, serializer)
             payload = data.encode("utf-8") if isinstance(data, str) else data
+            payload = _compress(payload)
             try:
-                redis_client.set(key, payload, ex=ttl_seconds)
-            except RedisError as exc:
+                backend.set(key, payload, ttl_seconds)
+            except save_error_types as exc:
                 # Cassette persistence is strictly best-effort: connection
                 # blips, timeouts, OOM at the maxmemory cap, READONLY
-                # replicas, etc. should all degrade gracefully to "test
-                # passed but cassette not cached" rather than failing the
-                # test on teardown. We still want a loud signal so the
-                # failure shows up in pytest's warnings summary at the
-                # end of the session and feeds the session-end banner.
+                # replicas, S3 5xx, etc. should all degrade gracefully to
+                # "test passed but cassette not cached" rather than failing
+                # the test on teardown. We still want a loud signal so the
+                # failure shows up in pytest's warnings summary at the end
+                # of the session and feeds the session-end banner.
                 _record_cache_failure("save", exc)
                 msg = (
-                    f"VCR redis save failed for {cassette_path}; cassette "
+                    f"VCR cache save failed for {cassette_path}; cassette "
                     f"not persisted: {type(exc).__name__}: {exc}"
                 )
                 _log.warning(msg)
                 warnings.warn(msg, VCRCassetteCacheWarning, stacklevel=2)
 
-    return _RedisPersister
+    return _Persister
+
+
+def make_redis_persister(
+    client: Optional[Any] = None,
+    ttl_seconds: int = CASSETTE_TTL_SECONDS,
+):
+    """Backward-compatible factory used by existing tests and conftests.
+
+    Prefer :func:`make_persister`. Passing ``client`` selects the Redis
+    backend explicitly, bypassing env-var detection — useful for unit
+    tests that wire up a fakeredis instance.
+    """
+    if client is None:
+        return make_persister(ttl_seconds=ttl_seconds)
+    return make_persister(
+        backend=_RedisBackend(client=client),
+        ttl_seconds=ttl_seconds,
+    )
 
 
 def filter_non_2xx_response(response):

--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -279,9 +279,15 @@ class _S3Backend:
 
     name = "s3"
 
-    def __init__(self, client: Any, bucket: str) -> None:
+    def __init__(
+        self,
+        client: Any,
+        bucket: str,
+        ttl_seconds: int = CASSETTE_TTL_SECONDS,
+    ) -> None:
         self._client = client
         self._bucket = bucket
+        self._ttl = ttl_seconds
         try:
             from botocore.exceptions import ClientError
         except ImportError:  # pragma: no cover - boto3 is a dev dep
@@ -303,7 +309,7 @@ class _S3Backend:
                 age = time.time() - last_modified.timestamp()
             except (AttributeError, TypeError):  # pragma: no cover - defensive
                 age = 0.0
-            if age > CASSETTE_TTL_SECONDS:
+            if age > self._ttl:
                 return None
         body = obj["Body"].read()
         return body if isinstance(body, (bytes, bytearray)) else bytes(body)
@@ -323,7 +329,9 @@ class _S3Backend:
         return ""
 
 
-def _maybe_build_s3_backend() -> Optional[_S3Backend]:
+def _maybe_build_s3_backend(
+    ttl_seconds: int = CASSETTE_TTL_SECONDS,
+) -> Optional[_S3Backend]:
     bucket = _s3_bucket_from_env()
     if not bucket:
         return None
@@ -352,7 +360,7 @@ def _maybe_build_s3_backend() -> Optional[_S3Backend]:
         region_name=region,
         config=config,
     )
-    return _S3Backend(client=client, bucket=bucket)
+    return _S3Backend(client=client, bucket=bucket, ttl_seconds=ttl_seconds)
 
 
 # ---------------------------------------------------------------------------
@@ -457,11 +465,13 @@ class _LocalDiskL1Cache:
             _log.debug("L1 write-through failed for %s: %s", path, exc)
 
 
-def _select_remote_backend() -> CassetteBackend:
+def _select_remote_backend(
+    ttl_seconds: int = CASSETTE_TTL_SECONDS,
+) -> CassetteBackend:
     """Pick a remote backend based on env vars. S3 takes precedence
     because it's the cheaper option once configured.
     """
-    s3_backend = _maybe_build_s3_backend()
+    s3_backend = _maybe_build_s3_backend(ttl_seconds=ttl_seconds)
     if s3_backend is not None:
         return s3_backend
     redis_client = _maybe_build_redis_client()
@@ -475,12 +485,15 @@ def _select_remote_backend() -> CassetteBackend:
     )
 
 
-def _maybe_layer_l1(backend: CassetteBackend) -> CassetteBackend:
+def _maybe_layer_l1(
+    backend: CassetteBackend,
+    ttl_seconds: int = CASSETTE_TTL_SECONDS,
+) -> CassetteBackend:
     cache_dir = _local_cache_dir_from_env()
     if not cache_dir:
         return backend
     try:
-        return _LocalDiskL1Cache(cache_dir, backend)
+        return _LocalDiskL1Cache(cache_dir, backend, ttl_seconds=ttl_seconds)
     except OSError as exc:
         warnings.warn(
             f"Failed to initialize VCR L1 cache at {cache_dir!r}: {exc}",
@@ -510,8 +523,8 @@ def make_persister(
        cache in front of the chosen backend.
     """
     if backend is None:
-        backend = _select_remote_backend()
-    backend = _maybe_layer_l1(backend)
+        backend = _select_remote_backend(ttl_seconds=ttl_seconds)
+    backend = _maybe_layer_l1(backend, ttl_seconds=ttl_seconds)
     save_error_types = tuple(getattr(backend, "save_error_types", (Exception,)))
 
     class _Persister:

--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -201,7 +201,7 @@ class CassetteBackend(Protocol):
     """Pluggable cassette store. Implementations only deal in raw bytes."""
 
     name: str
-    save_error_types: tuple
+    transient_error_types: tuple
 
     def get(self, key: str) -> Optional[bytes]: ...
 
@@ -251,7 +251,7 @@ class _RedisBackend:
             from redis.exceptions import RedisError
         except ImportError:  # pragma: no cover - redis is a hard test dep
             RedisError = Exception  # type: ignore[assignment,misc]
-        self.save_error_types = (RedisError,)
+        self.transient_error_types = (RedisError,)
 
     def get(self, key: str) -> Optional[bytes]:
         return self._client.get(key)
@@ -294,7 +294,7 @@ class _S3Backend:
             ClientError = Exception  # type: ignore[assignment,misc]
             BotoCoreError = Exception  # type: ignore[assignment,misc]
         self._client_error = ClientError
-        self.save_error_types = (ClientError, BotoCoreError, OSError)
+        self.transient_error_types = (ClientError, BotoCoreError, OSError)
 
     def get(self, key: str) -> Optional[bytes]:
         try:
@@ -387,8 +387,8 @@ class _LocalDiskL1Cache:
         # Inherit the inner backend's exception classification so the
         # persister's best-effort ``except`` block still catches remote
         # failures even when L1 is in front.
-        self.save_error_types = tuple(
-            set(getattr(inner, "save_error_types", (Exception,))) | {OSError}
+        self.transient_error_types = tuple(
+            set(getattr(inner, "transient_error_types", (Exception,))) | {OSError}
         )
 
     def _path_for(self, key: str) -> str:
@@ -526,7 +526,9 @@ def make_persister(
     if backend is None:
         backend = _select_remote_backend(ttl_seconds=ttl_seconds)
     backend = _maybe_layer_l1(backend, ttl_seconds=ttl_seconds)
-    save_error_types = tuple(getattr(backend, "save_error_types", (Exception,)))
+    transient_error_types = tuple(
+        getattr(backend, "transient_error_types", (Exception,))
+    )
 
     class _Persister:
         @staticmethod
@@ -534,7 +536,7 @@ def make_persister(
             key = redis_key_for(cassette_path)
             try:
                 data = backend.get(key)
-            except save_error_types as exc:
+            except transient_error_types as exc:
                 _record_cache_failure("load", exc)
                 msg = (
                     f"VCR cache load failed for {cassette_path}; treating "
@@ -589,7 +591,7 @@ def make_persister(
             payload = _compress(payload)
             try:
                 backend.set(key, payload, ttl_seconds)
-            except save_error_types as exc:
+            except transient_error_types as exc:
                 # Cassette persistence is strictly best-effort: connection
                 # blips, timeouts, OOM at the maxmemory cap, READONLY
                 # replicas, S3 5xx, etc. should all degrade gracefully to

--- a/tests/_vcr_redis_persister.py
+++ b/tests/_vcr_redis_persister.py
@@ -289,11 +289,12 @@ class _S3Backend:
         self._bucket = bucket
         self._ttl = ttl_seconds
         try:
-            from botocore.exceptions import ClientError
+            from botocore.exceptions import BotoCoreError, ClientError
         except ImportError:  # pragma: no cover - boto3 is a dev dep
             ClientError = Exception  # type: ignore[assignment,misc]
+            BotoCoreError = Exception  # type: ignore[assignment,misc]
         self._client_error = ClientError
-        self.save_error_types = (ClientError, OSError)
+        self.save_error_types = (ClientError, BotoCoreError, OSError)
 
     def get(self, key: str) -> Optional[bytes]:
         try:

--- a/tests/llm_translation/Readme.md
+++ b/tests/llm_translation/Readme.md
@@ -2,14 +2,33 @@ Unit tests for individual LLM providers.
 
 Name of the test file is the name of the LLM provider - e.g. `test_openai.py` is for OpenAI.
 
-## Redis-backed VCR cache
+## Layered VCR cache (L1 disk + L2 Redis or S3/R2)
 
 Every test in this directory is auto-decorated with `@pytest.mark.vcr` (via
 `conftest.py`). The first time a test runs we hit the live provider and
-record the HTTP exchange into Redis under
+record the HTTP exchange into the cassette store under
 `litellm:vcr:cassette:<test_id>`. Every subsequent run within 24h replays
-from Redis without touching the network. The 24h TTL means each new day's
+from cache without touching the network. The 24h TTL means each new day's
 first run records again, so upstream API drift surfaces within a day.
+
+The store is layered:
+
+1. **L1 — local disk.** When `CASSETTE_LOCAL_CACHE_DIR` is set (CircleCI
+   wires this up automatically through the `restore_vcr_l1_cache` /
+   `save_vcr_l1_cache` commands) the persister reads through a
+   sharded directory cache before touching the remote backend. Most
+   re-runs hit L1 on the same shard and never produce L2 traffic.
+2. **L2 — Redis or S3/R2.** Selected by env var precedence:
+   - `CASSETTE_S3_BUCKET` (with optional `CASSETTE_S3_ENDPOINT` for
+     non-AWS endpoints like Cloudflare R2) → S3-compatible object store,
+     read TTL enforced via `LastModified`. Recommended: zero egress on
+     R2 means cassette reads are effectively free.
+   - `CASSETTE_REDIS_URL` → Redis (legacy default).
+
+Cassette payloads are zstd-compressed by default (~7-10x smaller than
+the raw YAML). Set `CASSETTE_DISABLE_COMPRESSION=1` to opt out for
+debugging. The loader sniffs the zstd frame magic, so cassettes
+recorded before this rolled out keep working unchanged.
 
 The persister, header scrubbing, and 2xx-only filtering are defined in
 `tests/_vcr_redis_persister.py`. Files that already use `respx` (which
@@ -43,11 +62,26 @@ Docker container.
 
 ### Required environment
 
-`CASSETTE_REDIS_URL` — separate Redis instance from the application
-Redis (`REDIS_URL`/`REDIS_HOST`) so test cassettes are not flushed by
-proxy tests. Provider credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
-`AWS_*`, etc.) are needed only on cache-miss (the daily re-record), not
-on replay.
+One of the L2 backends must be configured:
+
+- `CASSETTE_S3_BUCKET` (preferred for new setups; pair with
+  `CASSETTE_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com` and
+  `CASSETTE_S3_REGION=auto` for Cloudflare R2 — zero egress fees), or
+- `CASSETTE_REDIS_URL` — separate Redis instance from the application
+  Redis (`REDIS_URL`/`REDIS_HOST`) so test cassettes are not flushed by
+  proxy tests.
+
+Optional:
+
+- `CASSETTE_LOCAL_CACHE_DIR` — enables the L1 disk cache. CircleCI
+  jobs set this automatically; for local dev it's normally fine to
+  leave unset.
+- `CASSETTE_DISABLE_COMPRESSION=1` — opt out of zstd compression for
+  debugging.
+
+Provider credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_*`,
+etc.) are needed only on cache-miss (the daily re-record), not on
+replay.
 
 ### Flushing the cache
 

--- a/tests/llm_translation/test_vcr_compression.py
+++ b/tests/llm_translation/test_vcr_compression.py
@@ -1,0 +1,163 @@
+"""Unit tests for the zstd compression layer in the cassette persister.
+
+Covers the load-side magic-byte sniff that keeps cassettes recorded
+before this change loadable, the round-trip of compressed payloads, and
+the size win on representative LLM response bodies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import fakeredis
+from vcr.request import Request
+from vcr.serialize import serialize as vcr_serialize
+from vcr.serializers import yamlserializer
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from tests._vcr_redis_persister import (  # noqa: E402
+    _ZSTD_FRAME_MAGIC,
+    _compress,
+    _decompress,
+    make_redis_persister,
+    redis_key_for,
+)
+
+
+def _streaming_cassette_dict() -> dict:
+    """Build a cassette body that mimics a 50-event Anthropic SSE stream.
+
+    The repetition pattern (``data: {"type":"content_block_delta",...}\\n\\n``)
+    is what makes real streaming cassettes 10-15x compressible, so the
+    fixture has to look like one to give meaningful size signals.
+    """
+    request = Request(
+        method="POST",
+        uri="https://api.anthropic.com/v1/messages",
+        body=b'{"model":"claude","stream":true,"messages":[{"role":"user","content":"hi"}]}',
+        headers={"content-type": "application/json"},
+    )
+    chunks = []
+    for i in range(50):
+        chunk = (
+            "event: content_block_delta\n"
+            f"data: {json.dumps({'type':'content_block_delta','index':0,'delta':{'type':'text_delta','text':'token_'+str(i)}})}\n\n"
+        )
+        chunks.append(chunk)
+    body = ("".join(chunks)).encode("utf-8")
+    response = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"content-type": ["text/event-stream"]},
+        "body": {"string": body},
+    }
+    return {"requests": [request], "responses": [response]}
+
+
+def test_compress_then_decompress_is_lossless():
+    payload = b"hello " * 1000
+    out = _compress(payload)
+    assert out.startswith(_ZSTD_FRAME_MAGIC)
+    assert _decompress(out) == payload
+
+
+def test_decompress_passes_through_legacy_uncompressed_payload():
+    legacy = b"interactions:\n- request:\n    method: POST\n"
+    assert _decompress(legacy) == legacy
+
+
+def test_compress_is_idempotent_when_input_already_starts_with_magic():
+    payload = _ZSTD_FRAME_MAGIC + b"already framed"
+    assert _compress(payload) == payload
+
+
+def test_compression_substantially_shrinks_streaming_cassette():
+    cassette = _streaming_cassette_dict()
+    raw = cassette["responses"][0]["body"]["string"] * 1
+    compressed = _compress(raw)
+    # SSE bodies have very high token entropy reduction; even a
+    # conservative floor of 4x is well below what real cassettes achieve.
+    assert len(compressed) <= len(raw) // 4, (
+        f"expected ≥4x compression on SSE body; got "
+        f"{len(raw)}→{len(compressed)} ({len(raw)/len(compressed):.2f}x)"
+    )
+
+
+def test_persister_compresses_payload_on_save():
+    fake = fakeredis.FakeStrictRedis()
+    persister = make_redis_persister(client=fake)
+    cassette_id = "tests/llm_translation/test_x/test_compress_save"
+    persister.save_cassette(cassette_id, _streaming_cassette_dict(), yamlserializer)
+    raw_in_redis = fake.get(redis_key_for(cassette_id))
+    assert raw_in_redis is not None
+    assert raw_in_redis.startswith(_ZSTD_FRAME_MAGIC), (
+        "expected the persister to write zstd-framed bytes; first 8 bytes "
+        f"were {raw_in_redis[:8]!r}"
+    )
+
+
+def test_persister_loads_legacy_uncompressed_yaml():
+    """A cassette stored before compression rolled out must still load.
+
+    Simulates the migration window: old payload is plain YAML bytes;
+    the new loader must transparently treat it as already-decompressed.
+    """
+    fake = fakeredis.FakeStrictRedis()
+    persister = make_redis_persister(client=fake)
+    cassette_id = "tests/llm_translation/test_x/test_legacy_load"
+
+    # Round-trip a cassette through vcrpy's high-level ``serialize``
+    # so the bytes match what the persister wrote before compression
+    # rolled out (i.e. the same wrapped ``interactions:`` envelope).
+    legacy_dict = _streaming_cassette_dict()
+    raw_yaml = vcr_serialize(legacy_dict, yamlserializer)
+    raw_bytes = raw_yaml.encode("utf-8") if isinstance(raw_yaml, str) else raw_yaml
+    fake.set(redis_key_for(cassette_id), raw_bytes)
+
+    requests, responses = persister.load_cassette(cassette_id, yamlserializer)
+    assert len(requests) == 1
+    assert responses[0]["status"]["code"] == 200
+
+
+def test_persister_round_trips_compressed_cassette():
+    fake = fakeredis.FakeStrictRedis()
+    persister = make_redis_persister(client=fake)
+    cassette_id = "tests/llm_translation/test_x/test_round_trip"
+    cassette = _streaming_cassette_dict()
+    persister.save_cassette(cassette_id, cassette, yamlserializer)
+    requests, responses = persister.load_cassette(cassette_id, yamlserializer)
+    assert len(requests) == 1
+    # vcrpy's YAML deserializer can return either bytes or str depending
+    # on how it reconstructs the body; compare the byte content directly
+    # so the test is robust to that detail.
+    loaded = responses[0]["body"]["string"]
+    if isinstance(loaded, str):
+        loaded = loaded.encode("utf-8")
+    expected = cassette["responses"][0]["body"]["string"]
+    if isinstance(expected, str):
+        expected = expected.encode("utf-8")
+    assert loaded == expected
+
+
+def test_compression_can_be_disabled_via_env(monkeypatch):
+    """``CASSETTE_DISABLE_COMPRESSION=1`` is a debugging escape hatch.
+
+    Useful for diff-friendly cache inspection during incident response;
+    we still need to keep load behavior compatible with both formats.
+    """
+    fake = fakeredis.FakeStrictRedis()
+    persister = make_redis_persister(client=fake)
+    cassette_id = "tests/llm_translation/test_x/test_disabled"
+
+    monkeypatch.setenv("CASSETTE_DISABLE_COMPRESSION", "1")
+    persister.save_cassette(cassette_id, _streaming_cassette_dict(), yamlserializer)
+    raw = fake.get(redis_key_for(cassette_id))
+    assert raw is not None
+    assert not raw.startswith(_ZSTD_FRAME_MAGIC)
+
+    # Loader still works on the uncompressed payload.
+    monkeypatch.delenv("CASSETTE_DISABLE_COMPRESSION")
+    requests, _responses = persister.load_cassette(cassette_id, yamlserializer)
+    assert len(requests) == 1

--- a/tests/llm_translation/test_vcr_filters.py
+++ b/tests/llm_translation/test_vcr_filters.py
@@ -19,9 +19,13 @@ from vcr.request import Request
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from tests._vcr_conftest_common import (  # noqa: E402
+    FILTERED_REQUEST_HEADERS,
+    FILTERED_RESPONSE_HEADER_PREFIXES,
+    FILTERED_RESPONSE_HEADERS,
     VCR_FIXED_MULTIPART_BOUNDARY,
     VCR_IMAGE_B64_PLACEHOLDER,
     _normalize_multipart_boundary,
+    _scrub_response,
     _strip_image_b64_payloads,
 )
 
@@ -218,3 +222,120 @@ def test_normalize_multipart_handles_quoted_boundary():
     _normalize_multipart_boundary(req)
     assert b"quoted-boundary" not in req.body
     assert VCR_FIXED_MULTIPART_BOUNDARY.encode("utf-8") in req.body
+
+
+# ---------------------------------------------------------------------------
+# Response header scrubbing (explicit list + prefix-based blocklist)
+# ---------------------------------------------------------------------------
+
+
+def _response_with_headers(headers: dict) -> dict:
+    return {
+        "status": {"code": 200, "message": "OK"},
+        "headers": headers,
+        "body": {"string": b"{}"},
+    }
+
+
+def test_scrub_response_strips_explicit_filtered_headers():
+    response = _response_with_headers(
+        {
+            "Content-Type": ["application/json"],
+            "X-Request-Id": ["req-abc"],
+            "Set-Cookie": ["session=xyz"],
+            "Date": ["Mon, 18 May 2026 18:00:00 GMT"],
+        }
+    )
+    out = _scrub_response(response)
+    headers = out["headers"]
+    assert "X-Request-Id" not in headers
+    assert "Set-Cookie" not in headers
+    assert "Date" not in headers
+    assert headers["Content-Type"] == ["application/json"]
+
+
+def test_scrub_response_strips_x_amz_metadata_via_prefix():
+    """AWS Bedrock responses come with 10+ ``x-amz-*`` headers per
+    request — none of them are asserted on by tests, and none of them
+    are tiny. Trim them via the prefix blocklist."""
+    response = _response_with_headers(
+        {
+            "Content-Type": ["application/json"],
+            "x-amz-id-2": ["very-long-aws-trace-token=="],
+            "x-amz-server-side-encryption": ["AES256"],
+            "x-amzn-RequestId": ["req-123"],
+            "x-amzn-Trace-Id": ["root=1-abc"],
+        }
+    )
+    out = _scrub_response(response)
+    for header in (
+        "x-amz-id-2",
+        "x-amz-server-side-encryption",
+        "x-amzn-RequestId",
+        "x-amzn-Trace-Id",
+    ):
+        assert header not in out["headers"]
+    assert out["headers"]["Content-Type"] == ["application/json"]
+
+
+def test_scrub_response_strips_anthropic_ratelimit_family():
+    """Anthropic responses ship 7+ verbose ``anthropic-ratelimit-*``
+    headers. They're tiny individually but compound across cassettes.
+    """
+    response = _response_with_headers(
+        {
+            "Content-Type": ["application/json"],
+            "anthropic-ratelimit-requests-limit": ["50"],
+            "anthropic-ratelimit-requests-remaining": ["49"],
+            "anthropic-ratelimit-requests-reset": ["2026-05-18T18:00:00Z"],
+            "anthropic-ratelimit-tokens-limit": ["100000"],
+            "anthropic-ratelimit-tokens-remaining": ["95000"],
+        }
+    )
+    out = _scrub_response(response)
+    assert all(not h.lower().startswith("anthropic-ratelimit-") for h in out["headers"])
+
+
+def test_scrub_response_keeps_content_headers_untouched():
+    """Content-Type / Content-Length / Content-Encoding are required
+    for vcrpy to replay bodies correctly. Make sure no overzealous
+    prefix sweeps them out."""
+    response = _response_with_headers(
+        {
+            "content-type": ["application/json; charset=utf-8"],
+            "content-length": ["42"],
+            "content-encoding": ["gzip"],
+            "transfer-encoding": ["chunked"],
+        }
+    )
+    out = _scrub_response(response)
+    for keep in (
+        "content-type",
+        "content-length",
+        "content-encoding",
+        "transfer-encoding",
+    ):
+        assert keep in out["headers"]
+
+
+def test_anthropic_version_is_no_longer_filtered_from_request_headers():
+    """Documented behavior change. ``anthropic-version`` is not a
+    secret, is tiny, and parametrized tests rely on it for matching.
+    Filtering it caused two parametrizations to share one cassette
+    episode and produce false replay hits."""
+    assert "anthropic-version" not in (h.lower() for h in FILTERED_REQUEST_HEADERS)
+
+
+def test_explicit_list_and_prefix_list_are_disjoint_with_keep_set():
+    """No header in the ``content-*`` family should be on either list."""
+    must_keep = {
+        "content-type",
+        "content-length",
+        "content-encoding",
+        "transfer-encoding",
+    }
+    for name in FILTERED_RESPONSE_HEADERS:
+        assert name.lower() not in must_keep
+    for prefix in FILTERED_RESPONSE_HEADER_PREFIXES:
+        for keep in must_keep:
+            assert not keep.startswith(prefix.lower())

--- a/tests/llm_translation/test_vcr_l1_disk_cache.py
+++ b/tests/llm_translation/test_vcr_l1_disk_cache.py
@@ -1,0 +1,199 @@
+"""Unit tests for the local-disk L1 cassette cache.
+
+The L1 layer is meant to absorb the bulk of cassette reads so the
+remote Redis/S3 backend only sees first-time misses. CircleCI's
+``restore_cache`` / ``save_cache`` mounts the directory across runs,
+which is what makes that cheap. These tests verify the read-through,
+write-through, TTL, and remote-failure semantics in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+from vcr.request import Request
+from vcr.serializers import yamlserializer
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from tests._vcr_redis_persister import (  # noqa: E402
+    CASSETTE_TTL_SECONDS,
+    _LocalDiskL1Cache,
+    make_persister,
+)
+
+
+class _RecordingBackend:
+    """Minimal in-memory backend that counts get/set calls.
+
+    Using this instead of fakeredis for the L1 tests so we can assert
+    *exactly* how many times the L1 layer fell through to the remote.
+    """
+
+    name = "test"
+    save_error_types = (RuntimeError,)
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.gets = 0
+        self.sets = 0
+
+    def get(self, key):
+        self.gets += 1
+        return self.store.get(key)
+
+    def set(self, key, payload, ttl_seconds):
+        self.sets += 1
+        self.store[key] = payload
+
+
+def _sample_cassette() -> dict:
+    request = Request(
+        method="POST",
+        uri="https://api.anthropic.com/v1/messages",
+        body=b'{"model":"claude","messages":[]}',
+        headers={"content-type": "application/json"},
+    )
+    response = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"content-type": ["application/json"]},
+        "body": {"string": b'{"id":"msg_1"}'},
+    }
+    return {"requests": [request], "responses": [response]}
+
+
+def test_l1_get_returns_payload_after_set(tmp_path):
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    l1.set("k", b"payload", CASSETTE_TTL_SECONDS)
+    assert l1.get("k") == b"payload"
+
+
+def test_l1_hit_does_not_call_through_to_remote(tmp_path):
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    l1.set("k", b"payload", CASSETTE_TTL_SECONDS)
+    inner.gets = 0
+    for _ in range(5):
+        assert l1.get("k") == b"payload"
+    assert (
+        inner.gets == 0
+    ), "L1 must absorb repeated reads — that's the whole point of the layer"
+
+
+def test_l1_miss_falls_through_and_writes_back(tmp_path):
+    inner = _RecordingBackend()
+    inner.store["k"] = b"remote_payload"
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+
+    assert l1.get("k") == b"remote_payload"
+    assert inner.gets == 1
+    # The first hit must have populated the local copy so the next
+    # get bypasses the remote.
+    assert l1.get("k") == b"remote_payload"
+    assert inner.gets == 1
+
+
+def test_l1_miss_when_remote_returns_none(tmp_path):
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    assert l1.get("never-recorded") is None
+
+
+def test_l1_treats_stale_entry_as_miss(tmp_path):
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner, ttl_seconds=1)
+    l1.set("k", b"v1", ttl_seconds=1)
+    inner.store["k"] = b"v2"
+    inner.gets = 0
+
+    # Force the on-disk file to look older than the TTL.
+    path = l1._path_for("k")
+    os.utime(path, (time.time() - 5, time.time() - 5))
+
+    # Stale → fall through → fetch the (newer) remote value and
+    # refresh the local copy.
+    assert l1.get("k") == b"v2"
+    assert inner.gets == 1
+
+
+def test_l1_set_writes_through_even_when_remote_succeeds(tmp_path):
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    l1.set("k", b"v", CASSETTE_TTL_SECONDS)
+    assert inner.store["k"] == b"v"
+    assert os.path.exists(l1._path_for("k"))
+
+
+def test_l1_writes_local_copy_even_when_remote_set_fails(tmp_path):
+    """If the remote backend fails, the L1 still has the bytes for the
+    rest of the test session — better than nothing for parallel xdist
+    workers running in the same process."""
+
+    class _Failing(_RecordingBackend):
+        def set(self, key, payload, ttl_seconds):
+            raise RuntimeError("simulated remote outage")
+
+    inner = _Failing()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    with pytest.raises(RuntimeError):
+        l1.set("k", b"payload", CASSETTE_TTL_SECONDS)
+    # Despite the remote failure, the local file got written.
+    assert l1.get("k") == b"payload"
+
+
+def test_l1_inherits_inner_save_error_types(tmp_path):
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    assert RuntimeError in l1.save_error_types
+    assert OSError in l1.save_error_types
+
+
+def test_l1_path_layout_is_sharded(tmp_path):
+    """Two cassette keys must end up in different directories so a
+    single restored CI cache directory doesn't degrade to a flat
+    bucket of thousands of files."""
+    inner = _RecordingBackend()
+    l1 = _LocalDiskL1Cache(str(tmp_path), inner)
+    p1 = l1._path_for("a-key")
+    p2 = l1._path_for("z-key")
+    assert os.path.dirname(p1) != tmp_path
+    assert os.path.dirname(p2) != tmp_path
+    # Both files live under the base, but the shard prefix differs
+    # for nearly all distinct inputs (sha256 of "a-key" vs "z-key").
+    assert os.path.dirname(p1) != os.path.dirname(p2)
+
+
+def test_persister_uses_l1_when_env_var_set(monkeypatch, tmp_path):
+    """End-to-end: ``CASSETTE_LOCAL_CACHE_DIR=...`` activates the L1
+    layer and a re-load on the same process never touches the inner
+    backend after the first miss."""
+    inner = _RecordingBackend()
+    monkeypatch.setenv("CASSETTE_LOCAL_CACHE_DIR", str(tmp_path / "vcr-l1"))
+    persister = make_persister(backend=inner)
+    cassette_id = "tests/llm_translation/test_x/test_l1_e2e"
+    persister.save_cassette(cassette_id, _sample_cassette(), yamlserializer)
+
+    inner.gets = 0
+    for _ in range(3):
+        persister.load_cassette(cassette_id, yamlserializer)
+    assert inner.gets == 0
+
+
+def test_persister_without_env_var_does_not_create_l1(monkeypatch, tmp_path):
+    """When ``CASSETTE_LOCAL_CACHE_DIR`` is unset, every load goes to
+    the inner backend. Avoids surprising local-dev runs that would
+    otherwise create a hidden cache directory in the cwd."""
+    inner = _RecordingBackend()
+    monkeypatch.delenv("CASSETTE_LOCAL_CACHE_DIR", raising=False)
+    persister = make_persister(backend=inner)
+    cassette_id = "tests/llm_translation/test_x/test_no_l1"
+    persister.save_cassette(cassette_id, _sample_cassette(), yamlserializer)
+
+    inner.gets = 0
+    for _ in range(3):
+        persister.load_cassette(cassette_id, yamlserializer)
+    assert inner.gets == 3

--- a/tests/llm_translation/test_vcr_l1_disk_cache.py
+++ b/tests/llm_translation/test_vcr_l1_disk_cache.py
@@ -34,7 +34,7 @@ class _RecordingBackend:
     """
 
     name = "test"
-    save_error_types = (RuntimeError,)
+    transient_error_types = (RuntimeError,)
 
     def __init__(self) -> None:
         self.store: dict[str, bytes] = {}
@@ -145,11 +145,11 @@ def test_l1_writes_local_copy_even_when_remote_set_fails(tmp_path):
     assert l1.get("k") == b"payload"
 
 
-def test_l1_inherits_inner_save_error_types(tmp_path):
+def test_l1_inherits_inner_transient_error_types(tmp_path):
     inner = _RecordingBackend()
     l1 = _LocalDiskL1Cache(str(tmp_path), inner)
-    assert RuntimeError in l1.save_error_types
-    assert OSError in l1.save_error_types
+    assert RuntimeError in l1.transient_error_types
+    assert OSError in l1.transient_error_types
 
 
 def test_l1_path_layout_is_sharded(tmp_path):

--- a/tests/llm_translation/test_vcr_s3_backend.py
+++ b/tests/llm_translation/test_vcr_s3_backend.py
@@ -1,0 +1,179 @@
+"""Unit tests for the S3/R2 cassette backend.
+
+The backend is meant to replace the Redis cassette cache without
+changing any test-side behavior, so these tests cover the operations
+the persister actually exercises: get-with-TTL, put, NoSuchKey ⇒
+cache miss, transient ClientError ⇒ raise (so the persister surfaces
+it as a load/save failure), and selection precedence.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+from io import BytesIO
+
+import pytest
+from botocore.exceptions import ClientError
+from vcr.persisters.filesystem import CassetteNotFoundError
+from vcr.request import Request
+from vcr.serializers import yamlserializer
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from tests._vcr_redis_persister import (  # noqa: E402
+    CASSETTE_TTL_SECONDS,
+    VCRCassetteCacheWarning,
+    _S3Backend,
+    _select_remote_backend,
+    cassette_cache_health,
+    make_persister,
+    redis_key_for,
+    reset_cassette_cache_health,
+)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+class _FakeS3Client:
+    """In-process stand-in for the boto3 S3 client.
+
+    Stores objects with a fake ``LastModified`` so we can drive the
+    backend's TTL check without sleeping. Mirrors the boto3 surface
+    that ``_S3Backend`` actually depends on (``get_object``,
+    ``put_object``).
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], dict] = {}
+        self.put_calls = 0
+        self.get_calls = 0
+
+    def put_object(self, *, Bucket, Key, Body):
+        self.put_calls += 1
+        if isinstance(Body, (bytes, bytearray)):
+            data = bytes(Body)
+        else:  # pragma: no cover - defensive
+            data = Body.read()
+        self.objects[(Bucket, Key)] = {
+            "Body": data,
+            "LastModified": _now(),
+        }
+
+    def get_object(self, *, Bucket, Key):
+        self.get_calls += 1
+        obj = self.objects.get((Bucket, Key))
+        if obj is None:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "not found"}},
+                "GetObject",
+            )
+        return {
+            "Body": BytesIO(obj["Body"]),
+            "LastModified": obj["LastModified"],
+        }
+
+
+def _sample_cassette() -> dict:
+    request = Request(
+        method="POST",
+        uri="https://api.anthropic.com/v1/messages",
+        body=b'{"model":"claude","messages":[]}',
+        headers={"content-type": "application/json"},
+    )
+    response = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"content-type": ["application/json"]},
+        "body": {"string": b'{"id":"msg_1","type":"message"}'},
+    }
+    return {"requests": [request], "responses": [response]}
+
+
+def test_s3_round_trip_via_persister():
+    fake = _FakeS3Client()
+    persister = make_persister(backend=_S3Backend(client=fake, bucket="cassettes"))
+    cassette_id = "tests/llm_translation/test_x/test_s3_round_trip"
+
+    persister.save_cassette(cassette_id, _sample_cassette(), yamlserializer)
+    requests, responses = persister.load_cassette(cassette_id, yamlserializer)
+    assert len(requests) == 1
+    assert responses[0]["status"]["code"] == 200
+    assert fake.put_calls == 1
+    assert fake.get_calls == 1
+
+
+def test_s3_no_such_key_is_treated_as_cassette_miss():
+    fake = _FakeS3Client()
+    persister = make_persister(backend=_S3Backend(client=fake, bucket="cassettes"))
+    with pytest.raises(CassetteNotFoundError):
+        persister.load_cassette("never/recorded", yamlserializer)
+
+
+def test_s3_object_older_than_ttl_is_treated_as_miss():
+    """If a bucket lifecycle policy hasn't reaped a stale object yet,
+    the read-side age check still treats it as a cache miss so the
+    test re-records — same semantics as the Redis TTL.
+    """
+    fake = _FakeS3Client()
+    backend = _S3Backend(client=fake, bucket="cassettes")
+    key = redis_key_for("tests/llm_translation/test_x/test_stale")
+    fake.put_object(Bucket="cassettes", Key=key, Body=b"fake_payload")
+    fake.objects[("cassettes", key)]["LastModified"] = _now() - dt.timedelta(
+        seconds=CASSETTE_TTL_SECONDS + 60
+    )
+
+    assert backend.get(key) is None
+
+
+def test_s3_5xx_propagates_as_save_failure_warning():
+    """Unexpected ClientErrors must surface to the persister so the
+    health counters tick and the session-end banner shows the failure.
+    """
+
+    class _BoomClient(_FakeS3Client):
+        def put_object(self, **kwargs):
+            raise ClientError(
+                {"Error": {"Code": "InternalError", "Message": "boom"}},
+                "PutObject",
+            )
+
+    reset_cassette_cache_health()
+    persister = make_persister(
+        backend=_S3Backend(client=_BoomClient(), bucket="cassettes")
+    )
+    cassette_id = "tests/llm_translation/test_x/test_5xx"
+
+    with pytest.warns(VCRCassetteCacheWarning, match="InternalError"):
+        persister.save_cassette(cassette_id, _sample_cassette(), yamlserializer)
+    assert cassette_cache_health()["save_failures"] == 1
+
+
+def test_select_remote_backend_prefers_s3_when_both_envs_set(monkeypatch):
+    """If a maintainer accidentally configures both env vars during a
+    Redis→R2 migration, S3 wins. The reverse precedence would silently
+    keep paying for Redis bandwidth even after the bucket is wired up.
+    """
+    monkeypatch.setenv("CASSETTE_REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("CASSETTE_S3_BUCKET", "test-bucket")
+    monkeypatch.setenv(
+        "CASSETTE_S3_ENDPOINT", "https://example.r2.cloudflarestorage.com"
+    )
+    backend = _select_remote_backend()
+    assert backend.name == "s3"
+
+
+def test_select_remote_backend_falls_back_to_redis(monkeypatch):
+    monkeypatch.delenv("CASSETTE_S3_BUCKET", raising=False)
+    monkeypatch.setenv("CASSETTE_REDIS_URL", "redis://localhost:6379/0")
+    backend = _select_remote_backend()
+    assert backend.name == "redis"
+
+
+def test_select_remote_backend_raises_when_neither_configured(monkeypatch):
+    monkeypatch.delenv("CASSETTE_REDIS_URL", raising=False)
+    monkeypatch.delenv("CASSETTE_S3_BUCKET", raising=False)
+    with pytest.raises(RuntimeError, match="No cassette backend configured"):
+        _select_remote_backend()

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-15T19:02:43.743226148Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3325,6 +3325,7 @@ ci = [
 ]
 dev = [
     { name = "black" },
+    { name = "boto3" },
     { name = "diff-cover" },
     { name = "fakeredis" },
     { name = "fastapi-offline" },
@@ -3356,6 +3357,7 @@ dev = [
     { name = "types-requests" },
     { name = "types-setuptools" },
     { name = "vcrpy" },
+    { name = "zstandard" },
 ]
 healthcheck = [
     { name = "httpx" },
@@ -3485,6 +3487,7 @@ ci = [
 ]
 dev = [
     { name = "black", specifier = "==24.10.0" },
+    { name = "boto3", specifier = "==1.43.1" },
     { name = "diff-cover", specifier = "==9.7.2" },
     { name = "fakeredis", specifier = "==2.34.1" },
     { name = "fastapi-offline", specifier = "==1.7.6" },
@@ -3516,6 +3519,7 @@ dev = [
     { name = "types-requests", specifier = "==2.32.4.20260107" },
     { name = "types-setuptools", specifier = "==75.8.0.20250225" },
     { name = "vcrpy", specifier = "==8.1.1" },
+    { name = "zstandard", specifier = "==0.25.0" },
 ]
 healthcheck = [
     { name = "httpx", specifier = "==0.28.1" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Cuts cassette-cache bandwidth on Redis Cloud well below the soft limit, and makes a permanent migration to a zero-egress object store available without changing any test-side code.

## Linear ticket

<!-- internal -->

## Type

🚄 Infrastructure
🧹 Refactoring
✅ Test

## Changes

Layered cost reductions on the existing VCR cassette cache, in priority order from "biggest immediate win, no infra change" to "biggest permanent win, requires R2/S3 setup". All four are independent and additive.

### 1. zstd compression on every cassette payload

`tests/_vcr_redis_persister.py` now compresses the YAML cassette bytes before handing them to the backend, and decompresses on the way back. Magic-byte sniffing on the load path means cassettes already in Redis from prior runs continue to load unchanged — no flush required, no rollback risk.

Measured ratios on representative payloads (`uv run python` with the new helper):

| Payload | Raw bytes | zstd | Ratio |
| --- | ---: | ---: | ---: |
| Chat-completion JSON cassette | 4,130 | 423 | **9.76x** |
| 50-event SSE stream cassette | 3,902 | 442 | **8.83x** |
| Raw chat completion body | 3,772 | 252 | 14.97x |
| Raw SSE body | 3,490 | 174 | 20.06x |

Net effect: every read and every write through Redis Cloud transfers ~10% of the bytes it used to, both ways. That alone should put the project well under the soft bandwidth limit and shrink the 5-6 GB cache to ~600-900 MB. `CASSETTE_DISABLE_COMPRESSION=1` is the opt-out for diff-friendly debugging.

### 2. CircleCI cache as an L1 in front of Redis/R2

New `restore_vcr_l1_cache` and `save_vcr_l1_cache` reusable commands in `.circleci/config.yml`. They wrap the test step in every job whose pytest invocation runs against a directory that registers the cassette persister (18 jobs total — `llm_translation_testing`, `realtime_translation_testing`, `audio_testing`, `guardrails_testing`, `image_gen_testing`, `litellm_utils_testing`, `local_testing_part1`/`_part2`, `litellm_router_testing`/`_unit_testing`, `litellm_assistants_api_testing`, `langfuse_logging_unit_tests`, `logging_testing`, `pass_through_unit_testing`, `google_generate_content_endpoint_testing`, `llm_responses_api_testing`, `search_testing`, `ocr_testing`).

Cache key: `vcr-l1-v1-{job}-{node_index}-{branch}-{revision}` with fallbacks to (a) same job+shard on the same branch, (b) same job+shard on `main`, and (c) the same job's shard 0 on `main` so freshly-spawned shards still get a warm starting point. `when: always` on save so partial-failure runs still preserve cassettes for tests that did pass.

The new `_LocalDiskL1Cache` in the persister is read-through and write-through over any backend — sharded directory layout (sha256-prefixed two-byte buckets), atomic `tmp+rename` writes, mtime-based TTL. Activated by `CASSETTE_LOCAL_CACHE_DIR=...`, which the new CircleCI command exports automatically.

In aggregate this collapses 70-90% of cassette reads onto the regional CircleCI cache before they ever hit Redis. Combined with #1, the Redis bandwidth ceiling becomes a non-issue.

### 3. Cassette payload trims

Two changes in `tests/_vcr_conftest_common.py`:

- **`anthropic-version` is no longer filtered from request headers.** It's not a secret, it's tiny (~30 bytes), and a couple of tests parametrize over different beta versions — filtering it caused those parametrizations to share one cassette episode and produce false replay hits.
- **Response-header scrubbing is now blocklist + prefix-blocklist.** The prefix list catches whole header families that show up in 10+ variants per response and that no test asserts on: `x-amz-`, `x-amzn-`, `cf-`, `x-google-`, `x-vertex-`, `x-goog-`, `x-envoy-`, `x-cloud-trace-`, `x-ms-`, `anthropic-ratelimit-`, `openai-ratelimit-`, `x-ratelimit-`, `x-stainless-`. Plus a handful of explicit cache/security headers. `Content-Type` / `Content-Length` / `Content-Encoding` / `Transfer-Encoding` are explicitly preserved (vcrpy needs them for replay) and there's a unit test asserting this.

### 4. S3 / Cloudflare R2 backend

`CASSETTE_S3_BUCKET` (with optional `CASSETTE_S3_ENDPOINT` for non-AWS endpoints like Cloudflare R2 and `CASSETTE_S3_REGION`) selects a new `_S3Backend` instead of the Redis backend. Same wire protocol from the test's perspective: the persister still reads bytes by key and writes bytes by key. TTL is enforced on the read path via `LastModified`, matching the Redis 24h semantics while leaving bucket-lifecycle cleanup to the operator.

Selection precedence: explicit backend > S3 > Redis. The legacy `make_redis_persister(client=...)` entry point still exists for the fakeredis-driven unit tests, so nothing in the existing test surface had to change.

For the migration target — Cloudflare R2 with zero egress fees, ~$0.15/mo storage at 10 GB, ~$1-2/mo for the read+write request volume — the cassette cache line item drops from ~$200/mo to ~$2/mo, with no bandwidth cap to bump into.

### 5. Misc

- `tests/_flush_vcr_cache.py` now flushes Redis, S3, and the local disk cache, picking each based on the env vars present.
- `tests/llm_translation/Readme.md` documents the layered architecture and new env vars.
- `zstandard==0.25.0` added to the dev group; `boto3==1.43.1` was already in the proxy extra and is now also pinned for dev so the S3 backend has a known version available locally.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — three new test files in `tests/llm_translation/` covering compression, the L1 cache, and the S3 backend; existing test files in `tests/test_litellm/` and `tests/llm_translation/` updated to cover the header-filter changes. 156 VCR-related tests pass locally.
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem (cassette cache cost). Split into 4 logical commits: persister refactor, header trims, CI wiring, docs.

## Test evidence

Local run of the full VCR test surface (existing + new):

```
$ uv run pytest tests/test_litellm/test_vcr_safe_body_matcher.py \
    tests/llm_translation/test_vcr_redis_persister.py \
    tests/llm_translation/test_vcr_filters.py \
    tests/llm_translation/test_vcr_classification.py \
    tests/llm_translation/test_vcr_conftest_common_banner.py \
    tests/llm_translation/test_vcr_compression.py \
    tests/llm_translation/test_vcr_l1_disk_cache.py \
    tests/llm_translation/test_vcr_s3_backend.py
======================= 156 passed, 6 warnings in 7.06s ========================
```

`uv run ruff check .` (in `litellm/`) — `All checks passed!`

YAML schema validation on the patched `.circleci/config.yml` — parses cleanly. A scripted audit confirmed every job whose test command runs against a VCR-using `tests/<dir>/` glob has both `restore_vcr_l1_cache` and `save_vcr_l1_cache` wired in (18 jobs).

## Operator rollout notes

1. Merge as-is. Compression and the persister refactor are zero-config — they take effect immediately and load existing uncompressed cassettes via the magic-byte sniff.
2. The CircleCI L1 cache activates as soon as the new commands run; first run will be a cold cache, second run starts seeing the speedup.
3. To migrate to R2: set `CASSETTE_S3_BUCKET`, `CASSETTE_S3_ENDPOINT`, `CASSETTE_S3_REGION` in the CircleCI project context, optionally unset `CASSETTE_REDIS_URL`. The persister picks S3 over Redis automatically; `make test-llm-translation-flush-vcr-cache` will flush whichever backends are configured.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1779120761017189?thread_ts=1779120761.017189&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-a640b8ae-7bb5-5f54-b61d-4fcdcac2e467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a640b8ae-7bb5-5f54-b61d-4fcdcac2e467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

