### PR TITLE
Fix agents key list page size

### DIFF
--- a/ui/litellm-dashboard/src/components/agents.test.tsx
+++ b/ui/litellm-dashboard/src/components/agents.test.tsx
@@ -89,6 +89,68 @@ describe("AgentsPanel", () => {
     });
   });
 
+  it("should fetch agent keys with the key list API max page size", async () => {
+    vi.mocked(networking.getAgentsList).mockResolvedValueOnce({
+      agents: [
+        {
+          agent_id: "agent-1",
+          agent_name: "Test Agent",
+          litellm_params: { model: "gpt-4o" },
+        },
+      ],
+    });
+
+    render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
+
+    await waitFor(() => {
+      expect(networking.keyListCall).toHaveBeenCalledWith(
+        "test-token",
+        null,
+        null,
+        null,
+        null,
+        null,
+        1,
+        100,
+      );
+    });
+  });
+
+  it("should keep fetching key list pages until visible agent keys are found", async () => {
+    vi.mocked(networking.getAgentsList).mockResolvedValueOnce({
+      agents: [
+        {
+          agent_id: "agent-1",
+          agent_name: "Test Agent",
+          litellm_params: { model: "gpt-4o" },
+        },
+      ],
+    });
+    vi.mocked(networking.keyListCall)
+      .mockResolvedValueOnce({ keys: [], total_pages: 2 })
+      .mockResolvedValueOnce({
+        keys: [{ agent_id: "agent-1", key_alias: "agent-key", token: "1234567890" }],
+        total_pages: 2,
+      });
+
+    render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
+
+    await waitFor(() => {
+      expect(networking.keyListCall).toHaveBeenCalledTimes(2);
+      expect(networking.keyListCall).toHaveBeenLastCalledWith(
+        "test-token",
+        null,
+        null,
+        null,
+        null,
+        null,
+        2,
+        100,
+      );
+      expect(screen.getByText("Active")).toBeInTheDocument();
+    });
+  });
+
   it("should call getAgentsList with health_check=true when toggle is enabled", async () => {
     render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
     await waitFor(() => {

--- a/ui/litellm-dashboard/src/components/agents.tsx
+++ b/ui/litellm-dashboard/src/components/agents.tsx
@@ -33,6 +33,37 @@ interface AgentsResponse {
   agents: Agent[];
 }
 
+interface AgentKeyRecord {
+  agent_id?: string;
+  key_alias?: string;
+  token?: string;
+}
+
+interface KeyListResponse {
+  keys?: AgentKeyRecord[];
+  total_pages?: number;
+}
+
+const KEY_LIST_PAGE_SIZE = 100;
+
+const addAgentKeysToMap = (
+  keys: AgentKeyRecord[],
+  keyInfoMap: Record<string, AgentKeyInfo>,
+  missingAgentIds: Set<string>,
+) => {
+  for (const key of keys) {
+    const agentId = key.agent_id;
+    if (agentId && missingAgentIds.has(agentId)) {
+      keyInfoMap[agentId] = {
+        has_key: true,
+        key_alias: key.key_alias,
+        token_prefix: key.token ? `${key.token.slice(0, 8)}…` : undefined,
+      };
+      missingAgentIds.delete(agentId);
+    }
+  }
+};
+
 const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams }) => {
   const [agentsList, setAgentsList] = useState<Agent[]>([]);
   const [keyInfoMap, setKeyInfoMap] = useState<Record<string, AgentKeyInfo>>({});
@@ -64,29 +95,27 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
   const fetchKeysForAgents = async () => {
     if (!accessToken) return;
     try {
-      const { keys = [] } = await keyListCall(
-        accessToken,
-        null,
-        null,
-        null,
-        null,
-        null,
-        1,
-        500
-      );
       const map: Record<string, AgentKeyInfo> = {};
-      for (const key of keys) {
-        const agentId = (key as { agent_id?: string }).agent_id;
-        if (agentId && !map[agentId]) {
-          map[agentId] = {
-            has_key: true,
-            key_alias: (key as { key_alias?: string }).key_alias,
-            token_prefix: (key as { token?: string }).token
-              ? `${(key as { token: string }).token.slice(0, 8)}…`
-              : undefined,
-          };
-        }
+      const missingAgentIds = new Set(agentsList.map((agent) => agent.agent_id));
+      let page = 1;
+      let totalPages = 1;
+
+      while (page <= totalPages && missingAgentIds.size > 0) {
+        const { keys = [], total_pages = 1 }: KeyListResponse = await keyListCall(
+          accessToken,
+          null,
+          null,
+          null,
+          null,
+          null,
+          page,
+          KEY_LIST_PAGE_SIZE
+        );
+        addAgentKeysToMap(keys, map, missingAgentIds);
+        totalPages = total_pages;
+        page += 1;
       }
+
       setKeyInfoMap(map);
     } catch (error) {
       console.error("Error fetching keys for agents:", error);


### PR DESCRIPTION
## Summary

Fixes #28585

- Fix the Agents page key lookup to request `size=100` from `/key/list`.
- Page through `/key/list` until all visible agents have matching key metadata or the API reports no more pages.
- Add regression tests for the backend page-size limit and multi-page key lookup.

## Context

The Agents page previously asked `/key/list` for `size=500` while also requesting:

```text
return_full_object=true&include_team_keys=true&include_created_by_keys=true
```

The backend endpoint defines `size` with `le=100`, so `size=500` fails FastAPI query validation and returns `422 Unprocessable Content` before key-list business logic runs.

The first fix aligned the UI with that backend limit. Review feedback then pointed out that a single `size=100` request could silently truncate key metadata in deployments with more than 100 visible keys. This update keeps the backend limit and fetches additional pages only while there are still visible agents missing key metadata.

## Verification

- `npm test -- agents.test.tsx --run` — pass, 13 tests
- `npm run build` — pass
- `npm run test -- --run` — pass, 383 files / 3867 tests
- `npm audit signatures` — pass, 802 packages with verified registry signatures and 122 packages with verified attestations

## Notes

No npm dependencies or lockfiles were changed.
