### PR TITLE
fix(guardrails): treat HTTPException 403 as guardrail_intervened, not API failure (LIT-3253)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -743,7 +743,9 @@ class CustomGuardrail(CustomLogger):
         Guardrails signal intentional blocks by raising:
         - GuardrailRaisedException (generic guardrail API, tool permission)
         - BlockedPiiEntityError (Presidio PII detection)
-        - HTTPException with status 400 (content policy violation)
+        - HTTPException with status 400 (content policy violation — preferred convention)
+        - HTTPException with status 403 (some guardrail hooks use 403 for blocks, e.g.
+          LiteLLM content filter, Akto; these are intentional blocks, not API errors)
         - ModifyResponseException (passthrough mode violation)
         """
         if isinstance(e, ModifyResponseException):
@@ -753,7 +755,11 @@ class CustomGuardrail(CustomLogger):
         if (
             HTTPException is not None
             and isinstance(e, HTTPException)
-            and e.status_code == 400
+            and e.status_code
+            in (
+                400,
+                403,
+            )
         ):
             return True
         return False

--- a/litellm/proxy/guardrails/guardrail_hooks/akto/akto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/akto/akto.py
@@ -442,12 +442,12 @@ class AktoGuardrail(CustomGuardrail):
                 )
 
             if not allowed:
-                # Build a blocked marker payload with 403 status and reason
+                # Build a blocked marker payload with 400 status and reason
                 blocked_payload = self.build_akto_payload(
                     inputs,
                     request_data,
                     include_response=False,
-                    status_code=403,
+                    status_code=400,
                 )
                 blocked_payload["responsePayload"] = json.dumps(
                     {
@@ -459,7 +459,7 @@ class AktoGuardrail(CustomGuardrail):
                 blocked_payload["responseHeaders"] = json.dumps(
                     {"content-type": "application/json"},
                 )
-                # Fire-and-forget ingest of the blocked request, then raise 403
+                # Fire-and-forget ingest of the blocked request, then raise 400
                 task = asyncio.create_task(
                     self.fire_and_forget_request(
                         guardrails=False,
@@ -470,7 +470,7 @@ class AktoGuardrail(CustomGuardrail):
                 self.background_tasks.add(task)
                 task.add_done_callback(self.background_tasks.discard)
                 raise HTTPException(
-                    status_code=403,
+                    status_code=400,
                     detail=reason or "Blocked by Akto Guardrails",
                 )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1202,7 +1202,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "category": category_name,
@@ -1242,7 +1242,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "category": category_name,
@@ -1285,7 +1285,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             error_msg = f"Content blocked: {pattern_name} pattern detected"
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={"error": error_msg, "pattern": pattern_name},
             )
         elif action == ContentFilterAction.MASK:
@@ -1325,7 +1325,7 @@ class ContentFilterGuardrail(CustomGuardrail):
                 error_msg += f" ({description})"
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "keyword": keyword,
@@ -1677,7 +1677,7 @@ class ContentFilterGuardrail(CustomGuardrail):
                 "ContentFilterGuardrail: competitor intent refuse - %s", intent_val
             )
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": msg,
                     "intent": intent_val,

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
@@ -59,7 +59,7 @@ def _run(checker, text: str) -> dict:
         checker.check(text)
         return {"decision": "ALLOW", "score": 0.0, "matched_topic": None}
     except HTTPException as e:
-        if e.status_code == 403:
+        if e.status_code == 400:
             detail: Dict[str, Any] = e.detail if isinstance(e.detail, dict) else {}
             return {
                 "decision": "BLOCK",
@@ -542,7 +542,7 @@ class _LlmJudgeChecker:
 
         if "BLOCK" in decision:
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": "Content blocked by LLM judge",
                     "topic": "financial_advice",

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -6,6 +6,11 @@ from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import CallTypes, UserAPIKeyAuth
 from litellm.types.utils import GuardrailTracingDetail
 
+try:
+    from fastapi import HTTPException
+except ImportError:
+    HTTPException = None  # type: ignore
+
 
 class TestCustomGuardrailDeploymentHook:
 
@@ -1190,3 +1195,107 @@ class TestCustomGuardrailSpendLogMatchRedaction:
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_response"]["filters"][0]["regex"] == "[REDACTED]"
         assert raw["filters"][0]["regex"] == r"\d{3}-\d{2}-\d{4}"
+
+
+class TestIsGuardrailIntervention:
+    """
+    Test that _is_guardrail_intervention correctly classifies intentional
+    guardrail blocks vs API failures.
+
+    LIT-3253: Topic/category-based guardrails gave guardrail_failed_to_respond
+    instead of guardrail_intervened because they raised HTTPException(403) and
+    _is_guardrail_intervention only accepted status 400.
+    """
+
+    def test_http_400_is_intervention(self):
+        """HTTPException with status 400 is an intentional guardrail block."""
+        assert HTTPException is not None
+        e = HTTPException(status_code=400, detail="Content blocked: keyword detected")
+        assert CustomGuardrail._is_guardrail_intervention(e) is True
+
+    def test_http_403_is_intervention(self):
+        """
+        HTTPException with status 403 is also an intentional guardrail block.
+
+        Several guardrail hooks (LiteLLM content filter, Akto) raise 403 for
+        content policy blocks.  These are intentional blocks — not API failures
+        — so they must be classified as guardrail_intervened, not
+        guardrail_failed_to_respond.
+        """
+        assert HTTPException is not None
+        e = HTTPException(status_code=403, detail="Blocked by Akto Guardrails")
+        assert CustomGuardrail._is_guardrail_intervention(e) is True
+
+    def test_http_500_is_not_intervention(self):
+        """HTTPException with status 500 is an API failure, not a block."""
+        assert HTTPException is not None
+        e = HTTPException(status_code=500, detail="Internal server error")
+        assert CustomGuardrail._is_guardrail_intervention(e) is False
+
+    def test_http_422_is_not_intervention(self):
+        """HTTPException with status 422 is a validation error, not a block."""
+        assert HTTPException is not None
+        e = HTTPException(status_code=422, detail="Unprocessable entity")
+        assert CustomGuardrail._is_guardrail_intervention(e) is False
+
+    def test_generic_exception_is_not_intervention(self):
+        """A generic Python exception is treated as an API failure."""
+        e = ValueError("Something went wrong")
+        assert CustomGuardrail._is_guardrail_intervention(e) is False
+
+    @pytest.mark.asyncio
+    async def test_process_error_403_logs_as_guardrail_intervened(self):
+        """
+        End-to-end: when a guardrail hook raises HTTPException(403),
+        _process_error must log guardrail_status="guardrail_intervened",
+        not "guardrail_failed_to_respond".
+        """
+        assert HTTPException is not None
+        guardrail = CustomGuardrail(guardrail_name="test-content-filter")
+        request_data: dict = {"metadata": {}}
+
+        e = HTTPException(
+            status_code=403,
+            detail={"error": "Content blocked: competitor detected"},
+        )
+
+        with pytest.raises(HTTPException):
+            guardrail._process_error(
+                e=e,
+                request_data=request_data,
+                start_time=0.0,
+                end_time=1.0,
+                duration=1.0,
+            )
+
+        slg_list = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg_list) == 1
+        assert slg_list[0]["guardrail_status"] == "guardrail_intervened"
+
+    @pytest.mark.asyncio
+    async def test_process_error_400_logs_as_guardrail_intervened(self):
+        """
+        End-to-end: when a guardrail hook raises HTTPException(400),
+        _process_error must log guardrail_status="guardrail_intervened".
+        """
+        assert HTTPException is not None
+        guardrail = CustomGuardrail(guardrail_name="test-content-filter")
+        request_data: dict = {"metadata": {}}
+
+        e = HTTPException(
+            status_code=400,
+            detail={"error": "Content blocked: SSN pattern detected"},
+        )
+
+        with pytest.raises(HTTPException):
+            guardrail._process_error(
+                e=e,
+                request_data=request_data,
+                start_time=0.0,
+                end_time=1.0,
+                duration=1.0,
+            )
+
+        slg_list = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg_list) == 1
+        assert slg_list[0]["guardrail_status"] == "guardrail_intervened"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -198,7 +198,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "us_ssn" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -563,7 +563,7 @@ class TestContentFilterGuardrail:
             ):
                 pass
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "us_ssn" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -1010,7 +1010,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "danger_word" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -1298,7 +1298,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
         if isinstance(detail, dict):
             assert detail.get("category") == "harm_toxic_abuse"
@@ -1327,7 +1327,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
         if isinstance(detail, dict):
             assert detail.get("category") == "harm_toxic_abuse"
@@ -1375,7 +1375,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1443,7 +1443,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "te*st" in str(exc_info.value.detail)
 
     def test_check_category_keywords_asterisk_pattern_matching(self):
@@ -1510,7 +1510,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1560,7 +1560,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1646,7 +1646,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block Spanish: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1683,7 +1683,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block French: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1720,7 +1720,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block German: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1766,7 +1766,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block Australian: '{test_input}'"
 
     async def test_html_tags_in_messages_not_blocked(self):
@@ -1942,7 +1942,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "harmful_child_safety" in str(exc_info.value.detail)
 
         # Test case 2: Should BLOCK - identifier + block word combination
@@ -1956,7 +1956,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 3: Should BLOCK - explicit content + minors
         with pytest.raises(HTTPException) as exc_info:
@@ -1967,7 +1967,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 4: Should NOT block - identifier word alone (no block word)
         result = await guardrail.apply_guardrail(
@@ -2009,7 +2009,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_conditional_category_sentence_boundaries(self):
@@ -2093,7 +2093,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "bias_racial" in str(exc_info.value.detail)
 
         # Test case 2: Should BLOCK - identifier + dehumanizing language
@@ -2107,7 +2107,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 3: Should BLOCK - supremacist content
         with pytest.raises(HTTPException) as exc_info:
@@ -2120,7 +2120,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 4: Should BLOCK - elimination rhetoric
         with pytest.raises(HTTPException) as exc_info:
@@ -2133,7 +2133,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 5: Should NOT block - identifier word alone (no block word)
         result = await guardrail.apply_guardrail(
@@ -2171,7 +2171,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 9: Should NOT block - block word alone (no identifier)
         result = await guardrail.apply_guardrail(


### PR DESCRIPTION
## Summary

Fixes [LIT-3253](https://linear.app/litellm-ai/issue/LIT-3253/bug-litellm-topiccategory-based-guardrails-give-403-response-instead): topic/category-based guardrail blocks were classified as `guardrail_failed_to_respond` (API failure) in spend logs and OTEL traces instead of `guardrail_intervened` (intentional block).

**Root cause (two-part):**
1. `_is_guardrail_intervention()` in `custom_guardrail.py` only recognized `HTTPException(status_code=400)` as an intentional block. Several guardrail hooks raise `status_code=403` for blocks:
   - `LiteLLM content filter` — 5 block-action raise sites (conditional category match, category keyword, regex pattern, blocked-word, competitor-intent refuse)
   - `Akto guardrail` — request blocked by Akto proxy
2. As a result, these 403 blocks fell through to `guardrail_failed_to_respond`, making them appear as API failures in the policy builder and downstream observability integrations.

**Fix:**
- `custom_guardrail.py`: `_is_guardrail_intervention()` now accepts both `400` and `403` as intentional interventions (403 is an explicit policy decision, not a technical failure; this also makes the code robust to other guardrail hooks that may use 403)
- `content_filter.py`: change all 5 block-action `HTTPException` raise sites from `403 → 400`, aligning with the established convention (`400 = content policy violation`)
- `akto.py`: change block raise from `403 → 400` for the same reason
- `test_eval.py` (benchmark helper): update `_run()` to match the new 400

## Tests

Added `TestIsGuardrailIntervention` class (7 tests) in `tests/test_litellm/integrations/test_custom_guardrail.py`:
- `test_http_400_is_intervention` — 400 still detected as intervention
- `test_http_403_is_intervention` — 403 now detected as intervention (regression test for this fix)
- `test_http_500_is_not_intervention` — 500 still treated as API failure
- `test_http_422_is_not_intervention` — 422 still treated as API failure
- `test_generic_exception_is_not_intervention` — generic exceptions still treated as API failure
- `test_process_error_403_logs_as_guardrail_intervened` — end-to-end: `_process_error` with 403 exception logs `guardrail_status="guardrail_intervened"`
- `test_process_error_400_logs_as_guardrail_intervened` — end-to-end: `_process_error` with 400 exception logs `guardrail_status="guardrail_intervened"`

Updated `test_content_filter.py`: 22 status-code assertions updated from `403 → 400`.

All 53 content filter tests and all 43 custom guardrail tests pass.

## Test plan
- [x] `uv run pytest tests/test_litellm/integrations/test_custom_guardrail.py -v` — 43 passed
- [x] `uv run pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py -v` — 53 passed
- [x] New `TestIsGuardrailIntervention` tests — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)