### PR TITLE
fix(datadog): drain cost-management queue + opt-in FinOps tag allowlist

### DIFF
--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
@@ -193,7 +193,9 @@ class DatadogCostManagementLogger(CustomBatchLogger):
         self._add_tag(tags, "model", log.get("model"))
         self._add_tag(tags, "model_id", log.get("model_id"))
 
-        metadata: Dict[str, Any] = log.get("metadata") or {}
+        # cast because StandardLoggingMetadata is a TypedDict; we iterate it
+        # as a generic mapping below.
+        metadata: Dict[str, Any] = cast(Dict[str, Any], log.get("metadata") or {})
 
         # Backwards-compat: team/user/model_group preserved regardless of allowlist.
         if metadata.get("user_api_key_alias"):

--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -22,6 +22,26 @@ from litellm.types.integrations.datadog_cost_management import (
 )
 from litellm.types.utils import StandardLoggingPayload
 
+# Reserved tag keys whose values come from trusted sources (infra env, LiteLLM
+# core payload fields, or proxy-controlled auth metadata). User-supplied
+# request_tags / metadata cannot overwrite these, even when the key is
+# allowlisted via cost_tag_keys, because that would let an authenticated caller
+# spoof cost attribution (e.g. request_tags=["team:victim-team"]).
+_RESERVED_TAG_KEYS: frozenset = frozenset(
+    {
+        "env",
+        "service",
+        "host",
+        "pod_name",
+        "provider",
+        "model",
+        "model_id",
+        "team",
+        "user",
+        "model_group",
+    }
+)
+
 
 class DatadogCostManagementLogger(CustomBatchLogger):
     def __init__(self, cost_tag_keys: Optional[List[str]] = None, **kwargs):
@@ -190,6 +210,8 @@ class DatadogCostManagementLogger(CustomBatchLogger):
             tags["model_group"] = str(metadata["model_group"])
 
         # Allowlist-gated: request_tags (split on `:`) and arbitrary metadata.*.
+        # Reserved keys are hard-blocked here regardless of allowlist membership —
+        # see _RESERVED_TAG_KEYS for the rationale.
         if self.cost_tag_keys:
             allow = set(self.cost_tag_keys)
             for rt in log.get("request_tags") or []:
@@ -197,10 +219,10 @@ class DatadogCostManagementLogger(CustomBatchLogger):
                     continue
                 k, _, v = rt.partition(":")
                 if k in allow and v:
-                    tags[k] = v
+                    self._set_custom_tag(tags, k, v)
             for k, v in metadata.items():
                 if k in allow and v is not None and not isinstance(v, (dict, list)):
-                    tags[k] = str(v)
+                    self._set_custom_tag(tags, k, str(v))
             for nested_key in ("spend_logs_metadata", "requester_metadata"):
                 nested = metadata.get(nested_key)
                 if isinstance(nested, dict):
@@ -210,9 +232,21 @@ class DatadogCostManagementLogger(CustomBatchLogger):
                             and v is not None
                             and not isinstance(v, (dict, list))
                         ):
-                            tags[k] = str(v)
+                            self._set_custom_tag(tags, k, str(v))
 
         return tags
+
+    @staticmethod
+    def _set_custom_tag(tags: Dict[str, str], key: str, value: str) -> None:
+        if key in _RESERVED_TAG_KEYS:
+            verbose_logger.debug(
+                "Datadog Cost Management: dropping user-supplied tag %r=%r — "
+                "key is reserved for trusted cost attribution.",
+                key,
+                value,
+            )
+            return
+        tags[key] = value
 
     @staticmethod
     def _add_tag(tags: Dict[str, str], key: str, value: Any) -> None:

--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -82,6 +82,11 @@ class DatadogCostManagementLogger(CustomBatchLogger):
         try:
             aggregated_entries = self._aggregate_costs(batch_to_send)
             if not aggregated_entries:
+                verbose_logger.debug(
+                    "Datadog Cost Management: batch produced no aggregable entries; "
+                    "dropping %d log(s) from queue.",
+                    len(batch_to_send),
+                )
                 return
             await self._upload_to_datadog(aggregated_entries)
         except Exception as e:

