### PR TITLE
Fix noisy unmapped model helper checks

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -140,6 +140,7 @@ def get_llm_provider(  # noqa: PLR0915
     api_base: Optional[str] = None,
     api_key: Optional[str] = None,
     litellm_params: Optional[LiteLLM_Params] = None,
+    suppress_debug_info: bool = False,
 ) -> Tuple[str, str, Optional[str], Optional[str]]:
     """
     Returns the provider for a given model name - e.g. 'azure/chatgpt-v-2' -> 'azure'
@@ -147,6 +148,8 @@ def get_llm_provider(  # noqa: PLR0915
     For router -> Can also give the whole litellm param dict -> this function will extract the relevant details
 
     Raises Error - if unable to map model to a provider
+
+    suppress_debug_info: avoid printing provider-list guidance before raising.
 
     Return model, custom_llm_provider, dynamic_api_key, api_base
     """
@@ -499,7 +502,7 @@ def get_llm_provider(  # noqa: PLR0915
         elif model.startswith("sap/"):
             custom_llm_provider = "sap"
         if not custom_llm_provider:
-            if litellm.suppress_debug_info is False:
+            if litellm.suppress_debug_info is False and suppress_debug_info is False:
                 print()  # noqa
                 print(  # noqa
                     "\033[1;31mProvider List: https://docs.litellm.ai/docs/providers\033[0m"  # noqa

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -26,7 +26,9 @@ def get_supported_openai_params(  # noqa: PLR0915
     """
     if not custom_llm_provider:
         try:
-            custom_llm_provider = litellm.get_llm_provider(model=model)[1]
+            custom_llm_provider = litellm.get_llm_provider(
+                model=model, suppress_debug_info=True
+            )[1]
         except BadRequestError:
             return None
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2464,7 +2464,9 @@ def supports_native_streaming(model: str, custom_llm_provider: Optional[str]) ->
     """
     try:
         model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            suppress_debug_info=True,
         )
 
         model_info = _get_model_info_helper(
@@ -2500,7 +2502,9 @@ def supports_response_schema(
     try:
         get_llm_provider = getattr(sys.modules[__name__], "get_llm_provider")
         model, custom_llm_provider, _, _ = get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            suppress_debug_info=True,
         )
     except Exception as e:
         verbose_logger.debug(
@@ -2603,7 +2607,9 @@ def _supports_factory(model: str, custom_llm_provider: Optional[str], key: str) 
     """
     try:
         model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            suppress_debug_info=True,
         )
 
         model_info = _get_model_info_helper(
@@ -2661,7 +2667,9 @@ def _is_explicitly_disabled_factory(
     """
     try:
         model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            suppress_debug_info=True,
         )
         model_info = _get_model_info_helper(
             model=model, custom_llm_provider=custom_llm_provider
@@ -2806,7 +2814,9 @@ def get_supported_regions(
     """
     try:
         model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            suppress_debug_info=True,
         )
 
         model_info = _get_model_info_helper(

--- a/tests/test_litellm/test_unmapped_model_helpers.py
+++ b/tests/test_litellm/test_unmapped_model_helpers.py
@@ -1,0 +1,25 @@
+from typing import Any, Callable
+
+import pytest
+
+import litellm
+
+
+@pytest.mark.parametrize(
+    ("helper", "expected"),
+    [
+        (litellm.get_supported_openai_params, None),
+        (litellm.supports_function_calling, False),
+        (litellm.supports_reasoning, False),
+        (litellm.supports_response_schema, False),
+    ],
+)
+def test_should_keep_quiet_for_unmapped_model_helpers(
+    capsys: pytest.CaptureFixture[str],
+    helper: Callable[..., Any],
+    expected: Any,
+) -> None:
+    assert helper(model="hhh") is expected
+
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Quiet helper-only provider resolution for unmapped model names. Helper APIs that return `None` or `False` for an unmapped model now suppress provider-list stdout while preserving the default guidance for direct provider resolution errors.

## Repro
Call model capability/introspection helpers with an unmapped placeholder model name such as `hhh`. Before this change, the helper returned the expected falsy value but also printed provider-list guidance to stdout.

## Evidence
```text
$ uv run --no-sync pytest tests/test_litellm/test_unmapped_model_helpers.py -vv
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /workspace/.venv/bin/python
cachedir: .pytest_cache
rootdir: /workspace
configfile: pyproject.toml
plugins: respx-0.22.0, cov-5.0.0, mock-3.15.1, xdist-3.8.0, postgresql-7.0.2, rerunfailures-15.1, requests-mock-1.12.1, timeout-2.4.0, anyio-4.13.0, recording-0.13.4, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collecting ... collected 4 items
tests/test_litellm/test_unmapped_model_helpers.py::test_should_keep_quiet_for_unmapped_model_helpers[get_supported_openai_params-None] PASSED [ 25%]
tests/test_litellm/test_unmapped_model_helpers.py::test_should_keep_quiet_for_unmapped_model_helpers[supports_function_calling-False] PASSED [ 50%]
tests/test_litellm/test_unmapped_model_helpers.py::test_should_keep_quiet_for_unmapped_model_helpers[supports_reasoning-False] PASSED [ 75%]
tests/test_litellm/test_unmapped_model_helpers.py::test_should_keep_quiet_for_unmapped_model_helpers[supports_response_schema-False] PASSED [100%]
============================== 4 passed in 0.09s ===============================
```

## Tests
- Added `tests/test_litellm/test_unmapped_model_helpers.py`.
- Confirmed the new test failed before the fix because stdout contained provider-list guidance.
- `uv run --no-sync pytest tests/test_litellm/test_unmapped_model_helpers.py -vv` passes locally.
- CI-scope lint workflow commands pass locally: lock check, frozen dependency sync, Black check, Ruff, MyPy, circular import check, and import safety check.
- `make test-unit` reached 4,716 passing tests before stopping on two environment-dependent failures outside this helper path: one live-provider authentication failure and one local connection failure.

## CI
- Remote checks: all visible GitHub Actions and CircleCI checks are passing except `ci/circleci: using_litellm_on_windows`, which was still pending as of 2026-05-22T04:53:51Z.
- Lint: ✅ https://github.com/BerriAI/litellm/actions/runs/26268740708/job/77317519344
- Core utils: ✅ https://github.com/BerriAI/litellm/actions/runs/26268740714/job/77317519443

## Review
- No automated review from the configured reviewer was posted after waiting more than 10 minutes from PR creation.

## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested automated review and received a sufficient confidence score before requesting maintainer review

## Screenshots / Proof of Fix

See the inline terminal transcript in the Evidence section.

## Type

🐛 Bug Fix
✅ Test

## Changes
- Added a silent provider-resolution option for helper/introspection paths.
- Used that option in support and supported-parameter helpers that already swallow unmapped model errors.
- Added regression coverage for the literal unmapped model shape from the report.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f285945b-1a34-4c39-97b9-19f7fc9c9d8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f285945b-1a34-4c39-97b9-19f7fc9c9d8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

