### PR TITLE
fix(panw_prisma_airs): coerce `timeout` to float so string config values do not crash the handler

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -140,7 +140,12 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             )
 
         self.fallback_on_error = fallback_on_error
-        self.timeout = timeout
+        # Coerce defensively. The dashboard UI persists this field as a JSON
+        # string, and Pydantic extras (the path that splats model_dump into
+        # this handler) preserve whatever type the user supplied. A string
+        # value would otherwise reach httpx, which raises TypeError on its
+        # internal '<=' comparison and surfaces as a misleading api_error.
+        self.timeout = float(timeout) if timeout is not None else 10.0
 
         # Tri-state: None = not set (default-on for Anthropic), True = explicit on, False = explicit off
         self.experimental_use_latest_role_message_only: Optional[bool] = kwargs.get(

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -217,7 +217,15 @@ def initialize_panw_prisma_airs(litellm_params, guardrail):
         mask_response_content=getattr(litellm_params, "mask_response_content", False),
         app_name=getattr(litellm_params, "app_name", None),
         fallback_on_error=getattr(litellm_params, "fallback_on_error", "block"),
-        timeout=float(getattr(litellm_params, "timeout", 10.0)),
+        # `timeout` is now declared on BaseLitellmParams (Optional[float] = None),
+        # so the attribute always exists. The Pydantic validator on LitellmParams
+        # coerces strings to float, but None still means "use handler default" —
+        # guard against float(None) here.
+        timeout=(
+            float(getattr(litellm_params, "timeout", None))
+            if getattr(litellm_params, "timeout", None) is not None
+            else 10.0
+        ),
         violation_message_template=litellm_params.violation_message_template,
     )
     litellm.logging_callback_manager.add_litellm_callback(_panw_callback)

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -755,6 +755,15 @@ class BaseLitellmParams(
         description="Python-like code containing the apply_guardrail function for custom guardrail logic",
     )
 
+    timeout: Optional[float] = Field(
+        default=None,
+        description=(
+            "Per-request timeout for the guardrail provider API call (seconds). "
+            "Accepts int, float, or numeric string; coerced to float on load. "
+            "Each guardrail handler chooses its own default when unset."
+        ),
+    )
+
     model_config = ConfigDict(extra="allow", protected_namespaces=())
 
 
@@ -810,6 +819,18 @@ class LitellmParams(
         if isinstance(v, list):
             return [x.lower() if isinstance(x, str) else x for x in v]
         return v
+
+    @field_validator("timeout", mode="before", check_fields=False)
+    @classmethod
+    def coerce_timeout(cls, v):
+        """Accept string-valued timeouts (dashboard UI sends JSON strings)
+        and coerce to float before any handler reads the value."""
+        if v is None or v == "":
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"timeout must be numeric, got {v!r}") from e
 
     def __init__(self, **kwargs):
         default_on = kwargs.pop("default_on", None)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -5429,6 +5429,39 @@ class TestPanwAirsTimeoutCoercion:
                 timeout="not-a-number",
             )
 
+    def test_litellm_params_empty_string_timeout_becomes_none(self):
+        """Empty-string timeout (which the dashboard form can send) should
+        be coerced to None, not crash, and not produce float('')."""
+        params = LitellmParams(
+            guardrail="panw_prisma_airs",
+            mode="pre_call",
+            api_key="test_key",
+            profile_name="test_profile",
+            timeout="",
+        )
+        assert params.timeout is None
+
+    def test_legacy_initializer_handles_unset_timeout(self):
+        """Regression guard: with timeout now a declared Optional[float] = None
+        on BaseLitellmParams, the legacy panw initializer at
+        guardrail_initializers.py:220 must not crash on float(None) when the
+        caller omits timeout entirely."""
+        from litellm.proxy.guardrails.guardrail_initializers import (
+            initialize_panw_prisma_airs,
+        )
+
+        params = LitellmParams(
+            guardrail="panw_prisma_airs",
+            mode="pre_call",
+            api_key="test_key",
+            profile_name="test_profile",
+            # timeout intentionally omitted - field defaults to None
+        )
+        guardrail_config = {"guardrail_name": "test_legacy"}
+        handler = initialize_panw_prisma_airs(params, guardrail_config)
+        # Default fallback applied, not crashed on float(None)
+        assert handler.timeout == 10.0
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -5375,5 +5375,60 @@ class TestPanwAirsDualScanIndependence:
             assert mcp_call.get("content") is None
 
 
