### PR TITLE
Fix cross site scripting (xss) vulnerabilities

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
@@ -107,6 +107,8 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
   const [topModelsLimit, setTopModelsLimit] = useState<number>(5);
   const [topAgentsLimit, setTopAgentsLimit] = useState<number>(5);
 
+  const safeHref = /^https?:\/\//.test(window.location.href) ? window.location.href : "/";
+
   const startTime = useMemo(() => (dateValue.from ? new Date(dateValue.from) : null), [dateValue.from]);
   const endTime = useMemo(() => (dateValue.to ? new Date(dateValue.to) : null), [dateValue.to]);
 
@@ -409,7 +411,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
                 Currently fetching spend data: fetched {progress.currentPage} / {progress.totalPages} pages. Charts will
                 update periodically as data loads. Moving off of this page will stop and reset this. To continue using
                 the UI in the meantime,{" "}
-                <a href={window.location.href} target="_blank" rel="noopener noreferrer">
+                <a href={safeHref} target="_blank" rel="noopener noreferrer">
                   open a new tab <ExportOutlined />
                 </a>
                 .
@@ -445,7 +447,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
                 Currently fetching agent data: fetched {agentProgress.currentPage} / {agentProgress.totalPages} pages.
                 Charts will update periodically as data loads. Moving off of this page will stop and reset this. To
                 continue using the UI in the meantime,{" "}
-                <a href={window.location.href} target="_blank" rel="noopener noreferrer">
+                <a href={safeHref} target="_blank" rel="noopener noreferrer">
                   open a new tab <ExportOutlined />
                 </a>
                 .

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -59,6 +59,7 @@ interface UsagePageProps {
 
 const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const { accessToken, userRole, userId: userID, premiumUser } = useAuthorized();
+  const safeHref = /^https?:\/\//.test(window.location.href) ? window.location.href : "/";
   // Aggregated endpoint: try first, fall back to paginated if unavailable
   const [aggregatedData, setAggregatedData] = useState<{ results: DailyData[]; metadata: any } | null>(null);
   const [aggregatedFailed, setAggregatedFailed] = useState(false);
@@ -465,7 +466,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                     Currently fetching spend data: fetched {paginatedResult.progress.currentPage} /{" "}
                     {paginatedResult.progress.totalPages} pages. Charts will update periodically as data loads. Moving
                     off of this page will stop and reset this. To continue using the UI in the meantime,{" "}
-                    <a href={window.location.href} target="_blank" rel="noopener noreferrer">
+                    <a href={safeHref} target="_blank" rel="noopener noreferrer">
                       open a new tab <ExportOutlined />
                     </a>
                     .

--- a/ui/litellm-dashboard/src/components/constants.tsx
+++ b/ui/litellm-dashboard/src/components/constants.tsx
@@ -7,7 +7,9 @@ export const useBaseUrl = () => {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const { protocol, host } = window.location;
-      setBaseUrl(`${protocol}//${host}`);
+      if (protocol === "http:" || protocol === "https:") {
+        setBaseUrl(`${protocol}//${host}`);
+      }
     }
   }, []); // Removed router dependency
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -353,7 +353,10 @@ export const handleError = async (errorData: string | any) => {
       clearTokenCookies();
       const browserLocation = getWindowLocation();
       if (browserLocation) {
-        window.location.href = browserLocation.pathname;
+        const pathname = browserLocation.pathname;
+        if (pathname.startsWith("/")) {
+          window.location.href = pathname;
+        }
       }
     }
     lastErrorTime = currentTime;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -354,7 +354,7 @@ export const handleError = async (errorData: string | any) => {
       const browserLocation = getWindowLocation();
       if (browserLocation) {
         const pathname = browserLocation.pathname;
-        if (pathname.startsWith("/")) {
+        if (pathname.startsWith("/") && !pathname.startsWith("//")) {
           window.location.href = pathname;
         }
       }

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -263,7 +263,8 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
 
     console.log("proxyBaseUrl:", baseUrl);
 
-    const url = baseUrl ? `${baseUrl}/sso/key/generate` : `/sso/key/generate`;
+    const safeBase = baseUrl && /^https?:\/\//.test(baseUrl) ? baseUrl : "";
+    const url = safeBase ? `${safeBase}/sso/key/generate` : `/sso/key/generate`;
 
     console.log("Full URL:", url);
     window.location.href = url;


### PR DESCRIPTION
## Relevant issues

Identified via an internal Security Risk Assessment & Audit (SRAA) — Source Code Review, scanned 2026-04-29.

| SRAA Item | Finding                                                                                                    | File                     | Status |
| --------- | ---------------------------------------------------------------------------------------------------------- | ------------------------ | ------ |
| #1        | Cross-Site Scripting: DOM — unvalidated `window.location.protocol` in `useBaseUrl`                         | `constants.tsx`          | Fixed  |
| #2        | Cross-Site Scripting: DOM — `window.location.pathname` assigned to `window.location.href` in `handleError` | `networking.tsx`         | Fixed  |
| #3        | Cross-Site Scripting: DOM — `window.location.href` in open-tab link                                        | `EntityUsage.tsx:412`    | Fixed  |
| #4        | Cross-Site Scripting: DOM — `window.location.href` in open-tab link                                        | `EntityUsage.tsx:448`    | Fixed  |
| #5        | Cross-Site Scripting: DOM — `window.location.href` in open-tab link                                        | `UsagePageView.tsx:455`  | Fixed  |
| #6        | Cross-Site Scripting: DOM — unvalidated `baseUrl` assigned to `window.location.href` in `gotoLogin`        | `user_dashboard.tsx:270` | Fixed  |

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" -->

## Pre-Submission checklist

> This is a **UI-only PR** — no proxy/backend files were changed.

- [x] I have signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/BerriAI/litellm)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] The UI builds successfully — `npm run build`
- [x] All UI unit tests pass — `npm run test`
- [x] No new components or logic were added — existing tests cover the affected code paths
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

No visible UI change — these are defensive guards on data already derived from the browser's own `window.location`. Behaviour is identical on any standard `http`/`https` deployment.

## Type

🐛 Bug Fix

## Changes

Addresses DOM-based XSS findings raised in a security audit. All five fixes follow the same principle: **validate that any value derived from `window.location` is a safe `http`/`https` URL before it is used as a navigation target or link `href`.**

### Files changed

| File                                                                                   | Fix                                                                                                                                                                                   |
| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `ui/litellm-dashboard/src/components/constants.tsx`                                    | `useBaseUrl` — only set `baseUrl` when `window.location.protocol` is `http:` or `https:`. Prevents a non-http(s) scheme from propagating into the non-SSO login link in `AdminPanel`. |
| `ui/litellm-dashboard/src/components/networking.tsx`                                   | `handleError` — guard `window.location.pathname` with a `startsWith("/")` check before assigning to `window.location.href` on session expiry redirect.                                |
| `ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx` | Compute `safeHref` (whitelist `http`/`https`, fall back to `"/"`) once per render and use it for both "open a new tab" links (lines 412 and 448).                                     |
| `ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx`           | Same `safeHref` pattern for the "open a new tab" link in the paginated spend-data loading banner.                                                                                     |
| `ui/litellm-dashboard/src/components/user_dashboard.tsx`                               | `gotoLogin` — validate `baseUrl` from `getProxyBaseUrl()` is `http`/`https` before constructing the SSO redirect URL; fall back to the safe relative path `/sso/key/generate`.        |
