### PR TITLE
fix(router): wrap aresponses streaming iterator for mid-stream fallbacks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2207,6 +2207,149 @@ class Router:
 
         return FallbackStreamWrapper(stream_with_fallbacks())
 
+    async def _aresponses_streaming_iterator(
+        self,
+        response: Any,
+        initial_kwargs: dict,
+    ) -> Any:
+        """
+        Wrap a Responses-API streaming iterator so MidStreamFallbackError
+        triggers the Router's fallback chain (parity with
+        _acompletion_streaming_iterator for the chat-completions path).
+
+        The Responses-API streaming path goes through
+        _ageneric_api_call_with_fallbacks rather than _acompletion, so the
+        returned iterator is never wrapped by the chat completions
+        fallback handler. Without this wrapper, MidStreamFallbackError
+        raised mid-stream from the underlying CustomStreamWrapper (used by
+        LiteLLMCompletionStreamingIterator when the Responses API is
+        served via the completion bridge) propagates unhandled and the
+        configured cross-provider fallback never fires.
+
+        Only pre-first-chunk retry is supported — the Responses-API input
+        shape differs from chat completions, so partial-content
+        continuation is intentionally out of scope.
+        """
+        from litellm.exceptions import MidStreamFallbackError
+        from litellm.responses.streaming_iterator import (
+            BaseResponsesAPIStreamingIterator,
+        )
+
+        source_iterator = response
+
+        class FallbackResponsesStreamWrapper(BaseResponsesAPIStreamingIterator):
+            """
+            Subclasses BaseResponsesAPIStreamingIterator only for isinstance
+            compatibility (proxy + interactions code paths check the type).
+            Bypasses the parent constructor and delegates iteration to an
+            async generator.
+            """
+
+            def __init__(self, async_generator: AsyncGenerator):
+                self._async_generator = async_generator
+                self.finished = False
+                # Preserve hidden params and identity attributes so response
+                # headers (model_id, api_base, additional_headers) still flow.
+                self._hidden_params = dict(
+                    getattr(source_iterator, "_hidden_params", {}) or {}
+                )
+                self.model = getattr(source_iterator, "model", "")
+                self.custom_llm_provider = getattr(
+                    source_iterator, "custom_llm_provider", None
+                )
+                self.logging_obj = getattr(source_iterator, "logging_obj", None)
+                self.litellm_metadata = getattr(
+                    source_iterator, "litellm_metadata", None
+                )
+                self.responses_api_provider_config = getattr(
+                    source_iterator, "responses_api_provider_config", None
+                )
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return await self._async_generator.__anext__()
+
+            async def aclose(self):
+                close = getattr(self._async_generator, "aclose", None)
+                if close is not None:
+                    await close()
+
+        async def stream_with_fallbacks():
+            fallback_response = None
+            try:
+                async for item in source_iterator:
+                    yield item
+            except MidStreamFallbackError as e:
+                try:
+                    model_group = cast(str, initial_kwargs.get("model"))
+                    fallbacks: Optional[List] = initial_kwargs.get(
+                        "fallbacks", self.fallbacks
+                    )
+                    context_window_fallbacks: Optional[List] = initial_kwargs.get(
+                        "context_window_fallbacks", self.context_window_fallbacks
+                    )
+                    content_policy_fallbacks: Optional[List] = initial_kwargs.get(
+                        "content_policy_fallbacks", self.content_policy_fallbacks
+                    )
+                    # Re-enter via the per-attempt helper so the fallback chain
+                    # picks deployments through
+                    # _ageneric_api_call_with_fallbacks_helper.
+                    # original_generic_function is preserved by the caller so
+                    # the helper knows what underlying API to invoke per attempt.
+                    initial_kwargs["original_function"] = (
+                        self._ageneric_api_call_with_fallbacks_helper
+                    )
+                    self._update_kwargs_before_fallbacks(
+                        model=model_group, kwargs=initial_kwargs
+                    )
+                    fallback_response = (
+                        await self.async_function_with_fallbacks_common_utils(
+                            e=e,
+                            disable_fallbacks=False,
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=context_window_fallbacks,
+                            content_policy_fallbacks=content_policy_fallbacks,
+                            model_group=model_group,
+                            args=(),
+                            kwargs=initial_kwargs,
+                        )
+                    )
+
+                    if hasattr(fallback_response, "__aiter__"):
+                        async for fallback_item in fallback_response:  # type: ignore
+                            yield fallback_item
+                    else:
+                        yield fallback_response
+                except Exception as fallback_error:
+                    verbose_router_logger.error(
+                        f"Responses streaming fallback also failed: {fallback_error}"
+                    )
+                    raise fallback_error
+            finally:
+                with anyio.CancelScope(shield=True):
+                    if hasattr(source_iterator, "aclose"):
+                        try:
+                            await source_iterator.aclose()  # type: ignore[func-returns-value]
+                        except BaseException as exc:
+                            verbose_router_logger.debug(
+                                "stream_with_fallbacks(aresponses): error closing source: %s",
+                                exc,
+                            )
+                    if fallback_response is not None and hasattr(
+                        fallback_response, "aclose"
+                    ):
+                        try:
+                            await fallback_response.aclose()
+                        except BaseException as exc:
+                            verbose_router_logger.debug(
+                                "stream_with_fallbacks(aresponses): error closing fallback: %s",
+                                exc,
+                            )
+
+        return FallbackResponsesStreamWrapper(stream_with_fallbacks())
+
     def _completion_streaming_iterator(  # noqa: PLR0915
         self,
         model_response: CustomStreamWrapper,
@@ -4253,6 +4396,41 @@ class Router:
                 self.fail_calls[model] += 1
             raise e
 
+    async def _aresponses_with_streaming_fallbacks(
+        self, original_function: Callable, **kwargs
+    ):
+        """
+        _ageneric_api_call_with_fallbacks for the Responses API, with the
+        addition of mid-stream fallback handling.
+
+        When stream=True and the underlying call returns a
+        BaseResponsesAPIStreamingIterator, wrap it with
+        _aresponses_streaming_iterator so MidStreamFallbackError raised
+        during iteration triggers the Router's cross-provider fallback chain.
+        """
+        from litellm.responses.streaming_iterator import (
+            BaseResponsesAPIStreamingIterator,
+        )
+
+        # Snapshot the request kwargs before _ageneric_api_call_with_fallbacks
+        # mutates them. The original_generic_function is preserved so the
+        # per-attempt helper knows which underlying API to call on fallback.
+        fallback_kwargs = kwargs.copy()
+        fallback_kwargs["original_generic_function"] = original_function
+
+        response = await self._ageneric_api_call_with_fallbacks(
+            original_function=original_function, **kwargs
+        )
+
+        if kwargs.get("stream") and isinstance(
+            response, BaseResponsesAPIStreamingIterator
+        ):
+            return await self._aresponses_streaming_iterator(
+                response=response,
+                initial_kwargs=fallback_kwargs,
+            )
+        return response
+
     def _generic_api_call_with_fallbacks(
         self, model: str, original_function: Callable, **kwargs
     ):
@@ -5441,9 +5619,13 @@ class Router:
                     custom_llm_provider=custom_llm_provider,
                     **kwargs,
                 )
