### PR TITLE
fix(aiohttp): block private/metadata IPs in   api_base to close SSRF gap from PR #26264 (CWE-918)

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -35,36 +35,50 @@ else:
 DEFAULT_TIMEOUT = 600
 
 _BLOCKED_NETWORKS = [
+    ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),  # Link-local / AWS IMDS
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("169.254.0.0/16"),  # Link-local / AWS IMDS
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
 ]
 
 
+def _is_blocked_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if addr falls in any blocked network."""
+    # Unwrap IPv4-mapped IPv6 (::ffff:10.0.0.1 → 10.0.0.1)
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return any(addr in net for net in _BLOCKED_NETWORKS)
+
+
 def _assert_not_private_url(url: str) -> None:
-    """Raise ValueError if url resolves to a private/reserved IP (SSRF protection)."""
+    """Raise ValueError if url resolves to any private/reserved IP (SSRF protection).
+
+    Validates all DNS answers, not just the first, to prevent A-record rotation attacks.
+    """
     parsed = urlparse(url)
     hostname = parsed.hostname
     if not hostname:
         return
     try:
-        resolved_ip = socket.getaddrinfo(hostname, None)[0][4][0]
+        answers = socket.getaddrinfo(hostname, None)
     except socket.gaierror:
         return  # DNS failure — request will fail naturally
-    try:
-        addr = ipaddress.ip_address(resolved_ip)
-    except ValueError:
-        return
-    for net in _BLOCKED_NETWORKS:
-        if addr in net:
+    for answer in answers:
+        raw_ip = answer[4][0]
+        try:
+            addr = ipaddress.ip_address(raw_ip)
+        except ValueError:
+            continue
+        if _is_blocked_address(addr):
             raise ValueError(
                 f"api_base '{url}' resolves to a private/reserved IP address "
-                f"({resolved_ip}) which is not allowed (SSRF protection)"
+                f"({raw_ip}) which is not allowed (SSRF protection)"
             )
 
 
@@ -236,6 +250,7 @@ class BaseLLMAIOHTTPHandler:
                     headers=headers,
                     json=data,
                     data=form_data,
+                    allow_redirects=False,
                 )
                 if not response.ok:
                     response.raise_for_status()
@@ -272,6 +287,8 @@ class BaseLLMAIOHTTPHandler:
         max_retry_on_unprocessable_entity_error = (
             provider_config.max_retry_on_unprocessable_entity_error
         )
+
+        _assert_not_private_url(api_base)
 
         response: Optional[httpx.Response] = None
 

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import ipaddress
 import socket
 from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union, cast
@@ -6,6 +7,7 @@ from urllib.parse import urlparse
 import aiohttp
 import httpx  # type: ignore
 from aiohttp import ClientSession, FormData
+from aiohttp.abc import AbstractResolver
 
 import litellm
 import litellm.litellm_core_utils
@@ -60,6 +62,7 @@ def _assert_not_private_url(url: str) -> None:
     """Raise ValueError if url resolves to any private/reserved IP (SSRF protection).
 
     Validates all DNS answers, not just the first, to prevent A-record rotation attacks.
