### PR TITLE
fix(embedding): normalize list encoding_format from model config to first element

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4809,6 +4809,8 @@ def embedding(  # noqa: PLR0915
     mock_response: Optional[List[float]] = kwargs.get("mock_response", None)  # type: ignore
     azure_ad_token_provider = kwargs.get("azure_ad_token_provider", None)
     aembedding: Optional[bool] = kwargs.get("aembedding", None)
+    if isinstance(encoding_format, list):
+        encoding_format = encoding_format[0] if encoding_format else None
     extra_headers = kwargs.get("extra_headers", None)
     headers = kwargs.get("headers", None) or extra_headers
     if headers is None:


### PR DESCRIPTION
## Root Cause

When `encoding_format` is set as a **list** in a model's `litellm_params` (e.g. to declare which formats the model supports):

```yaml
model_list:
  - model_name: my-embeddings
    litellm_params:
      model: hosted_vllm/bge-m3
      api_base: http://localhost:8000
      encoding_format:
        - float
        - base64
        - ubyte
        - int8
```

the list is forwarded verbatim to the upstream embedding API. vLLM rejects it with validation errors because it expects a single string, not an array.

The proxy "Test Connection" flow and any request that does **not** explicitly set `encoding_format` both hit this path.

## Fix

Normalize `encoding_format` at the top of `embedding()` in `litellm/main.py`, before `get_optional_params_embeddings` builds `optional_params`:

```python
if isinstance(encoding_format, list):
    encoding_format = encoding_format[0] if encoding_format else None
```

- A non-empty list → use the first element as the concrete format (natural default).
- An empty list → `None` (no format specified, let the backend choose).
- A plain string or `None` → unchanged.

This matches the `encoding_format: Optional[str]` contract on the function signature and applies uniformly to all providers (hosted_vllm, openai, azure, etc.).

## Test Plan

- [ ] `litellm.embedding(model="hosted_vllm/...", input=["hello"], encoding_format=["float","base64"])` no longer raises
- [ ] Model configured with `encoding_format: [float]` in litellm_params: proxy request without explicit `encoding_format` succeeds
- [ ] Model configured with `encoding_format: [float, base64]`: explicit request `encoding_format=base64` still uses `base64`
- [ ] `encoding_format="float"` (string) continues to work unchanged

Fixes #28239
