### PR TITLE
fix(proxy): pass search tool credentials to websearch

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -93,6 +93,7 @@ class WebSearchInterceptionLogger(CustomLogger):
         messages: List[Dict],
         tools: Optional[List[Dict]],
         custom_llm_provider: Optional[str],
+        kwargs: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Short-circuit web-search-only requests by executing the search directly.
@@ -179,8 +180,15 @@ class WebSearchInterceptionLogger(CustomLogger):
         # Execute search — keep the structured SearchResponse so the native
         # block can carry per-result url/title/page_age.
         try:
-            search_result_text, structured = await self._execute_search(query)
+            if kwargs is None:
+                search_result_text, structured = await self._execute_search(query)
+            else:
+                search_result_text, structured = await self._execute_search(
+                    query, kwargs=kwargs
+                )
         except Exception as e:
+            if self._is_proxy_exception(e):
+                raise
             verbose_logger.error(
                 f"WebSearchInterception: Short-circuit search failed: {e}"
             )
@@ -946,7 +954,7 @@ class WebSearchInterceptionLogger(CustomLogger):
                 verbose_logger.debug(
                     f"WebSearchInterception: Queuing search for query='{query}'"
                 )
-                search_tasks.append(self._execute_search(query))
+                search_tasks.append(self._execute_search(query, kwargs=kwargs))
             else:
                 verbose_logger.debug(
                     f"WebSearchInterception: Tool call {tool_call['id']} has no query"
@@ -967,6 +975,8 @@ class WebSearchInterceptionLogger(CustomLogger):
         structured_results: List[Optional[SearchResponse]] = []
         for i, result in enumerate(search_results):
             if isinstance(result, Exception):
+                if self._is_proxy_exception(result):
+                    raise result
                 verbose_logger.error(
                     f"WebSearchInterception: Search {i} failed with error: {str(result)}"
                 )
@@ -1046,7 +1056,141 @@ class WebSearchInterceptionLogger(CustomLogger):
         )
         return patch, structured_results
 