+    Used as a fast-fail guard on the sync path (httpx) and as defence-in-depth on async.
     """
     parsed = urlparse(url)
     hostname = parsed.hostname
@@ -80,6 +83,52 @@ def _assert_not_private_url(url: str) -> None:
                 f"api_base '{url}' resolves to a private/reserved IP address "
                 f"({raw_ip}) which is not allowed (SSRF protection)"
             )
+
+
+class _SSRFGuardResolver(AbstractResolver):
+    """Custom aiohttp resolver that validates IPs at TCP-connection time.
+
+    By hooking into aiohttp's resolver — used for every connection including
+    redirect targets — this eliminates the DNS-rebinding TOCTOU window that
+    a separate preflight check cannot close.  All DNS answers are validated,
+    not just the first, to defend against A-record rotation.
+    """
+
+    async def resolve(
+        self, host: str, port: int = 0, family: int = socket.AF_INET
+    ) -> list:
+        loop = asyncio.get_event_loop()
+        try:
+            infos = await loop.getaddrinfo(
+                host, port, family=family, type=socket.SOCK_STREAM
+            )
+        except socket.gaierror:
+            return []  # Let aiohttp surface the connection error naturally
+        for info in infos:
+            raw_ip = info[4][0]
+            try:
+                addr = ipaddress.ip_address(raw_ip)
+            except ValueError:
+                continue
+            if _is_blocked_address(addr):
+                raise ValueError(
+                    f"Host '{host}' resolves to a private/reserved IP address "
+                    f"({raw_ip}) which is not allowed (SSRF protection)"
+                )
+        return [
+            {
+                "hostname": host,
+                "host": info[4][0],
+                "port": info[4][1] if len(info[4]) > 1 else port,
+                "family": info[0],
+                "proto": info[2],
+                "flags": 0,
+            }
+            for info in infos
+        ]
+
+    async def close(self) -> None:
+        pass
 
 
 class BaseLLMAIOHTTPHandler:
@@ -145,8 +194,12 @@ class BaseLLMAIOHTTPHandler:
             session = aiohttp.ClientSession(connector=connector)
             return session
         else:
-            # Default session creation
-            session = aiohttp.ClientSession()
+            # Default session creation — attach SSRF guard resolver so every
+            # TCP connection (including redirect targets) is validated at the
+            # network layer, eliminating the DNS-rebinding TOCTOU window.
+            session = aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(resolver=_SSRFGuardResolver())
+            )
             return session
 
     def _get_async_client_session(
@@ -250,7 +303,6 @@ class BaseLLMAIOHTTPHandler:
                     headers=headers,
                     json=data,
                     data=form_data,
-                    allow_redirects=False,
                 )
                 if not response.ok:
                     response.raise_for_status()

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -1,4 +1,7 @@
+import ipaddress
+import socket
 from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union, cast
+from urllib.parse import urlparse
 
 import aiohttp
 import httpx  # type: ignore
@@ -30,6 +33,39 @@ else:
     LiteLLMLoggingObj = Any
 
 DEFAULT_TIMEOUT = 600
+
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),  # Link-local / AWS IMDS
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+
+def _assert_not_private_url(url: str) -> None:
+    """Raise ValueError if url resolves to a private/reserved IP (SSRF protection)."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return
+    try:
+        resolved_ip = socket.getaddrinfo(hostname, None)[0][4][0]
+    except socket.gaierror:
+        return  # DNS failure — request will fail naturally
+    try:
+        addr = ipaddress.ip_address(resolved_ip)
+    except ValueError:
+        return
+    for net in _BLOCKED_NETWORKS:
+        if addr in net:
+            raise ValueError(
+                f"api_base '{url}' resolves to a private/reserved IP address "
+                f"({resolved_ip}) which is not allowed (SSRF protection)"
+            )
 
 
 class BaseLLMAIOHTTPHandler:
@@ -190,6 +226,8 @@ class BaseLLMAIOHTTPHandler:
         async_client_session = self._get_async_client_session(
             dynamic_client_session=async_client_session
         )
+
+        _assert_not_private_url(api_base)
 
         for i in range(max(max_retry_on_unprocessable_entity_error, 1)):
             try:

--- a/tests/test_litellm/llms/test_aiohttp_ssrf_protection.py
+++ b/tests/test_litellm/llms/test_aiohttp_ssrf_protection.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import patch
+
+from litellm.llms.custom_httpx.aiohttp_handler import _assert_not_private_url
+
+
+class TestAiohttpSSRFProtection:
+    def test_aws_metadata_endpoint_blocked(self):
+        with pytest.raises(ValueError, match="private/reserved"):
+            _assert_not_private_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_localhost_blocked(self):
+        with pytest.raises(ValueError, match="private/reserved"):
+            _assert_not_private_url("http://127.0.0.1/admin")
+
+    def test_private_10_network_blocked(self):
+        with pytest.raises(ValueError, match="private/reserved"):
+            _assert_not_private_url("http://10.0.0.1/internal")
+
+    def test_private_172_16_network_blocked(self):
+        with pytest.raises(ValueError, match="private/reserved"):
+            _assert_not_private_url("http://172.16.0.1/internal")
+
+    def test_private_192_168_network_blocked(self):
+        with pytest.raises(ValueError, match="private/reserved"):
+            _assert_not_private_url("http://192.168.1.1/internal")
+
+    def test_cgnat_blocked(self):
+        with pytest.raises(ValueError, match="private/reserved"):
+            _assert_not_private_url("http://100.64.0.1/internal")
+
+    def test_public_ip_allowed(self):
+        with patch(
+            "socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("104.18.7.8", None))],
+        ):
+            # Should not raise for a public IP
+            _assert_not_private_url("https://api.openai.com/v1/chat/completions")
+
+    def test_empty_hostname_allowed(self):
+        # No hostname → skip check, no raise
+        _assert_not_private_url("not-a-url")
+
+    def test_dns_failure_does_not_block(self):
+        import socket as _socket
+
+        with patch("socket.getaddrinfo", side_effect=_socket.gaierror("DNS fail")):
+            # DNS failures should not block — let the request fail naturally
+            _assert_not_private_url("https://nonexistent.invalid/path")

