### PR TITLE
fix(bedrock): preserve tool choice for parallel tool calls

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -24,6 +24,7 @@ RUN for i in 1 2 3; do \
         curl \
         openssl \
         libsndfile \
+        libatomic \
         nodejs && break || sleep 5; \
     done
 
@@ -103,7 +104,7 @@ RUN for i in 1 2 3; do \
       apk upgrade --no-cache && break || sleep 5; \
     done && \
     for i in 1 2 3; do \
-      apk add --no-cache python3 bash openssl tzdata libsndfile nodejs && break || sleep 5; \
+      apk add --no-cache python3 bash openssl tzdata libsndfile libatomic nodejs && break || sleep 5; \
     done
 
 COPY --from=builder /app /app

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -606,6 +606,24 @@ class AmazonConverseConfig(BaseConfig):
                 status_code=400,
             )
 
+    @staticmethod
+    def _map_bedrock_tool_choice_to_anthropic_tool_choice(
+        tool_choice: Optional[ToolChoiceValuesBlock],
+    ) -> dict:
+        if tool_choice is None or "auto" in tool_choice:
+            return {"type": "auto"}
+        if "any" in tool_choice:
+            return {"type": "any"}
+
+        specific_tool_choice = tool_choice.get("tool")
+        if specific_tool_choice is not None:
+            name = specific_tool_choice.get("name")
+            if name:
+                return {"type": "tool", "name": name}
+            return {"type": "tool"}
+
+        return {"type": "auto"}
+
     def get_supported_image_types(self) -> List[str]:
         return ["png", "jpeg", "gif", "webp"]
 
@@ -1241,7 +1259,15 @@ class AmazonConverseConfig(BaseConfig):
             "_parallel_tool_use_config", None
         )
         if parallel_tool_use_config is not None and is_claude_4_5_on_bedrock(model):
+            bedrock_tool_choice = inference_params.pop("tool_choice", None)
+            anthropic_tool_choice = (
+                self._map_bedrock_tool_choice_to_anthropic_tool_choice(
+                    tool_choice=bedrock_tool_choice,
+                )
+            )
             for key, value in parallel_tool_use_config.items():
+                if key == "tool_choice" and isinstance(value, dict):
+                    value = {**anthropic_tool_choice, **value}
                 if (
                     key in additional_request_params
                     and isinstance(additional_request_params[key], dict)

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -187,6 +187,7 @@ class TestResponseCompliance:
             "failed",
             "cancelled",
             "incomplete",
+            "budget_exceeded",
         ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3795,28 +3795,34 @@ def test_parallel_tool_calls_true_includes_type_field():
 
 
 @pytest.mark.parametrize(
+    ("parallel_tool_calls", "disable_parallel_tool_use"),
+    [(True, False), (False, True)],
+    ids=["parallel-enabled", "parallel-disabled"],
+)
+@pytest.mark.parametrize(
     ("openai_tool_choice", "expected_anthropic_tool_choice"),
     [
         (
             "auto",
-            {"type": "auto", "disable_parallel_tool_use": True},
+            {"type": "auto"},
         ),
         (
             "required",
-            {"type": "any", "disable_parallel_tool_use": True},
+            {"type": "any"},
         ),
         (
             {"type": "function", "function": {"name": "get_weather"}},
             {
                 "type": "tool",
                 "name": "get_weather",
-                "disable_parallel_tool_use": True,
             },
         ),
     ],
     ids=["auto", "required", "named-tool"],
 )
 def test_parallel_tool_calls_moves_explicit_tool_choice_into_anthropic_extension(
+    parallel_tool_calls,
+    disable_parallel_tool_use,
     openai_tool_choice,
     expected_anthropic_tool_choice,
 ):
@@ -3829,7 +3835,7 @@ def test_parallel_tool_calls_moves_explicit_tool_choice_into_anthropic_extension
         non_default_params={
             "tools": _TOOL_PARAM,
             "tool_choice": openai_tool_choice,
-            "parallel_tool_calls": False,
+            "parallel_tool_calls": parallel_tool_calls,
         },
         optional_params={},
         model=model,
@@ -3844,6 +3850,10 @@ def test_parallel_tool_calls_moves_explicit_tool_choice_into_anthropic_extension
         headers={},
     )
 
