### PR TITLE
fix(router): wrap aresponses streaming iterator for mid-stream fallbacks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2206,6 +2206,149 @@ class Router:
 
         return FallbackStreamWrapper(stream_with_fallbacks())
 
+    async def _aresponses_streaming_iterator(
+        self,
+        response: Any,
+        initial_kwargs: dict,
+    ) -> Any:
+        """
+        Wrap a Responses-API streaming iterator so MidStreamFallbackError
+        triggers the Router's fallback chain (parity with
+        _acompletion_streaming_iterator for the chat-completions path).
+
+        The Responses-API streaming path goes through
+        _ageneric_api_call_with_fallbacks rather than _acompletion, so the
+        returned iterator is never wrapped by the chat completions
+        fallback handler. Without this wrapper, MidStreamFallbackError
+        raised mid-stream from the underlying CustomStreamWrapper (used by
+        LiteLLMCompletionStreamingIterator when the Responses API is
+        served via the completion bridge) propagates unhandled and the
+        configured cross-provider fallback never fires.
+
+        Only pre-first-chunk retry is supported — the Responses-API input
+        shape differs from chat completions, so partial-content
+        continuation is intentionally out of scope.
+        """
+        from litellm.exceptions import MidStreamFallbackError
+        from litellm.responses.streaming_iterator import (
+            BaseResponsesAPIStreamingIterator,
+        )
+
+        source_iterator = response
+
+        class FallbackResponsesStreamWrapper(BaseResponsesAPIStreamingIterator):
+            """
+            Subclasses BaseResponsesAPIStreamingIterator only for isinstance
+            compatibility (proxy + interactions code paths check the type).
+            Bypasses the parent constructor and delegates iteration to an
+            async generator.
+            """
+
+            def __init__(self, async_generator: AsyncGenerator):
+                self._async_generator = async_generator
+                self.finished = False
+                # Preserve hidden params and identity attributes so response
+                # headers (model_id, api_base, additional_headers) still flow.
+                self._hidden_params = dict(
+                    getattr(source_iterator, "_hidden_params", {}) or {}
+                )
+                self.model = getattr(source_iterator, "model", "")
+                self.custom_llm_provider = getattr(
+                    source_iterator, "custom_llm_provider", None
+                )
+                self.logging_obj = getattr(source_iterator, "logging_obj", None)
+                self.litellm_metadata = getattr(
+                    source_iterator, "litellm_metadata", None
+                )
+                self.responses_api_provider_config = getattr(
+                    source_iterator, "responses_api_provider_config", None
+                )
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return await self._async_generator.__anext__()
+
+            async def aclose(self):
+                close = getattr(self._async_generator, "aclose", None)
+                if close is not None:
+                    await close()
+
+        async def stream_with_fallbacks():
+            fallback_response = None
+            try:
+                async for item in source_iterator:
+                    yield item
+            except MidStreamFallbackError as e:
+                try:
+                    model_group = cast(str, initial_kwargs.get("model"))
+                    fallbacks: Optional[List] = initial_kwargs.get(
+                        "fallbacks", self.fallbacks
+                    )
+                    context_window_fallbacks: Optional[List] = initial_kwargs.get(
+                        "context_window_fallbacks", self.context_window_fallbacks
+                    )
+                    content_policy_fallbacks: Optional[List] = initial_kwargs.get(
+                        "content_policy_fallbacks", self.content_policy_fallbacks
+                    )
+                    # Re-enter via the per-attempt helper so the fallback chain
+                    # picks deployments through
+                    # _ageneric_api_call_with_fallbacks_helper.
+                    # original_generic_function is preserved by the caller so
+                    # the helper knows what underlying API to invoke per attempt.
+                    initial_kwargs["original_function"] = (
+                        self._ageneric_api_call_with_fallbacks_helper
+                    )
+                    self._update_kwargs_before_fallbacks(
+                        model=model_group, kwargs=initial_kwargs
+                    )
+                    fallback_response = (
+                        await self.async_function_with_fallbacks_common_utils(
+                            e=e,
+                            disable_fallbacks=False,
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=context_window_fallbacks,
+                            content_policy_fallbacks=content_policy_fallbacks,
+                            model_group=model_group,
+                            args=(),
+                            kwargs=initial_kwargs,
+                        )
+                    )
+
+                    if hasattr(fallback_response, "__aiter__"):
+                        async for fallback_item in fallback_response:  # type: ignore
+                            yield fallback_item
+                    else:
+                        yield fallback_response
+                except Exception as fallback_error:
+                    verbose_router_logger.error(
+                        f"Responses streaming fallback also failed: {fallback_error}"
+                    )
+                    raise fallback_error
+            finally:
+                with anyio.CancelScope(shield=True):
+                    if hasattr(source_iterator, "aclose"):
+                        try:
+                            await source_iterator.aclose()  # type: ignore[func-returns-value]
+                        except BaseException as exc:
+                            verbose_router_logger.debug(
+                                "stream_with_fallbacks(aresponses): error closing source: %s",
+                                exc,
+                            )
+                    if fallback_response is not None and hasattr(
+                        fallback_response, "aclose"
+                    ):
+                        try:
+                            await fallback_response.aclose()
+                        except BaseException as exc:
+                            verbose_router_logger.debug(
+                                "stream_with_fallbacks(aresponses): error closing fallback: %s",
+                                exc,
+                            )
+
+        return FallbackResponsesStreamWrapper(stream_with_fallbacks())
+
     def _completion_streaming_iterator(  # noqa: PLR0915
         self,
         model_response: CustomStreamWrapper,
@@ -4252,6 +4395,41 @@ class Router:
                 self.fail_calls[model] += 1
             raise e
 
+    async def _aresponses_with_streaming_fallbacks(
+        self, original_function: Callable, **kwargs
+    ):
+        """
+        _ageneric_api_call_with_fallbacks for the Responses API, with the
+        addition of mid-stream fallback handling.
+
+        When stream=True and the underlying call returns a
+        BaseResponsesAPIStreamingIterator, wrap it with
+        _aresponses_streaming_iterator so MidStreamFallbackError raised
+        during iteration triggers the Router's cross-provider fallback chain.
+        """
+        from litellm.responses.streaming_iterator import (
+            BaseResponsesAPIStreamingIterator,
+        )
+
+        # Snapshot the request kwargs before _ageneric_api_call_with_fallbacks
+        # mutates them. The original_generic_function is preserved so the
+        # per-attempt helper knows which underlying API to call on fallback.
+        fallback_kwargs = kwargs.copy()
+        fallback_kwargs["original_generic_function"] = original_function
+
+        response = await self._ageneric_api_call_with_fallbacks(
+            original_function=original_function, **kwargs
+        )
+
+        if kwargs.get("stream") and isinstance(
+            response, BaseResponsesAPIStreamingIterator
+        ):
+            return await self._aresponses_streaming_iterator(
+                response=response,
+                initial_kwargs=fallback_kwargs,
+            )
+        return response
+
     def _generic_api_call_with_fallbacks(
         self, model: str, original_function: Callable, **kwargs
     ):
@@ -5440,9 +5618,13 @@ class Router:
                     custom_llm_provider=custom_llm_provider,
                     **kwargs,
                 )
