### PR TITLE
fix(proxy): clean up budget reservations on cancellation

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2122,6 +2122,22 @@ async def _reconcile_budget_reservation_for_counter_update(
             actual_cost=response_cost or 0.0,
             finalize=False,
         )
+    except asyncio.CancelledError:
+        verbose_proxy_logger.warning(
+            "Budget reservation reconciliation was cancelled after persisted spend; invalidating reserved counters",
+            exc_info=True,
+        )
+        try:
+            await asyncio.shield(
+                invalidate_budget_reservation_counters(
+                    budget_reservation=budget_reservation
+                )
+            )
+        except Exception:
+            verbose_proxy_logger.exception(
+                "Failed to invalidate reserved counters after reservation reconciliation was cancelled"
+            )
+        raise
     except Exception:
         verbose_proxy_logger.warning(
             "Failed to reconcile budget reservation after persisted spend; invalidating reserved counters and continuing",
@@ -2351,6 +2367,9 @@ async def _increment_spend_counter_cache(counter_key: str, increment: float):
                 value=increment,
                 refresh_ttl=True,
             )
+        except asyncio.CancelledError:
+            await asyncio.shield(_invalidate_spend_counter(counter_key=counter_key))
+            raise
         except Exception:
             await _invalidate_spend_counter(counter_key=counter_key)
             raise

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -114,6 +115,9 @@ async def reserve_budget_for_request(
                     counter=counter,
                     reservation_cost=reservation_cost,
                 )
+            except asyncio.CancelledError:
+                applied_entries.remove(entry)
+                raise
             except _CounterReservationUnavailable as exc:
                 if exc.touched_counter and not exc.counter_invalidated:
                     await _release_applied_entries_best_effort(
@@ -152,6 +156,14 @@ async def reserve_budget_for_request(
                         f"Max budget: {counter.max_budget}"
                     ),
                 )
+    except asyncio.CancelledError:
+        await asyncio.shield(
+            _release_applied_entries_best_effort(
+                entries=applied_entries,
+                default_reserved_cost=reservation_cost,
+            )
+        )
+        raise
     except Exception:
         await _release_applied_entries_best_effort(
             entries=applied_entries,

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -53,6 +54,124 @@ def _request_body() -> dict:
         "messages": [{"role": "user", "content": "hello"}],
         "max_tokens": 10,
     }
+
+
+@pytest.mark.asyncio
+async def test_cancelled_redis_increment_invalidates_spend_counter():
+    import litellm.proxy.proxy_server as ps
+
+    class RedisCache:
+        async def async_increment(self, key, value, refresh_ttl):
+            raise asyncio.CancelledError()
+
+        async def async_delete_cache(self, key):
+            deleted_keys.append(key)
+
+    deleted_keys = []
+    counter_cache = DualCache()
+    counter_cache.redis_cache = RedisCache()
+    counter_cache.in_memory_cache.set_cache(
+        key="spend:team:cancelled-increment",
+        value=10.0,
+    )
+
+    original_counter_cache = ps.spend_counter_cache
+    ps.spend_counter_cache = counter_cache
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await ps._increment_spend_counter_cache(
+                counter_key="spend:team:cancelled-increment",
+                increment=-5.0,
+            )
+    finally:
+        ps.spend_counter_cache = original_counter_cache
+
+    assert deleted_keys == ["spend:team:cancelled-increment"]
+    assert (
+        counter_cache.in_memory_cache.get_cache(key="spend:team:cancelled-increment")
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_reservation_reconciliation_invalidates_reserved_counters():
+    import litellm.proxy.proxy_server as ps
+
+    budget_reservation = {
+        "reserved_cost": 1.0,
+        "entries": [{"counter_key": "spend:team:cancelled-reconcile"}],
+        "finalized": False,
+    }
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.reconcile_budget_reservation",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.invalidate_budget_reservation_counters",
+            new=AsyncMock(),
+        ) as mock_invalidate,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await ps._reconcile_budget_reservation_for_counter_update(
+                budget_reservation=budget_reservation,
+                response_cost=0.25,
+            )
+
+    mock_invalidate.assert_awaited_once_with(
+        budget_reservation=budget_reservation,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_pre_call_reservation_releases_only_applied_entries():
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+    valid_token = UserAPIKeyAuth(
+        token="key-cancelled-reservation",
+        spend=0.0,
+        max_budget=10.0,
+    )
+    team_object = LiteLLM_TeamTable(
+        team_id="team-cancelled-reservation",
+        team_alias="cancelled reservation",
+        spend=0.0,
+        max_budget=10.0,
+        models=[],
+    )
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+            return_value=1.0,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._reserve_counter",
+            new=AsyncMock(side_effect=[1.0, asyncio.CancelledError()]),
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._release_applied_entries_best_effort",
+            new=AsyncMock(),
+        ) as mock_release,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await reserve_budget_for_request(
+                request_body=_request_body(),
+                route="/chat/completions",
+                llm_router=None,
+                valid_token=valid_token,
+                team_object=team_object,
+                user_object=None,
+                prisma_client=None,
+                user_api_key_cache=DualCache(),
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
+    mock_release.assert_awaited_once()
+    released_entries = mock_release.await_args.kwargs["entries"]
+    assert [entry["counter_key"] for entry in released_entries] == [
+        "spend:key:key-cancelled-reservation"
+    ]
 
 
 def test_should_not_serialize_budget_reservation_on_user_api_key_auth():


### PR DESCRIPTION
## Summary
- handle asyncio.CancelledError in Redis spend-counter increments by invalidating the affected counter before re-raising
- handle cancellation during post-call budget reservation reconciliation by invalidating reserved counters before re-raising
- release already-applied pre-call reservations when reservation is cancelled before returning to the request path

## Why
CancelledError inherits from BaseException, so the existing broad Exception cleanup did not run when logging worker timeouts cancelled budget-reservation Redis work. That could leave Redis spend counters above persisted DB spend and cause quota checks to block early while UI spend still showed remaining budget.

## Tests
- python3 -m py_compile litellm/proxy/proxy_server.py litellm/proxy/spend_tracking/budget_reservation.py tests/test_litellm/proxy/test_budget_reservation.py
- pytest tests/test_litellm/proxy/test_budget_reservation.py::test_cancelled_redis_increment_invalidates_spend_counter tests/test_litellm/proxy/test_budget_reservation.py::test_cancelled_reservation_reconciliation_invalidates_reserved_counters tests/test_litellm/proxy/test_budget_reservation.py::test_cancelled_pre_call_reservation_releases_only_applied_entries -q