### PR TITLE
fix(logging): handle ResponseCompletedEvent in anthropic_messages spe…

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3424,7 +3424,9 @@ class Logging(LiteLLMLoggingBaseClass):
         else:
             return None
 
-    def _handle_anthropic_messages_response_logging(self, result: Any) -> ModelResponse:
+    def _handle_anthropic_messages_response_logging(
+        self, result: Any
+    ) -> Union[ModelResponse, ResponsesAPIResponse]:
         """
         Handles logging for Anthropic messages responses.
 
@@ -3442,6 +3444,18 @@ class Logging(LiteLLMLoggingBaseClass):
         if self.stream and isinstance(result, ModelResponse):
             return result
         elif isinstance(result, ModelResponse):
+            return result
+
+        # Responses API bridge: streaming delivers a ResponseCompletedEvent (or its
+        # incomplete/failed variants) rather than an AnthropicResponse. Extract the
+        # nested ResponsesAPIResponse so downstream logging (_transform_usage_objects,
+        # spend_logs) can process it without attempting AnthropicResponse.model_validate.
+        if isinstance(
+            result,
+            (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
+        ):
+            return result.response
+        elif isinstance(result, ResponsesAPIResponse):
             return result
 
         httpx_response = self.model_call_details.get("httpx_response", None)

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2968,3 +2968,22 @@ class TestHandleAnthropicMessagesResponseLoggingResponsesBridge:
 
         assert isinstance(result, ResponsesAPIResponse)
         assert result.id == "resp_abc123"
+
+    def test_handle_anthropic_messages_response_logging_response_failed_event_returns_responses_api_response(
+        self,
+    ):
+        from litellm.types.llms.openai import ResponseFailedEvent, ResponsesAPIResponse
+
+        logging_obj = self._make_logging_obj(stream=True)
+        inner_response = self._make_responses_api_response()
+        failed_event = ResponseFailedEvent(
+            type="response.failed",
+            response=inner_response,
+        )
+
+        result = logging_obj._handle_anthropic_messages_response_logging(
+            result=failed_event
+        )
+
+        assert isinstance(result, ResponsesAPIResponse)
+        assert result.id == "resp_abc123"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2872,3 +2872,99 @@ class TestFirstApiCallStartTimeSetOnce:
         assert obj.model_call_details["api_call_start_time"] > first
         assert obj.model_call_details["first_api_call_start_time"] == first
         assert user_meta == {}
+
+
+class TestHandleAnthropicMessagesResponseLoggingResponsesBridge:
+    """
+    Regression tests for _handle_anthropic_messages_response_logging when the
+    Responses API bridge is active (non-Anthropic backend behind /v1/messages).
+
+    Before the fix, result arrived as a ResponseCompletedEvent and
+    AnthropicResponse.model_validate(result) raised a ValidationError that was
+    swallowed as Non-Blocking, silently dropping the spend_logs row.
+    """
+
+    def _make_logging_obj(self, stream: bool) -> LitellmLogging:
+        return LitellmLogging(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=stream,
+            call_type="anthropic_messages",
+            start_time=time.time(),
+            litellm_call_id="test-responses-bridge-123",
+            function_id="test-fn",
+        )
+
+    def _make_responses_api_response(self) -> "ResponsesAPIResponse":
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        return ResponsesAPIResponse(
+            id="resp_abc123",
+            created_at=1700000000,
+            model="gpt-4o",
+            output=[],
+            usage={
+                "input_tokens": 20,
+                "output_tokens": 10,
+                "total_tokens": 30,
+            },
+        )
+
+    def test_handle_anthropic_messages_response_logging_streaming_response_completed_event_returns_responses_api_response(
+        self,
+    ):
+        from litellm.types.llms.openai import (
+            ResponseCompletedEvent,
+            ResponsesAPIResponse,
+        )
+
+        logging_obj = self._make_logging_obj(stream=True)
+        inner_response = self._make_responses_api_response()
+        completed_event = ResponseCompletedEvent(
+            type="response.completed",
+            response=inner_response,
+        )
+
+        result = logging_obj._handle_anthropic_messages_response_logging(
+            result=completed_event
+        )
+
+        assert isinstance(result, ResponsesAPIResponse)
+        assert result.id == "resp_abc123"
+
+    def test_handle_anthropic_messages_response_logging_response_incomplete_event_returns_responses_api_response(
+        self,
+    ):
+        from litellm.types.llms.openai import (
+            ResponseIncompleteEvent,
+            ResponsesAPIResponse,
+        )
+
+        logging_obj = self._make_logging_obj(stream=True)
+        inner_response = self._make_responses_api_response()
+        incomplete_event = ResponseIncompleteEvent(
+            type="response.incomplete",
+            response=inner_response,
+        )
+
+        result = logging_obj._handle_anthropic_messages_response_logging(
+            result=incomplete_event
+        )
+
+        assert isinstance(result, ResponsesAPIResponse)
+        assert result.id == "resp_abc123"
+
+    def test_handle_anthropic_messages_response_logging_responses_api_response_passthrough(
+        self,
+    ):
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        logging_obj = self._make_logging_obj(stream=False)
+        responses_api_response = self._make_responses_api_response()
+
+        result = logging_obj._handle_anthropic_messages_response_logging(
+            result=responses_api_response
+        )
+
+        assert isinstance(result, ResponsesAPIResponse)
+        assert result.id == "resp_abc123"


### PR DESCRIPTION
## Relevant issues

Fixes 28595

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
<img width="2549" height="864" alt="1" src="https://github.com/user-attachments/assets/e2edd0f1-b94e-410b-bf0e-9994e1f40f32" />


## Type

🐛 Bug Fix

## Changes
When `/v1/messages` routes to a non-Anthropic backend via the Responses API, the streaming success handler delivers a `ResponseCompletedEvent` to `_handle_anthropic_messages_response_logging`. That function had no branch for this type and fell through to `AnthropicResponse.model_validate(result)`, which raised a `ValidationError` because `ResponseCompletedEvent` is not an anthropic-shaped object. The exception was caught by `_success_handler_helper_fn` as "Non-Blocking", so client received the correct response but the request was silently dropped from `LiteLLM_SpendLogs`.

The fix adds two guards before the existing httpx_response branch -
If result is a `ResponseCompletedEvent`, `ResponseIncompleteEvent`, or `ResponseFailedEvent`, unwrap `result.response` (the ResponsesAPIResponse); if it is already a `ResponsesAPIResponse`, return it directly. Both types flow through the downstream logging pipeline correctly. `_transform_usage_objects` already handles `ResponsesAPIResponse` and converts its usage format for spend logging.