### PR TITLE
fix(proxy/key_management): warm user_api_key_cache on /key/generate

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -43,6 +43,7 @@ from litellm.proxy._experimental.mcp_server.db import (
 from litellm.proxy._types import *
 from litellm.proxy._types import LiteLLM_VerificationToken
 from litellm.proxy.auth.auth_checks import (
+    _cache_key_object,
     _delete_cache_key_object,
     can_team_access_model,
     get_org_object,
@@ -915,6 +916,30 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     response.token = (
         response.token_id
     )  # remap token to use the hash, and leave the key in the `key` field [TODO]: clean up generate_key_helper_fn to do this
+
+    # Warm the shared auth cache so the very first authenticated request with this
+    # key does not depend on instant DB visibility from /key/generate to the next
+    # replica's auth lookup. Best-effort: a Redis outage must not break key creation.
+    try:
+        from litellm.proxy.proxy_server import (
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if response.token is not None and user_api_key_cache is not None:
+            await _cache_key_object(
+                hashed_token=response.token,
+                user_api_key_obj=UserAPIKeyAuth(
+                    **response.model_dump(exclude_none=True)
+                ),
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            "generate_key_fn: failed to warm user_api_key_cache for newly created key (best-effort): %s",
+            str(e),
+        )
 
     asyncio.create_task(
         KeyManagementEventHooks.async_key_generated_hook(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3016,3 +3016,32 @@ async def test_team_member_budget_check_zero_per_member_row_still_blocks():
                 proxy_logging_obj=proxy_logging_obj,
             )
     assert exc_info.value.max_budget == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_key_object_returns_pre_warmed_entry_without_db_lookup():
+    """
+    Regression for case 2026-05-13-zurich-invalid-proxy-token: when
+    /key/generate has warmed the cache, get_key_object must serve the
+    key from cache without touching the DB. This is the path that
+    survives DB-side replication lag / pool isolation.
+    """
+    from litellm.proxy.auth.auth_checks import get_key_object
+
+    pre_warmed_key = UserAPIKeyAuth(token="hashed-warmed-token")
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=pre_warmed_key)
+    mock_cache.async_set_cache = AsyncMock()
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.get_data = AsyncMock()
+
+    result = await get_key_object(
+        hashed_token="hashed-warmed-token",
+        prisma_client=mock_prisma_client,
+        user_api_key_cache=mock_cache,
+    )
+
+    assert result.token == "hashed-warmed-token"
+    mock_prisma_client.get_data.assert_not_called()

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11201,3 +11201,101 @@ async def test_ghsa_q775_admin_bypasses_budget_ceiling():
             litellm_changed_by=None,
         )
         assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_common_key_generation_helper_warms_auth_cache():
+    """
+    /key/generate must warm user_api_key_cache so the first authenticated
+    request after creation does not depend on instant DB visibility.
+
+    Regression for case 2026-05-13-zurich-invalid-proxy-token:
+    multi-replica deployments behind pooled/replicated Postgres saw
+    token_not_found_in_db on the very first request after key creation.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    mock_cache = MagicMock()
+    mock_cache.async_set_cache = AsyncMock()
+    mock_proxy_logging = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        patch("litellm.proxy.proxy_server.llm_router") as mock_router,
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn"
+        ) as mock_generate_key,
+    ):
+        mock_prisma.return_value = AsyncMock()
+        mock_router.return_value = None
+        mock_generate_key.return_value = {
+            "key": "sk-test-warm-cache",
+            "token": "sk-test-warm-cache",
+            "token_id": "hashed-token-warm-cache",
+            "expires": None,
+            "user_id": "test-user",
+            "team_id": None,
+        }
+
+        await _common_key_generation_helper(
+            data=GenerateKeyRequest(),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+            ),
+            litellm_changed_by=None,
+            team_table=None,
+        )
+
+    mock_cache.async_set_cache.assert_awaited()
+    call_kwargs = mock_cache.async_set_cache.await_args.kwargs
+    assert call_kwargs["key"] == "hashed-token-warm-cache"
+    assert isinstance(call_kwargs["value"], UserAPIKeyAuth)
+    assert call_kwargs["value"].token == "hashed-token-warm-cache"
+
+
+@pytest.mark.asyncio
+async def test_common_key_generation_helper_cache_warm_is_best_effort():
+    """
+    A Redis (or any cache-layer) failure during the post-create cache warm
+    must NOT cause /key/generate to fail. The key is already in Postgres.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    mock_cache = MagicMock()
+    mock_cache.async_set_cache = AsyncMock(side_effect=ConnectionError("redis down"))
+    mock_proxy_logging = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        patch("litellm.proxy.proxy_server.llm_router") as mock_router,
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn"
+        ) as mock_generate_key,
+    ):
+        mock_prisma.return_value = AsyncMock()
+        mock_router.return_value = None
+        mock_generate_key.return_value = {
+            "key": "sk-test-cache-fail",
+            "token": "sk-test-cache-fail",
+            "token_id": "hashed-token-cache-fail",
+            "expires": None,
+            "user_id": "test-user",
+            "team_id": None,
+        }
+
+        # Must not raise — cache failure is logged, response is still returned.
+        result = await _common_key_generation_helper(
+            data=GenerateKeyRequest(),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+            ),
+            litellm_changed_by=None,
+            team_table=None,
+        )
+        assert result.token == "hashed-token-cache-fail"


