### PR TITLE
fix(anthropic): accept dict-shape reasoning_effort from Responses bridge

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1506,9 +1506,21 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 optional_params["metadata"] = {"user_id": value}
             elif param == "thinking":
                 optional_params["thinking"] = value
-            elif param == "reasoning_effort" and isinstance(value, str):
+            elif param == "reasoning_effort":
+                # Accept both string ("low") and dict ({"effort": "low",
+                # "summary": "concise"}). The Responses->Chat parser keeps the
+                # full dict when `summary` is set (see #25359), so a dict here
+                # is the standard shape Otto/OpenAI-Responses-Bridge callers
+                # send. Coerce to the effort string before mapping — same
+                # shape-tolerance the GPT-5 path already implements in
+                # `_normalize_reasoning_effort_for_chat_completion`.
+                effort_value = value
+                if isinstance(effort_value, dict):
+                    effort_value = effort_value.get("effort")
+                if not isinstance(effort_value, str):
+                    continue
                 mapped_thinking = AnthropicConfig._map_reasoning_effort(
-                    reasoning_effort=value,
+                    reasoning_effort=effort_value,
                     model=model,
                     llm_provider=self.custom_llm_provider or "anthropic",
                 )
@@ -1519,12 +1531,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     optional_params["thinking"] = mapped_thinking
                     if AnthropicConfig._is_adaptive_thinking_model(model):
                         mapped_effort = REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT.get(
-                            value
+                            effort_value
                         )
                         if mapped_effort is None:
                             AnthropicConfig._raise_invalid_reasoning_effort(
                                 model=model,
-                                value=value,
+                                value=effort_value,
                                 llm_provider=self.custom_llm_provider or "anthropic",
                             )
                         optional_params["output_config"] = {"effort": mapped_effort}

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2477,6 +2477,82 @@ def test_reasoning_effort_does_not_set_output_config_for_older_models():
 
 
 @pytest.mark.parametrize(
+    "reasoning_effort_value",
+    [
+        # String shape — what callers send when using `reasoning_effort="low"` directly.
+        "low",
+        # Dict shape with `effort` only — what the Responses->Chat parser produces
+        # when `reasoning={"effort": "low"}` is set without `summary`.
+        {"effort": "low"},
+        # Dict shape with `effort` AND `summary` — what the Responses->Chat parser
+        # produces when callers send `Reasoning(effort="low", summary="concise")`.
+        # PR #25359 added the dict-keeping branch for this case, but the Anthropic
+        # transformation must coerce the dict back to a string before mapping.
+        {"effort": "low", "summary": "concise"},
+        {"effort": "low", "summary": "detailed"},
+    ],
+)
+def test_reasoning_effort_accepts_dict_shape_from_responses_bridge(reasoning_effort_value):
+    """
+    Regression test for the dict-shape `reasoning_effort` produced by the
+    Responses->Chat parser when `summary` is set on the request's `reasoning`
+    field (see ``transform_responses_api_request_to_chat_completion_request``).
+
+    Before this fix, the Anthropic transformation guarded on
+    ``isinstance(value, str)`` and silently dropped the param when it arrived
+    as a dict — disabling extended thinking entirely. This test pins the
+    shape-tolerant behavior matching OpenAI's
+    ``_normalize_reasoning_effort_for_chat_completion``.
+    """
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": reasoning_effort_value},
+        optional_params={},
+        model="claude-sonnet-4-6-20260219",
+        drop_params=False,
+    )
+
+    # thinking must be set (adaptive for 4.6+)
+    assert "thinking" in result, (
+        f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
+    )
+    assert result["thinking"]["type"] == "adaptive"
+    # output_config must carry the mapped effort
+    assert "output_config" in result, (
+        f"output_config missing for reasoning_effort={reasoning_effort_value!r}"
+    )
+    assert result["output_config"]["effort"] == "low"
+
+
+def test_reasoning_effort_unparseable_dict_is_dropped():
+    """
+    A dict shape that doesn't carry a usable ``effort`` key (e.g. only
+    ``summary`` is set, or the value is some other unexpected type) should be
+    silently dropped — not crash, not partially apply.
+    """
+    config = AnthropicConfig()
+
+    for bad_value in [
+        {"summary": "concise"},  # missing effort
+        {"effort": None},  # explicit None effort
+        {"effort": 123},  # non-string effort
+    ]:
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": bad_value},
+            optional_params={},
+            model="claude-sonnet-4-6-20260219",
+            drop_params=False,
+        )
+        assert "thinking" not in result, (
+            f"thinking should not be set for bad value {bad_value!r}"
+        )
+        assert "output_config" not in result, (
+            f"output_config should not be set for bad value {bad_value!r}"
+        )
+
+
+@pytest.mark.parametrize(
     "model",
     [
         "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Fixes the regression I described in #28196 — Anthropic silently drops `reasoning_effort` when it arrives as a dict (the shape the Responses→Chat parser produces whenever `reasoning.summary` is set on the request).

## Root cause recap

PR #25359 added a new branch to `transform_responses_api_request_to_chat_completion_request`:

```python
# litellm/responses/litellm_completion_transformation/transformation.py
if isinstance(reasoning_param, dict):
    if "summary" in reasoning_param:
        reasoning_effort = reasoning_param        # ← keeps WHOLE DICT
    elif "effort" in reasoning_param:
        reasoning_effort = reasoning_param.get("effort")
```

But the Anthropic transformation downstream still guards on `isinstance(value, str)`:

```python
# litellm/llms/anthropic/chat/transformation.py:1509
elif param == "reasoning_effort" and isinstance(value, str):  # ← fails for dict
    mapped_thinking = AnthropicConfig._map_reasoning_effort(...)
```

So when a caller sends the standard `Reasoning(effort="low", summary="concise")` (e.g. via `aresponses` against an Anthropic-routed model), the dict fails the guard, `thinking` is never set, and Anthropic produces 0 reasoning tokens. OpenAI's `gpt_5_transformation._normalize_reasoning_effort_for_chat_completion` already accepts both shapes; this PR brings Anthropic to the same tolerance.

## Change

In `AnthropicConfig.map_openai_params`, coerce dict input to the effort string before calling `_map_reasoning_effort`. Drop silently if the dict has no usable effort (matches the prior behavior for unrecognized inputs — no crash, no half-applied state).

```diff
- elif param == "reasoning_effort" and isinstance(value, str):
+ elif param == "reasoning_effort":
+     effort_value = value
+     if isinstance(effort_value, dict):
+         effort_value = effort_value.get("effort")
+     if not isinstance(effort_value, str):
+         continue
      mapped_thinking = AnthropicConfig._map_reasoning_effort(
-         reasoning_effort=value,
+         reasoning_effort=effort_value,
          model=model,
          llm_provider=self.custom_llm_provider or "anthropic",
      )
      ...
          if AnthropicConfig._is_adaptive_thinking_model(model):
              mapped_effort = REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT.get(
-                 value
+                 effort_value
              )
```

## Tests

Two new regression tests in `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py`:

1. **`test_reasoning_effort_accepts_dict_shape_from_responses_bridge`** — parametrized over `"low"`, `{"effort": "low"}`, `{"effort": "low", "summary": "concise"}`, `{"effort": "low", "summary": "detailed"}`. Verifies `thinking` and `output_config` get set on `claude-sonnet-4-6` for every shape.

2. **`test_reasoning_effort_unparseable_dict_is_dropped`** — covers `{"summary": "concise"}` (missing effort), `{"effort": None}`, `{"effort": 123}` (non-string). All should be silently dropped, no crash.

All 26 `reasoning_effort` tests in that file pass:

```
tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
=========================== 26 passed in 0.51s ============================
```

## Empirical verification (live API)

| Call shape | Model | `reasoning_tokens` |
|---|---|---|
| `reasoning_effort="low"` (string) | `claude-sonnet-4-6` | **187+** ✅ |
| `Reasoning(effort="low", summary="concise")` (dict, pre-fix) | `claude-sonnet-4-6` | **0** (bug repro) |
| `Reasoning(effort="low", summary="concise")` (dict, post-fix) | `claude-sonnet-4-6` | **>0** ✅ (verified locally with patched build) |
| `Reasoning(effort="low", summary="concise")` | `gpt-5.2` | **87+** ✅ (unchanged) |

## Related

- Reported in #28196
- Regression introduced in #25359 (v1.84.0 / v1.85.0)
- Other providers using `AnthropicConfig._is_adaptive_thinking_model` (Bedrock, Vertex, Databricks) may want the same audit — they share the adaptive-thinking helper but I haven't verified their `reasoning_effort` handlers route through the same path.
