### PR TITLE
Fix/jwt user id reconciliation

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -1736,9 +1736,6 @@ class JWTAuthManager:
                 parent_otel_span=parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,
             )
-        # Extract alias fields for resolution (if configured)
-        org_alias = jwt_handler.get_org_alias(token=jwt_valid_token, default_value=None)
-
         # Get other objects
         (
             user_object,
@@ -1758,16 +1755,17 @@ class JWTAuthManager:
             parent_otel_span=parent_otel_span,
             proxy_logging_obj=proxy_logging_obj,
             route=route,
-            org_alias=org_alias,
+            org_alias=jwt_handler.get_org_alias(
+                token=jwt_valid_token, default_value=None
+            ),
         )
 
         # Reconcile to canonical UserTable.user_id if get_objects resolved via sso_user_id/email fuzzy match.
-        if (
-            user_object is not None
-            and user_object.user_id
-            and user_id != user_object.user_id
-        ):
-            user_id = user_object.user_id
+        user_id = (
+            user_object.user_id
+            if (user_object and user_object.user_id and user_id != user_object.user_id)
+            else user_id
+        )
 
         # Derive org_id from org_object if resolved by alias
         resolved_org_id = org_object.organization_id if org_object else org_id

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -1276,6 +1276,13 @@ class JWTAuthManager:
                 else None
             )
 
+        if (
+            user_object is not None
+            and user_object.user_id
+            and user_id != user_object.user_id
+        ):
+            user_id = user_object.user_id
+
         end_user_object: Optional[LiteLLM_EndUserTable] = None
         if end_user_id:
             end_user_object = (
@@ -1755,7 +1762,11 @@ class JWTAuthManager:
         )
 
         # Reconcile to canonical UserTable.user_id if get_objects resolved via sso_user_id/email fuzzy match.
-        if user_object is not None and user_object.user_id and user_id != user_object.user_id:
+        if (
+            user_object is not None
+            and user_object.user_id
+            and user_id != user_object.user_id
+        ):
             user_id = user_object.user_id
 
         # Derive org_id from org_object if resolved by alias

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -1754,6 +1754,10 @@ class JWTAuthManager:
             org_alias=org_alias,
         )
 
