### PR TITLE
test(realtime): expect session.created as xAI realtime initial event

### DIFF
--- a/tests/llm_translation/realtime/base_realtime_tests.py
+++ b/tests/llm_translation/realtime/base_realtime_tests.py
@@ -79,7 +79,7 @@ class RealTimeWebSocketClient:
 
     def _is_initial_event(self, msg_type: str) -> bool:
         """Check if message type is an initial connection event"""
-        # OpenAI sends "session.created", xAI sends "conversation.created"
+        # OpenAI and xAI send "session.created"; some providers send "conversation.created"
         return msg_type in ["session.created", "conversation.created"]
 
     async def receive_text(self):

--- a/tests/llm_translation/realtime/test_xai_realtime.py
+++ b/tests/llm_translation/realtime/test_xai_realtime.py
@@ -19,8 +19,8 @@ class TestXAIRealtime(BaseRealtimeTest):
     """
     E2E tests for xAI Realtime API.
 
-    xAI's Grok Voice Agent API is OpenAI-compatible but uses:
-    - Different initial event: "conversation.created" instead of "session.created"
+    xAI's Grok Voice Agent API is OpenAI-compatible:
+    - Initial event: "session.created" (matches OpenAI)
     - Different endpoint: wss://api.x.ai/v1/realtime
     - Model: grok-4-1-fast-non-reasoning
     """
@@ -32,4 +32,4 @@ class TestXAIRealtime(BaseRealtimeTest):
         return "XAI_API_KEY"
 
     def get_initial_event_type(self) -> str:
-        return "conversation.created"
+        return "session.created"


### PR DESCRIPTION
## Summary

The xAI realtime E2E test (`tests/llm_translation/realtime/test_xai_realtime.py`) failed in CI with:

```
AssertionError: Expected conversation.created, got session.created
```

xAI's Grok Voice Agent API now sends `session.created` as its **first** realtime event (matching OpenAI's protocol), followed by `conversation.created`. The test is a canary that pinned the old `conversation.created` value, so it correctly caught the upstream change.

This is **not** a LiteLLM-side regression. The xAI realtime path is a verbatim passthrough — `get_provider_realtime_config()` returns `None` for xai, so `RealTimeStreaming` runs the raw forwarding path and emits xAI's bytes unchanged. No code path rewrites the event type. The fix is simply to update the pinned expected value to match xAI's current behavior.

## Changes

- `test_xai_realtime.py`: `get_initial_event_type()` now returns `session.created`; docstring updated.
- `base_realtime_tests.py`: corrected a stale comment.

## Test plan

- [x] `pytest tests/llm_translation/realtime/test_xai_realtime.py` — all 4 tests pass, including the live `test_realtime_connection` against xAI's production API (`API RESPONSE #1 - Event: session.created` → PASSED).