### PR TITLE
fix: convert Usage to dict in non-streaming /v1/responses to preserve prompt_tokens and completion_tokens

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1814,7 +1814,16 @@ class Logging(LiteLLMLoggingBaseClass):
                     result.usage
                 )
             )
-            setattr(result, "usage", transformed_usage)
+            # Set as dict instead of Usage object so model_dump() serializes it correctly
+            setattr(
+                result,
+                "usage",
+                (
+                    transformed_usage.model_dump()
+                    if hasattr(transformed_usage, "model_dump")
+                    else dict(transformed_usage)
+                ),
+            )
             if (
                 standard_logging_payload := self.model_call_details.get(
                     "standard_logging_object"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2078,6 +2078,74 @@ async def test_async_success_handler_preserves_response_cost_for_pass_through_en
     assert slo["response_cost"] > 0
 
 
+def test_transform_usage_objects_non_streaming_preserves_prompt_and_completion_tokens():
+    """
+    Regression test: _transform_usage_objects for non-streaming /v1/responses
+    must convert the Usage object to a dict before setting it on the
+    ResponsesAPIResponse. Otherwise, model_dump() drops prompt_tokens and
+    completion_tokens because they don't match the ResponseAPIUsage schema.
+
+    The streaming path already did this correctly; this test ensures the
+    non-streaming path behaves the same way.
+    """
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+
+    # Build a ResponsesAPIResponse with ResponseAPIUsage (as returned by providers)
+    response = ResponsesAPIResponse(
+        id="resp-test-001",
+        created_at=1700000000,
+        output=[],
+        usage=ResponseAPIUsage(
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=150,
+        ),
+    )
+
+    logging_obj = LiteLLMLoggingObj(
+        model="gpt-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=False,
+        call_type="responses",
+        start_time=time.time(),
+        litellm_call_id="test-usage-preservation",
+        function_id="test-fn-usage",
+    )
+
+    # Call the method under test
+    result = logging_obj._transform_usage_objects(response)
+
+    # The usage should now be a dict (not a Pydantic Usage object)
+    assert isinstance(
+        result.usage, dict
+    ), f"Expected usage to be a dict after transformation, got {type(result.usage)}"
+
+    # All token fields must be present
+    assert (
+        result.usage.get("prompt_tokens") == 100
+    ), f"prompt_tokens should be 100, got {result.usage.get('prompt_tokens')}"
+    assert (
+        result.usage.get("completion_tokens") == 50
+    ), f"completion_tokens should be 50, got {result.usage.get('completion_tokens')}"
+    assert (
+        result.usage.get("total_tokens") == 150
+    ), f"total_tokens should be 150, got {result.usage.get('total_tokens')}"
+
+    # Crucially, model_dump() must also preserve these fields (this is the actual bug scenario)
+    dumped = result.model_dump()
+    dumped_usage = dumped.get("usage", {})
+    assert (
+        dumped_usage.get("prompt_tokens") == 100
+    ), f"prompt_tokens lost after model_dump(): {dumped_usage}"
+    assert (
+        dumped_usage.get("completion_tokens") == 50
+    ), f"completion_tokens lost after model_dump(): {dumped_usage}"
+    assert (
+        dumped_usage.get("total_tokens") == 150
+    ), f"total_tokens lost after model_dump(): {dumped_usage}"
+
+
 def test_function_setup_litellm_metadata_populates_metadata():
     """
     Test that function_setup() properly handles litellm_metadata (used by /v1/messages,


### PR DESCRIPTION
> **Attribution / context for maintainers**
>
> This PR carries forward [@faizaj0](https://github.com/faizaj0)'s original fix from [#22079](https://github.com/BerriAI/litellm/pull/22079), which is now several hundred commits behind `main` and has merge conflicts. The original author no longer works on our codebase, so I'm re-opening it on her behalf, rebased cleanly on current `main`.
>
> All credit for the bug discovery, the fix, and the regression test belongs to **@faizaj0**. The git commit on this branch preserves her as the `author` (`git log` will show her name/email); I am only the `committer`. No code changes were made beyond rebasing — the diff is byte-identical to her original commit [4f4fbf8](https://github.com/BerriAI/litellm/commit/4f4fbf8608ee1f0f2b2b17689a307ab326049783).
>
> Please feel free to close #22079 as superseded if/when this lands.

---

## Relevant issues

Supersedes #22079.

Fixes silent usage-data loss on non-streaming `/v1/responses`: `prompt_tokens` and `completion_tokens` are dropped during Pydantic serialisation of the response.

## Linear ticket

n/a — external contribution.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (relevant new test verified; see Test plan below for caveats on unrelated pre-existing failures)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Regression test fails against `main` (without the fix) and passes with the fix:

```text
tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_transform_usage_objects_non_streaming_preserves_prompt_and_completion_tokens PASSED [100%]

============================== 1 passed in 0.31s ===============================
```

Without the fix, the third assertion group (`model_dump()` round-trip) fails because Pydantic strips `prompt_tokens` and `completion_tokens` when serialising `ResponsesAPIResponse.usage` through its declared `Optional[ResponseAPIUsage]` schema.

## Type

🐛 Bug Fix

## Changes

- **`litellm/litellm_core_utils/litellm_logging.py`** — In `_transform_usage_objects`, the non-streaming `ResponsesAPIResponse` path was calling `setattr(result, "usage", transformed_usage)` with a Pydantic `Usage` object returned by `ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage`. When `model_dump()` later serialised the response, the `usage` field was coerced through its declared `Optional[ResponseAPIUsage]` schema, which only contains `input_tokens` / `output_tokens` / `total_tokens` — so `prompt_tokens` and `completion_tokens` were silently dropped. This PR converts `transformed_usage` to a dict via `model_dump()` before assigning it, matching the existing streaming-path behaviour (which already did this correctly a few lines below). Affected: all non-streaming `/v1/responses` calls that return usage data.

- **`tests/test_litellm/litellm_core_utils/test_litellm_logging.py`** — Adds `test_transform_usage_objects_non_streaming_preserves_prompt_and_completion_tokens`, a regression test that builds a `ResponsesAPIResponse` with `ResponseAPIUsage`, runs `_transform_usage_objects`, and asserts `prompt_tokens`, `completion_tokens`, and `total_tokens` are all preserved both on the result object and after `model_dump()` serialisation (the latter is the actual bug scenario).