### PR TITLE
Fix/content filter path traversal cwe022

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -333,15 +333,17 @@ class ContentFilterGuardrail(CustomGuardrail):
         resolved = os.path.realpath(path)
         allowed = os.path.realpath(categories_dir)
         try:
-            if os.path.commonpath([resolved, allowed]) != allowed:
-                raise ValueError(
-                    f"Category file path '{path}' is outside the allowed "
-                    f"categories directory '{categories_dir}'"
-                )
-        except ValueError as exc:
+            common = os.path.commonpath([resolved, allowed])
+        except ValueError:
+            # commonpath() raises ValueError on Windows when paths span different drives
             raise ValueError(
                 f"Category file path '{path}' is outside the allowed categories directory"
-            ) from exc
+            )
+        if common != allowed:
+            raise ValueError(
+                f"Category file path '{path}' is outside the allowed "
+                f"categories directory '{categories_dir}'"
+            )
 
     def _resolve_category_file_path(self, file_path: str) -> str:
         """
@@ -354,7 +356,7 @@ class ContentFilterGuardrail(CustomGuardrail):
         file isn't found.
 
         Resolution order:
-        1. Return as-is if absolute or already exists (jailed to categories/).
+        1. Return as-is if absolute or already exists (jailed to module dir).
         2. Try joining the full path relative to this module's directory (jailed).
         3. Progressively strip leading path components and try each suffix
            relative to this module's directory (jailed).
@@ -367,20 +369,18 @@ class ContentFilterGuardrail(CustomGuardrail):
             resolution fails (caller should check existence).
 
         Raises:
-            ValueError: If the resolved path escapes the categories directory.
+            ValueError: If the resolved path escapes the module directory.
         """
-        categories_dir = os.path.join(os.path.dirname(__file__), "categories")
+        module_dir = os.path.dirname(__file__)
 
         if os.path.isabs(file_path) or os.path.exists(file_path):
-            self._assert_within_categories_dir(file_path, categories_dir)
+            self._assert_within_categories_dir(file_path, module_dir)
             return file_path
-
-        module_dir = os.path.dirname(__file__)
 
         # Try the full relative path joined to the module directory
         candidate = os.path.join(module_dir, file_path)
         if os.path.exists(candidate):
-            self._assert_within_categories_dir(candidate, categories_dir)
+            self._assert_within_categories_dir(candidate, module_dir)
             return candidate
 
         # Progressively strip leading components to find a matching suffix
@@ -389,14 +389,14 @@ class ContentFilterGuardrail(CustomGuardrail):
             suffix = os.path.join(*parts[i:])
             candidate = os.path.join(module_dir, suffix)
             if os.path.exists(candidate):
-                self._assert_within_categories_dir(candidate, categories_dir)
+                self._assert_within_categories_dir(candidate, module_dir)
                 return candidate
 
         # File not found via any resolution strategy — jail the module-relative
         # path anyway to reject traversal attempts (e.g. "../../../../etc/passwd")
         # regardless of CWD or whether the target file exists.
         self._assert_within_categories_dir(
-            os.path.join(module_dir, file_path), categories_dir
+            os.path.join(module_dir, file_path), module_dir
         )
         return file_path
 
@@ -445,7 +445,13 @@ class ContentFilterGuardrail(CustomGuardrail):
 
             # Load category file (custom or default)
             if custom_file:
-                category_file_path = self._resolve_category_file_path(custom_file)
+                try:
+                    category_file_path = self._resolve_category_file_path(custom_file)
+                except ValueError as e:
+                    verbose_proxy_logger.warning(
+                        f"Category {category_name}: invalid category_file path, skipping. {e}"
+                    )
+                    continue
             else:
                 # Try .yaml first, then .json (e.g. harm_toxic_abuse.json)
                 yaml_path = os.path.join(categories_dir, f"{category_name}.yaml")

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -328,7 +328,22 @@ class ContentFilterGuardrail(CustomGuardrail):
         return result
 
     @staticmethod
