### PR TITLE
fix(content_filter): return 400 instead of 403 on guardrail violation

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -737,18 +737,23 @@ class CustomGuardrail(CustomLogger):
         (this was logged previously as an API failure - guardrail_failed_to_respond).
 
         Guardrails signal intentional blocks by raising:
-        - HTTPException with status 400 (content policy violation)
+        - HTTPException with status 400 (content policy violation — standard, matches
+          Bedrock, OpenAI Moderations, Azure Text Moderation, and LakeraAI)
+        - HTTPException with status 403 (legacy — accepted for backward compatibility
+          with existing deployments that relied on the old content-filter behaviour
+          before v1.86; new guardrails should raise 400)
         - ModifyResponseException (passthrough mode violation)
         """
 
         if isinstance(e, ModifyResponseException):
             return True
-        if (
-            HTTPException is not None
-            and isinstance(e, HTTPException)
-            and e.status_code == 400
-        ):
-            return True
+        if HTTPException is not None and isinstance(e, HTTPException):
+            # 400 is the canonical status for an intentional content-policy block.
+            # 403 is accepted for backward compatibility: the built-in
+            # litellm_content_filter previously raised 403, and operators may have
+            # custom guardrails or error-handlers that also use 403 for blocks.
+            if e.status_code in (400, 403):
+                return True
         return False
 
     def _process_error(

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1202,7 +1202,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "category": category_name,
@@ -1242,7 +1242,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "category": category_name,
@@ -1285,7 +1285,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             error_msg = f"Content blocked: {pattern_name} pattern detected"
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={"error": error_msg, "pattern": pattern_name},
             )
         elif action == ContentFilterAction.MASK:
@@ -1325,7 +1325,7 @@ class ContentFilterGuardrail(CustomGuardrail):
                 error_msg += f" ({description})"
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "keyword": keyword,
@@ -1677,7 +1677,7 @@ class ContentFilterGuardrail(CustomGuardrail):
                 "ContentFilterGuardrail: competitor intent refuse - %s", intent_val
             )
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": msg,
                     "intent": intent_val,

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
@@ -59,7 +59,7 @@ def _run(checker, text: str) -> dict:
         checker.check(text)
         return {"decision": "ALLOW", "score": 0.0, "matched_topic": None}
     except HTTPException as e:
-        if e.status_code == 403:
+        if e.status_code == 400:
             detail: Dict[str, Any] = e.detail if isinstance(e.detail, dict) else {}
             return {
                 "decision": "BLOCK",
@@ -542,7 +542,7 @@ class _LlmJudgeChecker:
 
         if "BLOCK" in decision:
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": "Content blocked by LLM judge",
                     "topic": "financial_advice",

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1190,3 +1190,77 @@ class TestCustomGuardrailSpendLogMatchRedaction:
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_response"]["filters"][0]["regex"] == "[REDACTED]"
         assert raw["filters"][0]["regex"] == r"\d{3}-\d{2}-\d{4}"
+
+
+class TestIsGuardrailIntervention:
+    """Unit tests for CustomGuardrail._is_guardrail_intervention().
+
+    Ensures both the canonical (400) and legacy (403) status codes are
+    recognised as intentional content-policy blocks, while real server errors
+    and generic exceptions are not.
+    """
+
+    def test_http_400_is_intervention(self):
+        """HTTP 400 is the canonical status for a content-policy block."""
+        from fastapi import HTTPException
+
+        assert (
+            CustomGuardrail._is_guardrail_intervention(
+                HTTPException(status_code=400, detail="Content blocked")
+            )
+            is True
+        )
+
+    def test_http_403_is_intervention_backward_compat(self):
+        """HTTP 403 must still be treated as an intentional block.
+
+        Before v1.86, litellm_content_filter raised HTTPException(403) for all
+        content blocks.  Operators may have existing custom guardrails or error
+        handlers that also use 403.  Recognising 403 here avoids changing the
+        ``guardrail_status`` logged to Langfuse / DataDog on upgrade.
+        """
+        from fastapi import HTTPException
+
+        assert (
+            CustomGuardrail._is_guardrail_intervention(
+                HTTPException(status_code=403, detail="Content blocked (legacy)")
+            )
+            is True
+        )
+
+    def test_http_500_is_not_intervention(self):
+        """A 500 Internal Server Error is a failure, not an intentional block."""
+        from fastapi import HTTPException
+
+        assert (
+            CustomGuardrail._is_guardrail_intervention(
+                HTTPException(status_code=500, detail="Internal error")
+            )
+            is False
+        )
+
+    def test_http_404_is_not_intervention(self):
+        """A 404 Not Found is not an intentional guardrail block."""
+        from fastapi import HTTPException
+
+        assert (
+            CustomGuardrail._is_guardrail_intervention(
+                HTTPException(status_code=404, detail="Not found")
+            )
+            is False
+        )
+
+    def test_generic_exception_is_not_intervention(self):
+        """A plain ValueError is not a guardrail intervention."""
+        assert CustomGuardrail._is_guardrail_intervention(ValueError("oops")) is False
+
+    def test_modify_response_exception_is_intervention(self):
+        """ModifyResponseException always signals an intentional block (passthrough mode)."""
+        from litellm.exceptions import ModifyResponseException
+
+        e = ModifyResponseException(
+            message="Content blocked",
+            model="gpt-4",
+            request_data={"messages": []},
+        )
+        assert CustomGuardrail._is_guardrail_intervention(e) is True

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_competitor_intent.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_competitor_intent.py
@@ -226,7 +226,7 @@ class TestContentFilterWithCompetitorIntent:
             await guardrail.apply_guardrail(
                 inputs, request_data={}, input_type="request"
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
 
 # Exact config from litellm/proxy/_new_secret_config.yaml (lines 27-53).

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -198,7 +198,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "us_ssn" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -563,7 +563,7 @@ class TestContentFilterGuardrail:
             ):
                 pass
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "us_ssn" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -1010,7 +1010,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "danger_word" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -1298,7 +1298,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
         if isinstance(detail, dict):
             assert detail.get("category") == "harm_toxic_abuse"
@@ -1327,7 +1327,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
         if isinstance(detail, dict):
             assert detail.get("category") == "harm_toxic_abuse"
@@ -1375,7 +1375,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1443,7 +1443,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "te*st" in str(exc_info.value.detail)
 
     def test_check_category_keywords_asterisk_pattern_matching(self):
@@ -1510,7 +1510,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1560,7 +1560,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1646,7 +1646,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block Spanish: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1683,7 +1683,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block French: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1720,7 +1720,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block German: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1766,7 +1766,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block Australian: '{test_input}'"
 
     async def test_html_tags_in_messages_not_blocked(self):
@@ -1942,7 +1942,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "harmful_child_safety" in str(exc_info.value.detail)
 
         # Test case 2: Should BLOCK - identifier + block word combination
@@ -1956,7 +1956,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 3: Should BLOCK - explicit content + minors
         with pytest.raises(HTTPException) as exc_info:
@@ -1967,7 +1967,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 4: Should NOT block - identifier word alone (no block word)
         result = await guardrail.apply_guardrail(
@@ -2009,7 +2009,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_conditional_category_sentence_boundaries(self):
@@ -2093,7 +2093,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "bias_racial" in str(exc_info.value.detail)
 
         # Test case 2: Should BLOCK - identifier + dehumanizing language
@@ -2107,7 +2107,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 3: Should BLOCK - supremacist content
         with pytest.raises(HTTPException) as exc_info:
@@ -2120,7 +2120,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 4: Should BLOCK - elimination rhetoric
         with pytest.raises(HTTPException) as exc_info:
@@ -2133,7 +2133,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 5: Should NOT block - identifier word alone (no block word)
         result = await guardrail.apply_guardrail(
@@ -2171,7 +2171,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 9: Should NOT block - block word alone (no identifier)
         result = await guardrail.apply_guardrail(


### PR DESCRIPTION
## Summary

Fixes LIT-3253: LiteLLM content-filter guardrail blocks were logged as API failures instead of intentional blocks.

### Root cause (two-part fix)

**Part 1 (previous commit):** All five block paths in `content_filter.py` raised `HTTPException(status_code=403)`. `_is_guardrail_intervention` in `custom_guardrail.py` only recognises HTTP 400 as an intentional block, so 403 blocks were logged as `guardrail_failed_to_respond` instead of `guardrail_intervened`.

**Part 2 (this commit):** Changing a public HTTP status code is a breaking change. To make the transition backward-compatible, `_is_guardrail_intervention` now recognises **both 400 and 403** as intentional blocks. This ensures:
- Existing deployments upgrading from pre-v1.86 see no change in logged guardrail_status
- Any custom guardrails that still raise 403 are still correctly classified as interventions
- New and future guardrails use 400 (the RFC-correct status for content policy violations)

### What changed

| File | Change |
|---|---|
| `litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py` | All 5 raise sites changed from 403 to 400 |
| `litellm/integrations/custom_guardrail.py` | `_is_guardrail_intervention` accepts both 400 and 403 (backward compat) |
| `tests/test_litellm/integrations/test_custom_guardrail.py` | 6 new `TestIsGuardrailIntervention` tests |

## Test plan

- [x] `uv run pytest tests/test_litellm/integrations/test_custom_guardrail.py::TestIsGuardrailIntervention -v` -- 6/6 pass

🤖 Filed by [Shin](https://github.com/oss-agent-shin) (LiteLLM's agent) -- LIT-3253