### PR TITLE
Fix zero/incorrect spend when deployment model IDs repeat the provider segment (openai/openai/…)

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -412,9 +412,28 @@ def cost_per_token(  # noqa: PLR0915
     prompt_tokens_cost_usd_dollar: float = 0
     completion_tokens_cost_usd_dollar: float = 0
     model_cost_ref = litellm.model_cost
+    if custom_llm_provider is None:
+        _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
+
+    # Router/proxy deployments may repeat the provider segment (e.g. model_name
+    # "openai/openai/gpt-5.5"). Strip duplicated `{provider}/` chains before joining.
+    if custom_llm_provider is not None:
+        _dup_prefix = f"{custom_llm_provider}/"
+        while model.startswith(_dup_prefix):
+            _remainder = model[len(_dup_prefix) :]
+            if _remainder.startswith(_dup_prefix):
+                model = _remainder
+            else:
+                break
+
     model_with_provider = model
     if custom_llm_provider is not None:
-        model_with_provider = custom_llm_provider + "/" + model
+        _prov_prefix = f"{custom_llm_provider}/"
+        model_with_provider = (
+            model
+            if model.startswith(_prov_prefix)
+            else f"{custom_llm_provider}/{model}"
+        )
         if region_name is not None:
             model_with_provider_and_region = (
                 f"{custom_llm_provider}/{region_name}/{model}"
@@ -423,8 +442,6 @@ def cost_per_token(  # noqa: PLR0915
                 model_with_provider_and_region in model_cost_ref
             ):  # use region based pricing, if it's available
                 model_with_provider = model_with_provider_and_region
-    else:
-        _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
     model_without_prefix = model
     model_parts = model.split("/", 1)
     if len(model_parts) > 1:

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -447,6 +447,9 @@ def cost_per_token(  # noqa: PLR0915
                 model_with_provider = model_with_provider_and_region
     else:
         _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
+
+    assert custom_llm_provider is not None  # caller-supplied or get_llm_provider
+
     model_without_prefix = model
     model_parts = model.split("/", 1)
     if len(model_parts) > 1:

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -412,12 +412,15 @@ def cost_per_token(  # noqa: PLR0915
     prompt_tokens_cost_usd_dollar: float = 0
     completion_tokens_cost_usd_dollar: float = 0
     model_cost_ref = litellm.model_cost
-    if custom_llm_provider is None:
-        _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
+    # Only callers that explicitly pass `custom_llm_provider` get the
+    # dedup/prefix-join treatment. When provider is omitted, preserve legacy
+    # behavior: `model_with_provider` stays equal to the raw `model` string
+    # (provider is detected below for downstream use only).
+    caller_supplied_provider = custom_llm_provider is not None
 
     # Router/proxy deployments may repeat the provider segment (e.g. model_name
     # "openai/openai/gpt-5.5"). Strip duplicated `{provider}/` chains before joining.
-    if custom_llm_provider is not None:
+    if caller_supplied_provider:
         _dup_prefix = f"{custom_llm_provider}/"
         while model.startswith(_dup_prefix):
             _remainder = model[len(_dup_prefix) :]
@@ -427,7 +430,7 @@ def cost_per_token(  # noqa: PLR0915
                 break
 
     model_with_provider = model
-    if custom_llm_provider is not None:
+    if caller_supplied_provider:
         _prov_prefix = f"{custom_llm_provider}/"
         model_with_provider = (
             model
@@ -442,6 +445,8 @@ def cost_per_token(  # noqa: PLR0915
                 model_with_provider_and_region in model_cost_ref
             ):  # use region based pricing, if it's available
                 model_with_provider = model_with_provider_and_region
+    else:
+        _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
     model_without_prefix = model
     model_parts = model.split("/", 1)
     if len(model_parts) > 1:

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -13,12 +13,31 @@ from pydantic import BaseModel
 import litellm
 from litellm.cost_calculator import (
     completion_cost,
+    cost_per_token,
     handle_realtime_stream_cost_calculation,
     response_cost_calculator,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
+
+
+def test_cost_per_token_duplicate_openai_prefix_matches_model_cost():
+    """
+    Router/proxy configs may use deployment ids like openai/openai/<model>. Cost lookup must
+    resolve to model_prices keys (e.g. gpt-5.5), not fail or multiply prefixes.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    prompt_usd, completion_usd = cost_per_token(
+        model="openai/openai/gpt-5.5",
+        prompt_tokens=100,
+        completion_tokens=50,
+        custom_llm_provider="openai",
+    )
+
+    assert prompt_usd + completion_usd > 0
 
 
 def test_completion_cost_uses_response_model_for_dynamic_routing():

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -22,13 +22,13 @@ from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
 
 
-def test_cost_per_token_duplicate_openai_prefix_matches_model_cost():
+def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):
     """
     Router/proxy configs may use deployment ids like openai/openai/<model>. Cost lookup must
     resolve to model_prices keys (e.g. gpt-5.5), not fail or multiply prefixes.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
     prompt_usd, completion_usd = cost_per_token(
         model="openai/openai/gpt-5.5",


### PR DESCRIPTION
Resolves LIT-3057
Summary
Proxy/router setups sometimes use deployment names where the LiteLLM provider prefix appears twice (for example openai/openai/gpt-5.5). Token spend uses cost_per_token, which builds a lookup key by combining custom_llm_provider with the model string. That combination assumed either a bare model name or a single prefix, so doubled prefixes broke model_cost lookup and produced wrong or failed pricing (often observed as $0 cost when lookup falls through incorrectly).

Cause
In cost_perculator.cost_per_token:

When custom_llm_provider is already set (common on proxy/router paths), the code did provider + "/" + model even when model already started with provider/.
That produced strings like openai/openai/openai/gpt-5.5 for lookups.
Stripping only the first path segment left openai/gpt-5.5, which often does not exist in model_prices_and_context_window.json for OpenAI-style entries keyed as gpt-5.5 (not openai/gpt-5.5), so the resolver never matched a priced row.
Fix
Resolve custom_llm_provider via get_llm_provider when it is missing (same behavior as before, structured earlier).
Normalize deployment strings by removing repeated {provider}/ chains at the start when the same provider is duplicated (e.g. openai/openai/gpt-5.5 → openai/gpt-5.5 → single-prefix form suitable for downstream stripping).
Build model_with_provider as provider/model only if the model string does not already begin with provider/, avoiding triple prefixes.
Added unit test: test_cost_per_token_duplicate_openai_prefix_matches_model_cost.

Before:
<img width="896" height="729" alt="Screenshot 2026-05-14 at 6 58 25 PM" src="https://github.com/user-attachments/assets/f79a5f43-d591-4c3f-8fce-4a1d52c93d1e" />

After:
<img width="911" height="496" alt="Screenshot 2026-05-14 at 6 58 08 PM" src="https://github.com/user-attachments/assets/00184801-3a43-4cee-af65-361a0189af1d" />