### PR TITLE
fix(responses): forward timeout to completion-transformation path in responses()

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1115,6 +1115,7 @@ def responses(
                 stream=stream,
                 extra_headers=extra_headers,
                 extra_body=extra_body,
+                timeout=timeout or request_timeout,
                 **kwargs,
             )
 


### PR DESCRIPTION
## Summary

The `responses()` function (Responses API) silently ignores the `timeout` parameter for non-native providers (Anthropic, Bedrock, Vertex AI).

**Root cause:** Two code paths handle provider dispatch inside `responses()`:

1. **Native path** (line ~1159) — calls `base_llm_http_handler.response_api_handler(...)` and explicitly passes `timeout=timeout or request_timeout`.

2. **Completion-transformation path** (line ~1109) — calls `litellm_completion_transformation_handler.response_api_handler(...)` and omits `timeout` entirely. Anthropic, Bedrock, and Vertex AI all go through this path.

**Before:**

```python
# completion-transformation path
return litellm_completion_transformation_handler.response_api_handler(
    model=model,
    input=input,
    ...
    extra_headers=extra_headers,
    extra_body=extra_body,
    # timeout missing ← bug
    **kwargs,
)
```

**After:**

```python
return litellm_completion_transformation_handler.response_api_handler(
    ...
    timeout=timeout or request_timeout,  # matches native path
    **kwargs,
)
```

## Test plan

- [ ] `responses(model="claude-sonnet-4-5", ..., timeout=5.0)` raises `Timeout` when the upstream is slow (Anthropic path)
- [ ] Same for Bedrock and Vertex AI Claude models
- [ ] Native-path providers (OpenAI) unaffected
- [ ] No regression in existing Responses API tests

Fixes #28132
