### PR TITLE
fix: handle "file" content type in token counter / trim_messages

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -736,6 +736,17 @@ def _count_content_list(
                 thinking_text = str(c.get("thinking", ""))
                 if thinking_text:
                     num_tokens += count_function(thinking_text)
+            elif c["type"] == "file":
+                # Document/file content block (e.g. a PDF input).
+                # The provider parses the file server-side, so the resulting
+                # token count is not known here. Count only human-readable
+                # metadata (e.g. filename) and skip the opaque file payload
+                # (file_data/file_id) so we don't crash or wildly overcount.
+                file_obj = c.get("file") or {}
+                if isinstance(file_obj, dict):
+                    filename = str(file_obj.get("filename", ""))
+                    if filename:
+                        num_tokens += count_function(filename)
             else:
                 content_type = (
                     c.get("type", type(c).__name__)
@@ -744,7 +755,7 @@ def _count_content_list(
                 )
                 raise ValueError(
                     f"Invalid content item type: {content_type}. "
-                    f"Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking)."
+                    f"Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking, file)."
                 )
         return num_tokens
     except Exception as e:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1005,3 +1005,72 @@ def test_token_counter_with_thinking_content():
     assert (
         tokens_no_thinking < 15
     ), f"Expected minimal token count for empty thinking block, got {tokens_no_thinking}"
+
+
+def test_token_counter_with_file_content():
+    """
+    Test that _count_content_list() handles the "file" content block type.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/28409 where
+    a PDF/document "file" content block (a valid OpenAI/Anthropic content type)
+    caused token_counter() / trim_messages() to raise a ValueError.
+
+    Validates that:
+    - a "file" content block does not raise
+    - the opaque base64 file_data blob is not counted as text tokens
+    - human-readable metadata (filename) is still counted
+    """
+    base64_pdf = "data:application/pdf;base64," + ("JVBERi0xLjQ=" * 50)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Summarize this document"},
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": "draconomicon.pdf",
+                        "file_data": base64_pdf,
+                    },
+                },
+            ],
+        }
+    ]
+
+    tokens = token_counter(model="gpt-4o", messages=messages)
+    assert tokens > 0, f"Expected positive token count, got {tokens}"
+
+    # The large base64 blob must not be counted as text, otherwise the count
+    # would balloon. Compare against the same message without the file block.
+    messages_text_only = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Summarize this document"}],
+        }
+    ]
+    tokens_text_only = token_counter(model="gpt-4o", messages=messages_text_only)
+    assert (
+        tokens - tokens_text_only < 50
+    ), f"file block should not count the base64 blob, got delta {tokens - tokens_text_only}"
+
+    # A file block without any text fields (e.g. file_id reference) must also
+    # not raise and should add no meaningful token cost.
+    messages_file_id = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file": {"file_id": "file-abc123"}},
+            ],
+        }
+    ]
+    tokens_file_id = token_counter(model="gpt-4o", messages=messages_file_id)
+    assert (
+        tokens_file_id >= 0
+    ), f"Expected non-negative token count for file_id block, got {tokens_file_id}"
+
+    # The reported entry point (trim_messages) must not silently fail either.
+    trimmed = litellm.utils.trim_messages(
+        messages=messages, model="gpt-4o", max_tokens=4096
+    )
+    assert trimmed is not None


### PR DESCRIPTION
## Summary

`trim_messages` / `token_counter` raise a `ValueError` when a message
contains a `"file"` content block (e.g. a PDF document input via
https://docs.litellm.ai/docs/completion/document_understanding).

`_count_content_list` in `litellm/litellm_core_utils/token_counter.py`
handles `text`, `image_url`, `tool_use`/`tool_result`, and `thinking`,
but `"file"` fell through to the catch-all `else` and raised a
`ValueError: Invalid content item type: file`.

`"file"` is a valid OpenAI/Anthropic content type, so this should not crash.

## Changes

- Add a `"file"` branch to `_count_content_list`. The provider parses the
  file server-side, so the real token count isn't known here. We count the
  human-readable `filename` metadata and skip the opaque payload
  (`file_data`/`file_id`) — the same approach the `"thinking"` branch uses
  for its signature blob. This avoids crashing and avoids counting the large
  base64 blob as text.
- Add `file` to the list of supported types in the fallback error message.
- Add a regression test (`test_token_counter_with_file_content`) covering a
  PDF file block, a `file_id`-only block, and the `trim_messages` entry point.

## Test plan

- [x] `pytest tests/test_litellm/litellm_core_utils/test_token_counter.py` passes
- [x] black / ruff / mypy pass on the changed file

Fixes #28409