### PR TITLE
fix: prevent mutation of fallback config dict in completion_with_fallbacks

### DIFF
--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -47,8 +47,9 @@ async def async_completion_with_fallbacks(**kwargs):
             completion_kwargs = safe_deep_copy(base_kwargs)
             # Handle dictionary fallback configurations
             if isinstance(fallback, dict):
-                model = fallback.pop("model", original_model)
-                completion_kwargs.update(fallback)
+                fallback_copy = safe_deep_copy(fallback)
+                model = fallback_copy.pop("model", original_model)
+                completion_kwargs.update(fallback_copy)
             else:
                 model = fallback
 

--- a/tests/test_litellm/test_fallback_utils.py
+++ b/tests/test_litellm/test_fallback_utils.py
@@ -1,0 +1,55 @@
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.fallback_utils import async_completion_with_fallbacks
+
+
+@pytest.mark.asyncio
+async def test_dict_fallback_does_not_mutate_original():
+    """Reusing the same fallback dict across calls must not lose the model key."""
+    fallback = {"model": "gpt-4o-mini", "temperature": 0.5}
+    fallback_original_copy = dict(fallback)
+
+    mock_response = AsyncMock()
+    mock_response.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    with patch("litellm.acompletion", new=mock_response):
+        await async_completion_with_fallbacks(
+            model="gpt-4o",
+            kwargs={"fallbacks": [fallback]},
+        )
+        # Original fallback dict must be unchanged after the call
+        assert fallback == fallback_original_copy, (
+            "fallback dict was mutated: "
+            f"expected {fallback_original_copy}, got {fallback}"
+        )
+
+        # Second call with the same dict must still work (model key still present)
+        await async_completion_with_fallbacks(
+            model="gpt-4o",
+            kwargs={"fallbacks": [fallback]},
+        )
+        assert fallback == fallback_original_copy
+
+
+@pytest.mark.asyncio
+async def test_dict_fallback_nested_mutable_not_mutated():
+    """Nested mutable values in the fallback dict must not be modified."""
+    extra_headers = {"X-Custom": "value"}
+    fallback = {"model": "gpt-4o-mini", "extra_headers": extra_headers}
+
+    mock_response = AsyncMock()
+    mock_response.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    with patch("litellm.acompletion", new=mock_response):
+        await async_completion_with_fallbacks(
+            model="gpt-4o",
+            kwargs={"fallbacks": [fallback]},
+        )
+        assert fallback["model"] == "gpt-4o-mini"
+        assert fallback["extra_headers"] is extra_headers


### PR DESCRIPTION
## Problem

`async_completion_with_fallbacks` calls `.pop("model")` directly on the fallback dict passed by the caller. This mutates the original config in-place, so subsequent calls using the same fallback config lose the `model` key and fall back to the primary (failed) model.

## Fix

Copy the fallback dict before popping from it:

```python
# Before
model = fallback.pop("model", original_model)

# After
fallback_copy = fallback.copy()
model = fallback_copy.pop("model", original_model)
```

## Impact

Affects all applications that reuse fallback configs across multiple calls (common in agent frameworks and retry logic).

Fixes #28251