### PR TITLE
fix(websearch): prevent internal flags from leaking to provider API (#28458)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4839,7 +4839,11 @@ def add_provider_specific_params_to_optional_params(
         ):
             extra_body = passed_params.pop("extra_body", None) or {}
             for k in passed_params.keys():
-                if k not in openai_params and passed_params[k] is not None:
+                if (
+                    k not in openai_params
+                    and passed_params[k] is not None
+                    and not k.startswith("_")
+                ):
                     extra_body[k] = passed_params[k]
             if not isinstance(optional_params.get("extra_body"), dict):
                 optional_params["extra_body"] = {}

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4869,7 +4869,11 @@ def add_provider_specific_params_to_optional_params(
             )
     else:
         for k in passed_params.keys():
-            if k not in openai_params and passed_params[k] is not None:
+            if (
+                k not in openai_params
+                and passed_params[k] is not None
+                and not k.startswith("_")
+            ):
                 if _should_drop_param(
                     k=k, additional_drop_params=additional_drop_params
                 ):

--- a/tests/test_litellm/test_websearch_interception_stream_param.py
+++ b/tests/test_litellm/test_websearch_interception_stream_param.py
@@ -103,6 +103,27 @@ class TestInternalFlagsNotInExtraBody:
         assert "_websearch_interception_converted_stream" not in extra_body
         assert extra_body.get("custom_param") == "value"
 
+    def test_non_openai_provider_flags_excluded(self):
+        """Internal flags should also be filtered for non-OpenAI providers (else branch)."""
+        passed_params = {
+            "_websearch_interception_converted_stream": True,
+            "_other_internal": "skip",
+            "custom_param": "keep",
+        }
+        optional_params = {}
+        openai_params = ["model", "messages"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="anthropic",
+            openai_params=openai_params,
+        )
+
+        assert "_websearch_interception_converted_stream" not in result
+        assert "_other_internal" not in result
+        assert result.get("custom_param") == "keep"
+
     def test_no_extra_body_when_only_internal_flags(self):
         """If only internal flags exist (besides openai params), extra_body should be empty."""
         passed_params = {

--- a/tests/test_litellm/test_websearch_interception_stream_param.py
+++ b/tests/test_litellm/test_websearch_interception_stream_param.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for fix #28458: Internal _websearch_interception_converted_stream flag
+must NOT leak into extra_body when building provider-specific params.
+
+The websearch interception deployment hook sets
+kwargs["_websearch_interception_converted_stream"] = True to track that stream
+was converted from True to False. This internal flag was leaking through
+add_provider_specific_params_to_optional_params into extra_body, causing
+OpenAI to reject the request with "Unknown parameter:
+'_websearch_interception_converted_stream'".
+
+The fix filters out any key starting with '_' from being added to extra_body,
+since underscore-prefixed keys are internal flags, not provider params.
+"""
+
+import pytest
+
+from litellm.utils import add_provider_specific_params_to_optional_params
+
+
+class TestInternalFlagsNotInExtraBody:
+    """Verify internal _-prefixed flags are excluded from extra_body."""
+
+    def test_websearch_flag_excluded_from_extra_body(self):
+        """_websearch_interception_converted_stream must not appear in extra_body."""
+        passed_params = {
+            "temperature": 0.7,
+            "_websearch_interception_converted_stream": True,
+        }
+        optional_params = {}
+        openai_params = ["temperature", "model", "messages"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="openai",
+            openai_params=openai_params,
+        )
+
+        extra_body = result.get("extra_body", {})
+        assert "_websearch_interception_converted_stream" not in extra_body
+
+    def test_regular_non_openai_params_still_in_extra_body(self):
+        """Non-underscore, non-OpenAI params should still go to extra_body."""
+        passed_params = {
+            "temperature": 0.7,
+            "custom_provider_param": "value",
+        }
+        optional_params = {}
+        openai_params = ["temperature", "model", "messages"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="openai",
+            openai_params=openai_params,
+        )
+
+        extra_body = result.get("extra_body", {})
+        assert extra_body.get("custom_provider_param") == "value"
+
+    def test_all_underscore_prefixed_flags_excluded(self):
+        """Any key starting with _ should be excluded from extra_body."""
+        passed_params = {
+            "_websearch_interception_converted_stream": True,
+            "_websearch_interception_other_flag": "test",
+            "_some_other_internal_flag": 42,
+            "valid_param": "keep",
+        }
+        optional_params = {}
+        openai_params = ["model", "messages"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="openai",
+            openai_params=openai_params,
+        )
+
+        extra_body = result.get("extra_body", {})
+        assert "_websearch_interception_converted_stream" not in extra_body
+        assert "_websearch_interception_other_flag" not in extra_body
+        assert "_some_other_internal_flag" not in extra_body
+        assert extra_body.get("valid_param") == "keep"
+
+    def test_openai_compatible_providers_also_filtered(self):
+        """Internal flags should also be filtered for openai-compatible providers."""
+        passed_params = {
+            "_websearch_interception_converted_stream": True,
+            "custom_param": "value",
+        }
+        optional_params = {}
+        openai_params = ["model", "messages"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="azure",
+            openai_params=openai_params,
+        )
+
+        extra_body = result.get("extra_body", {})
+        assert "_websearch_interception_converted_stream" not in extra_body
+        assert extra_body.get("custom_param") == "value"
+
+    def test_no_extra_body_when_only_internal_flags(self):
+        """If only internal flags exist (besides openai params), extra_body should be empty."""
+        passed_params = {
+            "temperature": 0.7,
+            "_websearch_interception_converted_stream": True,
+        }
+        optional_params = {}
+        openai_params = ["temperature", "model", "messages"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="openai",
+            openai_params=openai_params,
+        )
+
+        extra_body = result.get("extra_body", {})
+        assert len(extra_body) == 0


### PR DESCRIPTION
## Summary

- The websearch interception deployment hook sets `kwargs["_websearch_interception_converted_stream"] = True` to track that `stream` was converted from `True` to `False`
- This internal flag leaked through `add_provider_specific_params_to_optional_params` into `extra_body`, causing OpenAI to reject requests with `Unknown parameter: '_websearch_interception_converted_stream'`
- Fix: skip underscore-prefixed keys when building `extra_body` in `add_provider_specific_params_to_optional_params`, since they are internal flags and should never be forwarded to providers

## Root Cause

In `litellm/utils.py:add_provider_specific_params_to_optional_params()`, line 4822-4824:
```python
for k in passed_params.keys():
    if k not in openai_params and passed_params[k] is not None:
        extra_body[k] = passed_params[k]
```

Any param not in `openai_params` gets added to `extra_body`. Internal flags like `_websearch_interception_converted_stream` are not in `openai_params`, so they leak through to the provider API.

## Fix

Added `and not k.startswith("_")` guard to skip internal underscore-prefixed flags when building `extra_body`.

## Test plan

- [x] Added 5 unit tests in `tests/test_litellm/test_websearch_interception_stream_param.py`
- [x] Tests verify: flag excluded from extra_body, regular params preserved, all `_`-prefixed keys filtered, works for OpenAI and Azure, empty extra_body when only internal flags

Fixes #28458

🤖 Generated with [Claude Code](https://claude.com/claude-code)