### PR TITLE
 fix(logging): add CredentialScrubberFilter to strip secrets from all log output (CWE-312)

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-litellm.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       labels:
         {{- include "litellm.labels" . | nindent 8 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -377,3 +377,28 @@ tests:
           content:
             name: sidecar-tpl
             image: "ghcr.io/berriai/litellm-database:test"
+  - it: should support tpl in podAnnotations
+    template: deployment.yaml
+    set:
+      image:
+        repository: ghcr.io/berriai/litellm-database
+        tag: test
+      # Mirrors the real-world scenario this feature unblocks:
+      # user disables the built-in ConfigMap (and its built-in checksum/config
+      # annotation) and re-implements checksum/config themselves via tpl.
+      proxyConfigMap:
+        create: false
+      podAnnotations:
+        checksum/config: "{{ .Values.image.tag }}"
+        example.com/some-key: "{{ .Values.image.repository }}"
+        example.com/literal: "plain-string-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/config"]
+          value: "test"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/some-key"]
+          value: "ghcr.io/berriai/litellm-database"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/literal"]
+          value: "plain-string-value"

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -62,10 +62,11 @@ class SecretRedactionFilter(logging.Filter):
             if isinstance(record.msg, str):
                 record.msg = _redact_string(record.msg)
 
-        # Redact exception tracebacks
+        # Redact exception tracebacks — use _scrub_secrets so key-name patterns
+        # (e.g. encryption_key=...) are covered in addition to value-shape ones.
         if record.exc_info and record.exc_info[1] is not None:
             try:
-                record.exc_text = _redact_string(
+                record.exc_text = _scrub_secrets(
                     self._formatter.formatException(record.exc_info)
                 )
             except Exception:

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -496,20 +496,23 @@ class CredentialScrubberFilter(logging.Filter):
         if record.msg and isinstance(record.msg, str):
             record.msg = _scrub_secrets(record.msg)
         if record.args:
-            if isinstance(record.args, dict):
-                record.args = {
-                    k: (
-                        _REDACTED
-                        if isinstance(k, str) and _SECRET_KEY_NAME_RE.match(k)
-                        else _scrub_arg(v)
-                    )
-                    for k, v in record.args.items()
-                }
-            elif isinstance(record.args, tuple):
-                record.args = tuple(_scrub_arg(a) for a in record.args)
-            else:
-                # Single non-tuple arg (e.g. verbose_logger.error("msg", exc_obj))
-                record.args = (_scrub_arg(record.args),)
+            try:
+                if isinstance(record.args, dict):
+                    record.args = {
+                        k: (
+                            _REDACTED
+                            if isinstance(k, str) and _SECRET_KEY_NAME_RE.match(k)
+                            else _scrub_arg(v)
+                        )
+                        for k, v in record.args.items()
+                    }
+                elif isinstance(record.args, tuple):
+                    record.args = tuple(_scrub_arg(a) for a in record.args)
+                else:
+                    # Single non-tuple arg (e.g. verbose_logger.error("msg", exc_obj))
+                    record.args = (_scrub_arg(record.args),)
+            except Exception:
+                pass  # Never crash logging; leave args unmodified on error
         if record.exc_info and record.exc_info[1] is not None:
             try:
                 record.exc_text = _scrub_secrets(

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -1,6 +1,7 @@
 import ast
 import logging
 import os
+import re
 import sys
 from datetime import datetime
 from logging import Formatter
@@ -429,3 +430,87 @@ def _is_debugging_on() -> bool:
     Returns True if debugging is on
     """
     return verbose_logger.isEnabledFor(logging.DEBUG) or set_verbose is True
+
+
+_SECRET_KEY_RE = re.compile(
+    r"(?i)"
+    r"(api[_\-]?key|secret[_\-]?key|access[_\-]?key|auth[_\-]?token|"
+    r"password|passwd|access[_\-]?token|refresh[_\-]?token|id[_\-]?token|"
+    r"credential|private[_\-]?key|encryption[_\-]?key|master[_\-]?key|"
+    r"redis[_\-]?password|client[_\-]?secret|aws[_\-]?secret|"
+    r"gcp[_\-]?key|litellm[_\-]?key)"
+    r'(["\']?\s*[:=]\s*["\']?)(?!-----)([^\s\'"&,}\]]{6,})'
+)
+# Anchored version of the same key names — used to detect secret dict keys.
+_SECRET_KEY_NAME_RE = re.compile(
+    r"(?i)^(api[_\-]?key|secret[_\-]?key|access[_\-]?key|auth[_\-]?token|"
+    r"password|passwd|access[_\-]?token|refresh[_\-]?token|id[_\-]?token|"
+    r"credential|private[_\-]?key|encryption[_\-]?key|master[_\-]?key|"
+    r"redis[_\-]?password|client[_\-]?secret|aws[_\-]?secret|"
+    r"gcp[_\-]?key|litellm[_\-]?key)$"
+)
+_REDACTED = "[REDACTED]"
+
+
+def _scrub_secrets(text: str) -> str:
+    """Replace secret values in log text with [REDACTED]."""
+    text = _redact_string(text)
+    return _SECRET_KEY_RE.sub(lambda m: m.group(1) + m.group(2) + _REDACTED, text)
+
+
+class CredentialScrubberFilter(logging.Filter):
+    """Logging filter that redacts credential values from all log records.
+
+    Complements SecretRedactionFilter (value-shape matching) by matching on
+    secret key names (api_key=, encryption_key=, redis_password=, …).
+
+    Opt-out: set LITELLM_DISABLE_REDACT_SECRETS=true to disable all redaction.
+    Dict args: keys matching _SECRET_KEY_NAME_RE are redacted regardless of
+    value type; other keys have their string values pattern-scrubbed.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Honour the LITELLM_DISABLE_REDACT_SECRETS opt-out env var.
+        if not _ENABLE_SECRET_REDACTION:
+            return True
+        if record.msg and isinstance(record.msg, str):
+            record.msg = _scrub_secrets(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {
+                    k: (
+                        _REDACTED
+                        if _SECRET_KEY_NAME_RE.match(k)
+                        else (_scrub_secrets(str(v)) if isinstance(v, str) else v)
+                    )
+                    for k, v in record.args.items()
+                }
+            elif isinstance(record.args, tuple):
+                record.args = tuple(
+                    (
+                        _scrub_secrets(str(a))
+                        if not isinstance(a, (bool, int, float, type(None)))
+                        else a
+                    )
+                    for a in record.args
+                )
+        if record.exc_info and record.exc_info[1] is not None:
+            try:
+                record.exc_text = _scrub_secrets(
+                    logging.Formatter().formatException(record.exc_info)
+                )
+            except Exception:
+                pass
+        for key, value in list(record.__dict__.items()):
+            if key not in _STANDARD_RECORD_ATTRS:
+                if _SECRET_KEY_NAME_RE.match(key) and value is not None:
+                    setattr(record, key, _REDACTED)
+                elif isinstance(value, str):
+                    setattr(record, key, _scrub_secrets(value))
+        return True
+
+
+_credential_scrubber = CredentialScrubberFilter()
+verbose_logger.addFilter(_credential_scrubber)
+verbose_proxy_logger.addFilter(_credential_scrubber)
+verbose_router_logger.addFilter(_credential_scrubber)

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -449,13 +449,29 @@ _SECRET_KEY_NAME_RE = re.compile(
     r"redis[_\-]?password|client[_\-]?secret|aws[_\-]?secret|"
     r"gcp[_\-]?key|litellm[_\-]?key)$"
 )
-_REDACTED = "[REDACTED]"
+_REDACTED = "REDACTED"
 
 
 def _scrub_secrets(text: str) -> str:
-    """Replace secret values in log text with [REDACTED]."""
+    """Replace secret values in log text with REDACTED."""
     text = _redact_string(text)
     return _SECRET_KEY_RE.sub(lambda m: m.group(1) + m.group(2) + _REDACTED, text)
+
+
+def _scrub_arg(a: object) -> object:
+    """Scrub a single log arg, preserving the original type when no secret is found.
+
+    Returns the original object unchanged if its string representation contains
+    no recognised secret patterns — this prevents type-coercion side-effects such
+    as breaking %d/%f format specifiers for Decimal or numpy integer args.
+    """
+    if isinstance(a, (bool, int, float, type(None))):
+        return a
+    if isinstance(a, str):
+        return _scrub_secrets(a)
+    s = str(a)
+    scrubbed = _scrub_secrets(s)
+    return scrubbed if scrubbed != s else a
 
 
 class CredentialScrubberFilter(logging.Filter):
@@ -466,8 +482,11 @@ class CredentialScrubberFilter(logging.Filter):
 
     Opt-out: set LITELLM_DISABLE_REDACT_SECRETS=true to disable all redaction.
     Dict args: keys matching _SECRET_KEY_NAME_RE are redacted regardless of
-    value type; other keys have their string values pattern-scrubbed.
+    value type; other keys are passed through _scrub_arg which handles nested
+    containers and preserves original types when no secret is found.
     """
+
+    _formatter = logging.Formatter()
 
     def filter(self, record: logging.LogRecord) -> bool:
         # Honour the LITELLM_DISABLE_REDACT_SECRETS opt-out env var.
@@ -480,24 +499,20 @@ class CredentialScrubberFilter(logging.Filter):
                 record.args = {
                     k: (
                         _REDACTED
-                        if _SECRET_KEY_NAME_RE.match(k)
-                        else (_scrub_secrets(str(v)) if isinstance(v, str) else v)
+                        if isinstance(k, str) and _SECRET_KEY_NAME_RE.match(k)
+                        else _scrub_arg(v)
                     )
                     for k, v in record.args.items()
                 }
             elif isinstance(record.args, tuple):
-                record.args = tuple(
-                    (
-                        _scrub_secrets(str(a))
-                        if not isinstance(a, (bool, int, float, type(None)))
-                        else a
-                    )
-                    for a in record.args
-                )
+                record.args = tuple(_scrub_arg(a) for a in record.args)
+            else:
+                # Single non-tuple arg (e.g. verbose_logger.error("msg", exc_obj))
+                record.args = (_scrub_arg(record.args),)
         if record.exc_info and record.exc_info[1] is not None:
             try:
                 record.exc_text = _scrub_secrets(
-                    logging.Formatter().formatException(record.exc_info)
+                    self._formatter.formatException(record.exc_info)
                 )
             except Exception:
                 pass

--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -109,7 +109,7 @@ class BaseConfig(ABC):
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
         return (
-            non_default_params.get("thinking", {}).get("type") == "enabled"
+            (non_default_params.get("thinking") or {}).get("type") == "enabled"
             or non_default_params.get("reasoning_effort") is not None
         )
 

--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -108,10 +108,9 @@ class BaseConfig(ABC):
         return type_to_response_format_param(response_format=response_format)
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
-        return (
-            (non_default_params.get("thinking") or {}).get("type") == "enabled"
-            or non_default_params.get("reasoning_effort") is not None
-        )
+        return (non_default_params.get("thinking") or {}).get(
+            "type"
+        ) == "enabled" or non_default_params.get("reasoning_effort") is not None
 
     def is_max_tokens_in_request(self, non_default_params: dict) -> bool:
         """

--- a/tests/test_litellm/litellm_core_utils/test_credential_scrubber.py
+++ b/tests/test_litellm/litellm_core_utils/test_credential_scrubber.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from decimal import Decimal
 from unittest.mock import patch
 
 import litellm._logging as log_module
@@ -27,7 +28,10 @@ class TestScrubSecrets:
     def test_pem_value_not_partially_redacted(self):
         pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIE\n-----END RSA PRIVATE KEY-----"
         result = _scrub_secrets(f"private_key = {pem}")
-        assert "MIIE" not in result or "-----BEGIN" in result
+        # PEM body must not appear as an orphan without its surrounding structure.
+        # Header-only (body redacted) is acceptable; body-only (orphan fragment) is not.
+        if "MIIE" in result:
+            assert "-----BEGIN RSA PRIVATE KEY-----" in result
 
 
 class TestCredentialScrubberFilter:
@@ -72,11 +76,28 @@ class TestCredentialScrubberFilter:
         f.filter(record)
         assert "sk-secret123456789" not in str(record.args)
 
-    def test_dict_args_non_string_value_untouched(self):
+    def test_dict_args_non_secret_int_value_preserved(self):
+        # Non-secret key + int value: original type must survive (no str() coercion).
         f = CredentialScrubberFilter()
         record = self._make_record("config %s", {"count": 42})
         f.filter(record)
         assert record.args == {"count": 42}  # type: ignore[comparison-overlap]
+
+    def test_dict_args_non_string_key_no_crash(self):
+        # Non-string dict keys (unusual but legal) must not raise TypeError.
+        f = CredentialScrubberFilter()
+        record = self._make_record("config %s", {1: "api_key=sk-secret123456789"})
+        f.filter(record)  # must not raise
+        assert "sk-secret123456789" not in str(record.args)
+
+    def test_dict_args_nested_dict_value_scrubbed(self):
+        # Non-string nested dict under a non-secret key must still be scrubbed.
+        f = CredentialScrubberFilter()
+        record = self._make_record(
+            "headers %s", {"headers": {"Authorization": "Bearer sk-nestednested1234"}}
+        )
+        f.filter(record)
+        assert "sk-nestednested1234" not in str(record.args)
 
     def test_tuple_args_secret_redacted(self):
         f = CredentialScrubberFilter()
@@ -102,6 +123,22 @@ class TestCredentialScrubberFilter:
         assert args[1] is None
         assert "sk-secret123456789" not in str(args[2])
         assert "sk-dictval12345678901" not in str(args[3])
+
+    def test_tuple_args_numeric_type_preserved_when_no_secret(self):
+        # Decimal has no secret: original object must be kept so %f/%d still works.
+        f = CredentialScrubberFilter()
+        record = self._make_record("count=%s", (Decimal("42"),))
+        f.filter(record)
+        assert isinstance(record.args[0], Decimal)  # type: ignore[index]
+
+    def test_bare_exception_arg_scrubbed(self):
+        # verbose_logger.error("msg", exc) sets record.args = exc (not a tuple).
+        exc = ValueError("api_key=sk-bareexception12345")
+        f = CredentialScrubberFilter()
+        record = self._make_record("error %s")
+        record.args = exc  # type: ignore[assignment]
+        f.filter(record)
+        assert "sk-bareexception12345" not in str(record.args)
 
     def test_no_args_no_crash(self):
         f = CredentialScrubberFilter()
@@ -131,7 +168,7 @@ class TestCredentialScrubberFilter:
         record = self._make_record("config %s", {"api_key": "sk-rawsecretvalue123"})
         f.filter(record)
         assert "sk-rawsecretvalue123" not in str(record.args)
-        assert "[REDACTED]" in str(record.args)
+        assert "REDACTED" in str(record.args)
 
     def test_dict_args_secret_key_non_string_value_redacted(self):
         # Key-name check fires for non-string values too (e.g. bytes).
@@ -139,7 +176,7 @@ class TestCredentialScrubberFilter:
         record = self._make_record("config %s", {"api_key": b"sk-bytessecret123"})
         f.filter(record)
         assert "sk-bytessecret123" not in str(record.args)
-        assert "[REDACTED]" in str(record.args)
+        assert "REDACTED" in str(record.args)
 
     def test_exc_traceback_secret_redacted(self):
         try:
@@ -159,7 +196,7 @@ class TestCredentialScrubberFilter:
         record.api_key = "sk-extrasecret123456789"  # type: ignore[attr-defined]
         record.debug_info = "api_key=sk-embeddedsecret12345"  # type: ignore[attr-defined]
         f.filter(record)
-        assert getattr(record, "api_key") == "[REDACTED]"
+        assert getattr(record, "api_key") == "REDACTED"
         assert "sk-embeddedsecret12345" not in getattr(record, "debug_info", "")
 
     def test_exc_format_error_is_silently_ignored(self):

--- a/tests/test_litellm/litellm_core_utils/test_credential_scrubber.py
+++ b/tests/test_litellm/litellm_core_utils/test_credential_scrubber.py
@@ -140,6 +140,18 @@ class TestCredentialScrubberFilter:
         f.filter(record)
         assert "sk-bareexception12345" not in str(record.args)
 
+    def test_broken_str_arg_does_not_crash_logging(self):
+        # If __str__ on an arg raises, filter must leave args unchanged and not propagate.
+        class BadStr:
+            def __str__(self):
+                raise RuntimeError("broken __str__")
+
+        f = CredentialScrubberFilter()
+        original_args = (BadStr(),)
+        record = self._make_record("msg %s", original_args)
+        f.filter(record)  # must not raise
+        assert record.args is original_args  # left untouched
+
     def test_no_args_no_crash(self):
         f = CredentialScrubberFilter()
         record = self._make_record("plain message with no args")

--- a/tests/test_litellm/litellm_core_utils/test_credential_scrubber.py
+++ b/tests/test_litellm/litellm_core_utils/test_credential_scrubber.py
@@ -179,8 +179,11 @@ class TestCredentialScrubberFilter:
         assert "REDACTED" in str(record.args)
 
     def test_exc_traceback_secret_redacted(self):
+        # Use a key-name-only secret (no recognised value shape) so the test
+        # exercises the gap where SecretRedactionFilter would otherwise overwrite
+        # exc_text using only _redact_string and miss the key-name match.
         try:
-            raise ValueError("api_key=sk-secretinexception12345")
+            raise ValueError("encryption_key=hunter2secret99")
         except ValueError:
             ei = sys.exc_info()
         f = CredentialScrubberFilter()
@@ -188,7 +191,7 @@ class TestCredentialScrubberFilter:
         record.exc_info = ei
         f.filter(record)
         assert record.exc_text is not None
-        assert "sk-secretinexception12345" not in record.exc_text
+        assert "hunter2secret99" not in record.exc_text
 
     def test_extra_fields_secret_redacted(self):
         f = CredentialScrubberFilter()

--- a/tests/test_litellm/test_credential_scrubber.py
+++ b/tests/test_litellm/test_credential_scrubber.py
@@ -1,0 +1,178 @@
+import logging
+import sys
+from unittest.mock import patch
+
+import litellm._logging as log_module
+from litellm._logging import CredentialScrubberFilter, _scrub_secrets
+
+
+class TestScrubSecrets:
+
+    def test_known_patterns_are_redacted(self):
+        for text, secret in [
+            ("api_key=sk-abcdef123456789", "sk-abcdef"),
+            ("aws_secret_key: AKIAIOSFODNN7EXAMPLE", "AKIAIOSFODNN7EXAMPLE"),
+            ("access_token: eyJhbGciOiJSUzI1NiJ9abcdef", "eyJhbGciOiJSUzI1NiJ9abcdef"),
+        ]:
+            assert secret not in _scrub_secrets(text)
+
+    def test_non_secrets_pass_through(self):
+        result = _scrub_secrets(
+            "model=gpt-4o, endpoint=https://api.openai.com, api_key=abc"
+        )
+        assert "gpt-4o" in result
+        assert "api.openai.com" in result
+        assert "abc" in result  # < 6 chars, not redacted
+
+    def test_pem_value_not_partially_redacted(self):
+        pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIE\n-----END RSA PRIVATE KEY-----"
+        result = _scrub_secrets(f"private_key = {pem}")
+        assert "MIIE" not in result or "-----BEGIN" in result
+
+
+class TestCredentialScrubberFilter:
+
+    def _make_record(self, msg, args=None):
+        # Construct with args=() then set record.args directly — passing a dict
+        # to LogRecord.__init__ triggers a KeyError on Python 3.13.
+        record = logging.LogRecord(
+            name="test",
+            level=logging.DEBUG,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+        if args is not None:
+            record.args = args  # type: ignore[assignment]
+        return record
+
+    def test_string_msg_with_secret_is_redacted(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("api_key=sk-secret123456789")
+        assert f.filter(record) is True
+        assert "sk-secret123456789" not in record.msg
+
+    def test_non_string_msg_untouched(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record(12345)
+        f.filter(record)
+        assert record.msg == 12345
+
+    def test_none_msg_untouched(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record(None)
+        f.filter(record)
+        assert record.msg is None
+
+    def test_dict_args_secret_redacted(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("config %s", {"info": "api_key=sk-secret123456789"})
+        f.filter(record)
+        assert "sk-secret123456789" not in str(record.args)
+
+    def test_dict_args_non_string_value_untouched(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("config %s", {"count": 42})
+        f.filter(record)
+        assert record.args == {"count": 42}  # type: ignore[comparison-overlap]
+
+    def test_tuple_args_secret_redacted(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("config: %s", ("api_key=sk-secret123456789",))
+        f.filter(record)
+        assert "sk-secret123456789" not in str(record.args)
+
+    def test_tuple_args_mixed_types_non_string_passthrough(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record(
+            "vals=%s %s %s %s",
+            (
+                42,
+                None,
+                "api_key=sk-secret123456789",
+                {"api_key": "sk-dictval12345678901"},
+            ),
+        )
+        f.filter(record)
+        args = record.args
+        assert isinstance(args, tuple)
+        assert args[0] == 42
+        assert args[1] is None
+        assert "sk-secret123456789" not in str(args[2])
+        assert "sk-dictval12345678901" not in str(args[3])
+
+    def test_no_args_no_crash(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("plain message with no args")
+        f.filter(record)
+        assert record.msg == "plain message with no args"
+
+    def test_filter_registered_on_all_loggers(self):
+        for logger in (
+            log_module.verbose_logger,
+            log_module.verbose_proxy_logger,
+            log_module.verbose_router_logger,
+        ):
+            assert any(
+                type(f).__name__ == "CredentialScrubberFilter" for f in logger.filters
+            )
+
+    def test_filter_respects_disable_redaction_env_var(self):
+        with patch("litellm._logging._ENABLE_SECRET_REDACTION", False):
+            f = CredentialScrubberFilter()
+            record = self._make_record("api_key=sk-secret123456789")
+            f.filter(record)
+            assert "sk-secret123456789" in record.msg
+
+    def test_dict_args_secret_key_name_redacts_raw_value(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("config %s", {"api_key": "sk-rawsecretvalue123"})
+        f.filter(record)
+        assert "sk-rawsecretvalue123" not in str(record.args)
+        assert "[REDACTED]" in str(record.args)
+
+    def test_dict_args_secret_key_non_string_value_redacted(self):
+        # Key-name check fires for non-string values too (e.g. bytes).
+        f = CredentialScrubberFilter()
+        record = self._make_record("config %s", {"api_key": b"sk-bytessecret123"})
+        f.filter(record)
+        assert "sk-bytessecret123" not in str(record.args)
+        assert "[REDACTED]" in str(record.args)
+
+    def test_exc_traceback_secret_redacted(self):
+        try:
+            raise ValueError("api_key=sk-secretinexception12345")
+        except ValueError:
+            ei = sys.exc_info()
+        f = CredentialScrubberFilter()
+        record = self._make_record("error occurred")
+        record.exc_info = ei
+        f.filter(record)
+        assert record.exc_text is not None
+        assert "sk-secretinexception12345" not in record.exc_text
+
+    def test_extra_fields_secret_redacted(self):
+        f = CredentialScrubberFilter()
+        record = self._make_record("msg")
+        record.api_key = "sk-extrasecret123456789"  # type: ignore[attr-defined]
+        record.debug_info = "api_key=sk-embeddedsecret12345"  # type: ignore[attr-defined]
+        f.filter(record)
+        assert getattr(record, "api_key") == "[REDACTED]"
+        assert "sk-embeddedsecret12345" not in getattr(record, "debug_info", "")
+
+    def test_exc_format_error_is_silently_ignored(self):
+        # When formatException() raises, filter must not propagate the error.
+        try:
+            raise ValueError("api_key=sk-secretinexception12345")
+        except ValueError:
+            ei = sys.exc_info()
+        f = CredentialScrubberFilter()
+        record = self._make_record("error occurred")
+        record.exc_info = ei
+        with patch(
+            "logging.Formatter.formatException", side_effect=RuntimeError("fmt failed")
+        ):
+            f.filter(record)
+        assert record.exc_text is None

--- a/tests/test_litellm/test_thinking_enabled.py
+++ b/tests/test_litellm/test_thinking_enabled.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for is_thinking_enabled method in BaseConfig.
+
+Tests the fix for issue #28576: handle None thinking param without crashing.
+"""
+
+import pytest
+from litellm.llms.base_llm.chat.transformation import BaseConfig
+
+
+class TestIsThinkingEnabled:
+    """Test is_thinking_enabled handles various thinking parameter values."""
+
+    @pytest.fixture
+    def transformer(self):
+        """Create a BaseConfig instance for testing."""
+        # BaseConfig is abstract, so we create a minimal concrete subclass
+        class ConcreteConfig(BaseConfig):
+            def __init__(self):
+                pass
+
+            def get_complete_url(self, *args, **kwargs):
+                return ""
+
+            def validate_environment(self, *args, **kwargs):
+                return {}
+
+            def transform_request(self, *args, **kwargs):
+                return {}, {}
+
+            def transform_response(self, *args, **kwargs):
+                return None
+
+            def get_supported_openai_params(self, model: str):
+                return []
+
+            def map_openai_params(self, *args, **kwargs):
+                return {}
+
+            def get_error_class(self, *args, **kwargs):
+                from litellm.llms.base_llm.chat.transformation import BaseLLMException
+                return BaseLLMException(500, "test error")
+
+        return ConcreteConfig()
+
+    @pytest.mark.parametrize(
+        "non_default_params,expected",
+        [
+            # thinking=None should not crash, returns False
+            ({"thinking": None}, False),
+            # thinking={'type': 'enabled'} returns True
+            ({"thinking": {"type": "enabled"}}, True),
+            # thinking key missing returns False
+            ({}, False),
+            # thinking={} returns False
+            ({"thinking": {}}, False),
+            # thinking with different type returns False
+            ({"thinking": {"type": "disabled"}}, False),
+            # reasoning_effort present returns True
+            ({"reasoning_effort": "medium"}, True),
+            # both thinking enabled and reasoning_effort returns True
+            ({"thinking": {"type": "enabled"}, "reasoning_effort": "high"}, True),
+            # falsy thinking values should not crash
+            ({"thinking": False}, False),
+            ({"thinking": 0}, False),
+            ({"thinking": ""}, False),
+        ],
+    )
+    def test_is_thinking_enabled(self, transformer, non_default_params, expected):
+        """Test is_thinking_enabled with various parameter combinations."""
+        result = transformer.is_thinking_enabled(non_default_params)
+        assert result == expected, (
+            f"Expected {expected} for params {non_default_params}, got {result}"
+        )


### PR DESCRIPTION
## What   
  Adds `CredentialScrubberFilter` to `litellm/_logging.py` — a `logging.Filter`
  subclass that intercepts all LiteLLM log records and redacts secret values
  (API keys, passwords, encryption keys, tokens) by matching on secret key names.
  Registered on `verbose_logger`, `verbose_proxy_logger`, and `verbose_router_logger`
  at module import time, covering every log call across the codebase automatically.

  ## Why
  117 CodeQL findings (CWE-312) show secrets logged in plain text across the codebase.
  The most critical: `encrypt_decrypt_utils.py:31,65,69,74` logs the **encryption key**
  itself. If logs are shipped to Datadog / CloudWatch / Splunk, every credential is exposed.

  Patching all 117 call sites individually creates 117 separate diffs. A single logging
  filter at the logger level covers all present and future log sites in one change.

  The existing `SecretRedactionFilter` matches on secret **values** (formats like `sk-xxx`,
  `AKIA…`, PEM blocks). This filter is complementary — it matches on secret **key names**
  (`api_key=…`, `encryption_key=…`, `redis_password=…`), catching any value associated
  with a known secret key regardless of format.

  ## Changes
  
  ### `litellm/_logging.py`
  - Added `import re` to module-level imports
  - Added `_SECRET_KEY_RE` compiled regex matching 16 key-name patterns
  - Added `_SECRET_KEY_NAME_RE` anchored regex for detecting secret-named dict keys
  - Added `_scrub_secrets(text: str) -> str` helper
  - Added `CredentialScrubberFilter(logging.Filter)` with:
    - `LITELLM_DISABLE_REDACT_SECRETS` opt-out via `_ENABLE_SECRET_REDACTION` guard
    - Dict key-name redaction (keys matching `_SECRET_KEY_NAME_RE` always redacted)
    - exc_info and extra-field scrubbing
  - Registered filter on all three LiteLLM loggers

  ### `tests/test_litellm/test_credential_scrubber.py`
  - 18 unit tests covering every branch: known-pattern redaction, non-secret passthrough,
    PEM safe passthrough, str/non-str/None msg, dict args (string value, secret key name
    with raw value, secret key name with non-string value, non-secret key), tuple args
    (secret, mixed types), no args, filter registration on all 3 loggers,
    `LITELLM_DISABLE_REDACT_SECRETS` opt-out, exc_info scrubbing,
    formatException error silently ignored, extra-field scrubbing

  ## Testing
  - 18 new tests: all pass
  - All existing CI checks: pass (zero regressions)

  ## Screenshots
<img width="860" height="480" alt="before_after_logging" src="https://github.com/user-attachments/assets/036ece17-87da-4915-a962-3eeca37de140" />
<img width="1547" height="477" alt="image" src="https://github.com/user-attachments/assets/d177dd2a-96a4-4bdc-85f2-dfffad1060c4" />


 ### PR raised by Avani at Incubyte
  ---