+            elif call_type == "aresponses":
+                return await self._aresponses_with_streaming_fallbacks(
+                    original_function=original_function,
+                    **kwargs,
+                )
             elif call_type in (
                 "anthropic_messages",
-                "aresponses",
                 "_arealtime",
                 "_aresponses_websocket",
                 "acreate_fine_tuning_job",

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2415,20 +2415,37 @@ class Router:
             """
 
             def __init__(self, async_generator: AsyncGenerator):
+                import time
+
                 self._async_generator = async_generator
-                self.finished = False
-                # Preserve hidden params and identity attributes so response
-                # headers (model_id, api_base, additional_headers) still flow.
-                # Direct attribute access — all of these are defined on
-                # BaseResponsesAPIStreamingIterator.__init__.
-                self._hidden_params = dict(source_iterator._hidden_params or {})
+                # Mirror every attribute BaseResponsesAPIStreamingIterator.__init__
+                # would have set. The wrapper bypasses super().__init__ (it has no
+                # httpx.Response of its own and no provider config to drive), so
+                # we copy from source_iterator where applicable and use safe
+                # defaults elsewhere. This keeps inherited methods (e.g.
+                # _check_max_streaming_duration, _handle_failure) safe to call.
+                self.response = source_iterator.response
                 self.model = source_iterator.model
-                self.custom_llm_provider = source_iterator.custom_llm_provider
                 self.logging_obj = source_iterator.logging_obj
-                self.litellm_metadata = source_iterator.litellm_metadata
+                self.finished = False
                 self.responses_api_provider_config = (
                     source_iterator.responses_api_provider_config
                 )
+                self.completed_response = None
+                self.start_time = source_iterator.start_time
+                self._failure_handled = False
+                self._completed_response_cached = False
+                self._completed_response_logged = False
+                self._completed_response_cache_hit = None
+                self._persist_completed_response_before_logging = True
+                self._stream_created_time = time.time()
+                self.litellm_metadata = source_iterator.litellm_metadata
+                self.custom_llm_provider = source_iterator.custom_llm_provider
+                self.request_data = source_iterator.request_data
+                self.call_type = source_iterator.call_type
+                # Preserve hidden params so response headers (model_id,
+                # api_base, additional_headers) keep flowing.
+                self._hidden_params = dict(source_iterator._hidden_params or {})
 
             def __aiter__(self):
                 return self
@@ -2478,8 +2495,15 @@ class Router:
                                 e.generated_content,
                             )
                         )
+                    # The Responses-API path stores observability metadata
+                    # under "litellm_metadata" (not the default "metadata") —
+                    # see _ageneric_api_call_with_fallbacks. Mirroring that
+                    # here ensures model_group, model_group_alias, and trace
+                    # ids land in the same key litellm.aresponses reads from.
                     self._update_kwargs_before_fallbacks(
-                        model=model_group, kwargs=initial_kwargs
+                        model=model_group,
+                        kwargs=initial_kwargs,
+                        metadata_variable_name="litellm_metadata",
                     )
                     fallback_response = (
                         await self.async_function_with_fallbacks_common_utils(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -212,7 +212,11 @@ if TYPE_CHECKING:
         BaseResponsesAPIStreamingIterator,
     )
     from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
-    from litellm.types.llms.openai import ResponseInputParam, ResponsesAPIResponse
+    from litellm.types.llms.openai import (
+        ResponseAPIUsage,
+        ResponseInputParam,
+        ResponsesAPIResponse,
+    )
 
     Span = Union[_Span, Any]
 else:
@@ -2215,27 +2219,29 @@ class Router:
     @staticmethod
     def _extract_partial_responses_usage(
         source_iterator: "BaseResponsesAPIStreamingIterator",
-    ) -> Optional[Usage]:
+    ) -> Optional["ResponseAPIUsage"]:
         """
         Best-effort: pull partial token usage from a Responses-API streaming
-        iterator that errored mid-stream.
+        iterator that errored mid-stream, normalized to ResponseAPIUsage so
+        the caller can combine without crossing token-naming conventions.
 
         Two sources, in priority order:
           1. The bridge path (LiteLLMCompletionStreamingIterator) accumulates
              chat-completion chunks while streaming — feed them through
-             stream_chunk_builder to recover usage.
+             stream_chunk_builder to recover chat Usage, then translate
+             (prompt_tokens → input_tokens, completion_tokens → output_tokens).
           2. The native path (ResponsesAPIStreamingIterator) only has a
              completed_response object if the stream reached
              RESPONSE_COMPLETED before erroring — uncommon mid-stream but
-             worth checking.
+             worth checking. Already ResponseAPIUsage-shaped.
 
-        Returns None when no partial usage is recoverable (in which case
-        the caller skips usage combining).
+        Returns None when no partial usage is recoverable.
         """
         from litellm.responses.litellm_completion_transformation.streaming_iterator import (
             LiteLLMCompletionStreamingIterator,
         )
         from litellm.types.llms.openai import (
+            ResponseAPIUsage,
             ResponseCompletedEvent,
             ResponseFailedEvent,
             ResponseIncompleteEvent,
@@ -2252,34 +2258,40 @@ class Router:
 
                     built = stream_chunk_builder(chunks=chunks)
                     if built is not None and built.usage is not None:
-                        # stream_chunk_builder returns ModelResponse/
-                        # TextCompletionResponse whose .usage is Optional[Usage].
-                        return cast(Usage, built.usage)
+                        chat = built.usage
+                        # getattr-with-default because the test path may
+                        # substitute a SimpleNamespace lacking some fields;
+                        # real Usage instances always have them.
+                        prompt = int(getattr(chat, "prompt_tokens", 0) or 0)
+                        completion = int(getattr(chat, "completion_tokens", 0) or 0)
+                        total = int(
+                            getattr(chat, "total_tokens", prompt + completion)
+                            or (prompt + completion)
+                        )
+                        return ResponseAPIUsage(
+                            input_tokens=prompt,
+                            output_tokens=completion,
+                            total_tokens=total,
+                        )
                 except Exception:
                     # Builder is best-effort — fall through to native path.
                     pass
 
         # Native path: completed_response is set only if RESPONSE_COMPLETED
         # arrived before the error (uncommon mid-stream but worth checking).
-        # Only the three terminal event shapes carry a usage object; narrow
-        # via isinstance so the field accesses below stay strongly typed.
-        # Note: native usage is ResponseAPIUsage (input/output_tokens) rather
-        # than chat Usage (prompt/completion_tokens). combine_usage_objects
-        # merges attribute-by-attribute, so the two flavors coexist in the
-        # combined object — we just cast to Optional[Usage] for the static
-        # type. Runtime behavior is attribute-driven.
+        # Already ResponseAPIUsage-shaped — return as-is.
         completed = source_iterator.completed_response
         if isinstance(
             completed,
             (ResponseCompletedEvent, ResponseFailedEvent, ResponseIncompleteEvent),
         ):
-            return cast(Optional[Usage], completed.response.usage)
+            return completed.response.usage
         return None
 
     @staticmethod
     def _combine_responses_fallback_usage(
         fallback_item: "BaseLiteLLMOpenAIResponseObject",
-        partial_usage: Usage,
+        partial_usage: "ResponseAPIUsage",
     ) -> None:
         """
         Merge partial-stream usage with fallback-stream usage on a
@@ -2288,8 +2300,15 @@ class Router:
         Only mutates events that carry a `response` with a `usage` field
         (response.completed / response.failed / response.incomplete). Other
         events pass through unchanged.
+
+        Both inputs are ResponseAPIUsage-shaped (see
+        _extract_partial_responses_usage which normalizes the bridge path),
+        so we can sum input_tokens / output_tokens / total_tokens directly
+        and produce a clean ResponseAPIUsage — no token-naming split, no
+        setattr bypass.
         """
         from litellm.types.llms.openai import (
+            ResponseAPIUsage,
             ResponseCompletedEvent,
             ResponseFailedEvent,
             ResponseIncompleteEvent,
@@ -2303,16 +2322,13 @@ class Router:
         response = fallback_item.response
         if response.usage is None:
             return
-        from litellm.cost_calculator import BaseTokenUsageProcessor
 
-        combined = BaseTokenUsageProcessor.combine_usage_objects(
-            usage_objects=[partial_usage, cast(Usage, response.usage)]
+        fb = response.usage
+        response.usage = ResponseAPIUsage(
+            input_tokens=(partial_usage.input_tokens or 0) + (fb.input_tokens or 0),
+            output_tokens=(partial_usage.output_tokens or 0) + (fb.output_tokens or 0),
+            total_tokens=(partial_usage.total_tokens or 0) + (fb.total_tokens or 0),
         )
-        # combined is statically typed Usage but response.usage expects
-        # ResponseAPIUsage; field-name-driven merging produces an object that
-        # carries both flavors of token attributes, so setattr keeps the
-        # assignment runtime-correct without lying to the type checker.
-        setattr(response, "usage", combined)
 
     @staticmethod
     def _build_responses_continuation_input(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2232,30 +2232,49 @@ class Router:
         Returns None when no partial usage is recoverable (in which case
         the caller skips usage combining).
         """
-        chunks = getattr(source_iterator, "collected_chat_completion_chunks", None)
-        if chunks:
-            try:
-                from litellm.main import stream_chunk_builder
-
-                built = stream_chunk_builder(chunks=chunks)
-                usage = cast(Optional[Usage], getattr(built, "usage", None))
-                if usage is not None:
-                    return usage
-            except Exception:
-                # Builder is best-effort — fall through to native path.
-                pass
-        completed = getattr(source_iterator, "completed_response", None)
-        response_obj = getattr(completed, "response", None) if completed else None
-        # Native path emits ResponseAPIUsage (input_tokens/output_tokens) rather
-        # than chat Usage (prompt_tokens/completion_tokens); combine_usage_objects
-        # operates on attribute names so the two cannot be merged into a single
-        # combined object. Caller treats both as Optional[Usage]-shaped for the
-        # static type while runtime behavior is attribute-driven.
-        return (
-            cast(Optional[Usage], getattr(response_obj, "usage", None))
-            if response_obj
-            else None
+        from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+            LiteLLMCompletionStreamingIterator,
         )
+        from litellm.types.llms.openai import (
+            ResponseCompletedEvent,
+            ResponseFailedEvent,
+            ResponseIncompleteEvent,
+        )
+
+        # Bridge subclass is the only iterator that accumulates chat-completion
+        # chunks. isinstance narrows the type so we can read the attribute
+        # directly instead of getattr-ing on the base class.
+        if isinstance(source_iterator, LiteLLMCompletionStreamingIterator):
+            chunks = source_iterator.collected_chat_completion_chunks
+            if chunks:
+                try:
+                    from litellm.main import stream_chunk_builder
+
+                    built = stream_chunk_builder(chunks=chunks)
+                    if built is not None and built.usage is not None:
+                        # stream_chunk_builder returns ModelResponse/
+                        # TextCompletionResponse whose .usage is Optional[Usage].
+                        return cast(Usage, built.usage)
+                except Exception:
+                    # Builder is best-effort — fall through to native path.
+                    pass
+
+        # Native path: completed_response is set only if RESPONSE_COMPLETED
+        # arrived before the error (uncommon mid-stream but worth checking).
+        # Only the three terminal event shapes carry a usage object; narrow
+        # via isinstance so the field accesses below stay strongly typed.
+        # Note: native usage is ResponseAPIUsage (input/output_tokens) rather
+        # than chat Usage (prompt/completion_tokens). combine_usage_objects
+        # merges attribute-by-attribute, so the two flavors coexist in the
+        # combined object — we just cast to Optional[Usage] for the static
+        # type. Runtime behavior is attribute-driven.
+        completed = source_iterator.completed_response
+        if isinstance(
+            completed,
+            (ResponseCompletedEvent, ResponseFailedEvent, ResponseIncompleteEvent),
+        ):
+            return cast(Optional[Usage], completed.response.usage)
+        return None
 
     @staticmethod
     def _combine_responses_fallback_usage(
@@ -2267,19 +2286,32 @@ class Router:
         Responses-API streaming event.
 
         Only mutates events that carry a `response` with a `usage` field
-        (e.g. response.completed). Other events pass through unchanged.
+        (response.completed / response.failed / response.incomplete). Other
+        events pass through unchanged.
         """
-        response = getattr(fallback_item, "response", None)
-        if response is None:
+        from litellm.types.llms.openai import (
+            ResponseCompletedEvent,
+            ResponseFailedEvent,
+            ResponseIncompleteEvent,
+        )
+
+        if not isinstance(
+            fallback_item,
+            (ResponseCompletedEvent, ResponseFailedEvent, ResponseIncompleteEvent),
+        ):
             return
-        fallback_usage = cast(Optional[Usage], getattr(response, "usage", None))
-        if fallback_usage is None:
+        response = fallback_item.response
+        if response.usage is None:
             return
         from litellm.cost_calculator import BaseTokenUsageProcessor
 
         combined = BaseTokenUsageProcessor.combine_usage_objects(
-            usage_objects=[partial_usage, fallback_usage]
+            usage_objects=[partial_usage, cast(Usage, response.usage)]
         )
+        # combined is statically typed Usage but response.usage expects
+        # ResponseAPIUsage; field-name-driven merging produces an object that
+        # carries both flavors of token attributes, so setattr keeps the
+        # assignment runtime-correct without lying to the type checker.
         setattr(response, "usage", combined)
 
     @staticmethod
@@ -2387,19 +2419,15 @@ class Router:
                 self.finished = False
                 # Preserve hidden params and identity attributes so response
                 # headers (model_id, api_base, additional_headers) still flow.
-                self._hidden_params = dict(
-                    getattr(source_iterator, "_hidden_params", {}) or {}
-                )
-                self.model = getattr(source_iterator, "model", "")
-                self.custom_llm_provider = getattr(
-                    source_iterator, "custom_llm_provider", None
-                )
-                self.logging_obj = getattr(source_iterator, "logging_obj", None)
-                self.litellm_metadata = getattr(
-                    source_iterator, "litellm_metadata", None
-                )
-                self.responses_api_provider_config = getattr(
-                    source_iterator, "responses_api_provider_config", None
+                # Direct attribute access — all of these are defined on
+                # BaseResponsesAPIStreamingIterator.__init__.
+                self._hidden_params = dict(source_iterator._hidden_params or {})
+                self.model = source_iterator.model
+                self.custom_llm_provider = source_iterator.custom_llm_provider
+                self.logging_obj = source_iterator.logging_obj
+                self.litellm_metadata = source_iterator.litellm_metadata
+                self.responses_api_provider_config = (
+                    source_iterator.responses_api_provider_config
                 )
 
             def __aiter__(self):
@@ -2409,9 +2437,8 @@ class Router:
                 return await self._async_generator.__anext__()
 
             async def aclose(self):
-                close = getattr(self._async_generator, "aclose", None)
-                if close is not None:
-                    await close()
+                # async generators always expose aclose — no defensive check needed.
+                await self._async_generator.aclose()
 
         async def stream_with_fallbacks():
             fallback_response = None

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -208,6 +208,11 @@ if TYPE_CHECKING:
     from litellm.router_strategy.quality_router.quality_router import (
         QualityRouter,
     )
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+    from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
+    from litellm.types.llms.openai import ResponseInputParam, ResponsesAPIResponse
 
     Span = Union[_Span, Any]
 else:
@@ -2207,11 +2212,137 @@ class Router:
 
         return FallbackStreamWrapper(stream_with_fallbacks())
 
+    @staticmethod
+    def _extract_partial_responses_usage(
+        source_iterator: "BaseResponsesAPIStreamingIterator",
+    ) -> Optional[Usage]:
+        """
+        Best-effort: pull partial token usage from a Responses-API streaming
+        iterator that errored mid-stream.
+
+        Two sources, in priority order:
+          1. The bridge path (LiteLLMCompletionStreamingIterator) accumulates
+             chat-completion chunks while streaming — feed them through
+             stream_chunk_builder to recover usage.
+          2. The native path (ResponsesAPIStreamingIterator) only has a
+             completed_response object if the stream reached
+             RESPONSE_COMPLETED before erroring — uncommon mid-stream but
+             worth checking.
+
+        Returns None when no partial usage is recoverable (in which case
+        the caller skips usage combining).
+        """
+        chunks = getattr(source_iterator, "collected_chat_completion_chunks", None)
+        if chunks:
+            try:
+                from litellm.main import stream_chunk_builder
+
+                built = stream_chunk_builder(chunks=chunks)
+                usage = cast(Optional[Usage], getattr(built, "usage", None))
+                if usage is not None:
+                    return usage
+            except Exception:
+                # Builder is best-effort — fall through to native path.
+                pass
+        completed = getattr(source_iterator, "completed_response", None)
+        response_obj = getattr(completed, "response", None) if completed else None
+        # Native path emits ResponseAPIUsage (input_tokens/output_tokens) rather
+        # than chat Usage (prompt_tokens/completion_tokens); combine_usage_objects
+        # operates on attribute names so the two cannot be merged into a single
+        # combined object. Caller treats both as Optional[Usage]-shaped for the
+        # static type while runtime behavior is attribute-driven.
+        return (
+            cast(Optional[Usage], getattr(response_obj, "usage", None))
+            if response_obj
+            else None
+        )
+
+    @staticmethod
+    def _combine_responses_fallback_usage(
+        fallback_item: "BaseLiteLLMOpenAIResponseObject",
+        partial_usage: Usage,
+    ) -> None:
+        """
+        Merge partial-stream usage with fallback-stream usage on a
+        Responses-API streaming event.
+
+        Only mutates events that carry a `response` with a `usage` field
+        (e.g. response.completed). Other events pass through unchanged.
+        """
+        response = getattr(fallback_item, "response", None)
+        if response is None:
+            return
+        fallback_usage = cast(Optional[Usage], getattr(response, "usage", None))
+        if fallback_usage is None:
+            return
+        from litellm.cost_calculator import BaseTokenUsageProcessor
+
+        combined = BaseTokenUsageProcessor.combine_usage_objects(
+            usage_objects=[partial_usage, fallback_usage]
+        )
+        setattr(response, "usage", combined)
+
+    @staticmethod
+    def _build_responses_continuation_input(
+        input_val: Optional[Union[str, "ResponseInputParam"]],
+        generated_content: str,
+    ) -> "ResponseInputParam":
+        """
+        Convert Responses-API input + partial assistant output into a
+        continuation input that asks the fallback model to pick up where the
+        prior assistant message stopped.
+
+        Best effort across providers. The chat-completions path uses
+        Anthropic's `prefix: True` prefill trick on the assistant message;
+        the Responses-API input schema has no direct equivalent, so we
+        append an instruction (developer role) plus a prior assistant
+        message containing the partial output. Providers without prefill
+        semantics (OpenAI, Vertex) treat this as conversational context
+        and may regenerate — same trade-off as the chat-completions path
+        for non-Anthropic fallbacks.
+        """
+        base: List[Dict[str, Any]]
+        if isinstance(input_val, str):
+            base = [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": input_val}],
+                }
+            ]
+        elif isinstance(input_val, list):
+            base = list(input_val)
+        else:
+            base = []
+        continuation: List[Dict[str, Any]] = [
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "The previous assistant response was interrupted "
+                            "mid-stream. Continue exactly where it stopped — "
+                            "do not repeat any of its content. Your response "
+                            "must read as a seamless continuation."
+                        ),
+                    }
+                ],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": generated_content}],
+            },
+        ]
+        return cast("ResponseInputParam", base + continuation)
+
     async def _aresponses_streaming_iterator(
         self,
-        response: Any,
-        initial_kwargs: dict,
-    ) -> Any:
+        response: "BaseResponsesAPIStreamingIterator",
+        initial_kwargs: Dict[str, Any],
+    ) -> "BaseResponsesAPIStreamingIterator":
         """
         Wrap a Responses-API streaming iterator so MidStreamFallbackError
         triggers the Router's fallback chain (parity with
@@ -2226,9 +2357,15 @@ class Router:
         served via the completion bridge) propagates unhandled and the
         configured cross-provider fallback never fires.
 
-        Only pre-first-chunk retry is supported — the Responses-API input
-        shape differs from chat completions, so partial-content
-        continuation is intentionally out of scope.
+        Full parity with the chat-completions path:
+          - Pre-first-chunk: retry with the original input unchanged.
+          - Partial content: inject a developer instruction + prior
+            assistant message carrying the generated text so the fallback
+            model continues rather than restarts.
+          - Usage combining: merge partial-stream usage onto the fallback's
+            response.completed event so accounting reflects both attempts.
+          - Stream cleanup: shielded aclose() on both source and fallback
+            iterators on terminate.
         """
         from litellm.exceptions import MidStreamFallbackError
         from litellm.responses.streaming_iterator import (
@@ -2282,6 +2419,7 @@ class Router:
                 async for item in source_iterator:
                     yield item
             except MidStreamFallbackError as e:
+                partial_usage = Router._extract_partial_responses_usage(source_iterator)
                 try:
                     model_group = cast(str, initial_kwargs.get("model"))
                     fallbacks: Optional[List] = initial_kwargs.get(
@@ -2301,6 +2439,18 @@ class Router:
                     initial_kwargs["original_function"] = (
                         self._ageneric_api_call_with_fallbacks_helper
                     )
+                    if e.is_pre_first_chunk or not e.generated_content:
+                        # No content generated before the error — retry with the
+                        # original input. Adding a continuation prompt would
+                        # waste tokens and confuse the model.
+                        pass
+                    else:
+                        initial_kwargs["input"] = (
+                            Router._build_responses_continuation_input(
+                                initial_kwargs.get("input"),
+                                e.generated_content,
+                            )
+                        )
                     self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )
@@ -2319,6 +2469,10 @@ class Router:
 
                     if hasattr(fallback_response, "__aiter__"):
                         async for fallback_item in fallback_response:  # type: ignore
+                            if partial_usage is not None:
+                                Router._combine_responses_fallback_usage(
+                                    fallback_item, partial_usage
+                                )
                             yield fallback_item
                     else:
                         yield fallback_response
@@ -4397,8 +4551,8 @@ class Router:
             raise e
 
     async def _aresponses_with_streaming_fallbacks(
-        self, original_function: Callable, **kwargs
-    ):
+        self, original_function: Callable, **kwargs: Any
+    ) -> Union["ResponsesAPIResponse", "BaseResponsesAPIStreamingIterator"]:
         """
         _ageneric_api_call_with_fallbacks for the Responses API, with the
         addition of mid-stream fallback handling.
@@ -4415,7 +4569,7 @@ class Router:
         # Snapshot the request kwargs before _ageneric_api_call_with_fallbacks
         # mutates them. The original_generic_function is preserved so the
         # per-attempt helper knows which underlying API to call on fallback.
-        fallback_kwargs = kwargs.copy()
+        fallback_kwargs: Dict[str, Any] = kwargs.copy()
         fallback_kwargs["original_generic_function"] = original_function
 
         response = await self._ageneric_api_call_with_fallbacks(

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1790,6 +1790,7 @@ async def test_aresponses_streaming_iterator_fallback():
             self.litellm_metadata = None
             self.responses_api_provider_config = None
             self.finished = False
+            self.completed_response = None
 
         def __aiter__(self):
             return self
@@ -1910,6 +1911,7 @@ async def test_aresponses_streaming_iterator_pre_first_chunk_skips_continuation(
             self.litellm_metadata = None
             self.responses_api_provider_config = None
             self.finished = False
+            self.completed_response = None
 
         def __aiter__(self):
             return self
@@ -1990,6 +1992,7 @@ async def test_aresponses_streaming_iterator_partial_content_injects_continuatio
             self.litellm_metadata = None
             self.responses_api_provider_config = None
             self.finished = False
+            self.completed_response = None
 
         def __aiter__(self):
             return self
@@ -2071,7 +2074,14 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
 
     partial_usage = SimpleNamespace(prompt_tokens=10, completion_tokens=4)
 
-    class _BridgeStyleIterator(BaseResponsesAPIStreamingIterator):
+    # The bridge subclass is what the wrapper isinstance-narrows on to read
+    # collected_chat_completion_chunks. Inherit from it (and skip super().__init__)
+    # so the test exercises the same code path production hits.
+    from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+        LiteLLMCompletionStreamingIterator,
+    )
+
+    class _BridgeStyleIterator(LiteLLMCompletionStreamingIterator):
         """Emits a delta chunk then raises mid-stream. Mimics the bridge
         path's collected_chat_completion_chunks attribute, but here we
         intercept stream_chunk_builder so we don't have to construct real
@@ -2088,6 +2098,7 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
             self.litellm_metadata = None
             self.responses_api_provider_config = None
             self.finished = False
+            self.completed_response = None
 
         def __aiter__(self):
             return self
@@ -2104,11 +2115,22 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
                 generated_content="hello",
             )
 
-    fallback_response_object = SimpleNamespace(
-        usage=SimpleNamespace(prompt_tokens=20, completion_tokens=15)
+    # Use real event/response types so the wrapper's isinstance narrowing
+    # (ResponseCompletedEvent / ResponsesAPIResponse) matches.
+    from litellm.types.llms.openai import (
+        ResponseCompletedEvent,
+        ResponsesAPIResponse,
+        ResponsesAPIStreamEvents,
     )
-    fallback_completed_event = SimpleNamespace(
-        type="response.completed",
+
+    fallback_response_object = ResponsesAPIResponse(
+        id="resp_test", created_at=0, model="gpt-4", object="response", output=[]
+    )
+    fallback_response_object.usage = SimpleNamespace(  # type: ignore[assignment]
+        prompt_tokens=20, completion_tokens=15
+    )
+    fallback_completed_event = ResponseCompletedEvent(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
         response=fallback_response_object,
     )
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1791,6 +1791,10 @@ async def test_aresponses_streaming_iterator_fallback():
             self.responses_api_provider_config = None
             self.finished = False
             self.completed_response = None
+            self.response = None
+            self.start_time = None
+            self.request_data = {}
+            self.call_type = None
 
         def __aiter__(self):
             return self
@@ -1872,6 +1876,97 @@ async def test_aresponses_streaming_iterator_fallback():
 
 
 @pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_writes_litellm_metadata_on_fallback():
+    """On fallback re-entry, model_group / model_group_alias must land under
+    "litellm_metadata" (the key litellm.aresponses reads from) — not the
+    default "metadata" key the chat-completions path uses. Regression test
+    for greptile-apps comment on PR #28215."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
+            },
+        ],
+        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
+    )
+
+    error = MidStreamFallbackError(
+        message="boom",
+        model="gpt-4",
+        llm_provider="anthropic",
+        is_pre_first_chunk=True,
+        generated_content="",
+    )
+
+    class _ImmediateErrorIterator(BaseResponsesAPIStreamingIterator):
+        def __init__(self):
+            self._hidden_params = {}
+            self.model = "gpt-4"
+            self.custom_llm_provider = "anthropic"
+            self.logging_obj = MagicMock()
+            self.litellm_metadata = None
+            self.responses_api_provider_config = None
+            self.finished = False
+            self.completed_response = None
+            self.response = None
+            self.start_time = None
+            self.request_data = {}
+            self.call_type = None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise error
+
+    class _EmptyIter:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=_EmptyIter(),
+    ) as mock_fallback_utils:
+        wrapped = await router._aresponses_streaming_iterator(
+            response=_ImmediateErrorIterator(),
+            initial_kwargs={
+                "model": "gpt-4",
+                "stream": True,
+                "input": "Hello",
+                "original_generic_function": litellm.aresponses,
+            },
+        )
+        async for _ in wrapped:
+            pass
+
+    fallback_call_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
+    # Routing metadata must land under litellm_metadata, NOT the default
+    # "metadata" key (which litellm.aresponses doesn't read).
+    assert "litellm_metadata" in fallback_call_kwargs, (
+        "litellm_metadata key missing — _update_kwargs_before_fallbacks "
+        "called with the wrong metadata_variable_name"
+    )
+    assert fallback_call_kwargs["litellm_metadata"]["model_group"] == "gpt-4"
+    assert "metadata" not in fallback_call_kwargs or (
+        "model_group" not in fallback_call_kwargs.get("metadata", {})
+    ), "model_group leaked into 'metadata' instead of 'litellm_metadata'"
+
+
+@pytest.mark.asyncio
 async def test_aresponses_streaming_iterator_pre_first_chunk_skips_continuation():
     """Pre-first-chunk MidStreamFallbackError: original input is preserved
     unchanged, no continuation messages are injected."""