-    def _resolve_category_file_path(file_path: str) -> str:
+    def _assert_within_categories_dir(path: str, categories_dir: str) -> None:
+        """Raise ValueError if path escapes the categories directory."""
+        resolved = os.path.realpath(path)
+        allowed = os.path.realpath(categories_dir)
+        try:
+            if os.path.commonpath([resolved, allowed]) != allowed:
+                raise ValueError(
+                    f"Category file path '{path}' is outside the allowed "
+                    f"categories directory '{categories_dir}'"
+                )
+        except ValueError as exc:
+            raise ValueError(
+                f"Category file path '{path}' is outside the allowed categories directory"
+            ) from exc
+
+    def _resolve_category_file_path(self, file_path: str) -> str:
         """
         Resolve a category file path that may be relative.
 
@@ -339,12 +354,10 @@ class ContentFilterGuardrail(CustomGuardrail):
         file isn't found.
 
         Resolution order:
-        1. Return as-is if absolute or already exists.
-        2. Try joining the full path relative to this module's directory.
+        1. Return as-is if absolute or already exists (jailed to categories/).
+        2. Try joining the full path relative to this module's directory (jailed).
         3. Progressively strip leading path components and try each suffix
-           relative to this module's directory (handles paths like
-           "litellm/proxy/.../policy_templates/file.yaml" by finding the
-           "policy_templates/file.yaml" suffix that exists).
+           relative to this module's directory (jailed).
 
         Args:
             file_path: The file path to resolve (absolute or relative).
@@ -352,8 +365,14 @@ class ContentFilterGuardrail(CustomGuardrail):
         Returns:
             The resolved absolute-ish path, or the original path if
             resolution fails (caller should check existence).
+
+        Raises:
+            ValueError: If the resolved path escapes the categories directory.
         """
+        categories_dir = os.path.join(os.path.dirname(__file__), "categories")
+
         if os.path.isabs(file_path) or os.path.exists(file_path):
+            self._assert_within_categories_dir(file_path, categories_dir)
             return file_path
 
         module_dir = os.path.dirname(__file__)
@@ -361,6 +380,7 @@ class ContentFilterGuardrail(CustomGuardrail):
         # Try the full relative path joined to the module directory
         candidate = os.path.join(module_dir, file_path)
         if os.path.exists(candidate):
+            self._assert_within_categories_dir(candidate, categories_dir)
             return candidate
 
         # Progressively strip leading components to find a matching suffix
@@ -369,8 +389,15 @@ class ContentFilterGuardrail(CustomGuardrail):
             suffix = os.path.join(*parts[i:])
             candidate = os.path.join(module_dir, suffix)
             if os.path.exists(candidate):
+                self._assert_within_categories_dir(candidate, categories_dir)
                 return candidate
 
+        # File not found via any resolution strategy — jail the module-relative
+        # path anyway to reject traversal attempts (e.g. "../../../../etc/passwd")
+        # regardless of CWD or whether the target file exists.
+        self._assert_within_categories_dir(
+            os.path.join(module_dir, file_path), categories_dir
+        )
         return file_path
 
     def _load_categories(self, categories: List[ContentFilterCategoryConfig]) -> None:
@@ -392,6 +419,13 @@ class ContentFilterGuardrail(CustomGuardrail):
             if not category_name or not isinstance(category_name, str):
                 verbose_proxy_logger.warning(
                     "Category name missing or invalid in config, skipping"
+                )
+                continue
+
+            # Prevent path traversal via category_name (e.g. "../../etc/passwd")
+            if not re.match(r"^[a-zA-Z0-9_\-]+$", category_name):
+                verbose_proxy_logger.warning(
+                    f"Category name '{category_name}' contains invalid characters, skipping"
                 )
                 continue
 

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -361,6 +361,13 @@ class ContentFilterGuardrail(CustomGuardrail):
         3. Progressively strip leading path components and try each suffix
            relative to this module's directory (jailed).
 
+        The directory jail can be disabled for deployments that legitimately
+        store category files outside the package (e.g. mounted volumes) by
+        setting the environment variable
+        ``LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS=true``.  Use only in
+        trusted environments where the proxy configuration cannot be influenced
+        by untrusted input.
+
         Args:
             file_path: The file path to resolve (absolute or relative).
 
@@ -369,18 +376,31 @@ class ContentFilterGuardrail(CustomGuardrail):
             resolution fails (caller should check existence).
 
         Raises:
