### PR TITLE
fix(sagemaker): send native Cohere embed payload to Cohere SageMaker endpoints

### DIFF
--- a/litellm/llms/cohere/embed/v1_transformation.py
+++ b/litellm/llms/cohere/embed/v1_transformation.py
@@ -110,15 +110,35 @@ class CohereEmbeddingConfig:
             additional_args={"complete_input_dict": data},
             original_response=response_json,
         )
+        return self._populate_embedding_response(
+            response_json=response_json,
+            model_response=model_response,
+            model=model,
+            encoding=encoding,
+            input=input,
+        )
+
+    def _populate_embedding_response(
+        self,
+        response_json: dict,
+        model_response: EmbeddingResponse,
+        model: str,
+        encoding: Any,
+        input: list,
+    ) -> EmbeddingResponse:
         """
-            response 
+        Parse a Cohere embed response body into an OpenAI-style EmbeddingResponse.
+
+        Split out from `_transform_response` so callers that already log
+        `post_call` themselves (e.g. SageMaker's embedding handler) can reuse
+        the parsing without triggering a second `post_call`.
+
+        Response shape:
             {
                 'object': "list",
-                'data': [
-                
-                ]
-                'model', 
-                'usage'
+                'data': [...],
+                'model',
+                'usage',
             }
         """
         embeddings = response_json["embeddings"]
@@ -149,9 +169,6 @@ class CohereEmbeddingConfig:
         model_response.object = "list"
         model_response.data = output_data
         model_response.model = model
-        input_tokens = 0
-        for text in input:
-            input_tokens += len(encoding.encode(text))
 
         setattr(
             model_response,

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -578,7 +578,7 @@ class SagemakerLLM(BaseAWSLLM):
         logger_fn=None,
     ):
         """
-        Supports both Huggingface Jumpstart embeddings and Voyage models
+        Supports Hugging Face (TGI), Voyage, and Cohere embedding endpoints
         """
         ### BOTO3 INIT
         import boto3

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 from httpx._models import Headers, Response
 
 import litellm
