### PR TITLE
fix(ui/log-drawer): paginate session trace list to surface logs beyond the first 50

### DIFF
--- a/litellm/interactions/litellm_responses_transformation/streaming_iterator.py
+++ b/litellm/interactions/litellm_responses_transformation/streaming_iterator.py
@@ -2,7 +2,7 @@
 Streaming iterator for transforming Responses API stream to Interactions API stream.
 """
 
-from typing import Any, AsyncIterator, Dict, Iterator, Optional, cast
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, cast
 
 from litellm.responses.streaming_iterator import (
     BaseResponsesAPIStreamingIterator,
@@ -15,6 +15,7 @@ from litellm.types.interactions import (
     InteractionsAPIStreamingResponse,
 )
 from litellm.types.llms.openai import (
+    ContentPartAddedEvent,
     OutputTextDeltaEvent,
     ResponseCompletedEvent,
     ResponseCreatedEvent,
@@ -51,6 +52,7 @@ class LiteLLMResponsesInteractionsStreamingIterator:
         self.collected_text = ""
         self.sent_interaction_start = False
         self.sent_content_start = False
+        self._pending_events: List[InteractionsAPIStreamingResponse] = []
 
     def _transform_responses_chunk_to_interactions_chunk(
         self,
@@ -80,7 +82,49 @@ class LiteLLMResponsesInteractionsStreamingIterator:
             )
             self.collected_text += delta_text
 
-            # Send interaction.start if not sent
+            # Fallback: emit interaction.start, and queue content.start carrying this
+            # delta so the first token is preserved in the stream.
+            if not self.sent_interaction_start:
+                self.sent_interaction_start = True
+                self.sent_content_start = True
+                self._pending_events.append(
+                    InteractionsAPIStreamingResponse(
+                        event_type="content.start",
+                        id=getattr(responses_chunk, "item_id", None),
+                        object="content",
+                        delta={"type": "text", "text": delta_text},
+                    )
+                )
+                return InteractionsAPIStreamingResponse(
+                    event_type="interaction.start",
+                    id=getattr(responses_chunk, "item_id", None)
+                    or f"interaction_{id(self)}",
+                    object="interaction",
+                    status="in_progress",
+                    model=self.model,
+                )
+
+            # Fallback: emit content.start if ContentPartAddedEvent never arrived
+            if not self.sent_content_start:
+                self.sent_content_start = True
+                return InteractionsAPIStreamingResponse(
+                    event_type="content.start",
+                    id=getattr(responses_chunk, "item_id", None),
+                    object="content",
+                    delta={"type": "text", "text": delta_text},
+                )
+
+            # Normal path: emit content.delta with type field
+            return InteractionsAPIStreamingResponse(
+                event_type="content.delta",
+                id=getattr(responses_chunk, "item_id", None),
+                object="content",
+                delta={"type": "text", "text": delta_text},
+            )
+
+        # Handle ContentPartAddedEvent -> content.start (arrives before text deltas)
+        if isinstance(responses_chunk, ContentPartAddedEvent):
+            # Fallback: emit interaction.start if ResponseCreatedEvent never arrived
             if not self.sent_interaction_start:
                 self.sent_interaction_start = True
                 return InteractionsAPIStreamingResponse(
@@ -91,8 +135,6 @@ class LiteLLMResponsesInteractionsStreamingIterator:
                     status="in_progress",
                     model=self.model,
                 )
-
-            # Send content.start if not sent
             if not self.sent_content_start:
                 self.sent_content_start = True
                 return InteractionsAPIStreamingResponse(
@@ -101,14 +143,7 @@ class LiteLLMResponsesInteractionsStreamingIterator:
                     object="content",
                     delta={"type": "text", "text": ""},
                 )
-
-            # Send content.delta
-            return InteractionsAPIStreamingResponse(
-                event_type="content.delta",
-                id=getattr(responses_chunk, "item_id", None),
-                object="content",
-                delta={"text": delta_text},
-            )
+            return None
 
         # Handle ResponseCreatedEvent or ResponseInProgressEvent -> interaction.start
         if isinstance(responses_chunk, (ResponseCreatedEvent, ResponseInProgressEvent)):
@@ -172,6 +207,10 @@ class LiteLLMResponsesInteractionsStreamingIterator:
             delattr(self, "_pending_interaction_complete")
             return pending
 
+        # Drain events queued from a prior chunk (e.g. content.start emitted alongside
+        # the interaction.start fallback for the first OutputTextDeltaEvent).
+        if self._pending_events:
+            return self._pending_events.pop(0)
         # Use a loop instead of recursion to avoid stack overflow
         sync_iterator = cast(
             SyncResponsesAPIStreamingIterator, self.responses_stream_iterator
@@ -237,6 +276,10 @@ class LiteLLMResponsesInteractionsStreamingIterator:
             delattr(self, "_pending_interaction_complete")
             return pending
 
+        # Drain events queued from a prior chunk (e.g. content.start emitted alongside
+        # the interaction.start fallback for the first OutputTextDeltaEvent).
+        if self._pending_events:
+            return self._pending_events.pop(0)
         # Use a loop instead of recursion to avoid stack overflow
         async_iterator = cast(
             ResponsesAPIStreamingIterator, self.responses_stream_iterator

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -299,9 +299,9 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
             )
 
     def _get_response_stream_shape(self):
-        from litellm.llms.bedrock.common_utils import BEDROCK_RESPONSE_STREAM_SHAPE
+        from litellm.llms.bedrock.common_utils import get_bedrock_response_stream_shape
 
-        return BEDROCK_RESPONSE_STREAM_SHAPE
+        return get_bedrock_response_stream_shape()
 
     def _extract_response_content(self, events: InvokeAgentEventList) -> str:
         """Extract the final response content from parsed events."""

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -68,9 +68,9 @@ from litellm.utils import CustomStreamWrapper, get_secret
 
 from ..base_aws_llm import BaseAWSLLM
 from ..common_utils import (
-    BEDROCK_RESPONSE_STREAM_SHAPE,
     BedrockError,
     ModelResponseIterator,
+    get_bedrock_response_stream_shape,
     get_bedrock_tool_name,
 )
 
@@ -1828,7 +1828,8 @@ class AWSEventStreamDecoder:
                     yield self._chunk_parser(chunk_data=_data)
 
     def _parse_message_from_event(self, event) -> Optional[str]:
-        if BEDROCK_RESPONSE_STREAM_SHAPE is None:
+        response_stream_shape = get_bedrock_response_stream_shape()
+        if response_stream_shape is None:
             raise BedrockError(
                 status_code=500,
                 message=(
@@ -1837,9 +1838,7 @@ class AWSEventStreamDecoder:
                 ),
             )
         response_dict = event.to_response_dict()
-        parsed_response = self.parser.parse(
-            response_dict, BEDROCK_RESPONSE_STREAM_SHAPE
-        )
+        parsed_response = self.parser.parse(response_dict, response_stream_shape)
 
         if response_dict["status_code"] != 200:
             decoded_body = response_dict["body"].decode()

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 Common utilities used across bedrock chat/embedding/image generation
 """
 
+import functools
 import json
 import os
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
@@ -963,10 +964,8 @@ def _load_bedrock_response_stream_shape():
     """
     Load the ResponseStream shape from botocore's bundled bedrock-runtime schema.
 
-    Called once at module import time; the result is stored in
-    ``BEDROCK_RESPONSE_STREAM_SHAPE`` and reused for the process lifetime.
     Returns ``None`` if botocore is unavailable or the service model cannot be
-    loaded, so the module still imports cleanly.
+    loaded.
     """
     try:
         from botocore.loaders import Loader
@@ -977,15 +976,22 @@ def _load_bedrock_response_stream_shape():
         return ServiceModel(service_dict).shape_for("ResponseStream")
     except Exception as e:
         verbose_logger.warning(
-            "litellm: could not pre-load bedrock-runtime response stream shape "
+            "litellm: could not load bedrock-runtime response stream shape "
             "— Bedrock event-stream decoding will be unavailable. Error: %s",
             e,
         )
         return None
 
 
