### PR TITLE
fix(proxy): skip OpenAI model-override on passthrough httpx.Response

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -455,6 +455,13 @@ def _override_openai_response_model(
         response_obj["model"] = requested_model
         return
 
+    # Passthrough routes (e.g. /bedrock, /anthropic) return the upstream provider's raw
+    # httpx.Response. The response body is already in the provider's native shape and there
+    # is no OpenAI-compatible `model` field on the object to override — skip silently rather
+    # than logging an error for an expected, well-defined response type.
+    if isinstance(response_obj, httpx.Response):
+        return
+
     if not hasattr(response_obj, "model"):
         verbose_proxy_logger.error(
             "%s: cannot override response model; missing `model` attribute. response_type=%s",

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1828,6 +1828,26 @@ class TestOverrideOpenAIResponseModel:
 
         assert response_obj.model == requested_model
 
+    def test_passthrough_httpx_response_is_noop_without_error_log(self, caplog):
+        """
+        Passthrough routes (e.g. /bedrock, /anthropic) return a raw httpx.Response.
+        That object has no `.model` field to override and the body is already in the
+        provider's native shape, so the function should short-circuit silently rather
+        than logging an error.
+        """
+        import logging
+
+        import httpx
+
+        response_obj = httpx.Response(status_code=200)
+        with caplog.at_level(logging.ERROR, logger="LiteLLM Proxy"):
+            _override_openai_response_model(
+                response_obj=response_obj,
+                requested_model="bedrock/claude-sonnet-4-6",
+                log_context="test_context",
+            )
+        assert "cannot override response model" not in caplog.text
+
 
 class TestIsAzureModelRouterRequest:
     """Tests for _is_azure_model_router_request helper"""


### PR DESCRIPTION
## Title

fix(proxy): skip OpenAI model-override on passthrough `httpx.Response`

## Relevant issues

Removes a spurious `cannot override response model; missing model attribute` ERROR log that fires on every successful passthrough request — including the documented Bedrock AIP cost-tracking flow (`/bedrock/model/<arn>/converse`).

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) (Adding at least 1 test is a hard requirement) — see `tests/test_litellm/proxy/test_common_request_processing.py::TestOverrideOpenAIResponseModel::test_passthrough_httpx_response_is_noop_without_error_log`
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`_override_openai_response_model` exists to restamp the client-requested model name on OpenAI-compatible responses (so internal provider-prefixed identifiers don't leak through). The function already gracefully short-circuits when `response_obj` is a `dict` — but on passthrough routes (`/bedrock`, `/anthropic`, etc.) `response_obj` is the upstream provider's raw `httpx.Response`, which has no `model` field to override. The existing fallthrough then logs:

```
LiteLLM Proxy:ERROR: common_request_processing.py:460 - …: cannot override response model;
missing `model` attribute. response_type=<class 'httpx.Response'>
```

This is a known, well-defined response type for passthrough — not an error condition. In a recent prod rollout this single message generated ~25 ERROR-level log lines per minute for normal traffic and added significant noise to alerts/dashboards.

This PR adds an early-return for `httpx.Response`, matching the existing `dict` short-circuit one block above. No functional change — spend tracking, headers, and response forwarding are unaffected; only the false-positive log is silenced.

```diff
     if isinstance(response_obj, dict):
         ...
         response_obj["model"] = requested_model
         return

+    # Passthrough routes (e.g. /bedrock, /anthropic) return the upstream provider's raw
+    # httpx.Response. The response body is already in the provider's native shape and there
+    # is no OpenAI-compatible `model` field on the object to override — skip silently rather
+    # than logging an error for an expected, well-defined response type.
+    if isinstance(response_obj, httpx.Response):
+        return

     if not hasattr(response_obj, "model"):
         verbose_proxy_logger.error(
             "%s: cannot override response model; missing `model` attribute. response_type=%s",
             ...
```

`httpx` is already imported in this module (line 19).