--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -2,10 +2,17 @@ import asyncio
 import os
 import time
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
+from litellm.integrations.datadog.datadog_handler import (
+    get_datadog_env,
+    get_datadog_hostname,
+    get_datadog_pod_name,
+    get_datadog_service,
+)
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -17,7 +24,8 @@ from litellm.types.utils import StandardLoggingPayload
 
 
 class DatadogCostManagementLogger(CustomBatchLogger):
-    def __init__(self, **kwargs):
+    def __init__(self, cost_tag_keys: Optional[List[str]] = None, **kwargs):
+        self.cost_tag_keys: List[str] = list(cost_tag_keys) if cost_tag_keys else []
         self.dd_api_key = os.getenv("DD_API_KEY")
         self.dd_app_key = os.getenv("DD_APP_KEY")
         self.dd_site = os.getenv("DD_SITE", "datadoghq.com")
@@ -68,20 +76,16 @@ class DatadogCostManagementLogger(CustomBatchLogger):
         if not self.log_queue:
             return
 
-        try:
-            # Aggregate costs from the batch
-            aggregated_entries = self._aggregate_costs(self.log_queue)
+        batch_to_send = self.log_queue[:]
+        self.log_queue = []
 
+        try:
+            aggregated_entries = self._aggregate_costs(batch_to_send)
             if not aggregated_entries:
                 return
-
-            # Send to Datadog
             await self._upload_to_datadog(aggregated_entries)
-
-            # Clear queue only on success (or if we decide to drop on failure)
-            # CustomBatchLogger clears queue in flush_queue, so we just process here
-
         except Exception as e:
+            self.log_queue = batch_to_send + self.log_queue
             verbose_logger.exception(
                 f"Datadog Cost Management: Error in async_send_batch: {str(e)}"
             )
@@ -151,44 +155,64 @@ class DatadogCostManagementLogger(CustomBatchLogger):
         return list(aggregator.values())
 
     def _extract_tags(self, log: StandardLoggingPayload) -> Dict[str, str]:
-        from litellm.integrations.datadog.datadog_handler import (
-            get_datadog_env,
-            get_datadog_hostname,
-            get_datadog_pod_name,
-            get_datadog_service,
-        )
-
-        tags = {
+        tags: Dict[str, str] = {
             "env": get_datadog_env(),
             "service": get_datadog_service(),
             "host": get_datadog_hostname(),
             "pod_name": get_datadog_pod_name(),
         }
 
-        # Add metadata as tags
-        metadata = log.get("metadata", {})
-        if metadata:
-            # Add user info
-            # Add user info
-            if metadata.get("user_api_key_alias"):
-                tags["user"] = str(metadata["user_api_key_alias"])
+        # Always-on canonical FOCUS dimensions from top-level payload fields.
+        # Non-sensitive and required for Datadog Custom Costs per-model attribution.
+        self._add_tag(tags, "provider", log.get("custom_llm_provider"))
+        self._add_tag(tags, "model", log.get("model"))
+        self._add_tag(tags, "model_id", log.get("model_id"))
 
-            # Add Team Tag
-            team_tag = (
-                metadata.get("user_api_key_team_alias")
-                or metadata.get("team_alias")  # type: ignore
-                or metadata.get("user_api_key_team_id")
-                or metadata.get("team_id")  # type: ignore
-            )
+        metadata: Dict[str, Any] = log.get("metadata") or {}
 
-            if team_tag:
-                tags["team"] = str(team_tag)
-            # model_group is not in StandardLoggingMetadata TypedDict, so we need to access it via dict.get()
-            model_group = metadata.get("model_group")  # type: ignore[misc]
-            if model_group:
-                tags["model_group"] = str(model_group)
+        # Backwards-compat: team/user/model_group preserved regardless of allowlist.
+        if metadata.get("user_api_key_alias"):
+            tags["user"] = str(metadata["user_api_key_alias"])
+        team_tag = (
+            metadata.get("user_api_key_team_alias")
+            or metadata.get("team_alias")
+            or metadata.get("user_api_key_team_id")
+            or metadata.get("team_id")
+        )
+        if team_tag:
+            tags["team"] = str(team_tag)
+        if metadata.get("model_group"):
+            tags["model_group"] = str(metadata["model_group"])
+
+        # Allowlist-gated: request_tags (split on `:`) and arbitrary metadata.*.
+        if self.cost_tag_keys:
+            allow = set(self.cost_tag_keys)
+            for rt in log.get("request_tags") or []:
+                if not isinstance(rt, str) or ":" not in rt:
+                    continue
+                k, _, v = rt.partition(":")
+                if k in allow and v:
+                    tags[k] = v
+            for k, v in metadata.items():
+                if k in allow and v is not None and not isinstance(v, (dict, list)):
+                    tags[k] = str(v)
+            for nested_key in ("spend_logs_metadata", "requester_metadata"):
+                nested = metadata.get(nested_key)
+                if isinstance(nested, dict):
+                    for k, v in nested.items():
+                        if (
+                            k in allow
+                            and v is not None
+                            and not isinstance(v, (dict, list))
+                        ):
+                            tags[k] = str(v)
 
         return tags
+
+    @staticmethod
+    def _add_tag(tags: Dict[str, str], key: str, value: Any) -> None:
+        if value:
+            tags[key] = str(value)
 
     async def _upload_to_datadog(self, payload: List[Dict]):
         if not self.dd_api_key or not self.dd_app_key:
@@ -201,8 +225,6 @@ class DatadogCostManagementLogger(CustomBatchLogger):
         }
 
         # The API endpoint expects a list of objects directly in the body (file content behavior)