+        # Reconcile to canonical UserTable.user_id if get_objects resolved via sso_user_id/email fuzzy match.
+        if user_object is not None and user_object.user_id and user_id != user_object.user_id:
+            user_id = user_object.user_id
+
         # Derive org_id from org_object if resolved by alias
         resolved_org_id = org_object.organization_id if org_object else org_id
 

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -2774,9 +2774,7 @@ async def test_auth_builder_reconciles_jwt_email_to_canonical_uuid():
 
     with (
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
-        patch.object(
-            JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
-        ),
+        patch.object(JWTAuthManager, "check_rbac_role", new_callable=AsyncMock),
         patch.object(jwt_handler, "get_rbac_role", return_value=None),
         patch.object(jwt_handler, "get_scopes", return_value=[]),
         patch.object(jwt_handler, "get_object_id", return_value=None),
@@ -2852,9 +2850,7 @@ async def test_auth_builder_reconciles_sso_external_id_to_canonical_uuid():
 
     with (
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
-        patch.object(
-            JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
-        ),
+        patch.object(JWTAuthManager, "check_rbac_role", new_callable=AsyncMock),
         patch.object(jwt_handler, "get_rbac_role", return_value=None),
         patch.object(jwt_handler, "get_scopes", return_value=[]),
         patch.object(jwt_handler, "get_object_id", return_value=None),
@@ -2930,9 +2926,7 @@ async def test_auth_builder_no_reconciliation_when_jwt_user_id_already_canonical
 
     with (
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
-        patch.object(
-            JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
-        ),
+        patch.object(JWTAuthManager, "check_rbac_role", new_callable=AsyncMock),
         patch.object(jwt_handler, "get_rbac_role", return_value=None),
         patch.object(jwt_handler, "get_scopes", return_value=[]),
         patch.object(jwt_handler, "get_object_id", return_value=None),
@@ -2988,3 +2982,67 @@ async def test_auth_builder_no_reconciliation_when_jwt_user_id_already_canonical
 
         assert result["user_id"] == canonical_uuid
         assert result["user_object"] == user_object
+
+
+@pytest.mark.asyncio
+async def test_get_objects_passes_canonical_user_id_to_team_membership():
+    """
+    When get_user_object resolves an SSO email to a canonical UUID, get_team_membership
+    must receive the canonical UUID, not the raw JWT claim.
+    """
+    from litellm.caching import DualCache
+    from litellm.proxy._types import LiteLLM_JWTAuth
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_email = "user@example.com"
+    canonical_uuid = "uuid-canonical-1234"
+    team_id = "team-abc"
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=user_api_key_cache)
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(),
+    )
+
+    user_obj = LiteLLM_UserTable(
+        user_id=canonical_uuid, user_role=LitellmUserRoles.INTERNAL_USER
+    )
+
+    with (
+        patch(
+            "litellm.proxy.auth.handle_jwt.get_user_object",
+            new_callable=AsyncMock,
+            return_value=user_obj,
+        ),
+        patch(
+            "litellm.proxy.auth.handle_jwt.get_team_membership",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ) as mock_get_membership,
+    ):
+        await JWTAuthManager.get_objects(
+            user_id=jwt_email,
+            user_email=jwt_email,
+            org_id=None,
+            end_user_id=None,
+            team_id=team_id,
+            valid_user_email=True,
+            jwt_handler=jwt_handler,
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=proxy_logging_obj,
+            route="/chat/completions",
+        )
+
+        mock_get_membership.assert_called_once_with(
+            user_id=canonical_uuid,
+            team_id=team_id,
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=proxy_logging_obj,
+        )

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -2776,7 +2776,7 @@ async def test_auth_builder_reconciles_jwt_email_to_canonical_uuid():
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
         patch.object(
             JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
-        ) as mock_check_rbac,
+        ),
         patch.object(jwt_handler, "get_rbac_role", return_value=None),
         patch.object(jwt_handler, "get_scopes", return_value=[]),
         patch.object(jwt_handler, "get_object_id", return_value=None),
@@ -2854,7 +2854,7 @@ async def test_auth_builder_reconciles_sso_external_id_to_canonical_uuid():
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
         patch.object(
             JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
-        ) as mock_check_rbac,
+        ),
         patch.object(jwt_handler, "get_rbac_role", return_value=None),
         patch.object(jwt_handler, "get_scopes", return_value=[]),
         patch.object(jwt_handler, "get_object_id", return_value=None),
@@ -2932,7 +2932,7 @@ async def test_auth_builder_no_reconciliation_when_jwt_user_id_already_canonical
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
         patch.object(
             JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
-        ) as mock_check_rbac,
+        ),
         patch.object(jwt_handler, "get_rbac_role", return_value=None),
         patch.object(jwt_handler, "get_scopes", return_value=[]),
         patch.object(jwt_handler, "get_object_id", return_value=None),

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -2754,3 +2754,237 @@ def test_build_decode_kwargs_no_warning_when_scoped(
         if "neither JWT_AUDIENCE nor JWT_ISSUER" in r.getMessage()
     ]
     assert matching == []
