### PR TITLE
fix(mcp): preserve auth errors + advertise upstream IdP for delegate-auth discovery

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -787,6 +787,65 @@ async def oauth_protected_resource_mcp(
 """
 
 
+def _delegate_auth_authorization_server_response(
+    mcp_server: MCPServer,
+) -> Optional[dict]:
+    """
+    Build authorization-server metadata for an MCP server configured with
+    ``delegate_auth_to_upstream=True``.
+
+    In delegate-auth mode the end-user authenticates directly with the
+    upstream IdP (PKCE in their MCP client) and LiteLLM is just a network
+    relay. Advertising LiteLLM as the issuer would point the client at
+    LiteLLM's own ``/authorize`` and ``/token`` routes, which don't speak
+    OAuth — so the client either dead-ends or mints a token tied to the
+    wrong issuer. Re-advertise the upstream values that were resolved at
+    registration time (``MCPServer.authorization_url`` /
+    ``token_url`` / ``registration_url`` / ``scopes``) so spec-conforming
+    MCP clients (OpenWebUI, Cursor, mcp-inspector) can drive the flow
+    against the real authorization server.
+
+    Returns ``None`` when the upstream metadata wasn't resolved at
+    registration (network failure, server defined without ``auth_type``,
+    etc.) so the caller falls back to the LiteLLM-issuer response.
+    """
+    if not mcp_server.delegate_auth_to_upstream:
+        return None
+    if mcp_server.auth_type != MCPAuth.oauth2:
+        return None
+
+    authorization_endpoint = mcp_server.authorization_url
+    token_endpoint = mcp_server.token_url
+    if not authorization_endpoint or not token_endpoint:
+        verbose_logger.warning(
+            "MCP delegate-auth: server %s has no upstream authorization/token "
+            "URL stored; falling back to LiteLLM-issuer discovery, which the "
+            "upstream IdP cannot honor. Re-register the server so OAuth "
+            "discovery can populate these fields.",
+            mcp_server.name,
+        )
+        return None
+
+    # Issuer is the upstream authorization server's origin per RFC 8414.
+    parsed = urlparse(authorization_endpoint)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    issuer = f"{parsed.scheme}://{parsed.netloc}"
+
+    response: Dict[str, Any] = {
+        "issuer": issuer,
+        "authorization_endpoint": authorization_endpoint,
+        "token_endpoint": token_endpoint,
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "scopes_supported": mcp_server.scopes or [],
+    }
+    if mcp_server.registration_url:
+        response["registration_endpoint"] = mcp_server.registration_url
+    return response
+
+
 def _build_oauth_authorization_server_response(
     request: Request,
     mcp_server_name: Optional[str],
@@ -814,6 +873,17 @@ def _build_oauth_authorization_server_response(
         if resolved:
             mcp_server_name = resolved.server_name or resolved.name
 
+    mcp_server: Optional[MCPServer] = None
+    if mcp_server_name:
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
+            mcp_server_name, client_ip=client_ip
+        )
+
+    if mcp_server is not None:
+        delegated = _delegate_auth_authorization_server_response(mcp_server)
+        if delegated is not None:
+            return delegated
+
     authorization_endpoint = (
         f"{request_base_url}/{mcp_server_name}/authorize"
         if mcp_server_name
@@ -824,12 +894,6 @@ def _build_oauth_authorization_server_response(
         if mcp_server_name
         else f"{request_base_url}/token"
     )
-
-    mcp_server: Optional[MCPServer] = None
-    if mcp_server_name:
-        mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
-            mcp_server_name, client_ip=client_ip
-        )
 
     return {
         "issuer": request_base_url,  # point to your proxy

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -715,14 +715,27 @@ def _build_oauth_protected_resource_response(
     else:
         resource_url = f"{request_base_url}/mcp"
 
+    # Delegate-auth servers must advertise the upstream IdP as the
+    # authorization server — pointing PRM at LiteLLM would lead the
+    # client to LiteLLM's own auth-server metadata, defeating the
+    # delegate flow. ``_delegate_auth_authorization_server_response``
+    # already gates on ``auth_type == oauth2`` + cached upstream URLs;
+    # reuse the same check here so PRM and AS metadata stay in sync.
+    delegated_auth_server: Optional[str] = None
+    if mcp_server is not None and mcp_server.delegate_auth_to_upstream:
+        delegated_meta = _delegate_auth_authorization_server_response(mcp_server)
+        if delegated_meta is not None:
+            delegated_auth_server = delegated_meta["issuer"]
+
+    if delegated_auth_server is not None:
+        authorization_servers = [delegated_auth_server]
+    elif mcp_server_name:
+        authorization_servers = [f"{request_base_url}/{mcp_server_name}"]
+    else:
+        authorization_servers = [request_base_url]
+
     return {
-        "authorization_servers": [
-            (
-                f"{request_base_url}/{mcp_server_name}"
-                if mcp_server_name
-                else f"{request_base_url}"
-            )
-        ],
+        "authorization_servers": authorization_servers,
         "resource": resource_url,
         "scopes_supported": (
             mcp_server.scopes if mcp_server and mcp_server.scopes else []
@@ -745,6 +758,26 @@ async def oauth_protected_resource_mcp_standard(request: Request, mcp_server_nam
     This endpoint is compliant with MCP specification and works with standard
     MCP clients like mcp-inspector and VSCode Copilot.
     """
+    return _build_oauth_protected_resource_response(
+        request=request,
+        mcp_server_name=mcp_server_name,
+        use_standard_pattern=True,
+    )
+
+
+# Canonical resource path: /mcp/{server_name}/mcp (path == streamable-http
+# endpoint). RFC 9728 / MCP 2025-06-18+ clients construct PRM by inserting
+# /.well-known/oauth-protected-resource between host and the full resource
+# path — so the resource at /mcp/atlassian1/mcp is probed at
+# /.well-known/oauth-protected-resource/mcp/atlassian1/mcp. mcp-inspector
+# (>= 0.21) does this; without this route it 404s and falls back to root
+# PRM, which can't carry server-specific auth metadata.
+@router.get(
+    f"/.well-known/oauth-protected-resource{'' if get_server_root_path() == '/' else get_server_root_path()}/mcp/{{mcp_server_name}}/mcp"
+)
+async def oauth_protected_resource_mcp_canonical(
+    request: Request, mcp_server_name: str
+):
     return _build_oauth_protected_resource_response(
         request=request,
         mcp_server_name=mcp_server_name,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -56,7 +56,7 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.litellm_pre_call_utils import (
     LiteLLMProxyRequestSetup,
@@ -2989,6 +2989,27 @@ if MCP_AVAILABLE:
                     detail="Forbidden",
                 )
 
+    def _proxy_exception_to_http_exception(exc: ProxyException) -> HTTPException:
+        """Convert a ``ProxyException`` raised in the auth/router stack into an
+        ``HTTPException`` so the ASGI MCP handlers can let Starlette emit a
+        well-formed response instead of collapsing to a generic 500.
+
+        ``ProxyException.code`` is normalised to ``str`` in its ``__init__`` and
+        may be ``"None"`` or non-numeric when the caller didn't pass a status,
+        so coerce defensively rather than letting ``int("None")`` rewrite the
+        error as a 500. ``headers`` is preserved so auth bootstrap hints
+        (e.g. ``WWW-Authenticate``) survive the conversion.
+        """
+        try:
+            status_code = int(exc.code)
+        except (TypeError, ValueError):
+            status_code = 500
+        return HTTPException(
+            status_code=status_code,
+            detail=exc.message,
+            headers=exc.headers or None,
+        )
+
     async def handle_streamable_http_mcp(
         scope: Scope, receive: Receive, send: Send
     ) -> None:
@@ -3117,6 +3138,13 @@ if MCP_AVAILABLE:
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise
+        except ProxyException as e:
+            # ProxyException carries the auth/router status code (e.g. 401)
+            # and any auth headers (e.g. ``WWW-Authenticate``). Re-raising as
+            # HTTPException preserves both — the previous catch-all 500 path
+            # collapsed the discovery hint that MCP clients depend on for
+            # OAuth bootstrap.
+            raise _proxy_exception_to_http_exception(e)
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions
@@ -3178,6 +3206,12 @@ if MCP_AVAILABLE:
                 _sse_client_ip,
             ):
                 await sse_session_manager.handle_request(scope, receive, send)
+        except HTTPException:
+            raise
+        except ProxyException as e:
+            # See handle_streamable_http_mcp: preserve status code and any
+            # auth headers (e.g. WWW-Authenticate) instead of collapsing to 500.
+            raise _proxy_exception_to_http_exception(e)
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Instead of re-raising, try to send a graceful error response

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -2861,3 +2861,154 @@ def test_build_oauth_authorization_server_response_falls_through_for_non_delegat
     assert "auth.atlassian.com" not in response["authorization_endpoint"]
     assert "auth.atlassian.com" not in response["token_endpoint"]
     assert response["authorization_endpoint"].endswith("/proxied/authorize")
+
+
+def test_build_oauth_protected_resource_advertises_upstream_for_delegate_auth():
+    """RFC 9728 PRM ``authorization_servers`` must mirror the AS-metadata
+    fix: a delegate-auth server points clients at the upstream IdP issuer,
+    not LiteLLM. Otherwise the client follows PRM → LiteLLM AS metadata
+    → LiteLLM endpoints, losing the delegate flow we just wired up."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_protected_resource_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _delegate_auth_server(scopes=["read:jira-work"])
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        response = _build_oauth_protected_resource_response(
+            request=mock_request,
+            mcp_server_name="atlassian1",
+            use_standard_pattern=True,
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert response["authorization_servers"] == ["https://auth.atlassian.com"]
+    assert response["scopes_supported"] == ["read:jira-work"]
+
+
+def test_build_oauth_protected_resource_falls_through_for_non_delegate():
+    """Regression guard: non-delegate servers keep advertising the LiteLLM
+    proxy as their authorization server (the existing flow)."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_protected_resource_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _delegate_auth_server(
+        server_id="proxied",
+        name="proxied",
+        delegate_auth_to_upstream=False,
+    )
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        response = _build_oauth_protected_resource_response(
+            request=mock_request,
+            mcp_server_name="proxied",
+            use_standard_pattern=True,
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert len(response["authorization_servers"]) == 1
+    assert "auth.atlassian.com" not in response["authorization_servers"][0]
+    assert response["authorization_servers"][0].endswith("/proxied")
+
+
+def test_build_oauth_protected_resource_falls_through_when_upstream_unresolved():
+    """Defensive: a delegate-auth server with no cached upstream URLs
+    (e.g. discovery hasn't run yet) should fall back to the LiteLLM URL
+    rather than emit an empty/half-formed authorization server entry."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_protected_resource_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _delegate_auth_server(
+        authorization_url=None,
+        token_url=None,
+    )
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        response = _build_oauth_protected_resource_response(
+            request=mock_request,
+            mcp_server_name="atlassian1",
+            use_standard_pattern=True,
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert len(response["authorization_servers"]) == 1
+    assert "auth.atlassian.com" not in response["authorization_servers"][0]
+
+
+@pytest.mark.asyncio
+async def test_canonical_protected_resource_route_returns_200_for_streamable_path():
+    """Mirror of the AS-metadata canonical route: mcp-inspector and other
+    spec-conforming clients construct PRM URLs by inserting
+    ``/.well-known/oauth-protected-resource`` between host and the
+    streamable-http resource path. Without this route they 404 and fall
+    back to the root PRM, which can't carry server-specific auth metadata.
+    """
+    import httpx
+    from fastapi import FastAPI
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        router as discoverable_router,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _delegate_auth_server()
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    app = FastAPI()
+    app.include_router(discoverable_router)
+
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://litellm.example.com"
+        ) as client:
+            response = await client.get(
+                "/.well-known/oauth-protected-resource/mcp/atlassian1/mcp"
+            )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authorization_servers"] == ["https://auth.atlassian.com"]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -2655,3 +2655,209 @@ async def test_token_endpoint_sets_no_store_cache_control():
 
     assert response.headers["cache-control"] == "no-store"
     assert response.headers["pragma"] == "no-cache"
+
+
+# -------------------------------------------------------------------
+# Tests for delegate-auth-to-upstream issuer override (LIT-3193 / Bug E)
+# -------------------------------------------------------------------
+
+
+def _delegate_auth_server(
+    server_id: str = "atlassian1",
+    name: str = "atlassian1",
+    *,
+    authorization_url: str = "https://auth.atlassian.com/authorize",
+    token_url: str = "https://auth.atlassian.com/oauth/token",
+    registration_url=None,
+    scopes=None,
+    delegate_auth_to_upstream: bool = True,
+    auth_type=None,
+):
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    return MCPServer(
+        server_id=server_id,
+        name=name,
+        server_name=name,
+        alias=name,
+        transport=MCPTransport.http,
+        auth_type=auth_type if auth_type is not None else MCPAuth.oauth2,
+        authorization_url=authorization_url,
+        token_url=token_url,
+        registration_url=registration_url,
+        scopes=scopes,
+        delegate_auth_to_upstream=delegate_auth_to_upstream,
+    )
+
+
+def test_delegate_auth_helper_returns_upstream_metadata():
+    """A delegate-auth oauth2 server with cached upstream URLs must surface
+    the upstream issuer/endpoints — not the LiteLLM proxy URLs — so the
+    end-user's MCP client drives PKCE against the real authorization server.
+    """
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _delegate_auth_authorization_server_response,
+    )
+
+    server = _delegate_auth_server(
+        registration_url="https://auth.atlassian.com/register",
+        scopes=["read:jira-work"],
+    )
+
+    response = _delegate_auth_authorization_server_response(server)
+
+    assert response is not None
+    assert response["issuer"] == "https://auth.atlassian.com"
+    assert response["authorization_endpoint"] == "https://auth.atlassian.com/authorize"
+    assert response["token_endpoint"] == "https://auth.atlassian.com/oauth/token"
+    assert response["registration_endpoint"] == "https://auth.atlassian.com/register"
+    assert response["response_types_supported"] == ["code"]
+    assert response["code_challenge_methods_supported"] == ["S256"]
+    assert "authorization_code" in response["grant_types_supported"]
+    assert response["scopes_supported"] == ["read:jira-work"]
+
+
+def test_delegate_auth_helper_omits_registration_when_unset():
+    """``registration_endpoint`` must be omitted when the upstream IdP
+    didn't advertise a DCR endpoint — including a null entry would break
+    spec-conforming clients that probe for it."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _delegate_auth_authorization_server_response,
+    )
+
+    response = _delegate_auth_authorization_server_response(
+        _delegate_auth_server(registration_url=None)
+    )
+
+    assert response is not None
+    assert "registration_endpoint" not in response
+
+
+def test_delegate_auth_helper_returns_none_for_non_delegate_server():
+    """Non-delegate servers must continue to use the LiteLLM-issuer
+    response — this helper should opt out so the caller falls through to
+    the existing behaviour. Regression guard for the Allegro-style M2M
+    flow."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _delegate_auth_authorization_server_response,
+    )
+
+    response = _delegate_auth_authorization_server_response(
+        _delegate_auth_server(delegate_auth_to_upstream=False)
+    )
+
+    assert response is None
+
+
+def test_delegate_auth_helper_returns_none_when_upstream_urls_missing():
+    """If the upstream metadata hasn't been resolved (e.g. registration-
+    time discovery failed), defer to the LiteLLM-issuer fallback rather
+    than emitting a half-formed response with empty endpoints."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _delegate_auth_authorization_server_response,
+    )
+
+    response = _delegate_auth_authorization_server_response(
+        _delegate_auth_server(authorization_url=None, token_url=None)
+    )
+
+    assert response is None
+
+
+def test_delegate_auth_helper_returns_none_when_auth_type_not_oauth2():
+    """``delegate_auth_to_upstream`` is only meaningful for ``oauth2``
+    servers; if the auth type is something else the upstream-issuer
+    rewrite would point clients at endpoints that don't speak OAuth."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _delegate_auth_authorization_server_response,
+    )
+    from litellm.types.mcp import MCPAuth
+
+    response = _delegate_auth_authorization_server_response(
+        _delegate_auth_server(auth_type=MCPAuth.api_key)
+    )
+
+    assert response is None
+
+
+def test_build_oauth_authorization_server_response_uses_delegated_metadata():
+    """Integration: when ``_build_oauth_authorization_server_response`` is
+    called with a delegate-auth server name, it must return the upstream-
+    issuer payload — not the LiteLLM-issuer fallback. This is the actual
+    user-visible regression we're fixing for LIT-3193."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_authorization_server_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _delegate_auth_server(scopes=["read:jira-work"])
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        response = _build_oauth_authorization_server_response(
+            request=mock_request,
+            mcp_server_name="atlassian1",
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    assert response["issuer"] == "https://auth.atlassian.com"
+    assert response["authorization_endpoint"] == "https://auth.atlassian.com/authorize"
+    assert response["token_endpoint"] == "https://auth.atlassian.com/oauth/token"
+    # Critical: the LiteLLM-proxy URLs MUST NOT leak into the response.
+    assert "litellm.example.com" not in response["issuer"]
+    assert "litellm.example.com" not in response["authorization_endpoint"]
+
+
+def test_build_oauth_authorization_server_response_falls_through_for_non_delegate():
+    """Regression guard: a non-delegate OAuth2 server must keep its
+    existing LiteLLM-issuer response shape (the proxy mediates the flow
+    via its own ``/authorize`` and ``/token``)."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_authorization_server_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _delegate_auth_server(
+        server_id="proxied",
+        name="proxied",
+        delegate_auth_to_upstream=False,
+        scopes=["read"],
+    )
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        response = _build_oauth_authorization_server_response(
+            request=mock_request,
+            mcp_server_name="proxied",
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    # Existing behaviour: proxy mediates, so issuer/endpoints point at LiteLLM
+    # (resolved by ``get_request_base_url`` from the request / env), NOT at
+    # the upstream IdP. We assert on the upstream-rewrite NOT happening.
+    assert response["issuer"] != "https://auth.atlassian.com"
+    assert "auth.atlassian.com" not in response["authorization_endpoint"]
+    assert "auth.atlassian.com" not in response["token_endpoint"]
+    assert response["authorization_endpoint"].endswith("/proxied/authorize")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_handler_proxy_exception_mapping.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_handler_proxy_exception_mapping.py
@@ -1,0 +1,211 @@
+"""
+Regression coverage for the ASGI MCP handlers' ``ProxyException`` mapping.
+
+Auth and router failures inside ``extract_mcp_auth_context`` raise
+``ProxyException``, which is the rest-of-proxy convention but is not an
+``HTTPException``. Without explicit handling, the handler's catch-all
+``except Exception`` collapsed those into a generic
+``500 {"error": "MCP request failed", "details": ""}`` response — losing the
+real status code (401/403) and any auth-bootstrap headers (``WWW-Authenticate``)
+that MCP clients depend on for OAuth discovery. These tests pin the corrected
+behavior: status code preserved, ``headers`` preserved, message preserved.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
+)
+
+from litellm.proxy._types import ProxyException
+
+
+def test_proxy_exception_to_http_exception_preserves_status_message_headers():
+    from litellm.proxy._experimental.mcp_server.server import (
+        _proxy_exception_to_http_exception,
+    )
+
+    proxy_exc = ProxyException(
+        message="Unauthorized",
+        type="auth_error",
+        param=None,
+        code=401,
+        headers={
+            "WWW-Authenticate": (
+                "Bearer authorization_uri="
+                "http://localhost:4000/.well-known/oauth-authorization-server/atlassian1"
+            )
+        },
+    )
+
+    http_exc = _proxy_exception_to_http_exception(proxy_exc)
+
+    assert isinstance(http_exc, HTTPException)
+    assert http_exc.status_code == 401
+    assert http_exc.detail == "Unauthorized"
+    assert http_exc.headers is not None
+    assert http_exc.headers["WWW-Authenticate"].startswith("Bearer authorization_uri=")
+
+
+def test_proxy_exception_to_http_exception_handles_non_numeric_code():
+    """``ProxyException.__init__`` stringifies ``code``; ``int("None")`` would
+    rewrite the auth error as a 500 if we coerced naively. Default to 500
+    instead so unknown statuses don't masquerade as auth errors."""
+    from litellm.proxy._experimental.mcp_server.server import (
+        _proxy_exception_to_http_exception,
+    )
+
+    proxy_exc = ProxyException(
+        message="boom", type="internal_error", param=None, code=None
+    )
+    http_exc = _proxy_exception_to_http_exception(proxy_exc)
+    assert http_exc.status_code == 500
+    assert http_exc.detail == "boom"
+
+
+def test_proxy_exception_to_http_exception_treats_empty_headers_as_none():
+    """``HTTPException(headers={})`` is technically valid but signals "I have
+    auth hints" downstream — collapse the empty dict to ``None`` so Starlette
+    doesn't emit a header block for nothing."""
+    from litellm.proxy._experimental.mcp_server.server import (
+        _proxy_exception_to_http_exception,
+    )
+
+    proxy_exc = ProxyException(
+        message="Bad request", type="bad_request", param=None, code=400
+    )
+    http_exc = _proxy_exception_to_http_exception(proxy_exc)
+    assert http_exc.status_code == 400
+    assert http_exc.headers is None
+
+
+@pytest.mark.asyncio
+async def test_streamable_handler_re_raises_proxy_exception_as_http_exception():
+    """End-to-end: an auth-stack ``ProxyException(401)`` with WWW-Authenticate
+    must surface to the ASGI layer as a real ``HTTPException`` (so Starlette
+    emits 401 + the header) rather than the catch-all 500 wrapper."""
+    from litellm.proxy._experimental.mcp_server.server import (
+        handle_streamable_http_mcp,
+    )
+
+    scope = {
+        "type": "http",
+        "path": "/mcp/atlassian1/mcp",
+        "method": "POST",
+        "query_string": b"",
+        "headers": [(b"authorization", b"Bearer not-a-real-litellm-key")],
+    }
+
+    auth_failure = ProxyException(
+        message="Authentication Error, Invalid proxy server token passed.",
+        type="auth_error",
+        param="Authorization",
+        code=401,
+        headers={
+            "WWW-Authenticate": (
+                "Bearer authorization_uri="
+                "http://localhost:4000/.well-known/oauth-authorization-server/atlassian1"
+            )
+        },
+    )
+
+    async def fake_receive():
+        return {"type": "http.disconnect"}
+
+    sent = []
+
+    async def fake_send(msg):
+        sent.append(msg)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new=AsyncMock(side_effect=auth_failure),
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await handle_streamable_http_mcp(scope, fake_receive, fake_send)
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == auth_failure.message
+    assert excinfo.value.headers is not None
+    assert "Bearer authorization_uri=" in excinfo.value.headers["WWW-Authenticate"]
+    # Sanity check: no 500 body was sent. The handler should let Starlette
+    # produce the response, not call ``send`` itself with the legacy 500 shape.
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_sse_handler_re_raises_proxy_exception_as_http_exception():
+    """Mirror of the streamable test, for the SSE entry point."""
+    from litellm.proxy._experimental.mcp_server.server import handle_sse_mcp
+
+    scope = {
+        "type": "http",
+        "path": "/mcp/atlassian1/sse",
+        "method": "GET",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    auth_failure = ProxyException(
+        message="Forbidden", type="auth_error", param=None, code=403
+    )
+
+    async def fake_receive():
+        return {"type": "http.disconnect"}
+
+    sent = []
+
+    async def fake_send(msg):
+        sent.append(msg)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new=AsyncMock(side_effect=auth_failure),
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await handle_sse_mcp(scope, fake_receive, fake_send)
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Forbidden"
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_streamable_handler_still_collapses_unexpected_exceptions_to_500():
+    """The new ``ProxyException`` catch must not regress the existing graceful
+    500 fallback for arbitrary exceptions."""
+    from litellm.proxy._experimental.mcp_server.server import (
+        handle_streamable_http_mcp,
+    )
+
+    scope = {
+        "type": "http",
+        "path": "/mcp/atlassian1/mcp",
+        "method": "POST",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    async def fake_receive():
+        return {"type": "http.disconnect"}
+
+    sent = []
+
+    async def fake_send(msg):
+        sent.append(msg)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new=AsyncMock(side_effect=RuntimeError("kaboom")),
+    ):
+        # Should NOT raise — handler sends a JSONResponse via ``send``.
+        await handle_streamable_http_mcp(scope, fake_receive, fake_send)
+
+    # JSONResponse sends start + body messages.
+    statuses = [m.get("status") for m in sent if m.get("type") == "http.response.start"]
+    assert statuses == [500]


### PR DESCRIPTION
## Summary
- Bug G — preserve auth status code and `WWW-Authenticate` on `ProxyException`. The MCP ASGI handlers caught all exceptions and collapsed them to `500 {"error":"MCP request failed"}`, so a 401 from the auth stack lost its status and discovery headers.
- Bug E — return the upstream IdP's metadata (issuer + `authorization_endpoint` + `token_endpoint` + `registration_endpoint`) for OAuth servers configured with `delegate_auth_to_upstream=true`. Previously the proxy returned its own URLs and the client followed them right back to LiteLLM, defeating the delegate flow.
- Mirror Bug E to RFC 9728 protected-resource metadata so PRM `authorization_servers` advertises the upstream issuer; add the canonical `/.well-known/oauth-protected-resource/mcp/<name>/mcp` route that spec-conforming clients (mcp-inspector ≥ 0.21) actually probe.

Stacked on top of #28543. Once that merges, this PR auto-retargets to `litellm_internal_staging`.

## Test plan
- [x] `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_handler_proxy_exception_mapping.py` — Bug G regression suite (6 tests covering 401/403 preservation, header passthrough, non-numeric `code` defaulting to 500, empty-headers normalization, and graceful 500 fallback for arbitrary exceptions)
- [x] `uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py -k "delegate_auth or protected_resource"` — 10 tests covering the helper, AS metadata, PRM, and the new canonical route
- [x] End-to-end against `mcp.atlassian.com` via `mcp-inspector`: 401 + `WWW-Authenticate` from `/mcp/atlassian1/mcp` triggers discovery → PRM resolves to Atlassian → AS metadata resolves to Atlassian → DCR succeeds → user consents at Atlassian → token exchange succeeds → 31 Atlassian tools list successfully
