### PR TITLE
fix(presidio): skip output masker when output_parse_pii is enabled

### DIFF
--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -2,6 +2,7 @@
 from typing import Any, Dict, List, Optional
 
 import litellm
+from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import CommonProxyErrors
 from litellm.types.guardrails import *
 
@@ -76,7 +77,27 @@ def initialize_presidio(litellm_params: LitellmParams, guardrail: Guardrail):
         _OPTIONAL_PresidioPIIMasking,
     )
 
-    filter_scope = getattr(litellm_params, "presidio_filter_scope", None) or "both"
+    raw_filter_scope = getattr(litellm_params, "presidio_filter_scope", None)
+
+    if litellm_params.output_parse_pii:
+        # output_parse_pii is round-trip masking: pre_call masks PII -> tokens,
+        # post_call unmasker substitutes tokens -> original PII. Registering an
+        # apply_to_output=True callback alongside it re-runs analyze+anonymize on
+        # the already-unmasked stream and clobbers the restored values. Force the
+        # effective scope to "input" so only the input masker + post_call
+        # unmasker are registered.
+        if raw_filter_scope and raw_filter_scope != "input":
+            verbose_proxy_logger.warning(
+                "Presidio: output_parse_pii=True is incompatible with "
+                "presidio_filter_scope=%r; the output masker would re-mask "
+                "the already-unmasked response. Forcing input-only scope "
+                "with post-call unmask.",
+                raw_filter_scope,
+            )
+        filter_scope = "input"
+    else:
+        filter_scope = raw_filter_scope or "both"
+
     run_input = filter_scope in ("input", "both")
     run_output = filter_scope in ("output", "both")
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -798,8 +798,7 @@ async def test_presidio_filter_scope_initializer(monkeypatch):
     assert any(c.apply_to_output for c in created)
 
 