-from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.llms.bedrock.embed.cohere_transformation import (
     BedrockCohereEmbeddingConfig,
 )

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -101,7 +101,12 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
         litellm_params: dict = {},
     ) -> "EmbeddingResponse":
         """
-        Transform embedding response for Cohere models on SageMaker
+        Transform embedding response for Cohere models on SageMaker.
+
+        Uses `CohereEmbeddingConfig._populate_embedding_response` (not
+        `_transform_response`) so we do not log `post_call` a second time
+        — the SageMaker embedding handler already logs `post_call` before
+        invoking this transform.
         """
         input_value = (
             logging_obj.model_call_details.get("input")
@@ -112,11 +117,8 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
         if isinstance(input_value, str):
             input_value = [input_value]
 
-        return CohereEmbeddingConfig()._transform_response(
-            response=raw_response,
-            api_key=api_key,
-            logging_obj=logging_obj,
-            data=request_data,
+        return CohereEmbeddingConfig()._populate_embedding_response(
+            response_json=raw_response.json(),
             model_response=model_response,
             model=model,
             encoding=litellm.encoding,

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -1,0 +1,158 @@
+"""
+Cohere embedding request/response transformation for SageMaker Marketplace endpoints.
+
+AWS Marketplace Cohere containers expect the native Cohere embed API body
+(`texts`, `input_type`, etc.), not HuggingFace TGI `inputs`.
+"""
+
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
+
+import httpx
+
+import litellm
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.llms.bedrock.embed.cohere_transformation import (
+    BedrockCohereEmbeddingConfig,
+)
+from litellm.llms.cohere.embed.v1_transformation import CohereEmbeddingConfig
+from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
+from litellm.types.utils import EmbeddingResponse
+
+from ..common_utils import SagemakerError
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging as LiteLLMLoggingObj,
+    )
+else:
+    LiteLLMLoggingObj = Any
+
+
+COHERE_EMBED_NAME_MARKERS = (
+    "embed-multilingual",
+    "embed-english",
+    "embed-v4",
+    "embed-v3",
+)
+
+
+def is_cohere_sagemaker_embedding_model(model: str) -> bool:
+    """
+    Detect Cohere embedding endpoints from the SageMaker endpoint / model name.
+
+    The SageMaker endpoint name is opaque, so we match on substrings
+    ("cohere" or a Cohere embed model id fragment such as "embed-multilingual-v3").
+    Endpoint names should include one of these markers so LiteLLM selects the
+    Cohere payload format instead of the HuggingFace TGI default.
+    """
+    model_lower = model.lower()
+    if "cohere" in model_lower:
+        return True
+    return any(marker in model_lower for marker in COHERE_EMBED_NAME_MARKERS)
+
+
+class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
+    """
+    SageMaker invoke payload for self-hosted Cohere embed models
+    (AWS Marketplace / JumpStart).
+    """
+
+    def __init__(self) -> None:
+        self._bedrock_cohere = BedrockCohereEmbeddingConfig()
+        self._cohere_v1 = CohereEmbeddingConfig()
+
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        return ["encoding_format", "dimensions", "input_type"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        return self._bedrock_cohere.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+        )
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: Union[dict, httpx.Headers],
+    ) -> BaseLLMException:
+        return SagemakerError(
+            message=error_message, status_code=status_code, headers=headers
+        )
+
+    def _normalize_input(self, input: AllEmbeddingInputValues) -> List[str]:
+        if isinstance(input, str):
+            return [input]
+        if isinstance(input, list):
+            if input and (isinstance(input[0], list) or isinstance(input[0], int)):
+                raise ValueError("Input must be a list of strings")
+            return cast(List[str], input)
+        return [str(input)]
+
+    def transform_embedding_request(
+        self,
+        model: str,
+        input: AllEmbeddingInputValues,
+        optional_params: dict,
+        headers: dict,
+    ) -> dict:
+        input_list = self._normalize_input(input)
+        request = self._bedrock_cohere._transform_request(
+            model=model,
+            input=input_list,
+            inference_params=optional_params,
+        )
+        return dict(request)
+
+    def transform_embedding_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: EmbeddingResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str],
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> EmbeddingResponse:
+        input_value = logging_obj.model_call_details.get("input")
+        if input_value is None:
+            input_value = (
+                request_data.get("texts") or request_data.get("images") or []
+            )
+        if isinstance(input_value, str):
+            input_list = [input_value]
+        elif isinstance(input_value, list):
+            input_list = input_value
+        else:
+            input_list = []
+
+        return self._cohere_v1._transform_response(
+            response=raw_response,
+            api_key=api_key,
+            logging_obj=logging_obj,
+            data=request_data,
+            model_response=model_response,
+            model=model,
+            encoding=litellm.encoding,
+            input=input_list,
+        )
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        return {"Content-Type": "application/json"}

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -1,66 +1,41 @@
 """
-Cohere embedding request/response transformation for SageMaker Marketplace endpoints.
+Translate from OpenAI's `/v1/embeddings` to Sagemaker's `/invoke`
 
-AWS Marketplace Cohere containers expect the native Cohere embed API body
-(`texts`, `input_type`, etc.), not HuggingFace TGI `inputs`.
+In the native Cohere embed format for self-hosted Cohere endpoints
+(AWS Marketplace / JumpStart). Cohere containers expect
+`{"texts": [...], "input_type": "..."}` and reject the HuggingFace TGI shape
+`{"inputs": [...]}` with `422 EmbedReqV2.inputs is of type string but should
+be of type Object`.
+
+Reference: https://docs.cohere.com/v2/reference/embed
 """
 
 from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
-import httpx
+if TYPE_CHECKING:
+    from litellm.types.llms.openai import AllEmbeddingInputValues
+
+from httpx._models import Headers, Response
 
 import litellm
-from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.bedrock.embed.cohere_transformation import (
     BedrockCohereEmbeddingConfig,
 )
 from litellm.llms.cohere.embed.v1_transformation import CohereEmbeddingConfig
-from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
 from litellm.types.utils import EmbeddingResponse
 
 from ..common_utils import SagemakerError
 
