### PR TITLE
fix(ollama): remap tool role to tool_responses for Gemma models

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -287,8 +287,14 @@ class OllamaChatConfig(BaseConfig):
             content_str = convert_content_list_to_str(cast(AllMessageValues, m))
             images = extract_images_from_message(cast(AllMessageValues, m))
 
+            role = cast(str, m.get("role"))
+            # Gemma models (via Ollama) expect "tool_responses" for tool result
+            # messages instead of the OpenAI-standard "tool" role. Without this,
+            # the model ignores the result and loops infinitely.
+            if role == "tool" and "gemma" in model.lower():
+                role = "tool_responses"
             ollama_message = OllamaChatCompletionMessage(
-                role=cast(str, m.get("role")),
+                role=role,
             )
             if reasoning_content is not None:
                 ollama_message["thinking"] = reasoning_content


### PR DESCRIPTION
Closes #28530

## Problem

Gemma models served via Ollama (e.g. ) enter an infinite tool-calling loop when tool results are returned in conversation history.

The root cause is a role name mismatch: LiteLLM standardizes tool results to the OpenAI-compatible  role, but Gemma models expect . Because the model never sees a message with the expected role, it treats the tool as never having been called and issues the same tool call again.

This was also identified and fixed in the Google ADK project: https://github.com/google/adk-python/pull/5655

## Fix

In , remap the role from  to  when the target model name contains :



This is the minimal change needed. All other role values are passed through unchanged.