### PR TITLE
feat(proxy): add GET /config/export and POST /config/import endpoints

### DIFF
--- a/litellm/proxy/management_endpoints/config_export_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_export_endpoints.py
@@ -30,6 +30,9 @@ from litellm.proxy.management_endpoints.config_export_types import (
     _validate_envelope,
 )
 from litellm.proxy.management_endpoints.config_import_helpers import (
+    _encrypt_credential_values,
+    _encrypt_litellm_params_record,
+    _encrypt_mcp_credentials,
     _import_general_settings,
     _import_keys_section,
     _import_section,
@@ -67,7 +70,9 @@ async def _import_standard_section(
     records = getattr(data, section_name, None)
     if records is None:
         return
-    records = [_clean_litellm_params_record(r) for r in records]
+    records = [
+        _encrypt_litellm_params_record(_clean_litellm_params_record(r)) for r in records
+    ]
     result.sections_attempted.append(section_name)
     table = getattr(prisma_client.db, table_name)
     em = await _load_existing(
@@ -126,7 +131,7 @@ async def _import_all_sections(
                     "credential_values is redacted. Bind secrets manually."
                 )
             else:
-                importable_creds.append(rec)
+                importable_creds.append(_encrypt_credential_values(rec))
         em = await _load_existing(
             prisma_client.db.litellm_credentialstable,
             "credential_name",
@@ -169,9 +174,10 @@ async def _import_all_sections(
                 result.mcp_servers.warnings.append(
                     f"MCP server '{rec.get('server_name')}' — '{f}' is redacted; bind manually."
                 )
-            cleaned_servers.append(
+            cleaned = (
                 {k: v for k, v in rec.items() if k not in to_strip} if to_strip else rec
             )
+            cleaned_servers.append(_encrypt_mcp_credentials(cleaned))
         em = await _load_existing(
             prisma_client.db.litellm_mcpservertable,
             "server_id",
@@ -430,11 +436,6 @@ async def export_config(
         return Response(content=content, media_type="application/yaml")
     content = json.dumps(envelope, indent=2, default=str)
     return Response(content=content, media_type="application/json")
-
-
-# ---------------------------------------------------------------------------
-# POST /config/import
-# ---------------------------------------------------------------------------
 
 
 @router.post(

--- a/litellm/proxy/management_endpoints/config_export_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_export_endpoints.py
@@ -33,6 +33,7 @@ from litellm.proxy.management_endpoints.config_import_helpers import (
     _import_general_settings,
     _import_keys_section,
     _import_section,
+    _post_import_cache_refresh,
 )
 
 router = APIRouter()
@@ -345,9 +346,6 @@ async def _fetch_export_sections(
         }
 
 
-# ---------------------------------------------------------------------------
-# Auth helper
-# ---------------------------------------------------------------------------
 def _get_prisma_with_auth(user_api_key_dict: UserAPIKeyAuth, action: str = "access"):
     from litellm.proxy.proxy_server import prisma_client  # avoid circular import
 
@@ -366,9 +364,6 @@ def _get_prisma_with_auth(user_api_key_dict: UserAPIKeyAuth, action: str = "acce
     return prisma_client
 
 
-# ---------------------------------------------------------------------------
-# GET /config/export
-# ---------------------------------------------------------------------------
 @router.get(
     "/config/export",
     tags=["config.yaml"],
@@ -483,6 +478,8 @@ async def import_config(
     except Exception as e:
         verbose_proxy_logger.error("config/import failed: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
+
+    await _post_import_cache_refresh(result, dry_run)
 
     non_gs = [s for s in result.sections_attempted if s != "general_settings"]
     verbose_proxy_logger.info(

--- a/litellm/proxy/management_endpoints/config_export_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_export_endpoints.py
@@ -324,7 +324,11 @@ async def _fetch_export_sections(
             ),
         )
         envelope["guardrails"] = [
-            _redact_litellm_params(rec) if redact_secrets else rec
+            (
+                _redact_sensitive_header_fields(_redact_litellm_params(rec))
+                if redact_secrets
+                else rec
+            )
             for rec in [_strip(r, _STRIP_FIELDS["guardrails"]) for r in rows]
         ]
 

--- a/litellm/proxy/management_endpoints/config_export_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_export_endpoints.py
@@ -66,7 +66,6 @@ async def _import_standard_section(
     records = getattr(data, section_name, None)
     if records is None:
         return
-    # Drop "__redacted__" string sentinels from litellm_params before writing.
     records = [_clean_litellm_params_record(r) for r in records]
     result.sections_attempted.append(section_name)
     table = getattr(prisma_client.db, table_name)
@@ -161,7 +160,6 @@ async def _import_all_sections(
 
     if data.mcp_servers is not None:
         result.sections_attempted.append("mcp_servers")
-        # Strip dict-form redaction markers; don't write placeholders to the DB.
         _MCP_REDACTED_FIELDS = ("credentials", "static_headers", "env")
         cleaned_servers: List[Dict[str, Any]] = []
         for rec in data.mcp_servers:
@@ -200,9 +198,6 @@ async def _import_all_sections(
         )
 
 
-# ---------------------------------------------------------------------------
-# Export fetch helper
-# ---------------------------------------------------------------------------
 async def _fetch_export_sections(
     prisma_client: Any,
     sections: Set[str],

--- a/litellm/proxy/management_endpoints/config_export_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_export_endpoints.py
@@ -1,0 +1,504 @@
+"""GET /config/export and POST /config/import endpoints."""
+
+import datetime
+import json
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.management_endpoints.config_export_types import (
+    ALL_SECTIONS,
+    SAFE_GENERAL_SETTINGS_KEYS,
+    ImportRequest,
+    ImportResult,
+    LiteLLMExportEnvelope,
+    _STRIP_FIELDS,
+    _clean_litellm_params_record,
+    _is_redacted,
+    _load_existing,
+    _redact_credential_values,
+    _redact_litellm_params,
+    _redact_mcp_credentials,
+    _redact_sensitive_header_fields,
+    _resolve_sections,
+    _strip,
+    _validate_dependencies,
+    _validate_envelope,
+)
+from litellm.proxy.management_endpoints.config_import_helpers import (
+    _import_general_settings,
+    _import_keys_section,
+    _import_section,
+)
+
+router = APIRouter()
+
+_IDENTITY_SECTION_TABLES: List[Tuple[str, str, str]] = [
+    ("budgets", "litellm_budgettable", "budget_id"),
+    ("organizations", "litellm_organizationtable", "organization_id"),
+    ("teams", "litellm_teamtable", "team_id"),
+    ("users", "litellm_usertable", "user_id"),
+]
+
+_RESOURCE_SECTION_TABLES: List[Tuple[str, str, str]] = [
+    ("models", "litellm_proxymodeltable", "model_id"),
+    ("agents", "litellm_agentstable", "agent_name"),
+    ("guardrails", "litellm_guardrailstable", "guardrail_name"),
+    ("tags", "litellm_tagtable", "tag_name"),
+]
+
+
+async def _import_standard_section(
+    prisma_client: Any,
+    data: LiteLLMExportEnvelope,
+    section_name: str,
+    table_name: str,
+    id_field: str,
+    conflict: str,
+    dry_run: bool,
+    result: ImportResult,
+) -> None:
+    """Import a single standard section using the generic upsert flow."""
+    records = getattr(data, section_name, None)
+    if records is None:
+        return
+    # Drop "__redacted__" string sentinels from litellm_params before writing.
+    records = [_clean_litellm_params_record(r) for r in records]
+    result.sections_attempted.append(section_name)
+    table = getattr(prisma_client.db, table_name)
+    em = await _load_existing(
+        table, id_field, [r.get(id_field) for r in records if r.get(id_field)]
+    )
+    await _import_section(
+        table=table,
+        table_name=table_name,
+        records=records,
+        id_field=id_field,
+        conflict=conflict,
+        dry_run=dry_run,
+        section_result=getattr(result, section_name),
+        existing_map=em,
+    )
+
+
+async def _import_all_sections(
+    prisma_client: Any,
+    data: LiteLLMExportEnvelope,
+    conflict: str,
+    dry_run: bool,
+    result: ImportResult,
+) -> None:
+    """Process all sections in dependency order."""
+    for section_name, table_name, id_field in _IDENTITY_SECTION_TABLES:
+        await _import_standard_section(
+            prisma_client,
+            data,
+            section_name,
+            table_name,
+            id_field,
+            conflict,
+            dry_run,
+            result,
+        )
+    if data.keys is not None:
+        result.sections_attempted.append("keys")
+        await _import_keys_section(
+            prisma_client=prisma_client,
+            records=data.keys,
+            conflict=conflict,
+            dry_run=dry_run,
+            section_result=result.keys,
+        )
+
+    if data.credentials is not None:
+        result.sections_attempted.append("credentials")
+        importable_creds: List[Dict[str, Any]] = []
+        for rec in data.credentials:
+            if _is_redacted(rec.get("credential_values")):
+                result.credentials.skipped += 1
+                result.credentials.total_processed += 1
+                result.credentials.warnings.append(
+                    f"Skipped credential '{rec.get('credential_name')}' — "
+                    "credential_values is redacted. Bind secrets manually."
+                )
+            else:
+                importable_creds.append(rec)
+        em = await _load_existing(
+            prisma_client.db.litellm_credentialstable,
+            "credential_name",
+            [
+                r["credential_name"]
+                for r in importable_creds
+                if r.get("credential_name")
+            ],
+        )
+        await _import_section(
+            table=prisma_client.db.litellm_credentialstable,
+            table_name="litellm_credentialstable",
+            records=importable_creds,
+            id_field="credential_name",
+            conflict=conflict,
+            dry_run=dry_run,
+            section_result=result.credentials,
+            existing_map=em,
+        )
+
+    for section_name, table_name, id_field in _RESOURCE_SECTION_TABLES:
+        await _import_standard_section(
+            prisma_client,
+            data,
+            section_name,
+            table_name,
+            id_field,
+            conflict,
+            dry_run,
+            result,
+        )
+
+    if data.mcp_servers is not None:
+        result.sections_attempted.append("mcp_servers")
+        # Strip dict-form redaction markers; don't write placeholders to the DB.
+        _MCP_REDACTED_FIELDS = ("credentials", "static_headers", "env")
+        cleaned_servers: List[Dict[str, Any]] = []
+        for rec in data.mcp_servers:
+            to_strip = [f for f in _MCP_REDACTED_FIELDS if _is_redacted(rec.get(f))]
+            for f in to_strip:
+                result.mcp_servers.warnings.append(
+                    f"MCP server '{rec.get('server_name')}' — '{f}' is redacted; bind manually."
+                )
+            cleaned_servers.append(
+                {k: v for k, v in rec.items() if k not in to_strip} if to_strip else rec
+            )
+        em = await _load_existing(
+            prisma_client.db.litellm_mcpservertable,
+            "server_id",
+            [r.get("server_id") for r in cleaned_servers if r.get("server_id")],
+        )
+        await _import_section(
+            table=prisma_client.db.litellm_mcpservertable,
+            table_name="litellm_mcpservertable",
+            records=cleaned_servers,
+            id_field="server_id",
+            conflict=conflict,
+            dry_run=dry_run,
+            section_result=result.mcp_servers,
+            existing_map=em,
+        )
+
+    if data.general_settings is not None:
+        result.sections_attempted.append("general_settings")
+        await _import_general_settings(
+            prisma_client=prisma_client,
+            settings=data.general_settings,
+            conflict=conflict,
+            dry_run=dry_run,
+            section_result=result.general_settings,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Export fetch helper
+# ---------------------------------------------------------------------------
+async def _fetch_export_sections(
+    prisma_client: Any,
+    sections: Set[str],
+    limit: int,
+    redact_secrets: bool,
+    envelope: Dict[str, Any],
+) -> None:
+    """Fetch each requested section from the DB and write it into envelope."""
+
+    def _cap(section: str, rows: list) -> list:
+        if len(rows) == limit:
+            envelope["truncated_sections"].append(section)
+        return rows
+
+    if "budgets" in sections:
+        rows = _cap(
+            "budgets",
+            await prisma_client.db.litellm_budgettable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["budgets"] = [_strip(r, _STRIP_FIELDS["budgets"]) for r in rows]
+
+    if "organizations" in sections:
+        rows = _cap(
+            "organizations",
+            await prisma_client.db.litellm_organizationtable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["organizations"] = [
+            _strip(r, _STRIP_FIELDS["organizations"]) for r in rows
+        ]
+
+    if "teams" in sections:
+        rows = _cap(
+            "teams",
+            await prisma_client.db.litellm_teamtable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["teams"] = [_strip(r, _STRIP_FIELDS["teams"]) for r in rows]
+
+    if "users" in sections:
+        rows = _cap(
+            "users",
+            await prisma_client.db.litellm_usertable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["users"] = [_strip(r, _STRIP_FIELDS["users"]) for r in rows]
+
+    if "keys" in sections:
+        rows = _cap(
+            "keys",
+            await prisma_client.db.litellm_verificationtoken.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["keys"] = [_strip(r, _STRIP_FIELDS["keys"]) for r in rows]
+
+    if "credentials" in sections:
+        rows = _cap(
+            "credentials",
+            await prisma_client.db.litellm_credentialstable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["credentials"] = [
+            _redact_credential_values(rec) if redact_secrets else rec
+            for rec in [_strip(r, _STRIP_FIELDS["credentials"]) for r in rows]
+        ]
+
+    if "models" in sections:
+        rows = _cap(
+            "models",
+            await prisma_client.db.litellm_proxymodeltable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["models"] = [
+            _redact_litellm_params(rec) if redact_secrets else rec
+            for rec in [_strip(r, _STRIP_FIELDS["models"]) for r in rows]
+        ]
+
+    if "mcp_servers" in sections:
+        rows = _cap(
+            "mcp_servers",
+            await prisma_client.db.litellm_mcpservertable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["mcp_servers"] = [
+            (
+                _redact_sensitive_header_fields(_redact_mcp_credentials(rec))
+                if redact_secrets
+                else rec
+            )
+            for rec in [_strip(r, _STRIP_FIELDS["mcp_servers"]) for r in rows]
+        ]
+
+    if "agents" in sections:
+        rows = _cap(
+            "agents",
+            await prisma_client.db.litellm_agentstable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["agents"] = [
+            (
+                _redact_sensitive_header_fields(_redact_litellm_params(rec))
+                if redact_secrets
+                else rec
+            )
+            for rec in [_strip(r, _STRIP_FIELDS["agents"]) for r in rows]
+        ]
+
+    if "guardrails" in sections:
+        rows = _cap(
+            "guardrails",
+            await prisma_client.db.litellm_guardrailstable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["guardrails"] = [
+            _redact_litellm_params(rec) if redact_secrets else rec
+            for rec in [_strip(r, _STRIP_FIELDS["guardrails"]) for r in rows]
+        ]
+
+    if "tags" in sections:
+        rows = _cap(
+            "tags",
+            await prisma_client.db.litellm_tagtable.find_many(
+                take=limit, order={"created_at": "asc"}
+            ),
+        )
+        envelope["tags"] = [_strip(r, _STRIP_FIELDS["tags"]) for r in rows]
+
+    if "general_settings" in sections:
+        gs_rows = await prisma_client.db.litellm_config.find_many(
+            where={"param_name": {"in": list(SAFE_GENERAL_SETTINGS_KEYS)}}
+        )
+        envelope["general_settings"] = {
+            r.param_name: r.param_value for r in gs_rows if r.param_value is not None
+        }
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+def _get_prisma_with_auth(user_api_key_dict: UserAPIKeyAuth, action: str = "access"):
+    from litellm.proxy.proxy_server import prisma_client  # avoid circular import
+
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Only proxy admins can {action} config",
+        )
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Database not connected. Cannot {action} config.",
+        )
+
+    return prisma_client
+
+
+# ---------------------------------------------------------------------------
+# GET /config/export
+# ---------------------------------------------------------------------------
+@router.get(
+    "/config/export",
+    tags=["config.yaml"],
+    summary="Export all UI/API-managed proxy state as a versioned artifact",
+)
+async def export_config(
+    request: Request,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    include: Optional[str] = Query(
+        default=None,
+        description="Comma-separated list of sections to include. "
+        f"Available: {', '.join(ALL_SECTIONS)}. Defaults to all.",
+    ),
+    format: Literal["json", "yaml"] = Query(
+        default="json",
+        description="Output format: json or yaml",
+    ),
+    redact_secrets: bool = Query(
+        default=True,
+        description="When true, replaces credential_values and MCP server "
+        "credentials with {__redacted__: true}.",
+    ),
+    limit: int = Query(
+        default=1000,
+        ge=1,
+        le=5000,
+        description="Maximum number of rows to fetch per entity section. "
+        "Defaults to 1000; maximum 5000. Use the include parameter to export "
+        "individual sections on deployments with very large tables.",
+    ),
+) -> Response:
+    """
+    Returns a snapshot of all UI/API-managed proxy state.
+
+    **Excluded from export (by design):**
+    - Spend logs, audit logs, error logs (operational history)
+    - Master key / salt key material
+    - End-user records (LiteLLM_EndUserTable)
+    - Deployment-specific settings (database_url, host, port, etc.)
+    """
+    prisma_client = _get_prisma_with_auth(user_api_key_dict, action="export")
+    sections = _resolve_sections(include)
+    envelope: Dict[str, Any] = {
+        "exported_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "source_instance": str(request.base_url).rstrip("/"),
+        "include_filters": sorted(sections),
+        "row_limit": limit,
+        "truncated_sections": [],
+    }
+    try:
+        await _fetch_export_sections(
+            prisma_client, sections, limit, redact_secrets, envelope
+        )
+    except Exception as e:
+        verbose_proxy_logger.error(f"config/export failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Export failed: {str(e)}")
+
+    if format == "yaml":
+        content = yaml.dump(envelope, allow_unicode=True, sort_keys=False)
+        return Response(content=content, media_type="application/yaml")
+    content = json.dumps(envelope, indent=2, default=str)
+    return Response(content=content, media_type="application/json")
+
+
+# ---------------------------------------------------------------------------
+# POST /config/import
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/config/import",
+    tags=["config.yaml"],
+    response_model=ImportResult,
+    summary="Idempotently re-apply a config snapshot produced by GET /config/export",
+)
+async def import_config(
+    request: Request,
+    body: ImportRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> ImportResult:
+    """
+    Re-apply a config snapshot from GET /config/export.
+
+    - Conflict modes: `skip` (default), `replace`, `merge`
+    - `dry_run=true`: simulate import without DB writes
+    - Redacted secrets (`{__redacted__: true}`) are skipped
+    - Each section runs in its own transaction; failures roll back per section
+    """
+    prisma_client = _get_prisma_with_auth(user_api_key_dict, action="import")
+    data = body.data
+    _validate_envelope(data)
+    _validate_dependencies(data)
+    conflict = body.conflict
+    dry_run = body.dry_run
+    result = ImportResult(dry_run=dry_run, conflict=conflict)
+    triggered_by = getattr(user_api_key_dict, "user_id", None) or getattr(
+        user_api_key_dict, "api_key", "unknown"
+    )
+    verbose_proxy_logger.info(
+        "config/import started: triggered_by=%s dry_run=%s conflict=%s "
+        "source=%s exported_at=%s",
+        triggered_by,
+        dry_run,
+        conflict,
+        data.source_instance,
+        data.exported_at,
+    )
+    try:
+        await _import_all_sections(prisma_client, data, conflict, dry_run, result)
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.error("config/import failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
+
+    non_gs = [s for s in result.sections_attempted if s != "general_settings"]
+    verbose_proxy_logger.info(
+        "config/import complete: triggered_by=%s dry_run=%s sections=%s "
+        "totals=created:%d updated:%d skipped:%d errors:%d",
+        triggered_by,
+        dry_run,
+        result.sections_attempted,
+        sum(getattr(result, s).created for s in non_gs),
+        sum(getattr(result, s).updated for s in non_gs),
+        sum(getattr(result, s).skipped for s in non_gs),
+        sum(getattr(result, s).errors for s in non_gs),
+    )
+    return result

--- a/litellm/proxy/management_endpoints/config_export_types.py
+++ b/litellm/proxy/management_endpoints/config_export_types.py
@@ -279,6 +279,7 @@ def _validate_envelope(data: LiteLLMExportEnvelope) -> None:
     _check_ids("mcp_servers", data.mcp_servers, "server_id")
     _check_ids("agents", data.agents, "agent_name")
     _check_ids("guardrails", data.guardrails, "guardrail_name")
+    _check_ids("tags", data.tags, "tag_name")
 
     # keys: key_alias is optional (keyless keys are skipped at import time)
     # — we only warn about them during import, not here

--- a/litellm/proxy/management_endpoints/config_export_types.py
+++ b/litellm/proxy/management_endpoints/config_export_types.py
@@ -1,10 +1,12 @@
 """Types, constants, and pure helpers shared by the config export/import endpoints."""
 
+import json
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 from fastapi import HTTPException
 from pydantic import BaseModel
 
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 
 _MASKER = SensitiveDataMasker()
@@ -59,13 +61,15 @@ _STRIP_FIELDS: Dict[str, List[str]] = {
     "organizations": ["spend"],
     "teams": ["spend"],
     "users": ["spend", "user_api_key_hash", "password"],
-    "keys": ["token", "spend"],
+    # config and metadata are free-form blobs that operators may use to store
+    # callback credentials or webhook secrets; strip them rather than risk leaking.
+    "keys": ["token", "spend", "config", "metadata"],
     "credentials": [],  # credential_values handled separately (redaction)
     "models": [],
     "mcp_servers": [],  # credentials handled separately (redaction)
     "agents": ["spend"],
     "guardrails": [],
-    "tags": [],
+    "tags": ["spend"],
 }
 
 ALL_SECTIONS = list(_STRIP_FIELDS.keys()) + ["general_settings"]
@@ -182,22 +186,51 @@ def _redact_mcp_credentials(record: Dict[str, Any]) -> Dict[str, Any]:
     return record
 
 
+def _redact_params_dict(params: Dict[str, Any], depth: int = 0) -> Dict[str, Any]:
+    """Redact sensitive keys in a litellm_params dict, recursing into nested dicts.
+
+    Depth is bounded by DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER to
+    satisfy the repo's recursive-function checker.
+    """
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return {"__redacted__": True}
+    out: Dict[str, Any] = {}
+    for k, v in params.items():
+        if _MASKER.is_sensitive_key(k) and v is not None:
+            out[k] = "__redacted__"
+        elif isinstance(v, dict):
+            out[k] = _redact_params_dict(v, depth + 1)
+        else:
+            out[k] = v
+    return out
+
+
 def _redact_litellm_params(record: Dict[str, Any]) -> Dict[str, Any]:
-    """Redact credential sub-fields inside a litellm_params dict.
+    """Redact credential sub-fields inside a litellm_params value.
 
     Uses SensitiveDataMasker pattern-based detection to replace secret keys
     with the string sentinel ``"__redacted__"`` while leaving non-secret config
     fields (api_base, region_name, etc.) intact so the export remains useful
     for environment promotion.
+
+    Handles litellm_params stored as a dict or as a JSON-serialised string
+    (used by guardrails and some in-memory registry entries).  Recurses into
+    nested dicts so values like ``headers.Authorization`` are also redacted.
     """
     params = record.get("litellm_params")
-    if not isinstance(params, dict):
+    if params is None:
         return record
-    redacted_params = {
-        k: "__redacted__" if _MASKER.is_sensitive_key(k) and v is not None else v
-        for k, v in params.items()
-    }
-    return {**record, "litellm_params": redacted_params}
+    if isinstance(params, str):
+        try:
+            parsed = json.loads(params)
+        except (TypeError, ValueError):
+            return {**record, "litellm_params": "__redacted__"}
+        if isinstance(parsed, dict):
+            return {**record, "litellm_params": json.dumps(_redact_params_dict(parsed))}
+        return record
+    if isinstance(params, dict):
+        return {**record, "litellm_params": _redact_params_dict(params)}
+    return record
 
 
 def _clean_litellm_params_record(record: Dict[str, Any]) -> Dict[str, Any]:

--- a/litellm/proxy/management_endpoints/config_export_types.py
+++ b/litellm/proxy/management_endpoints/config_export_types.py
@@ -1,0 +1,458 @@
+"""Types, constants, and pure helpers shared by the config export/import endpoints."""
+
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
+
+_MASKER = SensitiveDataMasker()
+
+# Sections processed in dependency order:
+# budgets and organizations must exist before teams reference them,
+# users before keys, etc.
+_IMPORT_ORDER: List[str] = [
+    "budgets",
+    "organizations",
+    "teams",
+    "users",
+    "keys",
+    "credentials",
+    "models",
+    "mcp_servers",
+    "agents",
+    "guardrails",
+    "tags",
+    "general_settings",
+]
+
+# ---------------------------------------------------------------------------
+# General settings that are safe to round-trip across environments.
+# Deployment-specific keys (database_url, master_key, host, port, etc.) are
+# intentionally excluded.
+# ---------------------------------------------------------------------------
+SAFE_GENERAL_SETTINGS_KEYS = {
+    "alerting",
+    "alerting_threshold",
+    "alert_types",
+    "slack_alerting_settings",
+    "smtp_settings",
+    "default_team_settings",
+    "default_max_internal_user_budget",
+    "default_internal_user_budget_duration",
+    "disable_adding_master_key_hash_to_db",
+    "enforce_user_param",
+    "allowed_routes",
+    "max_parallel_requests",
+    "global_max_parallel_requests",
+    "infer_model_from_requests",
+    "default_internal_user_params",
+    "default_team_model_aliases",
+    "upperbound_key_generate_params",
+}
+
+# Fields to strip from each entity type — operational/ephemeral state that
+# should not be carried across environments.
+_STRIP_FIELDS: Dict[str, List[str]] = {
+    "budgets": [],
+    "organizations": ["spend"],
+    "teams": ["spend"],
+    "users": ["spend", "user_api_key_hash", "password"],
+    "keys": ["token", "spend"],
+    "credentials": [],  # credential_values handled separately (redaction)
+    "models": [],
+    "mcp_servers": [],  # credentials handled separately (redaction)
+    "agents": ["spend"],
+    "guardrails": [],
+    "tags": [],
+}
+
+ALL_SECTIONS = list(_STRIP_FIELDS.keys()) + ["general_settings"]
+
+# Fields that must never appear in a keys UPDATE payload.
+# token     — @id primary key, written once at creation, immutable thereafter.
+# key_alias — used as the WHERE clause; must not also be in the data dict.
+# spend     — operational counter managed by the proxy, not a configuration field.
+_KEYS_UPDATE_STRIP: Set[str] = {"token", "key_alias", "spend"}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class LiteLLMExportEnvelope(BaseModel):
+    exported_at: str
+    source_instance: str
+    include_filters: List[str]
+    # row_limit is the per-section take value used when producing this snapshot.
+    # A section whose length equals row_limit was likely truncated.
+    row_limit: int = 1000
+
+    budgets: Optional[List[Dict[str, Any]]] = None
+    organizations: Optional[List[Dict[str, Any]]] = None
+    teams: Optional[List[Dict[str, Any]]] = None
+    users: Optional[List[Dict[str, Any]]] = None
+    keys: Optional[List[Dict[str, Any]]] = None
+    credentials: Optional[List[Dict[str, Any]]] = None
+    models: Optional[List[Dict[str, Any]]] = None
+    mcp_servers: Optional[List[Dict[str, Any]]] = None
+    agents: Optional[List[Dict[str, Any]]] = None
+    guardrails: Optional[List[Dict[str, Any]]] = None
+    tags: Optional[List[Dict[str, Any]]] = None
+    general_settings: Optional[Dict[str, Any]] = None
+    # Sections where len(rows) == row_limit — the export was likely truncated.
+    truncated_sections: List[str] = []
+
+
+class ImportSectionResult(BaseModel):
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    errors: int = 0
+    total_processed: int = 0
+    warnings: List[str] = []
+
+
+class ImportResult(BaseModel):
+    dry_run: bool
+    conflict: str
+    sections_attempted: List[str] = []
+    budgets: ImportSectionResult = ImportSectionResult()
+    organizations: ImportSectionResult = ImportSectionResult()
+    teams: ImportSectionResult = ImportSectionResult()
+    users: ImportSectionResult = ImportSectionResult()
+    keys: ImportSectionResult = ImportSectionResult()
+    credentials: ImportSectionResult = ImportSectionResult()
+    models: ImportSectionResult = ImportSectionResult()
+    mcp_servers: ImportSectionResult = ImportSectionResult()
+    agents: ImportSectionResult = ImportSectionResult()
+    guardrails: ImportSectionResult = ImportSectionResult()
+    tags: ImportSectionResult = ImportSectionResult()
+    general_settings: ImportSectionResult = ImportSectionResult()
+
+
+class ImportRequest(BaseModel):
+    data: LiteLLMExportEnvelope
+    conflict: Literal["skip", "replace", "merge"] = "skip"
+    dry_run: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip(record: Any, fields: List[str]) -> Dict[str, Any]:
+    """Return a copy of the record (Prisma model or dict) with fields removed.
+
+    None values are preserved intentionally.  Dropping them would break
+    replace-mode import: a field that is NULL in the source would be absent
+    from the export payload and therefore absent from the UPDATE statement,
+    silently leaving the target's existing non-null value in place instead of
+    overwriting it with NULL.
+    """
+    if hasattr(record, "model_dump"):
+        d = record.model_dump()
+    elif hasattr(record, "dict"):
+        d = record.dict()
+    elif isinstance(record, dict):
+        d = dict(record)
+    else:
+        d = dict(record)
+    for f in fields:
+        d.pop(f, None)
+    return d
+
+
+def _redact_credential_values(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Replace credential_values with a redacted placeholder."""
+    record = dict(record)
+    if "credential_values" in record:
+        record["credential_values"] = {"__redacted__": True}
+    return record
+
+
+def _redact_mcp_credentials(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Replace MCP server credentials with a redacted placeholder."""
+    record = dict(record)
+    if "credentials" in record and record["credentials"]:
+        record["credentials"] = {"__redacted__": True}
+    return record
+
+
+def _redact_litellm_params(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Redact credential sub-fields inside a litellm_params dict.
+
+    Uses SensitiveDataMasker pattern-based detection to replace secret keys
+    with the string sentinel ``"__redacted__"`` while leaving non-secret config
+    fields (api_base, region_name, etc.) intact so the export remains useful
+    for environment promotion.
+    """
+    params = record.get("litellm_params")
+    if not isinstance(params, dict):
+        return record
+    redacted_params = {
+        k: "__redacted__" if _MASKER.is_sensitive_key(k) and v is not None else v
+        for k, v in params.items()
+    }
+    return {**record, "litellm_params": redacted_params}
+
+
+def _clean_litellm_params_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip string-sentinel sub-fields from litellm_params before a DB write.
+
+    _redact_litellm_params marks secret sub-fields with the plain string
+    ``"__redacted__"``.  If a redacted snapshot is imported those strings would
+    be written into the target DB, making models/agents non-functional and
+    silently overwriting working values in replace/merge mode.  This helper
+    removes any sub-field whose value is the sentinel so only non-secret config
+    fields (api_base, model, region_name, …) reach Prisma.
+    """
+    params = record.get("litellm_params")
+    if not isinstance(params, dict):
+        return record
+    cleaned = {k: v for k, v in params.items() if v != "__redacted__"}
+    return {**record, "litellm_params": cleaned}
+
+
+def _redact_sensitive_header_fields(record: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    ``static_headers`` can contain Authorization headers.
+    ``env`` can contain environment variable values including secrets.
+    ``url`` and ``spec_path`` are connectivity config, not credentials — kept.
+    """
+    record = dict(record)
+    if record.get("static_headers"):
+        record["static_headers"] = {"__redacted__": True}
+    if record.get("env"):
+        record["env"] = {"__redacted__": True}
+    return record
+
+
+def _is_redacted(value: Any) -> bool:
+    return isinstance(value, dict) and value.get("__redacted__") is True
+
+
+# ---------------------------------------------------------------------------
+# Envelope validation (runs before any DB writes)
+# ---------------------------------------------------------------------------
+
+
+def _validate_envelope(data: LiteLLMExportEnvelope) -> None:
+    """
+    Validate the snapshot before touching the DB.
+
+    Checks:
+    - required ID fields are present and non-empty
+    - no duplicate IDs within a section (would cause undefined upsert order)
+    - basic type sanity on a selection of critical fields
+
+    Raises HTTPException(400) with a descriptive message on first error.
+    """
+    errors: List[str] = []
+
+    def _check_ids(
+        section_name: str, records: Optional[List[Dict[str, Any]]], id_field: str
+    ) -> None:
+        if records is None:
+            return
+        seen: Set[str] = set()
+        for i, rec in enumerate(records):
+            val = rec.get(id_field)
+            if not val:
+                errors.append(
+                    f"{section_name}[{i}]: missing required field '{id_field}'"
+                )
+                continue
+            if val in seen:
+                errors.append(f"{section_name}: duplicate {id_field}='{val}'")
+            seen.add(str(val))
+
+    _check_ids("budgets", data.budgets, "budget_id")
+    _check_ids("organizations", data.organizations, "organization_id")
+    _check_ids("teams", data.teams, "team_id")
+    _check_ids("users", data.users, "user_id")
+    _check_ids("credentials", data.credentials, "credential_name")
+    _check_ids("models", data.models, "model_id")
+    _check_ids("mcp_servers", data.mcp_servers, "server_id")
+    _check_ids("agents", data.agents, "agent_name")
+    _check_ids("guardrails", data.guardrails, "guardrail_name")
+
+    # keys: key_alias is optional (keyless keys are skipped at import time)
+    # — we only warn about them during import, not here
+
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "Snapshot validation failed", "errors": errors},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-entity dependency validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_dependencies(data: LiteLLMExportEnvelope) -> None:
+    """
+    Verify that cross-entity references within the snapshot are satisfied.
+
+    For example: a team that references an organization_id must have that
+    organization present in the snapshot (or we assume it already exists in
+    the target — so this only fires when BOTH sections are present).
+
+    Raises HTTPException(400) listing all broken references.
+    """
+    errors: List[str] = []
+
+    org_ids: Set[str] = {
+        r["organization_id"]
+        for r in (data.organizations or [])
+        if r.get("organization_id")
+    }
+    team_ids: Set[str] = {r["team_id"] for r in (data.teams or []) if r.get("team_id")}
+    user_ids: Set[str] = {r["user_id"] for r in (data.users or []) if r.get("user_id")}
+    budget_ids: Set[str] = {
+        r["budget_id"] for r in (data.budgets or []) if r.get("budget_id")
+    }
+
+    # Teams referencing orgs — only validate when the orgs section is present in
+    # the snapshot (None means section was not requested/included).
+    if data.teams and data.organizations is not None:
+        for team in data.teams:
+            oid = team.get("organization_id")
+            if oid and oid not in org_ids:
+                errors.append(
+                    f"teams[team_id={team.get('team_id')}]: "
+                    f"references organization_id='{oid}' not found in snapshot"
+                )
+
+    # Orgs referencing budgets — only validate when the budgets section is present.
+    if data.organizations and data.budgets is not None:
+        for org in data.organizations:
+            bid = org.get("budget_id")
+            if bid and bid not in budget_ids:
+                errors.append(
+                    f"organizations[organization_id={org.get('organization_id')}]: "
+                    f"references budget_id='{bid}' not found in snapshot"
+                )
+
+    # Keys referencing teams / users.
+    # Only validate when the referenced section was included in the snapshot.
+    # Skip keys with no key_alias — they are skipped during import anyway
+    # (e.g. internal/system keys like the litellm-dashboard master key).
+    if data.keys and data.teams is not None:
+        for key in data.keys:
+            if key.get("key_alias") is None:
+                continue  # will be skipped during import; skip validation too
+            tid = key.get("team_id")
+            if tid and tid not in team_ids:
+                errors.append(
+                    f"keys[key_alias={key.get('key_alias')}]: "
+                    f"references team_id='{tid}' not found in snapshot"
+                )
+    if data.keys and data.users is not None:
+        for key in data.keys:
+            if key.get("key_alias") is None:
+                continue  # will be skipped during import
+            uid = key.get("user_id")
+            if uid and uid not in user_ids:
+                errors.append(
+                    f"keys[key_alias={key.get('key_alias')}]: "
+                    f"references user_id='{uid}' not found in snapshot"
+                )
+
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "Dependency validation failed", "errors": errors},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deep merge
+# ---------------------------------------------------------------------------
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Iteratively merge `override` into `base`.  For dict values, descend;
+    for everything else, override wins.  Neither input is mutated.
+
+    Implemented with an explicit stack to avoid recursion (the repo's circular-
+    import / CPU-spike checker flags recursive functions as unacceptable).
+    """
+    # Each stack frame is (target_dict, base_dict, override_dict).
+    # We build the result top-down and patch nested dicts in-place as we go.
+    result: Dict[str, Any] = dict(base)
+    stack: List[Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]] = [
+        (result, base, override)
+    ]
+    while stack:
+        target, b, o = stack.pop()
+        for key, val in o.items():
+            if (
+                key in target
+                and isinstance(target[key], dict)
+                and isinstance(val, dict)
+            ):
+                # Create a fresh copy of the nested base dict and schedule it
+                # for merging rather than calling _deep_merge again.
+                nested: Dict[str, Any] = dict(b.get(key, {}))
+                target[key] = nested
+                stack.append((nested, b.get(key, {}), val))
+            else:
+                target[key] = val
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Batch DB read helper
+# ---------------------------------------------------------------------------
+
+
+async def _load_existing(
+    table: Any,
+    id_field: str,
+    ids: List[Any],
+) -> Dict[str, Any]:
+    """
+    Fetch all records matching `ids` in a single query and return an
+    id → record dict.  Eliminates N+1 `find_unique` calls.
+    """
+    if not ids:
+        return {}
+    rows = await table.find_many(where={id_field: {"in": ids}})
+    result: Dict[str, Any] = {}
+    for row in rows:
+        if hasattr(row, "model_dump"):
+            d = row.model_dump()
+        elif hasattr(row, "dict"):
+            d = row.dict()
+        else:
+            d = dict(row)
+        key = d.get(id_field)
+        if key is not None:
+            result[str(key)] = d
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section list resolver (used by export endpoint)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_sections(include: Optional[str]) -> Set[str]:
+    """Parse and validate the ?include= query param; return the set of sections."""
+    if not include:
+        return set(ALL_SECTIONS)
+    requested = {s.strip() for s in include.split(",")}
+    unknown = requested - set(ALL_SECTIONS)
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown sections: {unknown}. Valid sections: {ALL_SECTIONS}",
+        )
+    return requested

--- a/litellm/proxy/management_endpoints/config_export_types.py
+++ b/litellm/proxy/management_endpoints/config_export_types.py
@@ -186,23 +186,32 @@ def _redact_mcp_credentials(record: Dict[str, Any]) -> Dict[str, Any]:
     return record
 
 
-def _redact_params_dict(params: Dict[str, Any], depth: int = 0) -> Dict[str, Any]:
-    """Redact sensitive keys in a litellm_params dict, recursing into nested dicts.
+def _redact_params_dict(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Redact sensitive keys in a litellm_params dict, iterating into nested dicts.
 
-    Depth is bounded by DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER to
-    satisfy the repo's recursive-function checker.
+    Uses an explicit stack to avoid recursion (the repo's CPU-spike checker
+    flags recursive functions as unacceptable — see recursive_detector.py).
+    Depth is bounded by DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER.
+    Each stack frame carries (target_dict, source_dict, depth).
     """
-    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
-        return {"__redacted__": True}
-    out: Dict[str, Any] = {}
-    for k, v in params.items():
-        if _MASKER.is_sensitive_key(k) and v is not None:
-            out[k] = "__redacted__"
-        elif isinstance(v, dict):
-            out[k] = _redact_params_dict(v, depth + 1)
-        else:
-            out[k] = v
-    return out
+    result: Dict[str, Any] = {}
+    stack: List[Tuple[Dict[str, Any], Dict[str, Any], int]] = [(result, params, 0)]
+    while stack:
+        target, source, depth = stack.pop()
+        if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+            for k in source:
+                target[k] = "__redacted__"
+            continue
+        for k, v in source.items():
+            if _MASKER.is_sensitive_key(k) and v is not None:
+                target[k] = "__redacted__"
+            elif isinstance(v, dict):
+                nested: Dict[str, Any] = {}
+                target[k] = nested
+                stack.append((nested, v, depth + 1))
+            else:
+                target[k] = v
+    return result
 
 
 def _redact_litellm_params(record: Dict[str, Any]) -> Dict[str, Any]:
@@ -403,11 +412,6 @@ def _validate_dependencies(data: LiteLLMExportEnvelope) -> None:
             status_code=400,
             detail={"message": "Dependency validation failed", "errors": errors},
         )
-
-
-# ---------------------------------------------------------------------------
-# Deep merge
-# ---------------------------------------------------------------------------
 
 
 def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:

--- a/litellm/proxy/management_endpoints/config_import_helpers.py
+++ b/litellm/proxy/management_endpoints/config_import_helpers.py
@@ -389,11 +389,18 @@ async def _import_keys_section(
         return
 
     # Phase 2 — batch-fetch existing rows (avoids N+1 queries).
+    # Also count occurrences per alias: key_alias is not @unique in the schema,
+    # so multiple tokens can share the same alias.  Updating all of them would
+    # silently apply imported auth fields to unrelated keys — skip duplicates.
     aliases = [r["key_alias"] for r in importable]
     existing_rows = await prisma_client.db.litellm_verificationtoken.find_many(
         where={"key_alias": {"in": aliases}}
     )
-    existing_aliases: set = {row.key_alias for row in existing_rows if row.key_alias}
+    alias_counts: Dict[str, int] = {}
+    for row in existing_rows:
+        if row.key_alias:
+            alias_counts[row.key_alias] = alias_counts.get(row.key_alias, 0) + 1
+    existing_aliases: set = set(alias_counts.keys())
     existing_by_alias: Dict[str, Any] = {
         row.key_alias: row for row in existing_rows if row.key_alias
     }
@@ -413,6 +420,16 @@ async def _import_keys_section(
 
         if conflict == "skip":
             section_result.skipped += 1
+            continue
+
+        # key_alias is not @unique — multiple tokens can share the same alias.
+        # Updating all of them would apply imported auth fields to unrelated keys.
+        if alias_counts.get(alias, 0) > 1:
+            section_result.skipped += 1
+            section_result.warnings.append(
+                f"Skipped key '{alias}' — {alias_counts[alias]} tokens share this alias. "
+                "Assign a unique alias before importing."
+            )
             continue
 
         if dry_run:

--- a/litellm/proxy/management_endpoints/config_import_helpers.py
+++ b/litellm/proxy/management_endpoints/config_import_helpers.py
@@ -134,6 +134,14 @@ async def _import_section(
             "falling back to non-transactional writes.",
             table_name,
         )
+        _snap = (
+            section_result.created,
+            section_result.updated,
+            section_result.skipped,
+            section_result.errors,
+            section_result.total_processed,
+            list(section_result.warnings),
+        )
         try:
             for rec in records:
                 await _upsert(
@@ -147,7 +155,16 @@ async def _import_section(
                     id_query_field=id_query_field,
                 )
         except Exception as e:
+            (
+                section_result.created,
+                section_result.updated,
+                section_result.skipped,
+                section_result.errors,
+                section_result.total_processed,
+                section_result.warnings,
+            ) = _snap
             section_result.errors += len(records)
+            section_result.total_processed += len(records)
             section_result.warnings.append(f"Section failed: {e}")
             verbose_proxy_logger.error(
                 "Section %s failed: %s", table_name, e, exc_info=True

--- a/litellm/proxy/management_endpoints/config_import_helpers.py
+++ b/litellm/proxy/management_endpoints/config_import_helpers.py
@@ -6,9 +6,47 @@ from litellm._logging import verbose_proxy_logger
 from litellm.proxy.management_endpoints.config_export_types import (
     SAFE_GENERAL_SETTINGS_KEYS,
     _KEYS_UPDATE_STRIP,
+    ImportResult,
     ImportSectionResult,
     _deep_merge,
 )
+
+_ROUTING_SECTIONS = frozenset(
+    {"models", "agents", "guardrails", "mcp_servers", "general_settings"}
+)
+_AUTH_SECTIONS = frozenset({"keys", "users", "teams"})
+
+
+async def _post_import_cache_refresh(result: ImportResult, dry_run: bool) -> None:
+    """Invalidate stale in-memory state after a successful import.
+
+    - Auth sections (keys/users/teams): flush user_api_key_cache so the next
+      request re-reads updated access/budget fields from the DB.
+    - Routing sections (models/agents/guardrails/mcp_servers/general_settings):
+      reload the llm_router deployment list from the DB via clear_cache().
+    """
+    if dry_run:
+        return
+    attempted = set(result.sections_attempted)
+    if attempted & _AUTH_SECTIONS:
+        try:
+            from litellm.proxy.proxy_server import user_api_key_cache  # avoid circular
+
+            user_api_key_cache.flush_cache()
+        except Exception as e:
+            verbose_proxy_logger.warning("post-import auth cache flush failed: %s", e)
+    if attempted & _ROUTING_SECTIONS:
+        try:
+            from litellm.proxy.management_endpoints.model_management_endpoints import (
+                clear_cache,
+            )
+
+            await clear_cache()
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "post-import router cache refresh failed: %s", e
+            )
+
 
 # ---------------------------------------------------------------------------
 # Generic upsert helper — uses pre-loaded cache (no N+1 queries)

--- a/litellm/proxy/management_endpoints/config_import_helpers.py
+++ b/litellm/proxy/management_endpoints/config_import_helpers.py
@@ -1,0 +1,392 @@
+"""Import helper functions for POST /config/import."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.management_endpoints.config_export_types import (
+    SAFE_GENERAL_SETTINGS_KEYS,
+    _KEYS_UPDATE_STRIP,
+    ImportSectionResult,
+    _deep_merge,
+)
+
+# ---------------------------------------------------------------------------
+# Generic upsert helper — uses pre-loaded cache (no N+1 queries)
+# ---------------------------------------------------------------------------
+
+
+async def _upsert(
+    table: Any,
+    rec: Dict[str, Any],
+    id_field: str,
+    conflict: str,
+    dry_run: bool,
+    section_result: ImportSectionResult,
+    existing_map: Dict[str, Any],
+    id_query_field: Optional[str] = None,
+) -> None:
+    """
+    Upsert a single record into `table`.
+
+    id_field       — the dict key in `rec` that holds the stable identifier
+    id_query_field — the Prisma `where` field name (defaults to id_field)
+    existing_map   — pre-loaded {id: record} map (avoids N+1 find_unique calls)
+
+    In dry_run mode: reads from existing_map but never writes.
+    """
+    id_query_field = id_query_field or id_field
+    record_id = rec.get(id_field)
+    section_result.total_processed += 1
+
+    if not record_id:
+        section_result.skipped += 1
+        section_result.warnings.append(f"Skipped record with missing {id_field}: {rec}")
+        return
+
+    existing = existing_map.get(str(record_id))
+
+    # Accurate dry-run: simulate actual outcome without writing
+    if dry_run:
+        if existing is None:
+            section_result.created += 1
+        elif conflict == "skip":
+            section_result.skipped += 1
+        else:
+            section_result.updated += 1
+        return
+
+    try:
+        if existing is None:
+            await table.create(data=rec)
+            section_result.created += 1
+        elif conflict == "skip":
+            section_result.skipped += 1
+        elif conflict == "replace":
+            update_data = {k: v for k, v in rec.items() if k != id_query_field}
+            update_data.pop(id_field, None)
+            await table.update(where={id_query_field: record_id}, data=update_data)
+            section_result.updated += 1
+        elif conflict == "merge":
+            merged = _deep_merge(existing, rec)
+            update_data = {k: v for k, v in merged.items() if k != id_query_field}
+            update_data.pop(id_field, None)
+            await table.update(where={id_query_field: record_id}, data=update_data)
+            section_result.updated += 1
+    except Exception as e:
+        section_result.errors += 1
+        section_result.warnings.append(f"Error upserting {id_field}={record_id}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Per-section transaction wrapper
+# ---------------------------------------------------------------------------
+
+
+async def _import_section(
+    table: Any,
+    table_name: str,
+    records: List[Dict[str, Any]],
+    id_field: str,
+    conflict: str,
+    dry_run: bool,
+    section_result: ImportSectionResult,
+    existing_map: Dict[str, Any],
+    id_query_field: Optional[str] = None,
+) -> None:
+    """
+    Process all records for one section inside a single DB transaction.
+
+    table_name must be the exact attribute name used to access this table on
+    the Prisma client (e.g. "litellm_teamtable").  It is used to look up the
+    corresponding accessor on the transaction object — prisma-client-py exposes
+    the same snake_case names on both the client and the transaction.
+
+    If any record raises an unhandled exception the entire section is rolled
+    back and the error is surfaced in section_result.  Per-record errors
+    (e.g. constraint violations) are caught by _upsert and counted without
+    aborting the section.
+
+    dry_run: skips the transaction context entirely.
+    """
+    if dry_run:
+        for rec in records:
+            await _upsert(
+                table=table,
+                rec=rec,
+                id_field=id_field,
+                conflict=conflict,
+                dry_run=True,
+                section_result=section_result,
+                existing_map=existing_map,
+                id_query_field=id_query_field,
+            )
+        return
+
+    # Check for transaction support BEFORE entering async with.
+    # Catching AttributeError *inside* the block would also swallow
+    # AttributeErrors raised by _upsert (e.g. a missing field on the data
+    # dict), misclassifying real bugs as "tx not available".
+    has_tx = hasattr(table, "_client") and hasattr(table._client, "tx")
+
+    if not has_tx:
+        verbose_proxy_logger.warning(
+            "Prisma transaction not available for %s; "
+            "falling back to non-transactional writes.",
+            table_name,
+        )
+        try:
+            for rec in records:
+                await _upsert(
+                    table=table,
+                    rec=rec,
+                    id_field=id_field,
+                    conflict=conflict,
+                    dry_run=False,
+                    section_result=section_result,
+                    existing_map=existing_map,
+                    id_query_field=id_query_field,
+                )
+        except Exception as e:
+            section_result.errors += len(records)
+            section_result.warnings.append(f"Section failed: {e}")
+            verbose_proxy_logger.error(
+                "Section %s failed: %s", table_name, e, exc_info=True
+            )
+        return
+
+    # Snapshot counts before entering the transaction so that a rollback can
+    # restore them to their pre-section state before recording the failure.
+    # Without this, _upsert increments created/updated/skipped inside the block
+    # and the except branch then adds errors on top, making
+    # created + updated + skipped + errors > total_processed.
+    _snap = (
+        section_result.created,
+        section_result.updated,
+        section_result.skipped,
+        section_result.errors,
+        section_result.total_processed,
+        list(section_result.warnings),
+    )
+
+    try:
+        async with table._client.tx() as tx:
+            # Use the explicit snake_case table_name to look up the accessor on
+            # the transaction object.  table.__class__.__name__.lower() would
+            # produce a name without underscores (e.g. "litellmteamtableactions")
+            # that never matches, causing getattr to silently return the original
+            # non-transactional table handle.
+            tx_table = getattr(tx, table_name)
+            for rec in records:
+                await _upsert(
+                    table=tx_table,
+                    rec=rec,
+                    id_field=id_field,
+                    conflict=conflict,
+                    dry_run=False,
+                    section_result=section_result,
+                    existing_map=existing_map,
+                    id_query_field=id_query_field,
+                )
+    except Exception as e:
+        # Restore pre-transaction counts, then record every record as an error.
+        (
+            section_result.created,
+            section_result.updated,
+            section_result.skipped,
+            section_result.errors,
+            section_result.total_processed,
+            section_result.warnings,
+        ) = _snap
+        section_result.errors += len(records)
+        section_result.total_processed += len(records)
+        section_result.warnings.append(f"Section transaction rolled back: {e}")
+        verbose_proxy_logger.error(
+            "Section %s transaction failed: %s", table_name, e, exc_info=True
+        )
+
+
+# ---------------------------------------------------------------------------
+# General settings import
+# ---------------------------------------------------------------------------
+
+
+async def _import_general_settings(
+    prisma_client: Any,
+    settings: Dict[str, Any],
+    conflict: str,
+    dry_run: bool,
+    section_result: ImportSectionResult,
+) -> None:
+    """
+    Import general_settings key/value rows.
+
+    Each key is written individually so that a failure on one setting does not
+    prevent the remaining keys from being persisted.  Errors are counted and
+    surfaced in section_result.warnings without aborting the section.
+    """
+    # Batch-read all relevant existing rows in one query
+    safe_keys = [k for k in settings if k in SAFE_GENERAL_SETTINGS_KEYS]
+    unsafe_keys = [k for k in settings if k not in SAFE_GENERAL_SETTINGS_KEYS]
+    for k in unsafe_keys:
+        section_result.skipped += 1
+        section_result.total_processed += 1
+        section_result.warnings.append(
+            f"Skipped general_settings key '{k}' — not in safe export allow-list"
+        )
+
+    if not safe_keys:
+        return
+
+    existing_rows = await prisma_client.db.litellm_config.find_many(
+        where={"param_name": {"in": safe_keys}}
+    )
+    existing_map = {r.param_name: r for r in existing_rows}
+
+    def _apply(param_name: str, param_value: Any) -> Tuple[str, Any]:
+        existing = existing_map.get(param_name)
+        if existing is None:
+            return ("create", param_value)
+        if conflict == "skip":
+            return ("skip", None)
+        if (
+            conflict == "merge"
+            and isinstance(existing.param_value, dict)
+            and isinstance(param_value, dict)
+        ):
+            return ("update", _deep_merge(existing.param_value, param_value))
+        return ("update", param_value)
+
+    if dry_run:
+        for k in safe_keys:
+            section_result.total_processed += 1
+            action, _ = _apply(k, settings[k])
+            if action == "create":
+                section_result.created += 1
+            elif action == "skip":
+                section_result.skipped += 1
+            else:
+                section_result.updated += 1
+        return
+
+    for param_name in safe_keys:
+        section_result.total_processed += 1
+        action, value = _apply(param_name, settings[param_name])
+        try:
+            if action == "create":
+                await prisma_client.db.litellm_config.create(
+                    data={"param_name": param_name, "param_value": value}
+                )
+                section_result.created += 1
+            elif action == "skip":
+                section_result.skipped += 1
+            else:
+                await prisma_client.db.litellm_config.update(
+                    where={"param_name": param_name},
+                    data={"param_value": value},
+                )
+                section_result.updated += 1
+        except Exception as e:
+            section_result.errors += 1
+            section_result.warnings.append(
+                f"Error importing general_settings[{param_name}]: {e}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Keys section — special handling (cannot create; update_many for non-unique WHERE)
+# ---------------------------------------------------------------------------
+
+
+async def _import_keys_section(
+    prisma_client: Any,
+    records: List[Dict[str, Any]],
+    conflict: str,
+    dry_run: bool,
+    section_result: "ImportSectionResult",
+) -> None:
+    """
+    Keys are exported for metadata visibility only.
+
+    - Create: impossible — token (@id, primary key) is not exported for
+      security reasons.  New keys must be created via POST /key/generate.
+    - Skip: existing records are left untouched.
+    - Replace / Merge: metadata fields are updated via update_many(), which
+      accepts a non-unique WHERE clause.  key_alias has @@index (not @unique
+      or @id), so table.update(where={"key_alias": ...}) would raise a Prisma
+      validation error; update_many() is the correct API for this schema.
+      token, key_alias, and spend are always stripped from the UPDATE payload.
+    """
+    # Phase 1 — separate keyless records (unconditionally skipped) from
+    # importable ones.  total_processed is counted here for all records so
+    # phase 3 does not double-count.
+    importable: List[Dict[str, Any]] = []
+    for rec in records:
+        section_result.total_processed += 1
+        if not rec.get("key_alias"):
+            section_result.skipped += 1
+            section_result.warnings.append(
+                "Skipped key with no key_alias — cannot re-import without a stable identifier"
+            )
+        else:
+            importable.append(rec)
+
+    if not importable:
+        return
+
+    # Phase 2 — batch-fetch existing rows (avoids N+1 queries).
+    aliases = [r["key_alias"] for r in importable]
+    existing_rows = await prisma_client.db.litellm_verificationtoken.find_many(
+        where={"key_alias": {"in": aliases}}
+    )
+    existing_aliases: set = {row.key_alias for row in existing_rows if row.key_alias}
+    existing_by_alias: Dict[str, Any] = {
+        row.key_alias: row for row in existing_rows if row.key_alias
+    }
+
+    # Phase 3 — per-record decisions.
+    for rec in importable:
+        alias = rec["key_alias"]
+
+        if alias not in existing_aliases:
+            # Cannot create: token (primary key) was not exported.
+            section_result.skipped += 1
+            section_result.warnings.append(
+                f"Skipped key '{alias}' — new keys cannot be created during import "
+                "(token/primary key is not exported). Create via POST /key/generate."
+            )
+            continue
+
+        if conflict == "skip":
+            section_result.skipped += 1
+            continue
+
+        if dry_run:
+            section_result.updated += 1
+            continue
+
+        # Build the UPDATE payload.
+        if conflict == "merge":
+            existing_obj = existing_by_alias[alias]
+            base = (
+                existing_obj.model_dump()
+                if hasattr(existing_obj, "model_dump")
+                else dict(existing_obj)
+            )
+            update_data = _deep_merge(base, rec)
+        else:
+            update_data = dict(rec)
+
+        # Strip fields that must not appear in the UPDATE statement.
+        for field in _KEYS_UPDATE_STRIP:
+            update_data.pop(field, None)
+
+        try:
+            # update_many() accepts non-unique WHERE clauses; update() does not.
+            await prisma_client.db.litellm_verificationtoken.update_many(
+                where={"key_alias": alias},
+                data=update_data,
+            )
+            section_result.updated += 1
+        except Exception as e:
+            section_result.errors += 1
+            section_result.warnings.append(f"Failed to update key '{alias}': {e}")

--- a/litellm/proxy/management_endpoints/config_import_helpers.py
+++ b/litellm/proxy/management_endpoints/config_import_helpers.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
 from litellm.proxy.management_endpoints.config_export_types import (
     SAFE_GENERAL_SETTINGS_KEYS,
     _KEYS_UPDATE_STRIP,
@@ -10,6 +11,31 @@ from litellm.proxy.management_endpoints.config_export_types import (
     ImportSectionResult,
     _deep_merge,
 )
+
+
+def _encrypt_dict_field(record: Dict[str, Any], field: str) -> Dict[str, Any]:
+    """Encrypt all values in a dict-typed field before a DB write.
+
+    Matches the encryption applied by /model/new, /credentials, and MCP paths.
+    Returns the record unchanged if the field is absent, None, or not a dict.
+    """
+    value = record.get(field)
+    if not isinstance(value, dict) or not value:
+        return record
+    return {**record, field: {k: encrypt_value_helper(v) for k, v in value.items()}}
+
+
+def _encrypt_litellm_params_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    return _encrypt_dict_field(record, "litellm_params")
+
+
+def _encrypt_credential_values(record: Dict[str, Any]) -> Dict[str, Any]:
+    return _encrypt_dict_field(record, "credential_values")
+
+
+def _encrypt_mcp_credentials(record: Dict[str, Any]) -> Dict[str, Any]:
+    return _encrypt_dict_field(record, "credentials")
+
 
 _ROUTING_SECTIONS = frozenset(
     {"models", "agents", "guardrails", "mcp_servers", "general_settings"}

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -390,6 +390,9 @@ from litellm.proxy.management_endpoints.tag_management_endpoints import (
 from litellm.proxy.management_endpoints.team_callback_endpoints import (
     router as team_callback_router,
 )
+from litellm.proxy.management_endpoints.config_export_endpoints import (
+    router as config_export_router,
+)
 from litellm.proxy.management_endpoints.team_endpoints import router as team_router
 from litellm.proxy.management_endpoints.team_endpoints import (
     update_team,
@@ -15547,6 +15550,7 @@ app.include_router(cost_tracking_settings_router)
 app.include_router(router_settings_router)
 app.include_router(fallback_management_router)
 app.include_router(cache_settings_router)
+app.include_router(config_export_router)
 app.include_router(user_agent_analytics_router)
 app.include_router(enterprise_router)
 app.include_router(ui_discovery_endpoints_router)

--- a/tests/test_litellm/proxy/management_endpoints/test_config_export_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_export_endpoints.py
@@ -1,0 +1,489 @@
+"""Unit tests for GET /config/export and POST /config/import endpoints."""
+
+import json
+import sys
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.management_endpoints.config_export_endpoints import (
+    export_config,
+    import_config,
+)
+from litellm.proxy.management_endpoints.config_export_types import (
+    ImportRequest,
+    ImportResult,
+    ImportSectionResult,
+    LiteLLMExportEnvelope,
+    _redact_litellm_params,
+    _resolve_sections,
+    _validate_dependencies,
+    _validate_envelope,
+)
+from litellm.proxy.management_endpoints.config_import_helpers import (
+    _import_section,
+    _upsert,
+)
+
+
+def make_admin_key() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(api_key="test-key", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+
+def make_viewer_key() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="test-key", user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
+    )
+
+
+def make_request(base_url: str = "http://testserver") -> MagicMock:
+    req = MagicMock()
+    req.base_url = base_url
+    return req
+
+
+@contextmanager
+def mock_prisma(prisma):
+    fake_module = MagicMock()
+    fake_module.prisma_client = prisma
+    with patch.dict(sys.modules, {"litellm.proxy.proxy_server": fake_module}):
+        yield
+
+
+def make_prisma(
+    teams=None, models=None, mcp_servers=None, keys=None, credentials=None,
+    agents=None, guardrails=None, tags=None, budgets=None, orgs=None,
+    users=None, config_rows=None,
+):
+    pc = MagicMock()
+
+    def _table(rows):
+        t = MagicMock()
+        t.find_many = AsyncMock(return_value=rows or [])
+        t.find_unique = AsyncMock(return_value=None)
+        t.create = AsyncMock()
+        t.update = AsyncMock()
+        return t
+
+    pc.db.litellm_budgettable = _table(budgets)
+    pc.db.litellm_organizationtable = _table(orgs)
+    pc.db.litellm_teamtable = _table(teams)
+    pc.db.litellm_usertable = _table(users)
+    pc.db.litellm_verificationtoken = _table(keys)
+    pc.db.litellm_credentialstable = _table(credentials)
+    pc.db.litellm_proxymodeltable = _table(models)
+    pc.db.litellm_mcpservertable = _table(mcp_servers)
+    pc.db.litellm_agentstable = _table(agents)
+    pc.db.litellm_guardrailstable = _table(guardrails)
+    pc.db.litellm_tagtable = _table(tags)
+    pc.db.litellm_config = _table(config_rows)
+    return pc
+
+
+class _NoTxTable:
+    """Minimal table stub without a Prisma transaction client (has_tx=False)."""
+
+    def __init__(self):
+        self.created = []
+        self.updated = []
+
+    async def create(self, data):
+        self.created.append(data)
+
+    async def update(self, where, data):
+        self.updated.append((where, data))
+
+    async def find_many(self, where=None):
+        return []
+
+
+class _FailCommitTxContext:
+    """Async context manager whose __aexit__ always raises (simulates commit failure)."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        raise Exception("commit failed")
+
+
+class _FailCommitTxClient:
+    def tx(self):
+        return _FailCommitTxContext()
+
+
+class _TxTable(_NoTxTable):
+    """_NoTxTable with a fail-on-commit transaction client attached."""
+
+    def __init__(self, client=None):
+        super().__init__()
+        self._client = client or _FailCommitTxClient()
+
+    def __getattr__(self, name):
+        return self
+
+
+@pytest.mark.asyncio
+async def test_export_models_redacts_litellm_params_secrets():
+    model_row = {
+        "model_id": "m1",
+        "model_name": "gpt-4",
+        "litellm_params": {
+            "model": "azure/gpt-4",
+            "api_key": "sk-secret",
+            "api_base": "https://my.openai.azure.com",
+            "aws_secret_access_key": "wJalrX",
+        },
+    }
+    prisma = make_prisma(models=[model_row])
+
+    with mock_prisma(prisma):
+        response = await export_config(
+            request=make_request(),
+            user_api_key_dict=make_admin_key(),
+            include="models",
+            format="json",
+            redact_secrets=True,
+            limit=1000,
+        )
+
+    body = json.loads(response.body)
+    params = body["models"][0]["litellm_params"]
+    assert params["api_key"] == "__redacted__"
+    assert params["aws_secret_access_key"] == "__redacted__"
+    assert params["api_base"] == "https://my.openai.azure.com"
+    assert params["model"] == "azure/gpt-4"
+
+
+@pytest.mark.asyncio
+async def test_export_requires_admin_role():
+    with mock_prisma(MagicMock()):
+        with pytest.raises(HTTPException) as exc_info:
+            await export_config(
+                request=make_request(),
+                user_api_key_dict=make_viewer_key(),
+                include=None,
+                format="json",
+                redact_secrets=True,
+                limit=1000,
+            )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_export_raises_500_when_db_not_connected():
+    fake_module = MagicMock()
+    fake_module.prisma_client = None
+    with patch.dict(sys.modules, {"litellm.proxy.proxy_server": fake_module}):
+        with pytest.raises(HTTPException) as exc_info:
+            await export_config(
+                request=make_request(),
+                user_api_key_dict=make_admin_key(),
+                include=None,
+                format="json",
+                redact_secrets=True,
+                limit=1000,
+            )
+    assert exc_info.value.status_code == 500
+    assert "Database not connected" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_import_dry_run_does_not_write():
+    prisma = make_prisma()
+    envelope = LiteLLMExportEnvelope(
+        exported_at="2024-01-01T00:00:00Z",
+        source_instance="http://dev",
+        include_filters=["teams"],
+        teams=[{"team_id": "t1", "team_alias": "alpha"}],
+    )
+    body = ImportRequest(data=envelope, dry_run=True)
+
+    with mock_prisma(prisma):
+        result = await import_config(
+            request=make_request(), body=body, user_api_key_dict=make_admin_key()
+        )
+
+    assert result.dry_run is True
+    assert result.teams.created == 1
+    prisma.db.litellm_teamtable.create.assert_not_called()
+    prisma.db.litellm_teamtable.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_import_all_sections_smoke(monkeypatch):
+    prisma = make_prisma()
+
+    async def fake_import_section(**kwargs):
+        sr = kwargs["section_result"]
+        sr.created += len(kwargs.get("records", []))
+        sr.total_processed += len(kwargs.get("records", []))
+
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_export_endpoints._import_section",
+        fake_import_section,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_export_endpoints._load_existing",
+        AsyncMock(return_value={}),
+    )
+
+    envelope = LiteLLMExportEnvelope(
+        exported_at="2024-01-01T00:00:00Z",
+        source_instance="http://dev",
+        include_filters=["*"],
+        budgets=[{"budget_id": "b1"}],
+        organizations=[{"organization_id": "o1"}],
+        teams=[{"team_id": "t1"}],
+        users=[{"user_id": "u1"}],
+        keys=[{"key_alias": "k1"}],
+        credentials=[{"credential_name": "c1", "credential_values": {}}],
+        models=[{"model_id": "m1"}],
+        mcp_servers=[{"server_id": "s1"}],
+        agents=[{"agent_name": "a1"}],
+        guardrails=[{"guardrail_name": "g1"}],
+        tags=[{"tag_name": "tag1"}],
+        general_settings={"max_parallel_requests": 10},
+    )
+    body = ImportRequest(data=envelope, dry_run=True)
+
+    with mock_prisma(prisma):
+        result = await import_config(
+            request=make_request(), body=body, user_api_key_dict=make_admin_key()
+        )
+
+    assert len(result.sections_attempted) >= 10
+
+
+@pytest.mark.asyncio
+async def test_import_handles_exception(monkeypatch):
+    prisma = make_prisma()
+
+    async def fail_import_section(**kwargs):
+        raise Exception("boom")
+
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_export_endpoints._import_section",
+        fail_import_section,
+    )
+
+    envelope = LiteLLMExportEnvelope(
+        exported_at="2024-01-01T00:00:00Z",
+        source_instance="http://dev",
+        include_filters=["teams"],
+        teams=[{"team_id": "t1"}],
+    )
+    body = ImportRequest(data=envelope)
+
+    with mock_prisma(prisma):
+        with pytest.raises(HTTPException) as exc:
+            await import_config(
+                request=make_request(), body=body, user_api_key_dict=make_admin_key()
+            )
+
+    assert exc.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_import_config_per_section_errors_are_isolated(monkeypatch):
+    class _FailCreateTable:
+        async def create(self, data):
+            raise Exception("models db error")
+
+        async def find_many(self, where=None):
+            return []
+
+        async def update(self, where, data):
+            pass
+
+    prisma = make_prisma()
+    prisma.db.litellm_teamtable.find_many = AsyncMock(return_value=[])
+    prisma.db.litellm_proxymodeltable = _FailCreateTable()
+
+    envelope = LiteLLMExportEnvelope(
+        exported_at="2024-01-01T00:00:00Z",
+        source_instance="http://dev",
+        include_filters=["teams", "models"],
+        teams=[{"team_id": "t1", "team_alias": "alpha"}],
+        models=[{"model_id": "m1", "model_name": "gpt-4"}],
+    )
+    body = ImportRequest(data=envelope, conflict="skip")
+
+    with mock_prisma(prisma):
+        result = await import_config(
+            request=make_request(), body=body, user_api_key_dict=make_admin_key()
+        )
+
+    assert result.teams.created == 1
+    assert result.teams.errors == 0
+    assert result.models.errors == 1
+    assert result.models.created == 0
+
+
+@pytest.mark.asyncio
+async def test_upsert_exception_counted_as_error():
+    table = MagicMock()
+    table.create = AsyncMock(side_effect=Exception("constraint violation"))
+
+    sr = ImportSectionResult()
+    await _upsert(
+        table=table,
+        rec={"team_id": "t1", "team_alias": "alpha"},
+        id_field="team_id",
+        conflict="skip",
+        dry_run=False,
+        section_result=sr,
+        existing_map={},
+    )
+
+    assert sr.errors == 1
+    assert any("constraint violation" in w for w in sr.warnings)
+
+
+@pytest.mark.asyncio
+async def test_import_section_transaction_rollback_does_not_double_count():
+    sr = ImportSectionResult()
+    await _import_section(
+        table=_TxTable(),
+        table_name="litellm_teamtable",
+        records=[{"team_id": "t1"}, {"team_id": "t2"}],
+        id_field="team_id",
+        conflict="skip",
+        dry_run=False,
+        section_result=sr,
+        existing_map={},
+    )
+
+    assert sr.errors == 2
+    assert sr.created == 0
+    assert sr.updated == 0
+    assert sr.skipped == 0
+    assert sr.total_processed == 2
+    assert sr.errors + sr.skipped + sr.created + sr.updated == sr.total_processed
+    assert any("rolled back" in w for w in sr.warnings)
+
+
+@pytest.mark.asyncio
+async def test_import_section_logs_error_on_transaction_failure():
+    with patch(
+        "litellm.proxy.management_endpoints.config_import_helpers.verbose_proxy_logger"
+    ) as mock_logger:
+        sr = ImportSectionResult()
+        await _import_section(
+            table=_TxTable(),
+            table_name="litellm_teamtable",
+            records=[{"team_id": "t1"}],
+            id_field="team_id",
+            conflict="skip",
+            dry_run=False,
+            section_result=sr,
+            existing_map={},
+        )
+
+    mock_logger.error.assert_called_once()
+    assert sr.errors == 1
+
+
+@pytest.mark.asyncio
+async def test_import_does_not_write_redacted_placeholders_to_db(monkeypatch):
+    captured: list = []
+
+    async def fake_import_section(**kwargs):
+        captured.extend(kwargs["records"])
+        sr = kwargs["section_result"]
+        sr.created += len(kwargs["records"])
+        sr.total_processed += len(kwargs["records"])
+
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_export_endpoints._import_section",
+        fake_import_section,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_export_endpoints._load_existing",
+        AsyncMock(return_value={}),
+    )
+
+    envelope = LiteLLMExportEnvelope(
+        exported_at="2024-01-01T00:00:00Z",
+        source_instance="http://dev",
+        include_filters=["models", "mcp_servers"],
+        models=[{
+            "model_id": "m1",
+            "litellm_params": {
+                "model": "azure/gpt-4",
+                "api_key": "__redacted__",
+                "aws_secret_access_key": "__redacted__",
+                "api_base": "https://my.openai.azure.com",
+            },
+        }],
+        mcp_servers=[{
+            "server_id": "s1",
+            "server_name": "my-mcp",
+            "url": "https://mcp.example.com",
+            "credentials": {"__redacted__": True},
+            "static_headers": {"__redacted__": True},
+            "env": {"__redacted__": True},
+        }],
+    )
+    body = ImportRequest(data=envelope, dry_run=False, conflict="replace")
+
+    with mock_prisma(make_prisma()):
+        result = await import_config(
+            request=make_request(), body=body, user_api_key_dict=make_admin_key()
+        )
+
+    # models — string-sentinel sub-fields stripped from litellm_params
+    model_rec = next(r for r in captured if r.get("model_id") == "m1")
+    params = model_rec["litellm_params"]
+    assert "api_key" not in params
+    assert "aws_secret_access_key" not in params
+    assert params["api_base"] == "https://my.openai.azure.com"
+
+    # mcp_servers — dict-form sentinel fields stripped, non-secret kept
+    mcp_rec = next(r for r in captured if r.get("server_id") == "s1")
+    assert "credentials" not in mcp_rec
+    assert "static_headers" not in mcp_rec
+    assert "env" not in mcp_rec
+    assert mcp_rec["url"] == "https://mcp.example.com"
+
+    # warnings emitted for each stripped MCP field
+    warns = result.mcp_servers.warnings
+    assert any("credentials" in w for w in warns)
+    assert any("static_headers" in w for w in warns)
+    assert any("env" in w for w in warns)
+
+
+@pytest.mark.asyncio
+async def test_upsert_replace_merge_and_edge_cases():
+    t = MagicMock()
+    t.update = AsyncMock()
+    sr = ImportSectionResult()
+    await _upsert(t, {"team_id": "t1", "x": 1}, "team_id", "replace", False, sr, {"t1": {}})
+    assert sr.updated == 1 and t.update.called
+    sr2 = ImportSectionResult()
+    await _upsert(t, {"team_id": "t2", "x": 2}, "team_id", "merge", False, sr2, {"t2": {"team_id": "t2", "x": 0}})
+    assert sr2.updated == 1
+    sr3 = ImportSectionResult()
+    await _upsert(t, {"team_id": "t3"}, "team_id", "skip", True, sr3, {"t3": {}})
+    assert sr3.skipped == 1
+    sr4 = ImportSectionResult()
+    await _upsert(t, {}, "team_id", "skip", False, sr4, {})
+    assert sr4.skipped == 1 and sr4.warnings
+
+
+def test_resolve_sections_rejects_unknown_section():
+    with pytest.raises(HTTPException) as exc:
+        _resolve_sections("not_a_real_section")
+    assert exc.value.status_code == 400
+
+
+def test_validate_envelope_rejects_duplicate_ids():
+    with pytest.raises(HTTPException) as exc:
+        _validate_envelope(LiteLLMExportEnvelope(
+            exported_at="2024-01-01T00:00:00Z", source_instance="http://dev",
+            include_filters=[], teams=[{"team_id": "t1"}, {"team_id": "t1"}],
+        ))
+    assert exc.value.status_code == 400

--- a/tests/test_litellm/proxy/management_endpoints/test_config_export_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_export_endpoints.py
@@ -24,6 +24,7 @@ from litellm.proxy.management_endpoints.config_export_types import (
     _validate_envelope,
 )
 from litellm.proxy.management_endpoints.config_import_helpers import (
+    _encrypt_dict_field,
     _import_section,
     _upsert,
 )
@@ -406,6 +407,13 @@ async def test_import_does_not_write_redacted_placeholders_to_db(monkeypatch):
         AsyncMock(return_value={}),
     )
 
+    # Bypass real encryption (requires a master key) — this test checks stripping
+    # of redacted sentinels, not encryption correctness.
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_import_helpers.encrypt_value_helper",
+        lambda v: v,
+    )
+
     envelope = LiteLLMExportEnvelope(
         exported_at="2024-01-01T00:00:00Z",
         source_instance="http://dev",
@@ -478,6 +486,27 @@ def test_resolve_sections_rejects_unknown_section():
     with pytest.raises(HTTPException) as exc:
         _resolve_sections("not_a_real_section")
     assert exc.value.status_code == 400
+
+
+def test_encrypt_dict_field(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.config_import_helpers.encrypt_value_helper",
+        lambda v: f"enc:{v}",
+    )
+    # encrypts values in the named field
+    rec = {"credential_name": "c1", "credential_values": {"api_key": "sk-secret", "region": "us-east-1"}}
+    result = _encrypt_dict_field(rec, "credential_values")
+    assert result["credential_values"] == {"api_key": "enc:sk-secret", "region": "enc:us-east-1"}
+    assert result["credential_name"] == "c1"  # other fields untouched
+
+    # returns record unchanged when field is absent
+    assert _encrypt_dict_field({"x": 1}, "credential_values") == {"x": 1}
+
+    # returns record unchanged when field is not a dict
+    assert _encrypt_dict_field({"credential_values": None}, "credential_values") == {"credential_values": None}
+
+    # returns record unchanged when dict is empty
+    assert _encrypt_dict_field({"credential_values": {}}, "credential_values") == {"credential_values": {}}
 
 
 def test_validate_envelope_rejects_duplicate_ids():


### PR DESCRIPTION
## Relevant issues

"Fixes #28168"

##Summary   

  - Adds GET /config/export and POST /config/import endpoints to the LiteLLM proxy                                                                                                                                                                  
  - Closes the gap where /config/yaml returns {"hello": "world"} and there is no way to snapshot UI/API-managed state for re-deployment or environment promotion
  - Fixes two P1 import-side bugs where redacted placeholder values would be written verbatim to the target DB                                                                                                                                      
                                                                                                                                                                                                                                                    
##Motivation                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  Teams running LiteLLM across multiple environments (dev → staging → prod) have no supported way to extract the state created through the UI or management APIs — teams, virtual keys, credentials, models, MCP servers, agents, guardrails, etc. —
   and re-apply it elsewhere. This PR adds that capability as a first-class, admin-gated export/import cycle.
                                                                                                                                                                                                                                                    
##What's exported                                                                                                                                                                                                                                 

 | Section          | Prisma Table              | Redacted Fields                                           |
|------------------|---------------------------|-----------------------------------------------------------|
| budgets          | litellm_budgettable       | —                                                         |
| organizations    | litellm_organizationtable | spend                                                     |
| teams            | litellm_teamtable         | spend                                                     |
| users            | litellm_usertable         | spend, user_api_key_hash, password                                  |
| keys             | litellm_verificationtoken | token, spend                                              |
| credentials      | litellm_credentialstable  | credential_values → {"__redacted__": true}               |
| models           | litellm_proxymodeltable   | litellm_params secrets → "__redacted__"                  |
| mcp_servers      | litellm_mcpservertable    | credentials, static_headers, env → {"__redacted__": true}|
| agents           | litellm_agentstable       | spend, litellm_params secrets → "__redacted__"           |
| guardrails       | litellm_guardrailstable   | litellm_params secrets → "__redacted__"                                                         |
| tags             | litellm_tagtable          | —                                                         |
| general_settings | litellm_config            | allow-listed safe keys only                               |                         
  
##API                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                  
  GET  /config/export?include=teams,models&format=json&redact_secrets=true
  POST /config/import   body: { data: <envelope>, conflict: "skip|replace|merge", dry_run: bool }                                                                                                                                                   
                                                                                                                                                                                                                                                    
  Both endpoints require PROXY_ADMIN role.                                                                                                                                                                                                          
                                                                                                                                                                                                                                                    
##Design decisions                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                  
  - Redacted placeholders — secrets export as {"__redacted__": true} (top-level fields) or "__redacted__" (litellm_params sub-keys) rather than encrypted blobs. Friendlier across environments with different salt material; re-bind credentials   
  separately after import.
  - Import-side redaction cleanup — before any Prisma write, string-sentinel sub-fields are stripped from litellm_params and dict-form sentinel fields are stripped from MCP server records, so placeholder values never reach the target DB.       
  - Per-section transactions — shorter lock window vs. one giant transaction; partial success is recoverable. Falls back to non-transactional writes if Prisma version lacks .tx().                                                                 
  - Batch DB reads — single find_many({id: {in: ids}}) per section, distributed in-memory. No N+1 queries.                                                                                                                                          
  - Accurate dry-run — reads the existing map to simulate real create/skip/update outcome without writing anything.                                                                                                                                 
  - Dependency validation — cross-section reference checks (teams→orgs, orgs→budgets, keys→teams/users) only fire when the referenced section is present in the snapshot, so built-in internal entities (e.g. litellm-dashboard) don't cause false  
  failures.                                                                                                                                                                                                                                         
  - Import order — budgets → organizations → teams → users → keys → credentials → models → mcp_servers → agents → guardrails → tags → general_settings to satisfy FK dependencies.
                                                                                                                                                                                                                                                                                                                                                                                                                             
  
##Testing   
  
  Screenshot - 
 
  
<img width="1601" height="903" alt="image" src="https://github.com/user-attachments/assets/259e080a-a789-4e99-ad23-ba4340699d02" />
                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                  
  14 unit tests in tests/test_litellm/proxy/management_endpoints/test_config_export_endpoints.py. No real database required — Prisma client is mocked via sys.modules patch.                                                                        
                                                                                                                                                                                                                                                  
  uv run pytest tests/test_litellm/proxy/management_endpoints/test_config_export_endpoints.py -v                                                                                                                                                    
  # 14 passed                                                                                                                                                                                                                                       
  
  Out of scope (follow-up PRs)                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                  
  - CLI wrapper (litellm config export)                                                                                                                                                                                                             
  - Encrypted secret export option                                                                                                                                                                                                                
  - End-user records, spend logs, audit logs 