### PR TITLE
fix(auth): union proxy models with team models in get_key_models when all-proxy-models sentinel present

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -115,7 +115,11 @@ def get_key_models(
                 user_api_key_dict.team_models
             )  # copy to avoid mutating cached objects
         if SpecialModelNames.all_proxy_models.value in all_models:
-            all_models = list(proxy_model_list)  # copy to avoid mutating caller's list
+            # Union team-specific models with proxy-wide list, matching get_team_models()
+            # which uses set.update(). Replacing discards team-specific models.
+            merged = set(all_models) | set(proxy_model_list)
+            merged.discard(SpecialModelNames.all_proxy_models.value)
+            all_models = list(merged)
             if include_model_access_groups:
                 all_models.extend(model_access_groups.keys())
 


### PR DESCRIPTION
## Summary

`GET /v1/models` silently drops team-specific models for keys bound to a team whose ACL contains the `"all-proxy-models"` sentinel alongside named models.

**Root cause — inconsistency between `get_key_models` and `get_team_models`:**

```python
# get_key_models — REPLACES (bug)
if SpecialModelNames.all_proxy_models.value in all_models:
    all_models = list(proxy_model_list)   # team-specific models lost

# get_team_models — UNIONS (correct)
if SpecialModelNames.all_proxy_models.value in all_models_set:
    all_models_set.update(proxy_model_list)   # keeps team models + adds proxy-wide
```

**How the sentinel ends up in a team's ACL:** a team created without specifying `models` gets `models=[]`, and `add_new_models_to_team` injects `"all-proxy-models"` because it treats an empty list as "all access". Named models added later coexist with the sentinel, but `get_key_models` then discards them when resolving `/v1/models`.

**Fix:** compute the union in `get_key_models`, consistent with `get_team_models`:

```python
if SpecialModelNames.all_proxy_models.value in all_models:
    merged = set(all_models) | set(proxy_model_list)
    merged.discard(SpecialModelNames.all_proxy_models.value)
    all_models = list(merged)
```

## Test plan

- [ ] Team key with `all-proxy-models` sentinel + named models → `/v1/models` returns union
- [ ] Team key with only `all-proxy-models` sentinel → `/v1/models` returns proxy-wide list (unchanged)
- [ ] Key without sentinel → unaffected
- [ ] Existing model ACL tests pass

Fixes #28173
