### PR TITLE
fix(responses): handle ResponseCustomToolCall in Chat Completions bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -484,6 +484,13 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         except ImportError:
             ResponseApplyPatchToolCall = None  # type: ignore[assignment,misc]
 
+        try:
+            from openai.types.responses.response_output_item import (
+                ResponseCustomToolCall,
+            )
+        except ImportError:
+            ResponseCustomToolCall = None  # type: ignore[assignment,misc]
+
         from litellm.types.utils import Choices, Message
 
         choices: List[Choices] = []
@@ -564,6 +571,20 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 )
 
                 tool_call_dict = LiteLLMCompletionResponsesConfig.convert_apply_patch_tool_call_to_chat_completion_tool_call(
+                    tool_call_item=item,
+                    index=tool_call_index,
+                )
+                accumulated_tool_calls.append(tool_call_dict)
+                tool_call_index += 1
+
+            elif ResponseCustomToolCall is not None and isinstance(
+                item, ResponseCustomToolCall
+            ):
+                from litellm.responses.litellm_completion_transformation.transformation import (
+                    LiteLLMCompletionResponsesConfig,
+                )
+
+                tool_call_dict = LiteLLMCompletionResponsesConfig.convert_custom_tool_call_to_chat_completion_tool_call(
                     tool_call_item=item,
                     index=tool_call_index,
                 )
@@ -1209,6 +1230,28 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         )
                     ]
                 )
+            elif output_item.get("type") == "custom_tool_call":
+                # Custom tool call added — emit tool call header (id + name).
+                # The full input content arrives in response.output_item.done.
+                tool_call_index = parsed_chunk.get("output_index", 0)
+                tool_call_chunk = ChatCompletionToolCallChunk(
+                    id=output_item.get("call_id"),
+                    index=tool_call_index,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=output_item.get("name", None),
+                        arguments="",
+                    ),
+                )
+                return ModelResponseStream(
+                    choices=[
+                        StreamingChoices(
+                            index=0,
+                            delta=Delta(tool_calls=[tool_call_chunk]),
+                            finish_reason=None,
+                        )
+                    ]
+                )
         elif event_type == "response.function_call_arguments.delta":
             content_part: Optional[str] = parsed_chunk.get("delta", None)
             if content_part:
@@ -1288,6 +1331,32 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         )
                     ]
                 )
+            elif output_item.get("type") == "custom_tool_call":
+                # Custom tool call done — emit the full input as arguments
+                # Custom tools use grammar-constrained output, so the complete
+                # input is only available in the done event (no incremental deltas).
+                import json as _json
+
+                custom_input = output_item.get("input", "")
+                tool_call_index = parsed_chunk.get("output_index", 0)
+                tool_call_chunk = ChatCompletionToolCallChunk(
+                    id=output_item.get("call_id"),
+                    index=tool_call_index,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=output_item.get("name", None),
+                        arguments=_json.dumps({"input": custom_input}),
+                    ),
+                )
+                return ModelResponseStream(
+                    choices=[
+                        StreamingChoices(
+                            index=0,
+                            delta=Delta(tool_calls=[tool_call_chunk]),
+                            finish_reason=None,
+                        )
+                    ]
+                )
             elif output_item.get("type") == "message":
                 # Message completion should NOT emit finish_reason
                 # This is the fix for issue #17246 - don't end stream prematurely
@@ -1337,7 +1406,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
             output_items = response_data.get("output", []) if response_data else []
 
             has_function_calls = any(
-                item.get("type") == "function_call"
+                item.get("type") in ("function_call", "custom_tool_call")
                 for item in output_items
                 if isinstance(item, dict)
             )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1644,6 +1644,38 @@ class LiteLLMCompletionResponsesConfig:
         return tool_call_dict
 
     @staticmethod