-        from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
-
         data_json = safe_dumps(payload)
 
         response = await self.async_client.put(

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -302,7 +302,10 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
                     DatadogCostManagementLogger,
                 )
 
-                datadog_cost_management_obj = DatadogCostManagementLogger()
+                init_params = {}
+                if "datadog_cost_management" in callback_specific_params:
+                    init_params = callback_specific_params["datadog_cost_management"]
+                datadog_cost_management_obj = DatadogCostManagementLogger(**init_params)
                 imported_list.append(datadog_cost_management_obj)
             elif isinstance(callback, CustomLogger):
                 imported_list.append(callback)

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -303,7 +303,12 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
                 )
 
                 init_params = {}
-                if "datadog_cost_management" in callback_specific_params:
+                if (
+                    "datadog_cost_management" in callback_specific_params
+                    and isinstance(
+                        callback_specific_params["datadog_cost_management"], dict
+                    )
+                ):
                     init_params = callback_specific_params["datadog_cost_management"]
                 datadog_cost_management_obj = DatadogCostManagementLogger(**init_params)
                 imported_list.append(datadog_cost_management_obj)

--- a/litellm/types/integrations/datadog_cost_management.py
+++ b/litellm/types/integrations/datadog_cost_management.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 
 from litellm.types.integrations.custom_logger import StandardCustomLoggerInitParams