@@ -1912,6 +2007,10 @@ async def test_aresponses_streaming_iterator_pre_first_chunk_skips_continuation(
             self.responses_api_provider_config = None
             self.finished = False
             self.completed_response = None
+            self.response = None
+            self.start_time = None
+            self.request_data = {}
+            self.call_type = None
 
         def __aiter__(self):
             return self
@@ -1993,6 +2092,10 @@ async def test_aresponses_streaming_iterator_partial_content_injects_continuatio
             self.responses_api_provider_config = None
             self.finished = False
             self.completed_response = None
+            self.response = None
+            self.start_time = None
+            self.request_data = {}
+            self.call_type = None
 
         def __aiter__(self):
             return self
@@ -2099,6 +2202,10 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
             self.responses_api_provider_config = None
             self.finished = False
             self.completed_response = None
+            self.response = None
+            self.start_time = None
+            self.request_data = {}
+            self.call_type = None
 
         def __aiter__(self):
             return self

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1742,6 +1742,135 @@ async def test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation
 
 
 @pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_fallback():
+    """_aresponses_streaming_iterator should catch MidStreamFallbackError and
+    re-enter the Router's fallback chain — parity with the chat-completions
+    streaming path. Mirrors test_acompletion_streaming_iterator for aresponses.
+    """
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "anthropic/claude-sonnet-4-6",
+                "litellm_params": {
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "api_key": "fake-anthropic-key",
+                },
+            },
+            {
+                "model_name": "vertex_ai/claude-sonnet-4-6",
+                "litellm_params": {
+                    "model": "vertex_ai/claude-sonnet-4-6",
+                    "api_key": "fake-vertex-key",
+                },
+            },
+        ],
+        fallbacks=[{"anthropic/claude-sonnet-4-6": ["vertex_ai/claude-sonnet-4-6"]}],
+    )
+
+    initial_kwargs = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "stream": True,
+        "input": "Hi",
+    }
+
+    # Source iterator: yields one chunk, then raises MidStreamFallbackError.
+    class _ErrorIterator(BaseResponsesAPIStreamingIterator):
+        def __init__(self):
+            self._chunks = [MagicMock(type="response.created")]
+            self._idx = 0
+            self._hidden_params = {"model_id": "src-deployment-1"}
+            self.model = "anthropic/claude-sonnet-4-6"
+            self.custom_llm_provider = "anthropic"
+            self.logging_obj = MagicMock()
+            self.litellm_metadata = None
+            self.responses_api_provider_config = None
+            self.finished = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx < len(self._chunks):
+                chunk = self._chunks[self._idx]
+                self._idx += 1
+                return chunk
+            raise MidStreamFallbackError(
+                message="anthropic socket timeout",
+                model="anthropic/claude-sonnet-4-6",
+                llm_provider="anthropic",
+                is_pre_first_chunk=False,
+                generated_content="",
+            )
+
+    # Fallback iterator: what the Router would return from the fallback chain.
+    fallback_chunks = [
+        MagicMock(type="response.output_text.delta"),
+        MagicMock(type="response.completed"),
+    ]
+
+    class _FallbackIterator:
+        def __init__(self, items):
+            self._items = items
+            self._idx = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx >= len(self._items):
+                raise StopAsyncIteration
+            item = self._items[self._idx]
+            self._idx += 1
+            return item
+
+    src = _ErrorIterator()
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=_FallbackIterator(fallback_chunks),
+    ) as mock_fallback_utils:
+        wrapped = await router._aresponses_streaming_iterator(
+            response=src,
+            initial_kwargs={
+                **initial_kwargs,
+                "original_generic_function": litellm.aresponses,
+            },
+        )
+
+        # Wrapper preserves isinstance for downstream consumers
+        assert isinstance(wrapped, BaseResponsesAPIStreamingIterator)
+        # Hidden params propagated through (needed for response headers)
+        assert wrapped._hidden_params.get("model_id") == "src-deployment-1"
+
+        collected = []
+        async for chunk in wrapped:
+            collected.append(chunk)
+
+    # 1 chunk before the error + 2 from fallback iterator
+    assert len(collected) == 3
+    assert mock_fallback_utils.called
+
+    call_kwargs = mock_fallback_utils.call_args.kwargs
+    fallback_call_kwargs = call_kwargs["kwargs"]
+    # Re-entry must hit the per-attempt helper, with original_generic_function
+    # preserved so the helper calls litellm.aresponses on each fallback attempt.
+    # (Bound methods compare equal when they share the same instance + __func__.)
+    assert (
+        fallback_call_kwargs["original_function"]
+        == router._ageneric_api_call_with_fallbacks_helper
+    )
+    assert fallback_call_kwargs["original_generic_function"] is litellm.aresponses
+    assert call_kwargs["model_group"] == "anthropic/claude-sonnet-4-6"
+    assert call_kwargs["disable_fallbacks"] is False
+
+
+@pytest.mark.asyncio
 async def test_async_function_with_fallbacks_common_utils():
     """Test the async_function_with_fallbacks_common_utils method"""
     # Create a basic router for testing

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2222,9 +2222,11 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
                 generated_content="hello",
             )
 
