### PR TITLE
docs(gemini-agents): fix misleading credential-passing examples in GET/DELETE docstrings

### DIFF
--- a/litellm/proxy/google_endpoints/agents_endpoints.py
+++ b/litellm/proxy/google_endpoints/agents_endpoints.py
@@ -187,11 +187,13 @@ async def list_gemini_agents(
     """
     List all custom agents on the Gemini side.
 
-    Pass per-request Gemini credentials via ``litellm_params_template``
-    (JSON-encoded) or as flat query parameters:
+    Pass per-request Gemini credentials via the JSON-encoded
+    ``litellm_params_template`` query parameter. Flat query parameters
+    (e.g. ``?api_key=AIza...``) are intentionally ignored — see
+    ``_merge_query_params_into_data`` for the rationale.
 
     ```bash
-    curl "http://localhost:4000/v1beta/agents?api_key=AIza..." \\
+    curl "http://localhost:4000/v1beta/agents?litellm_params_template=%7B%22api_key%22%3A%22AIza...%22%7D" \\
         -H "Authorization: Bearer sk-..."
     ```
     """
@@ -242,11 +244,13 @@ async def get_gemini_agent(
     """
     Get a specific custom agent by name.
 
-    Pass per-request Gemini credentials via ``litellm_params_template``
-    (JSON-encoded) or as flat query parameters:
+    Pass per-request Gemini credentials via the JSON-encoded
+    ``litellm_params_template`` query parameter. Flat query parameters
+    (e.g. ``?api_key=AIza...``) are intentionally ignored — see
+    ``_merge_query_params_into_data`` for the rationale.
 
     ```bash
-    curl "http://localhost:4000/v1beta/agents/my-custom-slides-agent?api_key=AIza..." \\
+    curl "http://localhost:4000/v1beta/agents/my-custom-slides-agent?litellm_params_template=%7B%22api_key%22%3A%22AIza...%22%7D" \\
         -H "Authorization: Bearer sk-..."
     ```
     """
@@ -297,11 +301,13 @@ async def delete_gemini_agent(
     """
     Delete a custom agent by name.
 
-    Pass per-request Gemini credentials via ``litellm_params_template``
-    (JSON-encoded) or as flat query parameters:
+    Pass per-request Gemini credentials via the JSON-encoded
+    ``litellm_params_template`` query parameter. Flat query parameters
+    (e.g. ``?api_key=AIza...``) are intentionally ignored — see
+    ``_merge_query_params_into_data`` for the rationale.
 
     ```bash
-    curl -X DELETE "http://localhost:4000/v1beta/agents/my-custom-slides-agent?api_key=AIza..." \\
+    curl -X DELETE "http://localhost:4000/v1beta/agents/my-custom-slides-agent?litellm_params_template=%7B%22api_key%22%3A%22AIza...%22%7D" \\
         -H "Authorization: Bearer sk-..."
     ```
     """
@@ -352,11 +358,13 @@ async def list_gemini_agent_versions(
     """
     List versions of a custom agent.
 
-    Pass per-request Gemini credentials via ``litellm_params_template``
-    (JSON-encoded) or as flat query parameters:
+    Pass per-request Gemini credentials via the JSON-encoded
+    ``litellm_params_template`` query parameter. Flat query parameters
+    (e.g. ``?api_key=AIza...``) are intentionally ignored — see
+    ``_merge_query_params_into_data`` for the rationale.
 
     ```bash
-    curl "http://localhost:4000/v1beta/agents/my-custom-slides-agent/versions?api_key=AIza..." \\
+    curl "http://localhost:4000/v1beta/agents/my-custom-slides-agent/versions?litellm_params_template=%7B%22api_key%22%3A%22AIza...%22%7D" \\
         -H "Authorization: Bearer sk-..."
     ```
     """


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Follow-up to #28270.

## Summary

The four GET/DELETE endpoint docstrings in `litellm/proxy/google_endpoints/agents_endpoints.py` actively direct callers to a non-functional pattern: they document passing per-request Gemini credentials as flat query parameters (e.g. `?api_key=AIza...`), but `_merge_query_params_into_data` only reads the JSON-encoded `litellm_params_template` query parameter and intentionally ignores flat params.

The `_merge_query_params_into_data` docstring itself already warns:

> Credentials MUST NOT be passed as plain flat query parameters (e.g. `?api_key=AIza...`) because URL query strings appear verbatim in web-server access logs, CDN edge logs, browser history, and Referer headers.

Callers following the documented `curl` examples in `list_gemini_agents`, `get_gemini_agent`, `delete_gemini_agent`, and `list_gemini_agent_versions` would have their credentials silently dropped and hit authentication failures against Gemini.

## Change

Docstring-only fix. The credential-passing examples now use the JSON-encoded `litellm_params_template` query parameter, matching the implementation and the helper's own docstring:

```bash
curl "http://localhost:4000/v1beta/agents?litellm_params_template=%7B%22api_key%22%3A%22AIza...%22%7D" \
    -H "Authorization: Bearer sk-..."
```

No behavioral changes; no test changes needed.

## Type

📖 Documentation
🐛 Bug Fix (documentation defect)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1779228647835919?thread_ts=1779228647.835919&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-0b1b2b36-fa69-59d1-96fb-4674873fcf34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b1b2b36-fa69-59d1-96fb-4674873fcf34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

