### PR TITLE
Fix team key wildcard model stack overflow

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getModelDisplayName } from "./fetch_available_models_team_key";
+import { getModelDisplayName, unfurlWildcardModelsInList } from "./fetch_available_models_team_key";
 
 describe("getModelDisplayName", () => {
   it("should return display label for all proxy models", () => {
@@ -9,5 +9,27 @@ describe("getModelDisplayName", () => {
 
   it("should return provider-wide label for wildcard models", () => {
     expect(getModelDisplayName("openai/*")).toBe("All openai models");
+  });
+});
+
+describe("unfurlWildcardModelsInList", () => {
+  it("should expand wildcard models while preserving display names and removing duplicates", () => {
+    expect(
+      unfurlWildcardModelsInList(
+        ["openai/*", "anthropic/claude-4", "openai/gpt-4"],
+        ["openai/gpt-4", "openai/gpt-4o", "anthropic/claude-4"],
+      ),
+    ).toEqual(["openai/*", "openai/gpt-4", "openai/gpt-4o", "anthropic/claude-4"]);
+  });
+
+  it("should not exceed the call stack when expanding a wildcard with many matching models", () => {
+    const allModels = Array.from({ length: 150_000 }, (_, index) => `openai/model-${index}`);
+
+    const result = unfurlWildcardModelsInList(["openai/*"], allModels);
+
+    expect(result).toHaveLength(allModels.length + 1);
+    expect(result[0]).toBe("openai/*");
+    expect(result[1]).toBe("openai/model-0");
+    expect(result.at(-1)).toBe("openai/model-149999");
   });
 });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
@@ -49,8 +49,6 @@ export const getModelDisplayName = (model: string) => {
 export const unfurlWildcardModelsInList = (teamModels: string[], allModels: string[]): string[] => {
   const wildcardDisplayNames: string[] = [];
   const expandedModels: string[] = [];
-  console.log("teamModels", teamModels);
-  console.log("allModels", allModels);
 
   teamModels.forEach((teamModel) => {
     if (teamModel.endsWith("/*")) {
@@ -59,7 +57,7 @@ export const unfurlWildcardModelsInList = (teamModels: string[], allModels: stri
 
       // Find all models that start with this provider
       const matchingModels = allModels.filter((model) => model.startsWith(provider + "/"));
-      expandedModels.push(...matchingModels);
+      matchingModels.forEach((model) => expandedModels.push(model));
       wildcardDisplayNames.push(teamModel);
     } else {
       expandedModels.push(teamModel);
@@ -67,5 +65,5 @@ export const unfurlWildcardModelsInList = (teamModels: string[], allModels: stri
   });
 
   // Combine arrays with wildcard display names first, then remove duplicates
-  return [...wildcardDisplayNames, ...expandedModels].filter((item, index, array) => array.indexOf(item) === index);
+  return Array.from(new Set([...wildcardDisplayNames, ...expandedModels]));
 };


### PR DESCRIPTION
## Relevant issues

Fixes #28446

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the dashboard test suite for the affected UI helper
- [ ] My PR passes all unit tests on `make test-unit` (not run; dashboard-only change)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

Validation run locally:

- `cd ui/litellm-dashboard && npm test -- src/components/key_team_helpers/fetch_available_models_team_key.test.tsx --run`
- `cd ui/litellm-dashboard && npx prettier --check src/components/key_team_helpers/fetch_available_models_team_key.tsx src/components/key_team_helpers/fetch_available_models_team_key.test.tsx`
- `cd ui/litellm-dashboard && NODE_OPTIONS=--max-old-space-size=4096 npm run build`

## Type

🐛 Bug Fix
✅ Test

## Changes

- Avoid spreading very large wildcard model expansions into `Array.prototype.push`, which can exceed the JS call stack.
- Use `Set` for de-duplication to avoid repeated `indexOf` scans on large model lists.
- Add regression coverage for preserving wildcard display names, de-duping, and expanding 150k matching models without a stack overflow.
