### PR TITLE
fix(pass-through): strip excluded headers from custom_headers to fix Content-Length: 0 on Bedrock /converse

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -330,7 +330,9 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         if litellm_call_id:
             return_headers["x-litellm-call-id"] = litellm_call_id
         if custom_headers:
-            return_headers.update(custom_headers)
+            return_headers.update(
+                {k: v for k, v in custom_headers.items() if k.lower() not in excluded_headers}
+            )
 
         return return_headers
 


### PR DESCRIPTION
## Summary

Fixes #28388

Non-streaming Bedrock `/converse` (and any other non-streaming pass-through) was returning `HTTP 200` with `Content-Length: 0` and an empty body since v1.85.0.

## Root cause

`base_passthrough_process_llm_request` accumulates LiteLLM custom response headers into `fastapi_response` (lines ~1442-1468 in `common_request_processing.py`), then passes `custom_headers=dict(fastapi_response.headers)` to `get_response_headers()`.

`get_response_headers()` correctly strips `content-length` from the **upstream** response headers via `excluded_headers`. But then:

```python
# BEFORE (buggy)
if custom_headers:
    return_headers.update(custom_headers)   # re-introduces content-length: 0
```

FastAPI initialises an empty `Response` with `content-length: 0`. That value was already in `fastapi_response.headers` by the time it was passed as `custom_headers`, so the `update()` call re-introduced `content-length: 0` into the final response — even though the body was non-empty.

AWS boto3 parsing the response then found `ResponseMetadata` only and raised `KeyError: 'output'`.

## Fix

Apply the same `excluded_headers` filter to `custom_headers` before merging:

```python
# AFTER
if custom_headers:
    return_headers.update(
        {k: v for k, v in custom_headers.items() if k.lower() not in excluded_headers}
    )
```

This keeps all `x-litellm-*` and callback headers flowing through while preventing `content-length`, `transfer-encoding`, and other hop-by-hop headers from leaking in from the FastAPI default response object.

## Affected paths

All routes that call `base_passthrough_process_llm_request`, including:
- `/bedrock/model/{modelId}/converse` (confirmed broken)
- Any other non-streaming LLM pass-through route

Streaming paths are unaffected (they return `StreamingResponse` directly and skip this code path).