+
+
+@pytest.mark.asyncio
+async def test_auth_builder_reconciles_jwt_email_to_canonical_uuid():
+    """JWT user_id is email; get_objects resolves the canonical UUID row — result must carry the UUID."""
+    api_key = "test_jwt_token"
+    request_data = {"model": "gpt-4"}
+    general_settings = {"enforce_rbac": False}
+    route = "/chat/completions"
+
+    canonical_uuid = "uuid-aaaa-1234-5678-canonical"
+    user_object = LiteLLM_UserTable(
+        user_id=canonical_uuid, user_role=LitellmUserRoles.INTERNAL_USER
+    )
+
+    jwt_handler = JWTHandler()
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth()
+
+    with (
+        patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
+        patch.object(
+            JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
+        ) as mock_check_rbac,
+        patch.object(jwt_handler, "get_rbac_role", return_value=None),
+        patch.object(jwt_handler, "get_scopes", return_value=[]),
+        patch.object(jwt_handler, "get_object_id", return_value=None),
+        patch.object(
+            JWTAuthManager,
+            "get_user_info",
+            new_callable=AsyncMock,
+            return_value=("user@example.com", "user@example.com", True),
+        ),
+        patch.object(jwt_handler, "get_org_id", return_value=None),
+        patch.object(jwt_handler, "get_end_user_id", return_value=None),
+        patch.object(
+            JWTAuthManager,
+            "check_admin_access",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            JWTAuthManager,
+            "find_and_validate_specific_team_id",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch.object(JWTAuthManager, "get_all_team_ids", return_value=set()),
+        patch.object(
+            JWTAuthManager,
+            "find_team_with_model_access",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch.object(
+            JWTAuthManager,
+            "get_objects",
+            new_callable=AsyncMock,
+            return_value=(user_object, None, None, None),
+        ),
+        patch.object(JWTAuthManager, "map_user_to_teams", new_callable=AsyncMock),
+        patch.object(JWTAuthManager, "validate_object_id", return_value=True),
+    ):
+        mock_auth_jwt.return_value = {"sub": "user@example.com", "scope": ""}
+
+        result = await JWTAuthManager.auth_builder(
+            api_key=api_key,
+            jwt_handler=jwt_handler,
+            request_data=request_data,
+            general_settings=general_settings,
+            route=route,
+            prisma_client=None,
+            user_api_key_cache=None,
+            parent_otel_span=None,
+            proxy_logging_obj=None,
+        )
+
+        assert result["user_id"] == canonical_uuid
+        assert result["user_object"] == user_object
+
+
+@pytest.mark.asyncio
+async def test_auth_builder_reconciles_sso_external_id_to_canonical_uuid():
+    """JWT user_id is an opaque SSO external ID; get_objects fuzzy-matches to the canonical UUID row."""
+    api_key = "test_jwt_token"
+    request_data = {"model": "gpt-4"}
+    general_settings = {"enforce_rbac": False}
+    route = "/chat/completions"
+
+    canonical_uuid = "uuid-bbbb-5678-canonical"
+    user_object = LiteLLM_UserTable(
+        user_id=canonical_uuid, user_role=LitellmUserRoles.INTERNAL_USER
+    )
+
+    jwt_handler = JWTHandler()
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth()
+
+    with (
+        patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
+        patch.object(
+            JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
+        ) as mock_check_rbac,
+        patch.object(jwt_handler, "get_rbac_role", return_value=None),
+        patch.object(jwt_handler, "get_scopes", return_value=[]),
+        patch.object(jwt_handler, "get_object_id", return_value=None),
+        patch.object(
+            JWTAuthManager,
+            "get_user_info",
+            new_callable=AsyncMock,
+            return_value=("ext-sso-id-xyz", "user@example.com", True),
+        ),
+        patch.object(jwt_handler, "get_org_id", return_value=None),
+        patch.object(jwt_handler, "get_end_user_id", return_value=None),
+        patch.object(
+            JWTAuthManager,
+            "check_admin_access",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            JWTAuthManager,
+            "find_and_validate_specific_team_id",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch.object(JWTAuthManager, "get_all_team_ids", return_value=set()),
+        patch.object(
+            JWTAuthManager,
+            "find_team_with_model_access",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch.object(
+            JWTAuthManager,
+            "get_objects",
+            new_callable=AsyncMock,
+            return_value=(user_object, None, None, None),
+        ),
+        patch.object(JWTAuthManager, "map_user_to_teams", new_callable=AsyncMock),
+        patch.object(JWTAuthManager, "validate_object_id", return_value=True),
+    ):
+        mock_auth_jwt.return_value = {"sub": "ext-sso-id-xyz", "scope": ""}
+
+        result = await JWTAuthManager.auth_builder(
+            api_key=api_key,
+            jwt_handler=jwt_handler,
+            request_data=request_data,
+            general_settings=general_settings,
+            route=route,
+            prisma_client=None,
+            user_api_key_cache=None,
+            parent_otel_span=None,
+            proxy_logging_obj=None,
+        )
+
+        assert result["user_id"] == canonical_uuid
+        assert result["user_object"] == user_object
+
+
+@pytest.mark.asyncio
+async def test_auth_builder_no_reconciliation_when_jwt_user_id_already_canonical():
+    """When JWT user_id already matches user_object.user_id, result is unchanged."""
+    api_key = "test_jwt_token"
+    request_data = {"model": "gpt-4"}
+    general_settings = {"enforce_rbac": False}
+    route = "/chat/completions"
+
+    canonical_uuid = "uuid-cccc-9999-canonical"
+    user_object = LiteLLM_UserTable(
+        user_id=canonical_uuid, user_role=LitellmUserRoles.INTERNAL_USER
+    )
+
+    jwt_handler = JWTHandler()
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth()
+
+    with (
+        patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
+        patch.object(
+            JWTAuthManager, "check_rbac_role", new_callable=AsyncMock
+        ) as mock_check_rbac,
+        patch.object(jwt_handler, "get_rbac_role", return_value=None),
+        patch.object(jwt_handler, "get_scopes", return_value=[]),
+        patch.object(jwt_handler, "get_object_id", return_value=None),
+        patch.object(
+            JWTAuthManager,
+            "get_user_info",
+            new_callable=AsyncMock,
+            return_value=(canonical_uuid, "user@example.com", True),
+        ),
+        patch.object(jwt_handler, "get_org_id", return_value=None),
+        patch.object(jwt_handler, "get_end_user_id", return_value=None),
+        patch.object(
+            JWTAuthManager,
+            "check_admin_access",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            JWTAuthManager,
+            "find_and_validate_specific_team_id",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch.object(JWTAuthManager, "get_all_team_ids", return_value=set()),
+        patch.object(
+            JWTAuthManager,
+            "find_team_with_model_access",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch.object(
+            JWTAuthManager,
+            "get_objects",
+            new_callable=AsyncMock,
+            return_value=(user_object, None, None, None),
+        ),
+        patch.object(JWTAuthManager, "map_user_to_teams", new_callable=AsyncMock),
+        patch.object(JWTAuthManager, "validate_object_id", return_value=True),
+    ):
+        mock_auth_jwt.return_value = {"sub": canonical_uuid, "scope": ""}
+
+        result = await JWTAuthManager.auth_builder(
+            api_key=api_key,
+            jwt_handler=jwt_handler,
+            request_data=request_data,
+            general_settings=general_settings,
+            route=route,
+            prisma_client=None,
+            user_api_key_cache=None,
+            parent_otel_span=None,
+            proxy_logging_obj=None,
+        )
+
+        assert result["user_id"] == canonical_uuid
+        assert result["user_object"] == user_object


### PR DESCRIPTION
## Relevant issues

Fixes #28537

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<img width="2550" height="1318" alt="1" src="https://github.com/user-attachments/assets/e01cf8c2-393d-4145-afd5-4d82e0b2706e" />
<img width="2525" height="1289" alt="2" src="https://github.com/user-attachments/assets/cf44f4f5-a7ac-4497-b868-319e0d2b4755" />

## Type

🐛 Bug Fix

## Changes
`auth_builder` in `handle_jwt.py` calls `get_objects()`, which resolves the canonical `LiteLLM_UserTable` row via fuzzy `sso_user_id`/email match and returns it as `user_object`. The resolved `user_object.user_id` (stable UUID) was never written back to the local `user_id` variable, so `JWTAuthBuilderResult.user_id` carried the raw JWT claim (e.g. the email when `user_id_jwt_field: "email"`) instead.

Every downstream consumer keyed off `user_id` (BYOK credential lookup, spend tracking, team membership, audit trail) received the email string. The sk-key path uses the canonical UUID (keys are FK-bound to it), silently splitting one SSO identity into two.

Fix: after `get_objects()` returns, set `user_id = user_object.user_id` when they differ. The `!=` guard is a no-op for the upsert path and RBAC flows where `user_id` is already the canonical UUID.