### PR TITLE
fix(vertex_ai/gemini): release streaming connection on aclose

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2625,6 +2625,7 @@ async def make_call(
         sync_stream=False,
         logging_obj=logging_obj,
         response_headers=response.headers,
+        response=response,
     )
     # LOGGING
     logging_obj.post_call(
@@ -2668,6 +2669,7 @@ def make_sync_call(
         sync_stream=True,
         logging_obj=logging_obj,
         response_headers=response.headers,
+        response=response,
     )
 
     # LOGGING
@@ -3129,12 +3131,14 @@ class ModelResponseIterator:
         sync_stream: bool,
         logging_obj: LoggingClass,
         response_headers: Optional[Dict[str, str]] = None,
+        response: Optional[httpx.Response] = None,
     ):
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             check_is_function_call,
         )
 
         self.streaming_response = streaming_response
+        self.response: Optional[httpx.Response] = response
         self.chunk_type: Literal["valid_json", "accumulated_json"] = "valid_json"
         self.accumulated_json = ""
         self.sent_first_chunk = False
@@ -3429,3 +3433,74 @@ class ModelResponseIterator:
             raise StopAsyncIteration
         except ValueError as e:
             raise RuntimeError(f"Error parsing chunk: {e},\nReceived chunk: {chunk}")