### PR DESCRIPTION
## Relevant issues

Fixes #24680

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Before / after on the new regression test, with the implementation change reverted vs applied (test files identical in both runs):

**Before — implementation reverted (`grep -c "Warm the shared auth cache" … = 0`)**:

```
$ uv run pytest \
    tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py::test_common_key_generation_helper_warms_auth_cache \
    tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py::test_common_key_generation_helper_cache_warm_is_best_effort \
    tests/test_litellm/proxy/auth/test_auth_checks.py::test_get_key_object_returns_pre_warmed_entry_without_db_lookup \
    -v
...
        await _common_key_generation_helper(
            data=GenerateKeyRequest(),
            user_api_key_dict=UserAPIKeyAuth(
                user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
            ),
            litellm_changed_by=None,
            team_table=None,
        )

>       mock_cache.async_set_cache.assert_awaited()
E       AssertionError: Expected async_set_cache to have been awaited.

FAILED tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py::test_common_key_generation_helper_warms_auth_cache
========================= 1 failed, 2 passed in 3.95s ==========================
```

The failure is the bug: `/key/generate` returns successfully but never writes to `user_api_key_cache`, so any auth lookup that happens before the new DB row is visible to the auth code path misses both cache and DB and raises 401.

**After — implementation applied (`grep -c "Warm the shared auth cache" … = 1`)**:

```
$ uv run pytest <same three test ids> -v
...
tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py::test_common_key_generation_helper_cache_warm_is_best_effort PASSED [ 33%]
tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py::test_common_key_generation_helper_warms_auth_cache PASSED [ 66%]
tests/test_litellm/proxy/auth/test_auth_checks.py::test_get_key_object_returns_pre_warmed_entry_without_db_lookup PASSED [100%]

============================== 3 passed in 3.69s ===============================
```

## Type

🐛 Bug Fix

## Changes

### Bug

`POST /key/generate` writes the new virtual key to `LiteLLM_VerificationToken` in Postgres but does not populate `user_api_key_cache`. If the very first authenticated request with that key reaches the proxy before the new DB row is visible to whatever connection / replica the auth lookup uses (read-replica replication lag, PgBouncer pooling, etc.), the lookup misses both the cache and the DB and raises HTTP 401 `Authentication Error, Invalid proxy server token passed` / `token_not_found_in_db`. The row exists — the auth lookup just cannot see it yet, and there is no cache entry to bridge the gap.

### Fix

Warm `user_api_key_cache` from inside `_common_key_generation_helper` immediately after the DB upsert, via the existing `_cache_key_object` helper (the same one `get_key_object` already calls after a successful DB lookup). The first authenticated request with the new key then resolves from cache, independent of DB-visibility timing.

- The hashed token used as the cache key is `response.token` (the SHA-256 hash, set on the line just above the warm block as part of the standard `token_id` remap).
- The cached value is `UserAPIKeyAuth(**response.model_dump(exclude_none=True))`, mirroring the construction at `auth_checks.get_key_object` after a DB hit. Pydantic's `extra="ignore"` drops the response-only fields (`key`, `litellm_budget_table`).
- The cache write is `await`ed so it is guaranteed complete before the 200 returns to the client — closing the same-tick race the bug requires.
- Wrapped in `try/except` + `verbose_proxy_logger.exception` so a cache-layer failure (e.g. Redis outage) cannot turn key creation into a 500. The DB row is the source of truth; on failure the endpoint reverts to the pre-fix behavior (cold cache, DB-on-first-auth) without regressing.
- `proxy_server` imports are intentionally local to the `try` block (mirrors the existing pattern further up in the same function for `user_api_key_cache`) — `proxy_server` imports `key_management_endpoints` at startup, so a module-level import would create a circular import.

For multi-worker / multi-replica deployments, `litellm_settings.enable_redis_auth_cache: true` is required for the warmed entry to be visible across processes — `UserApiKeyCache.async_set_cache` propagates to Redis only when Redis is attached to the auth cache at startup.

### Tests

Three new tests added under `tests/test_litellm/`:

- `test_common_key_generation_helper_warms_auth_cache` — asserts `user_api_key_cache.async_set_cache` is awaited with the hashed token and a `UserAPIKeyAuth` payload after a successful `/key/generate`. **This is the regression test; it fails without the fix and passes with it.**
- `test_common_key_generation_helper_cache_warm_is_best_effort` — asserts a cache-layer failure during the warm does not propagate; the endpoint still returns the `GenerateKeyResponse`.
- `test_get_key_object_returns_pre_warmed_entry_without_db_lookup` — asserts a pre-warmed cache entry is served by `get_key_object` without a DB call.

### Backwards compatibility

Pure addition inside `_common_key_generation_helper`. The 200 response shape, the fire-and-forget `async_key_generated_hook`, and `generate_key_helper_fn` are all unchanged. No schema migration, no config change required for single-worker deployments. Rollback is a revert of the single commit.
