### PR TITLE
fix(github-copilot): route per-model on /v1/responses based on model info

### DIFF
--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -2,7 +2,7 @@
 GitHub Copilot Responses API Configuration.
 
 This module provides the configuration for GitHub Copilot's Responses API,
-which is required for models like gpt-5.1-codex that only support the /responses endpoint.
+which is required for models like gpt-5.3-codex that only support the /responses endpoint.
 
 Implementation based on analysis of the copilot-api project by caozhiyuan:
 https://github.com/caozhiyuan/copilot-api
@@ -22,6 +22,7 @@ from litellm.types.llms.openai import (
 )
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
+from litellm.utils import _get_model_info_helper
 
 from ..authenticator import Authenticator
 from ..common_utils import (
@@ -36,6 +37,53 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+
+def github_copilot_supports_responses_api(model: str) -> bool:
+    """
+    Resolve whether to use the native Responses API for a github_copilot model.
+
+    Copilot's /v1/responses endpoint is per-model (only some models like
+    gpt-5.5, gpt-5.4, gpt-5.4-mini opt in upstream). The Responses API config
+    is registered for github_copilot provider-wide, so this function gates
+    per-model to keep /v1/responses calls from failing upstream on chat-only
+    Copilot models like claude-opus-4.7 or gemini-3.1-pro-preview.
+
+    The router calls ``litellm.register_model`` for every proxy deployment,
+    which merges the user's per-deployment ``model_info`` (e.g. ``mode: chat``
+    to force a chat-only override) into ``litellm.model_cost`` before any
+    request runs. ``_get_model_info_helper`` therefore returns merged data
+    with user overrides already applied.
+
+    Resolution order (first match wins):
+      1. ``mode == "responses"`` → True (positive opt-in; user or catalog).
+      2. ``mode == "chat"`` → False (explicit opt-out wins over endpoint
+         declarations, letting users force the bridge for dual-endpoint models).
+      3. ``"/v1/responses"`` in ``supported_endpoints`` → True.
+      4. Otherwise → False (conservative default; the bridge always works
+         because every Copilot model supports /chat/completions).
+
+    Catalog lookup raising (model not registered) → False (conservative).
+    """
+    try:
+        info = _get_model_info_helper(model=model, custom_llm_provider="github_copilot")
+    except Exception as e:
+        verbose_logger.debug(
+            "github_copilot_supports_responses_api: get_model_info failed "
+            "for %s: %s",
+            model,
+            e,
+        )
+        return False
+
+    mode = info.get("mode")
+    if mode == "responses":
+        return True
+    if mode == "chat":
+        return False
+
+    endpoints = info.get("supported_endpoints")
+    return isinstance(endpoints, list) and "/v1/responses" in endpoints
 
 
 class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8676,7 +8676,13 @@ class ProviderConfigManager:
         elif litellm.LlmProviders.XAI == provider:
             return litellm.XAIResponsesAPIConfig()
         elif litellm.LlmProviders.GITHUB_COPILOT == provider:
-            return litellm.GithubCopilotResponsesAPIConfig()
+            from litellm.llms.github_copilot.responses.transformation import (
+                github_copilot_supports_responses_api,
+            )
+
+            if model is None or github_copilot_supports_responses_api(model=model):
+                return litellm.GithubCopilotResponsesAPIConfig()
+            return None
         elif litellm.LlmProviders.CHATGPT == provider:
             return litellm.ChatGPTResponsesAPIConfig()
         elif litellm.LlmProviders.LITELLM_PROXY == provider:

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -14,6 +14,8 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 import pytest
+import litellm
+from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
 from litellm.llms.github_copilot.responses.transformation import (
@@ -22,13 +24,26 @@ from litellm.llms.github_copilot.responses.transformation import (
 from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
 
 
+@pytest.fixture(autouse=True)
+def use_local_model_cost_map(monkeypatch: pytest.MonkeyPatch):
+    """Pin litellm.model_cost to the bundled local backup so tests don't depend
+    on remote catalog fetches (and don't change behavior across remote refreshes)."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(
+        litellm, "model_cost", get_model_cost_map(url=litellm.model_cost_map_url)
+    )
+    litellm.add_known_models(model_cost_map=litellm.model_cost)
+
+
 class TestGithubCopilotResponsesAPITransformation:
     """Test GitHub Copilot Responses API configuration and transformations"""
 
     def test_github_copilot_provider_config_registration(self):
-        """Test that GitHub Copilot provider returns GithubCopilotResponsesAPIConfig"""
+        """Test that GitHub Copilot provider returns the native Responses API
+        config for a Responses-capable catalog model. Exercises the full stack:
+        catalog lookup -> github_copilot_supports_responses_api -> native config."""
         config = ProviderConfigManager.get_provider_responses_api_config(
-            model="github_copilot/gpt-5.1-codex",
+            model="github_copilot/gpt-5.3-codex",
             provider=LlmProviders.GITHUB_COPILOT,
         )
 
@@ -373,3 +388,174 @@ class TestGithubCopilotResponsesAPITransformation:
 
         # Non-reasoning items should pass through unchanged
         assert result == message_item
+
+
+class TestGithubCopilotResponsesAPIRouting:
+    """``ProviderConfigManager.get_provider_responses_api_config`` for github_copilot
+    returns the native Responses config only when the model has ``mode=responses``
+    in the (already-merged) model info; otherwise returns None so the dispatcher
+    routes through the chat-completions translation bridge."""
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_returns_config_when_mode_is_responses(self, mock_get_info):
+        """``mode=responses`` returns native config."""
+        mock_get_info.return_value = {"mode": "responses"}
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-responses-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_returns_none_when_mode_is_chat(self, mock_get_info):
+        """``mode=chat`` returns None so dispatcher uses bridge."""
+        mock_get_info.return_value = {"mode": "chat"}
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-chat-only-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert config is None
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_returns_none_when_mode_is_unset_and_no_endpoints(self, mock_get_info):
+        """Entry without ``mode`` and without ``supported_endpoints`` returns None
+        (conservative default)."""
+        mock_get_info.return_value = {}
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert config is None
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_returns_config_when_mode_unset_but_endpoints_have_responses(
+        self, mock_get_info
+    ):
+        """``mode`` unset but ``supported_endpoints`` declaring /v1/responses
+        returns native config (endpoint-list fallback for stale-but-correct
+        catalog entries that lack ``mode``)."""
+        mock_get_info.return_value = {
+            "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+        }
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_mode_chat_overrides_endpoints_with_responses(self, mock_get_info):
+        """``mode=chat`` is a hard opt-out: forces bridge even when
+        ``supported_endpoints`` includes /v1/responses. Lets users force the
+        bridge for dual-endpoint models without clearing endpoint metadata."""
+        mock_get_info.return_value = {
+            "mode": "chat",
+            "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
+        }
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert config is None
+
+    def test_returns_config_when_model_is_none(self):
+        """Follow-up GET/DELETE operations pass model=None and keep the native
+        config path (no per-model lookup is possible)."""
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model=None,
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_returns_none_when_get_model_info_raises(self, mock_get_info):
+        """Catalog lookup failure (model not registered) returns None
+        (conservative default; bridge handles unknown models safely)."""
+        mock_get_info.side_effect = Exception("model not in catalog")
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/never-seen-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert config is None
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_user_override_via_register_model(self, mock_get_info):
+        """User-supplied per-deployment ``model_info`` flows through
+        ``litellm.register_model`` (called by the router) into the merged
+        catalog read by ``_get_model_info_helper``. Setting ``mode=responses``
+        for a model whose catalog entry says ``mode=chat`` therefore opts in
+        to native dispatch without any per-call argument plumbing."""
+        mock_get_info.return_value = {"mode": "responses"}
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-chat-only-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_realistic_chat_only_entry_returns_none(self, mock_get_info):
+        """Realistic ``model_prices_and_context_window.json`` shape for a
+        chat-only Copilot model (e.g. github_copilot/gemini-3.1-pro-preview)
+        returns None so /v1/responses calls fall back to the bridge."""
+        mock_get_info.return_value = {
+            "litellm_provider": "github_copilot",
+            "max_input_tokens": 136000,
+            "max_output_tokens": 64000,
+            "max_tokens": 64000,
+            "mode": "chat",
+            "supported_endpoints": ["/v1/chat/completions"],
+            "supports_function_calling": True,
+            "supports_tool_choice": True,
+            "supports_parallel_function_calling": True,
+            "supports_vision": True,
+            "supports_reasoning": True,
+        }
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-chat-only-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert config is None
+
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._get_model_info_helper"
+    )
+    def test_realistic_responses_only_entry_returns_config(self, mock_get_info):
+        """Realistic catalog entry for a Responses-only Copilot model
+        (e.g. github_copilot/gpt-5.5) returns the native config."""
+        mock_get_info.return_value = {
+            "litellm_provider": "github_copilot",
+            "max_input_tokens": 272000,
+            "max_output_tokens": 128000,
+            "max_tokens": 128000,
+            "mode": "responses",
+            "supported_endpoints": ["/v1/responses"],
+            "supports_function_calling": True,
+            "supports_tool_choice": True,
+            "supports_parallel_function_calling": True,
+            "supports_response_schema": True,
+            "supports_vision": True,
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": True,
+            "supports_xhigh_reasoning_effort": True,
+        }
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/some-responses-only-model",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)


### PR DESCRIPTION
Reopening the old PR #19650 by creating a new PR targetting `litellm_internal_staging`, fixes #20103.

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #20103 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

**Note**: failing tests and lints are not caused by this change.

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

### Problem

GitHub Copilot's `/v1/responses` endpoint is per-model: only some models (e.g. `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`) support it natively upstream. The `GithubCopilotResponsesAPIConfig` provider config was registered for `github_copilot` provider-wide, so every model was forced to native `/v1/responses` dispatch. Chat-only models like `gemini-3.1-pro-preview` therefore failed upstream with `model X does not support Responses API`.

### Fix

- **`litellm/llms/github_copilot/responses/transformation.py`**: add `github_copilot_supports_responses_api(model)` helper. The helper reads `mode` and `supported_endpoints` from the merged model info (which incorporates user-supplied per-deployment `model_info` via the router's `litellm.register_model` call) using a 4-tier resolution:
  1. `mode == "responses"` → native dispatch (positive opt-in)
  2. `mode == "chat"` → chat-completions translation bridge (explicit opt-out, lets users force the bridge for dual-endpoint models)
  3. `"/v1/responses"` in `supported_endpoints` → native dispatch
  4. Otherwise → bridge (conservative default; the bridge always works because every Copilot model supports `/chat/completions`)

  Catalog lookup raising (model not registered) → bridge (conservative).

- **`litellm/utils.py`**: `ProviderConfigManager.get_provider_responses_api_config` now calls the helper for the `github_copilot` branch and returns `None` for non-supporting models, letting the existing dispatcher in `litellm/responses/main.py` fall back to the chat-completions translation bridge.

- **`model_prices_and_context_window.json`**: refresh `github_copilot/*` entries from upstream Copilot `/models` (replace 31 stale entries with 24 fresh ones). Each model now declares `mode` and (where applicable) `supported_endpoints` accurately, including `mode: "responses"` for Responses-capable models like `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`, `gpt-5-mini`, and the codex variants. I wrote a [small script on GitHub gist](https://gist.github.com/codgician/c81b411794f29ee024f627d87b13b5d8) for retrieving raw info and converted litellm convention to achieve this.

### Behavior

| Model | Before | After |
|---|---|---|
| `github_copilot/gemini-3.1-pro-preview` on `/v1/responses` | HTTP 400 from upstream | HTTP 200 via chat-completions bridge |
| `github_copilot/gpt-5.5` on `/v1/responses` | HTTP 200 (native) | HTTP 200 (native, unchanged) |
| `github_copilot/gpt-5.4` on `/v1/responses` | HTTP 200 (native) | HTTP 200 (native, unchanged) |

### Tests

- Added 10 unit tests covering the gate logic in `tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py`: every resolution tier (positive `mode`, negative `mode`, endpoint-list fallback, conservative defaults), `model=None` follow-up operations, and realistic catalog-shape fixtures for both chat-only and Responses-only Copilot models.
- Updated 1 pre-existing test to use a model unaffected by the gate (`model=None` path).
- All 28 tests in the file pass; sibling regression tests in `test_responses_api_bridge_flag.py` continue to pass.