### PR TITLE
ci(mutation): provision Postgres and fix mutmut's covered-lines pass

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -1,14 +1,22 @@
 name: "Mutation Test (manual)"
 
 # Manually-triggered mutation testing. Runs mutmut against the scope
-# configured in [tool.mutmut] in pyproject.toml (currently the
-# litellm/proxy/management_endpoints/ folder). Intended cadence is roughly
-# weekly — clicked from the Actions tab when someone wants a fresh report.
+# configured in [tool.mutmut] in pyproject.toml — paths_to_mutate is the
+# litellm/proxy/management_endpoints/ folder.
 #
-# Uploads a structured `mutation-report.md` (Meta ACH-style: original +
-# mutated function with `# MUTANT START`/`# MUTANT END` delimiters + the
-# existing tests + a task instruction) as a workflow artifact. Failures
-# do not block anything because nothing depends on this workflow.
+# The job is a 2-leg matrix, one leg per test suite that exercises those
+# endpoints:
+#   * legacy   — tests/test_litellm/proxy/management_endpoints/ (mocks the DB)
+#   * behavior — tests/proxy_behavior/management/ (drives a real proxy against
+#                a live Postgres service container)
+# The two suites cannot share one pytest session — the legacy suite patches
+# `prisma_client` globally — so each leg scopes [tool.mutmut].tests_dir to its
+# own suite (via scripts/scope_mutmut_tests_dir.py) and runs mutmut separately.
+#
+# Each leg uploads a structured `mutation-report.md` (Meta ACH-style: original
+# + mutated function with `# MUTANT START`/`# MUTANT END` delimiters + the
+# existing tests + a task instruction) as a workflow artifact. Failures do not
+# block anything because nothing depends on this workflow.
 
 on:
   workflow_dispatch:
@@ -22,11 +30,50 @@ concurrency:
 
 jobs:
   mutation:
-    name: Run mutmut
+    name: Run mutmut (${{ matrix.suite }})
     runs-on: ubuntu-latest
     # Whole-folder mutation against ~15 files / ~7.5k LOC can take hours.
     # 350 minutes is just under the GitHub-hosted job cap of 360 minutes.
     timeout-minutes: 350
+
+    strategy:
+      # Best-effort workflow — let one suite finish even if the other fails.
+      fail-fast: false
+      matrix:
+        include:
+          - suite: legacy
+            tests-dir: tests/test_litellm/proxy/management_endpoints/
+            needs-postgres: false
+          - suite: behavior
+            tests-dir: tests/proxy_behavior/management/
+            needs-postgres: true
+
+    # The postgres service container is spawned per-job on localhost and
+    # destroyed with the job — nothing outside the runner can reach it, and
+    # the user/password/database are throwaway bootstrap values, not secrets.
+    # GitHub Actions cannot declare a service conditionally per matrix leg, so
+    # (mirroring .github/workflows/_test-unit-services-base.yml) the container
+    # always starts; the legacy leg simply leaves it idle while the behavior
+    # leg pushes the proxy schema to it and points DATABASE_URL at it.
+    services:
+      postgres:
+        image: postgres@sha256:705a5d5b5836f3fcba0d02c4d281e6a7dd9ed2dd4078640f08a1e1e9896e097d # postgres:14
+        env:
+          POSTGRES_USER: litellm
+          POSTGRES_PASSWORD: litellm
+          POSTGRES_DB: litellm_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Empty for the legacy leg (it mocks the DB); the real URL for the
+      # behavior leg. Mirrors .github/workflows/_test-unit-services-base.yml.
+      DATABASE_URL: ${{ matrix.needs-postgres && 'postgresql://litellm:litellm@localhost:5432/litellm_test' || '' }}
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -63,6 +110,15 @@ jobs:
         run: |
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
+      # The behavior suite (tests/proxy_behavior/management/) connects Prisma
+      # to a real database at session start, so the proxy schema must exist
+      # before mutmut runs its stats pass. Mirrors the Prisma migration step
+      # in .github/workflows/_test-unit-services-base.yml.
+      - name: Push Prisma schema to Postgres
+        if: ${{ matrix.needs-postgres }}
+        run: |
+          uv run --no-sync prisma db push --schema litellm/proxy/schema.prisma --accept-data-loss
+
       # mutmut 3.x runs tests inside a `mutants/` sandbox where it injects
       # mutation trampolines. uv installs the project as editable by default,
       # which puts the original source dir on sys.path via a .pth file and
@@ -83,6 +139,16 @@ jobs:
         run: |
           uv pip uninstall pytest-retry || true
 