-    # Use real event/response types so the wrapper's isinstance narrowing
-    # (ResponseCompletedEvent / ResponsesAPIResponse) matches.
+    # Use real event/response/usage types so the wrapper's isinstance
+    # narrowing matches AND the combined output is a clean ResponseAPIUsage
+    # (no token-naming split between chat and responses conventions).
     from litellm.types.llms.openai import (
+        ResponseAPIUsage,
         ResponseCompletedEvent,
         ResponsesAPIResponse,
         ResponsesAPIStreamEvents,
@@ -2233,8 +2235,9 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
     fallback_response_object = ResponsesAPIResponse(
         id="resp_test", created_at=0, model="gpt-4", object="response", output=[]
     )
-    fallback_response_object.usage = SimpleNamespace(  # type: ignore[assignment]
-        prompt_tokens=20, completion_tokens=15
+    # Fallback usage arrives in responses-API shape (input/output_tokens).
+    fallback_response_object.usage = ResponseAPIUsage(
+        input_tokens=20, output_tokens=15, total_tokens=35
     )
     fallback_completed_event = ResponseCompletedEvent(
         type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
@@ -2279,10 +2282,19 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
         async for _ in wrapped:
             pass
 
-    # combine_usage_objects sums attribute-wise: 10+20 prompt, 4+15 completion
+    # Combined output must be a clean ResponseAPIUsage (no split between
+    # chat-style and responses-style token names). Bridge partial of 10/4
+    # gets translated to input/output_tokens, then summed with the fallback's
+    # 20/15 to produce 30/19/49.
     merged_usage = fallback_response_object.usage
-    assert getattr(merged_usage, "prompt_tokens") == 30
-    assert getattr(merged_usage, "completion_tokens") == 19
+    assert isinstance(merged_usage, ResponseAPIUsage)
+    assert merged_usage.input_tokens == 30
+    assert merged_usage.output_tokens == 19
+    assert merged_usage.total_tokens == 49
+    # Chat-style attributes should NOT leak onto the merged object.
+    assert not hasattr(merged_usage, "prompt_tokens") or getattr(
+        merged_usage, "prompt_tokens", None
+    ) in (None, 0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1871,6 +1871,292 @@ async def test_aresponses_streaming_iterator_fallback():
 
 
 @pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_pre_first_chunk_skips_continuation():
+    """Pre-first-chunk MidStreamFallbackError: original input is preserved
+    unchanged, no continuation messages are injected."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
+            },
+        ],
+        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
+    )
+
+    pre_first_chunk_error = MidStreamFallbackError(
+        message="socket timeout before first chunk",
+        model="gpt-4",
+        llm_provider="anthropic",
+        is_pre_first_chunk=True,
+        generated_content="",
+    )
+
+    class _ImmediateErrorIterator(BaseResponsesAPIStreamingIterator):
+        def __init__(self):
+            self._hidden_params = {}
+            self.model = "gpt-4"
+            self.custom_llm_provider = "anthropic"
+            self.logging_obj = MagicMock()
+            self.litellm_metadata = None
+            self.responses_api_provider_config = None
+            self.finished = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise pre_first_chunk_error
+
+    class _EmptyIter:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    initial_kwargs = {"model": "gpt-4", "stream": True, "input": "Hello"}
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=_EmptyIter(),
+    ) as mock_fallback_utils:
+        wrapped = await router._aresponses_streaming_iterator(
+            response=_ImmediateErrorIterator(),
+            initial_kwargs={
+                **initial_kwargs,
+                "original_generic_function": litellm.aresponses,
+            },
+        )
+        async for _ in wrapped:
+            pass
+
+    assert mock_fallback_utils.called
+    fallback_call_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
+    # Pre-first-chunk: input must be the original string, not a continuation list
+    assert fallback_call_kwargs["input"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_partial_content_injects_continuation():
+    """Mid-stream MidStreamFallbackError with generated_content: input is
+    rewritten to include a developer instruction + prior-assistant message
+    carrying the partial output."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
+            },
+        ],
+        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
+    )
+
+    mid_stream_error = MidStreamFallbackError(
+        message="socket reset mid-stream",
+        model="gpt-4",
+        llm_provider="anthropic",
+        is_pre_first_chunk=False,
+        generated_content="The capital of France is",
+    )
+
+    class _MidStreamErrorIterator(BaseResponsesAPIStreamingIterator):
+        def __init__(self):
+            self._chunks = [MagicMock(type="response.output_text.delta")]
+            self._idx = 0
+            self._hidden_params = {}
+            self.model = "gpt-4"
+            self.custom_llm_provider = "anthropic"
+            self.logging_obj = MagicMock()
+            self.litellm_metadata = None
+            self.responses_api_provider_config = None
+            self.finished = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx < len(self._chunks):
+                self._idx += 1
+                return self._chunks[self._idx - 1]
+            raise mid_stream_error
+
+    class _EmptyIter:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    initial_kwargs = {
+        "model": "gpt-4",
+        "stream": True,
+        "input": "What's the capital of France?",
+    }
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=_EmptyIter(),
+    ) as mock_fallback_utils:
+        wrapped = await router._aresponses_streaming_iterator(
+            response=_MidStreamErrorIterator(),
+            initial_kwargs={
+                **initial_kwargs,
+                "original_generic_function": litellm.aresponses,
+            },
+        )
+        async for _ in wrapped:
+            pass
+
+    fallback_call_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
+    new_input = fallback_call_kwargs["input"]
+
+    # Original string input is normalized to a user message
+    assert isinstance(new_input, list)
+    assert new_input[0]["role"] == "user"
+    assert new_input[0]["content"][0]["text"] == "What's the capital of France?"
+    # A developer instruction tells the model not to repeat
+    assert new_input[1]["role"] == "developer"
+    assert "do not repeat" in new_input[1]["content"][0]["text"].lower()
+    # Prior assistant message carries the partial output as output_text
+    assert new_input[2]["role"] == "assistant"
+    assert new_input[2]["content"][0]["type"] == "output_text"
+    assert new_input[2]["content"][0]["text"] == "The capital of France is"
+
+
+@pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_combines_partial_usage():
+    """Usage from partial chunks is merged onto the fallback's
+    response.completed event so downstream accounting reflects both attempts."""
+    from types import SimpleNamespace
+
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
+            },
+        ],
+        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
+    )
+
+    partial_usage = SimpleNamespace(prompt_tokens=10, completion_tokens=4)
+
+    class _BridgeStyleIterator(BaseResponsesAPIStreamingIterator):
+        """Emits a delta chunk then raises mid-stream. Mimics the bridge
+        path's collected_chat_completion_chunks attribute, but here we
+        intercept stream_chunk_builder so we don't have to construct real
+        ModelResponse chunks."""
+
+        def __init__(self):
+            self.collected_chat_completion_chunks = [MagicMock()]
+            self._chunks = [MagicMock(type="response.output_text.delta")]
+            self._idx = 0
+            self._hidden_params = {}
+            self.model = "gpt-4"
+            self.custom_llm_provider = "anthropic"
+            self.logging_obj = MagicMock()
+            self.litellm_metadata = None
+            self.responses_api_provider_config = None
+            self.finished = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx < len(self._chunks):
+                self._idx += 1
+                return self._chunks[self._idx - 1]
+            raise MidStreamFallbackError(
+                message="boom",
+                model="gpt-4",
+                llm_provider="anthropic",
+                is_pre_first_chunk=False,
+                generated_content="hello",
+            )
+
+    fallback_response_object = SimpleNamespace(
+        usage=SimpleNamespace(prompt_tokens=20, completion_tokens=15)
+    )
+    fallback_completed_event = SimpleNamespace(
+        type="response.completed",
+        response=fallback_response_object,
+    )
+
+    class _FallbackIter:
+        def __init__(self, items):
+            self._items = items
+            self._idx = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx >= len(self._items):
+                raise StopAsyncIteration
+            item = self._items[self._idx]
+            self._idx += 1
+            return item
+
+    with (
+        patch(
+            "litellm.main.stream_chunk_builder",
+            return_value=SimpleNamespace(usage=partial_usage),
+        ),
+        patch.object(
+            router,
+            "async_function_with_fallbacks_common_utils",
+            return_value=_FallbackIter([fallback_completed_event]),
+        ),
+    ):
+        wrapped = await router._aresponses_streaming_iterator(
+            response=_BridgeStyleIterator(),
+            initial_kwargs={
+                "model": "gpt-4",
+                "stream": True,
+                "input": "hi",
+                "original_generic_function": litellm.aresponses,
+            },
+        )
+        async for _ in wrapped:
+            pass
+
+    # combine_usage_objects sums attribute-wise: 10+20 prompt, 4+15 completion
+    merged_usage = fallback_response_object.usage
+    assert getattr(merged_usage, "prompt_tokens") == 30
+    assert getattr(merged_usage, "completion_tokens") == 19
+
+
+@pytest.mark.asyncio
 async def test_async_function_with_fallbacks_common_utils():
     """Test the async_function_with_fallbacks_common_utils method"""
     # Create a basic router for testing
