### PR TITLE
fix(images): cast n to int from multipart form data in image edit

### DIFF
--- a/litellm/images/utils.py
+++ b/litellm/images/utils.py
@@ -80,6 +80,14 @@ class ImageEditRequestUtils:
         filtered_params = {
             k: v for k, v in params.items() if k in valid_keys and v is not None
         }
+        # Multipart form data delivers all fields as strings; coerce n to int so
+        # Azure's backend validation (which does integer comparisons) doesn't fail
+        # with "TypeError: '<=' not supported between instances of 'str' and 'int'".
+        if "n" in filtered_params and isinstance(filtered_params["n"], str):
+            try:
+                filtered_params["n"] = int(filtered_params["n"])
+            except (ValueError, TypeError):
+                filtered_params.pop("n", None)
         return cast(ImageEditOptionalRequestParams, filtered_params)
 
     @staticmethod

--- a/tests/image_gen_tests/test_image_edits.py
+++ b/tests/image_gen_tests/test_image_edits.py
@@ -773,3 +773,50 @@ async def test_image_edit_array_handling():
 
         # Verify that both calls were made to the API
         assert mock_post.call_count == 2
+
+
+def test_image_edit_n_coercion_from_string():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/27978.
+
+    When the proxy receives a multipart/form-data request, all form fields
+    arrive as strings (e.g. n='1' instead of n=1).  Azure's backend validates
+    n as an integer and raises:
+        TypeError: '<=' not supported between instances of 'str' and 'int'
+    unless litellm coerces the value before forwarding the request.
+    """
+    from litellm.images.utils import ImageEditRequestUtils
+
+    # Simulate what _read_request_body returns for a multipart form upload
+    params_from_form = {
+        "n": "1",  # string, as delivered by multipart form data
+        "model": "azure/gpt-image-2",
+        "prompt": "make it ghibli",
+        "size": "1024x1024",
+    }
+
+    result = ImageEditRequestUtils.get_requested_image_edit_optional_param(
+        params_from_form
+    )
+
+    assert result["n"] == 1, f"Expected n=1 (int), got n={result['n']!r}"
+    assert isinstance(result["n"], int), f"Expected int, got {type(result['n'])}"
+
+
+def test_image_edit_n_coercion_invalid_string():
+    """n cannot be parsed → it is dropped silently rather than crashing."""
+    from litellm.images.utils import ImageEditRequestUtils
+
+    params = {"n": "not_a_number", "model": "azure/gpt-image-2", "prompt": "test"}
+    result = ImageEditRequestUtils.get_requested_image_edit_optional_param(params)
+    assert "n" not in result, "Invalid n string should be dropped, not passed through"
+
+
+def test_image_edit_n_already_int():
+    """When n is already an int (direct SDK call), it passes through unchanged."""
+    from litellm.images.utils import ImageEditRequestUtils
+
+    params = {"n": 2, "model": "azure/gpt-image-2", "prompt": "test"}
+    result = ImageEditRequestUtils.get_requested_image_edit_optional_param(params)
+    assert result["n"] == 2
+    assert isinstance(result["n"], int)


### PR DESCRIPTION
## Summary

- Fixes `TypeError: '<=' not supported between instances of 'str' and 'int'` when using the litellm proxy to route image-edit requests to Azure `gpt-image-2`.
- Root cause: `_read_request_body()` in `http_parsing_utils.py` parses all multipart form-data fields as strings, so `n` arrives as `"1"` (str) instead of `1` (int). Azure's backend validates `n` with an integer comparison (e.g. `1 <= n <= 10`), which raises a `TypeError` that is then surfaced as `APIError: AzureException APIError - '<=' not supported between instances of 'str' and 'int'`.
- Fix: `get_requested_image_edit_optional_param()` in `litellm/images/utils.py` now coerces `n` from `str` to `int` when it arrives as a string (proxy path). Invalid strings are silently dropped rather than forwarded. The integer path (direct SDK call) is unchanged.

## Issue

Closes #27978

## Local verification

```
=== LOCAL_TEST_PASSED ===
tests/image_gen_tests/test_image_edits.py::test_image_edit_n_coercion_from_string PASSED
tests/image_gen_tests/test_image_edits.py::test_image_edit_n_coercion_invalid_string PASSED
tests/image_gen_tests/test_image_edits.py::test_image_edit_n_already_int PASSED
3 passed in 0.03s
```

## Risk

- **Low.** The change is limited to a single helper used only in the image-edit path; it only activates when `n` is already a `str`, leaving all existing integer and `None` usages untouched. Invalid strings (e.g. `"abc"`) are dropped rather than forwarded, which is safe because `n` is optional.
- No behaviour change for direct SDK callers that already pass `n` as an integer.