-    async def _execute_search(self, query: str) -> Tuple[str, Optional[SearchResponse]]:
+    @staticmethod
+    def _get_user_api_key_auth_from_kwargs(kwargs: Optional[Dict[str, Any]]) -> Any:
+        if not kwargs:
+            return None
+
+        for metadata_key in ("metadata", "litellm_metadata"):
+            metadata = kwargs.get(metadata_key)
+            if isinstance(metadata, dict):
+                user_api_key_auth = metadata.get("user_api_key_auth")
+                if user_api_key_auth is not None:
+                    return user_api_key_auth
+
+        litellm_params = kwargs.get("litellm_params")
+        if isinstance(litellm_params, dict):
+            for metadata_key in ("metadata", "litellm_metadata"):
+                metadata = litellm_params.get(metadata_key)
+                if isinstance(metadata, dict):
+                    user_api_key_auth = metadata.get("user_api_key_auth")
+                    if user_api_key_auth is not None:
+                        return user_api_key_auth
+
+        return kwargs.get("user_api_key_auth") or kwargs.get("user_api_key_dict")
+
+    @staticmethod
+    def _get_auth_attr(user_api_key_auth: Any, attr_name: str) -> Any:
+        if isinstance(user_api_key_auth, dict):
+            return user_api_key_auth.get(attr_name)
+        return getattr(user_api_key_auth, attr_name, None)
+
+    @staticmethod
+    def _is_proxy_exception(exception: BaseException) -> bool:
+        from litellm.proxy._types import ProxyException
+
+        return isinstance(exception, ProxyException)
+
+    @staticmethod
+    def _get_search_tool_names_from_object_permission(
+        object_permission: Any,
+    ) -> List[str]:
+        if object_permission is None:
+            return []
+        if isinstance(object_permission, dict):
+            raw_search_tools = object_permission.get("search_tools")
+        else:
+            raw_search_tools = getattr(object_permission, "search_tools", None)
+        if not raw_search_tools:
+            return []
+        return list(raw_search_tools)
+
+    @staticmethod
+    def _assert_search_tool_allowed(
+        *,
+        search_tool_name: str,
+        object_permission: Any,
+        object_type: str,
+    ) -> None:
+        allowed_search_tools = (
+            WebSearchInterceptionLogger._get_search_tool_names_from_object_permission(
+                object_permission
+            )
+        )
+        if not allowed_search_tools or search_tool_name in allowed_search_tools:
+            return
+
+        from litellm.proxy._types import ProxyErrorTypes, ProxyException
+
+        raise ProxyException(
+            message=f"{object_type.capitalize()} not allowed to access search tool: {search_tool_name}. "
+            f"Allowed search tools: {allowed_search_tools}",
+            type=ProxyErrorTypes.key_model_access_denied,
+            param="search_tool_name",
+            code=403,
+        )
+
+    @staticmethod
+    async def _authorize_search_tool_access(
+        search_tool_name: Optional[str],
+        kwargs: Optional[Dict[str, Any]],
+    ) -> None:
+        if not search_tool_name:
+            return
+
+        user_api_key_auth = (
+            WebSearchInterceptionLogger._get_user_api_key_auth_from_kwargs(kwargs)
+        )
+        if user_api_key_auth is None:
+            return
+
+        WebSearchInterceptionLogger._assert_search_tool_allowed(
+            search_tool_name=search_tool_name,
+            object_permission=WebSearchInterceptionLogger._get_auth_attr(
+                user_api_key_auth, "object_permission"
+            ),
+            object_type="key",
+        )
+
+        team_id = WebSearchInterceptionLogger._get_auth_attr(
+            user_api_key_auth, "team_id"
+        )
+        if not team_id:
+            return
+
+        team_object_permission = WebSearchInterceptionLogger._get_auth_attr(
+            user_api_key_auth, "team_object_permission"
+        )
+        if team_object_permission is None:
+            from litellm.proxy.auth.auth_checks import get_team_object
+            from litellm.proxy.proxy_server import (
+                prisma_client,
+                proxy_logging_obj,
+                user_api_key_cache,
+            )
+
+            team_object = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=WebSearchInterceptionLogger._get_auth_attr(
+                    user_api_key_auth, "parent_otel_span"
+                ),
+                proxy_logging_obj=proxy_logging_obj,
+            )
+            team_object_permission = getattr(team_object, "object_permission", None)
+
+        WebSearchInterceptionLogger._assert_search_tool_allowed(
+            search_tool_name=search_tool_name,
+            object_permission=team_object_permission,
+            object_type="team",
+        )
+
+    async def _execute_search(
+        self,
+        query: str,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, Optional[SearchResponse]]:
         """
         Execute a single web search using router's search tools.
 
@@ -1082,6 +1226,10 @@ class WebSearchInterceptionLogger(CustomLogger):
                     ]
                     if matching_tools:
                         search_tool = matching_tools[0]
+                        selected_search_tool_name = search_tool.get("search_tool_name")
+                        await self._authorize_search_tool_access(
+                            selected_search_tool_name, kwargs
+                        )
                         litellm_params = search_tool.get("litellm_params", {})
                         search_provider = litellm_params.get("search_provider")
                         (
@@ -1103,6 +1251,10 @@ class WebSearchInterceptionLogger(CustomLogger):
                 # If no specific tool or not found, use first available
                 if not search_provider and llm_router.search_tools:
                     first_tool = llm_router.search_tools[0]
+                    selected_search_tool_name = first_tool.get("search_tool_name")
+                    await self._authorize_search_tool_access(
+                        selected_search_tool_name, kwargs
+                    )
                     litellm_params = first_tool.get("litellm_params", {})
                     search_provider = litellm_params.get("search_provider")
                     (
@@ -1208,7 +1360,7 @@ class WebSearchInterceptionLogger(CustomLogger):
                 verbose_logger.debug(
                     f"WebSearchInterception: Queuing search for query='{query}'"
                 )
-                search_tasks.append(self._execute_search(query))
+                search_tasks.append(self._execute_search(query, kwargs=kwargs))
             else:
                 verbose_logger.debug(
                     f"WebSearchInterception: Tool call {tool_call.get('id')} has no query"
@@ -1227,6 +1379,8 @@ class WebSearchInterceptionLogger(CustomLogger):
         final_search_results: List[str] = []
         for i, result in enumerate(search_results):
             if isinstance(result, Exception):
+                if self._is_proxy_exception(result):
+                    raise result
                 verbose_logger.error(
                     f"WebSearchInterception: Search {i} failed with error: {str(result)}"
                 )

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -27,6 +27,7 @@ from litellm.integrations.websearch_interception.transformation import (
     WebSearchTransformation,
 )
 from litellm.llms.base_llm.search.transformation import SearchResponse
+from litellm.router_utils.search_api_router import SearchAPIRouter
 from litellm.types.integrations.websearch_interception import (
     WebSearchInterceptionConfig,
 )
@@ -1068,6 +1069,8 @@ class WebSearchInterceptionLogger(CustomLogger):
                 llm_router = None
 
             # Determine search provider from router's search_tools
+            search_api_key: Optional[str] = None
+            search_api_base: Optional[str] = None
             search_provider: Optional[str] = None
             if llm_router is not None and hasattr(llm_router, "search_tools"):
                 if self.search_tool_name:
@@ -1079,8 +1082,13 @@ class WebSearchInterceptionLogger(CustomLogger):
                     ]
                     if matching_tools:
                         search_tool = matching_tools[0]
-                        search_provider = search_tool.get("litellm_params", {}).get(
-                            "search_provider"
+                        litellm_params = search_tool.get("litellm_params", {})
+                        search_provider = litellm_params.get("search_provider")
+                        (
+                            search_api_key,
+                            search_api_base,
+                        ) = SearchAPIRouter._resolve_search_provider_credentials(
+                            tool_litellm_params=litellm_params
                         )
                         verbose_logger.debug(
                             f"WebSearchInterception: Found search tool '{self.search_tool_name}' "
@@ -1095,8 +1103,13 @@ class WebSearchInterceptionLogger(CustomLogger):
                 # If no specific tool or not found, use first available
                 if not search_provider and llm_router.search_tools:
                     first_tool = llm_router.search_tools[0]
-                    search_provider = first_tool.get("litellm_params", {}).get(
-                        "search_provider"
+                    litellm_params = first_tool.get("litellm_params", {})
+                    search_provider = litellm_params.get("search_provider")
+                    (
+                        search_api_key,
+                        search_api_base,
+                    ) = SearchAPIRouter._resolve_search_provider_credentials(
+                        tool_litellm_params=litellm_params
                     )
                     verbose_logger.debug(
                         f"WebSearchInterception: Using first available search tool with provider '{search_provider}'"
@@ -1105,6 +1118,8 @@ class WebSearchInterceptionLogger(CustomLogger):
             # Fallback to perplexity if no router or no search tools configured
             if not search_provider:
                 search_provider = "perplexity"
+                search_api_key = None
+                search_api_base = None
                 verbose_logger.debug(
                     "WebSearchInterception: No search tools configured in router, "
                     f"using default provider '{search_provider}'"
@@ -1113,7 +1128,12 @@ class WebSearchInterceptionLogger(CustomLogger):
             verbose_logger.debug(
                 f"WebSearchInterception: Executing search for '{query}' using provider '{search_provider}'"
             )
-            result = await litellm.asearch(query=query, search_provider=search_provider)
+            result = await litellm.asearch(
+                query=query,
+                search_provider=search_provider,
+                api_key=search_api_key,
+                api_base=search_api_base,
+            )
 
             # Format using transformation function
             search_result_text = WebSearchTransformation.format_search_response(result)

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1270,8 +1270,6 @@ class WebSearchInterceptionLogger(CustomLogger):
             # Fallback to perplexity if no router or no search tools configured
             if not search_provider:
                 search_provider = "perplexity"
-                search_api_key = None
-                search_api_base = None
                 verbose_logger.debug(
                     "WebSearchInterception: No search tools configured in router, "
                     f"using default provider '{search_provider}'"

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -126,6 +126,7 @@ async def _try_websearch_short_circuit(
     tools: Optional[List[Dict]],
     custom_llm_provider: Optional[str],
     stream: Optional[bool],
+    kwargs: Optional[Dict[str, Any]] = None,
 ) -> Optional[Union[AnthropicMessagesResponse, AsyncIterator]]:
     """
     Attempt to short-circuit a web-search-only request.