@@ -3992,7 +4278,15 @@ def test_is_deployment_blocked_static_helper_reflects_blocked_flag():
     # No model_info on deployment object → treated as not blocked
     assert litellm.Router._is_deployment_blocked(object()) is False
     missing_blocked = types.SimpleNamespace()
-    assert litellm.Router._is_deployment_blocked(types.SimpleNamespace(model_info=missing_blocked)) is False
-    assert litellm.Router._is_deployment_blocked(
-        types.SimpleNamespace(model_info=types.SimpleNamespace(blocked=True))
-    ) is True
+    assert (
+        litellm.Router._is_deployment_blocked(
+            types.SimpleNamespace(model_info=missing_blocked)
+        )
+        is False
+    )
+    assert (
+        litellm.Router._is_deployment_blocked(
+            types.SimpleNamespace(model_info=types.SimpleNamespace(blocked=True))
+        )
+        is True
+    )

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1741,50 +1741,45 @@ async def test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation
         assert fallback_kwargs["messages"] == messages
 
 
-@pytest.mark.asyncio
-async def test_aresponses_streaming_iterator_fallback():
-    """_aresponses_streaming_iterator should catch MidStreamFallbackError and
-    re-enter the Router's fallback chain — parity with the chat-completions
-    streaming path. Mirrors test_acompletion_streaming_iterator for aresponses.
+# ---------------------------------------------------------------------------
+# Shared helpers for the _aresponses_streaming_iterator test suite.
+# ---------------------------------------------------------------------------
+def _make_responses_iterator(
+    *,
+    chunks=(),
+    error=None,
+    bridge=False,
+    model="gpt-4",
+    hidden_params=None,
+    chat_chunks=None,
+):
+    """Build a minimal mock Responses-API streaming iterator.
+
+    Bypasses BaseResponsesAPIStreamingIterator.__init__ but mirrors every
+    attribute production code reads. Yields *chunks*, then raises *error*
+    (or StopAsyncIteration). Set bridge=True to inherit from
+    LiteLLMCompletionStreamingIterator so the wrapper's bridge-path
+    isinstance check (used by usage extraction) matches.
     """
-    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+        LiteLLMCompletionStreamingIterator,
+    )
     from litellm.responses.streaming_iterator import (
         BaseResponsesAPIStreamingIterator,
     )
 
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "anthropic/claude-sonnet-4-6",
-                "litellm_params": {
-                    "model": "anthropic/claude-sonnet-4-6",
-                    "api_key": "fake-anthropic-key",
-                },
-            },
-            {
-                "model_name": "vertex_ai/claude-sonnet-4-6",
-                "litellm_params": {
-                    "model": "vertex_ai/claude-sonnet-4-6",
-                    "api_key": "fake-vertex-key",
-                },
-            },
-        ],
-        fallbacks=[{"anthropic/claude-sonnet-4-6": ["vertex_ai/claude-sonnet-4-6"]}],
+    base = (
+        LiteLLMCompletionStreamingIterator
+        if bridge
+        else BaseResponsesAPIStreamingIterator
     )
 
-    initial_kwargs = {
-        "model": "anthropic/claude-sonnet-4-6",
-        "stream": True,
-        "input": "Hi",
-    }
-
-    # Source iterator: yields one chunk, then raises MidStreamFallbackError.
-    class _ErrorIterator(BaseResponsesAPIStreamingIterator):
+    class _Iter(base):
         def __init__(self):
-            self._chunks = [MagicMock(type="response.created")]
+            self._chunks = list(chunks)
             self._idx = 0
-            self._hidden_params = {"model_id": "src-deployment-1"}
-            self.model = "anthropic/claude-sonnet-4-6"
+            self._hidden_params = hidden_params or {}
+            self.model = model
             self.custom_llm_provider = "anthropic"
             self.logging_obj = MagicMock()
             self.litellm_metadata = None
@@ -1795,154 +1790,140 @@ async def test_aresponses_streaming_iterator_fallback():
             self.start_time = None
             self.request_data = {}
             self.call_type = None
+            if chat_chunks is not None:
+                self.collected_chat_completion_chunks = chat_chunks
 
         def __aiter__(self):
             return self
 
         async def __anext__(self):
             if self._idx < len(self._chunks):
-                chunk = self._chunks[self._idx]
                 self._idx += 1
-                return chunk
-            raise MidStreamFallbackError(
-                message="anthropic socket timeout",
-                model="anthropic/claude-sonnet-4-6",
-                llm_provider="anthropic",
-                is_pre_first_chunk=False,
-                generated_content="",
-            )
+                return self._chunks[self._idx - 1]
+            if error is not None:
+                raise error
+            raise StopAsyncIteration
 
-    # Fallback iterator: what the Router would return from the fallback chain.
+    return _Iter()
+
+
+class _AsyncList:
+    """Generic async iterator over a list — used as the fallback response."""
+
+    def __init__(self, items=()):
+        self._items = list(items)
+        self._idx = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._idx >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._idx]
+        self._idx += 1
+        return item
+
+
+def _make_router_with_fallback(primary="gpt-4", secondary="gpt-3.5-turbo"):
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": primary,
+                "litellm_params": {"model": primary, "api_key": "k1"},
+            },
+            {
+                "model_name": secondary,
+                "litellm_params": {"model": secondary, "api_key": "k2"},
+            },
+        ],
+        fallbacks=[{primary: [secondary]}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_aresponses_streaming_iterator_fallback():
+    """Catches MidStreamFallbackError, re-enters the fallback chain via
+    async_function_with_fallbacks_common_utils with the per-attempt helper
+    and original_generic_function preserved. Mirrors
+    test_acompletion_streaming_iterator for the aresponses path."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.responses.streaming_iterator import (
+        BaseResponsesAPIStreamingIterator,
+    )
+
+    router = _make_router_with_fallback(
+        "anthropic/claude-sonnet-4-6", "vertex_ai/claude-sonnet-4-6"
+    )
+    src = _make_responses_iterator(
+        chunks=[MagicMock(type="response.created")],
+        error=MidStreamFallbackError(
+            message="anthropic socket timeout",
+            model="anthropic/claude-sonnet-4-6",
+            llm_provider="anthropic",
+            is_pre_first_chunk=False,
+            generated_content="",
+        ),
+        model="anthropic/claude-sonnet-4-6",
+        hidden_params={"model_id": "src-deployment-1"},
+    )
     fallback_chunks = [
         MagicMock(type="response.output_text.delta"),
         MagicMock(type="response.completed"),
     ]
 
