### PR TITLE
fix(a2a): forward agent_extra_headers through completion bridge for custom_llm_provider agents

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -132,6 +132,7 @@ async def _send_message_via_completion_bridge(
     custom_llm_provider: str,
     api_base: Optional[str],
     litellm_params: Dict[str, Any],
+    agent_extra_headers: Optional[Dict[str, str]] = None,
 ) -> LiteLLMSendMessageResponse:
     """
     Route a send_message through the LiteLLM completion bridge (e.g. LangGraph, Bedrock AgentCore).
@@ -151,6 +152,13 @@ async def _send_message_via_completion_bridge(
         if hasattr(request.params, "model_dump")
         else dict(request.params)
     )
+
+    if agent_extra_headers:
+        merged = dict(litellm_params)
+        existing = dict(merged.get("extra_headers") or {})
+        existing.update(agent_extra_headers)
+        merged["extra_headers"] = existing
+        litellm_params = merged
 
     response_dict = await A2ACompletionBridgeHandler.handle_non_streaming(
         request_id=str(request.id),
@@ -281,6 +289,7 @@ async def asend_message(
             custom_llm_provider=custom_llm_provider,
             api_base=api_base,
             litellm_params=litellm_params,
+            agent_extra_headers=agent_extra_headers,
         )
 
     # Standard A2A client flow
@@ -508,6 +517,13 @@ async def asend_message_streaming(  # noqa: PLR0915
             if hasattr(request.params, "model_dump")
             else dict(request.params)
         )
+
+        if agent_extra_headers:
+            merged = dict(litellm_params)
+            existing = dict(merged.get("extra_headers") or {})
+            existing.update(agent_extra_headers)
+            merged["extra_headers"] = existing
+            litellm_params = merged
 
         async for chunk in A2ACompletionBridgeHandler.handle_streaming(
             request_id=str(request.id),


### PR DESCRIPTION
## Root Cause

When an A2A agent is configured with `custom_llm_provider` (e.g. LangGraph, Bedrock AgentCore), `asend_message` and `asend_message_streaming` route through `_send_message_via_completion_bridge` instead of the native A2A client path.

The **native path** correctly merges `agent_extra_headers` into the HTTP client:
```python
if agent_extra_headers:
    extra_headers.update(agent_extra_headers)
a2a_client = await create_a2a_client(base_url=api_base, extra_headers=extra_headers)
```

The **completion-bridge path** silently drops them:
```python
return await _send_message_via_completion_bridge(
    request=request,
    custom_llm_provider=custom_llm_provider,
    api_base=api_base,
    litellm_params=litellm_params,
    # agent_extra_headers not passed!
)
```

The same problem exists in `asend_message_streaming` before its `handle_streaming` call.

## Impact

- Method 3 convention-based headers (`x-a2a-{alias}-{target}`) are dropped for all LangGraph/completion-bridge agents.
- Admin-allowlisted `extra_headers` configured on the agent are never forwarded.

## Fix

1. Add `agent_extra_headers: Optional[Dict[str, str]] = None` to `_send_message_via_completion_bridge`.
2. Before calling the bridge handler, shallow-copy `litellm_params` and merge `agent_extra_headers` into its `extra_headers` key — this flows through to `litellm.acompletion(**completion_params)` because the handler already does `completion_params.update(litellm_params_to_add)`.
3. Pass `agent_extra_headers` from `asend_message` to the bridge call.
4. Apply the same merge in the `custom_llm_provider` branch of `asend_message_streaming` before `handle_streaming`.

## Test Plan

- [ ] Configure a LangGraph agent with `custom_llm_provider: langgraph`
- [ ] Send a request with `x-a2a-<agent-name>-authorization: Bearer token` header
- [ ] Verify the `Authorization` header reaches the downstream LangGraph backend
- [ ] Same test for admin-allowlisted `extra_headers` on the agent config
- [ ] Verify standard A2A agents (no `custom_llm_provider`) are unaffected

Fixes #28267
