### PR TITLE
fix(bedrock,sagemaker): silence ModuleNotFoundError when botocore is not installed

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -976,7 +976,12 @@ def _load_bedrock_response_stream_shape():
         service_dict = loader.load_service_model("bedrock-runtime", "service-2")
         return ServiceModel(service_dict).shape_for("ResponseStream")
     except ModuleNotFoundError:
-        return None  # botocore not installed — expected for non-Bedrock users
+        # Expected when botocore is not installed; avoid WARNING on every import (#28175).
+        # DEBUG preserves opt-in diagnosability for integrators troubleshooting preload.
+        verbose_logger.debug(
+            "litellm: botocore not installed; skipping bedrock-runtime response stream preload"
+        )
+        return None
     except Exception as e:
         verbose_logger.warning(
             "litellm: could not pre-load bedrock-runtime response stream shape "

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -975,6 +975,8 @@ def _load_bedrock_response_stream_shape():
         loader = Loader()
         service_dict = loader.load_service_model("bedrock-runtime", "service-2")
         return ServiceModel(service_dict).shape_for("ResponseStream")
+    except ModuleNotFoundError:
+        return None  # botocore not installed — expected for non-Bedrock users
     except Exception as e:
         verbose_logger.warning(
             "litellm: could not pre-load bedrock-runtime response stream shape "

--- a/litellm/llms/sagemaker/common_utils.py
+++ b/litellm/llms/sagemaker/common_utils.py
@@ -21,7 +21,10 @@ def _load_sagemaker_response_stream_shape():
             "InvokeEndpointWithResponseStreamOutput"
         )
     except ModuleNotFoundError:
-        return None  # botocore not installed — expected for non-SageMaker users
+        verbose_logger.debug(
+            "litellm: botocore not installed; skipping sagemaker-runtime response stream preload"
+        )
+        return None
     except Exception as e:
         verbose_logger.warning(
             "litellm: could not pre-load sagemaker-runtime response stream shape "

--- a/litellm/llms/sagemaker/common_utils.py
+++ b/litellm/llms/sagemaker/common_utils.py
@@ -20,6 +20,8 @@ def _load_sagemaker_response_stream_shape():
         return ServiceModel(service_dict).shape_for(
             "InvokeEndpointWithResponseStreamOutput"
         )
+    except ModuleNotFoundError:
+        return None  # botocore not installed — expected for non-SageMaker users
     except Exception as e:
         verbose_logger.warning(
             "litellm: could not pre-load sagemaker-runtime response stream shape "

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -46,6 +46,62 @@ def test_bedrock_response_stream_shape_load_failure_returns_none():
         assert shape is None
 
 
+def test_bedrock_no_warning_when_botocore_missing():
+    """
+    When botocore is not installed, _load_bedrock_response_stream_shape must return
+    None silently — no WARNING log. Non-Bedrock users should not see noisy warnings
+    on every litellm import. Regression test for GitHub issue #28175.
+    """
+    import builtins
+    from unittest.mock import patch
+
+    import litellm.llms.bedrock.common_utils as mod
+
+    original_import = builtins.__import__
+
+    def _no_botocore(name, *args, **kwargs):
+        if name.startswith("botocore"):
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_no_botocore):
+        with patch.object(mod, "verbose_logger") as mock_logger:
+            shape = mod._load_bedrock_response_stream_shape()
+
+    assert shape is None
+    mock_logger.warning.assert_not_called()
+
+
+def test_bedrock_warning_emitted_on_unexpected_load_failure():
+    """
+    When botocore IS installed but loading fails for an unexpected reason,
+    a WARNING must still be emitted so the operator knows decoding is broken.
+    Uses a fake botocore module so the test runs even without botocore installed.
+    """
+    import sys
+    from types import ModuleType
+    from unittest.mock import MagicMock, patch
+
+    import litellm.llms.bedrock.common_utils as mod
+
+    fake_botocore = ModuleType("botocore")
+    fake_loaders = ModuleType("botocore.loaders")
+    fake_model = ModuleType("botocore.model")
+    mock_loader_instance = MagicMock()
+    mock_loader_instance.load_service_model.side_effect = RuntimeError("schema corrupted")
+    fake_loaders.Loader = MagicMock(return_value=mock_loader_instance)
+    fake_model.ServiceModel = MagicMock()
+    fake_botocore.loaders = fake_loaders
+    fake_botocore.model = fake_model
+
+    with patch.dict(sys.modules, {"botocore": fake_botocore, "botocore.loaders": fake_loaders, "botocore.model": fake_model}):
+        with patch.object(mod, "verbose_logger") as mock_logger:
+            shape = mod._load_bedrock_response_stream_shape()
+
+    assert shape is None
+    mock_logger.warning.assert_called_once()
+
+
 def test_bedrock_response_stream_shape_is_structure_shape():
     """
     The loaded shape should be the botocore StructureShape for ResponseStream,

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -70,6 +70,7 @@ def test_bedrock_no_warning_when_botocore_missing():
 
     assert shape is None
     mock_logger.warning.assert_not_called()
+    mock_logger.debug.assert_called_once()
 
 
 def test_bedrock_warning_emitted_on_unexpected_load_failure():

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
@@ -44,6 +44,62 @@ def test_sagemaker_response_stream_shape_load_failure_returns_none():
         assert shape is None
 
 
+def test_sagemaker_no_warning_when_botocore_missing():
+    """
+    When botocore is not installed, _load_sagemaker_response_stream_shape must return
+    None silently — no WARNING log. Non-SageMaker users should not see noisy warnings
+    on every litellm import. Regression test for GitHub issue #28175.
+    """
+    import builtins
+    from unittest.mock import patch
+
+    import litellm.llms.sagemaker.common_utils as mod
+
+    original_import = builtins.__import__
+
+    def _no_botocore(name, *args, **kwargs):
+        if name.startswith("botocore"):
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_no_botocore):
+        with patch.object(mod, "verbose_logger") as mock_logger:
+            shape = mod._load_sagemaker_response_stream_shape()
+
+    assert shape is None
+    mock_logger.warning.assert_not_called()
+
+
+def test_sagemaker_warning_emitted_on_unexpected_load_failure():
+    """
+    When botocore IS installed but loading fails for an unexpected reason,
+    a WARNING must still be emitted so the operator knows decoding is broken.
+    Uses a fake botocore module so the test runs even without botocore installed.
+    """
+    import sys
+    from types import ModuleType
+    from unittest.mock import MagicMock, patch
+
+    import litellm.llms.sagemaker.common_utils as mod
+
+    fake_botocore = ModuleType("botocore")
+    fake_loaders = ModuleType("botocore.loaders")
+    fake_model = ModuleType("botocore.model")
+    mock_loader_instance = MagicMock()
+    mock_loader_instance.load_service_model.side_effect = RuntimeError("schema corrupted")
+    fake_loaders.Loader = MagicMock(return_value=mock_loader_instance)
+    fake_model.ServiceModel = MagicMock()
+    fake_botocore.loaders = fake_loaders
+    fake_botocore.model = fake_model
+
+    with patch.dict(sys.modules, {"botocore": fake_botocore, "botocore.loaders": fake_loaders, "botocore.model": fake_model}):
+        with patch.object(mod, "verbose_logger") as mock_logger:
+            shape = mod._load_sagemaker_response_stream_shape()
+
+    assert shape is None
+    mock_logger.warning.assert_called_once()
+
+
 def test_sagemaker_response_stream_shape_is_structure_shape():
     """
     The loaded shape should be the botocore StructureShape for

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
@@ -68,6 +68,7 @@ def test_sagemaker_no_warning_when_botocore_missing():
 
     assert shape is None
     mock_logger.warning.assert_not_called()
+    mock_logger.debug.assert_called_once()
 
 
 def test_sagemaker_warning_emitted_on_unexpected_load_failure():


### PR DESCRIPTION
## Problem

Closes #28175.

Every `litellm` import emits two `WARNING` log lines for users who don't have `botocore` installed:

```
LiteLLM:WARNING: could not pre-load bedrock-runtime response stream shape — Bedrock event-stream decoding will be unavailable. Error: No module named 'botocore'
LiteLLM:WARNING: could not pre-load sagemaker-runtime response stream shape — SageMaker event-stream decoding will be unavailable. Error: No module named 'botocore'
```

This was introduced by #27257, which added module-level eager loading of `BEDROCK_RESPONSE_STREAM_SHAPE` and `SAGEMAKER_RESPONSE_STREAM_SHAPE`. The `except Exception` clause logs a `WARNING` for **all** failures — including `ModuleNotFoundError`, which is the normal, expected outcome for anyone not using AWS.

## Fix

Split the `except` clause in both `_load_*_response_stream_shape` helpers:

- `ModuleNotFoundError` → return `None` silently (botocore not installed — expected)
- Any other `Exception` → `WARNING` unchanged (botocore present but schema load failed — actionable)

**Two files changed, 2 lines added:**

- `litellm/llms/bedrock/common_utils.py`
- `litellm/llms/sagemaker/common_utils.py`

## Tests

Added 4 regression tests (2 per helper):

- `test_*_no_warning_when_botocore_missing` — simulates `ModuleNotFoundError`, asserts `verbose_logger.warning` is never called
- `test_*_warning_emitted_on_unexpected_load_failure` — injects a fake botocore whose `Loader` raises `RuntimeError`, asserts warning IS emitted

Tests pass with and without botocore installed (fake-module injection avoids the dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)