### PR TITLE
Fix/get key models preserve team models

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -118,10 +118,12 @@ def get_key_models(
                 user_api_key_dict.team_models
             )  # copy to avoid mutating cached objects
         if SpecialModelNames.all_proxy_models.value in all_models:
-            all_models = list(proxy_model_list)  # copy to avoid mutating caller's list
+            all_models_set = set(all_models)
+            all_models_set.discard(SpecialModelNames.all_proxy_models.value)
+            all_models_set.update(proxy_model_list)
             if include_model_access_groups:
-                all_models.extend(model_access_groups.keys())
-
+                all_models_set.update(model_access_groups.keys())
+            all_models = list(all_models_set)
     all_models = _get_models_from_access_groups(
         model_access_groups=model_access_groups,
         all_models=all_models,

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -487,3 +487,66 @@ async def test_get_available_models_for_user_expands_query_team_wildcard(
     )
 
     assert "openai/gpt-4o-mini" in result
+
+
+def test_get_key_models_all_proxy_models_preserves_team_specific_entries():
+    """
+    When a key's models list contains both 'all-proxy-models' and team-specific
+    entries, get_key_models must return the union, not just proxy_model_list.
+    Old branch used assignment instead of set.update(),
+    dropping any team-specific models alongside 'all-proxy-models'.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_key_models
+
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["all-proxy-models", "team-private-claude-sonnet"],
+        api_key="test-key",
+    )
+    proxy_model_list = ["gpt-4o", "gpt-4-turbo"]
+
+    result = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups={},
+    )
+
+    assert (
+        "team-private-claude-sonnet" in result
+    ), "team-specific model was dropped when all-proxy-models sentinel was present"
+    assert "gpt-4o" in result
+    assert "gpt-4-turbo" in result
+    assert len(result) == len(set(result)), "result contains duplicates"
+    assert (
+        "all-proxy-models" not in result
+    ), "all-proxy-models sentinel should not appear as a model name in the result"
+
+
+def test_get_key_models_all_team_models_then_all_proxy_models_chain():
+    """
+    When a key has all-team-models and the team's model list contains
+    all-proxy-models, get_key_models must return the union of proxy models and
+    any team-specific entries, with neither sentinel in the output.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_key_models
+
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["all-team-models"],
+        team_models=["all-proxy-models", "team-claude-opus"],
+        api_key="test-key",
+    )
+    proxy_model_list = ["gpt-4o", "gpt-4-turbo"]
+
+    result = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups={},
+    )
+
+    assert "team-claude-opus" in result
+    assert "gpt-4o" in result
+    assert "gpt-4-turbo" in result
+    assert "all-proxy-models" not in result
+    assert "all-team-models" not in result
+    assert len(result) == len(set(result)), "result contains duplicates"


### PR DESCRIPTION
## Relevant issues

Fixes #28173

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<img width="2555" height="1381" alt="litellmbugtestreport" src="https://github.com/user-attachments/assets/92821985-2ba4-4fae-91c8-33a64fbf18a6" />

<img width="2183" height="864" alt="litellmbugtestreport2" src="https://github.com/user-attachments/assets/b1d1fe1f-d270-46b5-8a76-9e0eb20dfc40" />


## Type

🐛 Bug Fix

## Changes

`get_key_models()` in `model_checks.py` used assignment (`all_models = list(proxy_model_list)`) in the `all-proxy-models` sentinel branch. The assignment replaced the key's entire model list with the proxy-wide list, dropping any team-specific entries already in `all_models`. `GET /v1/models` returned only proxy-wide models for keys that had team-specific entries alongside the sentinel.

`get_team_models()` in the same file handles the same sentinel with `all_models_set.update(proxy_model_list)`, which unions rather than replaces. `get_key_models()` now follows the same pattern and also discards the sentinel string from the returned list.

Two tests added in `tests/test_litellm/proxy/auth/test_model_checks.py`:
- `test_get_key_models_all_proxy_models_preserves_team_specific_entries`: key with `all-proxy-models` and a named team model; asserts the union is returned and the sentinel is absent from the output.
- `test_get_key_models_all_team_models_then_all_proxy_models_chain`: key with `all-team-models` where the team list contains `all-proxy-models`; covers the chained resolution path through both sentinel branches.