### PR TITLE
fix(vertex_gemma): strip `context_management` from request body

### DIFF
--- a/litellm/llms/vertex_ai/vertex_gemma_models/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_gemma_models/transformation.py
@@ -91,6 +91,10 @@ class VertexGemmaConfig(OpenAIGPTConfig):
             "stream", None
         )  # Streaming not supported, will be faked client-side
         openai_request.pop("stream_options", None)  # Stream options not supported
+        # Vertex Gemma's chatCompletions wrapper does not understand
+        # `context_management` (an Anthropic/Responses API concept). Strip it
+        # so the upstream endpoint does not 400 on the unknown field.
+        openai_request.pop("context_management", None)
 
         # Wrap in Vertex Gemma format
         return {

--- a/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
@@ -433,3 +433,123 @@ class TestVertexGemmaCompletion:
             # Verify other parameters are present
             assert "messages" in instance
             assert instance["@requestFormat"] == "chatCompletions"
+
+    @pytest.mark.asyncio
+    async def test_acompletion_filters_context_management(self):
+        """
+        Test that context_management is filtered out from the request.
+
+        Vertex AI Gemma's chatCompletions wrapper does not understand
+        `context_management` (an Anthropic / OpenAI Responses API concept).
+        It must be stripped from the request body so the upstream endpoint
+        does not reject the request with an unknown-field error.
+        """
+        mock_vertex_response = {
+            "deployedModelId": "1207280419999999999",
+            "model": "projects/993702345710/locations/us-central1/models/gemma-3-12b-it-1222199011122",
+            "modelDisplayName": "gemma-3-12b-it-1222199011122",
+            "modelVersionId": "1",
+            "predictions": {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "logprobs": None,
+                        "message": {
+                            "content": "ok",
+                            "reasoning_content": None,
+                            "role": "assistant",
+                            "tool_calls": [],
+                        },
+                        "stop_reason": None,
+                    }
+                ],
+                "created": 1759863903,
+                "id": "chatcmpl-test-ctxmgmt",
+                "model": "google/gemma-3-12b-it",
+                "object": "chat.completion",
+                "prompt_logprobs": None,
+                "usage": {
+                    "completion_tokens": 1,
+                    "prompt_tokens": 5,
+                    "prompt_tokens_details": None,
+                    "total_tokens": 6,
+                },
+            },
+        }
+
+        with (
+            patch(
+                "litellm.llms.custom_httpx.http_handler.get_async_httpx_client"
+            ) as mock_get_client,
+            patch(
+                "litellm.llms.vertex_ai.vertex_gemma_models.main.VertexAIGemmaModels._ensure_access_token",
+                return_value=("fake-access-token", "PROJECT_ID"),
+            ),
+        ):
+            mock_client = Mock()
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_vertex_response
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_get_client.return_value = mock_client
+
+            # Use `allowed_openai_params` so context_management actually
+            # reaches the transformation layer (otherwise the upstream
+            # validator drops it before we can prove the transformation
+            # strips it). This mirrors the real-world scenario where a
+            # caller explicitly opts in to forwarding an arbitrary param.
+            await litellm.acompletion(
+                model="vertex_ai/gemma/gemma-3-12b-it-1222199011122",
+                messages=[{"role": "user", "content": "Test"}],
+                context_management=[
+                    {"type": "compaction", "compact_threshold": 200000}
+                ],
+                allowed_openai_params=["context_management"],
+                api_base="https://test.us-central1-project.prediction.vertexai.goog/v1/projects/PROJECT_ID/locations/us-central1/endpoints/ENDPOINT_ID:predict",
+                vertex_project="PROJECT_ID",
+                vertex_location="us-central1",
+            )
+
+            call_args = mock_client.post.call_args
+            assert call_args is not None, "HTTP client was not called"
+
+            request_data = call_args.kwargs["json"]
+            print("request body=", json.dumps(request_data, indent=4))
+            instance = request_data["instances"][0]
+
+            assert (
+                "context_management" not in instance
+            ), "context_management should not be forwarded to Vertex Gemma"
+            assert instance["@requestFormat"] == "chatCompletions"
+            assert "messages" in instance
+
+    def test_transform_request_strips_context_management(self):
+        """
+        Direct unit test for VertexGemmaConfig.transform_request: verify that
+        `context_management` is stripped from `optional_params` regardless of
+        how it was supplied to the transformation layer.
+        """
+        from litellm.llms.vertex_ai.vertex_gemma_models.transformation import (
+            VertexGemmaConfig,
+        )
+
+        config = VertexGemmaConfig()
+        result = config.transform_request(
+            model="gemma-3-12b-it",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={
+                "max_tokens": 32,
+                "context_management": [
+                    {"type": "compaction", "compact_threshold": 200000}
+                ],
+            },
+            litellm_params={},
+            headers={},
+        )
+
+        assert "instances" in result
+        instance = result["instances"][0]
+        assert instance["@requestFormat"] == "chatCompletions"
+        assert "context_management" not in instance
+        assert instance.get("max_tokens") == 32


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Vertex AI Gemma's `chatCompletions` prediction wrapper does not understand the `context_management` parameter (an Anthropic / OpenAI Responses API concept). When callers route this field to a Gemma deployment — for example via `allowed_openai_params=["context_management"]` or through proxy passthrough from a Claude-Code-style client — the upstream Vertex endpoint rejects the request because of the unknown field.

This PR makes `VertexGemmaConfig.transform_request` drop `context_management` from the outgoing request body, matching the existing pattern that already strips `stream` and `stream_options`:

```python
openai_request.pop("model", None)
openai_request.pop("stream", None)            # streaming faked client-side
openai_request.pop("stream_options", None)    # not supported by Vertex Gemma
openai_request.pop("context_management", None)  # NEW — not supported either
```

### Tests

Added to `tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py`:

- `test_transform_request_strips_context_management` — direct unit test on `VertexGemmaConfig.transform_request` confirming the field is absent from the `instances[0]` payload while other params (e.g. `max_tokens`) survive.
- `test_acompletion_filters_context_management` — end-to-end `litellm.acompletion()` test using `allowed_openai_params=["context_management"]` (the realistic path that lets the field reach the transformation layer) and asserts the mocked Vertex HTTP call does not receive `context_management`.

All 6 tests in the file pass:

```
tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
  TestVertexGemmaCompletion::test_acompletion_basic_request                  PASSED
  TestVertexGemmaCompletion::test_acompletion_error_handling                 PASSED
  TestVertexGemmaCompletion::test_acompletion_fake_streaming                 PASSED
  TestVertexGemmaCompletion::test_acompletion_filters_context_management     PASSED
  TestVertexGemmaCompletion::test_acompletion_filters_stream_and_stream_options PASSED
  TestVertexGemmaCompletion::test_transform_request_strips_context_management PASSED
========================= 6 passed, 1 warning in 1.53s =========================
```

The full `tests/test_litellm/llms/vertex_ai/` directory (850 tests) also passes (one unrelated pre-existing failure in `videos/test_vertex_video_transformation.py` due to environment-variable redaction in the test sandbox).

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D0AUCPA0MLN/p1779337588825829?thread_ts=1779337588.825829&cid=D0AUCPA0MLN)

<div><a href="https://cursor.com/agents/bc-508d7e3c-927c-5f22-90d7-c4584c33d300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-508d7e3c-927c-5f22-90d7-c4584c33d300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