+            elif call_type == "aresponses":
+                return await self._aresponses_with_streaming_fallbacks(
+                    original_function=original_function,
+                    **kwargs,
+                )
             elif call_type in (
                 "anthropic_messages",
-                "aresponses",
                 "_arealtime",
                 "_aresponses_websocket",
                 "acreate_fine_tuning_job",

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1742,6 +1742,135 @@ async def test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation
 
 
 @pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_fallback():
+    """_aresponses_streaming_iterator should catch MidStreamFallbackError and
+    re-enter the Router's fallback chain — parity with the chat-completions
+    streaming path. Mirrors test_acompletion_streaming_iterator for aresponses.
+    """
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "anthropic/claude-sonnet-4-6",
+                "litellm_params": {
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "api_key": "fake-anthropic-key",
+                },
+            },
+            {
+                "model_name": "vertex_ai/claude-sonnet-4-6",
+                "litellm_params": {
+                    "model": "vertex_ai/claude-sonnet-4-6",
+                    "api_key": "fake-vertex-key",
+                },
+            },
+        ],
+        fallbacks=[{"anthropic/claude-sonnet-4-6": ["vertex_ai/claude-sonnet-4-6"]}],
+    )
+
+    initial_kwargs = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "stream": True,
+        "input": "Hi",
+    }
+
+    # Source iterator: yields one chunk, then raises MidStreamFallbackError.
+    class _ErrorIterator(BaseResponsesAPIStreamingIterator):
+        def __init__(self):
+            self._chunks = [MagicMock(type="response.created")]
+            self._idx = 0
+            self._hidden_params = {"model_id": "src-deployment-1"}
+            self.model = "anthropic/claude-sonnet-4-6"
+            self.custom_llm_provider = "anthropic"
+            self.logging_obj = MagicMock()
+            self.litellm_metadata = None
+            self.responses_api_provider_config = None
+            self.finished = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx < len(self._chunks):
+                chunk = self._chunks[self._idx]
+                self._idx += 1
+                return chunk
+            raise MidStreamFallbackError(
+                message="anthropic socket timeout",
+                model="anthropic/claude-sonnet-4-6",
+                llm_provider="anthropic",
+                is_pre_first_chunk=False,
+                generated_content="",
+            )
+
+    # Fallback iterator: what the Router would return from the fallback chain.
+    fallback_chunks = [
+        MagicMock(type="response.output_text.delta"),
+        MagicMock(type="response.completed"),
+    ]
+
+    class _FallbackIterator:
+        def __init__(self, items):
+            self._items = items
+            self._idx = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx >= len(self._items):
+                raise StopAsyncIteration
+            item = self._items[self._idx]
+            self._idx += 1
+            return item
+
+    src = _ErrorIterator()
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=_FallbackIterator(fallback_chunks),
+    ) as mock_fallback_utils:
+        wrapped = await router._aresponses_streaming_iterator(
+            response=src,
+            initial_kwargs={
+                **initial_kwargs,
+                "original_generic_function": litellm.aresponses,
+            },
+        )
+
+        # Wrapper preserves isinstance for downstream consumers
+        assert isinstance(wrapped, BaseResponsesAPIStreamingIterator)
+        # Hidden params propagated through (needed for response headers)
+        assert wrapped._hidden_params.get("model_id") == "src-deployment-1"
+
+        collected = []
+        async for chunk in wrapped:
+            collected.append(chunk)
+
+    # 1 chunk before the error + 2 from fallback iterator
+    assert len(collected) == 3
+    assert mock_fallback_utils.called
+
+    call_kwargs = mock_fallback_utils.call_args.kwargs
+    fallback_call_kwargs = call_kwargs["kwargs"]
+    # Re-entry must hit the per-attempt helper, with original_generic_function
+    # preserved so the helper calls litellm.aresponses on each fallback attempt.
+    # (Bound methods compare equal when they share the same instance + __func__.)
+    assert (
+        fallback_call_kwargs["original_function"]
+        == router._ageneric_api_call_with_fallbacks_helper
+    )
+    assert fallback_call_kwargs["original_generic_function"] is litellm.aresponses
+    assert call_kwargs["model_group"] == "anthropic/claude-sonnet-4-6"
+    assert call_kwargs["disable_fallbacks"] is False
+
+
+@pytest.mark.asyncio
 async def test_async_function_with_fallbacks_common_utils():
     """Test the async_function_with_fallbacks_common_utils method"""
     # Create a basic router for testing


