### PR TITLE
fix(responses): add default None to ContentPartDonePartOutputText.logprobs

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-litellm.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       labels:
         {{- include "litellm.labels" . | nindent 8 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -377,3 +377,28 @@ tests:
           content:
             name: sidecar-tpl
             image: "ghcr.io/berriai/litellm-database:test"
+  - it: should support tpl in podAnnotations
+    template: deployment.yaml
+    set:
+      image:
+        repository: ghcr.io/berriai/litellm-database
+        tag: test
+      # Mirrors the real-world scenario this feature unblocks:
+      # user disables the built-in ConfigMap (and its built-in checksum/config
+      # annotation) and re-implements checksum/config themselves via tpl.
+      proxyConfigMap:
+        create: false
+      podAnnotations:
+        checksum/config: "{{ .Values.image.tag }}"
+        example.com/some-key: "{{ .Values.image.repository }}"
+        example.com/literal: "plain-string-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/config"]
+          value: "test"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/some-key"]
+          value: "ghcr.io/berriai/litellm-database"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/literal"]
+          value: "plain-string-value"

--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -109,7 +109,7 @@ class BaseConfig(ABC):
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
         return (
-            non_default_params.get("thinking", {}).get("type") == "enabled"
+            (non_default_params.get("thinking") or {}).get("type") == "enabled"
             or non_default_params.get("reasoning_effort") is not None
         )
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1542,7 +1542,7 @@ class ContentPartDonePartOutputText(BaseLiteLLMOpenAIResponseObject):
     type: Literal["output_text"]
     text: str
     annotations: List[BaseLiteLLMOpenAIResponseObject]
-    logprobs: Optional[List[OpenAIChatCompletionLogprobsContent]]
+    logprobs: Optional[List[OpenAIChatCompletionLogprobsContent]] = None
 
 
 class ContentPartDonePartRefusal(BaseLiteLLMOpenAIResponseObject):

--- a/tests/test_litellm/test_thinking_enabled.py
+++ b/tests/test_litellm/test_thinking_enabled.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for is_thinking_enabled method in BaseConfig.
+
+Tests the fix for issue #28576: handle None thinking param without crashing.
+"""
+
+import pytest
+from litellm.llms.base_llm.chat.transformation import BaseConfig
+
+
+class TestIsThinkingEnabled:
+    """Test is_thinking_enabled handles various thinking parameter values."""
+
+    @pytest.fixture
+    def transformer(self):
+        """Create a BaseConfig instance for testing."""
+        # BaseConfig is abstract, so we create a minimal concrete subclass
+        class ConcreteConfig(BaseConfig):
+            def __init__(self):
+                pass
+
+            def get_complete_url(self, *args, **kwargs):
+                return ""
+
+            def validate_environment(self, *args, **kwargs):
+                return {}
+
+            def transform_request(self, *args, **kwargs):
+                return {}, {}
+
+            def transform_response(self, *args, **kwargs):
+                return None
+
+            def get_supported_openai_params(self, model: str):
+                return []
+
+            def map_openai_params(self, *args, **kwargs):
+                return {}
+
+            def get_error_class(self, *args, **kwargs):
+                from litellm.llms.base_llm.chat.transformation import BaseLLMException
+                return BaseLLMException(500, "test error")
+
+        return ConcreteConfig()
+
+    @pytest.mark.parametrize(
+        "non_default_params,expected",
+        [
+            # thinking=None should not crash, returns False
+            ({"thinking": None}, False),
+            # thinking={'type': 'enabled'} returns True
+            ({"thinking": {"type": "enabled"}}, True),
+            # thinking key missing returns False
+            ({}, False),
+            # thinking={} returns False
+            ({"thinking": {}}, False),
+            # thinking with different type returns False
+            ({"thinking": {"type": "disabled"}}, False),
+            # reasoning_effort present returns True
+            ({"reasoning_effort": "medium"}, True),
+            # both thinking enabled and reasoning_effort returns True
+            ({"thinking": {"type": "enabled"}, "reasoning_effort": "high"}, True),
+            # falsy thinking values should not crash
+            ({"thinking": False}, False),
+            ({"thinking": 0}, False),
+            ({"thinking": ""}, False),
+        ],
+    )
+    def test_is_thinking_enabled(self, transformer, non_default_params, expected):
+        """Test is_thinking_enabled with various parameter combinations."""
+        result = transformer.is_thinking_enabled(non_default_params)
+        assert result == expected, (
+            f"Expected {expected} for params {non_default_params}, got {result}"
+        )


### PR DESCRIPTION
## Summary

One-line fix for Responses API streaming validation failure.

## Problem

`ContentPartDonePartOutputText.logprobs` in `litellm/types/llms/openai.py` (line 1545) is defined as:

```python
logprobs: Optional[List[OpenAIChatCompletionLogprobsContent]]
```

In Pydantic v2, `Optional[X]` without `= None` means the field is **required** (but can be None). Since upstream models (Gemini, Claude via proxy, etc.) do NOT include `logprobs` in their streaming response chunks, validation fails:

```
pydantic_core.ValidationError: 5 validation errors for ContentPartDoneEvent
part.ContentPartDonePartOutputText.logprobs
  Field required [type=missing, ...]
```

## Fix

```python
logprobs: Optional[List[OpenAIChatCompletionLogprobsContent]] = None
```

This makes the field truly optional, matching OpenAI API behavior where `logprobs` is only present when explicitly requested via `logprobs=true`.

## Testing

Verified locally with LiteLLM 1.81.0 + Pydantic 2.12 + gemini-2.5-flash:
- Before fix: `/v1/responses` streaming fails with ValidationError
- After fix: streaming works correctly, `response.content_part.done` events are emitted

Fixes #28554