### PR TITLE
fix: respect cache_control ttl for prompt caching router affinity

### DIFF
--- a/litellm/router_utils/prompt_caching_cache.py
+++ b/litellm/router_utils/prompt_caching_cache.py
@@ -28,6 +28,17 @@ class PromptCachingCacheValue(TypedDict):
     model_id: str
 
 
+# Default affinity TTL (in seconds) - matches Anthropic's 5-minute ephemeral cache.
+DEFAULT_PROMPT_CACHING_AFFINITY_TTL = 300
+
+# Maps the `cache_control.ttl` values supported by providers (Anthropic / Bedrock)
+# to the affinity TTL the router should hold the deployment binding for.
+CACHE_CONTROL_TTL_TO_SECONDS = {
+    "5m": 300,
+    "1h": 3600,
+}
+
+
 class PromptCachingCache:
     def __init__(self, cache: DualCache):
         self.cache = cache
@@ -142,6 +153,65 @@ class PromptCachingCache:
         return cacheable_prefix
 
     @staticmethod
+    def get_cache_control_ttl(
+        messages: Optional[List[AllMessageValues]],
+        tools: Optional[List[ChatCompletionToolParam]],
+    ) -> int:
+        """
+        Determine the affinity TTL (in seconds) from the request's cache_control.
+
+        Providers (Anthropic / Bedrock) support a `ttl` sub-field on the
+        ephemeral cache_control block ("5m" or "1h"). The deployment affinity
+        should live for as long as the provider keeps the prefix warm, so the
+        longest declared ttl in the cacheable prefix wins. Falls back to the
+        default 5-minute TTL when no (or an unrecognized) ttl is declared.
+        """
+        affinity_ttl = DEFAULT_PROMPT_CACHING_AFFINITY_TTL
+
+        if messages:
+            cacheable_messages = PromptCachingCache.extract_cacheable_prefix(messages)
+            for message in cacheable_messages:
+                affinity_ttl = max(
+                    affinity_ttl,
+                    PromptCachingCache._cache_control_ttl_from_value(
+                        message.get("cache_control")
+                    ),
+                )
+                content = message.get("content")
+                if isinstance(content, list):
+                    for content_block in content:
+                        if isinstance(content_block, dict):
+                            affinity_ttl = max(
+                                affinity_ttl,
+                                PromptCachingCache._cache_control_ttl_from_value(
+                                    content_block.get("cache_control")
+                                ),
+                            )
+
+        if tools:
+            for tool in tools:
+                if isinstance(tool, dict):
+                    affinity_ttl = max(
+                        affinity_ttl,
+                        PromptCachingCache._cache_control_ttl_from_value(
+                            tool.get("cache_control")
+                        ),
+                    )
+
+        return affinity_ttl
+
+    @staticmethod
+    def _cache_control_ttl_from_value(cache_control: Any) -> int:
+        """Map a single cache_control block to its affinity TTL in seconds."""
+        if isinstance(cache_control, dict) and cache_control.get("type") == "ephemeral":
+            ttl = cache_control.get("ttl")
+            if isinstance(ttl, str):
+                return CACHE_CONTROL_TTL_TO_SECONDS.get(
+                    ttl, DEFAULT_PROMPT_CACHING_AFFINITY_TTL
+                )
+        return DEFAULT_PROMPT_CACHING_AFFINITY_TTL
+
+    @staticmethod
     def get_prompt_caching_cache_key(
         messages: Optional[List[AllMessageValues]],
         tools: Optional[List[ChatCompletionToolParam]],
@@ -193,8 +263,9 @@ class PromptCachingCache:
         if cache_key is None:
             return None
 
+        ttl = PromptCachingCache.get_cache_control_ttl(messages, tools)
         self.cache.set_cache(
-            cache_key, PromptCachingCacheValue(model_id=model_id), ttl=300
+            cache_key, PromptCachingCacheValue(model_id=model_id), ttl=ttl
         )
         return None
 
@@ -212,10 +283,13 @@ class PromptCachingCache:
         if cache_key is None:
             return None
 
+        # Store for as long as the provider keeps the prefix warm (5m default, 1h
+        # when the request marks the cacheable prefix with ttl="1h").
+        ttl = PromptCachingCache.get_cache_control_ttl(messages, tools)
         await self.cache.async_set_cache(
             cache_key,
             PromptCachingCacheValue(model_id=model_id),
-            ttl=300,  # store for 5 minutes
+            ttl=ttl,
         )
         return None
 

--- a/tests/test_litellm/router_utils/test_prompt_caching_cache.py
+++ b/tests/test_litellm/router_utils/test_prompt_caching_cache.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for PromptCachingCache affinity TTL handling.
+
+The affinity binding (cacheable_prefix_hash -> model_id) must live for as long
+as the provider keeps the prefix warm. A request marked with the 1-hour
+ephemeral cache (`cache_control: {"type": "ephemeral", "ttl": "1h"}`) should
+keep the affinity for ~3600s, while the default 5-minute cache keeps 300s.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Add the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.caching.dual_cache import DualCache
+from litellm.router_utils.prompt_caching_cache import PromptCachingCache
+
+
+def _messages_with_ttl(ttl=None):
+    """Build messages whose cacheable prefix carries the given cache_control ttl."""
+    cache_control = {"type": "ephemeral"}
+    if ttl is not None:
+        cache_control["ttl"] = ttl
+    return [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant. " * 400,
+                    "cache_control": cache_control,
+                },
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+
+
+def test_get_cache_control_ttl_one_hour():
+    """`ttl: "1h"` in the cacheable prefix maps to 3600 seconds."""
+    ttl = PromptCachingCache.get_cache_control_ttl(_messages_with_ttl("1h"), None)
+    assert ttl == 3600
+
+
+def test_get_cache_control_ttl_default_when_unset():
+    """No ttl declared falls back to the default 300 seconds."""
+    ttl = PromptCachingCache.get_cache_control_ttl(_messages_with_ttl(None), None)
+    assert ttl == 300
+
+
+def test_get_cache_control_ttl_explicit_five_minutes():
+    """`ttl: "5m"` keeps the default 300 seconds."""
+    ttl = PromptCachingCache.get_cache_control_ttl(_messages_with_ttl("5m"), None)
+    assert ttl == 300
+
+
+def test_add_model_id_uses_one_hour_ttl():
+    """add_model_id stores the affinity with a 3600s ttl for the 1h cache."""
+    mock_cache = MagicMock(spec=DualCache)
+    prompt_cache = PromptCachingCache(cache=mock_cache)
+
+    prompt_cache.add_model_id(
+        model_id="deployment-a",
+        messages=_messages_with_ttl("1h"),
+        tools=None,
+    )
+
+    assert mock_cache.set_cache.call_count == 1
+    assert mock_cache.set_cache.call_args.kwargs["ttl"] == 3600
+
+
+def test_add_model_id_defaults_to_five_minutes():
+    """add_model_id keeps the 300s default when no ttl is declared."""
+    mock_cache = MagicMock(spec=DualCache)
+    prompt_cache = PromptCachingCache(cache=mock_cache)
+
+    prompt_cache.add_model_id(
+        model_id="deployment-a",
+        messages=_messages_with_ttl(None),
+        tools=None,
+    )
+
+    assert mock_cache.set_cache.call_count == 1
+    assert mock_cache.set_cache.call_args.kwargs["ttl"] == 300
+
+
+@pytest.mark.asyncio
+async def test_async_add_model_id_uses_one_hour_ttl():
+    """async_add_model_id stores the affinity with a 3600s ttl for the 1h cache."""
+    mock_cache = MagicMock(spec=DualCache)
+    mock_cache.async_set_cache = AsyncMock()
+    prompt_cache = PromptCachingCache(cache=mock_cache)
+
+    await prompt_cache.async_add_model_id(
+        model_id="deployment-a",
+        messages=_messages_with_ttl("1h"),
+        tools=None,
+    )
+
+    assert mock_cache.async_set_cache.call_count == 1
+    assert mock_cache.async_set_cache.call_args.kwargs["ttl"] == 3600
+
+
+@pytest.mark.asyncio
+async def test_async_add_model_id_defaults_to_five_minutes():
+    """async_add_model_id keeps the 300s default when no ttl is declared."""
+    mock_cache = MagicMock(spec=DualCache)
+    mock_cache.async_set_cache = AsyncMock()
+    prompt_cache = PromptCachingCache(cache=mock_cache)
+
+    await prompt_cache.async_add_model_id(
+        model_id="deployment-a",
+        messages=_messages_with_ttl(None),
+        tools=None,
+    )
+
+    assert mock_cache.async_set_cache.call_count == 1
+    assert mock_cache.async_set_cache.call_args.kwargs["ttl"] == 300


### PR DESCRIPTION
## Summary

LiteLLM's prompt-caching-aware routing (`optional_pre_call_checks: ["prompt_caching"]`)
stored the `cacheable_prefix_hash -> model_id` affinity binding with a hardcoded
5-minute (300s) TTL in `prompt_caching_cache.py`. This was correct for Anthropic's
original 5-minute ephemeral cache, but it's now wrong for the 1-hour ephemeral cache
(`cache_control: {"type": "ephemeral", "ttl": "1h"}`, supported by Anthropic and Bedrock).

In a multi-deployment setup (same model across multiple AWS accounts/regions, or
multiple API keys), the affinity entry expired after 5 minutes while the provider kept
the prefix warm for ~60 minutes. Follow-up requests then fell back to the normal routing
strategy, could land on a different deployment, and incurred a provider-side cache miss
even though the original deployment was still holding the cache.

## Changes

- Add `PromptCachingCache.get_cache_control_ttl()`, which derives the affinity TTL from
  the `cache_control.ttl` sub-field in the cacheable prefix: `"1h"` -> 3600s, default /
  `"5m"` -> 300s (the longest declared ttl wins).
- Thread that TTL through `add_model_id` and `async_add_model_id` instead of the
  hardcoded `300`.

The default behavior is unchanged for requests that don't declare a ttl.

## Test plan

- [x] New unit tests in `tests/test_litellm/router_utils/test_prompt_caching_cache.py`
      assert the 1h cache sets a 3600s affinity TTL and the default/5m keeps 300s
      (sync + async paths).
- [x] black, ruff, mypy clean on the changed file.
- [x] Existing `tests/router_unit_tests/test_router_prompt_caching.py` still passes (no regressions).

Fixes #28427