### PR TITLE
fix(responses): preserve input_file in function_call_output during chat lowering

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1086,11 +1086,11 @@ class LiteLLMCompletionResponsesConfig:
                                 }
                             )
                     elif part_type in ("input_file", "file"):
-                        normalized_blocks.append(
-                            LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
-                                part
-                            )
+                        file_item = LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
+                            part
                         )
+                        if file_item.get("file"):
+                            normalized_blocks.append(file_item)
 
                 # Prefer structured blocks if we have any non-text part
                 # (images or files); otherwise return a string.

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1085,9 +1085,18 @@ class LiteLLMCompletionResponsesConfig:
                                     "image_url": {"url": image_url_val},
                                 }
                             )
+                    elif part_type in ("input_file", "file"):
+                        normalized_blocks.append(
+                            LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
+                                part
+                            )
+                        )
 
-                # Prefer structured blocks if we have images; otherwise return a string.
-                if any(b.get("type") == "image_url" for b in normalized_blocks):
+                # Prefer structured blocks if we have any non-text part
+                # (images or files); otherwise return a string.
+                if any(
+                    b.get("type") in ("image_url", "file") for b in normalized_blocks
+                ):
                     # Ensure we include any accumulated text as text blocks too
                     return normalized_blocks
                 if text_acc:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
@@ -107,3 +107,24 @@ def test_function_call_output_input_file_with_file_id_is_preserved():
     file_blocks = [b for b in content if b.get("type") == "file"]
     assert len(file_blocks) == 1
     assert file_blocks[0]["file"]["file_id"] == "file-abc123"
+
+
+def test_function_call_output_input_file_without_data_is_skipped():
+    """An input_file part with no file_id, file_url, or file_data carries no
+    payload — appending it as ``{"type": "file", "file": {}}`` would activate
+    the structured-content path and emit a hollow block that downstream
+    adapters (Gemini, Bedrock) reject or silently ignore. Skip it instead."""
+    out = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+        tool_call_output={
+            "type": "function_call_output",
+            "call_id": "call_empty_file",
+            "output": [
+                {"type": "input_text", "text": "Just text here."},
+                {"type": "input_file", "filename": "missing.pdf"},
+            ],
+        }
+    )
+
+    assert len(out) == 1
+    # No usable file payload -> fall back to the plain-string text path.
+    assert out[0]["content"] == "Just text here."

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
@@ -40,3 +40,70 @@ def test_function_call_output_string_passthrough():
     )
     assert len(out) == 1
     assert out[0]["content"] == '{"ok":true}'
+
+
+def test_function_call_output_input_file_is_preserved_as_file_block():
+    """A PDF returned from a tool call (input_file part inside
+    function_call_output.output) must survive the lowering to a chat-completions
+    tool message as a structured file content block. Previously the file part
+    was silently dropped and only the input_text sibling reached the model."""
+    pdf_data_url = "data:application/pdf;base64,JVBERi0xLjQKJfb=="
+
+    out = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+        tool_call_output={
+            "type": "function_call_output",
+            "call_id": "call_pdf",
+            "output": [
+                {"type": "input_text", "text": "Here is the PDF."},
+                {
+                    "type": "input_file",
+                    "file_data": pdf_data_url,
+                    "filename": "test.pdf",
+                },
+            ],
+        }
+    )
+
+    assert len(out) == 1
+    msg = out[0]
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "call_pdf"
+
+    content = msg["content"]
+    assert isinstance(content, list), (
+        "expected structured content list when a file part is present, "
+        f"got {type(content).__name__}: {content!r}"
+    )
+
+    text_blocks = [b for b in content if b.get("type") == "text"]
+    file_blocks = [b for b in content if b.get("type") == "file"]
+
+    assert any(b.get("text") == "Here is the PDF." for b in text_blocks)
+    assert len(file_blocks) == 1
+    assert file_blocks[0]["file"]["file_data"] == pdf_data_url
+
+
+def test_function_call_output_input_file_with_file_id_is_preserved():
+    """Same as above but for the file_id form (no inline bytes)."""
+    out = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+        tool_call_output={
+            "type": "function_call_output",
+            "call_id": "call_pdf_id",
+            "output": [
+                {"type": "input_text", "text": "See attached."},
+                {
+                    "type": "input_file",
+                    "file_id": "file-abc123",
+                    "filename": "report.pdf",
+                },
+            ],
+        }
+    )
+
+    assert len(out) == 1
+    content = out[0]["content"]
+    assert isinstance(content, list)
+
+    file_blocks = [b for b in content if b.get("type") == "file"]
+    assert len(file_blocks) == 1
+    assert file_blocks[0]["file"]["file_id"] == "file-abc123"