@@ -155,6 +156,7 @@ async def _try_websearch_short_circuit(
             messages=messages,
             tools=tools,
             custom_llm_provider=custom_llm_provider,
+            kwargs=kwargs,
         )
         if response is not None:
             anthropic_response = cast(AnthropicMessagesResponse, response)
@@ -250,6 +252,7 @@ async def anthropic_messages(
         tools=tools,
         custom_llm_provider=custom_llm_provider,
         stream=original_stream,
+        kwargs=kwargs,
     )
     if short_circuit_response is not None:
         return short_circuit_response

--- a/litellm/router_utils/search_api_router.py
+++ b/litellm/router_utils/search_api_router.py
@@ -8,9 +8,10 @@ import asyncio
 import random
 import traceback
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Mapping, Optional, Tuple
 
 from litellm._logging import verbose_router_logger
+from litellm.secret_managers.main import get_secret_str
 
 
 class SearchAPIRouter:
@@ -21,9 +22,17 @@ class SearchAPIRouter:
     """
 
     @staticmethod
+    def _resolve_configured_credential(value: Any) -> Optional[str]:
+        if isinstance(value, str) and value.startswith("os.environ/"):
+            return get_secret_str(value)
+        if isinstance(value, str) or value is None:
+            return value
+        return None
+
+    @staticmethod
     def _resolve_search_provider_credentials(
         *,
-        tool_litellm_params: Dict[str, Any],
+        tool_litellm_params: Mapping[str, Any],
     ) -> Tuple[Optional[str], Optional[str]]:
         """
         Resolve search provider credentials from tool configuration ONLY.
