### PR TITLE
fix(responses_adapter): read cache_read_tokens from input_tokens_details on Responses usage (#28354)

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -257,17 +257,33 @@ class AnthropicResponsesStreamWrapper:
                     stop_reason = "max_tokens"
                 usage = getattr(response_obj, "usage", None)
                 if usage is not None:
-                    input_tokens = getattr(usage, "input_tokens", 0) or 0
-                    output_tokens = getattr(usage, "output_tokens", 0) or 0
-                    cache_creation_tokens = getattr(usage, "input_tokens_details", None)  # type: ignore[assignment]
-                    cache_read_tokens = getattr(usage, "output_tokens_details", None)  # type: ignore[assignment]
-                    # Prefer direct cache fields if present
+                    input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+                    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+                    # OpenAI Responses API exposes cached prompt tokens at
+                    # ``usage.input_tokens_details.cached_tokens`` (parallel to
+                    # ``usage.prompt_tokens_details.cached_tokens`` on Chat Completions).
+                    itd = getattr(usage, "input_tokens_details", None)
+                    if itd is not None:
+                        if isinstance(itd, dict):
+                            cache_read_tokens = int(itd.get("cached_tokens", 0) or 0)
+                        else:
+                            cache_read_tokens = int(
+                                getattr(itd, "cached_tokens", 0) or 0
+                            )
+                    # Fall back to Anthropic-style direct fields if the upstream
+                    # provider already speaks Anthropic usage.
+                    if not cache_read_tokens:
+                        cache_read_tokens = int(
+                            getattr(usage, "cache_read_input_tokens", 0) or 0
+                        )
                     cache_creation_tokens = int(
                         getattr(usage, "cache_creation_input_tokens", 0) or 0
                     )
-                    cache_read_tokens = int(
-                        getattr(usage, "cache_read_input_tokens", 0) or 0
-                    )
+                    # Anthropic semantics: ``input_tokens`` is the *uncached* prompt
+                    # count. OpenAI reports total prompt tokens (cached + uncached),
+                    # so subtract to keep client-side accounting consistent.
+                    if cache_read_tokens and input_tokens >= cache_read_tokens:
+                        input_tokens = input_tokens - cache_read_tokens
 
             # Check if tool_use was in the output to override stop_reason
             if response_obj is not None:


### PR DESCRIPTION
## Summary

Fixes #28354.

`AnthropicResponsesStreamWrapper._process_event` reads `usage.cache_read_input_tokens` — an **Anthropic-only field name** — from the OpenAI Responses `usage` object on `response.completed`, so the value is always `0` and clients (Claude Code / Agent SDK, Langfuse, Sentry, billing dashboards) routed through `/v1/messages` → Responses see `cache_read_input_tokens = 0` even when OpenAI is correctly reporting thousands of cached prompt tokens.

The OpenAI Responses API exposes cached tokens at `usage.input_tokens_details.cached_tokens` — the same pattern the parallel Chat Completions adapter already handles via `prompt_tokens_details.cached_tokens` (`adapters/streaming_iterator.py:280-291`).

## Change

In `responses_adapters/streaming_iterator.py::AnthropicResponsesStreamWrapper._process_event`:

- Read `cache_read_tokens` from `usage.input_tokens_details.cached_tokens` (object or dict shape).
- Fall back to `usage.cache_read_input_tokens` if the upstream provider already speaks Anthropic usage.
- Subtract `cache_read_tokens` from `input_tokens` to preserve Anthropic's "uncached prompt" semantics, matching the Chat Completions path.
- Drop the dead first assignment that wrote `input_tokens_details` / `output_tokens_details` into the cache-token variables before immediately overwriting them.

`cache_creation_input_tokens` keeps reading the Anthropic-named field only — OpenAI Responses has no direct equivalent, so emitting 0 there is correct.

## Test plan
- [ ] Existing tests under `tests/.../responses_adapters/` still pass.
- [ ] Manual: hit `/v1/messages` against a configured `mode: "responses"` model with a >1024-token prompt repeated; confirm the streamed `message_delta` event emits a non-zero `cache_read_input_tokens` once OpenAI starts reporting `cached_tokens` on subsequent calls. Reproduction script in #28354.

AI-assisted, human reviewed.
