### PR TITLE
fix(proxy): direct-access models honor "all-proxy-models" and empty list

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10773,8 +10773,18 @@ def get_direct_access_models(
     llm_router: Router,
 ) -> List[str]:
     """
-    Get all models that user has direct access to
+    Get all models that user has direct access to.
+
+    If user.models is empty or contains the "all-proxy-models" sentinel,
+    return all non-team model IDs — same semantic as the PROXY_ADMIN branch
+    in get_all_team_and_direct_access_models and the "all model access"
+    handling in auth_checks._check_model_access_helper.
     """
+    if (
+        not user_db_object.models
+        or SpecialModelNames.all_proxy_models.value in user_db_object.models
+    ):
+        return llm_router.get_model_ids(exclude_team_models=True)
 
     direct_access_models: List[str] = []
     for model in user_db_object.models:

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1145,6 +1145,108 @@ async def test_get_all_team_models():
         assert result == {"gpt-4-model-1": ["team1"], "gpt-4-model-2": ["team1"]}
 
 
+def test_get_direct_access_models_sentinel_returns_all_non_team_models():
+    """models == ["all-proxy-models"] returns all non-team model IDs (issue #22791)."""
+    from litellm.proxy.proxy_server import get_direct_access_models
+
+    mock_user = MagicMock()
+    mock_user.models = ["all-proxy-models"]
+
+    mock_router = MagicMock()
+    mock_router.get_model_ids.return_value = ["m1", "m2", "m3"]
+
+    result = get_direct_access_models(user_db_object=mock_user, llm_router=mock_router)
+
+    assert result == ["m1", "m2", "m3"]
+    mock_router.get_model_ids.assert_called_once_with(exclude_team_models=True)
+    mock_router.get_model_list.assert_not_called()
+
+
+def test_get_direct_access_models_empty_list_returns_all_non_team_models():
+    """models == [] returns all non-team model IDs (Pfizer's case — the bug PR #22875 missed)."""
+    from litellm.proxy.proxy_server import get_direct_access_models
+
+    mock_user = MagicMock()
+    mock_user.models = []
+
+    mock_router = MagicMock()
+    mock_router.get_model_ids.return_value = ["m1", "m2"]
+
+    result = get_direct_access_models(user_db_object=mock_user, llm_router=mock_router)
+
+    assert result == ["m1", "m2"]
+    mock_router.get_model_ids.assert_called_once_with(exclude_team_models=True)
+    mock_router.get_model_list.assert_not_called()
+
+
+def test_get_direct_access_models_specific_model_preserved():
+    """Explicit model names continue to resolve via get_model_list (existing behaviour)."""
+    from litellm.proxy.proxy_server import get_direct_access_models
+
+    mock_user = MagicMock()
+    mock_user.models = ["gpt-4o-mini"]
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [
+        {"model_info": {"id": "deploy-1"}},
+        {"model_info": {"id": "deploy-2"}},
+    ]
+
+    result = get_direct_access_models(user_db_object=mock_user, llm_router=mock_router)
+
+    assert result == ["deploy-1", "deploy-2"]
+    mock_router.get_model_list.assert_called_once_with(model_name="gpt-4o-mini")
+    mock_router.get_model_ids.assert_not_called()
+
+
+def test_get_direct_access_models_unknown_model_returns_empty():
+    """Unknown model name returns [] (existing behaviour preserved)."""
+    from litellm.proxy.proxy_server import get_direct_access_models
+
+    mock_user = MagicMock()
+    mock_user.models = ["nonexistent-model"]
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = None
+
+    result = get_direct_access_models(user_db_object=mock_user, llm_router=mock_router)
+
+    assert result == []
+
+
+def test_get_direct_access_models_sentinel_with_extra_names_wins():
+    """If "all-proxy-models" appears alongside other names, sentinel wins — no per-name lookups."""
+    from litellm.proxy.proxy_server import get_direct_access_models
+
+    mock_user = MagicMock()
+    mock_user.models = ["all-proxy-models", "gpt-4"]
+
+    mock_router = MagicMock()
+    mock_router.get_model_ids.return_value = ["m1", "m2", "m3"]
+
+    result = get_direct_access_models(user_db_object=mock_user, llm_router=mock_router)
+
+    assert result == ["m1", "m2", "m3"]
+    mock_router.get_model_ids.assert_called_once_with(exclude_team_models=True)
+    mock_router.get_model_list.assert_not_called()
+
+
+def test_get_direct_access_models_excludes_team_models_for_all_access():
+    """exclude_team_models=True is passed so team-only models do not get a phantom direct_access flag."""
+    from litellm.proxy.proxy_server import get_direct_access_models
+
+    mock_user = MagicMock()
+    mock_user.models = []
+
+    mock_router = MagicMock()
+    mock_router.get_model_ids.return_value = ["public-1", "public-2"]
+
+    result = get_direct_access_models(user_db_object=mock_user, llm_router=mock_router)
+
+    assert result == ["public-1", "public-2"]
+    mock_router.get_model_ids.assert_called_once_with(exclude_team_models=True)
+
+
 def test_add_team_models_to_all_models():
     """
     Test add_team_models_to_all_models function

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1163,7 +1163,7 @@ def test_get_direct_access_models_sentinel_returns_all_non_team_models():
 
 
 def test_get_direct_access_models_empty_list_returns_all_non_team_models():
-    """models == [] returns all non-team model IDs (Pfizer's case — the bug PR #22875 missed)."""
+    """models == [] returns all non-team model IDs (empty-list shape — the bug PR #22875 missed)."""
     from litellm.proxy.proxy_server import get_direct_access_models
 
     mock_user = MagicMock()


### PR DESCRIPTION
## Relevant issues

Fixes #22791

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Minimal proxy with three loaded models (\`fake-model-a\`, \`fake-model-b\`, \`fake-model-c\`), an \`internal_user\` with no team assignments, and a virtual key minted for that user. \`user.models\` swept across the three relevant shapes.

**Before the fix** — \`GET /v2/model/info?include_team_models=true\`:

| \`user.models\`           | Response                                  |
| ----------------------- | ----------------------------------------- |
| \`["all-proxy-models"]\`  | \`{"data": [], "total_count": 0}\` ← bug    |
| \`[]\`                    | \`{"data": [], "total_count": 0}\` ← bug    |
| \`["fake-model-a"]\`      | \`fake-model-a\` with \`direct_access: true\` |

**After the fix** — same proxy, same user, same calls:

| \`user.models\`           | Response                                                       |
| ----------------------- | -------------------------------------------------------------- |
| \`["all-proxy-models"]\`  | All non-team models returned with \`direct_access: true\` ✅      |
| \`[]\`                    | All non-team models returned with \`direct_access: true\` ✅      |
| \`["fake-model-a"]\`      | \`fake-model-a\` with \`direct_access: true\` (unchanged) ✅        |

\`GET /v1/model/info\` returns the models in all three cases both before and after — only the \`/v2/\` read path was broken.

Unit tests added in \`tests/test_litellm/proxy/test_proxy_server.py\` cover all six shapes (sentinel, empty list, specific name, unknown name, sentinel + other names, \`exclude_team_models=True\` passthrough).

## Type

🐛 Bug Fix

## Changes

\`/v2/model/info?include_team_models=true\` (the endpoint backing the Models + Endpoints UI page) returned \`data: []\` for any \`internal_user\` whose \`models\` field was either \`[]\` or \`["all-proxy-models"]\`, even though \`/v1/model/info\` and the auth-check path resolve both shapes correctly. Result: a blank Models + Endpoints table for users provisioned with "Personal Models = All proxy models" or with a default-empty \`models\` column.

**Root cause** — \`get_direct_access_models\` in \`litellm/proxy/proxy_server.py\` enumerated \`user.models\` literally and had no semantic for the "all models" shapes:

- With \`models=[]\` the loop ran zero times.
- With \`models=["all-proxy-models"]\` \`llm_router.get_model_list(model_name="all-proxy-models")\` missed because no real deployment carries that name.

Either way, the function returned \`[]\`, and the downstream filter in \`get_all_team_and_direct_access_models\` stripped every model lacking \`direct_access\` or a non-empty \`access_via_team_ids\`.

**Fix** — add an early-return at the top of \`get_direct_access_models\` that recognises both wildcard shapes and returns \`llm_router.get_model_ids(exclude_team_models=True)\`. This mirrors three other call sites in the same module / \`auth_checks.py\` that already treat \`not models or "all-proxy-models" in models\` as "all model access":

- \`proxy_server.py\` — \`_add_team_models_to_all_models\` (PROXY_ADMIN branch and team branch).
- \`proxy_server.py\` — \`_add_access_group_models_to_team_models\`.
- \`auth/auth_checks.py\` — \`_check_model_access_helper\` (the reference implementation: why LLM calls keep working for affected users today).

\`exclude_team_models=True\` is preserved so team-only models do not get a phantom \`direct_access\` flag.

**Scope** — single function in a single file; six new unit tests. No schema, callers, downstream filters, or UI changes. Supersedes the closed community PR #22875, which addressed the sentinel string but missed the empty-list shape.