### PR TITLE
fix(fallbacks): copy fallback dict before pop to avoid mutating caller config

### DIFF
--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -47,8 +47,9 @@ async def async_completion_with_fallbacks(**kwargs):
             completion_kwargs = safe_deep_copy(base_kwargs)
             # Handle dictionary fallback configurations
             if isinstance(fallback, dict):
-                model = fallback.pop("model", original_model)
-                completion_kwargs.update(fallback)
+                fallback_copy = dict(fallback)  # avoid mutating caller's dict
+                model = fallback_copy.pop("model", original_model)
+                completion_kwargs.update(fallback_copy)
             else:
                 model = fallback
 


### PR DESCRIPTION
## Description

Fixes #28251

`async_completion_with_fallbacks` called `fallback.pop("model", original_model)` directly on the dict from the caller's fallbacks list, permanently removing the `"model"` key. On the second call with the same fallback configuration, the model name was gone, causing the fallback to silently use `original_model` for all subsequent fallbacks rather than the configured one.

## Root Cause

```python
# BEFORE (buggy) — mutates caller's dict
if isinstance(fallback, dict):
    model = fallback.pop("model", original_model)  # removes "model" from original
    completion_kwargs.update(fallback)
```

## Fix

Copy the fallback dict before extracting the model key:

```python
# AFTER (fixed) — caller's dict untouched
if isinstance(fallback, dict):
    fallback_copy = dict(fallback)          # shallow copy, caller's list unchanged
    model = fallback_copy.pop("model", original_model)
    completion_kwargs.update(fallback_copy)
```

## Verification

```python
import litellm

fallbacks = [{"model": "gpt-3.5-turbo", "api_key": "sk-test"}]

# First call: works correctly (fallback["model"] == "gpt-3.5-turbo")
# Second call: previously would silently fall back to original_model
#              because fallback["model"] was already popped
# After fix: both calls correctly use "gpt-3.5-turbo" from the fallback config
```
