### PR TITLE
fix(streaming): guard raise_on_model_repetition against empty choices chunks

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -269,6 +269,9 @@ class CustomStreamWrapper:
         if len(self.chunks) < 2:
             return
 
+        if not self.chunks[-1].choices or not self.chunks[-2].choices:
+            return
+
         last_content = self.chunks[-1].choices[0].delta.content
 
         if (

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -270,6 +270,7 @@ class CustomStreamWrapper:
             return
 
         if not self.chunks[-1].choices or not self.chunks[-2].choices:
+            self._repeated_messages_count = 1
             return
 
         last_content = self.chunks[-1].choices[0].delta.content

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1511,6 +1511,37 @@ def test_raise_on_model_repetition(
             wrapper.raise_on_model_repetition()
 
 
+def test_raise_on_model_repetition_empty_choices_no_crash(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    Regression test: Vertex Gemini Flash with web_search_options emits
+    metadata-only chunks with choices=[]. raise_on_model_repetition must
+    not raise IndexError on those chunks, and must reset the repetition
+    counter to 1 so subsequent real chunks are compared correctly.
+    """
+    wrapper = initialized_custom_stream_wrapper
+
+    empty_chunk = ModelResponseStream(
+        id="test",
+        created=1741037890,
+        model="test-model",
+        choices=[],  # metadata-only chunk — no choices
+    )
+
+    # Two empty-choices chunks: should not crash and counter should stay at 1
+    wrapper.chunks.append(empty_chunk)
+    wrapper.chunks.append(empty_chunk)
+    wrapper.raise_on_model_repetition()  # must not raise IndexError
+    assert wrapper._repeated_messages_count == 1
+
+    # Real content chunk after metadata chunks should still be compared correctly
+    real_chunk = _make_chunk("hello world content")
+    wrapper.chunks.append(real_chunk)
+    wrapper.raise_on_model_repetition()  # still must not raise
+    assert wrapper._repeated_messages_count == 1
+
+
 def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
     """
     Test that provider-reported usage from a post-finish_reason chunk


### PR DESCRIPTION
## Summary

`raise_on_model_repetition` unconditionally accesses `choices[0]` on the last two chunks in `self.chunks`. Vertex Gemini Flash / Flash Lite models with `web_search_options` emit metadata-only chunks that have `choices=[]`. These chunks are appended to `self.chunks` normally, so the next non-empty chunk triggers the repetition check on a zero-choices chunk, raising `IndexError` which propagates as `MidStreamFallbackError`.

## Change

`litellm/litellm_core_utils/streaming_handler.py` — add an early `return` when either of the two compared chunks has no choices, right after the existing `len < 2` guard:

```python
if not self.chunks[-1].choices or not self.chunks[-2].choices:
    return
```

The repetition check is meaningless for content-less metadata chunks (there is no content to repeat), so skipping them is both correct and safe.

## Reproduction

Any streaming call to `vertex_ai/gemini-*-flash*` or `vertex_ai/gemini-*-flash-lite*` with `web_search_options` set will hit this. The empty-choices metadata chunks are emitted unconditionally by those models.