-# Eagerly resolved once per process — avoids per-instance or per-request disk I/O.
-BEDROCK_RESPONSE_STREAM_SHAPE = _load_bedrock_response_stream_shape()
+@functools.lru_cache(maxsize=1)
+def get_bedrock_response_stream_shape():
+    """
+    Lazily load and cache the bedrock-runtime ResponseStream shape for the process.
+
+    Avoids importing botocore (and logging warnings) unless Bedrock event-stream
+    decoding is actually needed.
+    """
+    return _load_bedrock_response_stream_shape()
 
 
 class BedrockEventStreamDecoderBase:
@@ -999,7 +1005,8 @@ class BedrockEventStreamDecoderBase:
         self.parser = EventStreamJSONParser()
 
     def _parse_message_from_event(self, event) -> Optional[str]:
-        if BEDROCK_RESPONSE_STREAM_SHAPE is None:
+        response_stream_shape = get_bedrock_response_stream_shape()
+        if response_stream_shape is None:
             raise BedrockError(
                 status_code=500,
                 message=(
@@ -1008,9 +1015,7 @@ class BedrockEventStreamDecoderBase:
                 ),
             )
         response_dict = event.to_response_dict()
-        parsed_response = self.parser.parse(
-            response_dict, BEDROCK_RESPONSE_STREAM_SHAPE
-        )
+        parsed_response = self.parser.parse(response_dict, response_stream_shape)
 
         if response_dict["status_code"] != 200:
             decoded_body = response_dict["body"].decode()

--- a/litellm/llms/sagemaker/common_utils.py
+++ b/litellm/llms/sagemaker/common_utils.py
@@ -1,3 +1,4 @@
+import functools
 import json
 from typing import AsyncIterator, Iterator, List, Optional, Union
 
@@ -22,14 +23,22 @@ def _load_sagemaker_response_stream_shape():
         )
     except Exception as e:
         verbose_logger.warning(
-            "litellm: could not pre-load sagemaker-runtime response stream shape "
+            "litellm: could not load sagemaker-runtime response stream shape "
             "— SageMaker event-stream decoding will be unavailable. Error: %s",
             e,
         )
         return None
 
 
-SAGEMAKER_RESPONSE_STREAM_SHAPE = _load_sagemaker_response_stream_shape()
+@functools.lru_cache(maxsize=1)
+def get_sagemaker_response_stream_shape():
+    """
+    Lazily load and cache the sagemaker-runtime stream shape for the process.
+
+    Avoids importing botocore (and logging warnings) unless SageMaker event-stream
+    decoding is actually needed.
+    """
+    return _load_sagemaker_response_stream_shape()
 
 
 class SagemakerError(BaseLLMException):
@@ -207,7 +216,8 @@ class AWSEventStreamDecoder:
                 verbose_logger.error(f"Final error parsing accumulated JSON: {e}")
 
     def _parse_message_from_event(self, event) -> Optional[str]:
-        if SAGEMAKER_RESPONSE_STREAM_SHAPE is None:
+        response_stream_shape = get_sagemaker_response_stream_shape()
+        if response_stream_shape is None:
             raise SagemakerError(
                 status_code=500,
                 message=(
@@ -216,9 +226,7 @@ class AWSEventStreamDecoder:
                 ),
             )
         response_dict = event.to_response_dict()
-        parsed_response = self.parser.parse(
-            response_dict, SAGEMAKER_RESPONSE_STREAM_SHAPE
-        )
+        parsed_response = self.parser.parse(response_dict, response_stream_shape)
 
         if response_dict["status_code"] != 200:
             raise ValueError(f"Bad response code, expected 200: {response_dict}")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6917,6 +6917,15 @@ async def async_data_generator(  # noqa: PLR0915
 
             if isinstance(chunk, BaseModel):
                 chunk = _serialize_streaming_chunk(chunk)
+            elif isinstance(chunk, bytes):
+                # Some upstream streaming iterators (e.g. AsyncGoogleGenAIGenerateContentStreamingIterator
+                # for /v1beta/.../streamGenerateContent) yield raw SSE bytes from Gemini.
+                # Decode to str so the f-string below does not emit a Python b'...' literal,
+                # and pass already-formatted SSE through unchanged to avoid double "data:" prefix.
+                chunk = chunk.decode("utf-8", errors="replace")
+                if chunk.startswith(("data:", "event:", ":")):
+                    yield chunk if chunk.endswith("\n\n") else chunk + "\n\n"
+                    continue
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk
                 break

--- a/tests/test_litellm/interactions/test_gemini_interactions_transformation.py
+++ b/tests/test_litellm/interactions/test_gemini_interactions_transformation.py
@@ -9,14 +9,23 @@ Covers credential leak prevention changes:
 
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
+from litellm.interactions.litellm_responses_transformation.streaming_iterator import (
+    LiteLLMResponsesInteractionsStreamingIterator,
+)
 from litellm.llms.gemini.interactions.transformation import (
     GoogleAIStudioInteractionsConfig,
+)
+from litellm.types.llms.openai import (
+    ContentPartAddedEvent,
+    OutputTextDeltaEvent,
+    ResponseCompletedEvent,
+    ResponseCreatedEvent,
 )
 from litellm.types.router import GenericLiteLLMParams
 
@@ -111,6 +120,186 @@ class TestGetCompleteUrl:
                     model="gemini-2.5-flash",
                     litellm_params={"api_key": None},
                 )