+    expected_anthropic_tool_choice = {
+        **expected_anthropic_tool_choice,
+        "disable_parallel_tool_use": disable_parallel_tool_use,
+    }
     assert (
         request_data["additionalModelRequestFields"]["tool_choice"]
         == expected_anthropic_tool_choice

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3756,6 +3756,7 @@ def test_parallel_tool_calls_newer_model_adds_disable_flag():
 
     assert "additionalModelRequestFields" in request_data
     assert "tool_choice" in request_data["additionalModelRequestFields"]
+    assert request_data["additionalModelRequestFields"]["tool_choice"]["type"] == "auto"
     assert (
         request_data["additionalModelRequestFields"]["tool_choice"][
             "disable_parallel_tool_use"
@@ -3763,6 +3764,91 @@ def test_parallel_tool_calls_newer_model_adds_disable_flag():
         is True
     )
     assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
+
+
+def test_parallel_tool_calls_true_includes_type_field():
+    """parallel_tool_calls=True should include Anthropic's required tool_choice type."""
+    config = AmazonConverseConfig()
+    model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    messages = [{"role": "user", "content": "What's the weather in SF and NYC?"}]
+
+    optional_params = config.map_openai_params(
+        non_default_params={"parallel_tool_calls": True, "tools": _TOOL_PARAM},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    request_data = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "additionalModelRequestFields" in request_data
+    tool_choice = request_data["additionalModelRequestFields"]["tool_choice"]
+    assert tool_choice["type"] == "auto"
+    assert tool_choice["disable_parallel_tool_use"] is False
+    assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
+
+
+@pytest.mark.parametrize(
+    ("openai_tool_choice", "expected_anthropic_tool_choice"),
+    [
+        (
+            "auto",
+            {"type": "auto", "disable_parallel_tool_use": True},
+        ),
+        (
+            "required",
+            {"type": "any", "disable_parallel_tool_use": True},
+        ),
+        (
+            {"type": "function", "function": {"name": "get_weather"}},
+            {
+                "type": "tool",
+                "name": "get_weather",
+                "disable_parallel_tool_use": True,
+            },
+        ),
+    ],
+    ids=["auto", "required", "named-tool"],
+)
+def test_parallel_tool_calls_moves_explicit_tool_choice_into_anthropic_extension(
+    openai_tool_choice,
+    expected_anthropic_tool_choice,
+):
+    """Explicit tool_choice should not conflict with Anthropic's parallel tool extension."""
+    config = AmazonConverseConfig()
+    model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    messages = [{"role": "user", "content": "What's the weather in SF and NYC?"}]
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "tools": _TOOL_PARAM,
+            "tool_choice": openai_tool_choice,
+            "parallel_tool_calls": False,
+        },
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    request_data = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert (
+        request_data["additionalModelRequestFields"]["tool_choice"]
+        == expected_anthropic_tool_choice
+    )
+    assert "toolChoice" not in request_data["toolConfig"]
 
 
 def test_parallel_tool_calls_older_model_drops_disable_flag():


### PR DESCRIPTION
## Relevant issues

Fixes #22637

Related stale PR: #22638

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

These CI-run links are for the LiteLLM team during merge/cherry-pick handling:

- **Branch creation CI run**: N/A for external fork contributor
- **CI run for the last commit**: full GitHub Actions rollup is green on this PR
- **Merge / cherry-pick CI run**: N/A until a maintainer merges or cherry-picks

## Screenshots / Proof of Fix

Focused local checks:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache-litellm uv run --no-sync pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -k parallel_tool_calls -q
# 9 passed, 119 deselected

UV_CACHE_DIR=/private/tmp/uv-cache-litellm uv run --no-sync pytest tests/test_litellm/interactions/test_openapi_compliance.py -q
# 13 passed

UV_CACHE_DIR=/private/tmp/uv-cache-litellm uv run black --check litellm/llms/bedrock/chat/converse_transformation.py tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
# 2 files would be left unchanged

uv run ruff check litellm/llms/bedrock/chat/converse_transformation.py
# All checks passed

git diff --check
# passed

docker run --rm cgr.dev/chainguard/wolfi-base@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 sh -c 'apk add --no-cache libatomic >/dev/null && test -e /usr/lib/libatomic.so.1 && echo libatomic-ok'
# libatomic-ok
```

Full GitHub Actions rollup is green on the latest commit, including all unit-test shards, linting, code quality, server root path Docker checks, and Codecov. I did not rerun full local `make test-unit`.

`uv run ruff check tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py` currently reports unrelated pre-existing unused imports / print statements elsewhere in that file, so this PR keeps the lint scope to the changed source file and the focused test run.

## Type

Bug Fix
Test

## Changes

This fixes the Bedrock Claude 4.5+ `parallel_tool_calls` request shape for `additionalModelRequestFields.tool_choice`.

Current upstream code on the contribution base still creates:

```python
{"tool_choice": {"disable_parallel_tool_use": bool}}
```

Anthropic's Bedrock extension requires a `type` discriminator, otherwise Bedrock/Anthropic rejects the request with `tool_choice.type: Field required`.

This PR:

- adds the missing Anthropic `type` for `parallel_tool_calls=True` and `parallel_tool_calls=False`;
- preserves explicit caller `tool_choice` intent when `parallel_tool_calls` is also present:
  - `tool_choice="auto"` -> `{"type": "auto", ...}`;
  - `tool_choice="required"` -> `{"type": "any", ...}`;
  - named tool choice -> `{"type": "tool", "name": "...", ...}`;
- covers explicit `tool_choice` with both `parallel_tool_calls=True` and `parallel_tool_calls=False`;
- removes the duplicate Bedrock-native `toolConfig.toolChoice` from the request when that explicit choice has been moved into `additionalModelRequestFields.tool_choice`;
- adds focused Bedrock Converse transformation tests under `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`.

Difference from #22638: that PR adds `type: "auto"` for the base bug, but it does not preserve explicit `tool_choice="required"` or named-tool choices when combined with `parallel_tool_calls`, and it is currently merge-conflicting.

## CI follow-up

The first CI run had two unrelated failures outside the Bedrock transformation tests:

- `Unit Tests: MCP, Secrets, Containers & Misc / misc / Run tests` failed because the live Google Interactions OpenAPI spec added `budget_exceeded` to `Interaction.status`; this PR updates the compliance expectation.
- `Test Proxy SERVER_ROOT_PATH Routing / test-server-root-path` failed while building `docker/Dockerfile.non_root` because Prisma's Node binary needed `libatomic.so.1`; this PR adds Wolfi/Alpine `libatomic` to the non-root builder and runtime package lists.

`Code Quality Checks / code-quality` was already passing on that run.
