### PR TITLE
Validate fix for team key wildcard model stack overflow (#28446)

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getModelDisplayName } from "./fetch_available_models_team_key";
+import { getModelDisplayName, unfurlWildcardModelsInList } from "./fetch_available_models_team_key";
 
 describe("getModelDisplayName", () => {
   it("should return display label for all proxy models", () => {
@@ -9,5 +9,27 @@ describe("getModelDisplayName", () => {
 
   it("should return provider-wide label for wildcard models", () => {
     expect(getModelDisplayName("openai/*")).toBe("All openai models");
+  });
+});
+
+describe("unfurlWildcardModelsInList", () => {
+  it("should expand wildcard models while preserving display names and removing duplicates", () => {
+    expect(
+      unfurlWildcardModelsInList(
+        ["openai/*", "anthropic/claude-4", "openai/gpt-4"],
+        ["openai/gpt-4", "openai/gpt-4o", "anthropic/claude-4"],
+      ),
+    ).toEqual(["openai/*", "openai/gpt-4", "openai/gpt-4o", "anthropic/claude-4"]);
+  });
+
+  it("should not exceed the call stack when expanding a wildcard with many matching models", () => {
+    const allModels = Array.from({ length: 150_000 }, (_, index) => `openai/model-${index}`);
+
+    const result = unfurlWildcardModelsInList(["openai/*"], allModels);
+
+    expect(result).toHaveLength(allModels.length + 1);
+    expect(result[0]).toBe("openai/*");
+    expect(result[1]).toBe("openai/model-0");
+    expect(result.at(-1)).toBe("openai/model-149999");
   });
 });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
@@ -49,8 +49,6 @@ export const getModelDisplayName = (model: string) => {
 export const unfurlWildcardModelsInList = (teamModels: string[], allModels: string[]): string[] => {
   const wildcardDisplayNames: string[] = [];
   const expandedModels: string[] = [];
-  console.log("teamModels", teamModels);
-  console.log("allModels", allModels);
 
   teamModels.forEach((teamModel) => {
     if (teamModel.endsWith("/*")) {
@@ -59,7 +57,7 @@ export const unfurlWildcardModelsInList = (teamModels: string[], allModels: stri
 
       // Find all models that start with this provider
       const matchingModels = allModels.filter((model) => model.startsWith(provider + "/"));
-      expandedModels.push(...matchingModels);
+      matchingModels.forEach((model) => expandedModels.push(model));
       wildcardDisplayNames.push(teamModel);
     } else {
       expandedModels.push(teamModel);
@@ -67,5 +65,5 @@ export const unfurlWildcardModelsInList = (teamModels: string[], allModels: stri
   });
 
   // Combine arrays with wildcard display names first, then remove duplicates
-  return [...wildcardDisplayNames, ...expandedModels].filter((item, index, array) => array.indexOf(item) === index);
+  return Array.from(new Set([...wildcardDisplayNames, ...expandedModels]));
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Validates fix for #28446 (same changes as #28479)

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the dashboard test suite for the affected UI helper
- [ ] My PR passes all unit tests on `make test-unit` (not run; dashboard-only change)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

### Bug Reproduction (before fix)

Confirmed the bug by running the buggy `unfurlWildcardModelsInList` with 150,000 models:

```
BUG REPRODUCED: Maximum call stack size exceeded
```

### After Fix - Teams Page Working

Teams page loads successfully with wildcard models, no crash:

[Teams page loaded successfully with wildcard models](https://cursor.com/agents/bc-8e435482-c6df-52a8-8437-a610e3df7fb1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteams_page_loaded.webp)

### Team Details with Wildcard Models

test-team-1 showing `openai/*` wildcard model:

[test-team-1 details showing openai/* wildcard model](https://cursor.com/agents/bc-8e435482-c6df-52a8-8437-a610e3df7fb1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam1_wildcard_model_detail.webp)

test-team-2 showing `anthropic/*` and `openai/gpt-4` models:

[test-team-2 details showing anthropic/* and openai/gpt-4](https://cursor.com/agents/bc-8e435482-c6df-52a8-8437-a610e3df7fb1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam2_wildcard_models_detail.webp)

### Video Walkthrough

Full end-to-end demonstration of the fix working:

[teams_page_wildcard_models_working.mp4](https://cursor.com/agents/bc-8e435482-c6df-52a8-8437-a610e3df7fb1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteams_page_wildcard_models_working.mp4)

### Test Results

All 4 tests pass (2 existing + 2 new regression tests):

```
✓ src/components/key_team_helpers/fetch_available_models_team_key.test.tsx (4 tests) 99ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Replace `expandedModels.push(...matchingModels)` with `forEach` loop to avoid exceeding JS call stack with large model arrays
- Use `Set` for deduplication instead of O(n^2) `indexOf` scan
- Remove debug `console.log` statements
- Add regression tests for wildcard expansion, deduplication, and expanding 150k matching models without a stack overflow

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C09JWQ7PZ29/p1779379524904699?thread_ts=1779379524.904699&cid=C09JWQ7PZ29)

<div><a href="https://cursor.com/agents/bc-8e435482-c6df-52a8-8437-a610e3df7fb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e435482-c6df-52a8-8437-a610e3df7fb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