### PR DESCRIPTION
## Summary

`MidStreamFallbackError` raised mid-stream during `Router.aresponses(stream=True)` bypasses the Router's fallback chain, so configured cross-provider fallbacks (e.g. `anthropic → vertex_ai`) never fire when the primary provider's stream fails mid-flight.

The chat completions path wraps its `CustomStreamWrapper` via `_acompletion_streaming_iterator`, which catches `MidStreamFallbackError` and re-enters `async_function_with_fallbacks_common_utils`. The Responses API path doesn't have an equivalent: it dispatches through `_ageneric_api_call_with_fallbacks` → `_ageneric_api_call_with_fallbacks_helper`, which awaits `litellm.aresponses(**response_kwargs)` and returns the streaming iterator **unwrapped**. Any `MidStreamFallbackError` raised during iteration (e.g. by the underlying `CustomStreamWrapper` when `LiteLLMCompletionStreamingIterator` bridges through completion) propagates past the Router.

Observed in production: Anthropic socket timed out before the first chunk on `Router.aresponses(stream=True)`. Configured `anthropic → vertex_ai` fallback was never invoked; the error surfaced to the caller.

## Changes

- New `Router._aresponses_streaming_iterator` mirroring `_acompletion_streaming_iterator`. Wraps `BaseResponsesAPIStreamingIterator`, catches `MidStreamFallbackError`, re-enters `async_function_with_fallbacks_common_utils` with `original_function=_ageneric_api_call_with_fallbacks_helper` and `original_generic_function` preserved so the helper invokes `litellm.aresponses` on each fallback attempt. The wrapper subclasses `BaseResponsesAPIStreamingIterator` (bypassing the parent constructor) to preserve `isinstance` compatibility with downstream consumers (proxy cursor endpoint at `litellm/proxy/response_api_endpoints/endpoints.py` and `litellm/interactions/litellm_responses_transformation/handler.py`).
- New `Router._aresponses_with_streaming_fallbacks` dispatcher that snapshots kwargs (preserving `original_generic_function`), calls `_ageneric_api_call_with_fallbacks`, and wraps the result when `stream=True` and the response is a `BaseResponsesAPIStreamingIterator`.
- Split `"aresponses"` out of the generic `factory_function` dispatch bucket so it flows through the new wrapper.

## Scope

Pre-first-chunk retry only — covers the observed timeout-before-first-chunk case. The Responses-API input shape differs from chat completions, so the partial-content `prefix` assistant-message continuation used in `_acompletion_streaming_iterator` doesn't translate cleanly and is intentionally out of scope.

## Test plan

- [x] New unit test `tests/test_litellm/test_router.py::test_aresponses_streaming_iterator_fallback` mirrors `test_acompletion_streaming_iterator` and asserts:
  - initial chunks stream through
  - `MidStreamFallbackError` triggers `async_function_with_fallbacks_common_utils`
  - `kwargs["original_function"]` is `_ageneric_api_call_with_fallbacks_helper`
  - `kwargs["original_generic_function"]` is `litellm.aresponses`
  - `model_group` is the original model and `disable_fallbacks=False`
  - fallback chunks stream through
  - wrapper preserves `_hidden_params` and `isinstance(BaseResponsesAPIStreamingIterator)`
- [x] All 7 existing `_acompletion_streaming_iterator` tests still pass.
- [x] `uv run black .` and `uv run ruff check litellm/router.py` clean on touched files.
