### PR TITLE
feat: add pricing entry for openrouter/google/gemini-3.1-flash-lite

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26951,6 +26951,58 @@
         "supports_web_search": true,
         "tpm": 800000
     },
+    "openrouter/google/gemini-3.1-flash-lite": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_per_audio_token": 5e-08,
+        "input_cost_per_audio_token": 5e-07,
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "openrouter",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65536,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 1.5e-06,
+        "output_cost_per_token": 1.5e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-lite",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": false,
+        "supports_code_execution": true,
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 800000
+    },
     "openrouter/google/gemini-3.1-pro-preview": {
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27121,6 +27121,58 @@
         "supports_web_search": true,
         "tpm": 800000
     },
+    "openrouter/google/gemini-3.1-flash-lite": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_per_audio_token": 5e-08,
+        "input_cost_per_audio_token": 5e-07,
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "openrouter",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65536,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 1.5e-06,
+        "output_cost_per_token": 1.5e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-lite",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": false,
+        "supports_code_execution": true,
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 800000
+    },
     "openrouter/google/gemini-3.1-pro-preview": {
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2371,3 +2371,34 @@ def test_custom_pricing_without_cache_keys_preserves_legacy_behavior():
     expected = 1000 * 0.0000025 + 100 * 0.000015
 
     assert cost == pytest.approx(expected)
+
+
+def test_openrouter_gemini_3_1_flash_lite_stable_pricing():
+    """
+    Test that openrouter/google/gemini-3.1-flash-lite (stable, no -preview suffix)
+    has a pricing entry.
+
+    Google promoted gemini-3.1-flash-lite to GA on 2026-05-07. PR #27933 added the
+    stable pricing for the bare, gemini/, and vertex_ai/ prefixes but missed the
+    openrouter/google/ variant — every other Gemini family in the file has an
+    openrouter/google/ sibling (2.0-flash-001, 2.5-flash, 2.5-pro, 3-flash-preview,
+    3-pro-preview, 3.1-flash-lite-preview, 3.1-pro-preview), so the gap is a
+    consistency issue, not a design choice. Same shape as the preview-variant gap
+    fixed in PR #25610.
+
+    Pricing matches the existing -preview entry one-for-one (input $0.25/M, output
+    $1.50/M, cache-read $0.025/M) — Google did not change costs at the GA cutover.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_name = "openrouter/google/gemini-3.1-flash-lite"
+    model_info = litellm.model_cost.get(model_name)
+
+    assert model_info is not None, f"Missing model pricing entry: {model_name}"
+    assert model_info["litellm_provider"] == "openrouter"
+    assert model_info["input_cost_per_token"] == 2.5e-07
+    assert model_info["output_cost_per_token"] == 1.5e-06
+    assert model_info["cache_read_input_token_cost"] == 2.5e-08
+    assert model_info["max_input_tokens"] == 1048576
+    assert model_info["max_output_tokens"] == 65536


### PR DESCRIPTION
## Relevant issues

Continues the work in #27933 (which added stable pricing for the bare, `gemini/`, and `vertex_ai/` prefixes of `gemini-3.1-flash-lite` but did not include the `openrouter/google/` variant). Addresses the OpenRouter side of the GA cutover requested in issue #27651.

## Linear ticket

External contributor — no Linear ticket.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** — see `test_openrouter_gemini_3_1_flash_lite_stable_pricing` in `tests/test_litellm/test_cost_calculator.py`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem (a single missing `openrouter/google/` prefix for one model)
- [x] Ran `tests/test_litellm/test_cost_calculator.py` locally — 40 passed, no regression in sibling pricing tests
- [ ] My PR passes all unit tests on `make test-unit` — not run locally; deferring to CI (the change is data-only plus one isolated unit test)
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** — Greptile returned **Confidence Score: 5/5** ("Safe to merge — the change is purely additive data with a matching test; no logic paths are touched")

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

```
$ uv run pytest tests/test_litellm/test_cost_calculator.py::test_openrouter_gemini_3_1_flash_lite_stable_pricing tests/test_litellm/test_cost_calculator.py::test_openrouter_gemini_3_1_flash_lite_preview_pricing -v
=================================================== test session starts ===================================================
platform darwin -- Python 3.13.11, pytest-9.0.3, pluggy-1.6.0
collected 2 items

tests/test_litellm/test_cost_calculator.py::test_openrouter_gemini_3_1_flash_lite_preview_pricing PASSED [ 50%]
tests/test_litellm/test_cost_calculator.py::test_openrouter_gemini_3_1_flash_lite_stable_pricing PASSED [100%]

=============================== 2 passed in 0.11s ===============================
```

Full `tests/test_litellm/test_cost_calculator.py` (40 tests) also runs clean — 40 passed, no regression.

### Note on the two unrelated CI failures

The CI run on this PR shows two failures that are pre-existing on `shin_agent_oss_staging_05_19_2026` and unrelated to this diff:

- `misc / Run tests` → `tests/test_litellm/interactions/test_openapi_compliance.py::TestResponseCompliance::test_status_enum_values` — expected enum list misses `'budget_exceeded'` (which is present in the real `Interaction.status` schema). Reproduced locally on the base branch with this PR's changes reverted; the test/schema mismatch exists independently of this PR. File path is `tests/test_litellm/interactions/`, not the `tests/test_litellm/test_cost_calculator.py` this PR touches.
- `core-utils / Run tests` → `tests/test_litellm/litellm_core_utils/test_token_counter.py::test_img_url_token_counter[https://blog.purpureus.net/.../simplified-asset-graph.jpg]` — `ValueError: not enough values to unpack (expected 2, got 1)` while fetching an external image URL. The other parameterized URLs in the same test pass locally — looks like a flake on that one URL's fetch / image decode. Outside the code paths this PR touches.

This PR modifies only `model_prices_and_context_window.json`, `litellm/model_prices_and_context_window_backup.json`, and `tests/test_litellm/test_cost_calculator.py` — none of which sit in the failing tests' code paths.

## Type

🆕 New Feature

## Changes

Adds `openrouter/google/gemini-3.1-flash-lite` (the GA stable model id, no `-preview` suffix) to `model_prices_and_context_window.json` and its `litellm/model_prices_and_context_window_backup.json` counterpart, with a matching unit test in `tests/test_litellm/test_cost_calculator.py`. The new entry is identical in shape to the existing `openrouter/google/gemini-3.1-flash-lite-preview` row — same prices, same capability flags, same modalities — only the model id differs (preview suffix dropped) and the `source` URL is updated to the current Google pricing anchor that the other stable entries from #27933 already use.

Google promoted `gemini-3.1-flash-lite` to general availability on 2026-05-07 — see the [Firebase AI Logic models page](https://firebase.google.com/docs/ai-logic/models) ("`gemini-3.1-flash-lite`: Stable version of Gemini 3.1 Flash‑Lite, Stable, 2026-05-07") and the [OpenRouter listing](https://openrouter.ai/google/gemini-3.1-flash-lite) ("Released May 7, 2026"). PR #27933 added the stable pricing rows for three of the four prefixes the file tracks for Gemini models (bare name, `gemini/`, `vertex_ai/`) but did not add the `openrouter/google/` variant. Every other Gemini family in the file has an `openrouter/google/` sibling — `gemini-2.0-flash-001`, `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview` — so the gap is a consistency issue, not a design choice. Without this entry, calls routed through OpenRouter using the stable model id raise `ValueError: This model isn't mapped yet` during router pre-call checks, the same failure mode that PR #25610 fixed for the preview variant.

Pricing matches the preview entry one-for-one: input `$0.25` per 1M tokens (`2.5e-07`), output `$1.50` per 1M tokens (`1.5e-06`), cache-read `$0.025` per 1M tokens (`2.5e-08`), no cache-creation charge (`0.0`). Sources for each value: the [Google blog post that originally announced the model on 2026-03-03](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-lite/) ("Priced at $0.25/1M input tokens and $1.50/1M output tokens"), the [current Google API pricing page](https://ai.google.dev/gemini-api/docs/pricing) ("Context caching price ... $0.025 (text / image / video)"), the [OpenRouter listing](https://openrouter.ai/google/gemini-3.1-flash-lite) ("Input Price $0.25 per 1M ; Output Price $1.50 per 1M"), and the values used in PR #27933 for the three stable prefixes it added. Google did not change costs at the GA cutover — preview and stable share the same numbers — so this PR is genuinely a one-for-one mirror.

The unit test (`test_openrouter_gemini_3_1_flash_lite_stable_pricing`) follows the structure of the existing `test_openrouter_gemini_3_1_flash_lite_preview_pricing` from PR #25610 — same env-flag setup, same lookup pattern, same assertion shape, with one extra assertion on `cache_read_input_token_cost` since this PR also documents the cache-read value.