+
+
+class TestStreamingIterator:
+    def _make_iterator(self) -> LiteLLMResponsesInteractionsStreamingIterator:
+        return LiteLLMResponsesInteractionsStreamingIterator(
+            model="gpt-5.4",
+            litellm_custom_stream_wrapper=MagicMock(),
+            request_input="hi",
+            optional_params={},
+        )
+
+    def _make_text_delta(
+        self, text: str, item_id: str = "item_1"
+    ) -> OutputTextDeltaEvent:
+        event = MagicMock(spec=OutputTextDeltaEvent)
+        event.delta = text
+        event.item_id = item_id
+        return event
+
+    def _make_part_added(self, item_id: str = "item_1") -> ContentPartAddedEvent:
+        event = MagicMock(spec=ContentPartAddedEvent)
+        event.item_id = item_id
+        return event
+
+    def _make_response_created(self) -> ResponseCreatedEvent:
+        event = MagicMock(spec=ResponseCreatedEvent)
+        event.response = MagicMock(id="resp_123")
+        return event
+
+    def test_content_delta_includes_type_field(self):
+        """content.delta events must carry delta.type='text' so the UI can display them."""
+        it = self._make_iterator()
+        it.sent_interaction_start = True
+        it.sent_content_start = True
+
+        chunk = it._transform_responses_chunk_to_interactions_chunk(
+            self._make_text_delta("Hello")
+        )
+
+        assert chunk is not None
+        assert chunk.event_type == "content.delta"
+        assert chunk.delta == {"type": "text", "text": "Hello"}
+
+    def test_response_part_added_emits_content_start(self):
+        """ContentPartAddedEvent (arrives before text deltas) should emit content.start
+        so the first OutputTextDeltaEvent immediately emits content.delta without dropping text.
+        """
+        it = self._make_iterator()
+        it.sent_interaction_start = True
+
+        chunk = it._transform_responses_chunk_to_interactions_chunk(
+            self._make_part_added()
+        )
+
+        assert chunk is not None
+        assert chunk.event_type == "content.start"
+        assert it.sent_content_start is True
+
+    def test_first_text_delta_not_dropped_when_part_added_seen(self):
+        """After ContentPartAddedEvent, the first text delta must yield content.delta
+        (not content.start), preserving the token text."""
+        it = self._make_iterator()
+        it.sent_interaction_start = True
+        it._transform_responses_chunk_to_interactions_chunk(self._make_part_added())
+
+        chunk = it._transform_responses_chunk_to_interactions_chunk(
+            self._make_text_delta("Hello")
+        )
+
+        assert chunk is not None
+        assert chunk.event_type == "content.delta"
+        assert chunk.delta is not None
+        assert chunk.delta.get("text") == "Hello"
+
+    def test_part_added_emits_interaction_start_fallback_when_not_sent(self):
+        """If ContentPartAddedEvent arrives before any ResponseCreatedEvent,
+        the iterator must emit interaction.start before content.start to honor
+        the documented event ordering contract."""
+        it = self._make_iterator()
+
+        chunk = it._transform_responses_chunk_to_interactions_chunk(
+            self._make_part_added(item_id="item_42")
+        )
+
+        assert chunk is not None
+        assert chunk.event_type == "interaction.start"
+        assert chunk.id == "item_42"
+        assert chunk.status == "in_progress"
+        assert chunk.model == "gpt-5.4"
+        assert it.sent_interaction_start is True
+        assert it.sent_content_start is False
+
+    def test_part_added_returns_none_when_already_started(self):
+        """A second ContentPartAddedEvent (after content.start was already emitted)
+        should be a no-op so we don't re-emit content.start."""
+        it = self._make_iterator()
+        it.sent_interaction_start = True
+        it.sent_content_start = True
+
+        chunk = it._transform_responses_chunk_to_interactions_chunk(
+            self._make_part_added()
+        )
+
+        assert chunk is None
+
+    def test_part_added_without_item_id_falls_back_to_self_id(self):
+        """When ContentPartAddedEvent has no item_id and we emit the interaction.start
+        fallback, the id must default to an interaction_<id(self)> string."""
+        it = self._make_iterator()
+        event = MagicMock(spec=ContentPartAddedEvent)
+        event.item_id = None
+
+        chunk = it._transform_responses_chunk_to_interactions_chunk(event)
+
+        assert chunk is not None
+        assert chunk.event_type == "interaction.start"
+        assert chunk.id == f"interaction_{id(it)}"
+
+    def test_first_text_delta_not_dropped_when_no_prior_start_events(self):
+        """When OutputTextDeltaEvent arrives before any ResponseCreatedEvent or
+        ContentPartAddedEvent, the iterator must emit interaction.start *and*
+        immediately follow with a content.start that carries this delta's text,
+        so the first token is never silently dropped from the stream."""
+        events = [
+            self._make_text_delta("Hello"),
+            self._make_text_delta(" World"),
+        ]
+        wrapper = MagicMock()
+        wrapper.__iter__ = lambda self: iter(events)
+        wrapper.__next__ = lambda self, _it=iter(events): next(_it)
+        it = LiteLLMResponsesInteractionsStreamingIterator(
+            model="gpt-5.4",
+            litellm_custom_stream_wrapper=wrapper,
+            request_input="hi",
+            optional_params={},
+        )
+
+        first = it._transform_responses_chunk_to_interactions_chunk(events[0])
+        assert first is not None
+        assert first.event_type == "interaction.start"
+        assert it.sent_interaction_start is True
+        assert it.sent_content_start is True
+        assert len(it._pending_events) == 1
+        pending = it._pending_events[0]
+        assert pending.event_type == "content.start"
+        assert pending.delta == {"type": "text", "text": "Hello"}
+
+        second = it._transform_responses_chunk_to_interactions_chunk(events[1])
+        assert second is not None
+        assert second.event_type == "content.delta"
+        assert second.delta == {"type": "text", "text": " World"}
+
+
+class TestTransformRequest:
+    def test_stream_param_included_in_request_body(self, config):
+        """When stream=True is in optional_params, the request body must include it
+        so the proxy forwards the SSE streaming flag to Google's backend."""
+        body = config.transform_request(
+            model="gemini-2.5-flash",
+            agent=None,
+            input="Hello",
+            optional_params={"stream": True},
+            litellm_params=GenericLiteLLMParams(api_key="test-key"),
+            headers={},
+        )
+
+        assert body.get("stream") is True
+        assert body.get("input") == "Hello"
+
+    def test_stream_false_not_included_when_absent(self, config):
+        body = config.transform_request(
+            model="gemini-2.5-flash",
+            agent=None,
+            input="Hello",
+            optional_params={},
+            litellm_params=GenericLiteLLMParams(api_key="test-key"),
+            headers={},
+        )
+
+        assert "stream" not in body
 
 
 class TestInteractionOperationUrls:

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -14,18 +14,46 @@ from litellm.llms.bedrock.common_utils import BedrockModelInfo
 
 
 # --------------------------------------------------------------------------- #
-# BEDROCK_RESPONSE_STREAM_SHAPE eager-load tests                              #
+# get_bedrock_response_stream_shape lazy-load tests                           #
 # --------------------------------------------------------------------------- #
 
 
-def test_bedrock_response_stream_shape_loaded_at_import():
+@pytest.fixture(autouse=True)
+def _reset_bedrock_response_stream_shape_cache():
+    """Prevent lru_cache leakage between tests in this module."""
+    import litellm.llms.bedrock.common_utils as mod
+
+    mod.get_bedrock_response_stream_shape.cache_clear()
+    yield
+    mod.get_bedrock_response_stream_shape.cache_clear()
+
+
+def test_bedrock_response_stream_shape_lazy_loads_once():
     """
-    BEDROCK_RESPONSE_STREAM_SHAPE is resolved at module import time.
+    get_bedrock_response_stream_shape() loads from botocore at most once per process.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import litellm.llms.bedrock.common_utils as mod
+
+    sentinel = MagicMock()
+    with patch.object(
+        mod, "_load_bedrock_response_stream_shape", return_value=sentinel
+    ) as mock_load:
+        assert mod.get_bedrock_response_stream_shape() is sentinel
+        assert mod.get_bedrock_response_stream_shape() is sentinel
+        mock_load.assert_called_once()
+
+
+def test_bedrock_response_stream_shape_loaded_on_first_access():
+    """
+    get_bedrock_response_stream_shape() loads once on first use.
     In a standard environment with botocore installed it must be non-None.
     """
-    from litellm.llms.bedrock.common_utils import BEDROCK_RESPONSE_STREAM_SHAPE
+    pytest.importorskip("botocore")
+    from litellm.llms.bedrock.common_utils import get_bedrock_response_stream_shape
 
-    assert BEDROCK_RESPONSE_STREAM_SHAPE is not None
+    assert get_bedrock_response_stream_shape() is not None
 
 
 def test_bedrock_response_stream_shape_load_failure_returns_none():
@@ -38,6 +66,7 @@ def test_bedrock_response_stream_shape_load_failure_returns_none():
 
     import litellm.llms.bedrock.common_utils as mod
 
+    pytest.importorskip("botocore")
     with patch(
         "botocore.loaders.Loader.load_service_model",
         side_effect=Exception("no data"),
@@ -51,31 +80,29 @@ def test_bedrock_response_stream_shape_is_structure_shape():
     The loaded shape should be the botocore StructureShape for ResponseStream,
     not a plain dict or any other type.
     """
+    pytest.importorskip("botocore")
     from botocore.model import StructureShape
 
-    from litellm.llms.bedrock.common_utils import BEDROCK_RESPONSE_STREAM_SHAPE
+    from litellm.llms.bedrock.common_utils import get_bedrock_response_stream_shape
 
-    assert BEDROCK_RESPONSE_STREAM_SHAPE is not None, (
-        "BEDROCK_RESPONSE_STREAM_SHAPE is None — botocore may not be installed"
-    )
-    shape: StructureShape = BEDROCK_RESPONSE_STREAM_SHAPE  # remove Optional
+    loaded_shape = get_bedrock_response_stream_shape()
+    assert (
+        loaded_shape is not None
+    ), "get_bedrock_response_stream_shape() is None — botocore may not be installed"
+    shape: StructureShape = loaded_shape
     assert isinstance(shape, StructureShape)
     assert shape.name == "ResponseStream"
 
 
-def test_bedrock_response_stream_shape_same_object_across_imports():
+def test_bedrock_response_stream_shape_same_object_across_calls():
     """
-    Both bedrock modules that use the shape must reference the identical object —
-    confirming the constant is not re-loaded per import.
+    Repeated calls must return the identical cached object.
     """
-    from litellm.llms.bedrock.chat.invoke_handler import (
-        BEDROCK_RESPONSE_STREAM_SHAPE as invoke_shape,
-    )
-    from litellm.llms.bedrock.common_utils import (
-        BEDROCK_RESPONSE_STREAM_SHAPE as common_shape,
-    )
+    from litellm.llms.bedrock.common_utils import get_bedrock_response_stream_shape
 