-            ValueError: If the resolved path escapes the module directory.
+            ValueError: If the resolved path escapes the module directory
+                and ``LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS`` is not set.
         """
         module_dir = os.path.dirname(__file__)
+        allow_external = (
+            os.environ.get("LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS", "").lower()
+            == "true"
+        )
 
         if os.path.isabs(file_path) or os.path.exists(file_path):
-            self._assert_within_categories_dir(file_path, module_dir)
+            if not allow_external:
+                self._assert_within_categories_dir(file_path, module_dir)
+            else:
+                verbose_proxy_logger.warning(
+                    "LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS is set — "
+                    "skipping directory jail for category_file '%s'",
+                    file_path,
+                )
             return file_path
 
         # Try the full relative path joined to the module directory
         candidate = os.path.join(module_dir, file_path)
         if os.path.exists(candidate):
-            self._assert_within_categories_dir(candidate, module_dir)
+            if not allow_external:
+                self._assert_within_categories_dir(candidate, module_dir)
             return candidate
 
         # Progressively strip leading components to find a matching suffix
@@ -389,15 +409,17 @@ class ContentFilterGuardrail(CustomGuardrail):
             suffix = os.path.join(*parts[i:])
             candidate = os.path.join(module_dir, suffix)
             if os.path.exists(candidate):
-                self._assert_within_categories_dir(candidate, module_dir)
+                if not allow_external:
+                    self._assert_within_categories_dir(candidate, module_dir)
                 return candidate
 
         # File not found via any resolution strategy — jail the module-relative
         # path anyway to reject traversal attempts (e.g. "../../../../etc/passwd")
         # regardless of CWD or whether the target file exists.
-        self._assert_within_categories_dir(
-            os.path.join(module_dir, file_path), module_dir
-        )
+        if not allow_external:
+            self._assert_within_categories_dir(
+                os.path.join(module_dir, file_path), module_dir
+            )
         return file_path
 
     def _load_categories(self, categories: List[ContentFilterCategoryConfig]) -> None:

--- a/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 import pytest
 
 
@@ -98,3 +99,86 @@ class TestContentFilterPathTraversal:
         valid_file = str(tmp_path / "test.yaml")
         # Should not raise
         ContentFilterGuardrail._assert_within_categories_dir(valid_file, categories_dir)
+
+    def test_assert_within_categories_dir_commonpath_raises_valueerror(self, tmp_path):
+        """Cover the except-ValueError branch (Windows cross-drive paths)."""
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        categories_dir = str(tmp_path)
+        valid_file = str(tmp_path / "test.yaml")
+        with patch(
+            "os.path.commonpath", side_effect=ValueError("Paths on different drives")
+        ):
+            with pytest.raises(
+                ValueError, match="outside the allowed categories directory"
+            ):
+                ContentFilterGuardrail._assert_within_categories_dir(
+                    valid_file, categories_dir
+                )
+
+    def test_resolve_category_file_path_direct_join_hit(self):
+        """Cover the first-join-attempt success branch (lines 383-384)."""
+        guardrail = self._get_guardrail()
+        # "categories/<file>" joined directly to module_dir resolves to an existing file.
+        categories_dir = os.path.join(
+            os.path.dirname(
+                __import__(
+                    "litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter",
+                    fromlist=["content_filter"],
+                ).__file__
+            ),
+            "categories",
+        )
+        yaml_files = [f for f in os.listdir(categories_dir) if f.endswith(".yaml")]
+        if not yaml_files:
+            pytest.skip("No category YAML files present in this environment")
+        relative_path = os.path.join("categories", yaml_files[0])
+        result = guardrail._resolve_category_file_path(relative_path)
+        assert os.path.isabs(result) or os.path.exists(result)
+
+    def test_resolve_category_file_path_component_strip_hit(self):
+        """Cover the component-stripping loop success branch (lines 392-393)."""
+        guardrail = self._get_guardrail()
+        categories_dir = os.path.join(
+            os.path.dirname(
+                __import__(
+                    "litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter",
+                    fromlist=["content_filter"],
+                ).__file__
+            ),
+            "categories",
+        )
+        yaml_files = [f for f in os.listdir(categories_dir) if f.endswith(".yaml")]
+        if not yaml_files:
+            pytest.skip("No category YAML files present in this environment")
+        # Prefix with a fake leading component so the first-join attempt misses,
+        # but stripping that component reveals categories/<file> which exists.
+        prefixed_path = "some_prefix/categories/" + yaml_files[0]
+        result = guardrail._resolve_category_file_path(prefixed_path)
+        assert os.path.isabs(result) or os.path.exists(result)
+
+    def test_load_categories_traversal_category_file_skipped(self):
+        """Cover the except-ValueError branch in _load_categories (lines 451-454)."""
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        guardrail = ContentFilterGuardrail.__new__(ContentFilterGuardrail)
+        guardrail.loaded_categories = {}
+        guardrail.severity_threshold = "medium"
+        guardrail.category_keywords = {}
+        guardrail.always_block_category_keywords = {}
+        guardrail.conditional_categories = {}
+        # A traversal path in category_file must be skipped (not crash) via ValueError.
+        guardrail._load_categories(
+            [
+                {
+                    "category": "valid_name",
+                    "enabled": True,
+                    "category_file": "../../../../etc/passwd",
+                }
+            ]
+        )
+        assert "valid_name" not in guardrail.loaded_categories

--- a/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
@@ -1,0 +1,99 @@
+import os
+import pytest
+
+
+class TestContentFilterPathTraversal:
+    """Tests that _resolve_category_file_path rejects path traversal."""
+
+    def _get_guardrail(self):
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        return ContentFilterGuardrail.__new__(ContentFilterGuardrail)
+
+    def test_traversal_via_relative_dotdot_raises(self):
+        guardrail = self._get_guardrail()
+        with pytest.raises(ValueError, match="outside the allowed categories"):
+            guardrail._resolve_category_file_path("../../../../etc/passwd")
+
+    def test_traversal_via_absolute_path_raises(self):
+        guardrail = self._get_guardrail()
+        with pytest.raises(ValueError, match="outside the allowed categories"):
+            guardrail._resolve_category_file_path("/etc/passwd")
+
+    def test_valid_category_file_inside_categories_dir_allowed(self):
+        guardrail = self._get_guardrail()
+        categories_dir = os.path.join(
+            os.path.dirname(
+                __import__(
+                    "litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter",
+                    fromlist=["content_filter"],
+                ).__file__
+            ),
+            "categories",
+        )
+        valid_file = os.path.join(categories_dir, "harmful_self_harm.yaml")
+        if os.path.exists(valid_file):
+            result = guardrail._resolve_category_file_path(valid_file)
+            assert result == valid_file
+
+    def test_invalid_category_name_skipped(self):
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        guardrail = ContentFilterGuardrail.__new__(ContentFilterGuardrail)
+        guardrail.loaded_categories = {}
+        guardrail.severity_threshold = "medium"
+        guardrail.category_keywords = {}
+        guardrail.always_block_category_keywords = {}
+        guardrail.conditional_categories = {}
+        # category name with path traversal chars must be skipped, not crash
+        guardrail._load_categories([{"category": "../../etc/passwd", "enabled": True}])
+        assert "../../etc/passwd" not in guardrail.loaded_categories
+
+    def test_category_name_with_slash_skipped(self):
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        guardrail = ContentFilterGuardrail.__new__(ContentFilterGuardrail)
+        guardrail.loaded_categories = {}
+        guardrail.severity_threshold = "medium"
+        guardrail.category_keywords = {}
+        guardrail.always_block_category_keywords = {}
+        guardrail.conditional_categories = {}
+        guardrail._load_categories(
+            [{"category": "foo/../../etc/passwd", "enabled": True}]
+        )
+        assert "foo/../../etc/passwd" not in guardrail.loaded_categories
+
+    def test_assert_within_categories_dir_blocks_parent_traversal(self):
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        categories_dir = os.path.join(
+            os.path.dirname(
+                __import__(
+                    "litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter",
+                    fromlist=["content_filter"],
+                ).__file__
+            ),
+            "categories",
+        )
+        with pytest.raises(ValueError, match="outside the allowed categories"):
+            ContentFilterGuardrail._assert_within_categories_dir(
+                "/etc/passwd", categories_dir
+            )
+
+    def test_assert_within_categories_dir_allows_valid_file(self, tmp_path):
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        categories_dir = str(tmp_path)
+        valid_file = str(tmp_path / "test.yaml")
+        # Should not raise
+        ContentFilterGuardrail._assert_within_categories_dir(valid_file, categories_dir)

--- a/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
@@ -182,3 +182,32 @@ class TestContentFilterPathTraversal:
             ]
         )
         assert "valid_name" not in guardrail.loaded_categories
+
+    def test_allow_external_paths_env_var_bypasses_jail(self, tmp_path):
+        """LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS=true skips the directory jail."""
+        import os as _os
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+
+        guardrail = ContentFilterGuardrail.__new__(ContentFilterGuardrail)
+        # Create a real file outside the module directory (simulates mounted volume).
+        external_file = tmp_path / "external_categories.yaml"
+        external_file.write_text("category_name: test\n")
+
+        with patch.dict(
+            _os.environ, {"LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS": "true"}
+        ):
+            # Should return the path without raising ValueError.
+            result = guardrail._resolve_category_file_path(str(external_file))
+        assert result == str(external_file)
+
+    def test_traversal_blocked_when_allow_external_not_set(self):
+        """Without the env var the jail still blocks traversal paths."""
+        import os as _os
+
+        guardrail = self._get_guardrail()
+        with patch.dict(_os.environ, {}, clear=False):
+            _os.environ.pop("LITELLM_CONTENT_FILTER_ALLOW_EXTERNAL_PATHS", None)
+            with pytest.raises(ValueError, match="outside the allowed categories"):
+                guardrail._resolve_category_file_path("/etc/passwd")

--- a/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_filter_path_traversal.py
@@ -34,9 +34,10 @@ class TestContentFilterPathTraversal:
             "categories",
         )
         valid_file = os.path.join(categories_dir, "harmful_self_harm.yaml")
-        if os.path.exists(valid_file):
-            result = guardrail._resolve_category_file_path(valid_file)
-            assert result == valid_file
+        if not os.path.exists(valid_file):
+            pytest.skip("harmful_self_harm.yaml not present in this environment")
+        result = guardrail._resolve_category_file_path(valid_file)
+        assert result == valid_file
 
     def test_invalid_category_name_skipped(self):
         from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (


### PR DESCRIPTION
## What
  Fix CWE-022 (Path Traversal) in `litellm_content_filter`'s category file path resolution,
  identified via CodeQL static analysis scan.
  
  ## CodeQL Finding
  
  **Rule:** `py/path-injection`
  **Severity:** High
  **CWE:** CWE-022 — Improper Limitation of a Pathname to a Restricted Directory
  **File:** `litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py`
  **Function:** `_resolve_category_file_path()`
  
  User-controlled data from `litellm_params.categories[].category_file` flows into
  `os.path.exists()` and file open calls without any path sanitization or boundary check.
  An attacker who controls the proxy config can supply a path such as `../../../../etc/passwd`
  to read arbitrary files from the server filesystem.

  **Data flow:**
  cat_config.get("category_file")          # user-controlled source
    → _resolve_category_file_path(custom_file)   # no jail
      → os.path.exists(file_path)          # sink — arbitrary path
      → open(file_path)                    # sink — arbitrary file read

  ## Why
  `_resolve_category_file_path()` returned user-supplied paths on multiple branches without
  verifying the resolved path stays inside the package directory. Both relative traversal
  (`../../../../etc/passwd`) and absolute paths (`/etc/passwd`) were accepted unchecked.

  ## Changes

  ### `content_filter.py`
  - Added `_assert_within_categories_dir()` static method using `os.path.realpath()` +
    `os.path.commonpath()` to enforce a directory jail. Applied on all return branches of
    `_resolve_category_file_path()`.
  - Jail root is the `litellm_content_filter/` module directory (not just `categories/`),
    so built-in policy templates (`eu_ai_act_*`, `sg_pdpa_*`, `sql_injection`, etc.) continue
    to load correctly.
  - Added regex guard (`^[a-zA-Z0-9_\-]+$`) on `category_name` in `_load_categories()` to
    block traversal via the default `os.path.join(categories_dir, f"{category_name}.yaml")` path.
  - Wrapped `_resolve_category_file_path()` call in `try/except ValueError` so a traversal
    attempt logs a warning and skips the bad entry instead of aborting `ContentFilterGuardrail`
    construction entirely.
  - Fixed `try/except` structure in `_assert_within_categories_dir` so only `os.path.commonpath()`
    is guarded — the intentional `ValueError` now propagates with its full message.

  ### `test_content_filter_path_traversal.py`
  - 7 new unit tests covering: relative dotdot traversal, absolute path traversal, valid file
    inside categories dir, invalid category name, category name with slash, and direct
    `_assert_within_categories_dir` tests for both block and allow paths.
  - Fixed allow-path test to use `pytest.skip` instead of a silent `if` guard that made
    the test a no-op when the file was absent.

  ## Testing
  - 7 new path traversal tests: all pass
  - 1041 existing guardrail tests: all pass (zero regressions)
  - All 32 built-in category names confirmed compatible with the new regex guard
  - All 28 policy template files confirmed still loadable after jail boundary change
  
 ## Screenshots
  
<img width="1053" height="185" alt="image" src="https://github.com/user-attachments/assets/fce6d222-54ed-4c5f-a93c-b4acc011b3cb" />

 ## Breaking Change Note

  **Impact:** Operators who currently point `category_file` at an absolute path outside the
  `litellm_content_filter/` package directory (e.g. a mounted volume or shared config dir)
  will have those entries silently skipped after this upgrade, with a warning logged.

  **Migration:** Move custom category YAML files into the `litellm_content_filter/categories/`
  directory, or reference them via a relative path that resolves inside that directory.
  
  ### PR raised by Avani at [Incubyte](https://incubyte.co/)

