### PR TITLE
fix(sagemaker): Cohere embed request format for Marketplace endpoints

### DIFF
--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -578,7 +578,7 @@ class SagemakerLLM(BaseAWSLLM):
         logger_fn=None,
     ):
         """
-        Supports both Huggingface Jumpstart embeddings and Voyage models
+        Supports Hugging Face (TGI), Voyage, and Cohere embedding endpoints
         """
         ### BOTO3 INIT
         import boto3

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -1,0 +1,144 @@
+"""
+Cohere embedding request/response transformation for SageMaker Marketplace endpoints.
+
+AWS Marketplace Cohere containers expect the native Cohere embed API body
+(`texts`, `input_type`, etc.), not HuggingFace TGI `inputs`.
+"""
+
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
+
+import httpx
+
+import litellm
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.llms.bedrock.embed.cohere_transformation import BedrockCohereEmbeddingConfig
+from litellm.llms.cohere.embed.v1_transformation import CohereEmbeddingConfig
+from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
+from litellm.types.utils import EmbeddingResponse
+
+from ..common_utils import SagemakerError
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+def is_cohere_sagemaker_embedding_model(model: str) -> bool:
+    """
+    Detect Cohere embedding endpoints from the SageMaker endpoint / model name.
+
+    Endpoint names should include ``cohere`` or a Cohere embed model id fragment
+    (e.g. ``embed-multilingual-v3``) so LiteLLM selects the Cohere payload format.
+    """
+    model_lower = model.lower()
+    if "cohere" in model_lower:
+        return True
+    cohere_embed_markers = (
+        "embed-multilingual",
+        "embed-english",
+        "embed-v4",
+        "embed-v3",
+    )
+    return any(marker in model_lower for marker in cohere_embed_markers)
+
+
+class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
+    """
+    SageMaker invoke payload for self-hosted Cohere embed models (Marketplace / JumpStart).
+    """
+
+    def __init__(self) -> None:
+        self._bedrock_cohere = BedrockCohereEmbeddingConfig()
+        self._cohere_v1 = CohereEmbeddingConfig()
+
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        return ["encoding_format", "dimensions", "input_type"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        return self._bedrock_cohere.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+        )
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
+        return SagemakerError(
+            message=error_message, status_code=status_code, headers=headers
+        )
+
+    def _normalize_input(self, input: AllEmbeddingInputValues) -> List[str]:
+        if isinstance(input, str):
+            return [input]
+        if isinstance(input, list):
+            if input and (isinstance(input[0], list) or isinstance(input[0], int)):
+                raise ValueError("Input must be a list of strings")
+            return cast(List[str], input)
+        return [str(input)]
+
+    def transform_embedding_request(
+        self,
+        model: str,
+        input: AllEmbeddingInputValues,
+        optional_params: dict,
+        headers: dict,
+    ) -> dict:
+        input_list = self._normalize_input(input)
+        request = self._bedrock_cohere._transform_request(
+            model=model,
+            input=input_list,
+            inference_params=optional_params,
+        )
+        return dict(request)
+
+    def transform_embedding_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: EmbeddingResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str],
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> EmbeddingResponse:
+        input_value = logging_obj.model_call_details.get("input")
+        if input_value is None:
+            input_value = request_data.get("texts") or request_data.get("images") or []
+        if isinstance(input_value, str):
+            input_list = [input_value]
+        elif isinstance(input_value, list):
+            input_list = input_value
+        else:
+            input_list = []
+
+        return self._cohere_v1._transform_response(
+            response=raw_response,
+            api_key=api_key,
+            logging_obj=logging_obj,
+            data=request_data,
+            model_response=model_response,
+            model=model,
+            encoding=litellm.encoding,
+            input=input_list,
+        )
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        return {"Content-Type": "application/json"}

--- a/litellm/llms/sagemaker/embedding/transformation.py
+++ b/litellm/llms/sagemaker/embedding/transformation.py
@@ -17,6 +17,10 @@ from litellm.types.utils import Usage, EmbeddingResponse
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
 
 from ..common_utils import SagemakerError
+from .cohere_transformation import (
+    SagemakerCohereEmbeddingConfig,
+    is_cohere_sagemaker_embedding_model,
+)
 
 
 class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
