### PR TITLE
fix(proxy): ensure unique request_id before writing spend logs to DB

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5184,6 +5184,47 @@ class ProxyUpdateSpend:
                 )
 
     @staticmethod
+    def _ensure_unique_request_ids(logs_to_process: List[Dict[str, Any]]) -> None:
+        """
+        Make request_ids unique within a batch before writing to LiteLLM_SpendLogs.
+
+        Some upstream providers reuse short request IDs (e.g. ``chatcmpl-424``).
+        Since ``request_id`` is the table's primary key and the batch insert
+        uses ``skip_duplicates=True``, colliding entries were silently dropped.
+
+        Strategy (backward compatible):
+        - The FIRST entry with a given request_id keeps its original id, so
+          existing exact-match lookups, UI links, and external integrations
+          keep working for the common case of globally-unique upstream ids.
+        - Subsequent entries with the SAME id within the batch get a
+          deterministic sha256 content-hash suffix appended. Identical
+          re-enqueued entries hash to the same suffix (deduped by
+          skip_duplicates=True); different content is preserved as a new row.
+        - Entries missing a request_id entirely get their content hash as id.
+
+        This must be called ONCE per batch, before the retry loop, so retries
+        regenerate identical ids and already-committed rows are deduped.
+        """
+        seen_ids: set = set()
+        for entry in logs_to_process:
+            original_id = entry.get("request_id", "")
+            if not original_id:
+                entry["request_id"] = hashlib.sha256(
+                    json.dumps(entry, sort_keys=True, default=str).encode()
+                ).hexdigest()
+                seen_ids.add(entry["request_id"])
+                continue
+            if original_id not in seen_ids:
+                seen_ids.add(original_id)
+                continue
+            # Collision within batch: append deterministic content-hash suffix
+            entry_hash = hashlib.sha256(
+                json.dumps(entry, sort_keys=True, default=str).encode()
+            ).hexdigest()
+            entry["request_id"] = f"{original_id}-{entry_hash[:8]}"
+            seen_ids.add(entry["request_id"])
+
+    @staticmethod
     async def update_spend_logs(
         n_retry_times: int,
         prisma_client: PrismaClient,
@@ -5212,29 +5253,10 @@ class ProxyUpdateSpend:
                 "Spend tracking - processing %d spend logs for DB write",
                 len(logs_to_process),
             )
-            # Stamp unique request_id suffixes ONCE, before the retry loop.
-            # Upstream providers may reuse short request IDs (e.g. chatcmpl-424).
-            # Since request_id is the primary key, duplicates are silently dropped
-            # by skip_duplicates=True. Appending a suffix preserves every log.
-            #
-            # The suffix is a deterministic hash of the entry's content (not a
-            # random UUID) so that:
-            # 1. Retries after a partial batch failure regenerate the SAME ids,
-            #    letting skip_duplicates=True dedupe already-committed rows.
-            # 2. If the same log entry is ever re-enqueued, it cannot create a
-            #    second row under a different random suffix.
-            # Two entries with the same upstream request_id but different
-            # content (the provider-reuse bug) hash differently and are both
-            # preserved. This stamping MUST stay outside the retry loop.
-            for entry in logs_to_process:
-                original_id = entry.get("request_id", "")
-                entry_hash = hashlib.sha256(
-                    json.dumps(entry, sort_keys=True, default=str).encode()
-                ).hexdigest()
-                if original_id:
-                    entry["request_id"] = f"{original_id}-{entry_hash[:8]}"
-                else:
-                    entry["request_id"] = entry_hash
+            # Resolve request_id collisions ONCE, before the retry loop, so
+            # that retries reuse the same stable ids and skip_duplicates=True
+            # correctly dedupes batches that were already committed.
+            ProxyUpdateSpend._ensure_unique_request_ids(logs_to_process=logs_to_process)
         start_time = time.time()
         try:
             for i in range(n_retry_times + 1):

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -9,7 +9,6 @@ import sys
 import threading
 import time
 import traceback