@@ -37,8 +46,12 @@ class SearchAPIRouter:
         Returns:
             Tuple of (api_key, api_base) from tool configuration
         """
-        resolved_api_key: Optional[str] = tool_litellm_params.get("api_key")
-        resolved_api_base: Optional[str] = tool_litellm_params.get("api_base")
+        resolved_api_key = SearchAPIRouter._resolve_configured_credential(
+            tool_litellm_params.get("api_key")
+        )
+        resolved_api_base = SearchAPIRouter._resolve_configured_credential(
+            tool_litellm_params.get("api_base")
+        )
 
         return resolved_api_key, resolved_api_base
 

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -4,6 +4,9 @@ Unit tests for WebSearch Interception Handler
 Tests the WebSearchInterceptionLogger class and helper functions.
 """
 
+import builtins
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -11,6 +14,8 @@ import pytest
 from litellm.integrations.websearch_interception.handler import (
     WebSearchInterceptionLogger,
 )
+from litellm.llms.base_llm.search.transformation import SearchResponse, SearchResult
+from litellm.router_utils.search_api_router import SearchAPIRouter
 from litellm.types.utils import LlmProviders
 
 
@@ -125,6 +130,199 @@ async def test_async_build_agentic_loop_plan_returns_request_patch():
 
 
 @pytest.mark.asyncio