+    def convert_custom_tool_call_to_chat_completion_tool_call(
+        tool_call_item: Any,
+        index: int = 0,
+    ) -> Dict[str, Any]:
+        """
+        Convert ResponseCustomToolCall to ChatCompletionToolCallChunk format.
+
+        Custom tool calls have freeform `input` text (not JSON). We wrap
+        it in a JSON object `{"input": "<text>"}` so it fits the
+        Chat Completions `function.arguments` field.
+
+        Args:
+            tool_call_item: ResponseCustomToolCall object with call_id, name, and input
+            index: The index of this tool call
+
+        Returns:
+            Dictionary in ChatCompletionToolCallChunk format
+        """
+        import json
+
+        tool_call_dict: Dict[str, Any] = {
+            "id": tool_call_item.call_id,
+            "function": {
+                "name": tool_call_item.name,
+                "arguments": json.dumps({"input": tool_call_item.input}),
+            },
+            "type": "function",
+            "index": index,
+        }
+        return tool_call_dict
+
+    @staticmethod
     def transform_chat_completion_response_to_responses_api_response(
         request_input: Union[str, ResponseInputParam],
         responses_api_request: ResponsesAPIOptionalRequestParams,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2481,3 +2481,237 @@ def test_reasoning_items_streaming_emitted_on_response_completed():
         ri["encrypted_content"] == encrypted
     ), "encrypted_content must be preserved in streaming"
     assert ri["summary"][0]["text"] == summary_text
