### PR TITLE
feat(helm): support tpl rendering in podAnnotations

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-litellm.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       labels:
         {{- include "litellm.labels" . | nindent 8 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -377,3 +377,28 @@ tests:
           content:
             name: sidecar-tpl
             image: "ghcr.io/berriai/litellm-database:test"
+  - it: should support tpl in podAnnotations
+    template: deployment.yaml
+    set:
+      image:
+        repository: ghcr.io/berriai/litellm-database
+        tag: test
+      # Mirrors the real-world scenario this feature unblocks:
+      # user disables the built-in ConfigMap (and its built-in checksum/config
+      # annotation) and re-implements checksum/config themselves via tpl.
+      proxyConfigMap:
+        create: false
+      podAnnotations:
+        checksum/config: "{{ .Values.image.tag }}"
+        example.com/some-key: "{{ .Values.image.repository }}"
+        example.com/literal: "plain-string-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/config"]
+          value: "test"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/some-key"]
+          value: "ghcr.io/berriai/litellm-database"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/literal"]
+          value: "plain-string-value"


### PR DESCRIPTION
Closes #28332

## Summary

Render `Values.podAnnotations` through `tpl ... $` in `deploy/charts/litellm-helm/templates/deployment.yaml`, so users can include template expressions (e.g. a sha256 of their custom ConfigMap) inside pod annotations.

```diff
 {{- with .Values.podAnnotations }}
-{{- toYaml . | nindent 8 }}
+{{- tpl (toYaml .) $ | nindent 8 }}
 {{- end }}
```

## Motivation

When users disable `proxyConfigMap.create` to provide their own ConfigMap, the chart's built-in `checksum/config` annotation is also disabled, so changes to a user-managed ConfigMap no longer roll the deployment. Allowing `tpl` in `podAnnotations` lets users re-implement that annotation themselves, e.g.:

```yaml
podAnnotations:
  checksum/config: '{{ include "my-umbrella.litellm-config" . | sha256sum }}'
```

## Consistency with existing chart code

This matches the `tpl (toYaml .) $` pattern already used elsewhere in the same chart:

- `deploy/charts/litellm-helm/templates/deployment.yaml:50` — `extraInitContainers`
- `deploy/charts/litellm-helm/templates/deployment.yaml:215` — `extraContainers`
- `deploy/charts/litellm-helm/templates/migrations-job.yaml:40,99` — migrations job

Direct precedent: commit `87d7e86479` ("feat(helm): add tpl support to extraContainers and extraInitContainers", April 2026).

## Tests

Added one new `helm unittest` case to `deploy/charts/litellm-helm/tests/deployment_tests.yaml`:

- `should support tpl in podAnnotations` — sets `proxyConfigMap.create: false` to mirror the real-world scenario, then asserts that a templated annotation referencing `.Values.image.tag` resolves correctly (proves `$` is wired), a second key referencing `.Values.image.repository` resolves correctly, and a plain-string annotation passes through unchanged (backward-compat canary).

Run locally with `make test-unit-helm` — all 54 tests pass.

Also manually verified with `helm template` that `.Release.Name` and `| sha256sum` pipelines resolve correctly inside annotations.

## Backward compatibility

`tpl` passes plain strings (no `{{ }}`) through unchanged, so existing chart users see no behavior change. Users with a literal `{{` inside an annotation value would now see it rendered as a template — that caveat already applies to every other `tpl` usage in this chart, and to the precedent PR above.

## Checklist

- [x] Sign the Contributor License Agreement (CLA)
- [x] Keep scope isolated — one helm-only one-liner + one test
- [x] Helm unit test added — `make test-unit-helm` passes
- [x] `helm lint deploy/charts/litellm-helm` passes
