### PR TITLE
fix(guardrails): classify GuardrailRaisedException as guardrail_intervened, not guardrail_failed_to_respond

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -739,9 +739,13 @@ class CustomGuardrail(CustomLogger):
         Guardrails signal intentional blocks by raising:
         - HTTPException with status 400 (content policy violation)
         - ModifyResponseException (passthrough mode violation)
+        - GuardrailRaisedException (generic_guardrail_api and custom adapters)
         """
+        from litellm.exceptions import GuardrailRaisedException
 
         if isinstance(e, ModifyResponseException):
+            return True
+        if isinstance(e, GuardrailRaisedException):
             return True
         if (
             HTTPException is not None


### PR DESCRIPTION
## Summary

When `generic_guardrail_api` blocks a request (returns `{"action": "BLOCKED"}`), it raises `GuardrailRaisedException`. The `log_guardrail_information` decorator calls `_is_guardrail_intervention(e)` to decide whether to log the block as `guardrail_intervened` or `guardrail_failed_to_respond`. Because `GuardrailRaisedException` is not checked, every block is misclassified as an API failure.

**Downstream effect:** The Guardrails Monitor dashboard shows 0 blocked requests and a 100% pass rate even while the guardrail is actively blocking.

**Root cause:**

```python
# before
@staticmethod
def _is_guardrail_intervention(e: Exception) -> bool:
    if isinstance(e, ModifyResponseException):
        return True
    if HTTPException is not None and isinstance(e, HTTPException) and e.status_code == 400:
        return True
    return False  # GuardrailRaisedException falls through → logged as failed_to_respond
```

**Fix:** add `GuardrailRaisedException` check:

```python
from litellm.exceptions import GuardrailRaisedException

if isinstance(e, GuardrailRaisedException):
    return True
```

## Changes

`litellm/integrations/custom_guardrail.py` — one `isinstance` guard added to `_is_guardrail_intervention`.

## Test plan

- [ ] `generic_guardrail_api` block → logged as `guardrail_intervened`
- [ ] `generic_guardrail_api` timeout/connection error → still logged as `guardrail_failed_to_respond`
- [ ] `HTTPException(400)` path unchanged
- [ ] Existing guardrail tests pass

Fixes #28163
