### PR TITLE
fix: preserve proxy auth metadata in Langfuse for /v1/messages

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -617,6 +617,14 @@ class Logging(LiteLLMLoggingBaseClass):
             base_litellm_params["litellm_metadata"] = kwargs["litellm_metadata"]
             if "metadata" not in base_litellm_params:
                 base_litellm_params["metadata"] = kwargs["litellm_metadata"].copy()
+            else:
+                # Both metadata (from request body) and litellm_metadata (proxy auth) exist.
+                # Merge litellm_metadata into metadata without overwriting existing keys so
+                # proxy auth fields (user_api_key_alias, team_id, etc.) are visible to
+                # callbacks like Langfuse even when the request body also has a metadata field.
+                for k, v in kwargs["litellm_metadata"].items():
+                    if k not in base_litellm_params["metadata"]:
+                        base_litellm_params["metadata"][k] = v
 
         if litellm_params:
             # Merge metadata carefully — don't overwrite the merged metadata

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1160,6 +1160,15 @@ def function_setup(  # noqa: PLR0915
             # read API key info from litellm_params["metadata"] see the fields.
             if not litellm_params.get("metadata"):
                 litellm_params["metadata"] = kwargs["litellm_metadata"].copy()
+            else:
+                # Both metadata (from request body) and litellm_metadata (proxy auth) exist.
+                # Merge litellm_metadata into metadata without overwriting existing keys so
+                # proxy auth fields (user_api_key_alias, team_id, etc.) are visible to
+                # callbacks like Langfuse even when the request body also has a metadata field
+                # (e.g. Anthropic /v1/messages with a metadata: {user_id: ...} payload).
+                for k, v in kwargs["litellm_metadata"].items():
+                    if k not in litellm_params["metadata"]:
+                        litellm_params["metadata"][k] = v
 
         logging_obj.update_environment_variables(
             model=model,

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -930,3 +930,146 @@ def test_max_langfuse_clients_limit():
         assert litellm.initialized_langfuse_clients == 2
 
     litellm.initialized_langfuse_clients = original_initialized_langfuse_clients
+
+
+def test_function_setup_merges_litellm_metadata_into_metadata_when_both_present():
+    """
+    Regression test for LIT-3293.
+
+    When a request comes in to /v1/messages with a body-level `metadata` field
+    (Anthropic's API field, e.g. {user_id: "client-123"}) AND the proxy has
+    injected proxy auth fields into `litellm_metadata` (e.g. user_api_key_alias,
+    team_id), function_setup() must merge the litellm_metadata fields into
+    litellm_params["metadata"] so that callbacks like Langfuse can see them.
+
+    Previously the condition `if not litellm_params.get("metadata")` caused
+    litellm_metadata to be ignored when metadata was already populated from the
+    request body.
+    """
+    import litellm
+    from litellm.utils import function_setup
+
+    # Simulate a /v1/messages request where:
+    # - "metadata" comes from the Anthropic request body (user identification)
+    # - "litellm_metadata" is injected by the proxy auth middleware
+    kwargs = {
+        "model": "claude-3-opus-20240229",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "litellm_call_id": "test-call-id-123",
+        # Anthropic body metadata (provider-level field)
+        "metadata": {"user_id": "client-user-123"},
+        # Proxy auth metadata injected by add_user_api_key_auth_to_request_metadata
+        "litellm_metadata": {
+            "user_api_key_alias": "my-test-key",
+            "user_api_key_team_id": "team-abc",
+            "user_api_key_user_id": "user-xyz",
+            "user_api_key": "hashed-key",
+        },
+    }
+
+    import datetime
+
+    mock_rules = MagicMock()
+    mock_rules.has_pre_call_rules.return_value = False
+
+    logging_obj, updated_kwargs = function_setup(
+        original_function="anthropic_messages",
+        rules_obj=mock_rules,
+        start_time=datetime.datetime.now(),
+        **kwargs,
+    )
+
+    litellm_params = logging_obj.litellm_params
+
+    # The proxy auth fields from litellm_metadata MUST be merged into metadata
+    assert (
+        litellm_params.get("metadata", {}).get("user_api_key_alias") == "my-test-key"
+    ), "user_api_key_alias from litellm_metadata should be merged into litellm_params['metadata']"
+    assert (
+        litellm_params.get("metadata", {}).get("user_api_key_team_id") == "team-abc"
+    ), "user_api_key_team_id from litellm_metadata should be merged into litellm_params['metadata']"
+    assert (
+        litellm_params.get("metadata", {}).get("user_api_key_user_id") == "user-xyz"
+    ), "user_api_key_user_id from litellm_metadata should be merged into litellm_params['metadata']"
+
+    # The original request body metadata must NOT be overwritten
+    assert (
+        litellm_params.get("metadata", {}).get("user_id") == "client-user-123"
+    ), "user_id from original request body metadata must not be overwritten"
+
+    # litellm_metadata must also be stored separately
+    assert (
+        litellm_params.get("litellm_metadata", {}).get("user_api_key_alias")
+        == "my-test-key"
+    )
+
+
+def test_function_setup_metadata_only_no_litellm_metadata():
+    """
+    Ensure that when only metadata (no litellm_metadata) is provided,
+    the existing behaviour is unchanged.
+    """
+    from litellm.utils import function_setup
+    import datetime
+
+    kwargs = {
+        "model": "claude-3-opus-20240229",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "litellm_call_id": "test-call-id-456",
+        "metadata": {"session_id": "sess-abc"},
+    }
+
+    mock_rules = MagicMock()
+    mock_rules.has_pre_call_rules.return_value = False
+
+    logging_obj, _ = function_setup(
+        original_function="acompletion",
+        rules_obj=mock_rules,
+        start_time=datetime.datetime.now(),
+        **kwargs,
+    )
+
+    litellm_params = logging_obj.litellm_params
+    assert litellm_params.get("metadata", {}).get("session_id") == "sess-abc"
+    # litellm_metadata is not set from kwargs (only metadata was provided)
+    assert not litellm_params.get("litellm_metadata")
+
+
+def test_function_setup_litellm_metadata_only_no_metadata():
+    """
+    Ensure that when only litellm_metadata (no body metadata) is provided,
+    it is still copied into litellm_params["metadata"] as before.
+    """
+    from litellm.utils import function_setup
+    import datetime
+
+    kwargs = {
+        "model": "claude-3-opus-20240229",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "litellm_call_id": "test-call-id-789",
+        # No "metadata" key — simulates /v1/messages with no body metadata
+        "litellm_metadata": {
+            "user_api_key_alias": "proxy-key",
+            "user_api_key_team_id": "team-123",
+        },
+    }
+
+    mock_rules = MagicMock()
+    mock_rules.has_pre_call_rules.return_value = False
+
+    logging_obj, _ = function_setup(
+        original_function="anthropic_messages",
+        rules_obj=mock_rules,
+        start_time=datetime.datetime.now(),
+        **kwargs,
+    )
+
+    litellm_params = logging_obj.litellm_params
+    # litellm_metadata fields should be in metadata
+    assert litellm_params.get("metadata", {}).get("user_api_key_alias") == "proxy-key"
+    assert litellm_params.get("metadata", {}).get("user_api_key_team_id") == "team-123"
+    # And also in litellm_metadata
+    assert (
+        litellm_params.get("litellm_metadata", {}).get("user_api_key_alias")
+        == "proxy-key"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: When a `/v1/messages` request body includes Anthropic's provider-level `metadata` field (e.g. `{user_id: "client-123"}`), `function_setup()` only populated `litellm_params["metadata"]` from the proxy auth `litellm_metadata` when `metadata` was absent. If both were present, the proxy auth fields (`user_api_key_alias`, `team_id`, etc.) were silently dropped.
- **Fix in `litellm/utils.py`**: When both `metadata` and `litellm_metadata` are present, merge `litellm_metadata` fields into `metadata` without overwriting existing keys.
- **Fix in `litellm/litellm_core_utils/litellm_logging.py`**: Same merge logic in `update_from_kwargs()` for consistency.
- Langfuse (and any other callback) reads `litellm_params["metadata"]` — this fix ensures proxy auth context is always visible even for `/v1/messages` calls with a native metadata payload.

Fixes: LIT-3293

## Test plan

- [x] Added `test_function_setup_merges_litellm_metadata_into_metadata_when_both_present` — regression test verifying proxy auth fields from `litellm_metadata` are merged into `litellm_params["metadata"]` when the request body also has `metadata`
- [x] Added `test_function_setup_metadata_only_no_litellm_metadata` — existing behaviour unchanged when only `metadata` is present
- [x] Added `test_function_setup_litellm_metadata_only_no_metadata` — existing behaviour unchanged when only `litellm_metadata` is present
- [x] `uv run pytest tests/test_litellm/integrations/test_langfuse.py` — all 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)