### PR TITLE
fix(key-update): skip allowed_routes admin gate when value is unchanged

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1922,10 +1922,21 @@ async def _validate_update_key_data(
     """Validate permissions and constraints for key update."""
     _is_proxy_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
 
-    _check_allowed_routes_caller_permission(
-        allowed_routes=data.allowed_routes,
-        user_api_key_dict=user_api_key_dict,
+    # For updates, only raise if the caller is CHANGING allowed_routes.
+    # Round-tripping the value already set (e.g. by key_type at creation)
+    # must not require admin — the user cannot escalate by submitting a value
+    # that is already stored on the key.
+    _existing_allowed_routes = getattr(existing_key_row, "allowed_routes", None) or []
+    _routes_unchanged = (
+        data.allowed_routes is not None
+        and bool(_existing_allowed_routes)
+        and set(data.allowed_routes) == set(_existing_allowed_routes)
     )
+    if not _routes_unchanged:
+        _check_allowed_routes_caller_permission(
+            allowed_routes=data.allowed_routes,
+            user_api_key_dict=user_api_key_dict,
+        )
 
     # Prevent non-admin from removing user_id (setting to empty string) (LIT-1884)
     if data.user_id is not None and data.user_id == "" and not _is_proxy_admin:


### PR DESCRIPTION
Closes #26555

## Problem

Non-admin users who edit a virtual key via the UI receive a 403 when the key was originally created with a  (e.g. ). The UI round-trips the full key object back to , including  that was set by the system at creation. The  check treats any non-empty  in the update payload as an unauthorized escalation attempt and raises 403 - even though the value is identical to what is already stored.

## Root Cause

In  (), the permission check fires unconditionally on every update that includes , without comparing against the stored value:



## Fix

Before calling the permission check, compare the incoming  against the existing key row. Skip the check if the value is unchanged - the user cannot escalate by round-tripping a value already stored on the key. The guard still fires if the caller is actually adding or changing routes:



## Testing

1. Create a key with  (sets )
2. As a non-admin user, edit the key models list and save
3. Before fix: 403 error
4. After fix: save succeeds
5. Verify: non-admin trying to ADD a new route still gets 403