+
+    async def aclose(self) -> None:
+        """
+        Close the underlying async iterator and HTTP response, if present.
+
+        Invoked by CustomStreamWrapper.aclose so streaming connections are
+        released even when callers abort iteration early.
+        """
+        try:
+            streaming = self.streaming_response
+            if streaming is not None and hasattr(streaming, "aclose"):
+                await streaming.aclose()
+        except Exception as e:
+            verbose_logger.debug(
+                "ModelResponseIterator.aclose: error closing streaming_response: %s",
+                e,
+            )
+
+        try:
+            async_iter = getattr(self, "async_response_iterator", None)
+            if (
+                async_iter is not None
+                and async_iter is not self.streaming_response
+                and hasattr(async_iter, "aclose")
+            ):
+                await async_iter.aclose()
+        except Exception as e:
+            verbose_logger.debug(
+                "ModelResponseIterator.aclose: error closing async_response_iterator: %s",
+                e,
+            )
+
+        try:
+            if self.response is not None and not getattr(
+                self.response, "is_closed", False
+            ):
+                resp = self.response
+                if hasattr(resp, "aclose"):
+                    await resp.aclose()  # type: ignore[func-returns-value]
+                elif hasattr(resp, "close"):
+                    resp.close()
+        except Exception as e:
+            verbose_logger.debug(
+                "ModelResponseIterator.aclose: error closing response: %s",
+                e,
+            )
+
+    def close(self) -> None:
+        """Sync close hook for non-async streaming (iter_lines())."""
+        try:
+            iterator = getattr(self, "response_iterator", None)
+            if iterator is not None and hasattr(iterator, "close"):
+                iterator.close()
+        except Exception as e:
+            verbose_logger.debug(
+                "ModelResponseIterator.close: error closing response_iterator: %s",
+                e,
+            )
+
+        try:
+            if (
+                self.response is not None
+                and hasattr(self.response, "close")
+                and not getattr(self.response, "is_closed", False)
+            ):
+                self.response.close()
+        except Exception as e:
+            verbose_logger.debug(
+                "ModelResponseIterator.close: error closing response: %s",
+                e,
+            )

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_stream_connection_close.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_stream_connection_close.py
@@ -1,0 +1,91 @@
+from typing import Any, Dict
+
+import pytest
+
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+    ModelResponseIterator,
+)
+
+
+class _FakeAsyncLines:
+    """Minimal async iterator simulating httpx.Response.aiter_lines()."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str:
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakeResponse:
+    """Minimal httpx.Response-like object for testing close paths."""
+
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.headers: Dict[str, str] = {}
+        self.text = ""
+        self.is_closed = False
+        self.aclose_called = False
+        self.close_called = False
+
+    def aiter_lines(self) -> _FakeAsyncLines:
+        return _FakeAsyncLines()
+
+    async def aclose(self) -> None:
+        self.aclose_called = True
+        self.is_closed = True
+
+    def close(self) -> None:
+        self.close_called = True
+        self.is_closed = True
+
+
+class _DummyLoggingObj:
+    def __init__(self) -> None:
+        self.model_call_details: Dict[str, Any] = {"litellm_params": {}}
+        self.optional_params: Dict[str, Any] = {}
+
+
+@pytest.mark.asyncio
+async def test_model_response_iterator_aclose_closes_response_and_stream():
+    """
+    CustomStreamWrapper.aclose() must invoke ModelResponseIterator.aclose(),
+    which in turn must close both the async line iterator and the underlying response.
+    """
+
+    fake_response = _FakeResponse()
+    streaming_response = fake_response.aiter_lines()
+    logging_obj = _DummyLoggingObj()
+
+    iterator = ModelResponseIterator(
+        streaming_response=streaming_response,
+        sync_stream=False,
+        logging_obj=logging_obj,  # type: ignore[arg-type]
+        response=fake_response,
+    )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=iterator,
+        model="vertex-gemini-test",
+        logging_obj=logging_obj,  # type: ignore[arg-type]
+        custom_llm_provider="vertex_ai",
+    )
+
+    await wrapper.aclose()
+
+    # The aiter_lines generator must be closed even when iteration never started
+    # (early-abort / pre-__aiter__ path).
+    assert (
+        streaming_response.closed
+    ), "streaming_response (aiter_lines) was not closed by aclose()"
+
+    # The underlying HTTP response must also have been closed.
+    assert iterator.response is fake_response
+    assert fake_response.aclose_called or fake_response.close_called


### PR DESCRIPTION
## Relevant issues

Vertex AI Gemini streaming did not release the underlying `httpx.Response` when callers aborted the stream (client disconnect / `CustomStreamWrapper.aclose`). Under high concurrency this kept upstream Gemini connections open longer than necessary and increased connection-pool pressure.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem

- In `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`, `ModelResponseIterator` was constructed from `response.aiter_lines()` / `response.iter_lines()` without keeping a reference to the underlying `httpx.Response`.
- `ModelResponseIterator` did not implement `aclose()` / `close()`. When upper layers called `CustomStreamWrapper.aclose()` (e.g. on client disconnect), the call landed on the iterator but found no cleanup method — so Gemini streaming resources were never explicitly released on abort/disconnect paths.
- Result: under load or frequent client cancellations, streaming connections to Gemini stayed open until natural timeout, putting pressure on the httpx connection pool.

### Fix

- `make_call` (async) and `make_sync_call` (sync) now pass the raw `httpx.Response` into `ModelResponseIterator` alongside the existing `response_headers`.
- `ModelResponseIterator` gains:
  - a `response: Optional[httpx.Response]` reference
  - `async def aclose()` — closes `streaming_response` (the `aiter_lines()` generator), the distinct `async_response_iterator` if `__aiter__` ever ran, and the underlying `httpx.Response` (preferring `aclose()` when available, falling back to `close()`)
  - `def close()` — sync counterpart for `iter_lines()` paths
- Cleanup failures are surfaced via `verbose_logger.debug` rather than swallowed silently, so teardown issues remain diagnosable without masking request lifecycle behavior.

### Tests

- New regression test `tests/test_litellm/llms/vertex_ai/gemini/test_gemini_stream_connection_close.py` verifies that `CustomStreamWrapper.aclose()` propagates through `ModelResponseIterator.aclose()` and ends up closing both the line iterator and the underlying response — including the early-abort path where iteration never started.
- Existing `tests/test_litellm/llms/vertex_ai/gemini/` suite passes locally (199 passed / 1 skipped).
<img width="2260" height="481" alt="image" src="https://github.com/user-attachments/assets/7b997770-e766-4d51-a479-84a333dd0196" />

### Manual verification

- Started proxy with `--detailed_debug`, issued a streaming completion with `curl -N`, then Ctrl+C after a few chunks.
- Chunk logs on the proxy stop immediately; no exceptions in the cleanup path.