-if TYPE_CHECKING:
-    from litellm.litellm_core_utils.litellm_logging import (
-        Logging as LiteLLMLoggingObj,
-    )
-else:
-    LiteLLMLoggingObj = Any
-
-
-COHERE_EMBED_NAME_MARKERS = (
-    "embed-multilingual",
-    "embed-english",
-    "embed-v4",
-    "embed-v3",
-)
-
-
-def is_cohere_sagemaker_embedding_model(model: str) -> bool:
-    """
-    Detect Cohere embedding endpoints from the SageMaker endpoint / model name.
-
-    The SageMaker endpoint name is opaque, so we match on substrings
-    ("cohere" or a Cohere embed model id fragment such as "embed-multilingual-v3").
-    Endpoint names should include one of these markers so LiteLLM selects the
-    Cohere payload format instead of the HuggingFace TGI default.
-    """
-    model_lower = model.lower()
-    if "cohere" in model_lower:
-        return True
-    return any(marker in model_lower for marker in COHERE_EMBED_NAME_MARKERS)
-
 
 class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
     """
-    SageMaker invoke payload for self-hosted Cohere embed models
-    (AWS Marketplace / JumpStart).
+    SageMaker invoke payload for self-hosted Cohere embed models.
     """
 
     def __init__(self) -> None:
-        self._bedrock_cohere = BedrockCohereEmbeddingConfig()
-        self._cohere_v1 = CohereEmbeddingConfig()
+        pass
 
     def get_supported_openai_params(self, model: str) -> List[str]:
         return ["encoding_format", "dimensions", "input_type"]
@@ -72,69 +47,69 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        return self._bedrock_cohere.map_openai_params(
+        return BedrockCohereEmbeddingConfig().map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
         )
 
     def get_error_class(
-        self,
-        error_message: str,
-        status_code: int,
-        headers: Union[dict, httpx.Headers],
+        self, error_message: str, status_code: int, headers: Union[dict, Headers]
     ) -> BaseLLMException:
         return SagemakerError(
             message=error_message, status_code=status_code, headers=headers
         )
 
-    def _normalize_input(self, input: AllEmbeddingInputValues) -> List[str]:
-        if isinstance(input, str):
-            return [input]
-        if isinstance(input, list):
-            if input and (isinstance(input[0], list) or isinstance(input[0], int)):
-                raise ValueError("Input must be a list of strings")
-            return cast(List[str], input)
-        return [str(input)]
-
     def transform_embedding_request(
         self,
         model: str,
-        input: AllEmbeddingInputValues,
+        input: "AllEmbeddingInputValues",
         optional_params: dict,
         headers: dict,
     ) -> dict:
-        input_list = self._normalize_input(input)
-        request = self._bedrock_cohere._transform_request(
-            model=model,
-            input=input_list,
-            inference_params=optional_params,
+        """
+        Transform embedding request for Cohere models on SageMaker
+        """
+        if isinstance(input, str):
+            input_list: List[str] = [input]
+        elif isinstance(input, list):
+            if input and (isinstance(input[0], list) or isinstance(input[0], int)):
+                raise ValueError("Input must be a list of strings")
+            input_list = cast(List[str], input)
+        else:
+            input_list = [str(input)]
+
+        return dict(
+            BedrockCohereEmbeddingConfig()._transform_request(
+                model=model,
+                input=input_list,
+                inference_params=optional_params,
+            )
         )
-        return dict(request)
 
     def transform_embedding_response(
         self,
         model: str,
-        raw_response: httpx.Response,
-        model_response: EmbeddingResponse,
-        logging_obj: LiteLLMLoggingObj,
-        api_key: Optional[str],
-        request_data: dict,
-        optional_params: dict,
-        litellm_params: dict,
-    ) -> EmbeddingResponse:
-        input_value = logging_obj.model_call_details.get("input")
-        if input_value is None:
-            input_value = (
-                request_data.get("texts") or request_data.get("images") or []
-            )
+        raw_response: Response,
+        model_response: "EmbeddingResponse",
+        logging_obj: Any,
+        api_key: Optional[str] = None,
+        request_data: dict = {},
+        optional_params: dict = {},
+        litellm_params: dict = {},
+    ) -> "EmbeddingResponse":
+        """
+        Transform embedding response for Cohere models on SageMaker
+        """
+        input_value = (
+            logging_obj.model_call_details.get("input")
+            or request_data.get("texts")
+            or request_data.get("images")
+            or []
+        )
         if isinstance(input_value, str):
-            input_list = [input_value]
-        elif isinstance(input_value, list):
-            input_list = input_value
-        else:
-            input_list = []
+            input_value = [input_value]
 
