### PR TITLE
Add OpenAI chat-latest model metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9376,6 +9376,43 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "chat-latest": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "gpt-4o-transcribe-diarize": {
         "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9389,6 +9389,43 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "chat-latest": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "gpt-4o-transcribe-diarize": {
         "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,

--- a/tests/test_litellm/test_openai_chat_latest_model_metadata.py
+++ b/tests/test_litellm/test_openai_chat_latest_model_metadata.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+
+def test_openai_chat_latest_model_info():
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+    litellm.add_known_models(model_cost)
+
+    info = model_cost.get("chat-latest")
+    assert (
+        info is not None
+    ), "chat-latest not found in model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "openai"
+    assert info["mode"] == "chat"
+
+    assert info["input_cost_per_token"] == 5e-06
+    assert info["output_cost_per_token"] == 3e-05
+    assert info["cache_read_input_token_cost"] == 5e-07
+
+    assert info["max_input_tokens"] == 272000
+    assert info["max_output_tokens"] == 128000
+    assert info["max_tokens"] == 128000
+
+    assert info["supported_endpoints"] == [
+        "/v1/chat/completions",
+        "/v1/responses",
+    ]
+    assert info["supports_function_calling"] is True
+    assert info["supports_parallel_function_calling"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_system_messages"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_vision"] is True
+    assert info["supports_web_search"] is True
+
+    routed_model, provider, _, _ = get_llm_provider(model="chat-latest")
+    assert routed_model == "chat-latest"
+    assert provider == "openai"
+
+
+def test_openai_chat_latest_backup_matches_main():
+    repo_root = Path(__file__).parents[2]
+    main_path = repo_root / "model_prices_and_context_window.json"
+    backup_path = repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+
+    with open(main_path) as f:
+        main_cost = json.load(f)
+    with open(backup_path) as f:
+        backup_cost = json.load(f)
+
+    assert "chat-latest" in main_cost
+    assert "chat-latest" in backup_cost
+    assert backup_cost.get("chat-latest") == main_cost.get("chat-latest")


### PR DESCRIPTION
## What

Adds `openai/chat-latest` model metadata to both model pricing metadata
files.

This replaces the old closed PR #27478 and targets
`litellm_internal_staging`.

## Tests

- `.venv/bin/pytest tests/test_litellm/test_openai_chat_latest_model_metadata.py -q`
- `.venv/bin/black --check tests/test_litellm/test_openai_chat_latest_model_metadata.py`
- `.venv/bin/python -c "import json; [json.load(open(p)) for p in ['model_prices_and_context_window.json', 'litellm/model_prices_and_context_window_backup.json']]; print('json ok')"`
- `git diff --check origin/litellm_internal_staging..HEAD`
