### PR TITLE
fix(opentelemetry): normalize list-valued guardrail_mode for span dedupe (#28486)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1570,14 +1570,17 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             # (e.g. ``mode: ["pre_call", "post_call"]``); ``_emit_once``
             # requires hashable scope parts, so normalize lists to tuples.
             guardrail_mode = guardrail_information.get("guardrail_mode")
-            if isinstance(guardrail_mode, list):
-                guardrail_mode = tuple(guardrail_mode)
+            hashable_guardrail_mode: Any = (
+                tuple(guardrail_mode)
+                if isinstance(guardrail_mode, list)
+                else guardrail_mode
+            )
             if not self._emit_once(
                 kwargs,
                 "guardrail",
                 guardrail_information.get("guardrail_name"),
                 start_time_float,
-                guardrail_mode,
+                hashable_guardrail_mode,
             ):
                 continue
 

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1565,12 +1565,19 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             # ``_handle_failure``) and re-reads the (mutating) entry list
             # each time. Dedupe at entry granularity so a single real
             # guardrail invocation produces exactly one span per handler.
+            #
+            # ``guardrail_mode`` is user-configured and may be a list
+            # (e.g. ``mode: ["pre_call", "post_call"]``); ``_emit_once``
+            # requires hashable scope parts, so normalize lists to tuples.
+            guardrail_mode = guardrail_information.get("guardrail_mode")
+            if isinstance(guardrail_mode, list):
+                guardrail_mode = tuple(guardrail_mode)
             if not self._emit_once(
                 kwargs,
                 "guardrail",
                 guardrail_information.get("guardrail_name"),
                 start_time_float,
-                guardrail_information.get("guardrail_mode"),
+                guardrail_mode,
             ):
                 continue
 

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -146,6 +146,35 @@ class TestOpenTelemetryGuardrails(unittest.TestCase):
         ]
         self.assertNotIn("guardrail_response", attribute_keys)
 
+    def test_create_guardrail_span_with_list_mode_is_hashable(self):
+        """Regression: when ``guardrail_mode`` is configured as a list
+        (e.g. ``mode: ["pre_call", "post_call"]``), ``_emit_once`` builds
+        a dedupe-key tuple containing the mode; using the list directly
+        raised ``TypeError: unhashable type: 'list'`` and produced an
+        HTTP/500 for every guardrailed request. The mode must be
+        normalized to a hashable form before lookup.
+        """
+        otel = OpenTelemetry()
+        otel.tracer = MagicMock()
+        mock_span = MagicMock()
+        otel.tracer.start_span.return_value = mock_span
+
+        guardrail_info = {
+            "guardrail_name": "custom-guardrail",
+            "guardrail_mode": ["pre_call", "post_call"],
+            "start_time": 1609459200.0,
+            "end_time": 1609459201.0,
+        }
+        kwargs = {
+            "standard_logging_object": {"guardrail_information": [guardrail_info]}
+        }
+
+        # Must not raise ``TypeError: unhashable type: 'list'``.
+        otel._create_guardrail_span(kwargs=kwargs, context=None)
+
+        otel.tracer.start_span.assert_called_once()
+        mock_span.set_attribute.assert_any_call("guardrail_name", "custom-guardrail")
+
 
 class TestOpenTelemetryTeamAttributesOnChildSpans(unittest.TestCase):
     """team_id / team_alias must land on every child span of a


### PR DESCRIPTION
## Summary

Closes the HTTP/500 path reported in #28486. When a guardrail is configured with a list-valued `mode` (e.g. `mode: ["pre_call", "post_call"]`) and the OpenTelemetry integration is active, every guardrailed request crashes with `TypeError: unhashable type: 'list'`.

## Root cause

`OpenTelemetry._emit_once` builds the per-request dedupe key as a tuple:

```python
dedupe_key = (self.__class__.__name__, id(self), *scope)
if spans_logged.get(dedupe_key) is True:
    ...
```

`_create_guardrail_span` passes `guardrail_information.get("guardrail_mode")` into `*scope` directly. When the configured mode is a list, the resulting tuple contains a list, becomes unhashable, and `spans_logged.get(dedupe_key)` raises.

`_emit_once`'s docstring already says *“scope parts can be any hashable identity”* — so the fix belongs at the call site that knows guardrail_mode can be a user-supplied list.

Bisected to 1c4e4d4 (#27757), which introduced the `_emit_once`-based dedupe loop.

## Fix

Normalize `guardrail_mode` to a tuple before passing it into `_emit_once`. The value emitted as the `guardrail_mode` span attribute is unchanged — only the dedupe-key form is normalized.

## Test plan

- [x] Added `TestOpenTelemetryGuardrails.test_create_guardrail_span_with_list_mode_is_hashable` — exercises `_create_guardrail_span` with `guardrail_mode: ["pre_call", "post_call"]`. Without the fix it raises `TypeError: unhashable type: 'list'`; with the fix it produces exactly one span.
- [x] Existing `TestOpenTelemetryGuardrails` cases (string `guardrail_mode`) are unchanged.

AI-assisted, human reviewed.