### PR TITLE
fix(mcp): skip team-scope validation for deleted MCP server IDs on keys

### DIFF
--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -229,6 +229,19 @@ def _get_allow_all_keys_server_ids() -> Set[str]:
     return set(global_mcp_server_manager.get_allow_all_keys_server_ids())
 
 
+def _get_all_known_server_ids() -> Set[str]:
+    """Return all MCP server IDs currently registered in the server manager.
+
+    Servers are removed from the registry when deleted, so any ID absent from
+    this set is a stale (orphaned) reference to a server that no longer exists.
+    """
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    return global_mcp_server_manager.get_all_mcp_server_ids()
+
+
 async def _get_team_allowed_mcp_servers(
     team_obj: Optional["LiteLLM_TeamTableCachedObj"],
 ) -> Set[str]:
@@ -334,24 +347,42 @@ async def validate_key_mcp_servers_against_team(
     if requested_servers:
         disallowed_servers = requested_servers - all_allowed_servers
         if disallowed_servers:
-            if team_obj is not None:
-                team_id = team_obj.team_id
-                detail = (
-                    f"Key requests MCP servers not allowed by team '{team_id}': "
-                    f"{sorted(disallowed_servers)}. "
-                    f"Team allows: {sorted(team_allowed_servers)}. "
-                    f"Global (allow_all_keys) servers: {sorted(allow_all_keys_servers)}."
+            # Skip enforcement for MCP servers that have been deleted.
+            # When an MCP server is removed from the system its ID is no longer
+            # in the registry, but virtual keys may still carry that stale ID.
+            # Blocking key updates because of orphaned references traps admins
+            # in a state where they cannot clean up the key through the UI.
+            # We only enforce the team-scope restriction for server IDs that
+            # actually exist (are registered in the server manager).
+            known_server_ids = _get_all_known_server_ids()
+            disallowed_existing_servers = disallowed_servers & known_server_ids
+            deleted_server_ids = disallowed_servers - known_server_ids
+            if deleted_server_ids:
+                verbose_proxy_logger.debug(
+                    "validate_key_mcp_servers_against_team: ignoring %d deleted "
+                    "(unregistered) MCP server ID(s) during validation: %s",
+                    len(deleted_server_ids),
+                    sorted(deleted_server_ids),
                 )
-            else:
-                detail = (
-                    f"Key is not in a team. Only globally available (allow_all_keys) MCP servers "
-                    f"can be assigned: {sorted(allow_all_keys_servers)}. "
-                    f"Disallowed servers: {sorted(disallowed_servers)}."
+            if disallowed_existing_servers:
+                if team_obj is not None:
+                    team_id = team_obj.team_id
+                    detail = (
+                        f"Key requests MCP servers not allowed by team '{team_id}': "
+                        f"{sorted(disallowed_existing_servers)}. "
+                        f"Team allows: {sorted(team_allowed_servers)}. "
+                        f"Global (allow_all_keys) servers: {sorted(allow_all_keys_servers)}."
+                    )
+                else:
+                    detail = (
+                        f"Key is not in a team. Only globally available (allow_all_keys) MCP servers "
+                        f"can be assigned: {sorted(allow_all_keys_servers)}. "
+                        f"Disallowed servers: {sorted(disallowed_existing_servers)}."
+                    )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={"error": detail},
                 )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={"error": detail},
-            )
 
     # Validate requested access groups (must be subset of team's access groups)
     if requested_access_groups:

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -197,12 +197,16 @@ async def test_validate_key_servers_within_team_scope(
     return_value=set(),
 )
 @patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value={"server-1", "server-outside"},  # both servers exist in registry
+)
+@patch(
     "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
     new_callable=AsyncMock,
     return_value=[],
 )
 async def test_validate_key_servers_outside_team_scope_raises(
-    mock_access_groups, mock_allow_all
+    mock_access_groups, mock_known_ids, mock_allow_all
 ):
     """Key requests servers NOT in the team's scope — should raise 403."""
     team_obj = _make_team_obj(mcp_servers=["server-1"])
@@ -261,12 +265,16 @@ async def test_validate_no_team_only_allow_all_keys(mock_access_groups, mock_all
     return_value={"global-server"},
 )
 @patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value={"private-server"},  # server exists in registry