-    class _FallbackIterator:
-        def __init__(self, items):
-            self._items = items
-            self._idx = 0
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self._idx >= len(self._items):
-                raise StopAsyncIteration
-            item = self._items[self._idx]
-            self._idx += 1
-            return item
-
-    src = _ErrorIterator()
-
     with patch.object(
         router,
         "async_function_with_fallbacks_common_utils",
-        return_value=_FallbackIterator(fallback_chunks),
+        return_value=_AsyncList(fallback_chunks),
     ) as mock_fallback_utils:
         wrapped = await router._aresponses_streaming_iterator(
             response=src,
             initial_kwargs={
-                **initial_kwargs,
+                "model": "anthropic/claude-sonnet-4-6",
+                "stream": True,
+                "input": "Hi",
                 "original_generic_function": litellm.aresponses,
             },
         )
-
-        # Wrapper preserves isinstance for downstream consumers
         assert isinstance(wrapped, BaseResponsesAPIStreamingIterator)
-        # Hidden params propagated through (needed for response headers)
         assert wrapped._hidden_params.get("model_id") == "src-deployment-1"
+        collected = [c async for c in wrapped]
 
-        collected = []
-        async for chunk in wrapped:
-            collected.append(chunk)
-
-    # 1 chunk before the error + 2 from fallback iterator
-    assert len(collected) == 3
-    assert mock_fallback_utils.called
-
+    assert len(collected) == 3  # 1 primary chunk + 2 fallback chunks
     call_kwargs = mock_fallback_utils.call_args.kwargs
-    fallback_call_kwargs = call_kwargs["kwargs"]
-    # Re-entry must hit the per-attempt helper, with original_generic_function
-    # preserved so the helper calls litellm.aresponses on each fallback attempt.
-    # (Bound methods compare equal when they share the same instance + __func__.)
-    assert (
-        fallback_call_kwargs["original_function"]
-        == router._ageneric_api_call_with_fallbacks_helper
-    )
-    assert fallback_call_kwargs["original_generic_function"] is litellm.aresponses
+    fbk = call_kwargs["kwargs"]
+    # Bound methods compare equal when they share the same instance + __func__.
+    assert fbk["original_function"] == router._ageneric_api_call_with_fallbacks_helper
+    assert fbk["original_generic_function"] is litellm.aresponses
     assert call_kwargs["model_group"] == "anthropic/claude-sonnet-4-6"
     assert call_kwargs["disable_fallbacks"] is False
 
 
 @pytest.mark.asyncio
 async def test_aresponses_streaming_iterator_writes_litellm_metadata_on_fallback():
-    """On fallback re-entry, model_group / model_group_alias must land under
-    "litellm_metadata" (the key litellm.aresponses reads from) — not the
-    default "metadata" key the chat-completions path uses. Regression test
-    for greptile-apps comment on PR #28215."""
+    """Regression: model_group must land under "litellm_metadata" (the key
+    litellm.aresponses reads), not the default "metadata"."""
     from litellm.exceptions import MidStreamFallbackError
