### PR TITLE
feat(proxy): add `scim_routes` route group for SCIM-only virtual keys

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -457,6 +457,32 @@ class LiteLLMRoutes(enum.Enum):
     # allowed_routes=["mcp_routes"], which should cover both halves.
     mcp_routes = mcp_inference_routes + mcp_management_routes
 
+    # SCIM v2 (Enterprise) — provisioning routes for users and groups. Used by
+    # virtual keys minted exclusively for an IdP's SCIM connector, e.g.
+    # `allowed_routes=["scim_routes"]` with no models attached so the key
+    # cannot call /chat/completions or any other LLM surface.
+    # Keep in sync with the FastAPI routes registered on `scim_router` in
+    # litellm/proxy/management_endpoints/scim/scim_v2.py.
+    scim_routes = [
+        # discovery / config
+        "/scim/v2",
+        "/scim/v2/ResourceTypes",
+        "/scim/v2/ResourceTypes/{resource_type_id}",
+        "/scim/v2/Schemas",
+        # SCIM schema IDs are URNs (e.g. urn:ietf:params:scim:schemas:core:2.0:User)
+        # whose ':' characters defeat the `{var:path}` placeholder regex used by
+        # RouteChecks._route_matches_pattern. Use a wildcard so every schema id
+        # — including URN-style ones — is accepted by check_route_access.
+        "/scim/v2/Schemas/*",
+        "/scim/v2/ServiceProviderConfig",
+        # users
+        "/scim/v2/Users",
+        "/scim/v2/Users/{user_id}",
+        # groups
+        "/scim/v2/Groups",
+        "/scim/v2/Groups/{group_id}",
+    ]
+
     agent_routes = [
         "/v1/agents",
         "/v1/agents/{agent_id}",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -284,6 +284,82 @@ def test_mcp_inference_routes_classified_as_llm_api(route):
     assert RouteChecks.is_management_route(route=route) is False
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/scim/v2",
+        "/scim/v2/ServiceProviderConfig",
+        "/scim/v2/ResourceTypes",
+        "/scim/v2/ResourceTypes/User",
+        "/scim/v2/Schemas",
+        "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+        "/scim/v2/Users",
+        "/scim/v2/Users/abc-123",
+        "/scim/v2/Groups",
+        "/scim/v2/Groups/team-uuid-abc-123",
+    ],
+)
+def test_virtual_key_scim_routes_allows_all_scim_endpoints(route):
+    """A key minted for an IdP's SCIM connector with allowed_routes=['scim_routes']
+    must be able to call every endpoint registered on the SCIM v2 router —
+    discovery, users, and groups, including templated paths with {user_id} /
+    {group_id} / {resource_type_id} / {schema_id:path}.
+    """
+
+    valid_token = UserAPIKeyAuth(
+        user_id="scim_service_account",
+        allowed_routes=["scim_routes"],
+    )
+
+    assert (
+        RouteChecks.is_virtual_key_allowed_to_call_route(
+            route=route, valid_token=valid_token
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "blocked_route",
+    [
+        # llm api surfaces — the whole point of a SCIM-only key is "no model access"
+        "/chat/completions",
+        "/v1/chat/completions",
+        "/completions",
+        "/v1/completions",
+        "/embeddings",
+        "/v1/embeddings",
+        "/v1/messages",
+        "/anthropic/v1/messages",
+        # other management surfaces a SCIM connector has no business hitting
+        "/key/generate",
+        "/team/new",
+        "/user/new",
+        "/model/new",
+    ],
+)
+def test_virtual_key_scim_routes_blocks_non_scim_routes(blocked_route):
+    """A key with allowed_routes=['scim_routes'] must NOT be able to call
+    /chat/completions, /v1/messages, or any non-SCIM route — even though the
+    key's `models` list may be empty (which otherwise means 'all models').
+    Route-level restriction is what enforces 'no model access'.
+    """
+
+    valid_token = UserAPIKeyAuth(
+        user_id="scim_service_account",
+        allowed_routes=["scim_routes"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        RouteChecks.is_virtual_key_allowed_to_call_route(
+            route=blocked_route, valid_token=valid_token
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "Virtual key is not allowed to call this route" in str(exc_info.value.detail)
+    assert f"Tried to call route: {blocked_route}" in str(exc_info.value.detail)
+
+
 def test_virtual_key_allowed_routes_with_litellm_routes_member_name_denied():
     """Test that virtual key is denied when route is not in the allowed LiteLLMRoutes group"""
 


### PR DESCRIPTION
## Summary

Lets a virtual key be minted that **only** has access to the SCIM v2 routes and **no model access** — the canonical setup for an IdP's SCIM connector that needs to provision users/groups but should never be able to call `/chat/completions`.

- Adds `LiteLLMRoutes.scim_routes` enumerating the endpoints registered on `scim_router` in `litellm/proxy/management_endpoints/scim/scim_v2.py` (discovery, `/scim/v2/Users/*`, `/scim/v2/Groups/*`).
- `RouteChecks.is_virtual_key_allowed_to_call_route` already resolves `LiteLLMRoutes` member names via `LiteLLMRoutes._member_names_` (see [`route_checks.py:108-118`](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/auth/route_checks.py#L108-L118)), so no logic change is needed — adding the group to the enum is enough.
- The "no model access" guarantee comes from the route layer: `/v1/chat/completions` isn't in `scim_routes`, so the auth check 403s the request before `models` is ever consulted. Setting `models=[]` (which normally means "all models") on a SCIM-only key is therefore safe.

## Usage

```bash
curl -X POST https://your-proxy/key/generate \
  -H "Authorization: Bearer sk-master-key" \
  -H "Content-Type: application/json" \
  -d '{
    "key_alias": "okta-scim-connector",
    "allowed_routes": ["scim_routes"],
    "models": []
  }'
```

The returned key can call every `/scim/v2/...` endpoint and is 403'd on every other route.

## Test plan

Backend-only change. Proof comes from unit tests against the production code path and a direct invocation of the same function the proxy runs on every request (no PostgreSQL available in this sandbox).

- [x] `uv run pytest tests/test_litellm/proxy/auth/test_route_checks.py` — **290 passed**, including 22 new parametrized SCIM cases:
  - `test_virtual_key_scim_routes_allows_all_scim_endpoints` — 10 cases covering `/scim/v2`, `/scim/v2/ServiceProviderConfig`, `/scim/v2/ResourceTypes`, `/scim/v2/ResourceTypes/{id}`, `/scim/v2/Schemas`, `/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User` (URN), `/scim/v2/Users`, `/scim/v2/Users/{id}`, `/scim/v2/Groups`, `/scim/v2/Groups/{id}`
  - `test_virtual_key_scim_routes_blocks_non_scim_routes` — 12 cases covering `/chat/completions`, `/v1/chat/completions`, `/completions`, `/v1/completions`, `/embeddings`, `/v1/embeddings`, `/v1/messages`, `/anthropic/v1/messages`, plus management surfaces (`/key/generate`, `/team/new`, `/user/new`, `/model/new`)
- [x] Direct invocation of `RouteChecks.is_virtual_key_allowed_to_call_route(route, valid_token)` with `UserAPIKeyAuth(allowed_routes=["scim_routes"], models=[])` — the same function the proxy calls on every request. Output:

```
Virtual key under test: allowed_routes=['scim_routes']
                          models=[]

PART 1 — SCIM endpoints (must be ALLOWED)
  PASS  → True  /scim/v2
  PASS  → True  /scim/v2/ServiceProviderConfig
  PASS  → True  /scim/v2/ResourceTypes
  PASS  → True  /scim/v2/ResourceTypes/User
  PASS  → True  /scim/v2/Schemas
  PASS  → True  /scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User
  PASS  → True  /scim/v2/Users
  PASS  → True  /scim/v2/Users/91ac2c2f-9b07-4f72-b8ed-e75a8da00f50
  PASS  → True  /scim/v2/Groups
  PASS  → True  /scim/v2/Groups/team-id-okta-engineering

PART 2 — LLM / management routes (must be DENIED with 403)
  PASS  → 403 Forbidden  /chat/completions
  PASS  → 403 Forbidden  /v1/chat/completions
  PASS  → 403 Forbidden  /completions
  PASS  → 403 Forbidden  /v1/completions
  PASS  → 403 Forbidden  /embeddings
  PASS  → 403 Forbidden  /v1/embeddings
  PASS  → 403 Forbidden  /v1/messages
  PASS  → 403 Forbidden  /anthropic/v1/messages
  PASS  → 403 Forbidden  /v1/responses
  PASS  → 403 Forbidden  /audio/transcriptions
  PASS  → 403 Forbidden  /key/generate
  PASS  → 403 Forbidden  /team/new
  PASS  → 403 Forbidden  /user/new
  PASS  → 403 Forbidden  /model/new

All assertions passed.
```

## Notes

- The `/scim/v2/Schemas/*` wildcard entry (instead of `/scim/v2/Schemas/{schema_id:path}`) is intentional and documented inline: SCIM schema IDs are URNs like `urn:ietf:params:scim:schemas:core:2.0:User`, and the `{var:path}` placeholder regex in `RouteChecks._route_matches_pattern` emits `[^:]+`, which rejects URNs. The wildcard avoids that pre-existing limitation without changing the matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)