### PR TITLE
fix(bedrock): preserve tool choice for parallel tool calls

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -606,6 +606,24 @@ class AmazonConverseConfig(BaseConfig):
                 status_code=400,
             )
 
+    @staticmethod
+    def _map_bedrock_tool_choice_to_anthropic_tool_choice(
+        tool_choice: Optional[ToolChoiceValuesBlock],
+    ) -> dict:
+        if tool_choice is None or "auto" in tool_choice:
+            return {"type": "auto"}
+        if "any" in tool_choice:
+            return {"type": "any"}
+
+        specific_tool_choice = tool_choice.get("tool")
+        if specific_tool_choice is not None:
+            name = specific_tool_choice.get("name")
+            if name:
+                return {"type": "tool", "name": name}
+            return {"type": "tool"}
+
+        return {"type": "auto"}
+
     def get_supported_image_types(self) -> List[str]:
         return ["png", "jpeg", "gif", "webp"]
 
@@ -1241,7 +1259,15 @@ class AmazonConverseConfig(BaseConfig):
             "_parallel_tool_use_config", None
         )
         if parallel_tool_use_config is not None and is_claude_4_5_on_bedrock(model):
+            bedrock_tool_choice = inference_params.pop("tool_choice", None)
+            anthropic_tool_choice = (
+                self._map_bedrock_tool_choice_to_anthropic_tool_choice(
+                    tool_choice=bedrock_tool_choice,
+                )
+            )
             for key, value in parallel_tool_use_config.items():
+                if key == "tool_choice" and isinstance(value, dict):
+                    value = {**anthropic_tool_choice, **value}
                 if (
                     key in additional_request_params
                     and isinstance(additional_request_params[key], dict)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3756,6 +3756,7 @@ def test_parallel_tool_calls_newer_model_adds_disable_flag():
 
     assert "additionalModelRequestFields" in request_data
     assert "tool_choice" in request_data["additionalModelRequestFields"]
+    assert request_data["additionalModelRequestFields"]["tool_choice"]["type"] == "auto"
     assert (
         request_data["additionalModelRequestFields"]["tool_choice"][
             "disable_parallel_tool_use"
@@ -3763,6 +3764,91 @@ def test_parallel_tool_calls_newer_model_adds_disable_flag():
         is True
     )
     assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
+
+
+def test_parallel_tool_calls_true_includes_type_field():
+    """parallel_tool_calls=True should include Anthropic's required tool_choice type."""
+    config = AmazonConverseConfig()
+    model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    messages = [{"role": "user", "content": "What's the weather in SF and NYC?"}]
+
+    optional_params = config.map_openai_params(
+        non_default_params={"parallel_tool_calls": True, "tools": _TOOL_PARAM},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    request_data = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "additionalModelRequestFields" in request_data
+    tool_choice = request_data["additionalModelRequestFields"]["tool_choice"]
+    assert tool_choice["type"] == "auto"
+    assert tool_choice["disable_parallel_tool_use"] is False
+    assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
+
+
+@pytest.mark.parametrize(
+    ("openai_tool_choice", "expected_anthropic_tool_choice"),
+    [
+        (
+            "auto",
+            {"type": "auto", "disable_parallel_tool_use": True},
+        ),
+        (
+            "required",
+            {"type": "any", "disable_parallel_tool_use": True},
+        ),
+        (
+            {"type": "function", "function": {"name": "get_weather"}},
+            {
+                "type": "tool",
+                "name": "get_weather",
+                "disable_parallel_tool_use": True,
+            },
+        ),
+    ],
+    ids=["auto", "required", "named-tool"],
+)
+def test_parallel_tool_calls_moves_explicit_tool_choice_into_anthropic_extension(
+    openai_tool_choice,
+    expected_anthropic_tool_choice,
+):
+    """Explicit tool_choice should not conflict with Anthropic's parallel tool extension."""
+    config = AmazonConverseConfig()
+    model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    messages = [{"role": "user", "content": "What's the weather in SF and NYC?"}]
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "tools": _TOOL_PARAM,
+            "tool_choice": openai_tool_choice,
+            "parallel_tool_calls": False,
+        },
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    request_data = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert (
+        request_data["additionalModelRequestFields"]["tool_choice"]
+        == expected_anthropic_tool_choice
+    )
+    assert "toolChoice" not in request_data["toolConfig"]
 
 
 def test_parallel_tool_calls_older_model_drops_disable_flag():


### PR DESCRIPTION
## Relevant issues

Fixes #22637

Related stale PR: #22638

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Focused local checks:

```bash
uv run pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -k parallel_tool_calls -q
# 6 passed, 119 deselected in 0.22s

uv run ruff check litellm/llms/bedrock/chat/converse_transformation.py
# All checks passed

git diff --check
# passed
```

I did not run full `make test-unit`.

`uv run ruff check tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py` currently reports unrelated pre-existing unused imports / print statements elsewhere in that file, so this PR keeps the lint scope to the changed source file and the focused test run.

## Type

🐛 Bug Fix
✅ Test

## Changes

This fixes the Bedrock Claude 4.5+ `parallel_tool_calls` request shape for `additionalModelRequestFields.tool_choice`.

Current `main` still creates:

```python
{"tool_choice": {"disable_parallel_tool_use": bool}}
```

Anthropic's Bedrock extension requires a `type` discriminator, otherwise Bedrock/Anthropic rejects the request with `tool_choice.type: Field required`.

This PR:

- adds the missing Anthropic `type` for `parallel_tool_calls=True` and `parallel_tool_calls=False`;
- preserves explicit caller `tool_choice` intent when `parallel_tool_calls` is also present:
  - `tool_choice="auto"` -> `{"type": "auto", ...}`;
  - `tool_choice="required"` -> `{"type": "any", ...}`;
  - named tool choice -> `{"type": "tool", "name": "...", ...}`;
- removes the duplicate Bedrock-native `toolChoice` from `toolConfig` when that explicit choice has been moved into `additionalModelRequestFields.tool_choice`;
- adds focused Bedrock Converse transformation tests under `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`.

Difference from #22638: that PR adds `type: "auto"` for the base bug, but it does not preserve explicit `tool_choice="required"` or named-tool choices when combined with `parallel_tool_calls`, and it is currently merge-conflicting.