-    from litellm.responses.streaming_iterator import (
-        BaseResponsesAPIStreamingIterator,
+
+    router = _make_router_with_fallback()
+    src = _make_responses_iterator(
+        error=MidStreamFallbackError(
+            message="boom",
+            model="gpt-4",
+            llm_provider="anthropic",
+            is_pre_first_chunk=True,
+            generated_content="",
+        )
     )
-
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "gpt-4",
-                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
-            },
-            {
-                "model_name": "gpt-3.5-turbo",
-                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
-            },
-        ],
-        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
-    )
-
-    error = MidStreamFallbackError(
-        message="boom",
-        model="gpt-4",
-        llm_provider="anthropic",
-        is_pre_first_chunk=True,
-        generated_content="",
-    )
-
-    class _ImmediateErrorIterator(BaseResponsesAPIStreamingIterator):
-        def __init__(self):
-            self._hidden_params = {}
-            self.model = "gpt-4"
-            self.custom_llm_provider = "anthropic"
-            self.logging_obj = MagicMock()
-            self.litellm_metadata = None
-            self.responses_api_provider_config = None
-            self.finished = False
-            self.completed_response = None
-            self.response = None
-            self.start_time = None
-            self.request_data = {}
-            self.call_type = None
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            raise error
-
-    class _EmptyIter:
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            raise StopAsyncIteration
 
     with patch.object(
         router,
         "async_function_with_fallbacks_common_utils",
-        return_value=_EmptyIter(),
+        return_value=_AsyncList(),
     ) as mock_fallback_utils:
         wrapped = await router._aresponses_streaming_iterator(
-            response=_ImmediateErrorIterator(),
+            response=src,
             initial_kwargs={
                 "model": "gpt-4",
                 "stream": True,
@@ -1953,198 +1934,92 @@ async def test_aresponses_streaming_iterator_writes_litellm_metadata_on_fallback
         async for _ in wrapped:
             pass
 
-    fallback_call_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
-    # Routing metadata must land under litellm_metadata, NOT the default
-    # "metadata" key (which litellm.aresponses doesn't read).
-    assert "litellm_metadata" in fallback_call_kwargs, (
-        "litellm_metadata key missing — _update_kwargs_before_fallbacks "
-        "called with the wrong metadata_variable_name"
-    )
-    assert fallback_call_kwargs["litellm_metadata"]["model_group"] == "gpt-4"
-    assert "metadata" not in fallback_call_kwargs or (
-        "model_group" not in fallback_call_kwargs.get("metadata", {})
+    fbk = mock_fallback_utils.call_args.kwargs["kwargs"]
+    assert "litellm_metadata" in fbk, "wrong metadata_variable_name"
+    assert fbk["litellm_metadata"]["model_group"] == "gpt-4"
+    assert "model_group" not in fbk.get(
+        "metadata", {}
     ), "model_group leaked into 'metadata' instead of 'litellm_metadata'"
 
 
 @pytest.mark.asyncio
 async def test_aresponses_streaming_iterator_pre_first_chunk_skips_continuation():
-    """Pre-first-chunk MidStreamFallbackError: original input is preserved
-    unchanged, no continuation messages are injected."""
+    """Pre-first-chunk error: original input is preserved unchanged."""
     from litellm.exceptions import MidStreamFallbackError
-    from litellm.responses.streaming_iterator import (
-        BaseResponsesAPIStreamingIterator,
+
+    router = _make_router_with_fallback()
+    src = _make_responses_iterator(
+        error=MidStreamFallbackError(
+            message="socket timeout before first chunk",
+            model="gpt-4",
+            llm_provider="anthropic",
+            is_pre_first_chunk=True,
+            generated_content="",
+        )
     )
-
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "gpt-4",
-                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
-            },
-            {
-                "model_name": "gpt-3.5-turbo",
-                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
-            },
-        ],
-        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
-    )
-
-    pre_first_chunk_error = MidStreamFallbackError(
-        message="socket timeout before first chunk",
-        model="gpt-4",
-        llm_provider="anthropic",
-        is_pre_first_chunk=True,
-        generated_content="",
-    )
-
-    class _ImmediateErrorIterator(BaseResponsesAPIStreamingIterator):
-        def __init__(self):
-            self._hidden_params = {}
-            self.model = "gpt-4"
-            self.custom_llm_provider = "anthropic"
-            self.logging_obj = MagicMock()
-            self.litellm_metadata = None
-            self.responses_api_provider_config = None
-            self.finished = False
-            self.completed_response = None
-            self.response = None
-            self.start_time = None
-            self.request_data = {}
-            self.call_type = None
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            raise pre_first_chunk_error
-
-    class _EmptyIter:
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            raise StopAsyncIteration
-
-    initial_kwargs = {"model": "gpt-4", "stream": True, "input": "Hello"}
 
     with patch.object(
         router,
         "async_function_with_fallbacks_common_utils",
-        return_value=_EmptyIter(),
+        return_value=_AsyncList(),
     ) as mock_fallback_utils:
         wrapped = await router._aresponses_streaming_iterator(
-            response=_ImmediateErrorIterator(),
+            response=src,
             initial_kwargs={
-                **initial_kwargs,
+                "model": "gpt-4",
+                "stream": True,
+                "input": "Hello",
                 "original_generic_function": litellm.aresponses,
             },
         )
         async for _ in wrapped:
             pass
 
-    assert mock_fallback_utils.called
-    fallback_call_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
-    # Pre-first-chunk: input must be the original string, not a continuation list
-    assert fallback_call_kwargs["input"] == "Hello"
+    fbk = mock_fallback_utils.call_args.kwargs["kwargs"]
+    assert fbk["input"] == "Hello"  # original input, no continuation messages
 
 
 @pytest.mark.asyncio
 async def test_aresponses_streaming_iterator_partial_content_injects_continuation():
-    """Mid-stream MidStreamFallbackError with generated_content: input is
-    rewritten to include a developer instruction + prior-assistant message
-    carrying the partial output."""
+    """Mid-stream error: input is rewritten to include user prompt +
+    developer instruction + prior assistant message with partial output."""
     from litellm.exceptions import MidStreamFallbackError
-    from litellm.responses.streaming_iterator import (
-        BaseResponsesAPIStreamingIterator,
+
+    router = _make_router_with_fallback()
+    src = _make_responses_iterator(
+        chunks=[MagicMock(type="response.output_text.delta")],
+        error=MidStreamFallbackError(
+            message="socket reset mid-stream",
+            model="gpt-4",
+            llm_provider="anthropic",
+            is_pre_first_chunk=False,
+            generated_content="The capital of France is",
+        ),
     )
-
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "gpt-4",
-                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
-            },
-            {
-                "model_name": "gpt-3.5-turbo",
-                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
-            },
-        ],
-        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
-    )
-
-    mid_stream_error = MidStreamFallbackError(
-        message="socket reset mid-stream",
-        model="gpt-4",
-        llm_provider="anthropic",
-        is_pre_first_chunk=False,
-        generated_content="The capital of France is",
-    )
-
-    class _MidStreamErrorIterator(BaseResponsesAPIStreamingIterator):
-        def __init__(self):
-            self._chunks = [MagicMock(type="response.output_text.delta")]
-            self._idx = 0
-            self._hidden_params = {}
-            self.model = "gpt-4"
-            self.custom_llm_provider = "anthropic"
-            self.logging_obj = MagicMock()
-            self.litellm_metadata = None
-            self.responses_api_provider_config = None
-            self.finished = False
-            self.completed_response = None
-            self.response = None
-            self.start_time = None
-            self.request_data = {}
-            self.call_type = None
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self._idx < len(self._chunks):
-                self._idx += 1
-                return self._chunks[self._idx - 1]
-            raise mid_stream_error
-
-    class _EmptyIter:
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            raise StopAsyncIteration
-
-    initial_kwargs = {
-        "model": "gpt-4",
-        "stream": True,
-        "input": "What's the capital of France?",
-    }
 
     with patch.object(
         router,
         "async_function_with_fallbacks_common_utils",
-        return_value=_EmptyIter(),
+        return_value=_AsyncList(),
     ) as mock_fallback_utils:
         wrapped = await router._aresponses_streaming_iterator(
-            response=_MidStreamErrorIterator(),
+            response=src,
             initial_kwargs={
-                **initial_kwargs,
+                "model": "gpt-4",
+                "stream": True,
+                "input": "What's the capital of France?",
                 "original_generic_function": litellm.aresponses,
             },
         )
         async for _ in wrapped:
             pass
 
-    fallback_call_kwargs = mock_fallback_utils.call_args.kwargs["kwargs"]
-    new_input = fallback_call_kwargs["input"]
-
-    # Original string input is normalized to a user message
+    new_input = mock_fallback_utils.call_args.kwargs["kwargs"]["input"]
     assert isinstance(new_input, list)
     assert new_input[0]["role"] == "user"
     assert new_input[0]["content"][0]["text"] == "What's the capital of France?"
-    # A developer instruction tells the model not to repeat
     assert new_input[1]["role"] == "developer"
     assert "do not repeat" in new_input[1]["content"][0]["text"].lower()
-    # Prior assistant message carries the partial output as output_text
     assert new_input[2]["role"] == "assistant"
     assert new_input[2]["content"][0]["type"] == "output_text"
     assert new_input[2]["content"][0]["text"] == "The capital of France is"
@@ -2152,79 +2027,12 @@ async def test_aresponses_streaming_iterator_partial_content_injects_continuatio
 
 @pytest.mark.asyncio
 async def test_aresponses_streaming_iterator_combines_partial_usage():
-    """Usage from partial chunks is merged onto the fallback's
-    response.completed event so downstream accounting reflects both attempts."""
+    """Partial usage from the bridge path is normalized to ResponseAPIUsage
+    and summed onto the fallback's response.completed event — no token-name
+    split, clean ResponseAPIUsage on output."""
     from types import SimpleNamespace
 
     from litellm.exceptions import MidStreamFallbackError
-    from litellm.responses.streaming_iterator import (
-        BaseResponsesAPIStreamingIterator,
-    )
-
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "gpt-4",
-                "litellm_params": {"model": "gpt-4", "api_key": "k1"},
-            },
-            {
-                "model_name": "gpt-3.5-turbo",
-                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "k2"},
-            },
-        ],
-        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
-    )
-
-    partial_usage = SimpleNamespace(prompt_tokens=10, completion_tokens=4)
-
-    # The bridge subclass is what the wrapper isinstance-narrows on to read
-    # collected_chat_completion_chunks. Inherit from it (and skip super().__init__)
-    # so the test exercises the same code path production hits.
-    from litellm.responses.litellm_completion_transformation.streaming_iterator import (
-        LiteLLMCompletionStreamingIterator,
-    )
-
-    class _BridgeStyleIterator(LiteLLMCompletionStreamingIterator):
-        """Emits a delta chunk then raises mid-stream. Mimics the bridge
-        path's collected_chat_completion_chunks attribute, but here we
-        intercept stream_chunk_builder so we don't have to construct real
-        ModelResponse chunks."""
-
-        def __init__(self):
-            self.collected_chat_completion_chunks = [MagicMock()]
-            self._chunks = [MagicMock(type="response.output_text.delta")]
-            self._idx = 0
-            self._hidden_params = {}
-            self.model = "gpt-4"
-            self.custom_llm_provider = "anthropic"
-            self.logging_obj = MagicMock()
-            self.litellm_metadata = None
-            self.responses_api_provider_config = None
-            self.finished = False
-            self.completed_response = None
-            self.response = None
-            self.start_time = None
-            self.request_data = {}
-            self.call_type = None
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self._idx < len(self._chunks):
-                self._idx += 1
-                return self._chunks[self._idx - 1]
-            raise MidStreamFallbackError(
-                message="boom",
-                model="gpt-4",
-                llm_provider="anthropic",
-                is_pre_first_chunk=False,
-                generated_content="hello",
-            )
-
-    # Use real event/response/usage types so the wrapper's isinstance
-    # narrowing matches AND the combined output is a clean ResponseAPIUsage
-    # (no token-naming split between chat and responses conventions).
     from litellm.types.llms.openai import (
         ResponseAPIUsage,
         ResponseCompletedEvent,
@@ -2232,46 +2040,46 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
         ResponsesAPIStreamEvents,
     )
 
