### PR TITLE
fix: use router deployment id for anthropic messages cost

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -527,12 +527,18 @@ class Logging(LiteLLMLoggingBaseClass):
     def get_router_model_id(self) -> Optional[str]:
         """Extract the router deployment model_id from litellm_params.
 
-        Checks both litellm_metadata and metadata for model_info.id.
+        Checks direct model_info, litellm_metadata and metadata for model_info.id.
         Used by cost calculators to look up custom pricing registered
         under the deployment's model_info.id in litellm.model_cost.
         """
         if not hasattr(self, "litellm_params"):
             return None
+
+        info = self.litellm_params.get("model_info", {}) or {}
+        model_id = info.get("id")
+        if model_id is not None:
+            return model_id
+
         for key in ("litellm_metadata", "metadata"):
             meta = self.litellm_params.get(key, {}) or {}
             info = meta.get("model_info", {}) or {}
@@ -1767,16 +1773,22 @@ class Logging(LiteLLMLoggingBaseClass):
 
         if self.model_call_details.get("cache_hit") is True:
             self.model_call_details["response_cost"] = 0.0
-        elif "response_cost" in hidden_params:
+        elif (
+            "response_cost" in hidden_params
+            and hidden_params["response_cost"] is not None
+        ):
             self.model_call_details["response_cost"] = hidden_params["response_cost"]
         elif self.model_call_details.get("response_cost") is not None:
             # Preserve response_cost if already calculated (e.g., by pass-through
             # handlers like Gemini/Vertex which call completion_cost directly)
             pass
         else:
-            self.model_call_details["response_cost"] = self._response_cost_calculator(
+            calculated_response_cost = self._response_cost_calculator(
                 result=logging_result
             )
+            self.model_call_details["response_cost"] = calculated_response_cost
+            if isinstance(hidden_params, dict):
+                hidden_params["response_cost"] = calculated_response_cost
 
         self.model_call_details["standard_logging_object"] = (
             self._build_standard_logging_payload(logging_result, start_time, end_time)
@@ -4613,6 +4625,13 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
     for key in matching_keys:
         if litellm_params.get(key) is not None:
             return True
+
+    model_info: dict = litellm_params.get("model_info", {}) or {}
+    if model_info:
+        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+        for key in matching_keys:
+            if model_info.get(key) is not None:
+                return True
 
     # Check model_info from metadata or litellm_metadata (generic_api_call routes
     # like /responses and /messages store model_info under litellm_metadata)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -570,6 +570,13 @@ class ProxyBaseLLMRequestProcessing:
             litellm_logging_obj=litellm_logging_obj
         )
 
+        if (
+            response_cost in exclude_values
+            and litellm_logging_obj is not None
+            and getattr(litellm_logging_obj, "model_call_details", None) is not None
+        ):
+            response_cost = litellm_logging_obj.model_call_details.get("response_cost")
+
         # Calculate updated spend for header (include current response_cost)
         current_spend = user_api_key_dict.spend or 0.0
         updated_spend = current_spend

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -140,10 +140,12 @@ class AnthropicPassthroughLoggingHandler:
                 custom_llm_provider=custom_llm_provider,
                 custom_pricing=custom_pricing,
                 router_model_id=router_model_id,
+                litellm_logging_obj=logging_obj,
             )
 
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
+            logging_obj.model_call_details["response_cost"] = response_cost
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")
             )

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -272,6 +272,16 @@ def test_response_cost_calculator_uses_router_model_id_from_litellm_metadata():
 class TestGetRouterModelId:
     """Tests for the get_router_model_id helper method."""
 
