### PR TITLE
fix(responses-adapter): extract cache_read_input_tokens from OpenAI Responses API

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -259,15 +259,33 @@ class AnthropicResponsesStreamWrapper:
                 if usage is not None:
                     input_tokens = getattr(usage, "input_tokens", 0) or 0
                     output_tokens = getattr(usage, "output_tokens", 0) or 0
-                    cache_creation_tokens = getattr(usage, "input_tokens_details", None)  # type: ignore[assignment]
-                    cache_read_tokens = getattr(usage, "output_tokens_details", None)  # type: ignore[assignment]
-                    # Prefer direct cache fields if present
-                    cache_creation_tokens = int(
+
+                    # Extract cache tokens from OpenAI Responses API fields
+                    input_tokens_details = getattr(usage, "input_tokens_details", None)
+                    if input_tokens_details is not None:
+                        cache_read_tokens = int(
+                            getattr(input_tokens_details, "cached_tokens", 0) or 0
+                        )
+
+                    output_tokens_details = getattr(
+                        usage, "output_tokens_details", None
+                    )
+                    if output_tokens_details is not None:
+                        # No cache_creation field in OpenAI output_tokens_details,
+                        # but check for future compatibility
+                        pass
+
+                    # Fall back to Anthropic-native fields if present
+                    anthropic_cache_creation = int(
                         getattr(usage, "cache_creation_input_tokens", 0) or 0
                     )
-                    cache_read_tokens = int(
+                    if anthropic_cache_creation:
+                        cache_creation_tokens = anthropic_cache_creation
+                    anthropic_cache_read = int(
                         getattr(usage, "cache_read_input_tokens", 0) or 0
                     )
+                    if anthropic_cache_read:
+                        cache_read_tokens = anthropic_cache_read
 
             # Check if tool_use was in the output to override stop_reason
             if response_obj is not None:

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -501,10 +501,35 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
         output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
 
+        # Extract cache tokens from OpenAI Responses API fields
+        cache_creation_tokens = 0
+        cache_read_tokens = 0
+        if raw_usage is not None:
+            input_tokens_details = getattr(raw_usage, "input_tokens_details", None)
+            if input_tokens_details is not None:
+                cache_read_tokens = int(
+                    getattr(input_tokens_details, "cached_tokens", 0) or 0
+                )
+            # Fall back to Anthropic-native fields if present
+            anthropic_cache_creation = int(
+                getattr(raw_usage, "cache_creation_input_tokens", 0) or 0
+            )
+            if anthropic_cache_creation:
+                cache_creation_tokens = anthropic_cache_creation
+            anthropic_cache_read = int(
+                getattr(raw_usage, "cache_read_input_tokens", 0) or 0
+            )
+            if anthropic_cache_read:
+                cache_read_tokens = anthropic_cache_read
+
         anthropic_usage = AnthropicUsage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
+        if cache_creation_tokens:
+            anthropic_usage["cache_creation_input_tokens"] = cache_creation_tokens
+        if cache_read_tokens:
+            anthropic_usage["cache_read_input_tokens"] = cache_read_tokens
 
         return AnthropicMessagesResponse(
             id=response.id,

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -497,39 +497,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             stop_reason = "max_tokens"
 
         # usage
-        raw_usage: Optional[ResponseAPIUsage] = response.usage
-        input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
-        output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
-
-        # Extract cache tokens from OpenAI Responses API fields
-        cache_creation_tokens = 0
-        cache_read_tokens = 0
-        if raw_usage is not None:
-            input_tokens_details = getattr(raw_usage, "input_tokens_details", None)
-            if input_tokens_details is not None:
-                cache_read_tokens = int(
-                    getattr(input_tokens_details, "cached_tokens", 0) or 0
-                )
-            # Fall back to Anthropic-native fields if present
-            anthropic_cache_creation = int(
-                getattr(raw_usage, "cache_creation_input_tokens", 0) or 0
-            )
-            if anthropic_cache_creation:
-                cache_creation_tokens = anthropic_cache_creation
-            anthropic_cache_read = int(
-                getattr(raw_usage, "cache_read_input_tokens", 0) or 0
-            )
-            if anthropic_cache_read:
-                cache_read_tokens = anthropic_cache_read
-
-        anthropic_usage = AnthropicUsage(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-        )
-        if cache_creation_tokens:
-            anthropic_usage["cache_creation_input_tokens"] = cache_creation_tokens
-        if cache_read_tokens:
-            anthropic_usage["cache_read_input_tokens"] = cache_read_tokens
+        anthropic_usage = self._build_usage(response.usage)
 
         return AnthropicMessagesResponse(
             id=response.id,
@@ -541,3 +509,38 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             content=content,  # type: ignore
             stop_reason=stop_reason,
         )
+
+    @staticmethod
+    def _build_usage(raw_usage: Optional[Any]) -> "AnthropicUsage":
+        """Build AnthropicUsage dict from OpenAI Responses API usage."""
+        input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
+
+        cache_creation_tokens = 0
+        cache_read_tokens = 0
+        if raw_usage is not None:
+            input_tokens_details = getattr(raw_usage, "input_tokens_details", None)
+            if input_tokens_details is not None:
+                cache_read_tokens = int(
+                    getattr(input_tokens_details, "cached_tokens", 0) or 0
+                )
+            anthropic_cache_creation = int(
+                getattr(raw_usage, "cache_creation_input_tokens", 0) or 0
+            )
+            if anthropic_cache_creation:
+                cache_creation_tokens = anthropic_cache_creation
+            anthropic_cache_read = int(
+                getattr(raw_usage, "cache_read_input_tokens", 0) or 0
+            )
+            if anthropic_cache_read:
+                cache_read_tokens = anthropic_cache_read
+
+        usage = AnthropicUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+        if cache_creation_tokens:
+            usage["cache_creation_input_tokens"] = cache_creation_tokens
+        if cache_read_tokens:
+            usage["cache_read_input_tokens"] = cache_read_tokens
+        return usage

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -425,8 +425,6 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             ResponseReasoningItem,
         )
 
-        from litellm.types.llms.openai import ResponseAPIUsage
-
         content: List[Dict[str, Any]] = []
         stop_reason: AnthropicFinishReason = "end_turn"
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_cache.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_cache.py
@@ -1,0 +1,144 @@
+"""
+Tests for cache token extraction in AnthropicResponsesStreamWrapper.
+
+Verifies that the streaming adapter correctly extracts cache_read_input_tokens
+from both OpenAI Responses API (input_tokens_details.cached_tokens) and
+Anthropic-native fields (cache_read_input_tokens).
+
+Fixes: https://github.com/BerriAI/litellm/issues/28354
+"""
+
+import os
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../../../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
+    AnthropicResponsesStreamWrapper,
+)
+
+
+def _make_wrapper() -> AnthropicResponsesStreamWrapper:
+    """Create a wrapper with a mock stream."""
+    mock_stream = MagicMock()
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=mock_stream,
+        model="gpt-4o",
+    )
+    return wrapper
+
+
+def _make_completed_event(
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cached_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    use_openai_format: bool = True,
+) -> MagicMock:
+    """Build a mock response.completed event."""
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+
+    if use_openai_format and cached_tokens:
+        input_details = MagicMock()
+        input_details.cached_tokens = cached_tokens
+        usage.input_tokens_details = input_details
+    else:
+        usage.input_tokens_details = None
+
+    usage.output_tokens_details = None
+
+    # Set or delete Anthropic-native fields
+    if cache_creation_input_tokens:
+        usage.cache_creation_input_tokens = cache_creation_input_tokens
+    else:
+        # Use spec to make getattr return 0
+        usage.cache_creation_input_tokens = 0
+
+    if cache_read_input_tokens:
+        usage.cache_read_input_tokens = cache_read_input_tokens
+    else:
+        usage.cache_read_input_tokens = 0
+
+    response = MagicMock()
+    response.id = "resp_test"
+    response.model = "gpt-4o"
+    response.status = "completed"
+    response.output = []
+    response.usage = usage
+
+    event = MagicMock()
+    event.type = "response.completed"
+    event.response = response
+    # Make dict-like access fail so getattr path is used
+    event.__contains__ = lambda self, key: False
+    event.get = lambda key, default=None: default if key != "response" else response
+
+    return event
+
+
+class TestStreamingCacheTokenExtraction:
+    """Streaming adapter extracts cache tokens from OpenAI and Anthropic usage."""
+
+    def test_openai_cached_tokens_extracted(self):
+        """input_tokens_details.cached_tokens -> cache_read_input_tokens in usage delta."""
+        wrapper = _make_wrapper()
+        event = _make_completed_event(
+            input_tokens=1000,
+            output_tokens=50,
+            cached_tokens=800,
+            use_openai_format=True,
+        )
+        wrapper._process_event(event)
+
+        # Find the message_delta chunk
+        delta_chunks = [
+            c for c in wrapper._chunk_queue if c.get("type") == "message_delta"
+        ]
+        assert len(delta_chunks) == 1
+        usage = delta_chunks[0]["usage"]
+        assert usage["cache_read_input_tokens"] == 800
+
+    def test_anthropic_native_fields_used_as_fallback(self):
+        """Anthropic-native cache fields override when present."""
+        wrapper = _make_wrapper()
+        event = _make_completed_event(
+            input_tokens=1000,
+            output_tokens=50,
+            cached_tokens=0,
+            cache_creation_input_tokens=300,
+            cache_read_input_tokens=700,
+            use_openai_format=False,
+        )
+        wrapper._process_event(event)
+
+        delta_chunks = [
+            c for c in wrapper._chunk_queue if c.get("type") == "message_delta"
+        ]
+        assert len(delta_chunks) == 1
+        usage = delta_chunks[0]["usage"]
+        assert usage["cache_creation_input_tokens"] == 300
+        assert usage["cache_read_input_tokens"] == 700
+
+    def test_no_cache_tokens_omitted_from_usage(self):
+        """When no cache tokens, fields are omitted from usage delta."""
+        wrapper = _make_wrapper()
+        event = _make_completed_event(
+            input_tokens=100,
+            output_tokens=50,
+            cached_tokens=0,
+            use_openai_format=False,
+        )
+        wrapper._process_event(event)
+
+        delta_chunks = [
+            c for c in wrapper._chunk_queue if c.get("type") == "message_delta"
+        ]
+        assert len(delta_chunks) == 1
+        usage = delta_chunks[0]["usage"]
+        assert "cache_read_input_tokens" not in usage
+        assert "cache_creation_input_tokens" not in usage

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1043,3 +1043,51 @@ class TestTranslateResponse:
         assert "text" in types
         assert "tool_use" in types
         assert result["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# cache token extraction in translate_response
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTokenExtraction:
+    """translate_response extracts cache tokens from OpenAI Responses API usage."""
+
+    def test_openai_input_tokens_details_cached_tokens(self):
+        """cached_tokens from input_tokens_details maps to cache_read_input_tokens."""
+        response = _make_mock_response(output=[_make_output_message(["Hi"])])
+        # Simulate OpenAI Responses API usage with input_tokens_details
+        input_details = MagicMock()
+        input_details.cached_tokens = 500
+        response.usage.input_tokens_details = input_details
+        response.usage.output_tokens_details = None
+        # Ensure Anthropic-native fields are absent
+        del response.usage.cache_creation_input_tokens
+        del response.usage.cache_read_input_tokens
+
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["usage"]["cache_read_input_tokens"] == 500
+
+    def test_anthropic_native_cache_fields_fallback(self):
+        """Anthropic-native cache fields are used when input_tokens_details is absent."""
+        response = _make_mock_response(output=[_make_output_message(["Hi"])])
+        response.usage.input_tokens_details = None
+        response.usage.output_tokens_details = None
+        response.usage.cache_creation_input_tokens = 200
+        response.usage.cache_read_input_tokens = 1000
+
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["usage"]["cache_creation_input_tokens"] == 200
+        assert result["usage"]["cache_read_input_tokens"] == 1000
+
+    def test_no_cache_tokens_when_absent(self):
+        """No cache fields in usage when neither source provides them."""
+        response = _make_mock_response(output=[_make_output_message(["Hi"])])
+        response.usage.input_tokens_details = None
+        response.usage.output_tokens_details = None
+        del response.usage.cache_creation_input_tokens
+        del response.usage.cache_read_input_tokens
+
+        result: Any = _ADAPTER.translate_response(response)
+        assert "cache_read_input_tokens" not in result["usage"]
+        assert "cache_creation_input_tokens" not in result["usage"]


### PR DESCRIPTION
## Summary

Fixes #28354

The Anthropic→Responses API adapter (both streaming and non-streaming paths) always reported `cache_read_input_tokens = 0` when bridging to OpenAI models, because it read `usage.cache_read_input_tokens` (an Anthropic-only field name). OpenAI's Responses API exposes cached tokens at `usage.input_tokens_details.cached_tokens`.

**Changes:**
- **`streaming_iterator.py`**: Extract `cached_tokens` from `input_tokens_details` (OpenAI format), fall back to `cache_read_input_tokens` (Anthropic format)
- **`transformation.py`**: Add cache token extraction to the non-streaming `translate_response` path (was completely missing)
- **Tests**: 6 new unit tests covering both OpenAI and Anthropic cache token formats

## Root Cause

Lines 265-270 in `streaming_iterator.py` used `getattr(usage, "cache_read_input_tokens", 0)` — this field doesn't exist on OpenAI Response objects. The correct field is `usage.input_tokens_details.cached_tokens`, which is already handled correctly in the parallel Chat Completions adapter (`adapters/streaming_iterator.py:284-293`).

## Test plan

- [x] `pytest tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/` — 87 tests pass
- [x] Tests cover: OpenAI format extraction, Anthropic fallback, absence of fields
- [x] Black formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)