### PR TITLE
fix(proxy): add model_max_budget to NewTeamRequest and UpdateTeamRequest

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1819,6 +1819,7 @@ class TeamBase(LiteLLMPydanticObjectBase):
 
 class NewTeamRequest(TeamBase):
     model_aliases: Optional[dict] = None
+    model_max_budget: Optional[dict] = None
     tags: Optional[list] = None
     guardrails: Optional[List[str]] = None
     policies: Optional[List[str]] = None
@@ -1906,6 +1907,7 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
     enforced_batch_output_expires_after: Optional[dict] = None
     enforced_file_expires_after: Optional[dict] = None
+    model_max_budget: Optional[dict] = None
     router_settings: Optional[dict] = None
     access_group_ids: Optional[List[str]] = None
     budget_limits: Optional[List[BudgetLimitEntry]] = (


### PR DESCRIPTION
## Summary

`model_max_budget` (per-model budget dict, e.g. `{"gpt-4": 10.0}`) is missing from both `NewTeamRequest` and `UpdateTeamRequest` in `litellm/proxy/_types.py`.

When a caller sends `model_max_budget` in a `POST /team/new` or `POST /team/update` request, Pydantic silently strips the field because it is not declared on the model. `data.json(exclude_unset=True)` then omits the field from the DB write, so the value is never persisted (the column stays `{}`).

The column **does** exist on `LiteLLM_TeamTable` and is already handled by `jsonify_object` (which JSON-serializes all dict values before they reach Prisma). Adding the field to the two request classes is sufficient to close the gap.

By contrast, `UpdateUserRequest` already declares `model_max_budget: Optional[dict] = None`, so the user update path works correctly — this fix brings the team path in line with it.

## Root cause

```python
# litellm/proxy/_types.py

class NewTeamRequest(TeamBase):
    model_aliases: Optional[dict] = None
    # model_max_budget MISSING ← field silently dropped by Pydantic

class UpdateTeamRequest(LiteLLMPydanticObjectBase):
    ...
    model_rpm_limit: Optional[Dict[str, int]] = None
    model_tpm_limit: Optional[Dict[str, int]] = None
    # model_max_budget MISSING ← field silently dropped by Pydantic
```

## Fix

```python
class NewTeamRequest(TeamBase):
    model_aliases: Optional[dict] = None
    model_max_budget: Optional[dict] = None   # ← added
    ...

class UpdateTeamRequest(LiteLLMPydanticObjectBase):
    ...
    model_max_budget: Optional[dict] = None   # ← added
    router_settings: Optional[dict] = None
    ...
```

## Test Plan

- [ ] `POST /team/new` with `model_max_budget: {"gpt-4": 10.0}` → verify value persists in DB
- [ ] `POST /team/update` with `model_max_budget: {"gpt-4": 10.0}` → verify value persists in DB and response reflects it
- [ ] Existing team tests still pass

Fixes #28188