-import uuid
 from datetime import date, datetime, timedelta, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -5216,15 +5215,26 @@ class ProxyUpdateSpend:
             # Stamp unique request_id suffixes ONCE, before the retry loop.
             # Upstream providers may reuse short request IDs (e.g. chatcmpl-424).
             # Since request_id is the primary key, duplicates are silently dropped
-            # by skip_duplicates=True. Appending a UUID suffix preserves every log.
-            # This MUST happen outside the retry loop so that retries reuse the
-            # same stable IDs and skip_duplicates=True works correctly on retry.
+            # by skip_duplicates=True. Appending a suffix preserves every log.
+            #
+            # The suffix is a deterministic hash of the entry's content (not a
+            # random UUID) so that:
+            # 1. Retries after a partial batch failure regenerate the SAME ids,
+            #    letting skip_duplicates=True dedupe already-committed rows.
+            # 2. If the same log entry is ever re-enqueued, it cannot create a
+            #    second row under a different random suffix.
+            # Two entries with the same upstream request_id but different
+            # content (the provider-reuse bug) hash differently and are both
+            # preserved. This stamping MUST stay outside the retry loop.
             for entry in logs_to_process:
                 original_id = entry.get("request_id", "")
+                entry_hash = hashlib.sha256(
+                    json.dumps(entry, sort_keys=True, default=str).encode()
+                ).hexdigest()
                 if original_id:
-                    entry["request_id"] = f"{original_id}-{uuid.uuid4().hex[:8]}"
+                    entry["request_id"] = f"{original_id}-{entry_hash[:8]}"
                 else:
-                    entry["request_id"] = str(uuid.uuid4())
+                    entry["request_id"] = entry_hash
         start_time = time.time()
         try:
             for i in range(n_retry_times + 1):
@@ -5255,7 +5265,6 @@ class ProxyUpdateSpend:
                                 prisma_client.jsonify_object({**entry})
                                 for entry in batch
                             ]
-
                             await prisma_client.db.litellm_spendlogs.create_many(
                                 data=batch_with_dates, skip_duplicates=True
                             )

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 import traceback
+import uuid
 from datetime import date, datetime, timedelta, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -5212,6 +5213,18 @@ class ProxyUpdateSpend:
                 "Spend tracking - processing %d spend logs for DB write",
                 len(logs_to_process),
             )
+            # Stamp unique request_id suffixes ONCE, before the retry loop.
+            # Upstream providers may reuse short request IDs (e.g. chatcmpl-424).
+            # Since request_id is the primary key, duplicates are silently dropped
+            # by skip_duplicates=True. Appending a UUID suffix preserves every log.
+            # This MUST happen outside the retry loop so that retries reuse the
+            # same stable IDs and skip_duplicates=True works correctly on retry.
+            for entry in logs_to_process:
+                original_id = entry.get("request_id", "")
+                if original_id:
+                    entry["request_id"] = f"{original_id}-{uuid.uuid4().hex[:8]}"
+                else:
+                    entry["request_id"] = str(uuid.uuid4())
         start_time = time.time()
         try:
             for i in range(n_retry_times + 1):
@@ -5242,6 +5255,7 @@ class ProxyUpdateSpend:
                                 prisma_client.jsonify_object({**entry})
                                 for entry in batch
                             ]
+
                             await prisma_client.db.litellm_spendlogs.create_many(
                                 data=batch_with_dates, skip_duplicates=True
                             )

--- a/tests/test_litellm/proxy/test_update_spend_logs_request_id.py
+++ b/tests/test_litellm/proxy/test_update_spend_logs_request_id.py
@@ -5,15 +5,16 @@ Because ``request_id`` is the LiteLLM_SpendLogs primary key and the batch
 insert uses ``skip_duplicates=True``, reused IDs previously caused spend
 logs to be silently dropped.
 
