### PR TITLE
fix(proxy): allow budget_limits:[] to clear all budget windows on /key/update

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1843,17 +1843,18 @@ async def prepare_key_update_data(
             non_default_values["budget_reset_at"] = key_reset_at
             non_default_values["budget_duration"] = budget_duration
 
-    if "budget_limits" in non_default_values and non_default_values["budget_limits"]:
-        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
-
-        raw_windows = non_default_values["budget_limits"]
+    if "budget_limits" in non_default_values:
+        raw_windows = non_default_values["budget_limits"] or []
         initialized_windows = []
-        for window in raw_windows:
-            w = window if isinstance(window, dict) else window.model_dump()
-            w["reset_at"] = get_budget_reset_time(
-                budget_duration=w["budget_duration"]
-            ).isoformat()
-            initialized_windows.append(w)
+        if raw_windows:
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+            for window in raw_windows:
+                w = window if isinstance(window, dict) else window.model_dump()
+                w["reset_at"] = get_budget_reset_time(
+                    budget_duration=w["budget_duration"]
+                ).isoformat()
+                initialized_windows.append(w)
         non_default_values["budget_limits"] = json.dumps(initialized_windows)
 
     if "object_permission" in non_default_values:


### PR DESCRIPTION
## Summary

`POST /key/update` with `budget_limits: []` returns 200 but does **not** clear the existing budget windows. The old windows continue to enforce. This makes it impossible to remove a budget window from a key once set.

## Root Cause

In `prepare_key_update_data` (`key_management_endpoints.py`), the condition that converts the `budget_limits` list to a JSON string is:

```python
if "budget_limits" in non_default_values and non_default_values["budget_limits"]:
```

An empty Python list `[]` is **falsy**, so the entire block is skipped when the client sends `budget_limits: []`. `non_default_values["budget_limits"]` remains as an un-serialised Python list, which means the DB update does not receive the properly-formatted empty array. The existing budget windows are therefore never cleared.

## Fix

Enter the block whenever the `budget_limits` key is present (regardless of whether the list is empty), only run the window-initialisation loop when there are windows to initialise, and always write the JSON-serialised result:

```python
# Before (buggy):
if "budget_limits" in non_default_values and non_default_values["budget_limits"]:
    ...
    non_default_values["budget_limits"] = json.dumps(initialized_windows)

# After (fixed):
if "budget_limits" in non_default_values:
    raw_windows = non_default_values["budget_limits"] or []
    initialized_windows = []
    if raw_windows:
        ...  # populate initialized_windows with reset_at timestamps
    non_default_values["budget_limits"] = json.dumps(initialized_windows)
    # json.dumps([]) → "[]" when clearing; unchanged for non-empty
```

When `budget_limits: []` is sent, `initialized_windows` remains `[]`, and `json.dumps([])` → `"[]"` is written to the DB, which clears all existing windows.

## Test Plan

- [ ] `POST /key/update` with `budget_limits: [{"max_budget": 0.01, "budget_duration": "24h"}]` → budget window set and enforced
- [ ] `POST /key/update` with `budget_limits: []` → budget window removed; `GET /key/info` returns `budget_limits: []` or `null`
- [ ] `POST /key/update` without `budget_limits` → existing budget windows unchanged (not affected by this fix)

Fixes #28021