### PR TITLE
fix(exceptions): guard int() cast in MidStreamFallbackError for non-numeric status_code

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -955,7 +955,10 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         is_pre_first_chunk: bool = False,
     ):
         original_status = getattr(original_exception, "status_code", None)
-        self.status_code = int(original_status) if original_status is not None else 503
+        try:
+            self.status_code = int(original_status) if original_status is not None else 503
+        except (ValueError, TypeError):
+            self.status_code = 503
         self.message = f"litellm.MidStreamFallbackError: {message}"
         self.model = model
         self.llm_provider = llm_provider
@@ -997,7 +1000,10 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         )
 
         # Restore the propagated status and original response/request objects
-        self.status_code = int(original_status) if original_status is not None else 503
+        try:
+            self.status_code = int(original_status) if original_status is not None else 503
+        except (ValueError, TypeError):
+            self.status_code = 503
         self.response = _saved_response
         self.request = _saved_request
         self.message = _saved_message


### PR DESCRIPTION
## Description

Fixes #26913

`MidStreamFallbackError.__init__` calls `int(original_status)` to set `self.status_code`, where `original_status = getattr(original_exception, "status_code", None)`. When the original exception's `status_code` is a non-numeric string (e.g. `'litellm_error'`), this raises `ValueError: invalid literal for int() with base 10: 'litellm_error'`, crashing the exception constructor and returning HTTP 500 to the caller instead of triggering the fallback chain.

## Root cause

In `litellm/exceptions.py`, the pattern appears twice:
```python
self.status_code = int(original_status) if original_status is not None else 503
```

`CustomLLM` handlers that raise `RateLimitError` (or other exceptions) may not set a numeric `status_code`, leaving the attribute as a sentinel string.

## Fix

Wrap both occurrences in a `try/except (ValueError, TypeError)` that falls back to `503`:

```python
try:
    self.status_code = int(original_status) if original_status is not None else 503
except (ValueError, TypeError):
    self.status_code = 503
```

## Verification

```python
from litellm import CustomLLM, RateLimitError
from litellm.exceptions import MidStreamFallbackError

exc = RateLimitError(message="exhausted", model="m", llm_provider="openai")
# RateLimitError.status_code defaults to 429 (numeric) — works fine

# Simulate a non-numeric status_code
exc.status_code = "litellm_error"
mfe = MidStreamFallbackError(
    message="test", model="m", llm_provider="custom",
    original_exception=exc
)
assert mfe.status_code == 503   # before fix: raises ValueError
```