-``update_spend_logs`` now appends a deterministic content-hash suffix to
-each ``request_id`` before writing, so:
-1. Colliding upstream IDs with different content are both preserved.
-2. Retries / re-enqueues of identical entries regenerate the SAME ids,
+``update_spend_logs`` now resolves collisions before writing:
+1. The FIRST entry with a given request_id keeps its ORIGINAL id
+   (backward compatible - exact-match lookups keep working).
+2. Subsequent colliding entries get a deterministic content-hash suffix,
+   so both rows are preserved.
+3. Retries / re-enqueues of identical batches regenerate the SAME ids,
    letting ``skip_duplicates=True`` dedupe already-committed rows.
 """
 
 import asyncio
-import json
 import os
 import sys
 from typing import Any, Dict, List
@@ -76,7 +77,8 @@ async def _run_update_spend_logs(
 async def test_update_spend_logs_preserves_colliding_request_ids():
     """Two logs sharing an upstream request_id but with different content
     must be written under distinct request_ids (the original bug: one of
-    them was silently dropped by skip_duplicates=True)."""
+    them was silently dropped by skip_duplicates=True). The FIRST entry
+    keeps its original id for backward compatibility."""
     mock_prisma_client = _make_mock_prisma_client()
     request_ids = await _run_update_spend_logs(
         mock_prisma_client,
@@ -86,23 +88,41 @@ async def test_update_spend_logs_preserves_colliding_request_ids():
         ],
     )
     assert len(set(request_ids)) == 2
-    assert all(rid.startswith("chatcmpl-424-") for rid in request_ids)
+    assert request_ids[0] == "chatcmpl-424"  # first keeps original id
+    assert request_ids[1].startswith("chatcmpl-424-")  # collision suffixed
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_keeps_unique_request_ids_unchanged():
+    """Backward compatibility: entries whose upstream request_ids are
+    already unique must be written with their ORIGINAL ids, so exact-match
+    queries, UI links, and external integrations keep working."""
+    mock_prisma_client = _make_mock_prisma_client()
+    request_ids = await _run_update_spend_logs(
+        mock_prisma_client,
+        [
+            _make_spend_log_row(request_id="chatcmpl-abc123", spend=1.0),
+            _make_spend_log_row(request_id="chatcmpl-def456", spend=2.0),
+        ],
+    )
+    assert request_ids == ["chatcmpl-abc123", "chatcmpl-def456"]
 
 
 @pytest.mark.asyncio
 async def test_update_spend_logs_request_id_suffix_is_deterministic():
