### PR TITLE
fix(proxy): clear budget_duration and budget_reset_at when explicitly set to null

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1842,6 +1842,10 @@ async def prepare_key_update_data(
             key_reset_at = get_budget_reset_time(budget_duration=budget_duration)
             non_default_values["budget_reset_at"] = key_reset_at
             non_default_values["budget_duration"] = budget_duration
+        else:
+            # budget_duration explicitly set to null: clear the field and reset time
+            non_default_values["budget_duration"] = None
+            non_default_values["budget_reset_at"] = None
 
     if "budget_limits" in non_default_values and non_default_values["budget_limits"]:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1881,11 +1881,16 @@ async def update_team(  # noqa: PLR0915
 
 def _set_budget_reset_at(data: UpdateTeamRequest, updated_kv: dict) -> None:
     """Set budget_reset_at in updated_kv if budget_duration is provided."""
+    if "budget_duration" not in data.model_fields_set:
+        return
     if data.budget_duration is not None:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
         reset_at = get_budget_reset_time(budget_duration=data.budget_duration)
         updated_kv["budget_reset_at"] = reset_at
+    else:
+        # budget_duration explicitly set to null: clear the field and reset time
+        updated_kv["budget_reset_at"] = None
 
     if data.budget_limits is not None and len(data.budget_limits) > 0:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time


### PR DESCRIPTION
## Description

Fixes #27734

Sending `budget_duration: null` via `/key/update` or `/team/update` returned 200 OK but silently left the existing value unchanged, making it impossible to clear a budget duration once set.

## Root cause

**`/key/update` (`prepare_key_update_data`):**

```python
if "budget_duration" in non_default_values:
    budget_duration = non_default_values.pop("budget_duration")
    if budget_duration and isinstance(budget_duration, str) ...:   # None is falsy
        non_default_values["budget_duration"] = budget_duration
        non_default_values["budget_reset_at"] = ...
    # ← no else: budget_duration=None is dropped, never written to DB
```

**`/team/update` (`_set_budget_reset_at`):**

```python
def _set_budget_reset_at(data, updated_kv):
    if data.budget_duration is not None:    # None: function returns without touching updated_kv
        updated_kv["budget_reset_at"] = ...
    # ← budget_reset_at is never cleared when budget_duration is set to null
```

## Fix

**Key update**: add an `else` branch that explicitly writes `budget_duration=None` and `budget_reset_at=None` into `non_default_values` so the DB update carries the clear.

**Team update**: guard with `if "budget_duration" not in data.model_fields_set: return` to skip unset fields, then add an `else` branch to clear `budget_reset_at` when `budget_duration` is explicitly nulled.

## Verification

```bash
# Create key with budget_duration
curl -X POST http://localhost:4000/key/generate   -d '{"max_budget": 100, "budget_duration": "30d"}'

# Clear budget_duration
curl -X POST http://localhost:4000/key/update   -d '{"key": "sk-...", "budget_duration": null}'

# Verify budget_duration is now null, budget_reset_at is null
curl http://localhost:4000/key/info?key=sk-...
# Before fix: "budget_duration": "30d"  ← still set
# After fix:  "budget_duration": null   ← cleared
```
