### PR TITLE
Harden Redis spend counter reseed race coverage

### DIFF
--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -306,6 +306,7 @@ class SpendCounterReseed:
             )
             if window_spend is None:
                 return None
+            current_value = window_spend
             try:
                 if spend_counter_cache.redis_cache is not None:
                     seeded = await spend_counter_cache.redis_cache.async_set_cache(
@@ -321,15 +322,11 @@ class SpendCounterReseed:
                                 key=counter_key
                             )
                         )
-                        if current_cached_value is None:
-                            current_value = (
-                                await spend_counter_cache.redis_cache.async_increment(
-                                    key=counter_key,
-                                    value=window_spend,
-                                )
-                            )
-                        else:
-                            current_value = float(current_cached_value)
+                        current_value = (
+                            float(current_cached_value)
+                            if current_cached_value is not None
+                            else window_spend
+                        )
                     spend_counter_cache.in_memory_cache.set_cache(
                         key=counter_key,
                         value=current_value,
@@ -344,4 +341,4 @@ class SpendCounterReseed:
                     counter_key,
                 )
                 raise
-            return window_spend
+            return current_value

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5859,15 +5859,61 @@ async def test_primary_spend_counter_redis_concurrent_seed_does_not_double_seed(
         if call.kwargs.get("nx") is True
     ]
     assert len(nx_writes) == 2
-    assert sorted(set_results) == [False, True], (
-        f"expected exactly one SET NX winner and one loser, got {set_results}"
-    )
+    assert sorted(set_results) == [
+        False,
+        True,
+    ], f"expected exactly one SET NX winner and one loser, got {set_results}"
     # Loser path executed: after the winner's SET NX returned True, the
     # losing coalesced() call falls back to async_get_cache to read the
     # winner's value rather than re-seeding.
-    assert get_after_set_count >= 1, (
-        "loser branch (else: read back winner's value) was never exercised"
+    assert (
+        get_after_set_count >= 1
+    ), "loser branch (else: read back winner's value) was never exercised"
+
+
+@pytest.mark.asyncio
+async def test_spend_counter_reseed_returns_winning_redis_value_on_set_nx_loss():
+    from litellm.caching.dual_cache import DualCache
+    from litellm.proxy.db.spend_counter_reseed import SpendCounterReseed
+
+    counter_cache = DualCache()
+    counter_key = "spend:team:team-set-nx-loss"
+    redis_reads = 0
+
+    async def redis_get_cache(key, **_):
+        nonlocal redis_reads
+        redis_reads += 1
+        if redis_reads == 1:
+            return None
+        return 45.5
+
+    fake_redis = AsyncMock()
+    fake_redis.async_get_cache = AsyncMock(side_effect=redis_get_cache)
+    fake_redis.async_set_cache = AsyncMock(return_value=False)
+    fake_redis.async_increment = AsyncMock()
+    counter_cache.redis_cache = fake_redis
+
+    db_row = MagicMock()
+    db_row.spend = 42.0
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=db_row)
+
+    result = await SpendCounterReseed.coalesced(
+        prisma_client=fake_prisma,
+        spend_counter_cache=counter_cache,
+        counter_key=counter_key,
     )
+
+    assert result == pytest.approx(45.5)
+    assert counter_cache.in_memory_cache.get_cache(key=counter_key) == pytest.approx(
+        45.5
+    )
+    fake_redis.async_set_cache.assert_awaited_once_with(
+        key=counter_key,
+        value=42.0,
+        nx=True,
+    )
+    fake_redis.async_increment.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -6166,6 +6212,55 @@ async def test_window_spend_counter_redis_concurrent_seed_does_not_double_seed()
     finally:
         ps.spend_counter_cache = orig_counter
         ps.prisma_client = orig_prisma