-    """Identical entries processed twice (e.g. a retried or re-enqueued
-    batch) must be stamped with the SAME request_ids so that
+    """Identical colliding batches processed twice (e.g. a retried or
+    re-enqueued batch) must be stamped with the SAME request_ids so that
     skip_duplicates=True can dedupe already-committed rows."""
     mock_prisma_client = _make_mock_prisma_client()
-    ids_first = await _run_update_spend_logs(
-        mock_prisma_client,
-        [_make_spend_log_row(request_id="chatcmpl-424", spend=1.0)],
-    )
-    ids_second = await _run_update_spend_logs(
-        mock_prisma_client,
-        [_make_spend_log_row(request_id="chatcmpl-424", spend=1.0)],
-    )
+
+    def _colliding_batch() -> List[Dict[str, Any]]:
+        return [
+            _make_spend_log_row(request_id="chatcmpl-424", spend=1.0),
+            _make_spend_log_row(request_id="chatcmpl-424", spend=2.0),
+        ]
+
+    ids_first = await _run_update_spend_logs(mock_prisma_client, _colliding_batch())
+    ids_second = await _run_update_spend_logs(mock_prisma_client, _colliding_batch())
     assert ids_first == ids_second
 
 
@@ -131,7 +151,10 @@ async def test_update_spend_logs_stamps_ids_before_retry_loop():
         prisma_client=mock_prisma_client,
         db_writer_client=None,
         proxy_logging_obj=proxy_logging,
-        logs_to_process=[_make_spend_log_row(request_id="chatcmpl-424", spend=1.0)],
+        logs_to_process=[
+            _make_spend_log_row(request_id="chatcmpl-424", spend=1.0),
+            _make_spend_log_row(request_id="chatcmpl-424", spend=2.0),
+        ],
     )
     assert len(seen_ids_per_attempt) == 2
     assert seen_ids_per_attempt[0] == seen_ids_per_attempt[1]

--- a/tests/test_litellm/proxy/test_update_spend_logs_request_id.py
+++ b/tests/test_litellm/proxy/test_update_spend_logs_request_id.py
@@ -1,0 +1,148 @@
+"""Tests for unique request_id stamping in ``ProxyUpdateSpend.update_spend_logs``.
+
+Upstream providers may reuse short request IDs (e.g. ``chatcmpl-424``).
+Because ``request_id`` is the LiteLLM_SpendLogs primary key and the batch
+insert uses ``skip_duplicates=True``, reused IDs previously caused spend
+logs to be silently dropped.
+
+``update_spend_logs`` now appends a deterministic content-hash suffix to
+each ``request_id`` before writing, so:
+1. Colliding upstream IDs with different content are both preserved.
+2. Retries / re-enqueues of identical entries regenerate the SAME ids,
+   letting ``skip_duplicates=True`` dedupe already-committed rows.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.utils import ProxyUpdateSpend
+
+
+def _make_mock_prisma_client() -> MagicMock:
+    client = MagicMock()
+    client.spend_log_transactions = []
+    client._spend_log_transactions_lock = asyncio.Lock()
+    client.jsonify_object = lambda data: data
+    client.db.litellm_spendlogs.create_many = AsyncMock()
+    return client
+
+
+def _make_spend_log_row(
+    request_id: str = "req-1", spend: float = 0.01, **overrides: Any
+) -> Dict[str, Any]:
+    row = {
+        "request_id": request_id,
+        "spend": spend,
+        "model": "gpt-4o-mini",
+        "user": "user-1",
+        "api_key": "hashed-key",
+        "startTime": "2026-06-02T00:00:00Z",
+        "endTime": "2026-06-02T00:00:01Z",
+        "metadata": {},
+    }
+    row.update(overrides)
+    return row
+
+
+async def _run_update_spend_logs(
+    mock_prisma_client: MagicMock, logs: List[Dict[str, Any]]
+) -> List[str]:
+    mock_prisma_client.db.litellm_spendlogs.create_many = AsyncMock()
+    proxy_logging = MagicMock()
+    proxy_logging.failure_handler = AsyncMock()
+    await ProxyUpdateSpend.update_spend_logs(
+        n_retry_times=0,
+        prisma_client=mock_prisma_client,
+        db_writer_client=None,
+        proxy_logging_obj=proxy_logging,
+        logs_to_process=logs,
+    )
+    kwargs = mock_prisma_client.db.litellm_spendlogs.create_many.await_args.kwargs
+    assert kwargs["skip_duplicates"] is True
+    return [row["request_id"] for row in kwargs["data"]]
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_preserves_colliding_request_ids():
+    """Two logs sharing an upstream request_id but with different content
+    must be written under distinct request_ids (the original bug: one of
+    them was silently dropped by skip_duplicates=True)."""
+    mock_prisma_client = _make_mock_prisma_client()
+    request_ids = await _run_update_spend_logs(
+        mock_prisma_client,
+        [
+            _make_spend_log_row(request_id="chatcmpl-424", spend=1.0),
+            _make_spend_log_row(request_id="chatcmpl-424", spend=2.0),
+        ],
+    )
+    assert len(set(request_ids)) == 2
+    assert all(rid.startswith("chatcmpl-424-") for rid in request_ids)
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_request_id_suffix_is_deterministic():
+    """Identical entries processed twice (e.g. a retried or re-enqueued
+    batch) must be stamped with the SAME request_ids so that
+    skip_duplicates=True can dedupe already-committed rows."""
+    mock_prisma_client = _make_mock_prisma_client()
+    ids_first = await _run_update_spend_logs(
+        mock_prisma_client,
+        [_make_spend_log_row(request_id="chatcmpl-424", spend=1.0)],
+    )
+    ids_second = await _run_update_spend_logs(
+        mock_prisma_client,
+        [_make_spend_log_row(request_id="chatcmpl-424", spend=1.0)],
+    )
+    assert ids_first == ids_second
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_stamps_ids_before_retry_loop():
+    """If a DB connection error fires after a partial commit, the retry pass
+    must reuse the SAME stamped ids - otherwise already-committed batches
+    would be rewritten under new ids, duplicating spend entries."""
+    import httpx
+
+    mock_prisma_client = _make_mock_prisma_client()
+    seen_ids_per_attempt: List[List[str]] = []
+
+    async def _create_many(data: List[Dict[str, Any]], skip_duplicates: bool) -> None:
+        seen_ids_per_attempt.append([row["request_id"] for row in data])
+        if len(seen_ids_per_attempt) == 1:
+            raise httpx.ReadError("connection dropped mid-flush")
+
+    mock_prisma_client.db.litellm_spendlogs.create_many = AsyncMock(
+        side_effect=_create_many
+    )
+    proxy_logging = MagicMock()
+    proxy_logging.failure_handler = AsyncMock()
+    await ProxyUpdateSpend.update_spend_logs(
+        n_retry_times=1,
+        prisma_client=mock_prisma_client,
+        db_writer_client=None,
+        proxy_logging_obj=proxy_logging,
+        logs_to_process=[_make_spend_log_row(request_id="chatcmpl-424", spend=1.0)],
+    )
+    assert len(seen_ids_per_attempt) == 2
+    assert seen_ids_per_attempt[0] == seen_ids_per_attempt[1]
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_generates_id_when_request_id_missing():
+    """Entries without any request_id should still get a usable id."""
+    mock_prisma_client = _make_mock_prisma_client()
+    row = _make_spend_log_row()
+    row.pop("request_id")
+    request_ids = await _run_update_spend_logs(mock_prisma_client, [row])
+    assert len(request_ids) == 1
+    assert request_ids[0]  # non-empty


