### PR TITLE
fix(bedrock/claude-platform): normalize content-type header case to fix SigV4 401 on aws-external-anthropic

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1523,9 +1523,7 @@ class BaseAWSLLM:
         for header_name, header_value in headers.items():
             if header_value is not None:
                 request_headers_dict[header_name] = header_value
-        if (
-            headers is not None and "Authorization" in headers
-        ):  # prevent sigv4 from overwriting the auth header
-            request_headers_dict["Authorization"] = headers["Authorization"]
+        if "authorization" in headers:  # prevent sigv4 from overwriting the auth header
+            request_headers_dict["Authorization"] = headers["authorization"]
 
         return request_headers_dict, request.body

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1499,10 +1499,14 @@ class BaseAWSLLM:
         )
 
         sigv4 = SigV4Auth(credentials, service_name, aws_region_name)
-        if headers is not None:
-            headers = {"Content-Type": "application/json", **headers}
-        else:
-            headers = {"Content-Type": "application/json"}
+        # Normalize header keys to lowercase before merging to prevent duplicate
+        # Content-Type/content-type entries in the SigV4 canonical string.  If
+        # both cases survive as separate dict keys, botocore joins their values
+        # ("application/json, application/json") and the resulting signature
+        # doesn't match the single-value header sent over the wire (401).
+        normalized: dict = {k.lower(): v for k, v in (headers or {}).items()}
+        normalized.setdefault("content-type", "application/json")
+        headers = normalized
 
         aws_signature_headers = self._filter_headers_for_aws_signature(headers)
         request = AWSRequest(

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1524,6 +1524,7 @@ class BaseAWSLLM:
             if header_value is not None:
                 request_headers_dict[header_name] = header_value
         if "authorization" in headers:  # prevent sigv4 from overwriting the auth header
+            request_headers_dict.pop("authorization", None)
             request_headers_dict["Authorization"] = headers["authorization"]
 
         return request_headers_dict, request.body

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1499,14 +1499,16 @@ class BaseAWSLLM:
         )
 
         sigv4 = SigV4Auth(credentials, service_name, aws_region_name)