+      # mutmut reads tests_dir only from pyproject.toml (no CLI/env override),
+      # so scope it to this leg's suite before running. The legacy and
+      # behavior suites cannot share a pytest session — see the script
+      # docstring and the [tool.mutmut] comment in pyproject.toml.
+      - name: Scope mutmut tests_dir to the ${{ matrix.suite }} suite
+        env:
+          MUTMUT_TESTS_DIR: ${{ matrix.tests-dir }}
+        run: |
+          uv run --no-sync python scripts/scope_mutmut_tests_dir.py "${MUTMUT_TESTS_DIR}"
+
       - name: Run mutmut
         env:
           # Make the mutants/ sandbox win over site-packages on sys.path so the
@@ -100,6 +166,8 @@ jobs:
       # prompt template (arXiv 2501.12862).
       - name: Generate detailed mutation report
         if: always()
+        env:
+          SUITE: ${{ matrix.suite }}
         run: |
           set +e
           uv run --no-sync --with mutmut==3.5.0 mutmut export-cicd-stats > /dev/null 2>&1
@@ -109,6 +177,8 @@ jobs:
           # summary cuts off at 1 MB. Append the head of the report (summary
           # + survivor list) and link out to the artifact for the full body.
           {
+            echo "## Mutation report — \`${SUITE}\` suite"
+            echo ""
             head -c 900000 mutation-report.md
             echo ""
             echo ""
@@ -119,7 +189,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: mutmut-${{ github.run_id }}-${{ github.run_attempt }}
+          name: mutmut-${{ matrix.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             mutation-report.md
             mutmut-results.txt

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -154,6 +154,11 @@ jobs:
           # Make the mutants/ sandbox win over site-packages on sys.path so the
           # trampolined files are imported instead of the installed copy.
           PYTHONPATH: ${{ github.workspace }}/mutants
+          # mutmut's mutate_only_covered_lines pass looks up covered lines by
+          # absolute path; pyproject.toml's `relative_files = true` would make
+          # coverage.py store relative paths (every lookup misses -> zero
+          # mutants). This rcfile overrides it for the mutmut run only.
+          COVERAGE_RCFILE: ${{ github.workspace }}/scripts/mutmut.coveragerc
         run: |
           set -o pipefail
           mkdir -p mutants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,14 +286,17 @@ filterwarnings = [
 paths_to_mutate = [
     "litellm/proxy/management_endpoints/",
 ]
+# Each mutation run is scoped to a single test suite. Two suites exercise
+# litellm/proxy/management_endpoints/ — the legacy mock suite below and the
+# real-DB behavior suite (tests/proxy_behavior/management/) — but they cannot
+# share one pytest session: the legacy suite patches `prisma_client` globally
+# while the behavior suite drives a real proxy against a live Postgres. So
+# .github/workflows/mutation-test.yml runs mutmut once per suite (a 2-leg
+# matrix) and rewrites this value per leg via scripts/scope_mutmut_tests_dir.py.
+# The committed default is the legacy mock suite, which needs no database, so
+# a plain `mutmut run` works locally without extra setup.
 tests_dir = [
     "tests/test_litellm/proxy/management_endpoints/",
-    # PR1 (key Tier-1) behavior-pinning suite. Manual mutmut runs
-    # (.github/workflows/mutation-test.yml) include this directory so the
-    # behavior matrix contributes to mutation-score signal alongside the
-    # legacy mock suite. See tests/proxy_behavior/management/README.md
-    # for the G5 triage protocol.
-    "tests/proxy_behavior/management/",
 ]
 also_copy = [
     "litellm/",

--- a/scripts/mutmut.coveragerc
+++ b/scripts/mutmut.coveragerc
@@ -1,0 +1,16 @@
+# Coverage.py config used ONLY by .github/workflows/mutation-test.yml, selected
+# via the COVERAGE_RCFILE env var on the "Run mutmut" step.
+#
+# mutmut runs with `mutate_only_covered_lines = true` ([tool.mutmut] in
+# pyproject.toml): before generating mutants it measures coverage and then
+# looks up each file's covered lines by ABSOLUTE path. The project's
+# pyproject.toml sets `[tool.coverage.run] relative_files = true`, which makes
+# coverage.py store RELATIVE paths — so every absolute-path lookup misses,
+# mutmut sees zero covered lines, generates zero mutants, and aborts with
+# "we could not find any test case for any mutant".
+#
+# Pointing COVERAGE_RCFILE at this file overrides pyproject.toml for the mutmut
+# run only, keeping coverage paths absolute so the lookups match. The project's
+# real coverage/Codecov flow still uses pyproject.toml and is unaffected.
+[run]
+relative_files = false

--- a/scripts/scope_mutmut_tests_dir.py
+++ b/scripts/scope_mutmut_tests_dir.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Rewrite ``[tool.mutmut].tests_dir`` in pyproject.toml to a single suite.
+
+Mutation testing of ``litellm/proxy/management_endpoints/`` is exercised by
+two test suites that cannot share one pytest session: the legacy mock suite
+(``tests/test_litellm/proxy/management_endpoints/``) patches ``prisma_client``
+globally, while the behavior suite (``tests/proxy_behavior/management/``)
+drives a real proxy against a live Postgres database.
+
+mutmut reads ``tests_dir`` only from pyproject.toml and offers no CLI/env
+override, so .github/workflows/mutation-test.yml runs mutmut once per suite
+(a 2-leg matrix) and calls this script before each ``mutmut run`` to scope
+``tests_dir`` to that leg's suite.
+
+Usage: scope_mutmut_tests_dir.py <tests-dir>
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Matches the whole `tests_dir = [ ... ]` array in [tool.mutmut] — including a
+# multi-line body — up to the first `]` that begins a line.
+TESTS_DIR_BLOCK = re.compile(r"(?ms)^tests_dir = \[.*?^\]")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    suite = argv[1].strip()
+    if not suite:
+        print("error: <tests-dir> argument is empty", file=sys.stderr)
+        return 2
+
+    text = PYPROJECT.read_text()
+    new_text, count = TESTS_DIR_BLOCK.subn(
+        f'tests_dir = [\n    "{suite}",\n]', text, count=1
+    )
+    if count != 1:
+        print(
+            f"error: could not find [tool.mutmut] tests_dir block in {PYPROJECT}",
+            file=sys.stderr,
+        )
+        return 1
+
+    PYPROJECT.write_text(new_text)
+    print(f"mutmut tests_dir scoped to: {suite}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

The manually-triggered mutation-testing workflow (`.github/workflows/mutation-test.yml`) was failing. Fixing the reported failure uncovered a second, pre-existing bug; both are addressed here.

### Bug 1 — no database for the behavior suite

`[tool.mutmut].tests_dir` includes `tests/proxy_behavior/management/`, whose session fixtures connect Prisma to a real database. The workflow started no Postgres and set no `DATABASE_URL`, so mutmut's stats pass failed at fixture setup (`failed to collect stats. runner returned 1`).

That suite also cannot share a pytest session with the legacy mock suite (`tests/test_litellm/proxy/management_endpoints/`), which patches `prisma_client` globally — a single mutmut run over both would fail regardless of the database.

**Fix:** the `mutation` job is now a 2-leg matrix, one leg per suite. A `postgres:14` service container is added; the `behavior` leg exports `DATABASE_URL` and runs `prisma db push` before mutmut, mirroring `.github/workflows/_test-unit-services-base.yml`. mutmut reads `tests_dir` only from `pyproject.toml` (no CLI/env override), so `scripts/scope_mutmut_tests_dir.py` rewrites it to the leg's suite per run.

### Bug 2 — `relative_files` breaks mutmut's covered-lines lookup

With the database in place, mutmut got further but still aborted: *"we could not find any test case for any mutant."*

mutmut runs with `mutate_only_covered_lines = true`, so before generating mutants it measures coverage and looks up each file's covered lines by **absolute** path. coverage.py picks up `[tool.coverage.run] relative_files = true` from `pyproject.toml` and stores **relative** paths instead — every lookup misses, mutmut sees zero covered lines, generates zero mutants, and stops early. `relative_files = true` predates this workflow, so it has never produced a non-empty report.

**Fix:** `scripts/mutmut.coveragerc` (`relative_files = false`) is selected via `COVERAGE_RCFILE` on the `Run mutmut` step, overriding `pyproject.toml` for the mutmut run only. The project's real coverage/Codecov flow is unaffected.

## Test plan

Verified with a `workflow_dispatch` run on this branch ([run 26239641483](https://github.com/BerriAI/litellm/actions/runs/26239641483)):

- **`Run mutmut (behavior)`** — completed green end-to-end: Postgres provisioned → `prisma db push` → `tests_dir` scoped → `mutmut run` generated **1,492 mutants** (1,470 killed / 12 survived, 98.5% score) → report + artifact uploaded. Before the fix this step generated **0** mutants.
- **`Run mutmut (legacy)`** — ran well past mutmut's early-stop checkpoint and into the per-mutant phase, confirming it also generates mutants. (The full per-mutant run takes hours; not waited on.)