+    def test_returns_id_from_direct_model_info(self, logging_obj):
+        """Should prefer model_info.id stamped directly on litellm_params."""
+        logging_obj.litellm_params = {
+            "model_info": {"id": "direct-deploy-id"},
+            "litellm_metadata": {
+                "model_info": {"id": "from-litellm-meta"},
+            },
+        }
+        assert logging_obj.get_router_model_id() == "direct-deploy-id"
+
     def test_returns_id_from_litellm_metadata(self, logging_obj):
         """Should extract model_info.id from litellm_metadata."""
         logging_obj.litellm_params = {
@@ -385,6 +395,86 @@ class TestAnthropicPassthroughCustomPricing:
             call_kwargs = mock_cost.call_args
             assert call_kwargs.kwargs.get("custom_pricing") is True
             assert call_kwargs.kwargs.get("router_model_id") == "claude-custom-pricing"
+            assert call_kwargs.kwargs.get("litellm_logging_obj") is logging_obj
+            assert logging_obj.model_call_details["response_cost"] == 42.0
+
+    def test_response_cost_uses_actual_deployment_id_for_shared_model_group(self):
+        """Anthropic /v1/messages cost should use the selected deployment pricing.
+
+        Two deployments can share one public model name. The router-selected
+        deployment id is the only stable key for deployment-specific pricing.
+        """
+        import litellm
+
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LiteLLMLoggingObj,
+        )
+        from litellm.types.utils import Usage
+
+        provider_a_deployment_id = "provider-a-shared-public-model-test"
+        provider_b_deployment_id = "provider-b-shared-public-model-test"
+
+        litellm.register_model(
+            model_cost={
+                provider_a_deployment_id: {
+                    "litellm_provider": "anthropic",
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000002,
+                },
+                provider_b_deployment_id: {
+                    "litellm_provider": "anthropic",
+                    "input_cost_per_token": 0.000003,
+                    "output_cost_per_token": 0.000004,
+                },
+            }
+        )
+
+        try:
+            logging_obj = LiteLLMLoggingObj(
+                model="claude-shared-public-model",
+                messages=[{"role": "user", "content": "Hi"}],
+                stream=False,
+                call_type="anthropic_messages",
+                start_time=time.time(),
+                litellm_call_id="test-shared-public-model",
+                function_id="test-fn",
+            )
+            logging_obj.update_environment_variables(
+                model="claude-shared-public-model",
+                user="",
+                optional_params={},
+                litellm_params={
+                    "model_info": {
+                        "id": provider_b_deployment_id,
+                        "input_cost_per_token": 0.000003,
+                        "output_cost_per_token": 0.000004,
+                    },
+                    "litellm_metadata": {
+                        "model_info": {
+                            "id": provider_a_deployment_id,
+                            "input_cost_per_token": 0.000001,
+                            "output_cost_per_token": 0.000002,
+                        },
+                    },
+                },
+            )
+            logging_obj.model_call_details["custom_llm_provider"] = "anthropic"
+
+            response_obj = ModelResponse(
+                model="claude-shared-public-model",
+                usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            )
+
+            cost = logging_obj._response_cost_calculator(result=response_obj)
+
+            provider_a_cost = (10 * 0.000001) + (5 * 0.000002)
+            provider_b_cost = (10 * 0.000003) + (5 * 0.000004)
+            assert provider_a_cost != provider_b_cost
+            assert logging_obj.get_router_model_id() == provider_b_deployment_id
+            assert cost == pytest.approx(provider_b_cost)
+        finally:
+            litellm.model_cost.pop(provider_a_deployment_id, None)
+            litellm.model_cost.pop(provider_b_deployment_id, None)
 
 
 class TestUpdateFromKwargs:
@@ -489,6 +579,22 @@ class TestUpdateFromKwargs:
         kwargs = {"litellm_metadata": lm_meta}
 
         logging_obj.update_from_kwargs(kwargs=kwargs)
