### PR TITLE
fix(proxy): exclude proxy_server_request from its own body snapshot

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1510,10 +1510,16 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     # spend_tracking_utils, streaming_iterator) read `body` to audit the
     # request; taking the snapshot here ensures they see cleaned metadata.
     #
-    # Exclude secret_fields (which contains raw_headers with Authorization
-    # tokens) from the snapshot — they must never be persisted in spend logs
-    # or any other audit trail.
-    _body_snapshot = {k: v for k, v in data.items() if k != "secret_fields"}
+    # Exclude:
+    #   - secret_fields: contains raw_headers with Authorization tokens; must
+    #     never be persisted in spend logs or any other audit trail.
+    #   - proxy_server_request: already a key on `data` at this point (set
+    #     earlier in this function); including it would make the snapshot
+    #     self-reference — body.proxy_server_request.body would be the same
+    #     dict as body, producing an infinite traversal loop for any consumer
+    #     that walks the structure.
+    _body_snapshot_exclude = {"secret_fields", "proxy_server_request"}
+    _body_snapshot = {k: v for k, v in data.items() if k not in _body_snapshot_exclude}
     data["proxy_server_request"]["body"] = _body_snapshot
 
     # Snapshot the requester-supplied metadata for downstream consumers.

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -516,6 +516,59 @@ async def test_add_litellm_data_to_request_body_snapshot_excludes_secret_fields(
 
 
 @pytest.mark.asyncio
+async def test_add_litellm_data_to_request_body_snapshot_excludes_proxy_server_request():
+    """Regression: the body snapshot used to include the proxy_server_request
+    key itself, producing the path
+    ``proxy_server_request.body.proxy_server_request.body == body``. Custom
+    loggers and audit consumers must not see the self-referencing structure
+    (independent of redaction — fires on every successful call).
+    """
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        user_id="test-user",
+        metadata={},
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    snapshot_body = updated["proxy_server_request"]["body"]
+    assert "proxy_server_request" not in snapshot_body, (
+        "proxy_server_request must be excluded from its own body snapshot "
+        "to prevent the body from self-referencing"
+    )
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_strips_string_encoded_admin_injection():
     """Regression: metadata arriving as a JSON string (multipart/form-data or
     extra_body) must not bypass the admin-injection strip. The parse happens


### PR DESCRIPTION
## Relevant issues

n/a — internal bug found while investigating the redaction-gaps work in PR #28611. Independent file/owner, shipping separately.

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — added `test_add_litellm_data_to_request_body_snapshot_excludes_proxy_server_request` in `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`, mirroring the existing `_excludes_secret_fields` regression test.
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

n/a

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

**Before** — `add_litellm_data_to_request` writes the body snapshot at the end of pre-call processing:

```python
_body_snapshot = {k: v for k, v in data.items() if k != "secret_fields"}
data["proxy_server_request"]["body"] = _body_snapshot
```

At that point `data["proxy_server_request"]` was already set earlier in the same function, so the snapshot includes it and `body` self-references:

```
body["proxy_server_request"]["body"] is body["proxy_server_request"]
```

Any consumer that walks `proxy_server_request.body` (custom loggers, spend-tracking, audit exporters) hits an infinite loop. Reproduced on a test proxy by inspecting the kwargs payload passed to a `CustomLogger.async_log_success_event` hook — the body dict's KEYS include `proxy_server_request` on every successful call, regardless of redaction.

**After** — `proxy_server_request` is added to the snapshot exclude set alongside `secret_fields`. Same repro proxy, same hook, body's KEYS no longer include `proxy_server_request` on any of three test requests (baseline / redaction header non-reasoning / redaction header reasoning). New regression test covers it.

```
# inspect_dumps.py on the patched proxy
[ISSUE 2  ✓]  OK — 'proxy_server_request' appears 1× (expect 1)
```

(Pre-fix this read `2×` — one legitimate occurrence at `litellm_params.proxy_server_request`, one in the self-referenced snapshot.)

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/litellm_pre_call_utils.py` — one-line behavior change in `add_litellm_data_to_request`. The body snapshot exclude set goes from `{\"secret_fields\"}` to `{\"secret_fields\", \"proxy_server_request\"}`:

```diff
-    _body_snapshot = {k: v for k, v in data.items() if k != "secret_fields"}
+    _body_snapshot_exclude = {"secret_fields", "proxy_server_request"}
+    _body_snapshot = {k: v for k, v in data.items() if k not in _body_snapshot_exclude}
     data["proxy_server_request"]["body"] = _body_snapshot
```

Comment block above the snapshot updated to explain both exclusions (was: secret_fields only; now: secret_fields + the self-reference explanation for proxy_server_request).

`tests/test_litellm/proxy/test_litellm_pre_call_utils.py` — added `test_add_litellm_data_to_request_body_snapshot_excludes_proxy_server_request`. Asserts `"proxy_server_request" not in updated["proxy_server_request"]["body"]`.

**Known follow-up, intentionally out of scope**: the body snapshot also drags in other pipeline-internal keys (`litellm_call_id`, `litellm_trace_id`, `user_api_key_*`, `api_version`, `ttl`) that were never part of the user POST body. Broadening the exclude set risks breaking downstream consumers that read those keys today — flagging as a follow-up rather than bundling here.