### PR TITLE
fix(docker): restore npm to non_root builder image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -24,7 +24,8 @@ RUN for i in 1 2 3; do \
         curl \
         openssl \
         libsndfile \
-        nodejs && break || sleep 5; \
+        nodejs \
+        npm && break || sleep 5; \
     done
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \


### PR DESCRIPTION
## What

Restores `npm` to the builder-stage `apk add` list in `docker/Dockerfile.non_root`.

## Why

The non_root builder stage installs `nodejs` but not `npm`. prisma-python resolves `node` and `npm` independently — without `npm` on `PATH` it falls back to downloading a Node runtime via `nodeenv` from nodejs.org. That downloaded binary fails to load `libatomic.so.1`, so `prisma generate` exits non-zero and the image build fails:

```
node: error while loading shared libraries: libatomic.so.1: cannot open shared object file
ERROR: process "/bin/sh -c prisma generate --schema=./schema.prisma" did not complete successfully
```

`npm` was dropped from this apk list in `ca52e346b0`. With `npm` present, prisma-python uses the system Node + npm (`PRISMA_USE_GLOBAL_NODE` defaults on) and the nodeenv download path is never taken. `docker/Dockerfile` already installs `npm` for the same reason — this brings `Dockerfile.non_root` back in line with it.

## Test plan

- The `test-server-root-path` workflow builds `docker/Dockerfile.non_root` and runs the container — CI on this PR verifies the build.