### PR TITLE
fix(proxy/auth): clarify error message when wrong master key is used without DB

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1265,10 +1265,22 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         if (
             prisma_client is None
         ):  # if both master key + user key submitted, and user key != master key, and no db connected, raise an error
+            # NOTE: ``type`` stays as ``no_db_connection`` because
+            # ``auth_exception_handler.py`` keys off this value to enable the
+            # ``allow_requests_on_db_unavailable`` fallback path. Only the
+            # operator-facing message and the HTTP status code are corrected
+            # here — the message previously read "No connected db." which
+            # misled operators into believing a database needed to be
+            # configured, when the real problem is that the supplied token
+            # does not match the master key on a master-key-only deployment.
             raise ProxyException(
-                message="No connected db.",
+                message=(
+                    "Authentication Error, Invalid proxy server token passed. "
+                    "Token does not match the configured master key, and no "
+                    "database is connected to look up additional API keys."
+                ),
                 type=ProxyErrorTypes.no_db_connection,
-                code=400,
+                code=401,
                 param=None,
             )
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3335,3 +3335,118 @@ async def test_master_key_auth_substitutes_alias_for_api_key():
     finally:
         for k, v in _orig.items():
             setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_wrong_master_key_without_db_returns_clear_auth_error():
+    """Regression test for https://github.com/BerriAI/litellm/issues/12273
+    (and the older https://github.com/BerriAI/litellm/issues/4880).
+
+    When a bearer token does NOT match the configured master key AND no
+    database is connected, the proxy previously raised
+    ``"No connected db."`` with HTTP 400 -- which misled operators into
+    believing a database needed to be configured (it does not, for
+    master-key-only deployments). The user-visible error must instead
+    state that the token is invalid, with HTTP 401.
+
+    The ``ProxyErrorTypes.no_db_connection`` *type* is intentionally
+    preserved: ``auth_exception_handler.py`` keys off it to drive the
+    ``allow_requests_on_db_unavailable`` fallback path, and changing the
+    type would silently break that feature (see review feedback on the
+    earlier closed attempt at this fix).
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    attrs = _proxy_server_attrs_for_custom_auth(user_custom_auth=None)
+    # The whole point of this test is the no-DB code path.
+    attrs["prisma_client"] = None
+    _orig = {k: getattr(_proxy_server_mod, k, None) for k in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with pytest.raises(ProxyException) as exc_info:
+            await _user_api_key_auth_builder(
+                request=request,
+                api_key="Bearer sk-not-the-master-key",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert exc_info.value.code in (401, "401"), (
+            f"Expected HTTP 401, got {exc_info.value.code!r}. "
+            "Invalid credentials must return 401, not 400, so clients can "
+            "react to auth failures distinctly from bad-request errors."
+        )
+        assert "No connected db" not in str(
+            exc_info.value.message
+        ), f"Stale 'No connected db' message leaked: {exc_info.value.message!r}"
+        assert "token" in str(exc_info.value.message).lower(), (
+            f"Error message should reference the token, got: "
+            f"{exc_info.value.message!r}"
+        )
+    finally:
+        for k, v in _orig.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_wrong_master_key_without_db_preserves_no_db_connection_type():
+    """Companion to the message-fix test above: pin the error *type* so a
+    future change cannot silently switch it to ``auth_error`` and break
+    the ``allow_requests_on_db_unavailable`` fallback path.
+
+    ``auth_exception_handler.py`` (via
+    ``PrismaDBExceptionHandler.is_database_connection_error``) checks
+    ``e.type == ProxyErrorTypes.no_db_connection`` to decide whether to
+    issue the restricted INTERNAL_USER fallback token. If the type ever
+    changes, deployments relying on that fallback would start rejecting
+    requests they previously allowed through.
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    attrs = _proxy_server_attrs_for_custom_auth(user_custom_auth=None)
+    attrs["prisma_client"] = None
+    _orig = {k: getattr(_proxy_server_mod, k, None) for k in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with pytest.raises(ProxyException) as exc_info:
+            await _user_api_key_auth_builder(
+                request=request,
+                api_key="Bearer sk-not-the-master-key",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert exc_info.value.type == ProxyErrorTypes.no_db_connection, (
+            "Type must remain no_db_connection so the "
+            "allow_requests_on_db_unavailable fallback path in "
+            "auth_exception_handler.py continues to function."
+        )
+    finally:
+        for k, v in _orig.items():
+            setattr(_proxy_server_mod, k, v)


### PR DESCRIPTION
## Relevant issues

Fixes #12273
Also addresses #4880 (older issue raising the same operator confusion)

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/proxy/auth/test_user_api_key_auth.py`
- [x] My PR passes all unit tests on `make test-unit` (full file run: 90/90 pass)
- [x] My PR's scope is as isolated as possible — single error branch, two regression tests

## Problem

When a bearer token did not match the configured master key **and no database was connected**, `_user_api_key_auth_builder` raised:
HTTP 400
{"error":{"message":"No connected db.","type":"no_db_connection"}}

The message and status code both misrepresent the failure: master-key-only deployments do not require a database, so the user is not being told they need one — they typed the wrong token. Operators chasing this bug routinely set up a Postgres just to see the same error, burning hours per incident. This has been raised at least twice (#4880 in 2024, #12273 in 2025) and a contributor's comment on #4880 spelled out the correct behavior:
> "if you set a master key, and the api key passed in is not the master key, then we assume it's a key created from the db, and are making a check from there. In here, we set master key without setting db connection string, only master key shall be checked. Instead of reporting no_db_connection, shall report wrong key instead."
## Why this is the second attempt
An earlier attempt (closed February 2026) changed the error `type` from `no_db_connection` to `auth_error`. That broke the `allow_requests_on_db_unavailable` fallback path: `auth_exception_handler.py:64-67` (via `PrismaDBExceptionHandler.is_database_connection_error`) keys off the type to decide whether to issue a restricted INTERNAL_USER fallback token. Operators relying on that feature would have started rejecting requests they previously allowed through.
**This PR follows the reviewer's recommendation on the closed attempt**: keep the internal error `type` unchanged, fix only the user-facing message and the HTTP status code.
## Change
`litellm/proxy/auth/user_api_key_auth.py:1265-1283`:
```diff
         if (
             prisma_client is None
         ):  # if both master key + user key submitted, and user key != master key, and no db connected, raise an error
+            # NOTE: ``type`` stays as ``no_db_connection`` because
+            # ``auth_exception_handler.py`` keys off this value to enable the
+            # ``allow_requests_on_db_unavailable`` fallback path. Only the
+            # operator-facing message and the HTTP status code are corrected
+            # here.
             raise ProxyException(
-                message="No connected db.",
+                message=(
+                    "Authentication Error, Invalid proxy server token passed. "
+                    "Token does not match the configured master key, and no "
+                    "database is connected to look up additional API keys."
+                ),
                 type=ProxyErrorTypes.no_db_connection,
-                code=400,
+                code=401,
                 param=None,
             )
Three aligned changes:

Message — now reads "Authentication Error, Invalid proxy server token passed. Token does not match the configured master key, and no database is connected to look up additional API keys.", matching the existing "Authentication Error, Invalid proxy server token passed" wording used at lines 1314 and 1677 of this same file.
HTTP code — 400 → 401 so clients can branch on authentication failures distinctly from bad-request errors.
type is preserved as ProxyErrorTypes.no_db_connection so the allow_requests_on_db_unavailable behavior is unchanged. An inline comment documents the constraint for future contributors.
Tests
[tests/test_litellm/proxy/auth/test_user_api_key_auth.py](https://github.com/BlakeMatthews-dev/litellm/blob/fix/master-key-auth-error-message/tests/test_litellm/proxy/auth/test_user_api_key_auth.py):

test_wrong_master_key_without_db_returns_clear_auth_error — asserts the user-visible message no longer says "No connected db", references the token, and the status code is 401. Fails on main (verified via stash), passes with this change.
test_wrong_master_key_without_db_preserves_no_db_connection_type — companion regression test that pins the error type so a future change cannot silently switch it and break the allow_requests_on_db_unavailable fallback path. This is the test whose absence was flagged on the earlier closed attempt.
Full [tests/test_litellm/proxy/auth/test_user_api_key_auth.py](https://github.com/BlakeMatthews-dev/litellm/blob/fix/master-key-auth-error-message/tests/test_litellm/proxy/auth/test_user_api_key_auth.py) run: 90/90 pass.

Proof of Fix
Before:

$ curl -H "Authorization: Bearer sk-wrong" http://localhost:4000/v1/chat/completions
HTTP/1.1 400 Bad Request
{"error":{"message":"No connected db.","type":"no_db_connection","code":"400"}}
After:

$ curl -H "Authorization: Bearer sk-wrong" http://localhost:4000/v1/chat/completions
HTTP/1.1 401 Unauthorized
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Token does not match the configured master key, and no database is connected to look up additional API keys.","type":"no_db_connection","code":"401"}}
Type
🐛 Bug Fix
