### PR TITLE
Fix vector store file auth for team-scoped JWT users

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1143,7 +1143,6 @@ _MODEL_ROUTING_ID_FIELDS = (
     "fine_tuning_job_id",
     "training_file",
     "validation_file",
-    "vector_store_id",
     "video_id",
     "character_id",
 )

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -15,6 +15,10 @@ import pytest
 from fastapi import status
 
 import litellm
+from litellm.llms.base_llm.managed_resources.utils import (
+    encode_unified_id,
+    generate_unified_id_string,
+)
 from litellm.proxy._types import (
     CallInfo,
     Litellm_EntityType,
@@ -44,6 +48,7 @@ from litellm.proxy.auth.auth_checks import (
     _virtual_key_max_budget_alert_check,
     _virtual_key_max_budget_check,
     _virtual_key_soft_budget_check,
+    common_checks,
     get_key_object,
     get_user_object,
     vector_store_access_check,
@@ -231,6 +236,68 @@ def test_can_object_call_model_denials_return_forbidden(
 
     assert exc_info.value.type == expected_error_type
     assert int(exc_info.value.code) == status.HTTP_403_FORBIDDEN
+
+
+def _make_unified_vector_store_id(model_id: str = "internal-model") -> str:
+    return encode_unified_id(
+        generate_unified_id_string(
+            resource_type="vector_store",
+            unified_uuid="vs-unified-1",
+            target_model_names=[model_id],
+            provider_resource_id="vs-provider-1",
+            model_id=model_id,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_common_checks_does_not_team_model_check_managed_vector_store_id():
+    vector_store_id = _make_unified_vector_store_id()
+    route = f"/v1/vector_stores/{vector_store_id}/files"
+    request_body = {
+        "vector_store_id": vector_store_id,
+        "vector_store_ids": [vector_store_id],
+    }
+    request = MagicMock()
+    request.headers = {}
+    request.query_params = {}
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch(
+            "litellm.proxy.auth.auth_checks.can_team_access_model",
+            new_callable=AsyncMock,
+        ) as can_team_access_model_mock,
+        patch(
+            "litellm.proxy.auth.auth_checks.vector_store_access_check",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.auth.route_checks.RouteChecks.non_proxy_admin_allowed_routes_check"
+        ),
+    ):
+        assert (
+            await common_checks(
+                request_body=request_body,
+                team_object=LiteLLM_TeamTable(
+                    team_id="team-a", models=["public/team-model"]
+                ),
+                user_object=None,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route=route,
+                llm_router=None,
+                proxy_logging_obj=MagicMock(),
+                valid_token=UserAPIKeyAuth(user_id="internal-user", team_id="team-a"),
+                request=request,
+                skip_budget_checks=True,
+            )
+            is True
+        )
+
+    can_team_access_model_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -8,6 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from litellm.llms.base_llm.managed_resources.utils import (
+    encode_unified_id,
+    generate_unified_id_string,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.auth_utils import (
     _get_customer_id_from_standard_headers,
@@ -22,6 +26,18 @@ from litellm.proxy.auth.auth_utils import (
     get_request_route_template,
     is_request_body_safe,
 )
+
+
+def _make_unified_vector_store_id(model_id: str = "internal-model") -> str:
+    return encode_unified_id(
+        generate_unified_id_string(
+            resource_type="vector_store",
+            unified_uuid="vs-unified-1",
+            target_model_names=[model_id],
+            provider_resource_id="vs-provider-1",
+            model_id=model_id,
+        )
+    )
 
 
 class TestGetKeyModelRpmLimit:
@@ -341,6 +357,31 @@ def test_get_model_from_request_extracts_unified_file_id_models():
         request_data={"file_id": encoded_unified_file_id},
         route="/v1/files/{file_id}",
     ) == ["model-a", "model-b"]
+
+
+def test_get_model_from_request_does_not_extract_model_from_vector_store_id():
+    vector_store_id = _make_unified_vector_store_id()
+
+    assert (
+        get_model_from_request(
+            request_data={
+                "vector_store_id": vector_store_id,
+                "vector_store_ids": [vector_store_id],
+            },
+            route=f"/v1/vector_stores/{vector_store_id}/files",
+        )
+        is None
+    )
+
+
+def test_get_model_from_request_still_checks_vector_store_target_model_names():
+    assert (
+        get_model_from_request(
+            request_data={"target_model_names": ["allowed-model"]},
+            route="/v1/vector_stores",
+        )
+        == "allowed-model"
+    )
 
 
 def test_get_model_from_request_extracts_eval_completion_model():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Managed vector-store IDs were decoded as model-routing sources during common auth checks before the vector-store files endpoint could validate vector-store ownership. This caused team-scoped JWT callers to be denied on an internal routing model even when they were allowed to access the vector store; the fix stops deriving a model from existing `vector_store_id` values while preserving explicit `target_model_names` checks.

## Repro
A JWT-authenticated internal user with a team claim calls `GET /v1/vector_stores/{managed_vector_store_id}/files`. The managed vector-store ID embeds an internal routing model, while the team allow-list contains the public team model; pre-endpoint auth decoded the ID and raised `team_model_access_denied` for the internal model.

## Evidence
<a href="/opt/cursor/artifacts/vector_store_jwt_team_auth_proof.txt">Vector store JWT/team auth proof transcript</a>

## Tests
- Added regression coverage in `tests/test_litellm/proxy/auth/test_auth_utils.py` to verify `vector_store_id` is no longer treated as a model source and `target_model_names` remains enforced.
- Added regression coverage in `tests/test_litellm/proxy/auth/test_auth_checks.py` to verify `common_checks` does not invoke team model access for a managed vector-store files route.
- `uv run pytest tests/test_litellm/proxy/auth/test_auth_utils.py::test_get_model_from_request_does_not_extract_model_from_vector_store_id tests/test_litellm/proxy/auth/test_auth_utils.py::test_get_model_from_request_still_checks_vector_store_target_model_names tests/test_litellm/proxy/auth/test_auth_checks.py::test_common_checks_does_not_team_model_check_managed_vector_store_id -q` — 3 passed.
- `uv run pytest tests/test_litellm/proxy/auth/test_auth_utils.py tests/test_litellm/proxy/auth/test_auth_checks.py -q` — 278 passed.
- CI-scoped lint/type checks run locally: `uv lock --check`, `uv sync --frozen`, `black --check --exclude '/enterprise/' .`, `ruff check .`, `mypy .`, circular import check, and import safety — all passed.

## CI
- GitHub Actions and CircleCI started for this PR. Latest poll showed several checks already green and the remaining checks still in progress/pending; no PR-head failures observed at that poll.

## Review
- No automated review was posted at the latest poll.

## Relevant issues

Internal bug report.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, Adding at least 1 test is a hard requirement
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

See Evidence above.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Removed `vector_store_id` from common model-routing ID extraction.
- Added tests for model extraction and common auth checks on vector-store files routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20e6f565-0f66-425b-b7c2-2afb71d03be4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20e6f565-0f66-425b-b7c2-2afb71d03be4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

