### PR TITLE
fix(bedrock/converse): strip tool_choice from inference_params when no tools present

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1519,6 +1519,8 @@ class AmazonConverseConfig(BaseConfig):
             )
             if tool_choice_values is not None:
                 bedrock_tool_config["toolChoice"] = tool_choice_values
+        else:
+            inference_params.pop("tool_choice", None)
 
         data: CommonRequestObject = {
             "additionalModelRequestFields": additional_request_params,

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4578,3 +4578,42 @@ def test_transform_response_does_not_leak_body_on_parse_failure():
     msg = str(exc_info.value)
     assert "secret content" not in msg
     assert "Error converting to valid response block" in msg
+
+
+def test_tool_choice_stripped_when_no_tools():
+    """
+    When bedrock_tools is empty but inference_params contains tool_choice,
+    it must be popped before _transform_inference_params to avoid
+    ValidationException from Bedrock.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from litellm.llms.bedrock.chat.converse_transformation import (
+        AmazonConverseConfig,
+    )
+
+    config = AmazonConverseConfig()
+    inference_params = {
+        "temperature": 0.7,
+        "tool_choice": {"auto": {}},
+    }
+
+    with patch.object(
+        config,
+        "_transform_request",
+        wraps=config._transform_request,
+    ):
+        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+        optional_params = dict(inference_params)
+
+        result = config.transform_request(
+            model="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params=optional_params,
+            litellm_params={"api_base": None},
+            headers={},
+        )
+
+        inference_config = result.get("inferenceConfig", {})
+        assert "tool_choice" not in inference_config
+        assert result.get("toolConfig") is None

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4586,34 +4586,24 @@ def test_tool_choice_stripped_when_no_tools():
     it must be popped before _transform_inference_params to avoid
     ValidationException from Bedrock.
     """
-    from unittest.mock import MagicMock, patch
-
     from litellm.llms.bedrock.chat.converse_transformation import (
         AmazonConverseConfig,
     )
 
     config = AmazonConverseConfig()
-    inference_params = {
+    optional_params = {
         "temperature": 0.7,
         "tool_choice": {"auto": {}},
     }
 
-    with patch.object(
-        config,
-        "_transform_request",
-        wraps=config._transform_request,
-    ):
-        messages = [{"role": "user", "content": [{"text": "Hello"}]}]
-        optional_params = dict(inference_params)
+    result = config.transform_request(
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params=optional_params,
+        litellm_params={"api_base": None},
+        headers={},
+    )
 
-        result = config.transform_request(
-            model="anthropic.claude-3-sonnet-20240229-v1:0",
-            messages=[{"role": "user", "content": "Hello"}],
-            optional_params=optional_params,
-            litellm_params={"api_base": None},
-            headers={},
-        )
-
-        inference_config = result.get("inferenceConfig", {})
-        assert "tool_choice" not in inference_config
-        assert result.get("toolConfig") is None
+    inference_config = result.get("inferenceConfig", {})
+    assert "tool_choice" not in inference_config
+    assert result.get("toolConfig") is None


### PR DESCRIPTION
## Summary

Strips `tool_choice` from `inference_params` when the request has no tools, preventing Bedrock `ValidationException`.

## Problem

When a client sends `tool_choice` without any tools (e.g. n8n which sends `tool_choice` unconditionally), Bedrock Converse API returns:

```
ValidationException: tool_choice requires tools to be specified
```

## Fix

Added an `else` branch to the existing `if len(bedrock_tools) > 0:` block that pops `tool_choice` from `inference_params` when no tools are present.

## Test plan

- [x] `test_tool_choice_stripped_when_no_tools` — verifies `tool_choice` is removed from inference_params when bedrock_tools is empty
- [x] Existing tests pass (tool_choice is preserved when tools are present)

## Screenshot

Screenshot: N/A — internal logic fix with no UI impact, validated via unit test.