@@ -38,17 +42,20 @@ class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
         Returns:
             Appropriate embedding config instance
         """
-        if "voyage" in model.lower():
+        model_lower = model.lower()
+        if "voyage" in model_lower:
             return VoyageEmbeddingConfig()
-        else:
-            return cls()
+        if is_cohere_sagemaker_embedding_model(model):
+            return SagemakerCohereEmbeddingConfig()
+        return cls()
 
     def get_supported_openai_params(self, model: str) -> List[str]:
         # Check if this is an embedding model
         if "voyage" in model.lower():
             return VoyageEmbeddingConfig().get_supported_openai_params(model)
-        else:
-            return []
+        if is_cohere_sagemaker_embedding_model(model):
+            return SagemakerCohereEmbeddingConfig().get_supported_openai_params(model)
+        return []
 
     def map_openai_params(
         self,

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -17,6 +17,10 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 from litellm import embedding
+from litellm.llms.sagemaker.embedding.cohere_transformation import (
+    SagemakerCohereEmbeddingConfig,
+    is_cohere_sagemaker_embedding_model,
+)
 from litellm.llms.sagemaker.embedding.transformation import SagemakerEmbeddingConfig
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
 from litellm.types.utils import EmbeddingResponse, Usage
@@ -53,6 +57,80 @@ class TestSagemakerEmbeddingFactory:
         assert isinstance(config1, VoyageEmbeddingConfig)
         assert isinstance(config2, VoyageEmbeddingConfig)
         assert isinstance(config3, VoyageEmbeddingConfig)
+
+    def test_get_model_config_cohere_model(self):
+        """Test that Cohere SageMaker endpoints return SagemakerCohereEmbeddingConfig"""
+        for endpoint_name in (
+            "cohere-embed-multilingual-v3-prod",
+            "my-cohere-marketplace-endpoint",
+            "embed-multilingual-v3-sm-endpoint",
+        ):
+            config = SagemakerEmbeddingConfig.get_model_config(endpoint_name)
+            assert isinstance(config, SagemakerCohereEmbeddingConfig)
+
+    def test_is_cohere_sagemaker_embedding_model(self):
+        assert is_cohere_sagemaker_embedding_model("cohere-embed-endpoint")
+        assert is_cohere_sagemaker_embedding_model("embed-english-v3-endpoint")
+        assert not is_cohere_sagemaker_embedding_model("sentence-transformers-model")
+
+
+class TestSagemakerCohereEmbeddingConfig:
+    """Test Cohere-specific SageMaker embedding configuration"""
+
+    def setup_method(self):
+        self.config = SagemakerCohereEmbeddingConfig()
+
+    def test_transform_embedding_request(self):
+        result = self.config.transform_embedding_request(
+            model="cohere-embed-multilingual-v3",
+            input=["hello"],
+            optional_params={"input_type": "search_query"},
+            headers={},
+        )
+        assert result == {
+            "texts": ["hello"],
+            "input_type": "search_query",
+        }
+
+    def test_transform_embedding_request_default_input_type(self):
+        result = self.config.transform_embedding_request(
+            model="cohere-embed-multilingual-v3",
+            input=["hello"],
+            optional_params={},
+            headers={},
+        )
+        assert result["texts"] == ["hello"]
+        assert result["input_type"] == "search_document"
+
+    def test_transform_embedding_response(self):
+        cohere_response = {
+            "embeddings": [[0.1, 0.2, 0.3]],
+            "meta": {"billed_units": {"input_tokens": 2}},
+        }
+        mock_response = httpx.Response(
+            status_code=200,
+            content=json.dumps(cohere_response).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"input": ["hello"]}
+
+        model_response = EmbeddingResponse()
+        result = self.config.transform_embedding_response(
+            model="cohere-embed-multilingual-v3",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=logging_obj,
+            api_key=None,
+            request_data={"texts": ["hello"], "input_type": "search_query"},
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result.object == "list"
+        assert len(result.data) == 1
+        assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+        assert result.usage.prompt_tokens == 2
 
 
 class TestVoyageEmbeddingConfig:


### PR DESCRIPTION
## Summary

- SageMaker embeddings only special-cased **Voyage**; every other endpoint used HuggingFace TGI `{"inputs": [...]}`, which breaks **AWS Marketplace Cohere** containers expecting `{"texts": [...], "input_type": "..."}`.
- Adds `SagemakerCohereEmbeddingConfig` (reuses Bedrock/Cohere request + v1 response transforms) and selects it when the SageMaker endpoint name contains `cohere` or common Cohere embed id fragments (`embed-multilingual`, `embed-english`, etc.).
- Supports `input_type`, `encoding_format`, and `dimensions` on the Cohere SageMaker path.

## Test plan

- [x] `pytest tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py` (27 passed)
- [ ] Customer repro: `litellm.embedding(model="sagemaker/<cohere-endpoint>", input=["hello"], input_type="search_query")` against Marketplace endpoint
- [ ] Confirm HF / Voyage SageMaker embedding endpoints unchanged


Made with [Cursor](https://cursor.com)