+async def test_execute_search_passes_configured_search_tool_credentials(monkeypatch):
+    """Search interception should use credentials from the selected router search tool."""
+    monkeypatch.setenv("FOO_BAR", "custom-perplexity-key")
+    proxy_server_module = ModuleType("litellm.proxy.proxy_server")
+    proxy_server_module.llm_router = SimpleNamespace(
+        search_tools=[
+            {
+                "search_tool_name": "perplexity-search",
+                "litellm_params": {
+                    "search_provider": "perplexity",
+                    "api_key": "os.environ/FOO_BAR",
+                    "api_base": "https://custom.perplexity.example",
+                },
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
+
+    search_response = SearchResponse(
+        object="search",
+        results=[
+            SearchResult(
+                title="LiteLLM",
+                url="https://docs.litellm.ai",
+                snippet="LiteLLM search result",
+            )
+        ],
+    )
+    asearch = AsyncMock(return_value=search_response)
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+
+    logger = WebSearchInterceptionLogger(search_tool_name="perplexity-search")
+
+    search_text, structured_response = await logger._execute_search("what is litellm")
+
+    asearch.assert_awaited_once_with(
+        query="what is litellm",
+        search_provider="perplexity",
+        api_key="custom-perplexity-key",
+        api_base="https://custom.perplexity.example",
+    )
+    assert structured_response is search_response
+    assert "LiteLLM" in search_text
+
+
+@pytest.mark.asyncio
+async def test_execute_search_falls_back_to_first_search_tool_credentials(monkeypatch):
+    """If the requested search tool is missing, use the first configured tool's credentials."""
+    monkeypatch.setenv("CUSTOM_SEARCH_BASE", "https://fallback.perplexity.example")
+    proxy_server_module = ModuleType("litellm.proxy.proxy_server")
+    proxy_server_module.llm_router = SimpleNamespace(
+        search_tools=[
+            {
+                "search_tool_name": "default-perplexity-search",
+                "litellm_params": {
+                    "search_provider": "perplexity",
+                    "api_key": "literal-perplexity-key",
+                    "api_base": "os.environ/CUSTOM_SEARCH_BASE",
+                },
+            }
+        ]
+    )
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
+
+    search_response = SearchResponse(object="search", results=[])
+    asearch = AsyncMock(return_value=search_response)
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+
+    logger = WebSearchInterceptionLogger(search_tool_name="missing-search-tool")
+
+    search_text, structured_response = await logger._execute_search("what is litellm")
+
+    asearch.assert_awaited_once_with(
+        query="what is litellm",
+        search_provider="perplexity",
+        api_key="literal-perplexity-key",
+        api_base="https://fallback.perplexity.example",
+    )
+    assert structured_response is search_response
+    assert "search" in search_text
+
+
+@pytest.mark.asyncio
+async def test_execute_search_uses_default_perplexity_without_router_tools(monkeypatch):
+    """Search interception should not pass stale credentials when no router tools exist."""
+    proxy_server_module = ModuleType("litellm.proxy.proxy_server")
+    proxy_server_module.llm_router = SimpleNamespace(search_tools=[])
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
+
+    search_response = SearchResponse(object="search", results=[])
+    asearch = AsyncMock(return_value=search_response)
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+
+    logger = WebSearchInterceptionLogger()
+
+    search_text, structured_response = await logger._execute_search("what is litellm")
+
+    asearch.assert_awaited_once_with(
+        query="what is litellm",
+        search_provider="perplexity",
+        api_key=None,
+        api_base=None,
+    )
+    assert structured_response is search_response
+    assert "search" in search_text
+
+
+@pytest.mark.asyncio
+async def test_execute_search_uses_default_perplexity_when_router_import_fails(
+    monkeypatch,
+):
+    """Search interception should still work when proxy router import is unavailable."""
+    real_import = builtins.__import__
+
+    def raise_for_proxy_server(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "litellm.proxy.proxy_server":
+            raise ImportError("proxy unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", raise_for_proxy_server)
+
+    search_response = SearchResponse(object="search", results=[])
+    asearch = AsyncMock(return_value=search_response)
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+
+    logger = WebSearchInterceptionLogger()
+
+    search_text, structured_response = await logger._execute_search("what is litellm")
+
+    asearch.assert_awaited_once_with(
+        query="what is litellm",
+        search_provider="perplexity",
+        api_key=None,
+        api_base=None,
+    )
+    assert structured_response is search_response
+    assert "search" in search_text
+
+
+def test_search_provider_credentials_resolve_configured_values(monkeypatch):
+    """Credential resolver should resolve supported values and ignore unsupported ones."""
+    monkeypatch.setenv("FOO_BAR", "custom-perplexity-key")
+
+    api_key, api_base = SearchAPIRouter._resolve_search_provider_credentials(
+        tool_litellm_params={
+            "api_key": "os.environ/FOO_BAR",
+            "api_base": "https://custom.perplexity.example",
+        }
+    )
+
+    assert api_key == "custom-perplexity-key"
+    assert api_base == "https://custom.perplexity.example"
+
+    api_key, api_base = SearchAPIRouter._resolve_search_provider_credentials(
+        tool_litellm_params={"api_key": 123, "api_base": None}
+    )
+
+    assert api_key is None
+    assert api_base is None
+
+
+@pytest.mark.asyncio
+async def test_execute_search_reraises_search_errors(monkeypatch):
+    """Search interception should not hide provider search failures."""
+    proxy_server_module = ModuleType("litellm.proxy.proxy_server")
+    proxy_server_module.llm_router = SimpleNamespace(search_tools=[])
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
+
+    asearch = AsyncMock(side_effect=RuntimeError("search failed"))
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+
+    logger = WebSearchInterceptionLogger()
+
+    with pytest.raises(RuntimeError, match="search failed"):
+        await logger._execute_search("what is litellm")
+
+
+@pytest.mark.asyncio
 async def test_internal_flags_filtered_from_followup_kwargs():
     """Test that internal _websearch_interception flags are filtered from follow-up request kwargs.
 
@@ -132,8 +330,6 @@ async def test_internal_flags_filtered_from_followup_kwargs():
     to the follow-up LLM request, causing "Extra inputs are not permitted" errors
     from providers like Bedrock that use strict parameter validation.
     """
-    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
-
     # Simulate kwargs that would be passed during agentic loop execution
     kwargs_with_internal_flags = {
         "_websearch_interception_converted_stream": True,

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -426,6 +426,177 @@ async def test_chat_completion_agentic_loop_propagates_search_tool_permission_er
     asearch.assert_not_awaited()
 
 
+def test_search_tool_auth_helpers_cover_fallback_shapes():
+    """Auth helpers should handle proxy object and dict shapes used in tests/hooks."""
+    user_api_key_auth = _search_tool_auth(key_search_tools=["perplexity-search"])
+    auth_dict = {
+        "object_permission": {"search_tools": ["dict-search"]},
+        "team_id": "team-1",
+    }
+
+    assert (
+        WebSearchInterceptionLogger._get_user_api_key_auth_from_kwargs(
+            {"user_api_key_auth": user_api_key_auth}
+        )
+        is user_api_key_auth
+    )
+    assert (
+        WebSearchInterceptionLogger._get_user_api_key_auth_from_kwargs(
+            {"user_api_key_dict": user_api_key_auth}
+        )
+        is user_api_key_auth
+    )
+    assert WebSearchInterceptionLogger._get_auth_attr(auth_dict, "team_id") == "team-1"
+    assert (
+        WebSearchInterceptionLogger._get_search_tool_names_from_object_permission(None)
+        == []
+    )
+    assert WebSearchInterceptionLogger._get_search_tool_names_from_object_permission(
+        {"search_tools": ["dict-search"]}
+    ) == ["dict-search"]
+    assert (
+        WebSearchInterceptionLogger._get_search_tool_names_from_object_permission(
+            {"search_tools": []}
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorize_search_tool_access_loads_team_permission(monkeypatch):
+    """Team permissions should be loaded when auth context has only a team id."""
+    team_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="team-permission",
+        search_tools=["perplexity-search"],
+    )
+
+    async def get_team_object(**kwargs):
+        assert kwargs["team_id"] == "team-1"
+        assert kwargs["prisma_client"] == "prisma"
+        assert kwargs["user_api_key_cache"] == "cache"
+        assert kwargs["proxy_logging_obj"] == "proxy-logging"
+        return SimpleNamespace(object_permission=team_permission)
+
+    auth_checks_module = ModuleType("litellm.proxy.auth.auth_checks")
+    auth_checks_module.get_team_object = get_team_object
+    monkeypatch.setitem(
+        sys.modules, "litellm.proxy.auth.auth_checks", auth_checks_module
+    )
+
+    proxy_server_module = ModuleType("litellm.proxy.proxy_server")
+    proxy_server_module.prisma_client = "prisma"
+    proxy_server_module.proxy_logging_obj = "proxy-logging"
+    proxy_server_module.user_api_key_cache = "cache"
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
+
+    user_api_key_auth = _search_tool_auth(key_search_tools=["perplexity-search"])
+    user_api_key_auth.team_id = "team-1"
+    user_api_key_auth.team_object_permission = None
+
+    await WebSearchInterceptionLogger._authorize_search_tool_access(
+        "perplexity-search",
+        {"user_api_key_auth": user_api_key_auth},
+    )
+    await WebSearchInterceptionLogger._authorize_search_tool_access(
+        None,
+        {"user_api_key_auth": user_api_key_auth},
+    )
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_search_returns_text_for_non_auth_search_errors():
+    """Non-auth search failures should keep the existing synthetic error response."""
+    logger = WebSearchInterceptionLogger(enabled_providers=["test_provider"])
+    logger._execute_search = AsyncMock(side_effect=RuntimeError("search down"))  # type: ignore
+
+    response = await logger.try_short_circuit_search(
+        model="test-model",
+        messages=[{"role": "user", "content": "what is litellm"}],
+        tools=[{"name": "litellm_web_search"}],
+        custom_llm_provider="test_provider",
+    )
+
+    assert response is not None
+    assert response["content"] == [
+        {"type": "text", "text": "Search failed: search down"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_agentic_loop_keeps_non_auth_search_errors_as_tool_text():
+    """Non-auth search failures should still be passed to the follow-up model as text."""
+    logger = WebSearchInterceptionLogger()
+    logger._execute_search = AsyncMock(side_effect=RuntimeError("search down"))  # type: ignore
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+
+    patch, structured_results = await logger._build_anthropic_request_patch(
+        model="bedrock/claude",
+        messages=[{"role": "user", "content": "what is litellm"}],
+        tool_calls=[
+            {
+                "id": "toolu_123",
+                "type": "tool_use",
+                "name": "litellm_web_search",
+                "input": {"query": "what is litellm"},
+            },
+            {
+                "id": "toolu_empty",
+                "type": "tool_use",
+                "name": "litellm_web_search",
+                "input": {},
+            },
+        ],
+        thinking_blocks=[],
+        anthropic_messages_optional_request_params={},
+        logging_obj=logging_obj,
+        kwargs={},
+    )
+
+    assert patch.messages is not None
+    assert "Search failed: search down" in str(patch.messages)
+    assert structured_results == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_agentic_loop_keeps_non_auth_search_errors_as_tool_text():
+    """Chat-completion search failures should remain ordinary tool-result text."""
+    logger = WebSearchInterceptionLogger()
+    logger._execute_search = AsyncMock(side_effect=RuntimeError("search down"))  # type: ignore
+
+    patch = await logger._build_chat_completion_request_patch(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "what is litellm"}],
+        tool_calls=[
+            {
+                "id": "call_123",
+                "type": "function",
+                "name": "litellm_web_search",
+                "input": {"query": "what is litellm"},
+                "function": {
+                    "name": "litellm_web_search",
+                    "arguments": {"query": "what is litellm"},
+                },
+            },
+            {
+                "id": "call_empty",
+                "type": "function",
+                "name": "litellm_web_search",
+                "input": {},
+                "function": {
+                    "name": "litellm_web_search",
+                    "arguments": {},
+                },
+            },
+        ],
+        optional_params={},
+        kwargs={},
+    )
+
+    assert patch.messages is not None
+    assert "Search failed: search down" in str(patch.messages)
+
+
 @pytest.mark.asyncio
 async def test_execute_search_falls_back_to_first_search_tool_credentials(monkeypatch):
     """If the requested search tool is missing, use the first configured tool's credentials."""

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -15,6 +15,10 @@ from litellm.integrations.websearch_interception.handler import (
     WebSearchInterceptionLogger,
 )
 from litellm.llms.base_llm.search.transformation import SearchResponse, SearchResult
+from litellm.proxy._types import (
+    LiteLLM_ObjectPermissionTable,
+    ProxyException,
+)
 from litellm.router_utils.search_api_router import SearchAPIRouter
 from litellm.types.utils import LlmProviders
 
@@ -176,6 +180,250 @@ async def test_execute_search_passes_configured_search_tool_credentials(monkeypa
     )
     assert structured_response is search_response
     assert "LiteLLM" in search_text
+
+
+def _search_tool_auth(
+    *,
+    key_search_tools: list[str] | None = None,
+    team_search_tools: list[str] | None = None,
+):
+    key_permission = (
+        LiteLLM_ObjectPermissionTable(
+            object_permission_id="key-permission",
+            search_tools=key_search_tools,
+        )
+        if key_search_tools is not None
+        else None
+    )
+    team_permission = (
+        LiteLLM_ObjectPermissionTable(
+            object_permission_id="team-permission",
+            search_tools=team_search_tools,
+        )
+        if team_search_tools is not None
+        else None
+    )
+    return SimpleNamespace(
+        api_key="hashed-key",
+        object_permission=key_permission,
+        team_id="team-1" if team_permission is not None else None,
+        team_object_permission=team_permission,
+    )
+
+
+def _set_proxy_search_tools(monkeypatch, search_tools):
+    proxy_server_module = ModuleType("litellm.proxy.proxy_server")
+    proxy_server_module.llm_router = SimpleNamespace(search_tools=search_tools)
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
+
+
+def _mock_asearch(monkeypatch):
+    asearch = AsyncMock(return_value=SearchResponse(object="search", results=[]))
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+    return asearch
+
+
+def _perplexity_search_tool(
+    *,
+    search_tool_name: str = "perplexity-search",
+    api_key: str = "should-not-be-used",
+):
+    return {
+        "search_tool_name": search_tool_name,
+        "litellm_params": {
+            "search_provider": "perplexity",
+            "api_key": api_key,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_search_checks_key_search_tool_permission(monkeypatch):
+    """Search interception should not use configured credentials denied to the key."""
+    _set_proxy_search_tools(monkeypatch, [_perplexity_search_tool()])
+    asearch = _mock_asearch(monkeypatch)
+
+    logger = WebSearchInterceptionLogger(search_tool_name="perplexity-search")
+    user_api_key_auth = _search_tool_auth(key_search_tools=["other-search"])
+
+    with pytest.raises(ProxyException) as exc_info:
+        await logger._execute_search(
+            "what is litellm",
+            kwargs={"metadata": {"user_api_key_auth": user_api_key_auth}},
+        )
+
+    assert "not allowed to access search tool" in exc_info.value.message
+    asearch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_search_allows_key_search_tool_permission(monkeypatch):
+    """Allowed keys should keep the configured search credential path."""
+    monkeypatch.setenv("FOO_BAR", "custom-perplexity-key")
+    _set_proxy_search_tools(
+        monkeypatch, [_perplexity_search_tool(api_key="os.environ/FOO_BAR")]
+    )
+    search_response = SearchResponse(object="search", results=[])
+    asearch = AsyncMock(return_value=search_response)
+    monkeypatch.setattr(
+        "litellm.integrations.websearch_interception.handler.litellm.asearch",
+        asearch,
+    )
+
+    logger = WebSearchInterceptionLogger(search_tool_name="perplexity-search")
+    user_api_key_auth = _search_tool_auth(key_search_tools=["perplexity-search"])
+
+    _, structured_response = await logger._execute_search(
+        "what is litellm",
+        kwargs={"metadata": {"user_api_key_auth": user_api_key_auth}},
+    )
+
+    asearch.assert_awaited_once_with(
+        query="what is litellm",
+        search_provider="perplexity",
+        api_key="custom-perplexity-key",
+        api_base=None,
+    )
+    assert structured_response is search_response
+
+
+@pytest.mark.asyncio
+async def test_execute_search_checks_fallback_search_tool_permission(monkeypatch):
+    """Fallback to the first router tool should authorize that actual tool name."""
+    _set_proxy_search_tools(
+        monkeypatch,
+        [_perplexity_search_tool(search_tool_name="default-perplexity-search")],
+    )
+    asearch = _mock_asearch(monkeypatch)
+
+    logger = WebSearchInterceptionLogger(search_tool_name="missing-search-tool")
+    user_api_key_auth = _search_tool_auth(key_search_tools=["missing-search-tool"])
+
+    with pytest.raises(ProxyException) as exc_info:
+        await logger._execute_search(
+            "what is litellm",
+            kwargs={"metadata": {"user_api_key_auth": user_api_key_auth}},
+        )
+
+    assert "default-perplexity-search" in exc_info.value.message
+    asearch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_search_checks_team_search_tool_permission(monkeypatch):
+    """Team search-tool allowlists should still apply when the key allows access."""
+    _set_proxy_search_tools(monkeypatch, [_perplexity_search_tool()])
+    asearch = _mock_asearch(monkeypatch)
+
+    logger = WebSearchInterceptionLogger(search_tool_name="perplexity-search")
+    user_api_key_auth = _search_tool_auth(
+        key_search_tools=["perplexity-search"],
+        team_search_tools=["other-search"],
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await logger._execute_search(
+            "what is litellm",
+            kwargs={"metadata": {"user_api_key_auth": user_api_key_auth}},
+        )
+
+    assert "Team not allowed" in exc_info.value.message
+    asearch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_search_propagates_search_tool_permission_error(
+    monkeypatch,
+):
+    """Short-circuit requests should fail authorization instead of returning error text."""
+    _set_proxy_search_tools(monkeypatch, [_perplexity_search_tool()])
+    asearch = _mock_asearch(monkeypatch)
+
+    logger = WebSearchInterceptionLogger(
+        enabled_providers=["test_provider"],
+        search_tool_name="perplexity-search",
+    )
+    user_api_key_auth = _search_tool_auth(key_search_tools=["other-search"])
+
+    with pytest.raises(ProxyException):
+        await logger.try_short_circuit_search(
+            model="test-model",
+            messages=[{"role": "user", "content": "what is litellm"}],
+            tools=[{"name": "litellm_web_search"}],
+            custom_llm_provider="test_provider",
+            kwargs={
+                "litellm_params": {"metadata": {"user_api_key_auth": user_api_key_auth}}
+            },
+        )
+
+    asearch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_agentic_loop_propagates_search_tool_permission_error(
+    monkeypatch,
+):
+    """Anthropic agentic-loop searches should not turn auth failures into tool text."""
+    _set_proxy_search_tools(monkeypatch, [_perplexity_search_tool()])
+    asearch = _mock_asearch(monkeypatch)
+
+    logger = WebSearchInterceptionLogger(search_tool_name="perplexity-search")
+    user_api_key_auth = _search_tool_auth(key_search_tools=["other-search"])
+
+    with pytest.raises(ProxyException):
+        await logger._build_anthropic_request_patch(
+            model="bedrock/claude",
+            messages=[{"role": "user", "content": "what is litellm"}],
+            tool_calls=[
+                {
+                    "id": "toolu_123",
+                    "type": "tool_use",
+                    "name": "litellm_web_search",
+                    "input": {"query": "what is litellm"},
+                }
+            ],
+            thinking_blocks=[],
+            anthropic_messages_optional_request_params={},
+            logging_obj=None,
+            kwargs={"metadata": {"user_api_key_auth": user_api_key_auth}},
+        )
+
+    asearch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_agentic_loop_propagates_search_tool_permission_error(
+    monkeypatch,
+):
+    """Chat-completion agentic-loop searches should preserve auth failures."""
+    _set_proxy_search_tools(monkeypatch, [_perplexity_search_tool()])
+    asearch = _mock_asearch(monkeypatch)
+
+    logger = WebSearchInterceptionLogger(search_tool_name="perplexity-search")
+    user_api_key_auth = _search_tool_auth(key_search_tools=["other-search"])
+
+    with pytest.raises(ProxyException):
+        await logger._build_chat_completion_request_patch(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "what is litellm"}],
+            tool_calls=[
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "litellm_web_search",
+                        "arguments": {"query": "what is litellm"},
+                    },
+                }
+            ],
+            optional_params={},
+            kwargs={"metadata": {"user_api_key_auth": user_api_key_auth}},
+        )
+
+    asearch.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resolve `os.environ/...` search tool credential references in the shared search router helper
- carry the selected router search tool `api_key`/`api_base` into WebSearchInterception's `litellm.asearch()` call
- add a mocked regression for a Perplexity search tool configured with `api_key: os.environ/FOO_BAR`

Fixes #28334.

## Testing
- `uv run pytest tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py -q`
- `uv run pytest tests/test_litellm/integrations/websearch_interception -q`
- `uv run ruff check litellm/router_utils/search_api_router.py litellm/integrations/websearch_interception/handler.py tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py`
- `uv run black --check litellm/router_utils/search_api_router.py litellm/integrations/websearch_interception/handler.py tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py`
- `python3 -m py_compile litellm/router_utils/search_api_router.py litellm/integrations/websearch_interception/handler.py tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py`
- `git diff --check`