### PR TITLE
feat: add per-key IP address restrictions (allowed_ips) for virtual keys

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -390,6 +390,7 @@ model LiteLLM_VerificationToken {
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     allowed_routes   String[] @default([])
+    allowed_ips      String[] @default([])
     policies         String[] @default([])
     access_group_ids String[] @default([])
     model_spend      Json @default("{}")
@@ -483,6 +484,7 @@ model LiteLLM_DeletedVerificationToken {
     budget_reset_at         DateTime?
     allowed_cache_controls  String[] @default([])
     allowed_routes          String[] @default([])
+    allowed_ips             String[] @default([])
     policies                String[] @default([])
     access_group_ids String[] @default([])
     model_spend             Json     @default("{}")

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1066,6 +1066,7 @@ class KeyRequestBase(GenerateRequestBase):
     tags: Optional[List[str]] = None
     enforced_params: Optional[List[str]] = None
     allowed_routes: Optional[list] = []
+    allowed_ips: Optional[List[str]] = None
     allowed_passthrough_routes: Optional[list] = None
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
     rpm_limit_type: Optional[
@@ -2571,6 +2572,7 @@ class LiteLLM_VerificationToken(LiteLLMPydanticObjectBase):
     budget_reset_at: Optional[datetime] = None
     allowed_cache_controls: Optional[list] = []
     allowed_routes: Optional[list] = []
+    allowed_ips: Optional[List[str]] = None
     permissions: Dict = {}
     model_spend: Dict = {}
     model_max_budget: Dict = {}

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -54,6 +54,51 @@ def _check_valid_ip(
     return True, client_ip
 
 
+def _check_key_ip_allowed(
+    allowed_ips: Optional[List[str]],
+    request: Request,
+    use_x_forwarded_for: Optional[bool] = False,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Check if the request IP is in the key's allowed_ips list.
+
+    Supports both exact IP addresses and CIDR ranges (e.g. "10.0.0.0/8").
+    Returns (is_allowed, client_ip).
+    """
+    import ipaddress
+
+    if not allowed_ips:
+        return True, None
+
+    client_ip = _get_request_ip_address(
+        request=request, use_x_forwarded_for=use_x_forwarded_for
+    )
+
+    if not client_ip:
+        return False, client_ip
+
+    ip_to_check = client_ip.split(",")[0].strip() if "," in client_ip else client_ip
+
+    try:
+        client_addr = ipaddress.ip_address(ip_to_check)
+    except ValueError:
+        return False, client_ip
+
+    for entry in allowed_ips:
+        try:
+            if "/" in entry:
+                network = ipaddress.ip_network(entry, strict=False)
+                if client_addr in network:
+                    return True, client_ip
+            else:
+                if client_addr == ipaddress.ip_address(entry):
+                    return True, client_ip
+        except ValueError:
+            continue
+
+    return False, client_ip
+
+
 def check_complete_credentials(request_body: dict) -> bool:
     """
     if 'api_base' in request body. Check if complete credentials given. Prevent malicious attacks.

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1845,6 +1845,21 @@ async def _run_centralized_common_checks(  # noqa: PLR0915
     ):
         return
 
+    # Per-key IP restriction check
+    if user_api_key_auth_obj.allowed_ips:
+        from litellm.proxy.auth.auth_utils import _check_key_ip_allowed
+
+        _is_allowed, _client_ip = _check_key_ip_allowed(
+            allowed_ips=user_api_key_auth_obj.allowed_ips,
+            request=request,
+            use_x_forwarded_for=general_settings.get("use_x_forwarded_for", False),
+        )
+        if not _is_allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access forbidden: IP address {_client_ip} not allowed for this API key.",
+            )
+
     parent_otel_span = user_api_key_auth_obj.parent_otel_span
     # In the integrated auth flow ``_user_api_key_auth_builder`` has already
     # resolved the end-user id and attached it here. Reuse that to avoid a

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3382,6 +3382,7 @@ async def generate_key_helper_fn(  # noqa: PLR0915
     created_by: Optional[str] = None,
     updated_by: Optional[str] = None,
     allowed_routes: Optional[list] = None,
+    allowed_ips: Optional[list] = None,
     sso_user_id: Optional[str] = None,
     object_permission_id: Optional[
         str
@@ -3521,6 +3522,7 @@ async def generate_key_helper_fn(  # noqa: PLR0915
             "created_by": created_by,
             "updated_by": updated_by,
             "allowed_routes": allowed_routes or [],
+            "allowed_ips": allowed_ips or [],
             "object_permission_id": object_permission_id,
             "router_settings": router_settings_json,
             "access_group_ids": access_group_ids or [],

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -390,6 +390,7 @@ model LiteLLM_VerificationToken {
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     allowed_routes   String[] @default([])
+    allowed_ips      String[] @default([])
     policies         String[] @default([])
     access_group_ids String[] @default([])
     model_spend      Json @default("{}")
@@ -483,6 +484,7 @@ model LiteLLM_DeletedVerificationToken {
     budget_reset_at         DateTime?
     allowed_cache_controls  String[] @default([])
     allowed_routes          String[] @default([])
+    allowed_ips             String[] @default([])
     policies                String[] @default([])
     access_group_ids String[] @default([])
     model_spend             Json     @default("{}")

--- a/schema.prisma
+++ b/schema.prisma
@@ -390,6 +390,7 @@ model LiteLLM_VerificationToken {
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     allowed_routes   String[] @default([])
+    allowed_ips      String[] @default([])
     policies         String[] @default([])
     access_group_ids String[] @default([])
     model_spend      Json @default("{}")
@@ -483,6 +484,7 @@ model LiteLLM_DeletedVerificationToken {
     budget_reset_at         DateTime?
     allowed_cache_controls  String[] @default([])
     allowed_routes          String[] @default([])
+    allowed_ips             String[] @default([])
     policies                String[] @default([])
     access_group_ids String[] @default([])
     model_spend             Json     @default("{}")

--- a/tests/test_litellm/proxy/auth/test_key_ip_restrictions.py
+++ b/tests/test_litellm/proxy/auth/test_key_ip_restrictions.py
@@ -1,0 +1,255 @@
+"""
+Unit tests for per-key IP address restrictions.
+
+Tests that virtual keys with allowed_ips enforce IP-based access control,
+supporting both exact IP addresses and CIDR ranges.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.proxy.auth.auth_utils import _check_key_ip_allowed
+
+
+def _make_request(client_ip="192.168.1.100", xff_header=None):
+    request = MagicMock()
+    request.client = MagicMock()
+    request.client.host = client_ip
+    headers = {}
+    if xff_header is not None:
+        headers["x-forwarded-for"] = xff_header
+    request.headers = headers
+    return request
+
+
+class TestCheckKeyIpAllowed:
+    """Tests for _check_key_ip_allowed function."""
+
+    def test_should_allow_when_allowed_ips_is_none(self):
+        request = _make_request()
+        is_allowed, client_ip = _check_key_ip_allowed(allowed_ips=None, request=request)
+        assert is_allowed is True
+        assert client_ip is None
+
+    def test_should_allow_when_allowed_ips_is_empty(self):
+        request = _make_request()
+        is_allowed, client_ip = _check_key_ip_allowed(allowed_ips=[], request=request)
+        assert is_allowed is True
+        assert client_ip is None
+
+    def test_should_allow_exact_ip_match(self):
+        request = _make_request(client_ip="10.0.0.5")
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.5"], request=request
+        )
+        assert is_allowed is True
+        assert client_ip == "10.0.0.5"
+
+    def test_should_reject_ip_not_in_list(self):
+        request = _make_request(client_ip="10.0.0.99")
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.5", "10.0.0.10"], request=request
+        )
+        assert is_allowed is False
+        assert client_ip == "10.0.0.99"
+
+    def test_should_allow_ip_in_cidr_range(self):
+        request = _make_request(client_ip="10.0.0.42")
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.0/24"], request=request
+        )
+        assert is_allowed is True
+
+    def test_should_reject_ip_outside_cidr_range(self):
+        request = _make_request(client_ip="10.0.1.42")
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.0/24"], request=request
+        )
+        assert is_allowed is False
+
+    def test_should_allow_with_mixed_exact_and_cidr(self):
+        allowed = ["192.168.1.1", "10.0.0.0/8"]
+        request = _make_request(client_ip="10.5.3.2")
+        is_allowed, _ = _check_key_ip_allowed(allowed_ips=allowed, request=request)
+        assert is_allowed is True
+
+        request2 = _make_request(client_ip="192.168.1.1")
+        is_allowed2, _ = _check_key_ip_allowed(allowed_ips=allowed, request=request2)
+        assert is_allowed2 is True
+
+        request3 = _make_request(client_ip="172.16.0.1")
+        is_allowed3, _ = _check_key_ip_allowed(allowed_ips=allowed, request=request3)
+        assert is_allowed3 is False
+
+    def test_should_support_wide_cidr_range(self):
+        request = _make_request(client_ip="172.20.5.10")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["172.16.0.0/12"], request=request
+        )
+        assert is_allowed is True
+
+    def test_should_reject_ip_outside_wide_cidr(self):
+        request = _make_request(client_ip="172.32.0.1")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["172.16.0.0/12"], request=request
+        )
+        assert is_allowed is False
+
+    def test_should_use_xff_header_when_enabled(self):
+        request = _make_request(client_ip="127.0.0.1", xff_header="203.0.113.50")
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["203.0.113.50"],
+            request=request,
+            use_x_forwarded_for=True,
+        )
+        assert is_allowed is True
+        assert client_ip == "203.0.113.50"
+
+    def test_should_ignore_xff_when_disabled(self):
+        request = _make_request(client_ip="10.0.0.1", xff_header="203.0.113.50")
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.1"],
+            request=request,
+            use_x_forwarded_for=False,
+        )
+        assert is_allowed is True
+        assert client_ip == "10.0.0.1"
+
+    def test_should_use_leftmost_xff_ip(self):
+        request = _make_request(
+            client_ip="127.0.0.1",
+            xff_header="203.0.113.50, 10.0.0.1, 192.168.1.1",
+        )
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["203.0.113.0/24"],
+            request=request,
+            use_x_forwarded_for=True,
+        )
+        assert is_allowed is True
+
+    def test_should_reject_xff_ip_not_in_allowed(self):
+        request = _make_request(
+            client_ip="127.0.0.1",
+            xff_header="8.8.8.8, 10.0.0.1",
+        )
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["203.0.113.0/24"],
+            request=request,
+            use_x_forwarded_for=True,
+        )
+        assert is_allowed is False
+
+    def test_should_reject_empty_client_ip(self):
+        request = MagicMock()
+        request.client = None
+        request.headers = {}
+        is_allowed, client_ip = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.0/8"], request=request
+        )
+        assert is_allowed is False
+
+    def test_should_reject_invalid_client_ip(self):
+        request = _make_request(client_ip="not-an-ip")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.0/8"], request=request
+        )
+        assert is_allowed is False
+
+    def test_should_skip_invalid_allowed_ip_entries(self):
+        request = _make_request(client_ip="10.0.0.1")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["bad-cidr", "10.0.0.0/24"], request=request
+        )
+        assert is_allowed is True
+
+    def test_should_support_ipv6_exact(self):
+        request = _make_request(client_ip="::1")
+        is_allowed, _ = _check_key_ip_allowed(allowed_ips=["::1"], request=request)
+        assert is_allowed is True
+
+    def test_should_support_ipv6_cidr(self):
+        request = _make_request(client_ip="fd12:3456:789a::1")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["fd12:3456:789a::/48"], request=request
+        )
+        assert is_allowed is True
+
+    def test_should_reject_ipv6_outside_cidr(self):
+        request = _make_request(client_ip="fd12:3456:789b::1")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["fd12:3456:789a::/48"], request=request
+        )
+        assert is_allowed is False
+
+    def test_should_support_single_host_cidr(self):
+        request = _make_request(client_ip="10.0.0.5")
+        is_allowed, _ = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.5/32"], request=request
+        )
+        assert is_allowed is True
+
+        request2 = _make_request(client_ip="10.0.0.6")
+        is_allowed2, _ = _check_key_ip_allowed(
+            allowed_ips=["10.0.0.5/32"], request=request2
+        )
+        assert is_allowed2 is False
+
+
+class TestKeyIpRestrictionIntegration:
+    """Tests that the IP restriction integrates properly with UserAPIKeyAuth."""
+
+    def test_should_populate_allowed_ips_on_token(self):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        token = UserAPIKeyAuth(
+            api_key="sk-test",
+            allowed_ips=["10.0.0.0/8", "192.168.1.1"],
+        )
+        assert token.allowed_ips == ["10.0.0.0/8", "192.168.1.1"]
+
+    def test_should_default_allowed_ips_to_none(self):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        token = UserAPIKeyAuth(api_key="sk-test")
+        assert token.allowed_ips is None
+
+    def test_should_populate_allowed_ips_on_verification_token(self):
+        from litellm.proxy._types import LiteLLM_VerificationToken
+
+        token = LiteLLM_VerificationToken(
+            token="hashed-token",
+            allowed_ips=["10.0.0.0/8"],
+        )
+        assert token.allowed_ips == ["10.0.0.0/8"]
+
+    def test_should_include_allowed_ips_in_key_request(self):
+        from litellm.proxy._types import GenerateKeyRequest
+
+        req = GenerateKeyRequest(
+            allowed_ips=["192.168.0.0/16", "10.0.0.1"],
+        )
+        assert req.allowed_ips == ["192.168.0.0/16", "10.0.0.1"]
+
+    def test_should_include_allowed_ips_in_update_key_request(self):
+        from litellm.proxy._types import UpdateKeyRequest
+
+        req = UpdateKeyRequest(
+            key="sk-test",
+            allowed_ips=["10.0.0.0/8"],
+        )
+        assert req.allowed_ips == ["10.0.0.0/8"]
+
+    def test_should_exclude_unset_allowed_ips_from_model_dump(self):
+        from litellm.proxy._types import UpdateKeyRequest
+
+        req = UpdateKeyRequest(key="sk-test")
+        dumped = req.model_dump(exclude_unset=True)
+        assert "allowed_ips" not in dumped
+
+    def test_should_include_set_allowed_ips_in_model_dump(self):
+        from litellm.proxy._types import UpdateKeyRequest
+
+        req = UpdateKeyRequest(key="sk-test", allowed_ips=["10.0.0.0/8"])
+        dumped = req.model_dump(exclude_unset=True)
+        assert dumped["allowed_ips"] == ["10.0.0.0/8"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Adds per-virtual-key IP restrictions as requested by a customer — defense-in-depth against key exfiltration and lateral misuse within private networks.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

Adds support for restricting virtual keys to specific IP addresses or CIDR ranges. When `allowed_ips` is set on a key (via `/key/generate` or `/key/update`), the proxy rejects requests from non-matching source IPs with a 403.

### Schema changes
- Added `allowed_ips String[] @default([])` to `LiteLLM_VerificationToken` and `LiteLLM_DeletedVerificationToken` in all 3 `schema.prisma` files

### Type changes  
- Added `allowed_ips: Optional[List[str]]` to `KeyRequestBase` (flows to `GenerateKeyRequest`, `UpdateKeyRequest`, `RegenerateKeyRequest`)
- Added `allowed_ips: Optional[List[str]]` to `LiteLLM_VerificationToken` Pydantic model (flows to `UserAPIKeyAuth`)

### API endpoint changes
- `generate_key_helper_fn` now accepts and persists `allowed_ips`
- `/key/update` automatically flows `allowed_ips` through `prepare_key_update_data` via `model_dump(exclude_unset=True)`

### Auth enforcement
- New `_check_key_ip_allowed()` function in `auth_utils.py` supports both exact IP addresses and CIDR ranges (IPv4 and IPv6)
- Per-key IP check added to `_run_centralized_common_checks` — runs after the key is resolved from DB but before expensive team/user/budget fetches
- Respects `use_x_forwarded_for` general setting for proxy-behind-load-balancer deployments
- Handles XFF comma chains (uses leftmost = original client IP)
- Fails closed: invalid/empty IPs are rejected

### Usage

```bash
# Create a key restricted to a specific CIDR range
curl -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-master" \
  -d '{"allowed_ips": ["10.0.0.0/8", "192.168.1.1"]}'

# Update an existing key to add IP restrictions  
curl -X POST http://localhost:4000/key/update \
  -H "Authorization: Bearer sk-master" \
  -d '{"key": "sk-...", "allowed_ips": ["10.0.0.0/24"]}'
```

### Tests
- 27 new unit tests in `tests/test_litellm/proxy/auth/test_key_ip_restrictions.py`
- Covers: exact IPs, CIDR ranges, IPv6, XFF handling, mixed lists, edge cases (invalid IPs, empty lists), and Pydantic type integration

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1779359071739099?thread_ts=1779359071.739099&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-ad99a330-4fb4-5b74-9a75-610b74008072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad99a330-4fb4-5b74-9a75-610b74008072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