-@pytest.mark.asyncio
-async def test_presidio_filter_scope_with_output_parse_pii(monkeypatch):
+def test_presidio_filter_scope_with_output_parse_pii(monkeypatch):
     """
     When output_parse_pii=True, the round-trip masker/unmasker pair must not be
     accompanied by an apply_to_output=True callback — that companion callback
@@ -835,13 +834,9 @@ async def test_presidio_filter_scope_with_output_parse_pii(monkeypatch):
     monkeypatch.setattr(litellm, "logging_callback_manager", mgr, raising=False)
 
     import litellm.proxy.guardrails.guardrail_hooks.presidio as presidio_mod
-    import litellm.proxy.guardrails.guardrail_initializers as gi
 
     monkeypatch.setattr(
         presidio_mod, "_OPTIONAL_PresidioPIIMasking", DummyGuardrail, raising=False
-    )
-    monkeypatch.setattr(
-        gi, "_OPTIONAL_PresidioPIIMasking", DummyGuardrail, raising=False
     )
 
     from litellm.proxy.guardrails.guardrail_initializers import initialize_presidio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -799,6 +799,134 @@ async def test_presidio_filter_scope_initializer(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_presidio_filter_scope_with_output_parse_pii(monkeypatch):
+    """
+    When output_parse_pii=True, the round-trip masker/unmasker pair must not be
+    accompanied by an apply_to_output=True callback — that companion callback
+    re-masks the already-unmasked streaming response.
+    """
+
+    created = []
+
+    class DummyGuardrail:
+        def __init__(
+            self,
+            apply_to_output: bool = False,
+            event_hook=None,
+            output_parse_pii=None,
+            **kwargs,
+        ):
+            self.apply_to_output = apply_to_output
+            self.event_hook = event_hook
+            self.output_parse_pii = output_parse_pii
+            created.append(self)
+
+        def update_in_memory_litellm_params(self, litellm_params):
+            pass
+
+    class DummyManager:
+        def __init__(self):
+            self.added = []
+
+        def add_litellm_callback(self, cb):
+            self.added.append(cb)
+
+    mgr = DummyManager()
+    monkeypatch.setattr(litellm, "logging_callback_manager", mgr, raising=False)
+
+    import litellm.proxy.guardrails.guardrail_hooks.presidio as presidio_mod
+    import litellm.proxy.guardrails.guardrail_initializers as gi
+
+    monkeypatch.setattr(
+        presidio_mod, "_OPTIONAL_PresidioPIIMasking", DummyGuardrail, raising=False
+    )
+    monkeypatch.setattr(
+        gi, "_OPTIONAL_PresidioPIIMasking", DummyGuardrail, raising=False
+    )
+
+    from litellm.proxy.guardrails.guardrail_initializers import initialize_presidio
+
+    guardrail_dict = {"guardrail_name": "presidio-output-parse"}
+
+    # Case 1: output_parse_pii=True, no explicit filter_scope.
+    # Expected: exactly 2 callbacks (input masker + post_call unmasker),
+    # no apply_to_output=True callback.
+    created.clear()
+    params = LitellmParams(guardrail="presidio", mode="pre_call", output_parse_pii=True)
+    cb = initialize_presidio(params, guardrail_dict)
+    assert len(created) == 2, (
+        f"expected 2 callbacks for output_parse_pii=True default scope, "
+        f"got {len(created)}"
+    )
+    assert all(not c.apply_to_output for c in created)
+    assert any(
+        c.output_parse_pii is True and c.event_hook == "post_call" for c in created
+    )
+    assert cb.apply_to_output is False
+
+    # Case 2: output_parse_pii=True + explicit filter_scope="input".
+    # Same as case 1, no warning needed.
+    created.clear()
+    params = LitellmParams(
+        guardrail="presidio",
+        mode="pre_call",
+        output_parse_pii=True,
+        presidio_filter_scope="input",
+    )
+    initialize_presidio(params, guardrail_dict)
+    assert len(created) == 2
+    assert all(not c.apply_to_output for c in created)
+
+    # Case 3: output_parse_pii=True + explicit filter_scope="both".
+    # Contradictory config — must NOT register the apply_to_output callback;
+    # warning must be emitted.
+    created.clear()
+    params = LitellmParams(
+        guardrail="presidio",
+        mode="pre_call",
+        output_parse_pii=True,
+        presidio_filter_scope="both",
+    )
+    with patch(
+        "litellm.proxy.guardrails.guardrail_initializers.verbose_proxy_logger.warning"
+    ) as mock_warn:
+        initialize_presidio(params, guardrail_dict)
+    assert len(created) == 2
+    assert all(not c.apply_to_output for c in created)
+    assert mock_warn.called
+
+    # Case 4: output_parse_pii=True + explicit filter_scope="output".
+    # Also contradictory — must NOT register apply_to_output callback;
+    # warning must be emitted; input masker still registered so pii_tokens
+    # are populated for the unmasker.
+    created.clear()
+    params = LitellmParams(
+        guardrail="presidio",
+        mode="pre_call",
+        output_parse_pii=True,
+        presidio_filter_scope="output",
+    )
+    with patch(
+        "litellm.proxy.guardrails.guardrail_initializers.verbose_proxy_logger.warning"
+    ) as mock_warn:
+        initialize_presidio(params, guardrail_dict)
+    assert len(created) == 2
+    assert all(not c.apply_to_output for c in created)
+    assert mock_warn.called
+
+    # Case 5 (backwards compat): output_parse_pii=False, no filter_scope.
+    # Pre-existing default — 2 callbacks (input masker + apply_to_output masker).
+    created.clear()
+    params = LitellmParams(
+        guardrail="presidio", mode="pre_call", output_parse_pii=False
+    )
+    initialize_presidio(params, guardrail_dict)
+    assert len(created) == 2
+    assert any(not c.apply_to_output for c in created)
+    assert any(c.apply_to_output for c in created)
+
+
+@pytest.mark.asyncio
 async def test_empty_content_handling(
     presidio_guardrail, mock_user_api_key, mock_cache
 ):


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

End-to-end repro with Presidio analyzer + anonymizer running, and a streaming `/chat/completions` request through the proxy with `output_parse_pii: true`. Request body: `{"messages": [{"role": "user", "content": "hey my name is john doe"}], "stream": true, "guardrails": ["presidio-output-parse"]}`. The LLM response frame is pinned via `temperature=0` and `seed=42` so the only difference between BEFORE and AFTER is the masking behavior at the trailing greeting.

**Before fix** — streaming reconstructed response:

```
"Hey, nice to meet you! My name isn't really anything, I'm just an AI,
 but I'm here to chat with you, <PERSON>! What's on your mind?"
```

**After fix** — same pinned request, streaming reconstructed response:

```
"Hey, nice to meet you! My name isn't really anything, I'm just an AI,
 but I'm here to chat with you, john doe! What's on your mind?"
```

Non-streaming was correct in both runs (it goes through `apply_guardrail`, which short-circuits on the per-request `pii_tokens` map before reaching analyze/anonymize).

## Type

🐛 Bug Fix

## Changes

### Bug

When the Presidio guardrail is configured with `output_parse_pii: true`, `initialize_presidio` was registering **three** callbacks instead of two:

1. Input masker (pre-call) — masks PII to tokens like `<PERSON_1>` and stores the mapping in `request_data["metadata"]["pii_tokens"]`.
2. Post-call unmasker — substitutes the tokens back to the original PII using that map.
3. **An extra `apply_to_output=True` masker** — auto-registered because `presidio_filter_scope` defaults to `"both"`. This callback re-runs `analyze` + `anonymize` on the response text.

In the streaming path, the proxy dispatcher prefers `async_post_call_streaming_iterator_hook` over `apply_guardrail`, so both post-call callbacks ran in order: the unmasker correctly restored the PII, then the `apply_to_output=True` masker re-masked the result to a fresh `<PERSON>` token (no `_1` suffix, since it's a brand new anonymize call with no token map), clobbering the unmask. The client received `<PERSON>` instead of the original input.

The non-streaming path was unaffected because `apply_guardrail` short-circuits on the per-request `pii_tokens` map before reaching the analyze/anonymize step.

### Fix

`litellm/proxy/guardrails/guardrail_initializers.py` — in `initialize_presidio`, treat `output_parse_pii: true` as round-trip masking. When that flag is set, force the effective `filter_scope` to `"input"`, which registers only the input masker + post-call unmasker. If the user explicitly set a conflicting `presidio_filter_scope` (e.g. `"both"` or `"output"`), emit a `verbose_proxy_logger.warning` and still drop the `apply_to_output=True` callback so the round-trip behavior is preserved.

### Backwards compatibility

- `output_parse_pii: false` (or unset): unchanged — `filter_scope` still defaults to `"both"`.
- `output_parse_pii: true` + no explicit `presidio_filter_scope`: was producing 3 callbacks (the bug). Now produces 2, matching the documented round-trip behavior.
- `output_parse_pii: true` + explicit `presidio_filter_scope: input`: unchanged (no warning, 2 callbacks).
- `output_parse_pii: true` + explicit `presidio_filter_scope: output` or `both`: previously contradictory and broken in streaming. Now logs a warning and runs as input-only.

### Tests

New regression test in `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py`:

- `test_presidio_filter_scope_with_output_parse_pii` — 5 sub-cases covering the default scope + `output_parse_pii=True`, explicit `input`, conflicting `both` (warning + 2 callbacks, no `apply_to_output`), conflicting `output` (warning + 2 callbacks, no `apply_to_output`), and backwards-compat `output_parse_pii=False`.

Existing `test_presidio_filter_scope_initializer` continues to pass. The full presidio test file (64 tests) and `test_initialize_presidio_guardrail` are green locally.