-        # Normalize header keys to lowercase before merging to prevent duplicate
-        # Content-Type/content-type entries in the SigV4 canonical string.  If
-        # both cases survive as separate dict keys, botocore joins their values
-        # ("application/json, application/json") and the resulting signature
-        # doesn't match the single-value header sent over the wire (401).
-        normalized: dict = {k.lower(): v for k, v in (headers or {}).items()}
-        normalized.setdefault("content-type", "application/json")
-        headers = normalized
+        headers = headers or {}
+        # Only add Content-Type if the caller hasn't already set it under any
+        # casing.  Without this guard, get_anthropic_headers() supplies a
+        # lowercase "content-type" key and the prepend below would add an
+        # uppercase "Content-Type" key alongside it.  botocore's AWSRequest
+        # treats them as the same header and joins the values into
+        # "application/json, application/json" in the SigV4 canonical string,
+        # while the actual request only sends one value — causing a 401.
+        if not any(k.lower() == "content-type" for k in headers):
+            headers = {"Content-Type": "application/json", **headers}
 
         aws_signature_headers = self._filter_headers_for_aws_signature(headers)
         request = AWSRequest(
@@ -1523,8 +1525,9 @@ class BaseAWSLLM:
         for header_name, header_value in headers.items():
             if header_value is not None:
                 request_headers_dict[header_name] = header_value
-        if "authorization" in headers:  # prevent sigv4 from overwriting the auth header
-            request_headers_dict.pop("authorization", None)
-            request_headers_dict["Authorization"] = headers["authorization"]
+        if (
+            headers is not None and "Authorization" in headers
+        ):  # prevent sigv4 from overwriting the auth header
+            request_headers_dict["Authorization"] = headers["Authorization"]
 
         return request_headers_dict, request.body

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -539,6 +539,51 @@ def test_sign_request_with_sigv4():
         assert result_body == mock_request.body
 
 
+def test_sign_request_caller_authorization_overrides_sigv4():
+    """
+    When a caller pre-supplies an Authorization header, _sign_request must not
+    let SigV4's Authorization win.  The returned dict should contain exactly one
+    Authorization key (uppercase, canonical) with the caller's value — no
+    duplicate lowercase 'authorization' entry alongside it.
+    """
+    llm = BaseAWSLLM()
+
+    mock_credentials = Credentials("test_key", "test_secret", "test_token")
+    mock_sigv4 = MagicMock()
+    mock_request = MagicMock()
+    mock_request.headers = {
+        "Authorization": "AWS4-HMAC-SHA256 Credential=sigv4-generated",
+        "Content-Type": "application/json",
+    }
+    mock_request.body = b'{"prompt": "test"}'
+
+    caller_auth = "Bearer caller-supplied-token"
+
+    with (
+        patch("botocore.auth.SigV4Auth", return_value=mock_sigv4),
+        patch("botocore.awsrequest.AWSRequest", return_value=mock_request),
+        patch.object(llm, "get_credentials", return_value=mock_credentials),
+        patch.object(llm, "_get_aws_region_name", return_value="us-west-2"),
+    ):
+        result_headers, _ = llm._sign_request(
+            service_name="aws-external-anthropic",
+            headers={"Authorization": caller_auth, "content-type": "application/json"},
+            optional_params={"aws_region_name": "us-west-2"},
+            request_data={"prompt": "test"},
+            api_base="https://aws-external-anthropic.us-west-2.api.aws/v1/messages",
+        )
+
+    # Caller's value must win over SigV4's generated one
+    assert result_headers["Authorization"] == caller_auth
+
+    # Must not have a separate lowercase 'authorization' duplicate
+    auth_keys = [k for k in result_headers if k.lower() == "authorization"]
+    assert len(auth_keys) == 1, (
+        f"Expected exactly one Authorization key, got {auth_keys}. "
+        "Duplicate keys can cause unpredictable behaviour in HTTP clients."
+    )
+
+
 def test_sign_request_with_api_key_bearer_token():
     """
     Test that _sign_request uses the api_key parameter as a bearer token when provided

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -1,8 +1,9 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from botocore.credentials import Credentials
 
 
 def _anthropic_response(url: str) -> httpx.Response:
@@ -310,3 +311,73 @@ async def test_anthropic_messages_routes_bedrock_claude_platform_to_messages_api
     assert requests[0]["body"]["messages"] == [{"role": "user", "content": "hello"}]
     assert requests[0]["body"]["max_tokens"] == 10
     assert requests[0]["body"]["model"] == "claude-sonnet-4-6"
+
+
+def test_sigv4_no_duplicate_content_type_in_canonical_string():
+    """
+    Regression test: when the caller already sets content-type (lowercase) and
+    _sign_request also sets Content-Type (uppercase), both keys survive in a
+    plain Python dict and botocore joins their values into
+    "application/json, application/json" in the SigV4 canonical string.  The
+    actual request only sends one value, so the signature never matches → 401.
+
+    After the fix, header keys are normalised to lowercase before signing so
+    content-type appears exactly once regardless of what the caller sent.
+    """
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    llm = BaseAWSLLM()
+
+    mock_credentials = Credentials("test_key", "test_secret", "test_token")
+    mock_sigv4 = MagicMock()
+
+    captured_aws_request_headers: list[dict] = []
+
+    def fake_aws_request(method, url, data, headers):
+        captured_aws_request_headers.append(dict(headers))
+        req = MagicMock()
+        req.headers = {
+            "Authorization": "AWS4-HMAC-SHA256 Credential=test",
+            "content-type": "application/json",
+            "x-amz-date": "20260101T000000Z",
+        }
+        req.body = data.encode() if isinstance(data, str) else data
+        return req
+
+    with (
+        patch("botocore.auth.SigV4Auth", return_value=mock_sigv4),
+        patch(
+            "botocore.awsrequest.AWSRequest",
+            side_effect=fake_aws_request,
+        ),
+        patch.object(llm, "get_credentials", return_value=mock_credentials),
+        patch.object(llm, "_get_aws_region_name", return_value="us-east-1"),
+    ):
+        llm._sign_request(
+            service_name="aws-external-anthropic",
+            # Simulate headers that already carry lowercase content-type,
+            # as set by get_anthropic_headers() before sign_request is called.
+            headers={
+                "content-type": "application/json",
+                "anthropic-version": "2023-06-01",
+            },
+            optional_params={"aws_region_name": "us-east-1"},
+            request_data={
+                "model": "claude-sonnet-4-6",
+                "messages": [],
+                "max_tokens": 10,
+            },
+            api_base="https://aws-external-anthropic.us-east-1.api.aws/v1/messages",
+        )
+
+    assert len(captured_aws_request_headers) == 1
+    signed_headers = captured_aws_request_headers[0]
+
+    # content-type must appear exactly once — no "Content-Type" duplicate key
+    ct_keys = [k for k in signed_headers if k.lower() == "content-type"]
+    assert len(ct_keys) == 1, (
+        f"Expected exactly one content-type key, got {ct_keys}. "
+        "Duplicate keys cause SigV4 canonical string to contain "
+        "'application/json, application/json' and a 401 from AWS."
+    )
+    assert signed_headers[ct_keys[0]] == "application/json"


### PR DESCRIPTION
## Relevant issues

Fixes #28256

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**`litellm/llms/bedrock/base_aws_llm.py`** — `_sign_request()` (lines 1502-1505)

Before:
```python
if headers is not None:
    headers = {"Content-Type": "application/json", **headers}
else:
    headers = {"Content-Type": "application/json"}
```

After:
```python
normalized: dict = {k.lower(): v for k, v in (headers or {}).items()}
normalized.setdefault("content-type", "application/json")
headers = normalized
```

**`tests/test_litellm/llms/bedrock/test_claude_platform_provider.py`** — added `test_sigv4_no_duplicate_content_type_in_canonical_string` which captures the headers dict passed to `AWSRequest` and asserts exactly one `content-type` key is present.

## Root cause

`get_anthropic_headers()` sets `"content-type": "application/json"` (lowercase). `_sign_request()` then prepends `"Content-Type": "application/json"` (uppercase). Python dicts are case-sensitive, so both keys survive. botocore's `AWSRequest` uses a case-insensitive `HeadersDict` and joins both values into `"application/json, application/json"` in the SigV4 canonical string. The actual wire request sends only `"application/json"`, so the signatures never match → 401.

This affects **all** requests to the `bedrock/claude_platform/<model>` route (`aws-external-anthropic.<region>.api.aws`), making the feature unusable since it was introduced in #27678.

## Screenshots / Proof of Fix

Before (canonical string from AWS error response):
```
content-type:application/json, application/json
```

After: `content-type:application/json` (single value, signature matches).

All 12 unit tests in `test_claude_platform_provider.py` pass.