### PR TITLE
fix(anthropic/adapter): stop tool-level type leaking into parameters

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -805,7 +805,7 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         new_tools: List[ChatCompletionToolParam] = []
         tool_name_mapping: Dict[str, str] = {}
-        mapped_tool_params = ["name", "input_schema", "description", "cache_control"]
+        mapped_tool_params = ["name", "input_schema", "description", "cache_control", "type"]
 
         for idx, tool in enumerate(tools):
             # Check if this is an Anthropic-native tool that should be kept as-is
@@ -832,7 +832,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]  # type: ignore
+                function_chunk["parameters"] = copy.deepcopy(tool["input_schema"])  # type: ignore
             if "description" in tool:
                 function_chunk["description"] = tool["description"]  # type: ignore
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2427,3 +2427,59 @@ def test_translate_anthropic_tool_choice_none():
 
     result = adapter.translate_anthropic_tool_choice_to_openai({"type": "none"})
     assert result == "none"
+
+
+def test_translate_anthropic_tools_type_not_leaked_into_parameters():
+    """
+    Regression: tool-level "type" key (e.g. "custom") must not leak into
+    function_chunk["parameters"] via the catch-all loop. Additionally,
+    input_schema must be shallow-copied so mutations to parameters don't
+    affect the original tool dict.
+    """
+    original_input_schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+    tools = [
+        {
+            "name": "my_tool",
+            "type": "custom",
+            "description": "A custom tool",
+            "input_schema": original_input_schema,
+        }
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result, _ = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
+
+    assert len(result) == 1
+    params = result[0]["function"]["parameters"]
+    # "type" in parameters should be from input_schema ("object"), not tool-level ("custom")
+    assert params["type"] == "object"
+    assert "custom" not in params.values()
+
+    # Deep copy guarantee: modifying nested keys doesn't affect original
+    params["properties"]["injected"] = {"type": "string"}
+    assert "injected" not in original_input_schema["properties"]
+
+
+def test_translate_anthropic_tools_type_not_leaked_without_input_schema():
+    """
+    When a tool has "type" but no "input_schema", "type" must still not
+    appear in the output parameters dict via the catch-all loop.
+    """
+    tools = [
+        {
+            "name": "bare_tool",
+            "type": "custom",
+            "description": "Tool without input_schema",
+        }
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result, _ = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
+
+    assert len(result) == 1
+    func = result[0]["function"]
+    assert func["name"] == "bare_tool"
+    # "type" must not leak into parameters
+    params = func.get("parameters", {})
+    assert "type" not in params or params.get("type") == "object"
+    assert "custom" not in params.values()


### PR DESCRIPTION
## Summary

- Adds `type` to the `mapped_tool_params` exclusion list in `translate_anthropic_tools_to_openai_tools()` so the Anthropic tool-level `type` field (e.g. `custom`, `computer_20241022`) no longer overwrites `parameters["type"]` which should be `object` from `input_schema`.
- Deep-copies `tool["input_schema"]` before assigning to `function_chunk["parameters"]` to prevent downstream mutations from corrupting the original tool definition.

## Problem

When converting Anthropic tools to OpenAI format, the catch-all loop copies unmapped top-level keys into `parameters`. The `type` key was not excluded, causing it to overwrite `parameters["type"]` (should be `"object"` from `input_schema`) with the tool type (e.g. `"custom"`).

Additionally, `parameters` was a direct reference to `input_schema` — any mutation would corrupt the caller's original tool dict.

## Test plan

- [x] `test_translate_anthropic_tools_type_not_leaked_into_parameters` — verifies `parameters["type"]` stays `"object"` when tool has `"type": "custom"`; also verifies deep copy isolation via nested mutation
- [x] `test_translate_anthropic_tools_type_not_leaked_without_input_schema` — verifies `type` does not leak when `input_schema` is absent
- [x] Existing tests pass (Anthropic-native tools like `computer_20241022` pass through unchanged)