### PR TITLE
fix(azure): forward Azure AD token to v1 API OpenAI client (#27945)

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -472,10 +472,25 @@ class BaseAzureLLM(BaseOpenAILLM):
             # For Azure v1 API, use standard OpenAI client instead of AzureOpenAI
             # See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs
             if self._is_azure_v1_api_version(api_version):
-                # Extract only params that OpenAI client accepts
+                # The OpenAI client only sends `api_key` as `Authorization: Bearer <key>`;
+                # it does not understand Azure's `azure_ad_token` / `azure_ad_token_provider`.
+                # When the caller authenticates via Azure AD (no api_key set), resolve the
+                # token here so the bearer header is populated. Without this, every Azure AD
+                # request on a v1 api_version raises "The api_key client option must be set".
+                resolved_api_key = azure_client_params.get("api_key")
+                if not resolved_api_key:
+                    ad_token_provider = azure_client_params.get(
+                        "azure_ad_token_provider"
+                    )
+                    ad_token = azure_client_params.get("azure_ad_token")
+                    if callable(ad_token_provider):
+                        resolved_api_key = ad_token_provider()
+                    elif ad_token is not None:
+                        resolved_api_key = ad_token
+
                 # Always use /openai/v1/ regardless of whether user passed "v1", "latest", or "preview"
                 v1_params = {
-                    "api_key": azure_client_params.get("api_key"),
+                    "api_key": resolved_api_key,
                     "base_url": f"{api_base}/openai/v1/",
                 }
                 if "timeout" in azure_client_params:

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -1703,3 +1703,123 @@ def test_azure_traditional_api_uses_azure_openai_client():
         assert isinstance(
             async_client, AsyncAzureOpenAI
         ), f"Expected AsyncAzureOpenAI client for api_version={api_version}"
+
+
+@pytest.mark.parametrize("api_version", ["v1", "latest", "preview"])
+def test_azure_v1_api_resolves_ad_token_provider_when_no_api_key(api_version):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/27945.
+
+    When api_version routes through the Azure v1 (OpenAI-style) client and the
+    caller is authenticating via Azure AD (no api_key), the resolved
+    azure_ad_token_provider must be called and its result used as the bearer
+    api_key. Otherwise AsyncOpenAI raises "The api_key client option must be
+    set" because it does not understand azure_ad_token_provider.
+    """
+    from openai import AsyncOpenAI, OpenAI
+
+    base_llm = BaseAzureLLM()
+    api_base = "https://test.openai.azure.com"
+    provider_calls = {"count": 0}
+
+    def ad_token_provider():
+        provider_calls["count"] += 1
+        return "ad-token-from-provider"
+
+    azure_client_params = {
+        "api_key": None,
+        "azure_endpoint": api_base,
+        "api_version": api_version,
+        "azure_ad_token": None,
+        "azure_ad_token_provider": ad_token_provider,
+    }
+
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = azure_client_params
+        sync_client = base_llm.get_azure_openai_client(
+            api_key=None,
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=False,
+        )
+
+    assert isinstance(sync_client, OpenAI)
+    assert sync_client.api_key == "ad-token-from-provider"
+    assert "/openai/v1/" in str(sync_client.base_url)
+    assert provider_calls["count"] == 1
+
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = azure_client_params
+        async_client = base_llm.get_azure_openai_client(
+            api_key=None,
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=True,
+        )
+
+    assert isinstance(async_client, AsyncOpenAI)
+    assert async_client.api_key == "ad-token-from-provider"
+    assert provider_calls["count"] == 2
+
+
+@pytest.mark.parametrize("api_version", ["v1", "latest", "preview"])
+def test_azure_v1_api_uses_static_ad_token_when_no_provider(api_version):
+    """
+    When the caller supplies a static azure_ad_token (no api_key, no provider),
+    the v1 OpenAI client should send that token as the bearer api_key.
+    """
+    from openai import AsyncOpenAI
+
+    base_llm = BaseAzureLLM()
+    api_base = "https://test.openai.azure.com"
+
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = {
+            "api_key": None,
+            "azure_endpoint": api_base,
+            "api_version": api_version,
+            "azure_ad_token": "static-ad-token",
+            "azure_ad_token_provider": None,
+        }
+        client = base_llm.get_azure_openai_client(
+            api_key=None,
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=True,
+        )
+
+    assert isinstance(client, AsyncOpenAI)
+    assert client.api_key == "static-ad-token"
+
+
+@pytest.mark.parametrize("api_version", ["v1", "latest", "preview"])
+def test_azure_v1_api_prefers_api_key_over_ad_token(api_version):
+    """
+    A caller-supplied api_key takes precedence over Azure AD fallbacks even
+    when a token provider is also present in azure_client_params.
+    """
+    from openai import OpenAI
+
+    base_llm = BaseAzureLLM()
+    api_base = "https://test.openai.azure.com"
+
+    def unexpected_provider():
+        raise AssertionError("provider should not be called when api_key is set")
+
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = {
+            "api_key": "explicit-key",
+            "azure_endpoint": api_base,
+            "api_version": api_version,
+            "azure_ad_token": "static-ad-token",
+            "azure_ad_token_provider": unexpected_provider,
+        }
+        client = base_llm.get_azure_openai_client(
+            api_key="explicit-key",
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=False,
+        )
+
+    assert isinstance(client, OpenAI)
+    assert client.api_key == "explicit-key"


### PR DESCRIPTION
Fixes https://github.com/BerriAI/litellm/issues/27945 (regression reported by Barracuda, P0 — see LIT-3074).

## Summary

When `api_version` is `"v1"`, `"latest"`, or `"preview"`, `BaseAzureLLM.get_azure_openai_client` routes through the standard `OpenAI` / `AsyncOpenAI` client (instead of `AzureOpenAI`) at `/openai/v1/`. The v1 branch was building `v1_params` from only `api_key`, dropping the `azure_ad_token` and `azure_ad_token_provider` that `initialize_azure_sdk_client` had just resolved.

Result: any caller authenticating via Azure AD (e.g. `litellm_settings.enable_azure_ad_token_refresh: true` with no `api_key` on the model) hits

```
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

on every request, even though the logs show `"For Azure AD Token Provider, choosing credential type: AzureCredentialType.DefaultAzureCredential"` immediately before the failure.

The bug was introduced by #19313 (added v1 API support) and has been latent since `1.84.0`. The `OpenAI` SDK has no concept of `azure_ad_token_provider`, so the resolved token has to be passed as the bearer `api_key` instead.

## Fix

In the v1 branch, when no `api_key` is set, resolve the bearer token from `azure_client_params`:
1. call `azure_ad_token_provider()` if present, or
2. fall back to a static `azure_ad_token`.

The OpenAI client then sends it as `Authorization: Bearer <token>`, matching the behavior the AzureOpenAI client gets natively on the non-v1 path.

A caller-supplied `api_key` still takes precedence, so the explicit-key path is unchanged.

```python
resolved_api_key = azure_client_params.get("api_key")
if not resolved_api_key:
    ad_token_provider = azure_client_params.get("azure_ad_token_provider")
    ad_token = azure_client_params.get("azure_ad_token")
    if callable(ad_token_provider):
        resolved_api_key = ad_token_provider()
    elif ad_token is not None:
        resolved_api_key = ad_token
```

### Known limitation

Pre-resolving the token at client construction means a cached client won't pick up a refreshed token until the cache entry is evicted. The non-v1 path has the same limit on `azure_ad_token` (it only gets per-request refresh via `azure_ad_token_provider` because the AzureOpenAI SDK calls the provider on each request). A follow-up that wraps `http_client` in a custom `httpx.Auth` that calls the provider per-request would give true refresh on the v1 path too — out of scope for this regression fix.

## Test plan

- [x] `uv run pytest tests/test_litellm/llms/azure/test_azure_common_utils.py -k azure_v1_api` (19 passed)
- [x] `uv run pytest tests/test_litellm/llms/azure/test_azure_common_utils.py` (78 passed, 26 skipped — 2 azure-identity-dependent tests skipped locally without the optional `azure-identity` package; unrelated to this change)
- [x] `uv run black litellm/llms/azure/common_utils.py tests/test_litellm/llms/azure/test_azure_common_utils.py`

New tests:
- `test_azure_v1_api_resolves_ad_token_provider_when_no_api_key[v1|latest|preview]` — direct regression for #27945; asserts `OpenAI.api_key` ends up as the provider's return value for both sync and async clients, and the provider is called exactly once per client construction.
- `test_azure_v1_api_uses_static_ad_token_when_no_provider[v1|latest|preview]` — covers the OIDC / pre-resolved-token path where `azure_ad_token` is set but no provider exists.
- `test_azure_v1_api_prefers_api_key_over_ad_token[v1|latest|preview]` — guards against accidentally calling the provider when an explicit api_key is supplied.

## Customer workaround until merged

For chat models, pin `api_version` to a date version (e.g. `2024-10-21`) — that routes through `AsyncAzureOpenAI` which forwards `azure_ad_token_provider` correctly. Models in `responses` / `image_generation` / `video_generation` modes (codex-mini, gpt-5-pro, sora-2, etc.) need `preview` for the v1 routing and will remain blocked until this lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6cEedig5cKpZEstvqcyVk)_