@@ -9,7 +9,7 @@ class DatadogCostManagementInitParams(StandardCustomLoggerInitParams):
     Init params for Datadog Cost Management
     """
 
-    datadog_cost_management_params: Optional[Dict] = None
+    cost_tag_keys: Optional[List[str]] = None
 
 
 class DatadogFOCUSCostEntry(TypedDict):

--- a/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
@@ -330,7 +330,67 @@ async def test_extract_tags_nested_metadata_allowlisted(clean_env):
     )
     tags = logger._extract_tags(log)
     assert tags["platform"] == "web"
-    # Note: the always-on top-level "env" tag (from get_datadog_env) is overwritten
-    # by allowlisted requester_metadata.env. That's the intended override semantic.
-    assert tags["env"] == "prod"
+    # "env" is a reserved trusted dimension — requester_metadata.env must NOT
+    # overwrite the value sourced from get_datadog_env().
+    assert tags["env"] != "prod"
     assert "ignored" not in tags
+
+
+@pytest.mark.asyncio
+async def test_extract_tags_allowlist_cannot_override_reserved_dimensions(clean_env):
+    """
+    Reserved tag keys (env, service, host, pod_name, provider, model, model_id,
+    team, user, model_group) must not be overwritten by user-controlled
+    request_tags or metadata, even when listed in cost_tag_keys.
+    """
+    reserved = [
+        "env",
+        "service",
+        "host",
+        "pod_name",
+        "provider",
+        "model",
+        "model_id",
+        "team",
+        "user",
+        "model_group",
+    ]
+    logger = DatadogCostManagementLogger(cost_tag_keys=reserved)
+
+    metadata_attack = {k: f"attacker-meta-{k}" for k in reserved}
+    metadata_attack["user_api_key_alias"] = "trusted-user"
+    metadata_attack["user_api_key_team_alias"] = "trusted-team"
+    metadata_attack["model_group"] = "trusted-group"
+    metadata_attack["spend_logs_metadata"] = {
+        k: f"attacker-spend-{k}" for k in reserved
+    }
+    metadata_attack["requester_metadata"] = {k: f"attacker-req-{k}" for k in reserved}
+
+    log = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4",
+        model_id="router-id-123",
+        response_cost=0.01,
+        startTime=time.time(),
+        request_tags=[f"{k}:attacker-rt-{k}" for k in reserved],
+        metadata=metadata_attack,
+    )
+
+    tags = logger._extract_tags(log)
+
+    # Canonical FOCUS dims keep their trusted (top-level payload) values.
+    assert tags["provider"] == "openai"
+    assert tags["model"] == "gpt-4"
+    assert tags["model_id"] == "router-id-123"
+
+    # Backwards-compat trusted dims keep their proxy-controlled metadata values.
+    assert tags["user"] == "trusted-user"
+    assert tags["team"] == "trusted-team"
+    assert tags["model_group"] == "trusted-group"
+
+    # No reserved key carries an attacker-supplied prefix from any path.
+    for k in reserved:
+        assert not tags[k].startswith("attacker-"), (
+            f"reserved key {k!r} was overwritten by user-controlled input: "
+            f"{tags[k]!r}"
+        )

--- a/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_cost_management.py
@@ -3,7 +3,7 @@ import time
 from unittest.mock import AsyncMock
 
 import pytest
-from httpx import Response
+from httpx import Request, Response
 
 from litellm.integrations.datadog.datadog_cost_management import (
     DatadogCostManagementLogger,
@@ -167,3 +167,170 @@ async def test_async_send_batch(clean_env):
     content = json.loads(call_args[1]["content"])
     assert content[0]["ProviderName"] == "openai"
     assert content[0]["BilledCost"] == 0.01
+
+
+_PUT_REQUEST = Request("PUT", "https://api.test.datadoghq.com/api/v2/cost/custom_costs")
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_clears_queue_on_success(clean_env):
+    """Bug 1 regression: log_queue must be empty after a successful upload."""
+    logger = DatadogCostManagementLogger()
+    logger.async_client = AsyncMock()
+    logger.async_client.put.return_value = Response(
+        202, json={"status": "ok"}, request=_PUT_REQUEST
+    )
+    logger.log_queue = [
+        StandardLoggingPayload(
+            custom_llm_provider="openai",
+            model="gpt-4",
+            response_cost=0.01,
+            startTime=time.time(),
+        )
+    ]
+    await logger.async_send_batch()
+    assert logger.log_queue == []
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_preserves_events_added_during_upload(clean_env):
+    """Events appended while the upload is in flight survive (land on the cleared queue)."""
+    logger = DatadogCostManagementLogger()
+
+    later_event = StandardLoggingPayload(
+        custom_llm_provider="anthropic",
+        model="claude-3",
+        response_cost=0.02,
+        startTime=time.time(),
+    )
+
+    async def slow_put(*args, **kwargs):
+        logger.log_queue.append(later_event)
+        return Response(202, json={"status": "ok"}, request=_PUT_REQUEST)
+
+    logger.async_client = AsyncMock()
+    logger.async_client.put.side_effect = slow_put
+    logger.log_queue = [
+        StandardLoggingPayload(
+            custom_llm_provider="openai",
+            model="gpt-4",
+            response_cost=0.01,
+            startTime=time.time(),
+        )
+    ]
+    await logger.async_send_batch()
+    assert logger.log_queue == [later_event]
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_requeues_on_upload_failure(clean_env):
+    """Failed upload requeues the original batch (no data loss)."""
+    logger = DatadogCostManagementLogger()
+    logger.async_client = AsyncMock()
+    logger.async_client.put.side_effect = Exception("boom")
+    original = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4",
+        response_cost=0.01,
+        startTime=time.time(),
+    )
+    logger.log_queue = [original]
+    await logger.async_send_batch()
+    assert logger.log_queue == [original]
+
+
+@pytest.mark.asyncio
+async def test_extract_tags_emits_canonical_focus_dimensions(clean_env):
+    """provider, model, model_id always emitted regardless of cost_tag_keys."""
+    logger = DatadogCostManagementLogger()
+    log = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4o",
+        model_id="router-id-123",
+        response_cost=0.01,
+        startTime=time.time(),
+    )
+    tags = logger._extract_tags(log)
+    assert tags["provider"] == "openai"
+    assert tags["model"] == "gpt-4o"
+    assert tags["model_id"] == "router-id-123"
+
+
+@pytest.mark.asyncio
+async def test_extract_tags_allowlist_filters_request_tags(clean_env):
+    """Only request_tags whose key is in cost_tag_keys reach the Tags dict."""
+    logger = DatadogCostManagementLogger(cost_tag_keys=["capability", "tier"])
+    log = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4",
+        response_cost=0.01,
+        startTime=time.time(),
+        request_tags=["capability:chat", "tier:gold", "secret:disallowed"],
+    )
+    tags = logger._extract_tags(log)
+    assert tags["capability"] == "chat"
+    assert tags["tier"] == "gold"
+    assert "secret" not in tags
+
+
+@pytest.mark.asyncio
+async def test_extract_tags_allowlist_filters_metadata(clean_env):
+    """Only metadata keys in cost_tag_keys flow through; others (and dict/list values) are dropped."""
+    logger = DatadogCostManagementLogger(cost_tag_keys=["capability", "owner"])
+    log = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4",
+        response_cost=0.01,
+        startTime=time.time(),
+        metadata={
+            "capability": "chat",
+            "owner": "team-x",
+            "secret_field": "sensitive",
+            "nested_obj": {"a": 1},
+        },
+    )
+    tags = logger._extract_tags(log)
+    assert tags["capability"] == "chat"
+    assert tags["owner"] == "team-x"
+    assert "secret_field" not in tags
+    assert "nested_obj" not in tags
+
+
+@pytest.mark.asyncio
+async def test_extract_tags_empty_allowlist_default(clean_env):
+    """With no cost_tag_keys, request_tags and arbitrary metadata.* do NOT leak into Tags."""
+    logger = DatadogCostManagementLogger()
+    log = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4",
+        response_cost=0.01,
+        startTime=time.time(),
+        request_tags=["capability:chat"],
+        metadata={"capability": "chat", "user_api_key_alias": "alice"},
+    )
+    tags = logger._extract_tags(log)
+    assert "capability" not in tags
+    # Backwards-compat keys still flow:
+    assert tags["user"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_extract_tags_nested_metadata_allowlisted(clean_env):
+    """spend_logs_metadata and requester_metadata get spread one level under the allowlist."""
+    logger = DatadogCostManagementLogger(cost_tag_keys=["env", "platform"])
+    log = StandardLoggingPayload(
+        custom_llm_provider="openai",
+        model="gpt-4",
+        response_cost=0.01,
+        startTime=time.time(),
+        metadata={
+            "spend_logs_metadata": {"platform": "web", "ignored": "x"},
+            "requester_metadata": {"env": "prod"},
+        },
+    )
+    tags = logger._extract_tags(log)
+    assert tags["platform"] == "web"
+    # Note: the always-on top-level "env" tag (from get_datadog_env) is overwritten
+    # by allowlisted requester_metadata.env. That's the intended override semantic.
+    assert tags["env"] == "prod"
+    assert "ignored" not in tags


### PR DESCRIPTION
## Relevant issues

Closes #25660 (cost-management variant). Supersedes #27307, which addressed the same defects but was auto-closed.

## Linear ticket

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Direct unit-level repro against `DatadogCostManagementLogger` with the HTTP client mocked, exercised in two variants in a single run.

**Before fix** (on `litellm_internal_staging`):

\`\`\`
queue_len_after_successful_flush= 1
uploaded_entries[0].Tags = {
  "env": "...", "host": "", "model_group": "customer-facing",
  "pod_name": "...", "service": "litellm-server", "team": "team-a"
}
finops_tags_present  = ['model_group', 'team']
finops_tags_missing  = ['ai_product', 'environment', 'feature', 'model', 'provider', 'purpose']
\`\`\`

**After fix — default (no `cost_tag_keys`)**:

\`\`\`
queue_len_after_successful_flush= 0
emitted_tags includes: provider=openai, model=gpt-4o, model_id=router-id-123, model_group, team, env, service, host, pod_name
finops_tags_missing = ['ai_product', 'environment', 'feature', 'purpose']   # correctly NOT leaked without explicit allowlist
\`\`\`

**After fix — allowlist `cost_tag_keys=['ai_product','feature','environment','purpose']`**:

\`\`\`
queue_len_after_successful_flush= 0
emitted_tags includes all 8 expected dimensions: ai_product=chat, feature=summarize, environment=prod, purpose=support,
                                                 provider, model, model_id, team, model_group, env, service, host, pod_name
finops_tags_missing = []
\`\`\`

## Type

🐛 Bug Fix

## Changes

`DatadogCostManagementLogger` has two defects, both introduced in #19584 and not covered by the merged #25663 (which only addressed the main `DataDogLogger`):

1. **Queue not drained on threshold flushes.** `async_log_success_event` calls `async_send_batch()` directly when `len(log_queue) >= batch_size`, bypassing `CustomBatchLogger.flush_queue` (the only place `log_queue.clear()` runs). The same payloads get re-uploaded on every subsequent threshold trigger — the quadratic re-send pattern from #25660, but in the cost-management logger.
2. **Incomplete FOCUS tag extraction.** `_extract_tags` emits only `{env, service, host, pod_name, user, team, model_group}`. It never surfaces `provider`, the bare `model`, `model_id`, `request_tags:*`, or arbitrary `metadata.*`, which makes per-model attribution and FinOps dimension breakdowns impossible in Datadog Custom Costs.

### What this PR does

- **`async_send_batch`**: snapshot → clear → requeue-on-failure, mirroring the merged #25663 pattern in `DataDogLogger`. Events appended while an upload is in flight survive (they land on the now-empty queue, and on failure the requeue concat preserves them).
- **`_extract_tags`**: always-on canonical FOCUS dimensions (`provider`, `model`, `model_id`) on every entry; existing `team`/`user`/`model_group` backwards-compat path preserved; new opt-in allowlist for arbitrary `metadata.*`, `request_tags:*`, and one-level-nested `spend_logs_metadata` / `requester_metadata`. Gated by `cost_tag_keys: Optional[List[str]]` on the logger. Scalar-only filter prevents tagging nested dicts/lists.
- **Wiring**: `callback_utils.py` reads `callback_specific_params["datadog_cost_management"]` and forwards as kwargs — matches the existing `lakera_prompt_injection` pattern.
- **Types**: replace the unused `datadog_cost_management_params: Optional[Dict]` field on `DatadogCostManagementInitParams` with the typed `cost_tag_keys: Optional[List[str]]`.

### Config shape

\`\`\`yaml
litellm_settings:
  callbacks:
    - datadog_cost_management
  callback_specific_params:
    datadog_cost_management:
      cost_tag_keys:
        - capability
        - platform
        # ...
\`\`\`

Default behavior (no `cost_tag_keys` configured) is strictly safer than before — operators gain the always-on canonical dims and lose nothing; no arbitrary `metadata.*` leakage.

### Tests added

8 new unit tests in \`tests/test_litellm/integrations/datadog/test_datadog_cost_management.py\`:

- \`test_async_send_batch_clears_queue_on_success\` — queue empty after successful upload.
- \`test_async_send_batch_preserves_events_added_during_upload\` — events appended mid-upload survive.
- \`test_async_send_batch_requeues_on_upload_failure\` — failed upload requeues the original batch.
- \`test_extract_tags_emits_canonical_focus_dimensions\` — \`provider\`/\`model\`/\`model_id\` always on.
- \`test_extract_tags_allowlist_filters_request_tags\` — only allowlisted \`key:value\` request_tags flow through.
- \`test_extract_tags_allowlist_filters_metadata\` — only allowlisted \`metadata.*\` flow through; nested dict/list values dropped.
- \`test_extract_tags_empty_allowlist_default\` — no \`metadata.*\` / \`request_tags\` leakage by default.
- \`test_extract_tags_nested_metadata_allowlisted\` — \`spend_logs_metadata\`/\`requester_metadata\` spread one level under allowlist.

All 12 cost-management tests pass; full 54-test datadog suite passes; ruff + black clean.