--- a/tests/test_litellm/llms/test_aiohttp_ssrf_protection.py
+++ b/tests/test_litellm/llms/test_aiohttp_ssrf_protection.py
@@ -1,7 +1,34 @@
+import ipaddress
 import pytest
 from unittest.mock import patch
 
-from litellm.llms.custom_httpx.aiohttp_handler import _assert_not_private_url
+from litellm.llms.custom_httpx.aiohttp_handler import (
+    _assert_not_private_url,
+    _is_blocked_address,
+)
+
+
+class TestBlockedAddress:
+    def test_ipv4_mapped_ipv6_private_blocked(self):
+        # ::ffff:10.0.0.1 is IPv4-mapped IPv6 for 10.0.0.1 — must be blocked
+        addr = ipaddress.ip_address("::ffff:10.0.0.1")
+        assert _is_blocked_address(addr)
+
+    def test_ipv4_mapped_ipv6_public_allowed(self):
+        addr = ipaddress.ip_address("::ffff:104.18.7.8")
+        assert not _is_blocked_address(addr)
+
+    def test_ipv6_link_local_blocked(self):
+        addr = ipaddress.ip_address("fe80::1")
+        assert _is_blocked_address(addr)
+
+    def test_ipv6_ula_blocked(self):
+        addr = ipaddress.ip_address("fc00::1")
+        assert _is_blocked_address(addr)
+
+    def test_0_0_0_0_blocked(self):
+        addr = ipaddress.ip_address("0.0.0.0")
+        assert _is_blocked_address(addr)
 
 
 class TestAiohttpSSRFProtection:
@@ -29,21 +56,30 @@ class TestAiohttpSSRFProtection:
         with pytest.raises(ValueError, match="private/reserved"):
             _assert_not_private_url("http://100.64.0.1/internal")
 
+    def test_all_dns_answers_checked(self):
+        # Domain returns public IP first, private IP second — must still block
+        with patch(
+            "socket.getaddrinfo",
+            return_value=[
+                (None, None, None, None, ("104.18.7.8", None)),
+                (None, None, None, None, ("10.0.0.1", None)),
+            ],
+        ):
+            with pytest.raises(ValueError, match="private/reserved"):
+                _assert_not_private_url("https://evil-rebinding.example.com/")
+
     def test_public_ip_allowed(self):
         with patch(
             "socket.getaddrinfo",
             return_value=[(None, None, None, None, ("104.18.7.8", None))],
         ):
-            # Should not raise for a public IP
             _assert_not_private_url("https://api.openai.com/v1/chat/completions")
 
     def test_empty_hostname_allowed(self):
-        # No hostname → skip check, no raise
         _assert_not_private_url("not-a-url")
 
     def test_dns_failure_does_not_block(self):
         import socket as _socket
 
         with patch("socket.getaddrinfo", side_effect=_socket.gaierror("DNS fail")):
-            # DNS failures should not block — let the request fail naturally
             _assert_not_private_url("https://nonexistent.invalid/path")

--- a/tests/test_litellm/llms/test_aiohttp_ssrf_protection.py
+++ b/tests/test_litellm/llms/test_aiohttp_ssrf_protection.py
@@ -1,8 +1,10 @@
+import asyncio
 import ipaddress
 import pytest
 from unittest.mock import patch
 
 from litellm.llms.custom_httpx.aiohttp_handler import (
+    _SSRFGuardResolver,
     _assert_not_private_url,
     _is_blocked_address,
 )