-    assert common_shape is invoke_shape
+    first = get_bedrock_response_stream_shape()
+    second = get_bedrock_response_stream_shape()
+    assert first is second
 
 
 def test_bedrock_event_stream_decoder_base_uses_module_shape():
@@ -95,19 +122,23 @@ def test_bedrock_event_stream_decoder_base_uses_module_shape():
 
 def test_bedrock_parse_message_from_event_raises_on_none_shape():
     """
-    When BEDROCK_RESPONSE_STREAM_SHAPE is None (botocore unavailable),
+    When get_bedrock_response_stream_shape() returns None (botocore unavailable),
     _parse_message_from_event must raise BedrockError before touching the
     botocore parser — not an opaque AttributeError from inside botocore.
     """
     from unittest.mock import MagicMock, patch
 
     import litellm.llms.bedrock.common_utils as mod
-    from litellm.llms.bedrock.common_utils import BedrockError, BedrockEventStreamDecoderBase
+    from litellm.llms.bedrock.common_utils import (
+        BedrockError,
+        BedrockEventStreamDecoderBase,
+    )
 
-    decoder = BedrockEventStreamDecoderBase()
+    decoder = BedrockEventStreamDecoderBase.__new__(BedrockEventStreamDecoderBase)
+    decoder.parser = MagicMock()
     mock_event = MagicMock()
 
-    with patch.object(mod, "BEDROCK_RESPONSE_STREAM_SHAPE", None):
+    with patch.object(mod, "get_bedrock_response_stream_shape", return_value=None):
         with pytest.raises(BedrockError) as exc_info:
             decoder._parse_message_from_event(mock_event)
 

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
@@ -12,18 +12,46 @@ from litellm.llms.sagemaker.completion.transformation import SagemakerConfig
 
 
 # --------------------------------------------------------------------------- #
-# SAGEMAKER_RESPONSE_STREAM_SHAPE eager-load tests                            #
+# get_sagemaker_response_stream_shape lazy-load tests                         #
 # --------------------------------------------------------------------------- #
 
 
-def test_sagemaker_response_stream_shape_loaded_at_import():
+@pytest.fixture(autouse=True)
+def _reset_sagemaker_response_stream_shape_cache():
+    """Prevent lru_cache leakage between tests in this module."""
+    import litellm.llms.sagemaker.common_utils as mod
+
+    mod.get_sagemaker_response_stream_shape.cache_clear()
+    yield
+    mod.get_sagemaker_response_stream_shape.cache_clear()
+
+
+def test_sagemaker_response_stream_shape_lazy_loads_once():
     """
-    SAGEMAKER_RESPONSE_STREAM_SHAPE is resolved at module import time.
+    get_sagemaker_response_stream_shape() loads from botocore at most once per process.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import litellm.llms.sagemaker.common_utils as mod
+
+    sentinel = MagicMock()
+    with patch.object(
+        mod, "_load_sagemaker_response_stream_shape", return_value=sentinel
+    ) as mock_load:
+        assert mod.get_sagemaker_response_stream_shape() is sentinel
+        assert mod.get_sagemaker_response_stream_shape() is sentinel
+        mock_load.assert_called_once()
+
+
+def test_sagemaker_response_stream_shape_loaded_on_first_access():
+    """
+    get_sagemaker_response_stream_shape() loads once on first use.
     In a standard environment with botocore installed it must be non-None.
     """
-    from litellm.llms.sagemaker.common_utils import SAGEMAKER_RESPONSE_STREAM_SHAPE
+    pytest.importorskip("botocore")
+    from litellm.llms.sagemaker.common_utils import get_sagemaker_response_stream_shape
 
-    assert SAGEMAKER_RESPONSE_STREAM_SHAPE is not None
+    assert get_sagemaker_response_stream_shape() is not None
 
 
 def test_sagemaker_response_stream_shape_load_failure_returns_none():
@@ -36,6 +64,7 @@ def test_sagemaker_response_stream_shape_load_failure_returns_none():
 
     import litellm.llms.sagemaker.common_utils as mod
 
+    pytest.importorskip("botocore")
     with patch(
         "botocore.loaders.Loader.load_service_model",
         side_effect=Exception("no data"),
@@ -49,14 +78,16 @@ def test_sagemaker_response_stream_shape_is_structure_shape():
     The loaded shape should be the botocore StructureShape for
     InvokeEndpointWithResponseStreamOutput, not a plain dict or any other type.
     """
+    pytest.importorskip("botocore")
     from botocore.model import StructureShape
 
-    from litellm.llms.sagemaker.common_utils import SAGEMAKER_RESPONSE_STREAM_SHAPE
+    from litellm.llms.sagemaker.common_utils import get_sagemaker_response_stream_shape
 
-    assert SAGEMAKER_RESPONSE_STREAM_SHAPE is not None, (
-        "SAGEMAKER_RESPONSE_STREAM_SHAPE is None — botocore may not be installed"
-    )
-    shape: StructureShape = SAGEMAKER_RESPONSE_STREAM_SHAPE  # remove Optional
+    shape = get_sagemaker_response_stream_shape()
+    assert (
+        shape is not None
+    ), "get_sagemaker_response_stream_shape() is None — botocore may not be installed"
+    shape: StructureShape = shape  # remove Optional
     assert isinstance(shape, StructureShape)
     assert shape.name == "InvokeEndpointWithResponseStreamOutput"
 
@@ -64,29 +95,25 @@ def test_sagemaker_response_stream_shape_is_structure_shape():
 def test_sagemaker_response_stream_shape_not_reloaded_on_new_decoder():
     """
     Creating multiple AWSEventStreamDecoder instances must not trigger
-    additional botocore Loader calls — the shape is resolved once at import
-    time and reused.
+    additional botocore Loader calls — the shape is cached after first access.
     """
-    from litellm.llms.sagemaker.common_utils import SAGEMAKER_RESPONSE_STREAM_SHAPE
+    from litellm.llms.sagemaker.common_utils import get_sagemaker_response_stream_shape
 
-    decoder_a = AWSEventStreamDecoder(model="test-model-a")
-    decoder_b = AWSEventStreamDecoder(model="test-model-b")
+    decoder_a = AWSEventStreamDecoder.__new__(AWSEventStreamDecoder)
+    decoder_b = AWSEventStreamDecoder.__new__(AWSEventStreamDecoder)
 
-    # Both decoders should use the same pre-loaded shape object (identity check)
     assert "_response_stream_shape_cache" not in decoder_a.__dict__
     assert "_response_stream_shape_cache" not in decoder_b.__dict__
-    # The module constant is still the same object
-    from litellm.llms.sagemaker.common_utils import (
-        SAGEMAKER_RESPONSE_STREAM_SHAPE as shape_after,
-    )
 
-    assert SAGEMAKER_RESPONSE_STREAM_SHAPE is shape_after
+    first = get_sagemaker_response_stream_shape()
+    second = get_sagemaker_response_stream_shape()
+    assert first is second
 
 
 def test_sagemaker_parse_message_from_event_raises_on_none_shape():
     """
-    When SAGEMAKER_RESPONSE_STREAM_SHAPE is None (botocore unavailable),
-    _parse_message_from_event must raise ValueError before touching the
+    When get_sagemaker_response_stream_shape() returns None (botocore unavailable),
+    _parse_message_from_event must raise SagemakerError before touching the
     botocore parser — not an opaque AttributeError from inside botocore.
     """
     from unittest.mock import MagicMock, patch
@@ -94,10 +121,14 @@ def test_sagemaker_parse_message_from_event_raises_on_none_shape():
     import litellm.llms.sagemaker.common_utils as mod
     from litellm.llms.sagemaker.common_utils import SagemakerError
 
-    decoder = AWSEventStreamDecoder(model="test-model")
+    decoder = AWSEventStreamDecoder.__new__(AWSEventStreamDecoder)
+    decoder.model = "test-model"
+    decoder.parser = MagicMock()
+    decoder.content_blocks = []
+    decoder.is_messages_api = None
     mock_event = MagicMock()
 
