### PR TITLE
fix(proxy): close common streaming responses on exit

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1972,6 +1972,8 @@ class ProxyBaseLLMRequestProcessing:
             with anyio.CancelScope(shield=True):
                 if hasattr(response, "aclose"):
                     try:
+                        # This generator owns final cleanup of the raw upstream stream;
+                        # iterator hooks should transform/drain it without closing it.
                         await response.aclose()
                     except BaseException as e:
                         verbose_proxy_logger.debug(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
 )
 
+import anyio
 import httpx
 import orjson
 from fastapi import HTTPException, Request, status
@@ -1967,6 +1968,16 @@ class ProxyBaseLLMRequestProcessing:
                 code=getattr(e, "status_code", 500),
             )
             yield serialize_error(proxy_exception)
+        finally:
+            with anyio.CancelScope(shield=True):
+                if hasattr(response, "aclose"):
+                    try:
+                        await response.aclose()
+                    except BaseException as e:
+                        verbose_proxy_logger.debug(
+                            "async_streaming_data_generator: error closing response stream: %s",
+                            e,
+                        )
 
     @staticmethod
     async def async_sse_data_generator(

--- a/tests/test_litellm/test_common_request_processing_streaming_cleanup.py
+++ b/tests/test_litellm/test_common_request_processing_streaming_cleanup.py
@@ -106,3 +106,32 @@ async def test_async_streaming_data_generator_closes_response_on_error():
     assert "upstream connection reset" in chunks[1]
     mock_proxy_logging_obj.post_call_failure_hook.assert_awaited_once()
     mock_response.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_data_generator_swallows_close_errors():
+    mock_response = MagicMock()
+    mock_response.aclose = AsyncMock(side_effect=RuntimeError("already closed"))
+    mock_proxy_logging_obj = _mock_proxy_logging_obj()
+
+    async def mock_streaming_iterator(*args, **kwargs):
+        yield {"content": "hello"}
+
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = (
+        mock_streaming_iterator
+    )
+
+    chunks = [
+        chunk
+        async for chunk in ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+            response=mock_response,
+            user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+            request_data={"model": "gpt-3.5-turbo"},
+            proxy_logging_obj=mock_proxy_logging_obj,
+            serialize_chunk=lambda chunk: str(chunk),
+            serialize_error=lambda proxy_exception: str(proxy_exception.to_dict()),
+        )
+    ]
+
+    assert chunks == ["{'content': 'hello'}"]
+    mock_response.aclose.assert_awaited_once()

--- a/tests/test_litellm/test_common_request_processing_streaming_cleanup.py
+++ b/tests/test_litellm/test_common_request_processing_streaming_cleanup.py
@@ -1,0 +1,108 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.utils import ProxyLogging
+
+
+def _mock_proxy_logging_obj():
+    proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    proxy_logging_obj.async_post_call_streaming_hook = AsyncMock(
+        side_effect=lambda **kwargs: kwargs["response"]
+    )
+    proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+    return proxy_logging_obj
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_data_generator_closes_response_on_early_exit():
+    mock_response = MagicMock()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = _mock_proxy_logging_obj()
+
+    async def mock_streaming_iterator(*args, **kwargs):
+        yield {"content": "hello"}
+        yield {"content": " world"}
+
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = (
+        mock_streaming_iterator
+    )
+
+    generator = ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+        response=mock_response,
+        user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+        request_data={"model": "gpt-3.5-turbo"},
+        proxy_logging_obj=mock_proxy_logging_obj,
+        serialize_chunk=lambda chunk: str(chunk),
+        serialize_error=lambda proxy_exception: str(proxy_exception.to_dict()),
+    )
+
+    first_chunk = await generator.__anext__()
+    assert first_chunk == "{'content': 'hello'}"
+
+    await generator.aclose()
+
+    mock_response.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_data_generator_closes_response_on_completion():
+    mock_response = MagicMock()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = _mock_proxy_logging_obj()
+
+    async def mock_streaming_iterator(*args, **kwargs):
+        yield {"content": "hello"}
+
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = (
+        mock_streaming_iterator
+    )
+
+    chunks = [
+        chunk
+        async for chunk in ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+            response=mock_response,
+            user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+            request_data={"model": "gpt-3.5-turbo"},
+            proxy_logging_obj=mock_proxy_logging_obj,
+            serialize_chunk=lambda chunk: str(chunk),
+            serialize_error=lambda proxy_exception: str(proxy_exception.to_dict()),
+        )
+    ]
+
+    assert chunks == ["{'content': 'hello'}"]
+    mock_response.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_data_generator_closes_response_on_error():
+    mock_response = MagicMock()
+    mock_response.aclose = AsyncMock()
+    mock_proxy_logging_obj = _mock_proxy_logging_obj()
+
+    async def mock_streaming_iterator(*args, **kwargs):
+        yield {"content": "hello"}
+        raise RuntimeError("upstream connection reset")
+
+    mock_proxy_logging_obj.async_post_call_streaming_iterator_hook = (
+        mock_streaming_iterator
+    )
+
+    chunks = [
+        chunk
+        async for chunk in ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+            response=mock_response,
+            user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+            request_data={"model": "gpt-3.5-turbo"},
+            proxy_logging_obj=mock_proxy_logging_obj,
+            serialize_chunk=lambda chunk: str(chunk),
+            serialize_error=lambda proxy_exception: str(proxy_exception.to_dict()),
+        )
+    ]
+
+    assert chunks[0] == "{'content': 'hello'}"
+    assert "upstream connection reset" in chunks[1]
+    mock_proxy_logging_obj.post_call_failure_hook.assert_awaited_once()
+    mock_response.aclose.assert_awaited_once()


### PR DESCRIPTION
## Relevant issues

Related to #25776.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Targeted tests pass locally:

```bash
uv run --no-sync pytest tests/test_litellm/test_common_request_processing_streaming_cleanup.py
# 3 passed
```

Lint on changed files passes locally:

```bash
uv run --no-sync ruff check litellm/proxy/common_request_processing.py tests/test_litellm/test_common_request_processing_streaming_cleanup.py
# All checks passed
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Close `response.aclose()` from `ProxyBaseLLMRequestProcessing.async_streaming_data_generator` in a shielded `finally` block.
- Prevent leaked upstream streaming responses when the downstream generator is closed early, such as on client disconnect.
- Add regression coverage for early exit, normal completion, and mid-stream error paths.