+)
+@patch(
     "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
     new_callable=AsyncMock,
     return_value=[],
 )
 async def test_validate_no_team_non_global_server_raises(
-    mock_access_groups, mock_allow_all
+    mock_access_groups, mock_known_ids, mock_allow_all
 ):
     """Key without a team requesting a non-global server — should raise 403."""
     with pytest.raises(HTTPException) as exc_info:
@@ -284,12 +292,16 @@ async def test_validate_no_team_non_global_server_raises(
     return_value=set(),
 )
 @patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value={"some-server"},  # server exists in registry
+)
+@patch(
     "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
     new_callable=AsyncMock,
     return_value=[],
 )
 async def test_validate_team_no_mcp_config_blocks_all(
-    mock_access_groups, mock_allow_all
+    mock_access_groups, mock_known_ids, mock_allow_all
 ):
     """Team with no object_permission — key can't use any non-global MCP servers."""
     team_obj = _make_team_obj()  # No object_permission
@@ -307,12 +319,16 @@ async def test_validate_team_no_mcp_config_blocks_all(
     return_value=set(),
 )
 @patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value={"server-1", "server-outside"},  # both servers exist in registry
+)
+@patch(
     "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
     new_callable=AsyncMock,
     return_value=[],
 )
 async def test_validate_tool_permissions_validated_against_team(
-    mock_access_groups, mock_allow_all
+    mock_access_groups, mock_known_ids, mock_allow_all
 ):
     """Server IDs in mcp_tool_permissions should also be validated."""
     team_obj = _make_team_obj(mcp_servers=["server-1"])