+
+
+def test_custom_tool_call_converted_to_chat_completion_tool_call():
+    """
+    Test that ResponseCustomToolCall items from the Responses API are
+    correctly converted to ChatCompletions-style tool calls by the bridge.
+
+    Custom tools (type: "custom" with format.grammar) produce freeform text
+    output. The bridge should wrap the input text in {"input": "<text>"} JSON
+    and return it as a standard function tool call.
+    """
+    pytest.importorskip("openai.types.responses.response_output_item")
+
+    import json
+    from unittest.mock import Mock
+
+    from openai.types.responses.response_output_item import (
+        ResponseCustomToolCall,
+    )
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import (
+        InputTokensDetails,
+        OutputTokensDetails,
+        ResponseAPIUsage,
+        ResponsesAPIResponse,
+    )
+    from litellm.types.utils import ModelResponse, Usage
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    # Build a custom_tool_call item like the model would return
+    custom_tool_item = ResponseCustomToolCall(
+        id="ctc_001",
+        call_id="call_custom_patch",
+        name="apply_patch",
+        input="*** Begin Patch\n*** Add File: hello.txt\n+Hello, World!\n*** End Patch\n",
+        type="custom_tool_call",
+    )
+
+    # Minimal usage
+    usage = ResponseAPIUsage(
+        input_tokens=30,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens=40,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        total_tokens=70,
+    )
+
+    raw_response = ResponsesAPIResponse(
+        id="resp_custom_tool_test",
+        created_at=1234567890,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        model="gpt-5.4",
+        object="response",
+        output=[custom_tool_item],
+        parallel_tool_calls=True,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text=None,
+        truncation="disabled",
+        usage=usage,
+        user=None,
+        store=True,
+        background=False,
+    )
+
+    model_response = ModelResponse(
+        id="chatcmpl-custom-tool",
+        created=1234567890,
+        model=None,
+        object="chat.completion",
+        choices=[],
+        usage=Usage(completion_tokens=0, prompt_tokens=0, total_tokens=0),
+    )
+
+    logging_obj = Mock()
+
+    result = handler.transform_response(
+        model="gpt-5.4",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=logging_obj,
+        request_data={"model": "gpt-5.4"},
+        messages=[
+            {"role": "system", "content": "You are a coding assistant."},
+            {"role": "user", "content": "Create hello.txt"},
+        ],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+
+    # Should have exactly one choice with finish_reason="tool_calls"
+    assert len(result.choices) == 1, f"Expected 1 choice, got {len(result.choices)}"
+
+    choice = result.choices[0]
+    assert choice.finish_reason == "tool_calls"
+
+    # The choice should contain one tool call for apply_patch
+    tool_calls = choice.message.tool_calls
+    assert tool_calls is not None, "tool_calls should not be None"
+    assert len(tool_calls) == 1, f"Expected 1 tool_call, got {len(tool_calls)}"
+
+    tc = tool_calls[0]
+    assert tc["id"] == "call_custom_patch"
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "apply_patch"
+
+    # The input should be wrapped in {"input": "..."} JSON
+    args = json.loads(tc["function"]["arguments"])
+    assert "input" in args
+    assert "*** Begin Patch" in args["input"]
+    assert "*** Add File: hello.txt" in args["input"]
+    assert "+Hello, World!" in args["input"]
+    assert "*** End Patch" in args["input"]
+
+
+def test_custom_tool_call_streaming_output_item_done():
+    """
+    Test that custom_tool_call in streaming mode emits tool call chunks correctly.
+
+    In streaming, custom_tool_call content arrives in the response.output_item.done
+    event (not incrementally), because grammar-constrained output is validated
+    server-side before being sent.
+    """
+    import json
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    # Simulate response.output_item.added event (header only)
+    added_chunk = {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "custom_tool_call",
+            "call_id": "call_stream_patch",
+            "name": "apply_patch",
+            "input": "",  # empty at added time
+            "id": "ctc_stream001",
+            "status": "in_progress",
+        },
+    }
+
+    result_added = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+        added_chunk
+    )
+
+    # Should emit a tool call header with empty arguments
+    assert result_added.choices[0].delta.tool_calls is not None
+    tc_added = result_added.choices[0].delta.tool_calls[0]
+    assert tc_added.id == "call_stream_patch"
+    assert tc_added.function.name == "apply_patch"
+    assert tc_added.function.arguments == ""
+
+    # Simulate response.output_item.done event (full content)
+    done_chunk = {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "custom_tool_call",
+            "call_id": "call_stream_patch",
+            "name": "apply_patch",
+            "input": "*** Begin Patch\n*** Add File: test.txt\n+test content\n*** End Patch\n",
+            "id": "ctc_stream001",
+            "status": "completed",
+        },
+    }
+
+    result_done = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+        done_chunk
+    )
+
+    # Should emit tool call with full arguments
+    assert result_done.choices[0].delta.tool_calls is not None
+    tc_done = result_done.choices[0].delta.tool_calls[0]
+    assert tc_done.id == "call_stream_patch"
+    assert tc_done.function.name == "apply_patch"
+
+    args = json.loads(tc_done.function.arguments)
+    assert "*** Begin Patch" in args["input"]
+    assert "+test content" in args["input"]
+
+
+def test_response_completed_with_custom_tool_calls_emits_tool_calls_finish_reason():
+    """
+    Test that response.completed event correctly sets finish_reason="tool_calls"
+    when the output contains custom_tool_call items.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    completed_chunk = {
+        "type": "response.completed",
+        "response": {
+            "output": [
+                {"type": "reasoning", "id": "rs_001", "summary": []},
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_xyz",
+                    "name": "apply_patch",
+                    "input": "*** Begin Patch\n*** End Patch\n",
+                    "id": "ctc_002",
+                },
+            ],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 10},
+            },
+        },
+    }
+
+    result = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+        completed_chunk
+    )
+
+    assert result.choices[0].finish_reason == "tool_calls"


### PR DESCRIPTION
## Summary

When LiteLLM auto-routes Chat Completions requests to OpenAI's Responses API (for models like gpt-5.4 with tools + reasoning), custom tool calls (`type: "custom"`) are returned as `ResponseCustomToolCall` objects. Previously, these were silently dropped (streaming) or caused a 500 error (non-streaming) because the bridge code only handled `ResponseFunctionToolCall` and `ResponseApplyPatchToolCall`.

## Changes

### Non-streaming (`_convert_response_output_to_choices`)
- Added `isinstance(item, ResponseCustomToolCall)` branch
- New helper: `convert_custom_tool_call_to_chat_completion_tool_call()`

### Streaming (`translate_responses_chunk_to_openai_stream`)
- `response.output_item.added`: handle `type == "custom_tool_call"` → emit tool call delta
- `response.output_item.done`: handle `type == "custom_tool_call"` → emit final arguments
- `response.completed`: include custom tool calls in `has_function_calls` detection for correct `finish_reason: "tool_calls"`

### Tests
- 3 new unit tests covering non-streaming conversion, streaming chunk translation, and finish_reason detection
- All 53 existing tests pass

## Related
- Related to #27276 (custom tool type handling)
- Previous PR #28469 was closed due to targeting `main` from a fork

## Impact
- **Pure additive** — no existing code paths are modified for function_call/apply_patch_call types
- `ResponseCustomToolCall` import is wrapped in try/except for backwards compatibility