### PR TITLE
fix(model_catalog): add Azure priority pricing for gpt-4.1/5.1/5.2

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3371,8 +3371,10 @@
     },
     "azure/gpt-4.1": {
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1047576,
         "max_output_tokens": 32768,
@@ -3380,6 +3382,7 @@
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -3405,8 +3408,10 @@
     "azure/gpt-4.1-2025-04-14": {
         "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1047576,
         "max_output_tokens": 32768,
@@ -3414,6 +3419,7 @@
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -4510,13 +4516,16 @@
     },
     "azure/gpt-5.1": {
         "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -4668,13 +4677,16 @@
     },
     "azure/gpt-5.2": {
         "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4548,6 +4548,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "supports_service_tier": true,
         "supports_vision": true,
         "supports_none_reasoning_effort": true
     },
@@ -4709,6 +4710,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "supports_service_tier": true,
         "supports_vision": true
     },
     "azure/gpt-5.2-2025-12-11": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3371,8 +3371,10 @@
     },
     "azure/gpt-4.1": {
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1047576,
         "max_output_tokens": 32768,
@@ -3380,6 +3382,7 @@
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -3405,8 +3408,10 @@
     "azure/gpt-4.1-2025-04-14": {
         "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1047576,
         "max_output_tokens": 32768,
@@ -3414,6 +3419,7 @@
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -4510,13 +4516,16 @@
     },
     "azure/gpt-5.1": {
         "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -4668,13 +4677,16 @@
     },
     "azure/gpt-5.2": {
         "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4548,6 +4548,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "supports_service_tier": true,
         "supports_vision": true,
         "supports_none_reasoning_effort": true
     },
@@ -4709,6 +4710,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "supports_service_tier": true,
         "supports_vision": true
     },
     "azure/gpt-5.2-2025-12-11": {

--- a/tests/test_litellm/test_azure_priority_pricing_metadata.py
+++ b/tests/test_litellm/test_azure_priority_pricing_metadata.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+# (model_name, input_priority, output_priority, cache_read_priority)
+AZURE_PRIORITY_PRICING = [
+    ("azure/gpt-4.1", 3.5e-06, 1.4e-05, 8.75e-07),
+    ("azure/gpt-4.1-2025-04-14", 3.5e-06, 1.4e-05, 8.75e-07),
+    ("azure/gpt-5.1", 2.5e-06, 2e-05, 2.5e-07),
+    ("azure/gpt-5.2", 3.5e-06, 2.8e-05, 3.5e-07),
+]
+
+
+@pytest.mark.parametrize(
+    "model, input_priority, output_priority, cache_read_priority",
+    AZURE_PRIORITY_PRICING,
+)
+def test_azure_priority_pricing_keys_present(
+    model, input_priority, output_priority, cache_read_priority
+):
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    info = model_cost.get(model)
+    assert info is not None, f"{model} not found in model catalog"
+    assert info["litellm_provider"] == "azure"
+
+    assert info["input_cost_per_token_priority"] == input_priority
+    assert info["output_cost_per_token_priority"] == output_priority
+    assert info["cache_read_input_token_cost_priority"] == cache_read_priority
+
+
+def test_azure_priority_pricing_backup_matches_main():
+    """Ensure the bundled model cost map stays in sync with the canonical file."""
+    repo_root = Path(__file__).parents[2]
+    main_path = repo_root / "model_prices_and_context_window.json"
+    backup_path = repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+
+    with open(main_path) as f:
+        main_cost = json.load(f)
+    with open(backup_path) as f:
+        backup_cost = json.load(f)
+
+    for model, *_ in AZURE_PRIORITY_PRICING:
+        assert backup_cost.get(model) == main_cost.get(
+            model
+        ), f"{model} differs between main and backup model cost maps"

--- a/tests/test_litellm/test_azure_priority_pricing_metadata.py
+++ b/tests/test_litellm/test_azure_priority_pricing_metadata.py
@@ -33,6 +33,27 @@ def test_azure_priority_pricing_keys_present(
     assert info["cache_read_input_token_cost_priority"] == cache_read_priority
 
 
+# Aliases that should carry supports_service_tier to match their dated counterparts
+# (azure/gpt-5.1-2025-11-13, azure/gpt-5.2-2025-12-11). PR #24924 covers the gpt-4.1 aliases.
+AZURE_SUPPORTS_SERVICE_TIER_ALIASES = [
+    "azure/gpt-5.1",
+    "azure/gpt-5.2",
+]
+
+
+@pytest.mark.parametrize("model", AZURE_SUPPORTS_SERVICE_TIER_ALIASES)
+def test_azure_undated_aliases_advertise_service_tier_support(model):
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    info = model_cost.get(model)
+    assert info is not None, f"{model} not found in model catalog"
+    assert (
+        info.get("supports_service_tier") is True
+    ), f"{model} should advertise supports_service_tier=true to match its dated variant"
+
+
 def test_azure_priority_pricing_backup_matches_main():
     """Ensure the bundled model cost map stays in sync with the canonical file."""
     repo_root = Path(__file__).parents[2]


### PR DESCRIPTION
## Relevant issues

Related: #24926 (merged 2026-04-02 — wires `service_tier` through the Azure cost branch). Adjacent open: #24924 (adds `supports_service_tier: true` to `azure/gpt-4.1` / `azure/gpt-4.1-2025-04-14`).

## Linear ticket

Resolves LIT-2850

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Unit-test output (5 new tests + adjacent existing tests):

```
$ uv run pytest tests/test_litellm/test_azure_priority_pricing_metadata.py -v
tests/test_litellm/test_azure_priority_pricing_metadata.py::test_azure_priority_pricing_backup_matches_main PASSED
tests/test_litellm/test_azure_priority_pricing_metadata.py::test_azure_priority_pricing_keys_present[azure/gpt-4.1-2025-04-14-3.5e-06-1.4e-05-8.75e-07] PASSED
tests/test_litellm/test_azure_priority_pricing_metadata.py::test_azure_priority_pricing_keys_present[azure/gpt-4.1-3.5e-06-1.4e-05-8.75e-07] PASSED
tests/test_litellm/test_azure_priority_pricing_metadata.py::test_azure_priority_pricing_keys_present[azure/gpt-5.1-2.5e-06-2e-05-2.5e-07] PASSED
tests/test_litellm/test_azure_priority_pricing_metadata.py::test_azure_priority_pricing_keys_present[azure/gpt-5.2-3.5e-06-2.8e-05-3.5e-07] PASSED
============================== 5 passed in 0.31s ==============================

$ uv run pytest tests/test_litellm/llms/azure/test_azure_cost_calculation.py -v
============================== 3 passed in 0.21s ==============================

$ uv run pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py -v
============================== 41 passed in 0.43s ==============================
```

`test_service_tier_fallback_pricing` (existing) continues to pass: it covers the resolver's intentional fallback when `_priority` keys are absent, which is exactly the behavior this PR turns into a hit instead of a miss for the four Azure entries.

## Type

🐛 Bug Fix

## Changes

When an Azure deployment returns `"service_tier": "priority"` on a completion, LiteLLM was applying **standard-tier** pricing in `x-litellm-response-cost` and in the spend-log row. The cost-routing wiring through `cost_calculator.py` / `azure/cost_calculation.py` was fixed by #24926 (already on `litellm_internal_staging`), but a data-coverage gap remained: four Azure model entries on Azure's official priority-processing list — `azure/gpt-4.1`, `azure/gpt-4.1-2025-04-14`, `azure/gpt-5.1`, `azure/gpt-5.2` — lacked the `_priority` pricing keys. The generic cost resolver's intentional fallback (`litellm/litellm_core_utils/llm_cost_calc/utils.py`) silently substitutes the standard rate when a `_priority` key is missing, converting that gap into silent under-billing.

This PR adds `input_cost_per_token_priority`, `output_cost_per_token_priority`, and `cache_read_input_token_cost_priority` to the four entries in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, mirroring the values on the OpenAI counterparts and on the already-correct dated Azure variants (`azure/gpt-5.1-2025-11-13`, `azure/gpt-5.2-2025-12-11`).

**Values added**:

| Entry | input_priority | output_priority | cache_read_priority |
|---|---|---|---|
| `azure/gpt-4.1` | 3.5e-06 | 1.4e-05 | 8.75e-07 |
| `azure/gpt-4.1-2025-04-14` | 3.5e-06 | 1.4e-05 | 8.75e-07 |
| `azure/gpt-5.1` | 2.5e-06 | 2e-05 | 2.5e-07 |
| `azure/gpt-5.2` | 3.5e-06 | 2.8e-05 | 3.5e-07 |

**Out of scope** (intentional):

- Other Azure entries (gpt-4o family, gpt-5/gpt-5-mini, o3, o4-mini, codex variants, etc.) are not modified. Azure's published priority-processing matrix lists only `gpt-4.1`, `gpt-5.1`, `gpt-5.2`, and `gpt-5.4`, so adding priority pricing for the rest would be unsourced.
- `supports_service_tier: true` on `azure/gpt-4.1` / `azure/gpt-4.1-2025-04-14` — owned by open PR #24924, not duplicated here.

**Risk**: purely additive JSON keys. Backwards-compatible: no existing key is changed; models that were silently under-billing at standard rates when responses carried `service_tier: priority` will start billing at the correct priority rate, which is the intended behavior. Rollback is a single-PR revert.