+    router = _make_router_with_fallback()
+    src = _make_responses_iterator(
+        bridge=True,
+        chat_chunks=[MagicMock()],
+        chunks=[MagicMock(type="response.output_text.delta")],
+        error=MidStreamFallbackError(
+            message="boom",
+            model="gpt-4",
+            llm_provider="anthropic",
+            is_pre_first_chunk=False,
+            generated_content="hello",
+        ),
+    )
+
     fallback_response_object = ResponsesAPIResponse(
         id="resp_test", created_at=0, model="gpt-4", object="response", output=[]
     )
-    # Fallback usage arrives in responses-API shape (input/output_tokens).
     fallback_response_object.usage = ResponseAPIUsage(
         input_tokens=20, output_tokens=15, total_tokens=35
     )
-    fallback_completed_event = ResponseCompletedEvent(
+    fallback_event = ResponseCompletedEvent(
         type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
         response=fallback_response_object,
     )
 
-    class _FallbackIter:
-        def __init__(self, items):
-            self._items = items
-            self._idx = 0
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self._idx >= len(self._items):
-                raise StopAsyncIteration
-            item = self._items[self._idx]
-            self._idx += 1
-            return item
-
     with (
         patch(
             "litellm.main.stream_chunk_builder",
-            return_value=SimpleNamespace(usage=partial_usage),
+            return_value=SimpleNamespace(
+                usage=SimpleNamespace(prompt_tokens=10, completion_tokens=4)
+            ),
         ),
         patch.object(
             router,
             "async_function_with_fallbacks_common_utils",
-            return_value=_FallbackIter([fallback_completed_event]),
+            return_value=_AsyncList([fallback_event]),
         ),
     ):
         wrapped = await router._aresponses_streaming_iterator(
-            response=_BridgeStyleIterator(),
+            response=src,
             initial_kwargs={
                 "model": "gpt-4",
                 "stream": True,
@@ -2282,19 +2090,11 @@ async def test_aresponses_streaming_iterator_combines_partial_usage():
         async for _ in wrapped:
             pass
 
-    # Combined output must be a clean ResponseAPIUsage (no split between
-    # chat-style and responses-style token names). Bridge partial of 10/4
-    # gets translated to input/output_tokens, then summed with the fallback's
-    # 20/15 to produce 30/19/49.
-    merged_usage = fallback_response_object.usage
-    assert isinstance(merged_usage, ResponseAPIUsage)
-    assert merged_usage.input_tokens == 30
-    assert merged_usage.output_tokens == 19
-    assert merged_usage.total_tokens == 49
-    # Chat-style attributes should NOT leak onto the merged object.
-    assert not hasattr(merged_usage, "prompt_tokens") or getattr(
-        merged_usage, "prompt_tokens", None
-    ) in (None, 0)
+    merged = fallback_response_object.usage
+    assert isinstance(merged, ResponseAPIUsage)
+    assert merged.input_tokens == 30  # 10 (translated from prompt_tokens) + 20
+    assert merged.output_tokens == 19  # 4 (translated from completion_tokens) + 15
+    assert merged.total_tokens == 49
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> Re-opened from #28214 to target the contributor staging branch (`shin_agent_oss_staging_05_19_2026`) per the [Guard main branch](https://github.com/BerriAI/litellm/blob/main/.github/workflows/guard-main-branch.yml) policy.

## Summary

`MidStreamFallbackError` raised mid-stream during `Router.aresponses(stream=True)` bypasses the Router's fallback chain, so configured cross-provider fallbacks (e.g. `anthropic → vertex_ai`) never fire when the primary provider's stream fails mid-flight.

The chat completions path wraps its `CustomStreamWrapper` via `_acompletion_streaming_iterator`, which catches `MidStreamFallbackError` and re-enters `async_function_with_fallbacks_common_utils`. The Responses API path doesn't have an equivalent: it dispatches through `_ageneric_api_call_with_fallbacks` → `_ageneric_api_call_with_fallbacks_helper`, which awaits `litellm.aresponses(**response_kwargs)` and returns the streaming iterator **unwrapped**. Any `MidStreamFallbackError` raised during iteration (e.g. by the underlying `CustomStreamWrapper` when `LiteLLMCompletionStreamingIterator` bridges through completion) propagates past the Router.

Observed in production: Anthropic socket timed out before the first chunk on `Router.aresponses(stream=True)`. Configured `anthropic → vertex_ai` fallback was never invoked; the error surfaced to the caller.

## Change

Full parity with the chat-completions streaming path:

- **`Router._aresponses_streaming_iterator`** mirroring `_acompletion_streaming_iterator`. Wraps `BaseResponsesAPIStreamingIterator`, catches `MidStreamFallbackError`, re-enters `async_function_with_fallbacks_common_utils` with `original_function=_ageneric_api_call_with_fallbacks_helper` and `original_generic_function` preserved so the helper invokes `litellm.aresponses` on each fallback attempt. The wrapper subclasses `BaseResponsesAPIStreamingIterator` (bypassing the parent constructor) to preserve `isinstance` compatibility with downstream consumers ([proxy cursor endpoint](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/response_api_endpoints/endpoints.py) and [`litellm/interactions/litellm_responses_transformation/handler.py`](https://github.com/BerriAI/litellm/blob/main/litellm/interactions/litellm_responses_transformation/handler.py)).
- **Pre-first-chunk retry** (`e.is_pre_first_chunk or not e.generated_content`): re-issue with the original input unchanged. Adding a continuation prompt with no partial content would waste tokens and confuse the model.
- **Partial-content continuation** (mid-stream errors with `generated_content`): rewrite the Responses input via `Router._build_responses_continuation_input` — append a developer-role instruction telling the model not to repeat, plus a prior assistant message with the partial output as `output_text`. String inputs are normalized to a single `user` message first. Best effort across providers; same trade-off as the chat-completions path for non-Anthropic fallbacks (the `prefix: True` prefill trick has no Responses-API equivalent).
- **Usage combining** via `Router._extract_partial_responses_usage` + `Router._combine_responses_fallback_usage`. Bridge path: `isinstance(LiteLLMCompletionStreamingIterator)` → `collected_chat_completion_chunks` → `stream_chunk_builder` → `Usage`. Native path: `isinstance(ResponseCompletedEvent | ResponseFailedEvent | ResponseIncompleteEvent)` → `response.usage`. Merged onto the fallback's `response.completed` event via `BaseTokenUsageProcessor.combine_usage_objects`.
- **Stream cleanup**: shielded `aclose()` on both source and fallback iterators in `finally`.
- **`Router._aresponses_with_streaming_fallbacks`** dispatcher that snapshots kwargs (preserving `original_generic_function`), calls `_ageneric_api_call_with_fallbacks`, and wraps the result when `stream=True` and the response is a `BaseResponsesAPIStreamingIterator`.
- Split `"aresponses"` out of the generic `factory_function` dispatch bucket so it flows through the new wrapper.
- Strong types throughout (`BaseResponsesAPIStreamingIterator`, `ResponseInputParam`, `ResponsesAPIResponse`, `BaseLiteLLMOpenAIResponseObject`, `Usage`) imported under `TYPE_CHECKING`. Wrapper internals use direct field access — no defensive `getattr` for attributes the base class guarantees.

## Tests

Four new tests in `tests/test_litellm/test_router.py`:

1. `test_aresponses_streaming_iterator_fallback` — initial chunks stream through; `MidStreamFallbackError` triggers `async_function_with_fallbacks_common_utils` with `original_function=_ageneric_api_call_with_fallbacks_helper` and `original_generic_function=litellm.aresponses`; fallback chunks stream through; wrapper preserves `_hidden_params` and `isinstance(BaseResponsesAPIStreamingIterator)`.
2. `test_aresponses_streaming_iterator_pre_first_chunk_skips_continuation` — pre-first-chunk error preserves the original input string unchanged.
3. `test_aresponses_streaming_iterator_partial_content_injects_continuation` — mid-stream error rewrites input: original prompt becomes a `user` message, followed by a `developer` instruction containing "do not repeat", followed by an `assistant` message with the partial output as `output_text`.
4. `test_aresponses_streaming_iterator_combines_partial_usage` — `stream_chunk_builder` returns partial usage (10 prompt + 4 completion); fallback's `response.completed` event carries usage (20 prompt + 15 completion); combined event has 30 prompt + 19 completion.

All 10 streaming-iterator tests pass (7 existing + new aresponses base + 3 new partial-content/usage cases). `uv run ruff check litellm/router.py` and `uv run black .` clean.

## Empirical verification (live API)

Cross-provider chain: `anthropic/claude-sonnet-4-5` primary → `openai/gpt-4o-mini` fallback. Primary's stream is intercepted at `_ageneric_api_call_with_fallbacks_helper` to return an iterator that yields one delta event then raises `MidStreamFallbackError(is_pre_first_chunk=False, generated_content="from-primary ")` — simulating the production socket-timeout case. Fallback attempt goes through the real OpenAI API.

| Scenario | Wrapper state | `MidStreamFallbackError` propagates | Final text |
|---|---|---|---|
| BEFORE | `_aresponses_with_streaming_fallbacks` monkey-patched back to bare `_ageneric_api_call_with_fallbacks` | ✅ yes (bug reproduced) | `''` |
| AFTER | wrapper active | ❌ no (fallback fires) | `'from-primary Pong'` |

The `AFTER` result includes the partial output from the failed primary (`"from-primary "`) followed by a real OpenAI generation (`"Pong"`), confirming end-to-end:
- The new wrapper caught `MidStreamFallbackError` from the primary's stream.
- It re-entered `async_function_with_fallbacks_common_utils` with the correct kwargs.
- The fallback chain picked the `fallback` deployment.
- The real OpenAI streaming response was delivered to the caller.

Script: [`verify_aresponses_fallback.py`](https://gist.github.com/) (run via `bash run_aresponses_verification.sh` — pulls keys from AWS Secrets Manager).

## Proof of fix
<img width="750" height="620" alt="aresponses_verification_screenshot" src="https://github.com/user-attachments/assets/c06a1010-db53-4c7d-b7d6-a272159a71ba" />