-    with patch.object(mod, "SAGEMAKER_RESPONSE_STREAM_SHAPE", None):
+    with patch.object(mod, "get_sagemaker_response_stream_shape", return_value=None):
         with pytest.raises(SagemakerError) as exc_info:
             decoder._parse_message_from_event(mock_event)
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5066,6 +5066,66 @@ async def test_async_data_generator_uses_direct_stream_fast_path_without_callbac
 
 
 @pytest.mark.asyncio
+async def test_async_data_generator_passes_through_google_native_sse_bytes():
+    """
+    Google-native streamGenerateContent yields raw SSE bytes; they must not be
+    re-wrapped as data: b'data: {...}'.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+    mock_request_data = {
+        "model": "gemini-2.0-flash",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+    gemini_event = b'data: {"candidates": [{"content": "hi"}]}\n\n'
+    gemini_event_without_terminator = b'data: {"candidates": [{"content": "there"}]}'
+    raw_payload = b'{"partial": true}'
+
+    class MockStream:
+        def __aiter__(self):
+            return self._stream()
+
+        async def _stream(self):
+            yield gemini_event
+            yield gemini_event_without_terminator
+            yield raw_payload
+
+        async def aclose(self):
+            pass
+
+    mock_response = MockStream()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging_obj.has_streaming_callbacks.return_value = False
+    mock_proxy_logging_obj.needs_iterator_wrap.return_value = False
+    mock_proxy_logging_obj.needs_per_chunk_streaming_hook.return_value = False
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = MagicMock()
+    mock_proxy_logging_obj.async_post_call_streaming_hook = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj):
+        with patch.object(ProxyLogging, "_fire_deferred_stream_logging"):
+            yielded_data = []
+            async for data in async_data_generator(
+                mock_response, mock_user_api_key_dict, mock_request_data
+            ):
+                yielded_data.append(data)
+
+    yielded_text = [
+        chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        for chunk in yielded_data
+    ]
+    assert yielded_text[0] == gemini_event.decode("utf-8")
+    assert yielded_text[1] == gemini_event_without_terminator.decode("utf-8") + "\n\n"
+    assert yielded_text[2] == f'data: {raw_payload.decode("utf-8")}\n\n'
+    assert "b'data:" not in "".join(yielded_text)
+    assert yielded_text[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
 async def test_async_data_generator_cleanup_on_normal_completion():
     """
     Test that async_data_generator calls response.aclose() even on normal completion.

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -7485,11 +7485,17 @@ export const teamPermissionsUpdateCall = async (accessToken: string, teamId: str
 /**
  * Get all spend logs for a particular session
  */
-export const sessionSpendLogsCall = async (accessToken: string, session_id: string) => {
+export const sessionSpendLogsCall = async (
+  accessToken: string,
+  session_id: string,
+  page: number = 1,
+  page_size: number = 50,
+) => {
   try {
+    const query = `session_id=${encodeURIComponent(session_id)}&page=${page}&page_size=${page_size}`;
     let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/spend/logs/session/ui?session_id=${encodeURIComponent(session_id)}`
-      : `/spend/logs/session/ui?session_id=${encodeURIComponent(session_id)}`;
+      ? `${proxyBaseUrl}/spend/logs/session/ui?${query}`
+      : `/spend/logs/session/ui?${query}`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
@@ -49,6 +49,7 @@ import { fetchAvailableModels, ModelGroup } from "../llm_calls/fetch_models";
 import { makeOpenAIImageEditsRequest } from "../llm_calls/image_edits";
 import { makeOpenAIImageGenerationRequest } from "../llm_calls/image_generation";
 import { makeOpenAIResponsesRequest } from "../llm_calls/responses_api";
+import { makeInteractionsRequest } from "../llm_calls/interactions_api";
 import A2AMetrics from "./A2AMetrics";
 import AdditionalModelSettings from "./AdditionalModelSettings";
 import AudioRenderer from "./AudioRenderer";
@@ -649,6 +650,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
       EndpointType.ANTHROPIC_MESSAGES,
       EndpointType.EMBEDDINGS,
       EndpointType.TRANSCRIPTION,
+      EndpointType.INTERACTIONS,
     ];
 
     if (modelRequiredEndpoints.includes(endpointType as EndpointType) && !selectedModel) {
@@ -914,6 +916,16 @@ const ChatUI: React.FC<ChatUIProps> = ({
               customProxyBaseUrl || undefined,
             );
           }
+        } else if (endpointType === EndpointType.INTERACTIONS) {
+          await makeInteractionsRequest(
+            inputMessage,
+            (text, model) => updateTextUI("assistant", text, model),
+            selectedModel,
+            effectiveApiKey,
+            selectedTags,
+            signal,
+            customProxyBaseUrl || undefined,
+          );
         }
       }
 
@@ -1241,10 +1253,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
                                 return true;
                               }
                               const optionEndpoint = getEndpointType(option.mode);
-                              // Show chat models for responses/anthropic_messages endpoints as they are compatible
+                              // Show chat models for responses/anthropic_messages/interactions endpoints as they are compatible
                               if (
                                 endpointType === EndpointType.RESPONSES ||
-                                endpointType === EndpointType.ANTHROPIC_MESSAGES
+                                endpointType === EndpointType.ANTHROPIC_MESSAGES ||
+                                endpointType === EndpointType.INTERACTIONS
                               ) {
                                 return optionEndpoint === endpointType || optionEndpoint === EndpointType.CHAT;
                               }
@@ -2089,7 +2102,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         endpointType === EndpointType.CHAT ||
                         endpointType === EndpointType.EMBEDDINGS ||
                         endpointType === EndpointType.RESPONSES ||
-                        endpointType === EndpointType.ANTHROPIC_MESSAGES
+                        endpointType === EndpointType.ANTHROPIC_MESSAGES ||
+                        endpointType === EndpointType.INTERACTIONS
                           ? "Type your message... (Shift+Enter for new line)"
                           : endpointType === EndpointType.A2A_AGENTS
                             ? "Send a message to the A2A agent..."

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/chatConstants.ts
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/chatConstants.ts
@@ -45,4 +45,5 @@ export const ENDPOINT_OPTIONS = [
   { value: EndpointType.A2A_AGENTS, label: "/v1/a2a/message/send" },
   { value: EndpointType.MCP, label: "/mcp-rest/tools/call" },
   { value: EndpointType.REALTIME, label: "/v1/realtime" },
+  { value: EndpointType.INTERACTIONS, label: "/v1beta/interactions" },
 ];

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/mode_endpoint_mapping.tsx
@@ -28,6 +28,7 @@ export enum EndpointType {
   A2A_AGENTS = "a2a_agents",
   MCP = "mcp",
   REALTIME = "realtime",
+  INTERACTIONS = "interactions",
 }
 
 // Create a mapping between the model mode and the corresponding endpoint type

--- a/ui/litellm-dashboard/src/components/playground/llm_calls/interactions_api.tsx
+++ b/ui/litellm-dashboard/src/components/playground/llm_calls/interactions_api.tsx
@@ -1,0 +1,124 @@
+import NotificationManager from "@/components/molecules/notifications_manager";
+import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
+
+export async function makeInteractionsRequest(
+  input: string,
+  updateUI: (text: string, model?: string) => void,
+  selectedModel: string,
+  accessToken: string,
+  tags?: string[],
+  signal?: AbortSignal,
+  customBaseUrl?: string,
+  previousInteractionId?: string,
+): Promise<void> {
+  if (!accessToken) {
+    throw new Error("Virtual Key is required");
+  }
+
+  const isLocal = process.env.NODE_ENV === "development";
+  if (isLocal !== true) {
+    console.log = function () {};
+  }
+
+  const proxyBaseUrl = customBaseUrl || getProxyBaseUrl();
+  const normalizedBaseUrl = proxyBaseUrl.endsWith("/") ? proxyBaseUrl.slice(0, -1) : proxyBaseUrl;
+  const requestUrl = `${normalizedBaseUrl}/v1beta/interactions`;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+  };
+  if (tags && tags.length > 0) {
+    headers["x-litellm-tags"] = tags.join(",");
+  }
+
+  const body: Record<string, unknown> = {
+    model: selectedModel,
+    input,
+    stream: true,
+  };
+  if (previousInteractionId) {
+    body.previous_interaction_id = previousInteractionId;
+  }
+
+  try {
+    const response = await fetch(requestUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || `Request failed with status ${response.status}`);
+    }
+
+    if (!response.body) {
+      throw new Error("No response body received");
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let responseModel: string | undefined;
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE lines are separated by double newlines; split on single newlines and
+      // look for "data: " prefixed lines.
+      const lines = buffer.split("\n");
+      // Keep the last (potentially incomplete) line in the buffer
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data:")) continue;
+
+        const jsonStr = trimmed.slice("data:".length).trim();
+        if (!jsonStr || jsonStr === "[DONE]") continue;
+
+        let event: Record<string, unknown>;
+        try {
+          event = JSON.parse(jsonStr);
+        } catch {
+          continue;
+        }
+
+        const eventType = event.event_type as string | undefined;
+
+        if (eventType === "interaction.start" || eventType === "interaction.complete") {
+          // Capture model from either the native Gemini shape (nested under
+          // `interaction`) or the bridge shape (top-level `model` field).
+          const interaction = event.interaction as Record<string, unknown> | undefined;
+          if (typeof interaction?.model === "string" && interaction.model) {
+            responseModel = interaction.model;
+          } else if (typeof event.model === "string" && event.model) {
+            responseModel = event.model;
+          }
+        } else if (eventType === "content.delta" || eventType === "content.start") {
+          const delta = event.delta as Record<string, unknown> | undefined;
+          // Accept both native Gemini format {"type":"text","text":"..."} and bridge
+          // format {"text":"..."} (no type discriminator)
+          if (typeof delta?.text === "string" && delta.text) {
+            updateUI(delta.text, responseModel ?? selectedModel);
+          }
+        }
+        // content.start, content.stop, interaction.status_update — no UI action needed
+      }
+    }
+  } catch (error: unknown) {
+    if (signal?.aborted) {
+      console.log("Interactions request was cancelled");
+      throw error;
+    }
+    NotificationManager.fromBackend(
+      `Error occurred while making Interactions API request. Error: ${error}`,
+    );
+    throw error;
+  }
+}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
@@ -1,5 +1,11 @@
 import { Button, Space, Tag, Tooltip, Typography } from "antd";
-import { CloseOutlined, UpOutlined, DownOutlined } from "@ant-design/icons";
+import {
+  CloseOutlined,
+  UpOutlined,
+  DownOutlined,
+  DoubleLeftOutlined,
+  DoubleRightOutlined,
+} from "@ant-design/icons";
 import moment from "moment";
 import { LogEntry } from "../columns";
 import { getProviderLogoAndName } from "../../provider_info_helpers";
@@ -22,6 +28,11 @@ interface DrawerHeaderProps {
   onClose: () => void;
   onPrevious: () => void;
   onNext: () => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
+  canGoPreviousPage?: boolean;
+  canGoNextPage?: boolean;
+  showPageControls?: boolean;
   statusLabel: string;
   statusColor: "error" | "success";
   environment: string;
@@ -36,6 +47,11 @@ export function DrawerHeader({
   onClose,
   onPrevious,
   onNext,
+  onPreviousPage,
+  onNextPage,
+  canGoPreviousPage = false,
+  canGoNextPage = false,
+  showPageControls = false,
   statusLabel,
   statusColor,
   environment,
@@ -60,7 +76,16 @@ export function DrawerHeader({
       {/* Row 1: Request ID + Actions */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: SPACING_MEDIUM }}>
         <RequestIdSection requestId={log.request_id} />
-        <NavigationSection onPrevious={onPrevious} onNext={onNext} onClose={onClose} />
+        <NavigationSection
+          onPrevious={onPrevious}
+          onNext={onNext}
+          onClose={onClose}
+          onPreviousPage={onPreviousPage}
+          onNextPage={onNextPage}
+          canGoPreviousPage={canGoPreviousPage}
+          canGoNextPage={canGoNextPage}
+          showPageControls={showPageControls}
+        />
       </div>
 
       {/* Row 2: Status + Env + Timestamp */}
@@ -142,10 +167,20 @@ function NavigationSection({
   onPrevious,
   onNext,
   onClose,
+  onPreviousPage,
+  onNextPage,
+  canGoPreviousPage = false,
+  canGoNextPage = false,
+  showPageControls = false,
 }: {
   onPrevious: () => void;
   onNext: () => void;
   onClose: () => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
+  canGoPreviousPage?: boolean;
+  canGoNextPage?: boolean;
+  showPageControls?: boolean;
 }) {
   const keyboardShortcutStyle = {
     border: "1px solid #d9d9d9",
@@ -167,6 +202,32 @@ function NavigationSection({
         <DownOutlined />
         <span style={keyboardShortcutStyle}>J</span>
       </Button>
+      {showPageControls && (
+        <>
+          <Tooltip title="Previous page (Shift+K)">
+            <Button
+              type="text"
+              size="small"
+              onClick={onPreviousPage}
+              disabled={!canGoPreviousPage}
+            >
+              <DoubleLeftOutlined />
+              <span style={keyboardShortcutStyle}>⇧K</span>
+            </Button>
+          </Tooltip>
+          <Tooltip title="Next page (Shift+J)">
+            <Button
+              type="text"
+              size="small"
+              onClick={onNextPage}
+              disabled={!canGoNextPage}
+            >
+              <DoubleRightOutlined />
+              <span style={keyboardShortcutStyle}>⇧J</span>
+            </Button>
+          </Tooltip>
+        </>
+      )}
       <Tooltip title="ESC to close">
         <Button type="text" icon={<CloseOutlined />} onClick={onClose} />
       </Tooltip>

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -116,14 +116,16 @@ export function LogDetailsDrawer({
   const [selectedSessionRequestId, setSelectedSessionRequestId] = useState<string | null>(null);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [copiedLeftPanelId, setCopiedLeftPanelId] = useState(false);
+  const [sessionPage, setSessionPage] = useState(1);
+  const SESSION_PAGE_SIZE = 50;
 
-  const { data: sessionLogs = [] } = useQuery({
-    queryKey: ["sessionLogs", sessionId],
+  const { data: sessionQueryResult } = useQuery({
+    queryKey: ["sessionLogs", sessionId, sessionPage],
     queryFn: async () => {
-      if (!sessionId || !accessToken) return [];
-      const response = await sessionSpendLogsCall(accessToken, sessionId);
+      if (!sessionId || !accessToken) return { logs: [] as LogEntry[], totalPages: 1 };
+      const response = await sessionSpendLogsCall(accessToken, sessionId, sessionPage, SESSION_PAGE_SIZE);
       const allSessionLogs: LogEntry[] = response.data || response || [];
-      return allSessionLogs
+      const logs = allSessionLogs
         .map((row) => ({
           ...row,
           request_duration_ms: row.request_duration_ms ?? (Date.parse(row.endTime) - Date.parse(row.startTime)),
@@ -134,9 +136,27 @@ export function LogDetailsDrawer({
           if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
           return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
         });
+      return { logs, totalPages: response.total_pages ?? 1 };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
   });
+
+  const sessionLogs = sessionQueryResult?.logs ?? [];
+  const sessionTotalPages = sessionQueryResult?.totalPages ?? 1;
+  const canGoPreviousPage = isSessionMode && sessionPage > 1;
+  const canGoNextPage = isSessionMode && sessionPage < sessionTotalPages;
+
+  const goToPreviousPage = () => {
+    if (!canGoPreviousPage) return;
+    setSelectedSessionRequestId(null);
+    setSessionPage((p) => p - 1);
+  };
+
+  const goToNextPage = () => {
+    if (!canGoNextPage) return;
+    setSelectedSessionRequestId(null);
+    setSessionPage((p) => p + 1);
+  };
 
   const currentLog = useMemo(() => {
     if (!isSessionMode) return logEntry;
@@ -166,7 +186,10 @@ export function LogDetailsDrawer({
     if (open) {
       setIsSidebarCollapsed(false);
     } else {
-      if (isSessionMode) setSelectedSessionRequestId(null);
+      if (isSessionMode) {
+        setSelectedSessionRequestId(null);
+        setSessionPage(1);
+      }
       setCopiedLeftPanelId(false);
     }
   }, [open, isSessionMode]);
@@ -183,6 +206,8 @@ export function LogDetailsDrawer({
       }
       onSelectLog?.(selected);
     },
+    onPreviousPage: canGoPreviousPage ? goToPreviousPage : undefined,
+    onNextPage: canGoNextPage ? goToNextPage : undefined,
   });
 
   // Lazy-load log details (messages/response) only when drawer is open.
@@ -390,6 +415,11 @@ export function LogDetailsDrawer({
               onClose={onClose}
               onPrevious={selectPreviousLog}
               onNext={selectNextLog}
+              onPreviousPage={isSessionMode ? goToPreviousPage : undefined}
+              onNextPage={isSessionMode ? goToNextPage : undefined}
+              canGoPreviousPage={canGoPreviousPage}
+              canGoNextPage={canGoNextPage}
+              showPageControls={isSessionMode}
               statusLabel={statusLabel}
               statusColor={statusColor}
               environment={environment}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -122,7 +122,9 @@ export function LogDetailsDrawer({
   const { data: sessionQueryResult } = useQuery({
     queryKey: ["sessionLogs", sessionId, sessionPage],
     queryFn: async () => {
-      if (!sessionId || !accessToken) return { logs: [] as LogEntry[], totalPages: 1 };
+      if (!sessionId || !accessToken) {
+        return { logs: [] as LogEntry[], totalPages: 1, total: 0 };
+      }
       const response = await sessionSpendLogsCall(accessToken, sessionId, sessionPage, SESSION_PAGE_SIZE);
       const allSessionLogs: LogEntry[] = response.data || response || [];
       const logs = allSessionLogs
@@ -136,13 +138,19 @@ export function LogDetailsDrawer({
           if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
           return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
         });
-      return { logs, totalPages: response.total_pages ?? 1 };
+      return {
+        logs,
+        totalPages: response.total_pages ?? 1,
+        total: response.total ?? logs.length,
+      };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
   });
 
   const sessionLogs = sessionQueryResult?.logs ?? [];
   const sessionTotalPages = sessionQueryResult?.totalPages ?? 1;
+  const sessionTotal = sessionQueryResult?.total ?? sessionLogs.length;
+  const isSessionPaginated = isSessionMode && sessionTotalPages > 1;
   const canGoPreviousPage = isSessionMode && sessionPage > 1;
   const canGoNextPage = isSessionMode && sessionPage < sessionTotalPages;
 
@@ -193,6 +201,15 @@ export function LogDetailsDrawer({
       setCopiedLeftPanelId(false);
     }
   }, [open, isSessionMode]);
+
+  // If the parent swaps to a different session while the drawer stays open,
+  // reset page/selection so we don't request page N of a shorter session and
+  // render an empty sidebar.
+  useEffect(() => {
+    if (!isSessionMode) return;
+    setSessionPage(1);
+    setSelectedSessionRequestId(null);
+  }, [sessionId, isSessionMode]);
 
   // Keyboard navigation
   const { selectNextLog, selectPreviousLog } = useKeyboardNavigation({
@@ -330,7 +347,7 @@ export function LogDetailsDrawer({
                 </div>
               </div>
               <div className="mt-1 text-[11px] text-slate-500 font-mono">
-                {logsForList.length} req
+                {isSessionMode ? sessionTotal : logsForList.length} req
                 {[
                   isSessionMode
                     ? llmCount
@@ -358,6 +375,12 @@ export function LogDetailsDrawer({
                   <>
                     <span className="mx-1.5">·</span>
                     {sessionDurationSeconds}s
+                  </>
+                )}
+                {isSessionPaginated && (
+                  <>
+                    <span className="mx-1.5">·</span>
+                    <span>page {sessionPage}/{sessionTotalPages} (cost/duration/counts shown for this page)</span>
                   </>
                 )}
               </div>

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Drawer } from "antd";
 import {
   CheckOutlined,
@@ -154,17 +154,20 @@ export function LogDetailsDrawer({
   const canGoPreviousPage = isSessionMode && sessionPage > 1;
   const canGoNextPage = isSessionMode && sessionPage < sessionTotalPages;
 
-  const goToPreviousPage = () => {
+  // useCallback so the function identity only changes when the boundary
+  // flag flips, preventing the keydown listener in useKeyboardNavigation
+  // from churning on every parent re-render.
+  const goToPreviousPage = useCallback(() => {
     if (!canGoPreviousPage) return;
     setSelectedSessionRequestId(null);
     setSessionPage((p) => p - 1);
-  };
+  }, [canGoPreviousPage]);
 
-  const goToNextPage = () => {
+  const goToNextPage = useCallback(() => {
     if (!canGoNextPage) return;
     setSelectedSessionRequestId(null);
     setSessionPage((p) => p + 1);
-  };
+  }, [canGoNextPage]);
 
   const currentLog = useMemo(() => {
     if (!isSessionMode) return logEntry;
@@ -223,8 +226,11 @@ export function LogDetailsDrawer({
       }
       onSelectLog?.(selected);
     },
-    onPreviousPage: canGoPreviousPage ? goToPreviousPage : undefined,
-    onNextPage: canGoNextPage ? goToNextPage : undefined,
+    // goToPreviousPage / goToNextPage are useCallback'd and self-guard
+    // against out-of-bounds, so pass them directly to keep the reference
+    // stable across renders.
+    onPreviousPage: goToPreviousPage,
+    onNextPage: goToNextPage,
   });
 
   // Lazy-load log details (messages/response) only when drawer is open.

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts
@@ -167,4 +167,51 @@ describe("useKeyboardNavigation", () => {
     expect(onSelectLog).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it("does not re-register the keydown listener when callback identities are stable", () => {
+    // Regression guard: the effect deps include the page handlers, so unstable
+    // (inline) functions from the parent caused remove/addEventListener to fire
+    // on every render. With the parent passing stable refs (useCallback'd),
+    // a re-render with identical props must not churn the listener.
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onClose = vi.fn();
+    const onPreviousPage = vi.fn();
+    const onNextPage = vi.fn();
+
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    const { rerender } = renderHook(
+      (props) => useKeyboardNavigation(props),
+      {
+        initialProps: {
+          isOpen: true,
+          currentLog: logs[0],
+          allLogs: logs,
+          onClose,
+          onSelectLog,
+          onPreviousPage,
+          onNextPage,
+        },
+      },
+    );
+
+    const callsAfterMount = addSpy.mock.calls.filter(([type]) => type === "keydown").length;
+
+    // Re-render with the exact same prop references — should not re-attach.
+    rerender({
+      isOpen: true,
+      currentLog: logs[0],
+      allLogs: logs,
+      onClose,
+      onSelectLog,
+      onPreviousPage,
+      onNextPage,
+    });
+
+    const callsAfterRerender = addSpy.mock.calls.filter(([type]) => type === "keydown").length;
+    expect(callsAfterRerender).toBe(callsAfterMount);
+
+    addSpy.mockRestore();
+  });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts
@@ -1,0 +1,170 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useKeyboardNavigation } from "./useKeyboardNavigation";
+import { LogEntry } from "../columns";
+
+// Three rows is enough to exercise prev/next at head, middle, and tail.
+const makeLogs = (): LogEntry[] =>
+  [
+    { request_id: "req-a", call_type: "completion", model: "gpt-4o", startTime: "", endTime: "" },
+    { request_id: "req-b", call_type: "completion", model: "gpt-4o", startTime: "", endTime: "" },
+    { request_id: "req-c", call_type: "completion", model: "gpt-4o", startTime: "", endTime: "" },
+  ] as unknown as LogEntry[];
+
+const dispatchKey = (key: string, opts: { shift?: boolean } = {}) => {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, shiftKey: opts.shift ?? false }));
+};
+
+describe("useKeyboardNavigation", () => {
+  it("J selects the next log within the current page", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+      }),
+    );
+
+    dispatchKey("j");
+    expect(onSelectLog).toHaveBeenCalledWith(logs[1]);
+  });
+
+  it("K selects the previous log within the current page", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[2],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+      }),
+    );
+
+    dispatchKey("k");
+    expect(onSelectLog).toHaveBeenCalledWith(logs[1]);
+  });
+
+  it("J at the end of the page is a no-op (does not page forward)", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onNextPage = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[2],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+        onNextPage,
+      }),
+    );
+
+    dispatchKey("j");
+    expect(onSelectLog).not.toHaveBeenCalled();
+    expect(onNextPage).not.toHaveBeenCalled();
+  });
+
+  it("Shift+J calls onNextPage and does NOT walk to the next row", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onNextPage = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+        onNextPage,
+      }),
+    );
+
+    // With shift held, the browser delivers e.key === "J" (uppercase). The
+    // hook must route to onNextPage and skip selectNextLog so the two paths
+    // stay mutually exclusive.
+    dispatchKey("J", { shift: true });
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+    expect(onSelectLog).not.toHaveBeenCalled();
+  });
+
+  it("Shift+K calls onPreviousPage and does NOT walk to the previous row", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onPreviousPage = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[2],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+        onPreviousPage,
+      }),
+    );
+
+    dispatchKey("K", { shift: true });
+    expect(onPreviousPage).toHaveBeenCalledTimes(1);
+    expect(onSelectLog).not.toHaveBeenCalled();
+  });
+
+  it("Shift+J without an onNextPage handler is a safe no-op", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+      }),
+    );
+
+    expect(() => dispatchKey("J", { shift: true })).not.toThrow();
+    // Critically, plain row-walk must not fire either — Shift+J is reserved
+    // for paging even when no handler is wired.
+    expect(onSelectLog).not.toHaveBeenCalled();
+  });
+
+  it("Escape calls onClose", () => {
+    const onClose = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: makeLogs()[0],
+        allLogs: makeLogs(),
+        onClose,
+        onSelectLog: vi.fn(),
+      }),
+    );
+
+    dispatchKey("Escape");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keys when isOpen is false", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onClose = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: false,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose,
+        onSelectLog,
+      }),
+    );
+
+    dispatchKey("j");
+    dispatchKey("Escape");
+    expect(onSelectLog).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
@@ -8,15 +8,16 @@ interface UseKeyboardNavigationProps {
   allLogs: LogEntry[];
   onClose: () => void;
   onSelectLog?: (log: LogEntry) => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
 }
 
 /**
  * Custom hook for keyboard navigation in the log details drawer.
- * Handles J/K for next/previous and Escape for close.
  *
  * Keyboard shortcuts:
- * - J: Navigate to next log (down)
- * - K: Navigate to previous log (up)
+ * - J / K: Navigate to next / previous log within the current page
+ * - Shift+J / Shift+K: Page next / previous (session mode)
  * - Escape: Close drawer
  */
 export function useKeyboardNavigation({
@@ -25,6 +26,8 @@ export function useKeyboardNavigation({
   allLogs,
   onClose,
   onSelectLog,
+  onPreviousPage,
+  onNextPage,
 }: UseKeyboardNavigationProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -35,24 +38,29 @@ export function useKeyboardNavigation({
 
       if (!isOpen) return;
 
-      switch (e.key) {
-        case KEY_ESCAPE:
-          onClose();
-          break;
-        case KEY_J_LOWER:
-        case KEY_J_UPPER:
-          selectNextLog();
-          break;
-        case KEY_K_LOWER:
-        case KEY_K_UPPER:
-          selectPreviousLog();
-          break;
+      if (e.key === KEY_ESCAPE) {
+        onClose();
+        return;
+      }
+
+      // With Shift held, e.key is already uppercase ("J"/"K"). Compare against
+      // both cases so the page shortcuts work regardless of caps lock.
+      const isJ = e.key === KEY_J_LOWER || e.key === KEY_J_UPPER;
+      const isK = e.key === KEY_K_LOWER || e.key === KEY_K_UPPER;
+      if (!isJ && !isK) return;
+
+      if (e.shiftKey) {
+        if (isJ) onNextPage?.();
+        else onPreviousPage?.();
+      } else {
+        if (isJ) selectNextLog();
+        else selectPreviousLog();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, currentLog, allLogs]);
+  }, [isOpen, currentLog, allLogs, onPreviousPage, onNextPage]);
 
   const selectNextLog = () => {
     if (!currentLog || !allLogs.length || !onSelectLog) return;


### PR DESCRIPTION
## Relevant issues

Fixes #28224

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — see note below; tests live next to the changed files in `ui/litellm-dashboard/...` per existing convention.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] My PR passes all unit tests on `make test-unit` — UI-only PR; ran `npx vitest run src/components/view_logs/LogDetailsDrawer/` → **109 specs pass** (Python `make test-unit` is not applicable to a frontend-only change).
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 — **Greptile gave 5/5** (see review comment dated 2026-05-19T07:10Z); both initially flagged P1/P2 issues addressed in follow-up commits.

> **Note on test placement:** `tests/test_litellm/` is for the Python SDK / proxy. The LiteLLM dashboard already follows the convention of co-locating `*.test.tsx` next to source files (e.g. `view_logs/time_cell.test.tsx`, `view_logs/columns` neighbors, the existing tests inside `LogDetailsDrawer/`). I added a vitest spec under the same path to match.

## Type

🐛 Bug Fix

## Changes

When the Log Details drawer opens in session mode, the left "Session" sidebar fetches `/spend/logs/session/ui` to enumerate every spend log for that session. The frontend ignored the endpoint's pagination params, so on sessions with more than 50 entries the sidebar silently truncated to the earliest 50 (ordered by `startTime ASC`) — see #28224 for the reproduction.

This PR threads the existing backend pagination (`page`, `page_size`, `total_pages`) through the UI:

- **`ui/litellm-dashboard/src/components/networking.tsx`** — `sessionSpendLogsCall` now takes `page` / `page_size` and forwards them in the query string. Defaults preserve the previous behavior.
- **`view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx`** — adds `sessionPage` state, includes it in the React Query key so the page is keyed independently, and reads `total_pages` from the response. `goToPreviousPage` / `goToNextPage` clear the selected request id so the existing effect picks the first row of the new page. Page state resets to 1 on drawer close.
- **`view_logs/LogDetailsDrawer/DrawerHeader.tsx`** — `NavigationSection` grows two new buttons (`DoubleLeftOutlined` / `DoubleRightOutlined`) that mirror the K/J style, only render in session mode, and disable at page boundaries.
- **`view_logs/LogDetailsDrawer/useKeyboardNavigation.ts`** — routes `Shift+J` / `Shift+K` to `onNextPage` / `onPreviousPage`. Plain `J`/`K` still walks rows within the current page; the hook now checks `e.shiftKey` so the two paths stay mutually exclusive (with shift held, `e.key` is already `"J"`/`"K"`, which would otherwise conflate them).

### Tests

`view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts` (new) covers:

- `J` / `K` walk the current page within bounds and no-op at head/tail
- `Shift+J` / `Shift+K` invoke the page handlers and never fall through to row-walk
- `Shift+J` without an `onNextPage` handler is a safe no-op (doesn't silently walk forward)
- `Escape` and `isOpen=false` honor existing semantics

```
$ npx vitest run src/components/view_logs/LogDetailsDrawer/
PASS (109) FAIL (0)
```

### Manual verification

- Session with 137 spend logs (3 pages):
  - Drawer opens on page 1 with the earliest 50 events; both `⇧K` button and Shift+K disabled.
  - `⇧J` / Shift+J → page 2, sidebar refreshes, `currentLog` jumps to the new page's first row, both prev and next page controls are enabled.
  - `⇧J` again → page 3, `⇧J` button disabled.
  - `J` / `K` continue to walk only within the visible page (50 rows).
- Non-session mode (clicking a row without `session_id`): the page-control buttons are not rendered, and `Shift+J` / `Shift+K` are no-ops; existing behavior unchanged.

### What this does NOT do

- Does not change the backend default `page_size=50` or upper bound `100`. If a maintainer would prefer auto-fetching all pages over surfacing pagination controls, happy to re-spin.
- Does not add cumulative / infinite-scroll behavior — each page independently replaces the sidebar. Mirrors how the outer logs table already paginates.

## Screenshots / Proof of Fix

(UI-only change; will attach screenshots in a follow-up comment after the PR opens.)