@@ -10,7 +12,6 @@ from litellm.llms.custom_httpx.aiohttp_handler import (
 
 class TestBlockedAddress:
     def test_ipv4_mapped_ipv6_private_blocked(self):
-        # ::ffff:10.0.0.1 is IPv4-mapped IPv6 for 10.0.0.1 — must be blocked
         addr = ipaddress.ip_address("::ffff:10.0.0.1")
         assert _is_blocked_address(addr)
 
@@ -19,16 +20,13 @@ class TestBlockedAddress:
         assert not _is_blocked_address(addr)
 
     def test_ipv6_link_local_blocked(self):
-        addr = ipaddress.ip_address("fe80::1")
-        assert _is_blocked_address(addr)
+        assert _is_blocked_address(ipaddress.ip_address("fe80::1"))
 
     def test_ipv6_ula_blocked(self):
-        addr = ipaddress.ip_address("fc00::1")
-        assert _is_blocked_address(addr)
+        assert _is_blocked_address(ipaddress.ip_address("fc00::1"))
 
     def test_0_0_0_0_blocked(self):
-        addr = ipaddress.ip_address("0.0.0.0")
-        assert _is_blocked_address(addr)
+        assert _is_blocked_address(ipaddress.ip_address("0.0.0.0"))
 
 
 class TestAiohttpSSRFProtection:
@@ -57,7 +55,6 @@ class TestAiohttpSSRFProtection:
             _assert_not_private_url("http://100.64.0.1/internal")
 
     def test_all_dns_answers_checked(self):
-        # Domain returns public IP first, private IP second — must still block
         with patch(
             "socket.getaddrinfo",
             return_value=[
@@ -83,3 +80,54 @@ class TestAiohttpSSRFProtection:
 
         with patch("socket.getaddrinfo", side_effect=_socket.gaierror("DNS fail")):
             _assert_not_private_url("https://nonexistent.invalid/path")
+
+
+class TestSSRFGuardResolver:
+    """Tests for the async resolver that eliminates TOCTOU DNS rebinding."""
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_private_ip_blocked_at_connection_time(self):
+        resolver = _SSRFGuardResolver()
+        mock_infos = [
+            (2, 1, 6, "", ("10.0.0.1", 443)),
+        ]
+        with patch("asyncio.AbstractEventLoop.getaddrinfo", return_value=mock_infos):
+
+            async def run():
+                loop = asyncio.get_event_loop()
+                with patch.object(loop, "getaddrinfo", return_value=mock_infos):
+                    with pytest.raises(ValueError, match="private/reserved"):
+                        await resolver.resolve("evil.internal", 443)
+
+            self._run(run())
+
+    def test_public_ip_passes_resolver(self):
+        resolver = _SSRFGuardResolver()
+        mock_infos = [
+            (2, 1, 6, "", ("104.18.7.8", 443)),
+        ]
+
+        async def run():
+            loop = asyncio.get_event_loop()
+            with patch.object(loop, "getaddrinfo", return_value=mock_infos):
+                result = await resolver.resolve("api.openai.com", 443)
+            assert result[0]["host"] == "104.18.7.8"
+
+        self._run(run())
+
+    def test_all_answers_checked_by_resolver(self):
+        resolver = _SSRFGuardResolver()
+        mock_infos = [
+            (2, 1, 6, "", ("104.18.7.8", 443)),
+            (2, 1, 6, "", ("169.254.169.254", 443)),
+        ]
+
+        async def run():
+            loop = asyncio.get_event_loop()
+            with patch.object(loop, "getaddrinfo", return_value=mock_infos):
+                with pytest.raises(ValueError, match="private/reserved"):
+                    await resolver.resolve("rebinding.example.com", 443)
+
+        self._run(run())


### PR DESCRIPTION
                                                                            
  ## Relevant issues                          
                                                                                              
 Closes SSRF gap in `aiohttp_handler.py` (CWE-918, findings #13–14).          
                                                                                              
  ## Summary                                                                                    
                                              
  PR #26264 blocked private IPs in the main HTTP handler but `aiohttp_handler.py` was not       
  covered. User-controlled `api_base` is passed directly to `session.post(url=api_base, ...)` at
   line ~196 without IP validation, allowing requests to `169.254.169.254` (AWS IMDS),          
  `10.x.x.x` internal hosts, loopback, or CGNAT addresses.
                                                                                              
  ### Fix                                                                                     
                                                                                                
  Added `_assert_not_private_url()` which resolves the hostname via `socket.getaddrinfo()` and  
  checks against RFC-1918 / link-local / loopback / CGNAT networks before the request is made.
  Called once per invocation of `_make_common_async_call()`, before the retry loop.             
                                              
  ### Networks blocked                                                                        
  - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC-1918)                                
  - `169.254.0.0/16` (link-local / AWS IMDSv1)                                                  
  - `127.0.0.0/8` (loopback)                                                                    
  - `100.64.0.0/10` (CGNAT)                                                                     
  - `::1/128`, `fc00::/7` (IPv6 loopback / ULA)                                                 
                                                                                                
  DNS failures are not blocked — the request fails naturally with a connection error.           
                                                                                                
                                                                                                
  - [x] Added 9 tests in `tests/test_litellm/llms/test_aiohttp_ssrf_protection.py`            
  - [x] All tests pass (`uv run pytest tests/test_litellm/llms/test_aiohttp_ssrf_protection.py  
  -v`)                                                                                        
  - [x] `uv run black .` — no changes needed                                                    
  - [x] `uv run ruff check` — all checks passed                                               
  - [x] Scope isolated — only `aiohttp_handler.py` SSRF guard + test                            
                                                                                                
  ## Type                                                                                       
                                                                                                
  🐛 Bug Fix                                                                                    
                                                                                                                                 
                                                                                                
  ---
  What changed: Added _assert_not_private_url() to aiohttp_handler.py + 9 tests (all passing).  
  The key improvement over the playbook: the ValueError-inside-try bug was fixed so private-IP  
  errors and DNS failures are handled separately.