### PR TITLE
fix(core): snapshot dict in safe_json_dumps to prevent concurrent mutation crash

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -26,7 +26,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
         result: Union[dict, list, tuple, set, str]
         if isinstance(obj, dict):
             result = {}
-            for k, v in obj.items():
+            for k, v in list(obj.items()):
                 if isinstance(k, (str)):
                     result[k] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -32,7 +32,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             seen.remove(id(obj))
             return result
         elif isinstance(obj, list):
-            result = [_serialize(item, seen, depth + 1) for item in obj]
+            result = [_serialize(item, seen, depth + 1) for item in list(obj)]
             seen.remove(id(obj))
             return result
         elif isinstance(obj, tuple):
@@ -40,7 +40,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             seen.remove(id(obj))
             return result
         elif isinstance(obj, set):
-            result = sorted([_serialize(item, seen, depth + 1) for item in obj])
+            result = sorted([_serialize(item, seen, depth + 1) for item in list(obj)])
             seen.remove(id(obj))
             return result
         elif isinstance(obj, BaseModel):

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -209,3 +209,39 @@ def test_no_runtime_error_on_concurrent_dict_mutation():
             assert len(results[0]) > 0
 
     assert not errors, f"safe_dumps raised {errors[0]!r} on concurrent mutation"
+
+
+def test_no_runtime_error_on_concurrent_list_mutation():
+    """safe_dumps must not raise RuntimeError when another thread mutates a nested list."""
+    errors: list = []
+
+    for _ in range(50):
+        data = {"messages": [f"msg_{i}" for i in range(100)]}
+        barrier = threading.Barrier(2, timeout=5)
+        results: list = []
+
+        def mutator():
+            barrier.wait()
+            for i in range(100, 200):
+                data["messages"].append(f"msg_{i}")
+
+        def serializer():
+            barrier.wait()
+            try:
+                result = safe_dumps(data)
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=mutator)
+        t2 = threading.Thread(target=serializer)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        if results:
+            assert isinstance(results[0], str)
+            assert '"messages"' in results[0]
+
+    assert not errors, f"safe_dumps raised {errors[0]!r} on concurrent list mutation"

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import threading
 
 import pytest
 
@@ -172,3 +173,32 @@ def test_pydantic_base_model():
     assert len(result["healthy_endpoints"]) == 2
     assert result["healthy_endpoints"][0]["name"] == "test"
     assert result["healthy_endpoints"][1] == {"value": 1, "label": "one"}
+
+
+def test_no_runtime_error_on_concurrent_dict_mutation():
+    """safe_dumps must not raise RuntimeError when another thread mutates the dict."""
+    data = {f"key_{i}": f"value_{i}" for i in range(200)}
+    barrier = threading.Barrier(2, timeout=5)
+    errors = []
+
+    def mutator():
+        barrier.wait()
+        for i in range(200, 400):
+            data[f"key_{i}"] = f"value_{i}"
+
+    def serializer():
+        barrier.wait()
+        try:
+            safe_dumps(data)
+        except RuntimeError as e:
+            if "dictionary changed size during iteration" in str(e):
+                errors.append(e)
+
+    t1 = threading.Thread(target=mutator)
+    t2 = threading.Thread(target=serializer)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not errors, "safe_dumps raised RuntimeError on concurrent mutation"

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -177,28 +177,35 @@ def test_pydantic_base_model():
 
 def test_no_runtime_error_on_concurrent_dict_mutation():
     """safe_dumps must not raise RuntimeError when another thread mutates the dict."""
-    data = {f"key_{i}": f"value_{i}" for i in range(200)}
-    barrier = threading.Barrier(2, timeout=5)
-    errors = []
+    errors: list = []
 
-    def mutator():
-        barrier.wait()
-        for i in range(200, 400):
-            data[f"key_{i}"] = f"value_{i}"
+    for _ in range(50):
+        data = {f"key_{i}": f"value_{i}" for i in range(200)}
+        barrier = threading.Barrier(2, timeout=5)
+        results: list = []
 
-    def serializer():
-        barrier.wait()
-        try:
-            safe_dumps(data)
-        except RuntimeError as e:
-            if "dictionary changed size during iteration" in str(e):
+        def mutator():
+            barrier.wait()
+            for i in range(200, 400):
+                data[f"key_{i}"] = f"value_{i}"
+
+        def serializer():
+            barrier.wait()
+            try:
+                result = safe_dumps(data)
+                results.append(result)
+            except Exception as e:
                 errors.append(e)
 
-    t1 = threading.Thread(target=mutator)
-    t2 = threading.Thread(target=serializer)
-    t1.start()
-    t2.start()
-    t1.join(timeout=5)
-    t2.join(timeout=5)
+        t1 = threading.Thread(target=mutator)
+        t2 = threading.Thread(target=serializer)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
 
-    assert not errors, "safe_dumps raised RuntimeError on concurrent mutation"
+        if results:
+            assert isinstance(results[0], str)
+            assert len(results[0]) > 0
+
+    assert not errors, f"safe_dumps raised {errors[0]!r} on concurrent mutation"


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: dictionary changed size during iteration` in `safe_dumps()` by snapshotting `obj.items()` into a list before iterating.

## Problem

`safe_dumps()` iterates over `obj.items()` directly. When another thread mutates the dict concurrently, Python raises `RuntimeError`. This crashes async logging callbacks that serialize request data for observability.

## Fix

Changed `for k, v in obj.items():` to `for k, v in list(obj.items()):` — snapshots the dict before iteration.

## Screenshot

N/A — this is a pure internal code fix (no UI, no CLI output, no visible behavior change). The fix is verified by unit tests that exercise the concurrent-mutation scenario.

## Test plan

- [x] `test_no_runtime_error_on_concurrent_dict_mutation` — 50-iteration loop spawning a writer thread that mutates a dict while the serializer thread calls `safe_dumps`; asserts no exceptions and validates result is non-empty JSON string
- [x] Existing tests pass (normal dict serialization behavior preserved)