### PR TITLE
fix(reset_budget_job): write minimal reset updates

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -455,13 +455,29 @@ class ResetBudgetJob:
                 )
 
                 if updated_keys:
+                    key_updates = [
+                        {
+                            "token": (
+                                key["token"] if isinstance(key, dict) else key.token
+                            ),
+                            "spend": (
+                                key["spend"] if isinstance(key, dict) else key.spend
+                            ),
+                            "budget_reset_at": (
+                                key["budget_reset_at"]
+                                if isinstance(key, dict)
+                                else key.budget_reset_at
+                            ),
+                        }
+                        for key in updated_keys
+                    ]
                     await self.prisma_client.update_data(
                         query_type="update_many",
-                        data_list=updated_keys,
+                        data_list=key_updates,
                         table_name="key",
                     )
-                    for k in updated_keys:
-                        token = getattr(k, "token", None)
+                    for k in key_updates:
+                        token = k.get("token")
                         if token:
                             await self._invalidate_spend_counter(f"spend:key:{token}")
 
@@ -641,13 +657,31 @@ class ResetBudgetJob:
                     "Updated teams %s", json.dumps(updated_teams, indent=4, default=str)
                 )
                 if updated_teams:
+                    team_updates = [
+                        {
+                            "team_id": (
+                                team["team_id"]
+                                if isinstance(team, dict)
+                                else team.team_id
+                            ),
+                            "spend": (
+                                team["spend"] if isinstance(team, dict) else team.spend
+                            ),
+                            "budget_reset_at": (
+                                team["budget_reset_at"]
+                                if isinstance(team, dict)
+                                else team.budget_reset_at
+                            ),
+                        }
+                        for team in updated_teams
+                    ]
                     await self.prisma_client.update_data(
                         query_type="update_many",
-                        data_list=updated_teams,
+                        data_list=team_updates,
                         table_name="team",
                     )
