### PR TITLE
fix(bedrock invoke): strip `output_config.format` so Claude Code requests don't 400

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -69,6 +69,14 @@ class AmazonAnthropicClaudeMessagesConfig(
         BedrockInvokeAnthropicMessagesRequest.__annotations__.keys()
     )
 
+    # Subkeys of ``output_config`` that Bedrock Invoke accepts on Anthropic
+    # Claude models. Bedrock currently only supports ``effort`` here; any other
+    # subkey (notably ``format``, which Anthropic added for Structured Outputs
+    # and which newer Claude Code releases send) causes Bedrock to 400 with
+    # ``output_config.<key>: Extra inputs are not permitted``. Add an entry
+    # only when AWS officially documents support for it on Bedrock Invoke.
+    BEDROCK_INVOKE_ALLOWED_OUTPUT_CONFIG_KEYS = frozenset({"effort"})
+
     def __init__(self, **kwargs):
         BaseAnthropicMessagesConfig.__init__(self, **kwargs)
         AmazonInvokeConfig.__init__(self, **kwargs)
@@ -449,6 +457,59 @@ class AmazonAnthropicClaudeMessagesConfig(
         else:
             anthropic_messages_request.pop("context_management", None)
 
+    def _sanitize_output_config_for_bedrock_invoke(
+        self,
+        anthropic_messages_request: Dict,
+    ) -> None:
+        """
+        Strip ``output_config`` subkeys that Bedrock Invoke does not accept.
+
+        Bedrock Invoke on Anthropic Claude only accepts ``effort`` inside
+        ``output_config``. Other subkeys — notably ``format`` (the new Anthropic
+        Structured Outputs sub-key that some Claude Code releases send
+        automatically) — cause Bedrock to 400 with
+        ``output_config.format: Extra inputs are not permitted``.
+
+        Behavior (in-place):
+          * Non-dict ``output_config`` is removed entirely.
+          * ``output_config.format`` is converted to an inline schema in the
+            last user message (same path as the legacy top-level
+            ``output_format`` field) so structured-output intent is preserved
+            on Bedrock instead of silently dropped.
+          * Any other unsupported subkey is removed.
+          * If nothing remains after filtering, ``output_config`` is removed
+            entirely so the safety-net allowlist sees a clean request body.
+        """
+        output_config = anthropic_messages_request.get("output_config")
+        if output_config is None:
+            return
+        if not isinstance(output_config, dict):
+            anthropic_messages_request.pop("output_config", None)
+            return
+
+        output_format = output_config.get("format")
+        if isinstance(output_format, dict):
+            self._convert_output_format_to_inline_schema(
+                output_format=output_format,
+                anthropic_messages_request=anthropic_messages_request,
+            )
+
+        sanitized = {
+            k: v
+            for k, v in output_config.items()
+            if k in self.BEDROCK_INVOKE_ALLOWED_OUTPUT_CONFIG_KEYS
+        }
+        dropped = sorted(set(output_config) - set(sanitized))
+        if dropped:
+            verbose_logger.debug(
+                "Bedrock Invoke: stripping unsupported output_config subkeys: %s",
+                dropped,
+            )
+        if sanitized:
+            anthropic_messages_request["output_config"] = sanitized
+        else:
+            anthropic_messages_request.pop("output_config", None)
+
     def _convert_output_format_to_inline_schema(
         self,
         output_format: Dict,
@@ -630,6 +691,14 @@ class AmazonAnthropicClaudeMessagesConfig(
 
         if filtered_betas:
             anthropic_messages_request["anthropic_beta"] = filtered_betas
+
+        # Strip output_config subkeys that Bedrock Invoke doesn't accept
+        # (e.g. `format`, which newer Claude Code releases send for Structured
+        # Outputs). Done before the drop_params check below so the latter only
+        # has to reason about whether `effort` itself is supported.
+        self._sanitize_output_config_for_bedrock_invoke(
+            anthropic_messages_request=anthropic_messages_request,
+        )
 
         if (
             litellm.drop_params is True

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -648,6 +648,114 @@ def test_bedrock_messages_forwards_output_config_with_output_format():
     assert "output_format" not in result
 
 
+def test_bedrock_messages_strips_output_config_format_subkey():
+    """``output_config.format`` is stripped (and converted to inline schema) so Bedrock doesn't 400.
+
+    Bedrock Invoke rejects ``output_config.format`` with
+    ``"output_config.format: Extra inputs are not permitted"``. Newer Claude
+    Code releases send this subkey automatically; LiteLLM must drop it (and
+    preserve the structured-output intent via inline schema) so the request
+    reaches Bedrock successfully.
+    """
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "output_config": {
+            "effort": "medium",
+            "format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                },
+            },
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-7",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("output_config") == {"effort": "medium"}
+    # Schema is embedded as inline text in the last user message so the
+    # structured-output intent is preserved on Bedrock.
+    last_user_content = result["messages"][-1]["content"]
+    assert isinstance(last_user_content, list)
+    schema_texts = [
+        b.get("text", "")
+        for b in last_user_content
+        if isinstance(b, dict) and b.get("type") == "text"
+    ]
+    assert any('"answer"' in t for t in schema_texts)
+
+
+def test_bedrock_messages_drops_output_config_when_only_unsupported_subkeys():
+    """``output_config`` containing only unsupported subkeys is dropped entirely."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                },
+            },
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-7",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert "output_config" not in result
+    last_user_content = result["messages"][-1]["content"]
+    assert isinstance(last_user_content, list)
+    schema_texts = [
+        b.get("text", "")
+        for b in last_user_content
+        if isinstance(b, dict) and b.get("type") == "text"
+    ]
+    assert any('"answer"' in t for t in schema_texts)
+
+
+def test_bedrock_messages_drops_non_dict_output_config():
+    """Non-dict ``output_config`` is removed entirely to avoid malformed downstream payload."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "output_config": "not-a-dict",
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-7",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert "output_config" not in result
+
+
 def test_bedrock_messages_forwards_output_config_for_non_adaptive_model():
     """``output_config`` is forwarded for non-adaptive models so the provider's error surfaces."""
     from litellm.types.router import GenericLiteLLMParams
@@ -917,9 +1025,7 @@ def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
     optional_params = {
         "max_tokens": 4096,
-        "context_management": {
-            "edits": [{"type": "compact_20260112"}]
-        },
+        "context_management": {"edits": [{"type": "compact_20260112"}]},
     }
 
     result = cfg.transform_anthropic_messages_request(
@@ -930,9 +1036,7 @@ def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
         headers={},
     )
 
-    assert result.get("context_management") == {
-        "edits": [{"type": "compact_20260112"}]
-    }
+    assert result.get("context_management") == {"edits": [{"type": "compact_20260112"}]}
     assert "compact-2026-01-12" in result.get("anthropic_beta", [])
     assert result["max_tokens"] == 4096
 
@@ -964,9 +1068,7 @@ def test_bedrock_messages_filters_unsupported_context_management_edits():
         headers={},
     )
 
-    assert result.get("context_management") == {
-        "edits": [{"type": "compact_20260112"}]
-    }
+    assert result.get("context_management") == {"edits": [{"type": "compact_20260112"}]}
     assert "compact-2026-01-12" in result.get("anthropic_beta", [])
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Reported internally: every Claude Code request through Bedrock Invoke (`claude-code-opus-4-7-invoke`) was failing with:

```
{"message":"output_config.format: Extra inputs are not permitted"}
```

## Root cause

Bedrock InvokeModel on Anthropic Claude accepts `output_config` but only with `effort` inside it. Anthropic's new Structured Outputs spec adds an `output_config.format` sub-key (shape: `{"format": {"type": "json_schema", "schema": {...}}}`) — and recent Claude Code releases now send it automatically on every request.

LiteLLM's existing `drop_params` handling only drops the entire `output_config` when the model doesn't support `effort` at all. For Opus 4.7 (which does support `effort`), the whole `output_config={"effort": "...", "format": {...}}` payload was being forwarded to Bedrock, which then rejected it with the 400 above.

## Fix

Add a Bedrock-Invoke-specific sanitizer for `output_config` subkeys (parallel to the existing top-level allowlist):

- New `BEDROCK_INVOKE_ALLOWED_OUTPUT_CONFIG_KEYS = frozenset({"effort"})` — single source of truth, extend only when AWS officially adds support for a subkey.
- New `_sanitize_output_config_for_bedrock_invoke()` method that:
  - Converts `output_config.format` to inline schema in the last user message (reuses the existing `_convert_output_format_to_inline_schema` helper used for the legacy top-level `output_format` field) so structured-output intent is preserved on Bedrock instead of silently dropped.
  - Strips any other unsupported subkey.
  - Drops `output_config` entirely if no supported subkeys remain.
  - Drops non-dict `output_config` values.

Called before the existing `drop_params` block so that path only has to reason about whether `effort` itself is supported.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Screenshots / Proof of Fix

All 665 bedrock tests pass, including the 3 new ones covering the Claude Code repro:

```
tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_bedrock_messages_strips_output_config_format_subkey PASSED
tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_bedrock_messages_drops_output_config_when_only_unsupported_subkeys PASSED
tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py::test_bedrock_messages_drops_non_dict_output_config PASSED
...
665 passed
```

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py` — add `BEDROCK_INVOKE_ALLOWED_OUTPUT_CONFIG_KEYS` allowlist + `_sanitize_output_config_for_bedrock_invoke()` helper, wire it into `transform_anthropic_messages_request` before the drop_params block.
- `tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py` — 3 new tests covering the Claude Code repro (`effort + format`), the `format`-only case (whole `output_config` dropped, schema preserved as inline text), and the non-dict input case.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1779237706324359?thread_ts=1779237706.324359&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-2fd0c011-f902-500d-94d7-00c3e903b959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd0c011-f902-500d-94d7-00c3e903b959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

