### PR TITLE
Fix handling of dictionary fallback configurations in async completion

### DIFF
--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -47,8 +47,9 @@ async def async_completion_with_fallbacks(**kwargs):
             completion_kwargs = safe_deep_copy(base_kwargs)
             # Handle dictionary fallback configurations
             if isinstance(fallback, dict):
-                model = fallback.pop("model", original_model)
-                completion_kwargs.update(fallback)
+                fallback_config = safe_deep_copy(dict(fallback))
+                model = fallback_config.pop("model", original_model)
+                completion_kwargs.update(fallback_config)
             else:
                 model = fallback
 

--- a/tests/test_litellm/litellm_core_utils/test_fallback_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_utils.py
@@ -1,0 +1,43 @@
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.fallback_utils import async_completion_with_fallbacks
+
+
+@pytest.mark.asyncio
+async def test_fallback_dict_not_mutated(monkeypatch):
+    fallback_dict = {"model": "fallback-model", "temperature": 0.2}
+    original_fallback_dict = dict(fallback_dict)
+
+    attempted_models: list[str] = []
+
+    async def _fake_acompletion(*, model: str, **kwargs):
+        attempted_models.append(model)
+        if model == "primary-model":
+            raise Exception("primary failed")
+        return {"model": model, "temperature": kwargs.get("temperature")}
+
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    # Call 1: primary fails, fallback dict succeeds
+    response_1 = await async_completion_with_fallbacks(
+        model="primary-model",
+        kwargs={"fallbacks": [fallback_dict]},
+    )
+    assert response_1["model"] == "fallback-model"
+    assert fallback_dict == original_fallback_dict
+
+    # Call 2: re-use the same dict object; it should still work and remain unchanged
+    response_2 = await async_completion_with_fallbacks(
+        model="primary-model",
+        kwargs={"fallbacks": [fallback_dict]},
+    )
+    assert response_2["model"] == "fallback-model"
+    assert fallback_dict == original_fallback_dict
+
+    assert attempted_models == [
+        "primary-model",
+        "fallback-model",
+        "primary-model",
+        "fallback-model",
+    ]


### PR DESCRIPTION

This pull request addresses an issue where fallback configuration dictionaries could be unintentionally mutated during fallback handling in the `async_completion_with_fallbacks` function. The fix ensures that fallback dictionaries remain unchanged, and a new test is added to verify this behavior.

**Bug fix: Prevent mutation of fallback dictionaries**
- Updated `async_completion_with_fallbacks` in `fallback_utils.py` to copy the fallback dictionary before modifying it, ensuring the original dictionary is not mutated.

**Testing:**
- Added `test_fallback_dict_not_mutated` in `test_fallback_utils.py` to confirm that fallback dictionaries are not changed after use, even when reused across multiple calls.


## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/28251

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

<img width="1019" height="190" alt="image" src="https://github.com/user-attachments/assets/4a605633-58a9-4ddf-ac9b-2e5e1e7341bc" />