-        return self._cohere_v1._transform_response(
+        return CohereEmbeddingConfig()._transform_response(
             response=raw_response,
             api_key=api_key,
             logging_obj=logging_obj,
@@ -142,17 +117,20 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
             model_response=model_response,
             model=model,
             encoding=litellm.encoding,
-            input=input_list,
+            input=input_value,
         )
 
     def validate_environment(
         self,
         headers: dict,
         model: str,
-        messages: List[AllMessageValues],
+        messages: List[Any],
         optional_params: dict,
         litellm_params: dict,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
+        """
+        Validate environment for SageMaker Cohere embeddings
+        """
         return {"Content-Type": "application/json"}

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -47,10 +47,13 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        return BedrockCohereEmbeddingConfig().map_openai_params(
+        optional_params = BedrockCohereEmbeddingConfig().map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
         )
+        if "input_type" in non_default_params:
+            optional_params["input_type"] = non_default_params["input_type"]
+        return optional_params
 
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, Headers]

--- a/litellm/llms/sagemaker/embedding/transformation.py
+++ b/litellm/llms/sagemaker/embedding/transformation.py
@@ -11,10 +11,10 @@ if TYPE_CHECKING:
 
 from httpx._models import Headers, Response
 
-from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
-from litellm.types.utils import Usage, EmbeddingResponse
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
+from litellm.types.utils import EmbeddingResponse, Usage
 
 from ..common_utils import SagemakerError
 from .cohere_transformation import SagemakerCohereEmbeddingConfig

--- a/litellm/llms/sagemaker/embedding/transformation.py
+++ b/litellm/llms/sagemaker/embedding/transformation.py
@@ -17,6 +17,10 @@ from litellm.types.utils import Usage, EmbeddingResponse
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
 
 from ..common_utils import SagemakerError
+from .cohere_transformation import (
+    SagemakerCohereEmbeddingConfig,
+    is_cohere_sagemaker_embedding_model,
+)
 
 
 class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
@@ -38,17 +42,20 @@ class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
         Returns:
             Appropriate embedding config instance
         """
-        if "voyage" in model.lower():
+        model_lower = model.lower()
+        if "voyage" in model_lower:
             return VoyageEmbeddingConfig()
-        else:
-            return cls()
+        if is_cohere_sagemaker_embedding_model(model):
+            return SagemakerCohereEmbeddingConfig()
+        return cls()
 
     def get_supported_openai_params(self, model: str) -> List[str]:
         # Check if this is an embedding model
         if "voyage" in model.lower():
             return VoyageEmbeddingConfig().get_supported_openai_params(model)
-        else:
-            return []
+        if is_cohere_sagemaker_embedding_model(model):
+            return SagemakerCohereEmbeddingConfig().get_supported_openai_params(model)
+        return []
 
     def map_openai_params(
         self,

--- a/litellm/llms/sagemaker/embedding/transformation.py
+++ b/litellm/llms/sagemaker/embedding/transformation.py
@@ -17,10 +17,7 @@ from litellm.types.utils import Usage, EmbeddingResponse
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
 
 from ..common_utils import SagemakerError
-from .cohere_transformation import (
-    SagemakerCohereEmbeddingConfig,
-    is_cohere_sagemaker_embedding_model,
-)
+from .cohere_transformation import SagemakerCohereEmbeddingConfig
 
 
 class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
@@ -45,15 +42,15 @@ class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
         model_lower = model.lower()
         if "voyage" in model_lower:
             return VoyageEmbeddingConfig()
-        if is_cohere_sagemaker_embedding_model(model):
+        if "cohere" in model_lower:
             return SagemakerCohereEmbeddingConfig()
         return cls()
 
     def get_supported_openai_params(self, model: str) -> List[str]:
-        # Check if this is an embedding model
-        if "voyage" in model.lower():
+        model_lower = model.lower()
+        if "voyage" in model_lower:
             return VoyageEmbeddingConfig().get_supported_openai_params(model)
-        if is_cohere_sagemaker_embedding_model(model):
+        if "cohere" in model_lower:
             return SagemakerCohereEmbeddingConfig().get_supported_openai_params(model)
         return []
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3343,6 +3343,17 @@ def get_optional_params_embeddings(  # noqa: PLR0915
             model=model,
             drop_params=drop_params if drop_params is not None else False,
         )
+        # Provider-specific params (e.g. Cohere input_type) are not in
+        # OPENAI_EMBEDDING_PARAMS, so they are not in non_default_params after
+        # embedding_pre_process. Restore them from passed_params when supported.
+        if supported_params:
+            for param in supported_params:
+                if (
+                    param in passed_params
+                    and passed_params[param] is not None
+                    and param not in optional_params
+                ):
+                    optional_params[param] = passed_params[param]
     ## raise exception if non-default value passed for non-openai/azure embedding calls
     elif custom_llm_provider == "openai":
         # 'dimensions` is only supported in `text-embedding-3` and later models

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3343,11 +3343,15 @@ def get_optional_params_embeddings(  # noqa: PLR0915
             model=model,
             drop_params=drop_params if drop_params is not None else False,
         )
-        # Provider-specific params (e.g. Cohere input_type) are not in
-        # OPENAI_EMBEDDING_PARAMS, so they are not in non_default_params after
-        # embedding_pre_process. Restore them from passed_params when supported.
+        # Provider-only params (e.g. Cohere input_type) are not in
+        # OPENAI_EMBEDDING_PARAMS, so embedding_pre_process drops them from
+        # non_default_params before map_openai_params. Restore only those extras
+        # from passed_params — skip OPENAI_EMBEDDING_PARAMS to avoid duplicating
+        # values already mapped (e.g. dimensions -> output_dimension).
         if supported_params:
             for param in supported_params:
+                if param in OPENAI_EMBEDDING_PARAMS:
+                    continue
                 if (
                     param in passed_params
                     and passed_params[param] is not None

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -147,6 +147,20 @@ class TestSagemakerCohereEmbeddingConfig:
         assert body["texts"] == ["hello"]
         assert body["input_type"] == "search_query"
 
+    def test_get_optional_params_embeddings_maps_dimensions_without_duplicate(self):
+        """dimensions must map to output_dimension only, not also stay as dimensions."""
+        from litellm.utils import get_optional_params_embeddings
+
+        optional_params = get_optional_params_embeddings(
+            model=self.MODEL,
+            custom_llm_provider="sagemaker",
+            dimensions=512,
+            input_type="search_query",
+        )
+        assert optional_params.get("output_dimension") == 512
+        assert "dimensions" not in optional_params
+        assert optional_params.get("input_type") == "search_query"
+
     def test_transform_response_parses_cohere_payload(self):
         cohere_response = {
             "embeddings": [[0.1, 0.2, 0.3]],

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -190,6 +190,39 @@ class TestSagemakerCohereEmbeddingConfig:
         assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]
         assert result.usage.prompt_tokens == 2
 
+    def test_transform_response_does_not_double_call_post_call(self):
+        """
+        Greptile review fix: SageMaker handler already calls
+        `logging_obj.post_call` once before invoking
+        `transform_embedding_response`. The transform must NOT call it again,
+        otherwise callbacks, cost calculators, and log handlers double-fire
+        for every Cohere SageMaker embedding call.
+        """
+        cohere_response = {
+            "embeddings": [[0.1, 0.2, 0.3]],
+            "meta": {"billed_units": {"input_tokens": 2}},
+        }
+        mock_response = httpx.Response(
+            status_code=200,
+            content=json.dumps(cohere_response).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"input": ["hello"]}
+
+        self.config.transform_embedding_response(
+            model=self.MODEL,
+            raw_response=mock_response,
+            model_response=EmbeddingResponse(),
+            logging_obj=logging_obj,
+            api_key=None,
+            request_data={"texts": ["hello"], "input_type": "search_query"},
+            optional_params={},
+            litellm_params={},
+        )
+
+        logging_obj.post_call.assert_not_called()
+
 
 class TestVoyageEmbeddingConfig:
     """Test Voyage-specific embedding configuration"""

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -19,7 +19,6 @@ sys.path.insert(0, os.path.abspath("../../../../.."))
 from litellm import embedding
 from litellm.llms.sagemaker.embedding.cohere_transformation import (
     SagemakerCohereEmbeddingConfig,
-    is_cohere_sagemaker_embedding_model,
 )
 from litellm.llms.sagemaker.embedding.transformation import SagemakerEmbeddingConfig
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
@@ -61,20 +60,13 @@ class TestSagemakerEmbeddingFactory:
     def test_get_model_config_cohere_model(self):
         """Cohere SageMaker endpoints route to SagemakerCohereEmbeddingConfig"""
         for endpoint_name in (
-            "cohere-embed-multilingual-v3-prod",
+            "cohere.embed-multilingual-v3",
+            "cohere-embed-english-v3-prod",
             "my-cohere-marketplace-endpoint",
-            "embed-multilingual-v3-sm-endpoint",
-            "embed-english-v3-endpoint",
+            "COHERE-EMBED-V4",
         ):
             config = SagemakerEmbeddingConfig.get_model_config(endpoint_name)
             assert isinstance(config, SagemakerCohereEmbeddingConfig), endpoint_name
-
-    def test_is_cohere_sagemaker_embedding_model(self):
-        assert is_cohere_sagemaker_embedding_model("cohere-embed-endpoint")
-        assert is_cohere_sagemaker_embedding_model("embed-english-v3-endpoint")
-        assert is_cohere_sagemaker_embedding_model("EMBED-MULTILINGUAL-V3")
-        assert not is_cohere_sagemaker_embedding_model("sentence-transformers-model")
-        assert not is_cohere_sagemaker_embedding_model("voyage-3-5-embedding")
 
 
 class TestSagemakerCohereEmbeddingConfig:
@@ -83,10 +75,12 @@ class TestSagemakerCohereEmbeddingConfig:
     def setup_method(self):
         self.config = SagemakerCohereEmbeddingConfig()
 
+    MODEL = "cohere.embed-multilingual-v3"
+
     def test_transform_request_uses_cohere_payload(self):
         """Bug repro: request must use `texts` + `input_type`, not HF `inputs`"""
         result = self.config.transform_embedding_request(
-            model="cohere-embed-multilingual-v3",
+            model=self.MODEL,
             input=["hello"],
             optional_params={"input_type": "search_query"},
             headers={},
@@ -97,7 +91,7 @@ class TestSagemakerCohereEmbeddingConfig:
 
     def test_transform_request_default_input_type(self):
         result = self.config.transform_embedding_request(
-            model="cohere-embed-multilingual-v3",
+            model=self.MODEL,
             input=["hello"],
             optional_params={},
             headers={},
@@ -107,7 +101,7 @@ class TestSagemakerCohereEmbeddingConfig:
 
     def test_transform_request_normalizes_string_input(self):
         result = self.config.transform_embedding_request(
-            model="cohere-embed-english-v3",
+            model=self.MODEL,
             input="hello",
             optional_params={},
             headers={},
@@ -118,7 +112,7 @@ class TestSagemakerCohereEmbeddingConfig:
         params = self.config.map_openai_params(
             non_default_params={"dimensions": 512, "encoding_format": "float"},
             optional_params={},
-            model="cohere-embed-multilingual-v3",
+            model=self.MODEL,
             drop_params=False,
         )
         assert params["output_dimension"] == 512
@@ -138,7 +132,7 @@ class TestSagemakerCohereEmbeddingConfig:
         logging_obj.model_call_details = {"input": ["hello"]}
 
         result = self.config.transform_embedding_response(
-            model="cohere-embed-multilingual-v3",
+            model=self.MODEL,
             raw_response=mock_response,
             model_response=EmbeddingResponse(),
             logging_obj=logging_obj,

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -118,6 +118,35 @@ class TestSagemakerCohereEmbeddingConfig:
         assert params["output_dimension"] == 512
         assert params["embedding_types"] == ["float"]
 
+    def test_map_openai_params_input_type_from_non_default_params(self):
+        params = self.config.map_openai_params(
+            non_default_params={"input_type": "search_query"},
+            optional_params={},
+            model=self.MODEL,
+            drop_params=False,
+        )
+        assert params["input_type"] == "search_query"
+
+    def test_get_optional_params_embeddings_preserves_input_type(self):
+        """Exercises get_optional_params_embeddings, not transform in isolation."""
+        from litellm.utils import get_optional_params_embeddings
+
+        optional_params = get_optional_params_embeddings(
+            model=self.MODEL,
+            custom_llm_provider="sagemaker",
+            input_type="search_query",
+        )
+        assert optional_params.get("input_type") == "search_query"
+
+        body = self.config.transform_embedding_request(
+            model=self.MODEL,
+            input=["hello"],
+            optional_params=optional_params,
+            headers={},
+        )
+        assert body["texts"] == ["hello"]
+        assert body["input_type"] == "search_query"
+
     def test_transform_response_parses_cohere_payload(self):
         cohere_response = {
             "embeddings": [[0.1, 0.2, 0.3]],

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -17,6 +17,10 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 from litellm import embedding
+from litellm.llms.sagemaker.embedding.cohere_transformation import (
+    SagemakerCohereEmbeddingConfig,
+    is_cohere_sagemaker_embedding_model,
+)
 from litellm.llms.sagemaker.embedding.transformation import SagemakerEmbeddingConfig
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig
 from litellm.types.utils import EmbeddingResponse, Usage
@@ -53,6 +57,101 @@ class TestSagemakerEmbeddingFactory:
         assert isinstance(config1, VoyageEmbeddingConfig)
         assert isinstance(config2, VoyageEmbeddingConfig)
         assert isinstance(config3, VoyageEmbeddingConfig)
+
+    def test_get_model_config_cohere_model(self):
+        """Cohere SageMaker endpoints route to SagemakerCohereEmbeddingConfig"""
+        for endpoint_name in (
+            "cohere-embed-multilingual-v3-prod",
+            "my-cohere-marketplace-endpoint",
+            "embed-multilingual-v3-sm-endpoint",
+            "embed-english-v3-endpoint",
+        ):
+            config = SagemakerEmbeddingConfig.get_model_config(endpoint_name)
+            assert isinstance(config, SagemakerCohereEmbeddingConfig), endpoint_name
+
+    def test_is_cohere_sagemaker_embedding_model(self):
+        assert is_cohere_sagemaker_embedding_model("cohere-embed-endpoint")
+        assert is_cohere_sagemaker_embedding_model("embed-english-v3-endpoint")
+        assert is_cohere_sagemaker_embedding_model("EMBED-MULTILINGUAL-V3")
+        assert not is_cohere_sagemaker_embedding_model("sentence-transformers-model")
+        assert not is_cohere_sagemaker_embedding_model("voyage-3-5-embedding")
+
+
+class TestSagemakerCohereEmbeddingConfig:
+    """Cohere-specific SageMaker embedding request/response transforms"""
+
+    def setup_method(self):
+        self.config = SagemakerCohereEmbeddingConfig()
+
+    def test_transform_request_uses_cohere_payload(self):
+        """Bug repro: request must use `texts` + `input_type`, not HF `inputs`"""
+        result = self.config.transform_embedding_request(
+            model="cohere-embed-multilingual-v3",
+            input=["hello"],
+            optional_params={"input_type": "search_query"},
+            headers={},
+        )
+        assert "inputs" not in result
+        assert result["texts"] == ["hello"]
+        assert result["input_type"] == "search_query"
+
+    def test_transform_request_default_input_type(self):
+        result = self.config.transform_embedding_request(
+            model="cohere-embed-multilingual-v3",
+            input=["hello"],
+            optional_params={},
+            headers={},
+        )
+        assert result["texts"] == ["hello"]
+        assert result["input_type"] == "search_document"
+
+    def test_transform_request_normalizes_string_input(self):
+        result = self.config.transform_embedding_request(
+            model="cohere-embed-english-v3",
+            input="hello",
+            optional_params={},
+            headers={},
+        )
+        assert result["texts"] == ["hello"]
+
+    def test_map_openai_params_dimensions_to_output_dimension(self):
+        params = self.config.map_openai_params(
+            non_default_params={"dimensions": 512, "encoding_format": "float"},
+            optional_params={},
+            model="cohere-embed-multilingual-v3",
+            drop_params=False,
+        )
+        assert params["output_dimension"] == 512
+        assert params["embedding_types"] == ["float"]
+
+    def test_transform_response_parses_cohere_payload(self):
+        cohere_response = {
+            "embeddings": [[0.1, 0.2, 0.3]],
+            "meta": {"billed_units": {"input_tokens": 2}},
+        }
+        mock_response = httpx.Response(
+            status_code=200,
+            content=json.dumps(cohere_response).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"input": ["hello"]}
+
+        result = self.config.transform_embedding_response(
+            model="cohere-embed-multilingual-v3",
+            raw_response=mock_response,
+            model_response=EmbeddingResponse(),
+            logging_obj=logging_obj,
+            api_key=None,
+            request_data={"texts": ["hello"], "input_type": "search_query"},
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result.object == "list"
+        assert len(result.data) == 1
+        assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+        assert result.usage.prompt_tokens == 2
 
 
 class TestVoyageEmbeddingConfig:


### PR DESCRIPTION
## Relevant issues

Customer report: SageMaker + AWS Marketplace Cohere (`cohere.embed-multilingual-v3`) fails via LiteLLM with `422 EmbedReqV2.inputs is of type string but should be of type Object`; same endpoint works with direct `boto3` and Bedrock. Reproduced on LiteLLM `1.81.15` and `1.84.0`.

**Root cause:** `SagemakerEmbeddingConfig` only special-cases Voyage; all other endpoints get HuggingFace TGI `{"inputs": [...]}`. Marketplace Cohere containers expect `{"texts": [...], "input_type": "..."}`.

**Fix:** Add `SagemakerCohereEmbeddingConfig` (reuses Bedrock/Cohere request + response transforms). Route when `"cohere" in model.lower()`, same pattern as Voyage. HF and Voyage SageMaker paths unchanged.

## Linear ticket

Fixes LIT-3289

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) _(CI on PR)_
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: _(fill after PR opened)_

- [ ] **CI run for the last commit**  
       Link: _(fill after PR opened)_

- [ ] **Merge / cherry-pick CI run**  
       Links: _(fill after PR opened)_

# Screenshots / Proof of Fix

### What we validated

End-to-end `litellm.embedding()` on the SageMaker provider path — the same code path the customer hits (`SagemakerLLM.embedding` → `transform_embedding_request` → `boto3` `invoke_endpoint`). Not a transform-only unit test in isolation.

| Check | What it proves |
| ----- | -------------- |
| **Request body** | LiteLLM sends the JSON the container actually expects before any AWS call is made |
| **Success path** | Cohere-shaped mock response is parsed into OpenAI-style `EmbeddingResponse` |
| **Factory routing** | Only Cohere-named endpoints pick up the new config; Voyage and HF defaults stay the same |

**Method:** `boto3.Session` is patched so `invoke_endpoint` never runs against AWS. The mock records `Body`, then either returns a minimal Cohere `embeddings` payload or raises `ClientError` with the customer's 422 text. Input: `model="sagemaker/cohere-embed-multilingual-v3-prod"`, `input=["hello"]`, `input_type="search_query"`.

### Request body (customer failure mode)

| | Staging (bug) | This PR |
| --- | --- | --- |
| Body sent to SageMaker | `{"inputs": ["hello"], "input_type": "search_query"}` | `{"texts": ["hello"], "input_type": "search_query"}` |
| Matches HF TGI | yes — wrong for Cohere | no |
| Matches Cohere Marketplace API | no — causes customer 422 | yes |

On staging, a mock that returns the customer's 422 reproduces `BadRequestError` with `EmbedReqV2.inputs is of type string but should be of type Object` — same message as their log.

On this branch, the body is correct in both mock modes below; the 422 no longer reflects a LiteLLM formatting bug.

### Mock scenarios (runtime)

**A — Happy path:** mock returns `{"embeddings": [[0.1, 0.2, 0.3]], "meta": {...}}`. Call completes; `data[0].embedding` populated. Confirms response transform works with the new request shape.

**B — Server error path:** mock raises the exact 422 string from the ticket. LiteLLM still surfaces `BadRequestError`, but the captured body is already `texts` + `input_type` — i.e. we are not sending `inputs` anymore; a real Cohere endpoint would not reject the payload for this reason.

### Factory routing (no boto3)

`SagemakerEmbeddingConfig.get_model_config(endpoint_name)` for representative names:

| Endpoint name | Config | Expected |
| ------------- | ------ | -------- |
| `cohere.embed-multilingual-v3` | `SagemakerCohereEmbeddingConfig` | new |
| `cohere-marketplace-endpoint` | `SagemakerCohereEmbeddingConfig` | new |
| `COHERE-EMBED-V4` | `SagemakerCohereEmbeddingConfig` | new (case-insensitive) |
| `voyage-3-5-embedding` | `VoyageEmbeddingConfig` | unchanged |
| `sentence-transformers-mpnet` | `SagemakerEmbeddingConfig` | unchanged (HF) |
| `embed-multilingual-v3-prod` | `SagemakerEmbeddingConfig` | unchanged* |

\* Names without `cohere` still use HF `inputs`; intentional — customer ticket used a `cohere.*` endpoint name.

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/sagemaker/embedding/cohere_transformation.py` — new `SagemakerCohereEmbeddingConfig`
- `litellm/llms/sagemaker/embedding/transformation.py` — factory routes `"cohere"` endpoints to Cohere config
- `litellm/llms/sagemaker/completion/handler.py` — docstring only
- `tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py` — Cohere request/response + factory tests