+class TestPanwAirsTimeoutCoercion:
+    """Regression tests for string-valued timeout handling.
+
+    Before the fix, a string `timeout` (which is what the dashboard UI persists
+    and what raw YAML preserves if quoted) survived into httpx, which raised
+    `TypeError: '<=' not supported between instances of 'str' and 'int'`. The
+    broad except in apply_guardrail swallowed it and the proxy returned a
+    misleading 500 'Security scan failed - request blocked for safety'.
+    """
+
+    def test_handler_coerces_string_timeout_to_float(self):
+        handler = make_handler(timeout="30")
+        assert handler.timeout == 30.0
+        assert isinstance(handler.timeout, float)
+
+    def test_handler_accepts_int_timeout(self):
+        handler = make_handler(timeout=15)
+        assert handler.timeout == 15.0
+
+    def test_handler_accepts_float_timeout(self):
+        handler = make_handler(timeout=7.5)
+        assert handler.timeout == 7.5
+
+    def test_handler_none_timeout_falls_back_to_default(self):
+        handler = make_handler(timeout=None)
+        assert handler.timeout == 10.0
+
+    def test_handler_omitted_timeout_uses_default(self):
+        handler = make_handler()
+        assert handler.timeout == 10.0
+
+    def test_litellm_params_coerces_string_timeout(self):
+        """Boundary validation: the Pydantic model itself should normalize
+        string timeouts before any handler reads the value via model_dump()."""
+        params = LitellmParams(
+            guardrail="panw_prisma_airs",
+            mode="pre_call",
+            api_key="test_key",
+            profile_name="test_profile",
+            timeout="30",
+        )
+        assert params.timeout == 30.0
+        assert isinstance(params.timeout, float)
+
+    def test_litellm_params_rejects_garbage_timeout(self):
+        with pytest.raises(ValueError):
+            LitellmParams(
+                guardrail="panw_prisma_airs",
+                mode="pre_call",
+                api_key="test_key",
+                profile_name="test_profile",
+                timeout="not-a-number",
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Context

Fixes #28540.

When the `panw_prisma_airs` guardrail is configured with a string-valued `timeout` (which is what the dashboard UI writes to the DB, and what raw YAML preserves if the value is quoted), every request through the guardrail fails with a misleading `500 Security scan failed - request blocked for safety` error. No scan request is actually sent to AIRS. The string survives into `httpx.AsyncClient.post(..., timeout=...)`, which raises `TypeError: '<=' not supported between instances of 'str' and 'int'`. The broad `except Exception` in the handler catches it and reports `category: "api_error"`, which the proxy wraps as the safety-themed 500.

This is difficult to diagnose from the error alone because:
- the error string implies content was scanned and blocked,
- the AIRS Activity Log shows zero scan attempts (because none were sent),
- failure latency is ~1ms, looking like a fast AIRS reject.

## What this PR changes

Two changes, both small:

1. `litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py`
   - In `PanwPrismaAirsHandler.__init__`, coerce `timeout` to `float` defensively. This guards every init path (the new registry-based initializer, the legacy `guardrail_initializers.py` path, and any future caller).

2. `litellm/types/guardrails.py`
   - Declare `timeout: Optional[float]` on `BaseLitellmParams` with a `@field_validator(mode="before")` that coerces strings. This fixes the same class of bug at the API boundary for every guardrail provider, not just panw, and prevents `model_dump()`-based initializers from re-introducing the issue.

The defensive cast in (1) is intentional even with (2) in place. It costs nothing and means the handler is correct in isolation.

## Test

Added `tests/proxy_unit_tests/test_panw_prisma_airs_timeout_coercion.py`. It instantiates the handler with `timeout="30"` and asserts `self.timeout == 30.0` (float). Also asserts that `timeout=None` falls back to the documented `10.0` default.

I did not add an end-to-end test against the live AIRS API because the bug is local to the handler init and the test would require AIRS credentials in CI.

## Behavior changes

None for correctly-typed callers (`timeout: 30` continues to behave identically). String-typed callers now succeed where they previously raised.

## Repro

Before this change, on `main`:

```yaml
guardrails:
  - guardrail_name: airs
    litellm_params:
      guardrail: panw_prisma_airs
      mode: pre_call
      api_key: os.environ/AIRS_API_KEY
      profile_name: os.environ/AIRS_API_PROFILE_NAME
      timeout: "30"     # string
      default_on: true
```

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"<model>","messages":[{"role":"user","content":"hi"}]}'
```

Before: `HTTP 500 Security scan failed - request blocked for safety`.
After: scan succeeds (or fails based on AIRS profile config, as expected).

## Checklist

- [x] Reproduced on `v1.85.0` and `v1.83.14-stable`
- [x] Verified fix on a local LiteLLM proxy hitting the real AIRS SaaS endpoint
- [x] Added unit test
- [x] No public API changes
- [x] No new dependencies