@@ -454,6 +470,136 @@ async def test_resolve_team_allowed_mcp_servers_dict_tool_permissions(
 
     result = await _resolve_team_allowed_mcp_servers(mock_perm)
     assert result == {"server-a"}
+
+
+# ---- Tests for deleted (stale) MCP server ID handling (LIT-3278) ----
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value=set(),  # empty registry — all requested servers are "deleted"
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_deleted_servers_do_not_block_key_update(
+    mock_access_groups, mock_known_ids, mock_allow_all
+):
+    """
+    Stale MCP server IDs on a key (left over after server deletion) must NOT
+    block a key update.  The team is no longer configured with those servers,
+    and the servers no longer exist — the validation should pass so the admin
+    can clean up the key.
+    """
+    team_obj = _make_team_obj(mcp_servers=["active-server"])
+    # Key has two deleted server IDs + one active server
+    await validate_key_mcp_servers_against_team(
+        object_permission={
+            "mcp_servers": ["deleted-server-1", "deleted-server-2", "active-server"]
+        },
+        team_obj=team_obj,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value={"server-outside"},  # this server exists but is not in the team
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_existing_disallowed_server_still_raises(
+    mock_access_groups, mock_known_ids, mock_allow_all
+):
+    """
+    An MCP server that EXISTS but is not in the team's scope must still raise
+    403.  Only truly deleted (unregistered) servers are silently skipped.
+    """
+    team_obj = _make_team_obj(mcp_servers=["server-1"])
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_key_mcp_servers_against_team(
+            object_permission={"mcp_servers": ["server-1", "server-outside"]},
+            team_obj=team_obj,
+        )
+    assert exc_info.value.status_code == 403
+    assert "server-outside" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value={"global-server"},
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value=set(),  # all non-global servers are deleted
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_deleted_servers_with_no_team_do_not_raise(
+    mock_access_groups, mock_known_ids, mock_allow_all
+):
+    """
+    A key with no team that carries stale (deleted) server IDs should be
+    updatable.  The global-server is also requested and is valid.
+    """
+    await validate_key_mcp_servers_against_team(
+        object_permission={"mcp_servers": ["deleted-server", "global-server"]},
+        team_obj=None,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
+    return_value={"deleted-server"},  # wait — this server IS in registry (not deleted)
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_mixed_deleted_and_existing_disallowed_raises_for_existing_only(
+    mock_access_groups, mock_known_ids, mock_allow_all
+):
+    """
+    When a key has both a truly deleted server and an existing-but-disallowed
+    server, only the existing one should appear in the error detail.
+    """
+    team_obj = _make_team_obj(mcp_servers=["server-1"])
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_key_mcp_servers_against_team(
+            object_permission={
+                "mcp_servers": ["server-1", "deleted-server", "phantom-server"]
+            },
+            team_obj=team_obj,
+        )
+    assert exc_info.value.status_code == 403
+    # deleted-server is in the known registry so it's treated as existing-but-disallowed
+    assert "deleted-server" in str(exc_info.value.detail)
+    # phantom-server is NOT in the known registry so it's silently ignored
+    assert "phantom-server" not in str(exc_info.value.detail)
 
 
 # ---- Tests for validate_key_search_tools_against_team ----

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -573,7 +573,9 @@ async def test_deleted_servers_with_no_team_do_not_raise(
 )
 @patch(
     "litellm.proxy.management_helpers.object_permission_utils._get_all_known_server_ids",
-    return_value={"deleted-server"},  # wait — this server IS in registry (not deleted)
+    # "disallowed-existing-server" is in the registry but NOT in the team's allowed list.
+    # "orphaned-server" is absent from the registry — it was deleted.
+    return_value={"disallowed-existing-server"},
 )
 @patch(
     "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
@@ -584,22 +586,27 @@ async def test_mixed_deleted_and_existing_disallowed_raises_for_existing_only(
     mock_access_groups, mock_known_ids, mock_allow_all
 ):
     """
-    When a key has both a truly deleted server and an existing-but-disallowed
-    server, only the existing one should appear in the error detail.
+    When a key has both a truly deleted (orphaned) server ID and an existing-but-
+    disallowed server, only the existing-but-disallowed one should appear in the
+    403 error.  The orphaned ID is silently skipped.
     """
     team_obj = _make_team_obj(mcp_servers=["server-1"])
     with pytest.raises(HTTPException) as exc_info:
         await validate_key_mcp_servers_against_team(
             object_permission={
-                "mcp_servers": ["server-1", "deleted-server", "phantom-server"]
+                "mcp_servers": [
+                    "server-1",
+                    "disallowed-existing-server",  # exists in registry but not in team
+                    "orphaned-server",  # not in registry (deleted) — should be ignored
+                ]
             },
             team_obj=team_obj,
         )
     assert exc_info.value.status_code == 403
-    # deleted-server is in the known registry so it's treated as existing-but-disallowed
-    assert "deleted-server" in str(exc_info.value.detail)
-    # phantom-server is NOT in the known registry so it's silently ignored
-    assert "phantom-server" not in str(exc_info.value.detail)
+    # The existing-but-disallowed server IS flagged
+    assert "disallowed-existing-server" in str(exc_info.value.detail)
+    # The orphaned (deleted) server is silently skipped and must NOT appear in the error
+    assert "orphaned-server" not in str(exc_info.value.detail)
 
 
 # ---- Tests for validate_key_search_tools_against_team ----


### PR DESCRIPTION
## Summary

Fixes **LIT-3278**: The UI cannot update (or remove MCPs from) a virtual key that holds stale references to deleted MCP servers.

**Root cause:** When an MCP server is deleted (`DELETE /v1/mcp/server/{id}`), the server is removed from the registry, but existing virtual keys still carry that ID in their `object_permission.mcp_servers`. The backend's `validate_key_mcp_servers_against_team` runs on every key update and checks all requested server IDs against the team's allowed list. Deleted server IDs are no longer in the team's allowed list, so the update fails with:

```
Key requests MCP servers not allowed by team '...': ['deleted-id-1', ...]
```

This traps admins — they can't remove the stale MCPs through the UI, and the error blocks every other key edit too. Direct REST API calls work as a workaround, but the UI path is broken.

**Fix:** After computing `disallowed_servers`, intersect with `_get_all_known_server_ids()` (the live server manager registry). Only raise 403 for server IDs that actually exist but aren't in the team's scope. Server IDs absent from the registry (i.e., deleted servers) are logged at DEBUG level and silently skipped.

This means:
- ✅ Deleted server IDs on a key → no longer block key updates
- ✅ Existing-but-disallowed server IDs → still correctly raise 403
- ✅ Key creation with a non-existent server → silently allowed (server can't be used anyway; admins control server creation)

## Changes

- `litellm/proxy/management_helpers/object_permission_utils.py`:
  - Added `_get_all_known_server_ids()` helper (mirrors `_get_allow_all_keys_server_ids()` pattern)
  - Updated `validate_key_mcp_servers_against_team` to filter deleted server IDs before raising 403

- `tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py`:
  - Updated 4 existing "should raise" tests to mock `_get_all_known_server_ids` (needed since empty test registry would otherwise treat all server IDs as deleted)
  - Added 4 new tests covering the deleted-server scenarios (in-team, no-team, mixed, existing-disallowed)

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py -v` → 29 passed
- [x] `uv run pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k mcp -v` → 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)