+
+
+@pytest.mark.asyncio
+async def test_window_spend_counter_reseed_returns_winning_redis_value():
+    from litellm.caching.dual_cache import DualCache
+    from litellm.proxy.db.spend_counter_reseed import SpendCounterReseed
+
+    counter_cache = DualCache()
+    counter_key = "spend:key:key-window-set-nx-loss:window:1h"
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    redis_reads = 0
+
+    async def redis_get_cache(key):
+        nonlocal redis_reads
+        redis_reads += 1
+        if redis_reads == 1:
+            return None
+        return 2.75
+
+    fake_redis = AsyncMock()
+    fake_redis.async_get_cache = AsyncMock(side_effect=redis_get_cache)
+    fake_redis.async_set_cache = AsyncMock(return_value=False)
+    fake_redis.async_increment = AsyncMock()
+    counter_cache.redis_cache = fake_redis
+
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_spendlogs.group_by = AsyncMock(
+        return_value=[{"api_key": "key-window-set-nx-loss", "_sum": {"spend": 2.25}}]
+    )
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=fake_prisma,
+        spend_counter_cache=counter_cache,
+        counter_key=counter_key,
+        entity_type="Key",
+        entity_id="key-window-set-nx-loss",
+        window_start=window_start,
+    )
+
+    assert result == pytest.approx(2.75)
+    assert counter_cache.in_memory_cache.get_cache(key=counter_key) == pytest.approx(
+        2.75
+    )
+    fake_redis.async_set_cache.assert_awaited_once_with(
+        key=counter_key,
+        value=2.25,
+        nx=True,
+    )
+    fake_redis.async_increment.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_redis_auth_cache_flag.py
+++ b/tests/test_litellm/proxy/test_redis_auth_cache_flag.py
@@ -43,6 +43,20 @@ class _FakeRedisCache(RedisCache):
             return None
         return json.loads(raw)
 
+    async def async_get_cache(self, key, **kwargs):  # type: ignore[override]
+        return self.get_cache(key=key, **kwargs)
+
+    async def async_set_cache(self, key, value, **kwargs):  # type: ignore[override]
+        if kwargs.get("nx") and key in self._store:
+            return False
+        return self.set_cache(key=key, value=value, **kwargs)
+
+    async def async_increment(self, key, value, **kwargs):  # type: ignore[override]
+        current_value = self.get_cache(key=key) or 0.0
+        new_value = float(current_value) + float(value)
+        self.set_cache(key=key, value=new_value, **kwargs)
+        return new_value
+
 
 @contextmanager
 def _patched_init_cache(litellm_settings: dict, cache_params: dict):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Primary Redis spend counter seeding already uses atomic `SET NX` on the staging base. This PR closes the remaining reseed edge case for window counters by returning the winning Redis value after a lost `SET NX` race and avoiding fallback additive seeding, then adds regression coverage for both primary and window counter loser paths.

## Repro
A shared Redis spend window counter is missing while another proxy worker wins the `SET NX` seed race first. Before this change, the window reseed path returned the DB window spend and could fall back to an additive increment in the loser path; after this change, it reads and returns the existing Redis winner value.

## Evidence
<a href="/opt/cursor/artifacts/redis_spend_counter_staging_evidence.txt">Terminal evidence transcript</a>

## Tests
- Regression test on staging base: `test_window_spend_counter_reseed_returns_winning_redis_value` fails as expected because `coalesced_window` returns `2.25` instead of the winning Redis value `2.75`.
- `uv run --no-sync pytest tests/test_litellm/proxy/test_proxy_server.py -k 'spend_counter or current_spend or reseed' -q` -> 28 passed, 150 deselected.
- `make test-unit-proxy-misc` -> new tests passed; remaining 3 spend-log payload failures reproduce on staging base with the same extra response keys.
- CI lint workflow scope after `uv sync --frozen`: Black check, Ruff, MyPy, circular import check, import safety check, and hardcoded-secret test all passed.

## CI
- ✅ Lint, code quality, UI build, Codecov, and unit-test workflows completed successfully.
- ⚠️ `test-server-root-path (/api/v1)` failed before tests during Docker build while installing Prisma tooling (`npm install prisma@5.4.2` returned exit 127). The paired `/llmproxy` job was cancelled after that failure. This does not exercise the modified spend-counter code.

## Review
- No automated code-review result was posted after waiting for the initial review window.

## Relevant issues

Fixes #28283

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

See terminal evidence above.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Return the current Redis winner value from window-counter reseeds after a lost `SET NX` race.
- Avoid additive fallback seeding for window counters when `SET NX` loses.
- Add regression tests for primary and window counter race loser paths.
- Extend the Redis auth-cache test fake with async methods used by spend-counter reseeding.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7646204f-944c-4e1f-80d5-4e3200102a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7646204f-944c-4e1f-80d5-4e3200102a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