+
+        assert use_custom_pricing_for_model(logging_obj.litellm_params) is True
+
+    def test_custom_pricing_detected_via_direct_model_info(self, logging_obj):
+        """Custom pricing in litellm_params.model_info should set custom_pricing flag."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            use_custom_pricing_for_model,
+        )
+
+        logging_obj.litellm_params = {
+            "model_info": {
+                "id": "deploy-custom-direct",
+                "input_cost_per_token": 0.005,
+                "output_cost_per_token": 0.015,
+            }
+        }
 
         assert use_custom_pricing_for_model(logging_obj.litellm_params) is True
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -875,6 +875,42 @@ class TestProxyBaseLLMRequestProcessing:
             float(headers_7["x-litellm-key-spend"]) == 0.001
         )  # Should use original spend on error
 
+    def test_get_custom_headers_uses_logging_obj_response_cost_fallback(self):
+        """
+        Passthrough routes can calculate response_cost in the logging object
+        before response hidden params are populated.
+        """
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LiteLLMLoggingObj,
+        )
+
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.spend = 0.001
+
+        logging_obj = LiteLLMLoggingObj(
+            model="claude-shared-public-model",
+            messages=[{"role": "user", "content": "test"}],
+            stream=False,
+            call_type="anthropic_messages",
+            start_time=None,
+            litellm_call_id="test-call-id-fallback",
+            function_id="test-function-id",
+        )
+        logging_obj.model_call_details["response_cost"] = 0.0007
+
+        headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
+            user_api_key_dict=mock_user_api_key_dict,
+            call_id="test-call-id-fallback",
+            response_cost="",
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert float(headers["x-litellm-response-cost"]) == pytest.approx(0.0007)
+        assert float(headers["x-litellm-key-spend"]) == pytest.approx(0.0017)
+
     @pytest.mark.asyncio
     async def test_queue_time_seconds_is_set_in_metadata(self, monkeypatch):
         """


### PR DESCRIPTION
## Relevant issues

Fixes #28228

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - Not run locally; scoped tests below were run instead.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Scoped local verification:

```shell
python3 -m py_compile litellm/litellm_core_utils/litellm_logging.py litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py litellm/proxy/common_request_processing.py tests/test_litellm/litellm_core_utils/test_litellm_logging.py tests/test_litellm/proxy/test_common_request_processing.py
# passed

git diff --check
# passed

uv run pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py -k 'router_model_id or custom_pricing or AnthropicPassthroughCustomPricing or direct_model_info' -q
# 9 passed, 73 deselected

uv run --extra proxy pytest tests/test_litellm/proxy/test_common_request_processing.py -k 'response_cost or get_custom_headers' -q
# 8 passed, 80 deselected

uv run black --check litellm/litellm_core_utils/litellm_logging.py litellm/proxy/common_request_processing.py litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py tests/test_litellm/litellm_core_utils/test_litellm_logging.py tests/test_litellm/proxy/test_common_request_processing.py
# passed

uv run ruff check litellm/litellm_core_utils/litellm_logging.py litellm/proxy/common_request_processing.py litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
# passed
```

`uv run ruff check` over the full touched test files was not used as a pass/fail signal because `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` currently has pre-existing lint violations unrelated to this change.

## Type

🐛 Bug Fix
✅ Test

## Changes

This fixes Anthropic native `/v1/messages` cost tracking when several router deployments share the same public model group but have deployment-specific custom pricing.

- Prefer direct `litellm_params["model_info"].id` when resolving the router deployment id for cost lookup, before falling back to `litellm_metadata` / `metadata`.
- Detect custom pricing in direct `litellm_params["model_info"]`, not only nested metadata.
- Preserve calculated response cost in hidden params after the logging cost calculator runs, so proxy headers/spend can use the same cost.
- Pass the logging object into Anthropic passthrough `completion_cost()` and store the calculated response cost on `model_call_details`, matching other passthrough handlers.
- Fall back to `litellm_logging_obj.model_call_details["response_cost"]` in proxy custom headers when response hidden params do not contain a cost yet.
- Add regression coverage for two deployments under one public model group with different custom pricing, verifying cost uses the selected deployment id.
