### PR TITLE
fix(anthropic): guard is_thinking_enabled against thinking=None (fixes #28576)

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -108,9 +108,14 @@ class BaseConfig(ABC):
         return type_to_response_format_param(response_format=response_format)
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
+        if not non_default_params:
+            return False
+        thinking = non_default_params.get("thinking")
+        thinking_enabled = (
+            isinstance(thinking, dict) and thinking.get("type") == "enabled"
+        )
         return (
-            non_default_params.get("thinking", {}).get("type") == "enabled"
-            or non_default_params.get("reasoning_effort") is not None
+            thinking_enabled or non_default_params.get("reasoning_effort") is not None
         )
 
     def is_max_tokens_in_request(self, non_default_params: dict) -> bool:

--- a/tests/test_litellm/llms/base_llm/test_base_chat_transformation.py
+++ b/tests/test_litellm/llms/base_llm/test_base_chat_transformation.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for BaseLLMChatTransformation helper methods.
+"""
+
+import pytest
+
+from litellm.llms.base_llm.chat.transformation import BaseConfig
+
+
+class _ConcreteTransformation(BaseConfig):
+    """Minimal concrete subclass for testing — stubs out all abstract methods."""
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return []
+
+    def map_openai_params(self, non_default_params, optional_params, model, drop_params):  # type: ignore[override]
+        return optional_params
+
+    def validate_environment(self, headers, model, messages, optional_params, litellm_params, api_key=None, api_base=None):  # type: ignore[override]
+        return headers
+
+    def transform_request(self, model, messages, optional_params, litellm_params, headers):  # type: ignore[override]
+        return {}
+
+    def transform_response(self, model, raw_response, model_response, logging_obj, request_data, messages, optional_params, litellm_params, encoding, api_key=None, json_mode=None):  # type: ignore[override]
+        return model_response
+
+    def get_error_class(self, error_message, status_code, headers=None):  # type: ignore[override]
+        raise NotImplementedError
+
+
+class TestIsThinkingEnabled:
+    """Tests for BaseLLMChatTransformation.is_thinking_enabled."""
+
+    def setup_method(self):
+        self.transformation = _ConcreteTransformation()
+
+    def test_thinking_none_returns_false(self):
+        """thinking=None must not raise AttributeError — returns False (GitHub #28576)."""
+        assert self.transformation.is_thinking_enabled({"thinking": None}) is False
+
+    def test_thinking_enabled(self):
+        """thinking={'type': 'enabled', 'budget_tokens': 1024} returns True."""
+        assert (
+            self.transformation.is_thinking_enabled(
+                {"thinking": {"type": "enabled", "budget_tokens": 1024}}
+            )
+            is True
+        )
+
+    def test_thinking_disabled_type(self):
+        """thinking={'type': 'disabled'} returns False."""
+        assert (
+            self.transformation.is_thinking_enabled({"thinking": {"type": "disabled"}})
+            is False
+        )
+
+    def test_thinking_key_absent_returns_false(self):
+        """No thinking key in params returns False."""
+        assert self.transformation.is_thinking_enabled({}) is False
+
+    def test_non_default_params_none_returns_false(self):
+        """None dict returns False without raising."""
+        assert self.transformation.is_thinking_enabled(None) is False  # type: ignore[arg-type]
+
+    def test_reasoning_effort_set_returns_true(self):
+        """reasoning_effort present (without thinking key) returns True."""
+        assert (
+            self.transformation.is_thinking_enabled({"reasoning_effort": "high"})
+            is True
+        )
+
+    def test_reasoning_effort_none_returns_false(self):
+        """reasoning_effort=None is treated as absent — returns False."""
+        assert (
+            self.transformation.is_thinking_enabled({"reasoning_effort": None}) is False
+        )
+
+    def test_thinking_non_dict_returns_false(self):
+        """thinking set to a non-dict value (e.g. a string) returns False without raising."""
+        assert self.transformation.is_thinking_enabled({"thinking": "enabled"}) is False
+        assert self.transformation.is_thinking_enabled({"thinking": 1}) is False
+
+    def test_thinking_and_reasoning_effort_both_set(self):
+        """Both thinking enabled and reasoning_effort set returns True."""
+        assert (
+            self.transformation.is_thinking_enabled(
+                {
+                    "thinking": {"type": "enabled", "budget_tokens": 512},
+                    "reasoning_effort": "medium",
+                }
+            )
+            is True
+        )


### PR DESCRIPTION
## Summary

Fixes #28576 — `is_thinking_enabled` raises `AttributeError` when `optional_params` contains `{"thinking": None}` (key present, value is `None`).

**Root cause**: the chained `.get("thinking", {}).get("type")` only uses the `{}` default when the key is *absent*. If the key exists with value `None`, the first `.get` returns `None` and the second `.get("type")` raises `AttributeError: 'NoneType' object has no attribute 'get'`.

**Fix**: use `isinstance(thinking, dict)` guard before calling `.get("type")`, and short-circuit early if `non_default_params` itself is `None`/empty.

```python
# Before
def is_thinking_enabled(self, non_default_params: dict) -> bool:
    return (
        non_default_params.get("thinking", {}).get("type") == "enabled"
        or non_default_params.get("reasoning_effort") is not None
    )

# After
def is_thinking_enabled(self, non_default_params: dict) -> bool:
    if not non_default_params:
        return False
    thinking = non_default_params.get("thinking")
    thinking_enabled = (
        isinstance(thinking, dict) and thinking.get("type") == "enabled"
    )
    return thinking_enabled or non_default_params.get("reasoning_effort") is not None
```

The fix also defends against `thinking` being any other non-dict value (string, int, etc.).

## Test plan

- [x] Added `tests/test_litellm/llms/base_llm/test_base_chat_transformation.py` with 9 unit tests covering:
  - `thinking=None` → `False` (the crash case)
  - `thinking={"type": "enabled"}` → `True`
  - `thinking={"type": "disabled"}` → `False`
  - `thinking` key absent → `False`
  - `non_default_params=None` → `False`
  - `reasoning_effort="high"` → `True`
  - `reasoning_effort=None` → `False`
  - `thinking` is non-dict (str, int) → `False`
  - Both `thinking` enabled and `reasoning_effort` set → `True`
- [x] `uv run pytest tests/test_litellm/llms/base_llm/test_base_chat_transformation.py -v` — 9/9 passed
- [x] `uv run black .` applied

🤖 Generated with [Claude Code](https://claude.ai/claude-code)