### PR TITLE
fix: use credential_provider for GCP IAM auth with sync RedisCluster

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -294,6 +294,15 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
         if arg in args:
             cluster_kwargs[arg] = redis_kwargs[arg]
 
+    # redis_connect_func is not honored by RedisCluster bootstrap (CLUSTER SLOTS
+    # runs before the hook fires). Swap it for credential_provider so GCP IAM
+    # tokens authenticate the bootstrap connection — mirrors the async cluster path.
+    _rcf = cluster_kwargs.pop("redis_connect_func", None)
+    if _rcf and hasattr(_rcf, "_gcp_service_account"):
+        cluster_kwargs["credential_provider"] = GCPIAMCredentialProvider(
+            _rcf._gcp_service_account
+        )
+
     new_startup_nodes: List[ClusterNode] = []
 
     for item in redis_kwargs["startup_nodes"]:


### PR DESCRIPTION
## Summary

Fixes #28379.

`init_redis_cluster` (sync) passes `redis_connect_func` to `redis.RedisCluster`, but `RedisCluster.NodesManager.initialize()` runs `CLUSTER SLOTS` before any connection hook fires — so the GCP IAM token is never applied to the bootstrap connection. The server replies with `Authentication required`, crashing the proxy at startup.

## Root Cause

```python
# BEFORE — redis_connect_func silently ignored by RedisCluster bootstrap
args = _get_redis_cluster_kwargs()
cluster_kwargs = {}
for arg in redis_kwargs:
    if arg in args:
        cluster_kwargs[arg] = redis_kwargs[arg]   # redis_connect_func passes through
# redis_connect_func is in cluster_kwargs but RedisCluster never calls it on bootstrap
return redis.RedisCluster(startup_nodes=..., **cluster_kwargs)
```

The async path (`get_redis_async_client`) already handles this correctly by converting `redis_connect_func` → `credential_provider=GCPIAMCredentialProvider(...)`, which redis-py *does* honor on every connection including bootstrap.

## Fix

Mirror the async cluster path in the sync `init_redis_cluster`:

```python
# Pop redis_connect_func before passing to RedisCluster
_rcf = cluster_kwargs.pop("redis_connect_func", None)
if _rcf and hasattr(_rcf, "_gcp_service_account"):
    cluster_kwargs["credential_provider"] = GCPIAMCredentialProvider(
        _rcf._gcp_service_account
    )
```

`GCPIAMCredentialProvider` is a `redis.credentials.CredentialProvider` subclass that generates a fresh IAM token on every new connection (already present in `litellm/_redis_credential_provider.py` and used by the async path).

## Test plan

- [ ] GCP IAM + `startup_nodes` (cluster mode): proxy starts without `RedisClusterException: Authentication required`
- [ ] GCP IAM + no `startup_nodes` (standalone mode): `redis_connect_func` path unchanged, behavior unchanged
- [ ] No GCP IAM: `_rcf` is `None`, early-exit, no change to cluster_kwargs
- [ ] Async cluster path: untouched, continues working as before