-                    for t in updated_teams:
-                        team_id = getattr(t, "team_id", None)
+                    for t in team_updates:
+                        team_id = t.get("team_id")
                         if team_id:
                             await self._invalidate_spend_counter(
                                 f"spend:team:{team_id}"

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3874,17 +3874,30 @@ class PrismaClient:
                 """
                 batcher = self.db.batch_()
                 for idx, t in enumerate(data_list):
-                    # check if plain text or hash
-                    if t.token.startswith("sk-"):  # type: ignore
-                        t.token = self.hash_token(token=t.token)  # type: ignore
-                    try:
+                    if isinstance(t, dict):
+                        token = t["token"]
+                        if token.startswith("sk-"):
+                            token = self.hash_token(token=token)
+                            t["token"] = token
                         data_json = self.jsonify_object(
-                            data=t.model_dump(exclude_none=True)
+                            data={k: v for k, v in t.items() if v is not None}
                         )
-                    except Exception:
-                        data_json = self.jsonify_object(data=t.dict(exclude_none=True))
+                        data_json["token"] = token
+                    else:
+                        # check if plain text or hash
+                        if t.token.startswith("sk-"):  # type: ignore
+                            t.token = self.hash_token(token=t.token)  # type: ignore
+                        token = t.token  # type: ignore
+                        try:
+                            data_json = self.jsonify_object(
+                                data=t.model_dump(exclude_none=True)
+                            )
+                        except Exception:
+                            data_json = self.jsonify_object(
+                                data=t.dict(exclude_none=True)
+                            )
                     batcher.litellm_verificationtoken.update(
-                        where={"token": t.token},  # type: ignore
+                        where={"token": token},  # type: ignore
                         data={**data_json},  # type: ignore
                     )
                 await batcher.commit()
@@ -3994,16 +4007,23 @@ class PrismaClient:
                 # Batch write update queries
                 batcher = self.db.batch_()
                 for idx, team in enumerate(data_list):
-                    try:
+                    if isinstance(team, dict):
+                        team_id = team["team_id"]
                         data_json = self.jsonify_team_object(
-                            db_data=team.model_dump(exclude_none=True)
+                            db_data={k: v for k, v in team.items() if v is not None}
                         )
-                    except Exception:
-                        data_json = self.jsonify_object(
-                            data=team.dict(exclude_none=True)
-                        )
+                    else:
+                        team_id = team.team_id  # type: ignore
+                        try:
+                            data_json = self.jsonify_team_object(
+                                db_data=team.model_dump(exclude_none=True)
+                            )
+                        except Exception:
+                            data_json = self.jsonify_object(
+                                data=team.dict(exclude_none=True)
+                            )
                     batcher.litellm_teamtable.upsert(
-                        where={"team_id": team.team_id},  # type: ignore
+                        where={"team_id": team_id},  # type: ignore
                         data={
                             "create": {**data_json},  # type: ignore
                             "update": {

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3882,7 +3882,6 @@ class PrismaClient:
                         data_json = self.jsonify_object(
                             data={k: v for k, v in t.items() if v is not None}
                         )
-                        data_json["token"] = token
                     else:
                         # check if plain text or hash
                         if t.token.startswith("sk-"):  # type: ignore

--- a/tests/litellm_utils_tests/test_proxy_budget_reset.py
+++ b/tests/litellm_utils_tests/test_proxy_budget_reset.py
@@ -31,14 +31,40 @@ async def test_reset_budget_keys_partial_failure():
     # Arrange
     key1 = {
         "id": "key1",
+        "token": "token1",
         "spend": 10.0,
         "budget_duration": 60,
     }  # Will trigger simulated failure
-    key2 = {"id": "key2", "spend": 15.0, "budget_duration": 60}  # Should be updated
-    key3 = {"id": "key3", "spend": 20.0, "budget_duration": 60}  # Should be updated
-    key4 = {"id": "key4", "spend": 25.0, "budget_duration": 60}  # Should be updated
-    key5 = {"id": "key5", "spend": 30.0, "budget_duration": 60}  # Should be updated
-    key6 = {"id": "key6", "spend": 35.0, "budget_duration": 60}  # Should be updated
+    key2 = {
+        "id": "key2",
+        "token": "token2",
+        "spend": 15.0,
+        "budget_duration": 60,
+    }  # Should be updated
+    key3 = {
+        "id": "key3",
+        "token": "token3",
+        "spend": 20.0,
+        "budget_duration": 60,
+    }  # Should be updated
+    key4 = {
+        "id": "key4",
+        "token": "token4",
+        "spend": 25.0,
+        "budget_duration": 60,
+    }  # Should be updated
+    key5 = {
+        "id": "key5",
+        "token": "token5",
+        "spend": 30.0,
+        "budget_duration": 60,
+    }  # Should be updated
+    key6 = {
+        "id": "key6",
+        "token": "token6",
+        "spend": 35.0,
+        "budget_duration": 60,
+    }  # Should be updated
 
     prisma_client = MagicMock()
     prisma_client.get_data = AsyncMock(
@@ -86,11 +112,12 @@ async def test_reset_budget_keys_partial_failure():
     assert update_call.kwargs.get("table_name") == "key"
     updated_keys = update_call.kwargs.get("data_list", [])
     assert len(updated_keys) == 5
-    assert updated_keys[0]["id"] == "key2"
-    assert updated_keys[1]["id"] == "key3"
-    assert updated_keys[2]["id"] == "key4"
-    assert updated_keys[3]["id"] == "key5"
-    assert updated_keys[4]["id"] == "key6"
+    assert updated_keys[0]["token"] == "token2"
+    assert updated_keys[1]["token"] == "token3"
+    assert updated_keys[2]["token"] == "token4"
+    assert updated_keys[3]["token"] == "token5"
+    assert updated_keys[4]["token"] == "token6"
+    assert set(updated_keys[0].keys()) == {"token", "spend", "budget_reset_at"}
 
     # Verify that the failure logging hook was scheduled (due to the failure for key1)
     failure_hook_calls = (
@@ -300,10 +327,16 @@ async def test_reset_budget_teams_partial_failure():
     """
     team1 = {
         "id": "team1",
+        "team_id": "team1",
         "spend": 30.0,
         "budget_duration": 180,
     }  # Will trigger simulated failure
-    team2 = {"id": "team2", "spend": 35.0, "budget_duration": 180}  # Should be updated
+    team2 = {
+        "id": "team2",
+        "team_id": "team2",
+        "spend": 35.0,
+        "budget_duration": 180,
+    }  # Should be updated
 
     prisma_client = MagicMock()
     prisma_client.get_data = AsyncMock(return_value=[team1, team2])
@@ -338,7 +371,8 @@ async def test_reset_budget_teams_partial_failure():
     assert update_call.kwargs.get("table_name") == "team"
     updated_teams = update_call.kwargs.get("data_list", [])
     assert len(updated_teams) == 1
-    assert updated_teams[0]["id"] == "team2"
+    assert updated_teams[0]["team_id"] == "team2"
+    assert set(updated_teams[0].keys()) == {"team_id", "spend", "budget_reset_at"}
 
     failure_hook_calls = (
         proxy_logging_obj.service_logging_obj.async_service_failure_hook.call_args_list
@@ -365,16 +399,16 @@ async def test_reset_budget_continues_other_categories_on_failure():
       - Each get_data call is made (indicating that one failing category did not abort the others).
     """
     # Arrange dummy items for each table
-    key1 = {"id": "key1", "spend": 10.0, "budget_duration": 60}
-    key2 = {"id": "key2", "spend": 15.0, "budget_duration": 60}
+    key1 = {"id": "key1", "token": "token1", "spend": 10.0, "budget_duration": 60}
+    key2 = {"id": "key2", "token": "token2", "spend": 15.0, "budget_duration": 60}
     user1 = {
         "id": "user1",
         "spend": 20.0,
         "budget_duration": 120,
     }  # Will fail in user reset
     user2 = {"id": "user2", "spend": 25.0, "budget_duration": 120}  # Succeeds
-    team1 = {"id": "team1", "spend": 30.0, "budget_duration": 180}
-    team2 = {"id": "team2", "spend": 35.0, "budget_duration": 180}
+    team1 = {"id": "team1", "team_id": "team1", "spend": 30.0, "budget_duration": 180}
+    team2 = {"id": "team2", "team_id": "team2", "spend": 35.0, "budget_duration": 180}
     enduser1 = {"user_id": "user1", "spend": 25.0, "budget_id": "budget1"}
     budget1 = LiteLLM_BudgetTableFull(
         **{
@@ -527,8 +561,8 @@ async def test_service_logger_keys_success():
     logger success hook is called with the correct event metadata and no exception is logged.
     """
     keys = [
-        {"id": "key1", "spend": 10.0, "budget_duration": 60},
-        {"id": "key2", "spend": 15.0, "budget_duration": 60},
+        {"id": "key1", "token": "token1", "spend": 10.0, "budget_duration": 60},
+        {"id": "key2", "token": "token2", "spend": 15.0, "budget_duration": 60},
     ]
     prisma_client = MagicMock()
     prisma_client.get_data = AsyncMock(return_value=keys)
@@ -583,8 +617,8 @@ async def test_service_logger_keys_failure():
     logger exception is called.
     """
     keys = [
-        {"id": "key1", "spend": 10.0, "budget_duration": 60},
-        {"id": "key2", "spend": 15.0, "budget_duration": 60},
+        {"id": "key1", "token": "token1", "spend": 10.0, "budget_duration": 60},
+        {"id": "key2", "token": "token2", "spend": 15.0, "budget_duration": 60},
     ]
     prisma_client = MagicMock()
     prisma_client.get_data = AsyncMock(return_value=keys)
@@ -756,8 +790,8 @@ async def test_service_logger_teams_success():
     the proper metadata and nothing is logged as an exception.
     """
     teams = [
-        {"id": "team1", "spend": 30.0, "budget_duration": 180},
-        {"id": "team2", "spend": 35.0, "budget_duration": 180},
+        {"id": "team1", "team_id": "team1", "spend": 30.0, "budget_duration": 180},
+        {"id": "team2", "team_id": "team2", "spend": 35.0, "budget_duration": 180},
     ]
     prisma_client = MagicMock()
     prisma_client.get_data = AsyncMock(return_value=teams)
@@ -808,8 +842,8 @@ async def test_service_logger_teams_failure():
     results in an exception log and no success hook call.
     """
     teams = [
-        {"id": "team1", "spend": 30.0, "budget_duration": 180},
-        {"id": "team2", "spend": 35.0, "budget_duration": 180},
+        {"id": "team1", "team_id": "team1", "spend": 30.0, "budget_duration": 180},
+        {"id": "team2", "team_id": "team2", "spend": 35.0, "budget_duration": 180},
     ]
     prisma_client = MagicMock()
     prisma_client.get_data = AsyncMock(return_value=teams)

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -187,6 +187,7 @@ class TestResponseCompliance:
             "failed",
             "cancelled",
             "incomplete",
+            "budget_exceeded",
         ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1086,6 +1086,54 @@ def _make_prisma_update_data_client():
     return client
 
 
+class _UpdateDataKeyObject:
+    def __init__(self, token: str, budget_reset_at: datetime, fail_model_dump=False):
+        self.token = token
+        self.spend = 0.0
+        self.budget_reset_at = budget_reset_at
+        self.fail_model_dump = fail_model_dump
+
+    def model_dump(self, exclude_none=True):
+        if self.fail_model_dump:
+            raise RuntimeError("model_dump unavailable")
+        return {
+            "token": self.token,
+            "spend": self.spend,
+            "budget_reset_at": self.budget_reset_at,
+        }
+
+    def dict(self, exclude_none=True):
+        return {
+            "token": self.token,
+            "spend": self.spend,
+            "budget_reset_at": self.budget_reset_at,
+        }
+
+
+class _UpdateDataTeamObject:
+    def __init__(self, team_id: str, budget_reset_at: datetime, fail_model_dump=False):
+        self.team_id = team_id
+        self.spend = 0.0
+        self.budget_reset_at = budget_reset_at
+        self.fail_model_dump = fail_model_dump
+
+    def model_dump(self, exclude_none=True):
+        if self.fail_model_dump:
+            raise RuntimeError("model_dump unavailable")
+        return {
+            "team_id": self.team_id,
+            "spend": self.spend,
+            "budget_reset_at": self.budget_reset_at,
+        }
+
+    def dict(self, exclude_none=True):
+        return {
+            "team_id": self.team_id,
+            "spend": self.spend,
+            "budget_reset_at": self.budget_reset_at,
+        }
+
+
 def test_update_data_key_update_many_accepts_minimal_dict_payloads():
     from litellm.proxy.utils import hash_token
 
@@ -1118,6 +1166,34 @@ def test_update_data_key_update_many_accepts_minimal_dict_payloads():
     }
 
 
+def test_update_data_key_update_many_preserves_object_payloads():
+    from litellm.proxy.utils import hash_token
+
+    prisma_client = _make_prisma_update_data_client()
+    now = datetime.now(timezone.utc)
+
+    asyncio.run(
+        prisma_client.update_data(
+            query_type="update_many",
+            table_name="key",
+            data_list=[
+                _UpdateDataKeyObject("sk-object-key", now),
+                _UpdateDataKeyObject("sk-fallback-key", now, fail_model_dump=True),
+            ],
+        )
+    )
+
+    batcher = prisma_client.db.batchers[0]
+    assert batcher.commit_calls == 1
+    calls = batcher.litellm_verificationtoken.update_calls
+    assert [call["where"] for call in calls] == [
+        {"token": hash_token("sk-object-key")},
+        {"token": hash_token("sk-fallback-key")},
+    ]
+    assert calls[0]["data"]["spend"] == 0.0
+    assert calls[1]["data"]["budget_reset_at"] == now
+
+
 def test_update_data_team_update_many_accepts_minimal_dict_payloads():
     prisma_client = _make_prisma_update_data_client()
     now = datetime.now(timezone.utc)
@@ -1146,6 +1222,32 @@ def test_update_data_team_update_many_accepts_minimal_dict_payloads():
         "spend": 0.0,
         "budget_reset_at": now,
     }
+
+
+def test_update_data_team_update_many_preserves_object_payloads():
+    prisma_client = _make_prisma_update_data_client()
+    now = datetime.now(timezone.utc)
+
+    asyncio.run(
+        prisma_client.update_data(
+            query_type="update_many",
+            table_name="team",
+            data_list=[
+                _UpdateDataTeamObject("team-object", now),
+                _UpdateDataTeamObject("team-fallback", now, fail_model_dump=True),
+            ],
+        )
+    )
+
+    batcher = prisma_client.db.batchers[0]
+    assert batcher.commit_calls == 1
+    calls = batcher.litellm_teamtable.upsert_calls
+    assert [call["where"] for call in calls] == [
+        {"team_id": "team-object"},
+        {"team_id": "team-fallback"},
+    ]
+    assert calls[0]["data"]["update"]["spend"] == 0.0
+    assert calls[1]["data"]["update"]["budget_reset_at"] == now
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -201,9 +201,12 @@ def test_reset_budget_for_key(reset_budget_job, mock_prisma_client):
         "LiteLLM_VerificationToken",
         (),
         {
+            "token": "hashed-key-token",
             "spend": 100.0,
             "budget_duration": "30d",
             "budget_reset_at": now,
+            "budget_limits": [{"budget_duration": "1d", "budget_limit": 10.0}],
+            "object_permission_id": "obj-perm-123",
             "id": "test-key-1",
         },
     )
@@ -216,8 +219,10 @@ def test_reset_budget_for_key(reset_budget_job, mock_prisma_client):
     # Verify results
     assert len(mock_prisma_client.updated_data["key"]) == 1
     updated_key = mock_prisma_client.updated_data["key"][0]
-    assert updated_key.spend == 0.0
-    assert updated_key.budget_reset_at > now
+    assert updated_key["token"] == "hashed-key-token"
+    assert updated_key["spend"] == 0.0
+    assert updated_key["budget_reset_at"] > now
+    assert set(updated_key.keys()) == {"token", "spend", "budget_reset_at"}
 
 
 def test_reset_budget_for_user(reset_budget_job, mock_prisma_client):
@@ -253,9 +258,12 @@ def test_reset_budget_for_team(reset_budget_job, mock_prisma_client):
         "LiteLLM_TeamTable",
         (),
         {
+            "team_id": "test-team-id",
             "spend": 500.0,
             "budget_duration": "1mo",
             "budget_reset_at": now,
+            "budget_limits": [{"budget_duration": "7d", "budget_limit": 50.0}],
+            "object_permission_id": "team-obj-perm-123",
             "id": "test-team-1",
         },
     )
@@ -268,8 +276,10 @@ def test_reset_budget_for_team(reset_budget_job, mock_prisma_client):
     # Verify results
     assert len(mock_prisma_client.updated_data["team"]) == 1
     updated_team = mock_prisma_client.updated_data["team"][0]
-    assert updated_team.spend == 0.0
-    assert updated_team.budget_reset_at > now
+    assert updated_team["team_id"] == "test-team-id"
+    assert updated_team["spend"] == 0.0
+    assert updated_team["budget_reset_at"] > now
+    assert set(updated_team.keys()) == {"team_id", "spend", "budget_reset_at"}
 
 
 def test_reset_budget_for_enduser(reset_budget_job, mock_prisma_client):
@@ -320,6 +330,7 @@ def test_reset_budget_all(reset_budget_job, mock_prisma_client):
         "LiteLLM_VerificationToken",
         (),
         {
+            "token": "hashed-key-token",
             "spend": 100.0,
             "budget_duration": "30d",
             "budget_reset_at": now,
@@ -342,6 +353,7 @@ def test_reset_budget_all(reset_budget_job, mock_prisma_client):
         "LiteLLM_TeamTable",
         (),
         {
+            "team_id": "test-team-id",
             "spend": 500.0,
             "budget_duration": "1mo",
             "budget_reset_at": now,
@@ -387,9 +399,9 @@ def test_reset_budget_all(reset_budget_job, mock_prisma_client):
     assert len(mock_prisma_client.updated_data["budget"]) == 1
 
     # Check that all spends were reset to 0
-    assert mock_prisma_client.updated_data["key"][0].spend == 0.0
+    assert mock_prisma_client.updated_data["key"][0]["spend"] == 0.0
     assert mock_prisma_client.updated_data["user"][0].spend == 0.0
-    assert mock_prisma_client.updated_data["team"][0].spend == 0.0
+    assert mock_prisma_client.updated_data["team"][0]["spend"] == 0.0
     assert mock_prisma_client.updated_data["enduser"][0].spend == 0.0
 
 
@@ -1026,6 +1038,114 @@ def test_reset_budget_for_team_members_preserves_total_spend():
     assert call_kwargs["where"]["budget_id"]["in"] == ["budget-1"]
     assert call_kwargs["data"] == {"spend": 0}
     assert "total_spend" not in call_kwargs["data"]
+
+
+class _RecordingVerificationTokenTable:
+    def __init__(self):
+        self.update_calls: List[Dict[str, Any]] = []
+
+    def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> None:
+        self.update_calls.append({"where": where, "data": data})
+
+
+class _RecordingTeamTable:
+    def __init__(self):
+        self.upsert_calls: List[Dict[str, Any]] = []
+
+    def upsert(self, where: Dict[str, Any], data: Dict[str, Any]) -> None:
+        self.upsert_calls.append({"where": where, "data": data})
+
+
+class _RecordingBatcher:
+    def __init__(self):
+        self.litellm_verificationtoken = _RecordingVerificationTokenTable()
+        self.litellm_teamtable = _RecordingTeamTable()
+        self.commit_calls = 0
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+
+class _RecordingDB:
+    def __init__(self):
+        self.batchers: List[_RecordingBatcher] = []
+
+    def batch_(self) -> _RecordingBatcher:
+        batcher = _RecordingBatcher()
+        self.batchers.append(batcher)
+        return batcher
+
+
+def _make_prisma_update_data_client():
+    from litellm.proxy.utils import PrismaClient
+
+    client = PrismaClient.__new__(PrismaClient)
+    client.db = _RecordingDB()
+    client.proxy_logging_obj = MagicMock()
+    client.proxy_logging_obj.failure_handler = AsyncMock()
+    return client
+
+
+def test_update_data_key_update_many_accepts_minimal_dict_payloads():
+    from litellm.proxy.utils import hash_token
+
+    prisma_client = _make_prisma_update_data_client()
+    now = datetime.now(timezone.utc)
+
+    asyncio.run(
+        prisma_client.update_data(
+            query_type="update_many",
+            table_name="key",
+            data_list=[
+                {
+                    "token": "sk-test-key",
+                    "spend": 0.0,
+                    "budget_reset_at": now,
+                }
+            ],
+        )
+    )
+
+    batcher = prisma_client.db.batchers[0]
+    assert batcher.commit_calls == 1
+    calls = batcher.litellm_verificationtoken.update_calls
+    assert len(calls) == 1
+    assert calls[0]["where"] == {"token": hash_token("sk-test-key")}
+    assert calls[0]["data"] == {
+        "token": hash_token("sk-test-key"),
+        "spend": 0.0,
+        "budget_reset_at": now,
+    }
+
+
+def test_update_data_team_update_many_accepts_minimal_dict_payloads():
+    prisma_client = _make_prisma_update_data_client()
+    now = datetime.now(timezone.utc)
+
+    asyncio.run(
+        prisma_client.update_data(
+            query_type="update_many",
+            table_name="team",
+            data_list=[
+                {
+                    "team_id": "team-1",
+                    "spend": 0.0,
+                    "budget_reset_at": now,
+                }
+            ],
+        )
+    )
+
+    batcher = prisma_client.db.batchers[0]
+    assert batcher.commit_calls == 1
+    calls = batcher.litellm_teamtable.upsert_calls
+    assert len(calls) == 1
+    assert calls[0]["where"] == {"team_id": "team-1"}
+    assert calls[0]["data"]["update"] == {
+        "team_id": "team-1",
+        "spend": 0.0,
+        "budget_reset_at": now,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1040,26 +1040,10 @@ def test_reset_budget_for_team_members_preserves_total_spend():
     assert "total_spend" not in call_kwargs["data"]
 
 
-class _RecordingVerificationTokenTable:
-    def __init__(self):
-        self.update_calls: List[Dict[str, Any]] = []
-
-    def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> None:
-        self.update_calls.append({"where": where, "data": data})
-
-
-class _RecordingTeamTable:
-    def __init__(self):
-        self.upsert_calls: List[Dict[str, Any]] = []
-
-    def upsert(self, where: Dict[str, Any], data: Dict[str, Any]) -> None:
-        self.upsert_calls.append({"where": where, "data": data})
-
-
 class _RecordingBatcher:
     def __init__(self):
-        self.litellm_verificationtoken = _RecordingVerificationTokenTable()
-        self.litellm_teamtable = _RecordingTeamTable()
+        self.litellm_verificationtoken = MagicMock()
+        self.litellm_teamtable = MagicMock()
         self.commit_calls = 0
 
     async def commit(self) -> None:
@@ -1086,55 +1070,86 @@ def _make_prisma_update_data_client():
     return client
 
 
-class _UpdateDataKeyObject:
-    def __init__(self, token: str, budget_reset_at: datetime, fail_model_dump=False):
-        self.token = token
+class _UpdateDataObject:
+    def __init__(
+        self,
+        id_field: str,
+        id_value: str,
+        budget_reset_at: datetime,
+        fail_model_dump=False,
+    ):
+        self.id_field = id_field
         self.spend = 0.0
         self.budget_reset_at = budget_reset_at
         self.fail_model_dump = fail_model_dump
+        setattr(self, id_field, id_value)
+
+    def _data(self):
+        return {
+            self.id_field: getattr(self, self.id_field),
+            "spend": self.spend,
+            "budget_reset_at": self.budget_reset_at,
+        }
 
     def model_dump(self, exclude_none=True):
         if self.fail_model_dump:
             raise RuntimeError("model_dump unavailable")
-        return {
-            "token": self.token,
-            "spend": self.spend,
-            "budget_reset_at": self.budget_reset_at,
-        }
+        return self._data()
 
     def dict(self, exclude_none=True):
-        return {
-            "token": self.token,
-            "spend": self.spend,
-            "budget_reset_at": self.budget_reset_at,
-        }
+        return self._data()
 
 
-class _UpdateDataTeamObject:
-    def __init__(self, team_id: str, budget_reset_at: datetime, fail_model_dump=False):
-        self.team_id = team_id
-        self.spend = 0.0
-        self.budget_reset_at = budget_reset_at
-        self.fail_model_dump = fail_model_dump
+@pytest.mark.parametrize(
+    ("table_name", "id_field", "id_value"),
+    [("key", "token", "sk-test-key"), ("team", "team_id", "team-1")],
+)
+def test_update_data_update_many_accepts_minimal_dict_payloads(
+    table_name, id_field, id_value
+):
+    from litellm.proxy.utils import hash_token
 
-    def model_dump(self, exclude_none=True):
-        if self.fail_model_dump:
-            raise RuntimeError("model_dump unavailable")
-        return {
-            "team_id": self.team_id,
-            "spend": self.spend,
-            "budget_reset_at": self.budget_reset_at,
-        }
+    prisma_client = _make_prisma_update_data_client()
+    now = datetime.now(timezone.utc)
+    payload = {id_field: id_value, "spend": 0.0, "budget_reset_at": now}
 
-    def dict(self, exclude_none=True):
-        return {
-            "team_id": self.team_id,
-            "spend": self.spend,
-            "budget_reset_at": self.budget_reset_at,
-        }
+    asyncio.run(
+        prisma_client.update_data(
+            query_type="update_many",
+            table_name=table_name,
+            data_list=[payload],
+        )
+    )
+
+    batcher = prisma_client.db.batchers[0]
+    assert batcher.commit_calls == 1
+    expected_id_value = hash_token(id_value) if table_name == "key" else id_value
+    call = (
+        batcher.litellm_verificationtoken.update.call_args
+        if table_name == "key"
+        else batcher.litellm_teamtable.upsert.call_args
+    )
+    written_data = (
+        call.kwargs["data"] if table_name == "key" else call.kwargs["data"]["update"]
+    )
+    assert call.kwargs["where"] == {id_field: expected_id_value}
+    assert written_data == {
+        id_field: expected_id_value,
+        "spend": 0.0,
+        "budget_reset_at": now,
+    }
 
 
-def test_update_data_key_update_many_accepts_minimal_dict_payloads():
+@pytest.mark.parametrize(
+    ("table_name", "id_field", "id_values"),
+    [
+        ("key", "token", ("sk-object-key", "sk-fallback-key")),
+        ("team", "team_id", ("team-object", "team-fallback")),
+    ],
+)
+def test_update_data_update_many_preserves_object_payloads(
+    table_name, id_field, id_values
+):
     from litellm.proxy.utils import hash_token
 
     prisma_client = _make_prisma_update_data_client()
@@ -1143,111 +1158,32 @@ def test_update_data_key_update_many_accepts_minimal_dict_payloads():
     asyncio.run(
         prisma_client.update_data(
             query_type="update_many",
-            table_name="key",
+            table_name=table_name,
             data_list=[
-                {
-                    "token": "sk-test-key",
-                    "spend": 0.0,
-                    "budget_reset_at": now,
-                }
+                _UpdateDataObject(id_field, id_values[0], now),
+                _UpdateDataObject(id_field, id_values[1], now, fail_model_dump=True),
             ],
         )
     )
 
     batcher = prisma_client.db.batchers[0]
     assert batcher.commit_calls == 1
-    calls = batcher.litellm_verificationtoken.update_calls
-    assert len(calls) == 1
-    assert calls[0]["where"] == {"token": hash_token("sk-test-key")}
-    assert calls[0]["data"] == {
-        "token": hash_token("sk-test-key"),
-        "spend": 0.0,
-        "budget_reset_at": now,
-    }
-
-
-def test_update_data_key_update_many_preserves_object_payloads():
-    from litellm.proxy.utils import hash_token
-
-    prisma_client = _make_prisma_update_data_client()
-    now = datetime.now(timezone.utc)
-
-    asyncio.run(
-        prisma_client.update_data(
-            query_type="update_many",
-            table_name="key",
-            data_list=[
-                _UpdateDataKeyObject("sk-object-key", now),
-                _UpdateDataKeyObject("sk-fallback-key", now, fail_model_dump=True),
-            ],
-        )
+    calls = (
+        batcher.litellm_verificationtoken.update.call_args_list
+        if table_name == "key"
+        else batcher.litellm_teamtable.upsert.call_args_list
     )
-
-    batcher = prisma_client.db.batchers[0]
-    assert batcher.commit_calls == 1
-    calls = batcher.litellm_verificationtoken.update_calls
-    assert [call["where"] for call in calls] == [
-        {"token": hash_token("sk-object-key")},
-        {"token": hash_token("sk-fallback-key")},
+    expected_ids = [
+        hash_token(value) if table_name == "key" else value for value in id_values
     ]
-    assert calls[0]["data"]["spend"] == 0.0
-    assert calls[1]["data"]["budget_reset_at"] == now
-
-
-def test_update_data_team_update_many_accepts_minimal_dict_payloads():
-    prisma_client = _make_prisma_update_data_client()
-    now = datetime.now(timezone.utc)
-
-    asyncio.run(
-        prisma_client.update_data(
-            query_type="update_many",
-            table_name="team",
-            data_list=[
-                {
-                    "team_id": "team-1",
-                    "spend": 0.0,
-                    "budget_reset_at": now,
-                }
-            ],
-        )
-    )
-
-    batcher = prisma_client.db.batchers[0]
-    assert batcher.commit_calls == 1
-    calls = batcher.litellm_teamtable.upsert_calls
-    assert len(calls) == 1
-    assert calls[0]["where"] == {"team_id": "team-1"}
-    assert calls[0]["data"]["update"] == {
-        "team_id": "team-1",
-        "spend": 0.0,
-        "budget_reset_at": now,
-    }
-
-
-def test_update_data_team_update_many_preserves_object_payloads():
-    prisma_client = _make_prisma_update_data_client()
-    now = datetime.now(timezone.utc)
-
-    asyncio.run(
-        prisma_client.update_data(
-            query_type="update_many",
-            table_name="team",
-            data_list=[
-                _UpdateDataTeamObject("team-object", now),
-                _UpdateDataTeamObject("team-fallback", now, fail_model_dump=True),
-            ],
-        )
-    )
-
-    batcher = prisma_client.db.batchers[0]
-    assert batcher.commit_calls == 1
-    calls = batcher.litellm_teamtable.upsert_calls
-    assert [call["where"] for call in calls] == [
-        {"team_id": "team-object"},
-        {"team_id": "team-fallback"},
+    assert [call.kwargs["where"] for call in calls] == [
+        {id_field: value} for value in expected_ids
     ]
-    assert calls[0]["data"]["update"]["spend"] == 0.0
-    assert calls[1]["data"]["update"]["budget_reset_at"] == now
+    written_data = [
+        call.kwargs["data"] if table_name == "key" else call.kwargs["data"]["update"]
+        for call in calls
+    ]
+    assert written_data[1]["spend"] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1122,7 +1122,6 @@ def test_update_data_update_many_accepts_minimal_dict_payloads(
     )
 
     batcher = prisma_client.db.batchers[0]
-    assert batcher.commit_calls == 1
     expected_id_value = hash_token(id_value) if table_name == "key" else id_value
     call = (
         batcher.litellm_verificationtoken.update.call_args


### PR DESCRIPTION
## Summary
- Fixes reset budget key/team writes by sending only identifier, spend, and budget_reset_at through update_data.
- Adds dict payload support to PrismaClient.update_data update_many for key/team, preserving existing object payload behavior.
- Adds regression coverage for key/team rows with object_permission_id and budget_limits, including dict/object update_data payload variants.

Fixes #27730.

## Testing
- uv run pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -x -vv (49 passed)
- uv run pytest tests/litellm_utils_tests/test_proxy_budget_reset.py -x -vv (14 passed)
- Live k8s dev validation on ai-tools-dev/litellm: unpatched pod reproduced the Prisma DataError for key and team reset rows with object_permission_id + budget_limits; patched pod reset both rows successfully with spend=0.0, advanced budget_reset_at, retained object_permission_id and budget_limits, and failure hook count 0. Both running dev pods were hot-patched with the implementation files afterward.