### PR DESCRIPTION
## What this PR does

Fixes #28232.

When a request hits the LiteLLM proxy at `/responses` and the input contains a `function_call_output` whose `output` array carries an `input_file` part (e.g. a PDF returned from a tool call, lowered from the OpenAI Agents SDK's `ToolOutputFileContent`), the Responses→ChatCompletions lowering was **silently dropping the `input_file` part**. Only sibling `input_text` parts survived into the resulting `role: "tool"` message, flattened to a plain string.

This affected every provider that lacks a native `/responses` endpoint and goes through the lowering path (`vertex_ai/*` confirmed, `bedrock/*` highly likely). Azure was unaffected because LiteLLM passes through to Azure OpenAI's native `/openai/responses` endpoint.

## Root cause

In `litellm/responses/litellm_completion_transformation/transformation.py`, the nested helper `_normalize_function_call_output_to_tool_content` walks the `output` array but only matches text and image parts:

```python
if part_type in ("input_text", "output_text", "text"):
    ...
elif part_type in ("input_image", "image_url"):
    ...
# no input_file branch ← BUG
```

So `input_file` parts fell through and were discarded.

## Fix

Add an `input_file` / `file` branch to the same walker that reuses the existing `_transform_input_file_item_to_file_item` helper (already used by the user/system message content path at `_transform_responses_api_content_to_chat_completion_content`). Also extends the "prefer structured blocks" check so the tool message gets a list `content` whenever a file part is present (previously only triggered by image parts).

This is the symmetric counterpart, in the opposite direction, of #17799 (which handled `input_image` in Chat→Responses).

## Tests

Added two mocked tests to `tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py`:

- `test_function_call_output_input_file_is_preserved_as_file_block` — PDF via `file_data` survives into a structured `{"type": "file", "file": {"file_data": ...}}` block alongside the sibling text.
- `test_function_call_output_input_file_with_file_id_is_preserved` — same for the `file_id` form (no inline bytes).

All four tests in the file pass locally (2 pre-existing + 2 new). The two changed files pass `black --check`, `ruff check`, and `mypy --ignore-missing-imports`.

Note on `make format-check`: there is unrelated pre-existing formatting drift in `enterprise/litellm_enterprise/` that fails `black --check`. Verified that this drift exists on the base branch before any of my changes (`git stash` + `make format-check` at HEAD~1 still reports the same 13 files). I did not include those reformats here to keep PR scope isolated, as `CONTRIBUTING.md` requires.

## Repro before / after

Smoke from #28232 (Agents SDK → Vertex Gemini via LiteLLM, synthetic 2-page PDF with distinctive tokens `TEST-A1B2`, `INVOICE-7777`, `123.45`):

- **Before:** model produces generic description, none of the distinctive tokens appear → PDF was dropped.
- **After:** PDF reaches the model end-to-end via the existing chat-completions `{"type": "file", ...}` part; downstream Gemini adapter then lowers that to `inline_data` with `mime_type: application/pdf`.

## Checklist

- [x] Scope isolated — one specific problem
- [x] At least one mocked test added (two)
- [x] `black --check`, `ruff check`, `mypy` clean on changed files
- [x] CLA signed (signing now)