### PR DESCRIPTION
## Problem

Some upstream providers (e.g. certain OpenAI-compatible APIs) reuse short request IDs such as `chatcmpl-424`. Because `LiteLLM_SpendLogs` uses `request_id` as its primary key and the insert uses `skip_duplicates=True`, these collisions cause spend logs to be silently dropped with no error or warning.

Users see requests succeeding and being charged, but no entries appear in the UI Logs tab.

## Fix

Add `ProxyUpdateSpend._ensure_unique_request_ids`, called once per batch **before** the retry loop in `update_spend_logs`:

- **Backward compatible:** the FIRST entry with a given `request_id` keeps its original id unchanged — exact-match queries, UI links, and external integrations keep working for the common case of globally-unique upstream ids.
- **Collision-only suffixing:** only subsequent entries with the same id within the batch get a deterministic sha256 content-hash suffix (`chatcmpl-424-<8 hex chars>`), so both rows are preserved.
- **Retry-safe:** stamping happens once, outside the retry loop, and the suffix is derived from entry content — a retry after a partial batch commit regenerates the *same* ids, and `skip_duplicates=True` correctly dedupes already-committed rows.
- Entries missing a `request_id` entirely get their content hash as id.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `tests/test_litellm/proxy/test_update_spend_logs_request_id.py` covering:
- colliding upstream request_ids: first keeps original id, second gets suffixed, both written
- already-unique request_ids pass through completely unchanged (backward compat)
- identical colliding batches re-processed produce identical stamped IDs
- a retry after a simulated mid-flush connection error reuses the same IDs
- entries with no request_id still get a usable ID

`uv run pytest tests/test_litellm/proxy/test_update_spend_logs_request_id.py tests/test_litellm/proxy/test_proxy_utils.py` — 29 passed.
