### PR TITLE
fix(websearch): preserve NIM provider prefix

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1273,7 +1273,8 @@ class WebSearchInterceptionLogger(CustomLogger):
         full_model_name = model
         if "custom_llm_provider" in kwargs:
             custom_llm_provider = kwargs["custom_llm_provider"]
-            if not model.startswith(custom_llm_provider) and "/" not in model:
+            provider_prefix = f"{custom_llm_provider}/"
+            if not model.startswith(provider_prefix):
                 full_model_name = f"{custom_llm_provider}/{model}"
 
         verbose_logger.debug(

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -125,6 +125,61 @@ async def test_async_build_agentic_loop_plan_returns_request_patch():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "custom_llm_provider", "expected_model"),
+    [
+        (
+            "qwen/qwen3.5-397b-a17b",
+            "nvidia_nim",
+            "nvidia_nim/qwen/qwen3.5-397b-a17b",
+        ),
+        (
+            "nvidia_nim/qwen/qwen3.5-397b-a17b",
+            "nvidia_nim",
+            "nvidia_nim/qwen/qwen3.5-397b-a17b",
+        ),
+        (
+            "nvidia_nim/qwen/qwen3.5-397b-a17b",
+            "nvidia",
+            "nvidia/nvidia_nim/qwen/qwen3.5-397b-a17b",
+        ),
+    ],
+)
+async def test_chat_completion_followup_preserves_provider_for_slashed_models(
+    model, custom_llm_provider, expected_model
+):
+    """Follow-up chat completions must not drop providers for namespaced models."""
+    logger = WebSearchInterceptionLogger(enabled_providers=[custom_llm_provider])
+    logger._execute_search = AsyncMock(  # type: ignore
+        return_value=("Title: LiteLLM\nURL: docs\nSnippet: test", None)
+    )
+
+    request_patch = await logger._build_chat_completion_request_patch(
+        model=model,
+        messages=[{"role": "user", "content": "search LiteLLM"}],
+        tool_calls=[
+            {
+                "id": "call_123",
+                "name": "litellm_web_search",
+                "input": {"query": "what is litellm"},
+            }
+        ],
+        optional_params={"tools": [{"name": "litellm_web_search"}]},
+        kwargs={
+            "custom_llm_provider": custom_llm_provider,
+            "temperature": 0.2,
+        },
+        response_format="openai",
+    )
+
+    assert request_patch.model == expected_model
+    assert request_patch.messages is not None
+    assert len(request_patch.messages) == 3
+    assert request_patch.kwargs["temperature"] == 0.2
+    assert "custom_llm_provider" not in request_patch.kwargs
+
+
+@pytest.mark.asyncio
 async def test_internal_flags_filtered_from_followup_kwargs():
     """Test that internal _websearch_interception flags are filtered from follow-up request kwargs.
 
@@ -132,8 +187,6 @@ async def test_internal_flags_filtered_from_followup_kwargs():
     to the follow-up LLM request, causing "Extra inputs are not permitted" errors
     from providers like Bedrock that use strict parameter validation.
     """
-    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
-
     # Simulate kwargs that would be passed during agentic loop execution
     kwargs_with_internal_flags = {
         "_websearch_interception_converted_stream": True,


### PR DESCRIPTION
## Relevant issues

Fixes #23970.

Supersedes the closed unmerged #24040. That PR had the right production direction, but its regression tests duplicated the prefix logic inline instead of exercising the websearch handler. This PR keeps the production change small and adds coverage through `_build_chat_completion_request_patch()`.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, `websearch_interception` follow-up chat completions only restored `custom_llm_provider` when the model string had no slash. NIM-style model IDs such as `qwen/qwen3.5-397b-a17b` kept the slash from their own namespace, so the follow-up call used `qwen/qwen3.5-397b-a17b` and LiteLLM raised `LLM Provider NOT provided`.

The new regression calls the real chat-completion request patch builder and verifies:

- `qwen/qwen3.5-397b-a17b` + `custom_llm_provider=nvidia_nim` becomes `nvidia_nim/qwen/qwen3.5-397b-a17b`
- already-prefixed `nvidia_nim/qwen/...` stays unchanged
- provider-prefix collisions such as `nvidia` vs `nvidia_nim/...` still use an exact `<provider>/` boundary

Validation run locally:

- `uv run pytest tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py -q` -> 14 passed
- `uv run pytest tests/test_litellm/integrations/websearch_interception -q` -> 81 passed, 2 skipped
- `uv run ruff check litellm/integrations/websearch_interception/handler.py tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py` -> passed
- `uv run black --check litellm/integrations/websearch_interception/handler.py tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py` -> passed
- `uv run mypy litellm/integrations/websearch_interception/handler.py tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py` -> passed
- `git diff --check` -> passed

## Type

🐛 Bug Fix
✅ Test

## Changes

- replace the slash-presence heuristic with an exact `<custom_llm_provider>/` prefix check when building websearch follow-up chat completions
- add mocked regression coverage through the real request-patch builder for slashed NIM model names, already-prefixed models, and provider-prefix collisions
