### PR TITLE
fix(openai-responses): strip Anthropic cache_control from Responses API requests

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -126,9 +126,18 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> Dict:
-        """No transform applied since inputs are in OpenAI spec already"""
+        """Strip Anthropic-only `cache_control` markers before sending to OpenAI.
+
+        OpenAI's Responses API rejects unknown fields on input content blocks
+        with HTTP 400 ("Unknown parameter: 'input[0].content[0].cache_control'").
+        Chat Completions strips these in
+        `remove_cache_control_flag_from_messages_and_tools`; mirror that here.
+        """
 
         input = self._validate_input_param(input)
+        input, response_api_optional_request_params = (
+            self._strip_cache_control_flag(input, response_api_optional_request_params)
+        )
         final_request_params = dict(
             ResponsesAPIRequestParams(
                 model=model, input=input, **response_api_optional_request_params
@@ -136,6 +145,28 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         )
 
         return final_request_params
+
+    @staticmethod
+    def _strip_cache_control_flag(
+        input: Union[str, ResponseInputParam],
+        response_api_optional_request_params: Dict,
+    ) -> tuple:
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            filter_value_from_dict,
+        )
+
+        if isinstance(input, list):
+            for item in input:
+                if isinstance(item, dict):
+                    filter_value_from_dict(cast(dict, item), "cache_control")
+
+        tools = response_api_optional_request_params.get("tools")
+        if isinstance(tools, list):
+            for tool in tools:
+                if isinstance(tool, dict):
+                    filter_value_from_dict(cast(dict, tool), "cache_control")
+
+        return input, response_api_optional_request_params
 
     def _validate_input_param(
         self, input: Union[str, ResponseInputParam]

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -135,9 +135,12 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         """
 
         input = self._validate_input_param(input)
-        input, response_api_optional_request_params = (
-            self._strip_cache_control_flag(input, response_api_optional_request_params)
+        tools = response_api_optional_request_params.get("tools")
+        input, tools = self.remove_cache_control_flag_from_input_and_tools(
+            model=model, input=input, tools=tools
         )
+        if tools is not None:
+            response_api_optional_request_params["tools"] = tools
         final_request_params = dict(
             ResponsesAPIRequestParams(
                 model=model, input=input, **response_api_optional_request_params
@@ -146,11 +149,22 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
 
         return final_request_params
 
-    @staticmethod
-    def _strip_cache_control_flag(
+    def remove_cache_control_flag_from_input_and_tools(
+        self,
+        model: str,  # allows overrides to selectively run this
         input: Union[str, ResponseInputParam],
-        response_api_optional_request_params: Dict,
-    ) -> tuple:
+        tools: Optional[List[ALL_RESPONSES_API_TOOL_PARAMS]] = None,
+    ) -> Tuple[
+        Union[str, ResponseInputParam],
+        Optional[List[ALL_RESPONSES_API_TOOL_PARAMS]],
+    ]:
+        """Sibling of `remove_cache_control_flag_from_messages_and_tools` on
+        the chat path. Strips Anthropic-only `cache_control` markers from
+        Responses API input content blocks and tools.
+
+        `filter_value_from_dict` mutates each dict in place, so the same
+        objects are returned.
+        """
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             filter_value_from_dict,
         )
@@ -160,13 +174,12 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                 if isinstance(item, dict):
                     filter_value_from_dict(cast(dict, item), "cache_control")
 
-        tools = response_api_optional_request_params.get("tools")
-        if isinstance(tools, list):
+        if tools is not None:
             for tool in tools:
                 if isinstance(tool, dict):
                     filter_value_from_dict(cast(dict, tool), "cache_control")
 
-        return input, response_api_optional_request_params
+        return input, tools
 
     def _validate_input_param(
         self, input: Union[str, ResponseInputParam]

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -86,6 +86,90 @@ class TestOpenAIResponsesAPIConfig:
 
         self.validate_responses_api_request_params(result, expected_fields)
 
+    def test_transform_strips_cache_control_from_input_content_blocks(self):
+        """`cache_control` markers (Anthropic-only) must be stripped from
+        Responses API input content blocks before sending to OpenAI.
+
+        OpenAI rejects unknown params on input content blocks with HTTP 400:
+            "Unknown parameter: 'input[0].content[0].cache_control'"
+        Chat Completions strips these via
+        `remove_cache_control_flag_from_messages_and_tools`; the Responses
+        path must do the same.
+        """
+        input_with_cache_control = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_with_cache_control,
+            response_api_optional_request_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert "cache_control" not in result["input"][0]["content"][0]
+        assert result["input"][0]["content"][0]["type"] == "input_text"
+        assert result["input"][0]["content"][0]["text"] == "Hello"
+
+    def test_transform_strips_cache_control_from_tools(self):
+        """`cache_control` markers must also be stripped from tools for
+        symmetry with the Chat Completions path. OpenAI currently accepts
+        cache_control on tools silently but stripping keeps the wire payload
+        clean and matches `remove_cache_control_flag_from_messages_and_tools`.
+        """
+        tools_with_cache_control = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input="hi",
+            response_api_optional_request_params={"tools": tools_with_cache_control},
+            litellm_params={},
+            headers={},
+        )
+
+        assert "cache_control" not in result["tools"][0]
+        assert result["tools"][0]["name"] == "get_weather"
+
+    def test_transform_preserves_input_without_cache_control(self):
+        """Inputs without cache_control must pass through unmodified."""
+        input_clean = [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hello"}],
+            }
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_clean,
+            response_api_optional_request_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert result["input"] == input_clean
+
     def test_transform_streaming_response(self):
         """Test streaming response transformation"""
         # Test with a text delta event


### PR DESCRIPTION
## Title

`fix(openai-responses): strip Anthropic cache_control from Responses API requests`

## Relevant issues

OpenAI's Responses API rejects unknown fields on input content blocks with HTTP 400:

```
BadRequestError: Unknown parameter: 'input[0].content[0].cache_control'.
```

This bites callers who layer the Anthropic cache-control hook above a fallback chain whose primary route is the native OpenAI Responses API. The chat completions path already strips `cache_control` via `remove_cache_control_flag_from_messages_and_tools` (`litellm/llms/openai/chat/gpt_transformation.py`); the Responses path didn't.

## Pre-Submission checklist

- [x] Made sure tests pass
- [x] Added new tests (3 new cases — input strip, tool strip, no-cache passthrough)
- [x] No regressions in openai/responses (103), chatgpt/responses (14), azure/response (22) — 139 passed
- [x] Mypy clean on touched file
- [x] Live-verified end-to-end against real OpenAI Responses API

## Type

🐛 Bug Fix

## Changes

`litellm/llms/openai/responses/transformation.py`
- `transform_responses_api_request` now calls `remove_cache_control_flag_from_input_and_tools` after `_validate_input_param`.
- New helper is the sibling of the chat path's `remove_cache_control_flag_from_messages_and_tools`: same signature shape (`model`, `input`, `tools`), same recursive primitive (`filter_value_from_dict`), strips from both `input` content blocks and `tools` for symmetry.
- Returns `Tuple[Union[str, ResponseInputParam], Optional[List[ALL_RESPONSES_API_TOOL_PARAMS]]]` — precise types so callers stay mypy-strict.
- `model: str` parameter is unused today but mirrors the chat helper, leaving room for subclasses to selectively skip stripping (same hook the chat path comment calls out).

`tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py`
- `test_transform_strips_cache_control_from_input_content_blocks` — the failing case (matches the live OpenAI 400 wording).
- `test_transform_strips_cache_control_from_tools` — symmetry with chat path.
- `test_transform_preserves_input_without_cache_control` — no-op regression guard.

## Proof

### Unit tests + mypy
<img width="1198" height="452" alt="litellm_pr_proof" src="https://github.com/user-attachments/assets/96bc2cdd-fbf9-48cc-a15e-716bb7a9afd3" />

### Live verification (real OpenAI Responses API)

Ran a script that calls `litellm.aresponses(model="gpt-4o-mini", input=…, tools=…)` with `cache_control: {"type": "ephemeral"}` injected on both an input content block and a tool definition, then performs the same call directly through the raw `openai` SDK as a negative control:

```
[1] Calling litellm.aresponses() with cache_control on input + tools…
    OK — response text: 'pong'

[2] Calling raw OpenAI SDK with cache_control on input (no strip)…
    OK — OpenAI rejected as expected: BadRequestError
    error: Error code: 400 - {'error': {'message': "Unknown parameter: 'input[0].content[0].cache_control'.", 'type': 'invalid_request_error', 'param': 'input[0].content[0].cache_control', 'code': 'unknown_param…

=== Summary ===
  litellm strip works (200 OK):           True
  raw openai rejects cache_control (400): True
```

Confirms (a) the bug is reproducible against the live API and (b) this PR's strip lets the same payload through unchanged from the caller's perspective.
