### PR TITLE
docs: add docstring to check_coroutine utility

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1253,6 +1253,21 @@ def _get_wrapper_timeout(
 
 
 def check_coroutine(value) -> bool:
+    """Return True if ``value`` is an async callable (coroutine function).
+
+    Thin wrapper around the process-wide :class:`CoroutineChecker`, which
+    caches results to avoid repeated ``inspect.iscoroutinefunction`` calls
+    on the hot path. For callables that are not plain functions or methods
+    (e.g. class instances with ``__call__``), the underlying check looks at
+    ``__call__`` to decide.
+
+    Args:
+        value: Any object — typically a callback or callable.
+
+    Returns:
+        True if ``value`` is recognized as an async callable, False otherwise
+        (including when introspection fails).
+    """
     get_coroutine_checker = getattr(sys.modules[__name__], "get_coroutine_checker")
     return get_coroutine_checker().is_async_callable(value)
 


### PR DESCRIPTION
## Summary

- Adds a docstring to `check_coroutine` in `litellm/utils.py`.
- The function is a thin wrapper around the cached `CoroutineChecker` and is invoked from the hot path (`post_call_processing`), but had no documentation describing its contract, fallback behavior, or how it handles non-function callables.
- No behavior change.

## Test plan

- [x] No runtime change — `check_coroutine` body is unchanged.
- [x] Formatted with `uv run black .` (no diff).