### PR TITLE
fix: use safe_deep_copy for fallback dict to prevent mutation across calls

### DIFF
--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -47,8 +47,9 @@ async def async_completion_with_fallbacks(**kwargs):
             completion_kwargs = safe_deep_copy(base_kwargs)
             # Handle dictionary fallback configurations
             if isinstance(fallback, dict):
-                model = fallback.pop("model", original_model)
-                completion_kwargs.update(fallback)
+                fallback_copy = safe_deep_copy(fallback)
+                model = fallback_copy.pop("model", original_model)
+                completion_kwargs.update(fallback_copy)
             else:
                 model = fallback
 

--- a/tests/test_litellm/test_fallback_utils.py
+++ b/tests/test_litellm/test_fallback_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -9,47 +9,64 @@ sys.path.insert(0, os.path.abspath("../../.."))
 from litellm.litellm_core_utils.fallback_utils import async_completion_with_fallbacks
 
 
+def _ok():
+    """Minimal non-None response that satisfies the `if response is not None` check."""
+    return MagicMock()
+
+
 @pytest.mark.asyncio
 async def test_dict_fallback_does_not_mutate_original():
-    """Reusing the same fallback dict across calls must not lose the model key."""
+    """Reusing the same fallback dict across calls must not lose the model key.
+
+    The primary model must fail so the loop actually reaches the dict fallback
+    entry and exercises the mutation fix.
+    """
     fallback = {"model": "gpt-4o-mini", "temperature": 0.5}
-    fallback_original_copy = dict(fallback)
+    fallback_original = {"model": "gpt-4o-mini", "temperature": 0.5}
 
-    mock_response = AsyncMock()
-    mock_response.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    # Call 1: primary raises → fallback dict path runs → returns ok
+    # Call 2: same pattern — model key must still be present in fallback
+    mock = AsyncMock(side_effect=[
+        Exception("primary failed"),  # call 1, primary "gpt-4o"
+        _ok(),                        # call 1, fallback "gpt-4o-mini"
+        Exception("primary failed"),  # call 2, primary "gpt-4o"
+        _ok(),                        # call 2, fallback "gpt-4o-mini"
+    ])
 
-    with patch("litellm.acompletion", new=mock_response):
+    with patch("litellm.acompletion", new=mock):
         await async_completion_with_fallbacks(
             model="gpt-4o",
             kwargs={"fallbacks": [fallback]},
         )
-        # Original fallback dict must be unchanged after the call
-        assert fallback == fallback_original_copy, (
-            "fallback dict was mutated: "
-            f"expected {fallback_original_copy}, got {fallback}"
+        assert fallback == fallback_original, (
+            f"fallback dict mutated after call 1: got {fallback}"
         )
 
-        # Second call with the same dict must still work (model key still present)
         await async_completion_with_fallbacks(
             model="gpt-4o",
             kwargs={"fallbacks": [fallback]},
         )
-        assert fallback == fallback_original_copy
+        assert fallback == fallback_original, (
+            f"fallback dict mutated after call 2: got {fallback}"
+        )
 
 
 @pytest.mark.asyncio
 async def test_dict_fallback_nested_mutable_not_mutated():
-    """Nested mutable values in the fallback dict must not be modified."""
+    """Nested mutable values in the fallback dict must survive after a call."""
     extra_headers = {"X-Custom": "value"}
     fallback = {"model": "gpt-4o-mini", "extra_headers": extra_headers}
 
-    mock_response = AsyncMock()
-    mock_response.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock = AsyncMock(side_effect=[
+        Exception("primary failed"),
+        _ok(),
+    ])
 
-    with patch("litellm.acompletion", new=mock_response):
+    with patch("litellm.acompletion", new=mock):
         await async_completion_with_fallbacks(
             model="gpt-4o",
             kwargs={"fallbacks": [fallback]},
         )
         assert fallback["model"] == "gpt-4o-mini"
         assert fallback["extra_headers"] is extra_headers
+        assert extra_headers == {"X-Custom": "value"}

--- a/tests/test_litellm/test_fallback_utils.py
+++ b/tests/test_litellm/test_fallback_utils.py
@@ -1,0 +1,55 @@
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.fallback_utils import async_completion_with_fallbacks
+
+
+@pytest.mark.asyncio
+async def test_dict_fallback_does_not_mutate_original():
+    """Reusing the same fallback dict across calls must not lose the model key."""
+    fallback = {"model": "gpt-4o-mini", "temperature": 0.5}
+    fallback_original_copy = dict(fallback)
+
+    mock_response = AsyncMock()
+    mock_response.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    with patch("litellm.acompletion", new=mock_response):
+        await async_completion_with_fallbacks(
+            model="gpt-4o",
+            kwargs={"fallbacks": [fallback]},
+        )
+        # Original fallback dict must be unchanged after the call
+        assert fallback == fallback_original_copy, (
+            "fallback dict was mutated: "
+            f"expected {fallback_original_copy}, got {fallback}"
+        )
+
+        # Second call with the same dict must still work (model key still present)
+        await async_completion_with_fallbacks(
+            model="gpt-4o",
+            kwargs={"fallbacks": [fallback]},
+        )
+        assert fallback == fallback_original_copy
+
+
+@pytest.mark.asyncio
+async def test_dict_fallback_nested_mutable_not_mutated():
+    """Nested mutable values in the fallback dict must not be modified."""
+    extra_headers = {"X-Custom": "value"}
+    fallback = {"model": "gpt-4o-mini", "extra_headers": extra_headers}
+
+    mock_response = AsyncMock()
+    mock_response.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    with patch("litellm.acompletion", new=mock_response):
+        await async_completion_with_fallbacks(
+            model="gpt-4o",
+            kwargs={"fallbacks": [fallback]},
+        )
+        assert fallback["model"] == "gpt-4o-mini"
+        assert fallback["extra_headers"] is extra_headers


### PR DESCRIPTION
## Problem

`async_completion_with_fallbacks` calls `fallback.pop("model")` directly on the caller-supplied dict. This mutates the original config in-place — any application that reuses the same fallback config across calls loses the `model` key after the first invocation, causing all subsequent fallback attempts to silently use the primary (failed) model.

## Fix

Replace the in-place `pop` with a deep copy using the existing `safe_deep_copy` utility (already imported and used for `base_kwargs` on line 47):

```python
# Before
model = fallback.pop("model", original_model)
completion_kwargs.update(fallback)

# After
fallback_copy = safe_deep_copy(fallback)
model = fallback_copy.pop("model", original_model)
completion_kwargs.update(fallback_copy)
```

This is consistent with how `base_kwargs` is already handled. `safe_deep_copy` (unlike `dict.copy()`) also protects nested mutable values such as `extra_headers` dicts.

## Tests

Added `tests/test_litellm/test_fallback_utils.py` with two unit tests:

- `test_dict_fallback_does_not_mutate_original` — calls the function twice with the same dict, asserts `model` key survives both calls
- `test_dict_fallback_nested_mutable_not_mutated` — asserts nested dicts are not modified

Both tests pass with the fix applied.

Fixes #28251