### PR TITLE
fix(a2a): stop injecting context_id into messages; add tasks/get proxy support

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -317,14 +317,18 @@ async def asend_message(
     )
     card_url = getattr(agent_card, "url", None) if agent_card else None
 
-    context_id = trace_id or str(uuid.uuid4())
-    message = request.params.message
-    if isinstance(message, dict):
-        if message.get("context_id") is None:
-            message["context_id"] = context_id
-    else:
-        if getattr(message, "context_id", None) is None:
-            message.context_id = context_id
+    # Do NOT auto-inject context_id when the caller omitted it.
+    #
+    # context_id is an A2A session handle (A2A spec §3.4.1).  Strict agents
+    # reject unknown contextId values with -32054 "Session not found".  The
+    # proxy has no knowledge of which sessions exist on the upstream agent, so
+    # silently injecting a UUID breaks those agents with no way for the caller
+    # to opt out.
+    #
+    # context_id (A2A session) and trace_id (LiteLLM distributed tracing) are
+    # distinct concepts and must not be conflated.  If the caller wants to
+    # maintain a session context_id, they must supply it in the message
+    # themselves.
 
     a2a_response = await _execute_a2a_send_with_retry(
         a2a_client=a2a_client,

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -12,12 +12,69 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from litellm._logging import verbose_proxy_logger
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.agent_endpoints.utils import merge_agent_headers
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.types.utils import all_litellm_params
 
 router = APIRouter()
+
+
+async def _forward_jsonrpc_to_agent(
+    agent_url: str,
+    body: dict,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> JSONResponse:
+    """
+    Forward a raw JSON-RPC request to the upstream agent and return the response.
+
+    Used for A2A methods that are not handled by the A2A SDK (e.g. tasks/get,
+    tasks/cancel, tasks/resubscribe).  The request is forwarded verbatim so
+    that the caller's params and id are preserved unchanged.
+    """
+    request_id = body.get("id")
+
+    try:
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
+
+        http_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.A2AProvider,
+        )
+        response = await http_handler.client.post(
+            agent_url,
+            json=body,
+            headers=headers,
+        )
+        try:
+            content = response.json()
+        except Exception:
+            content = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32603,
+                    "message": f"Agent returned non-JSON response: {response.text[:200]}",
+                },
+            }
+        return JSONResponse(content=content, status_code=response.status_code)
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            f"Error forwarding JSON-RPC request to agent at {agent_url}: {e}"
+        )
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
+            },
+            status_code=500,
+        )
 
 
 def _jsonrpc_error(
@@ -330,7 +387,12 @@ async def invoke_agent_a2a(  # noqa: PLR0915
         method = body.get("method")
         params = body.get("params", {})
 
-        if params:
+        # Extract litellm-specific params (e.g. 'guardrails') from the JSON-RPC
+        # params for message-sending methods only.  Task-lifecycle methods such
+        # as tasks/get carry their own params (e.g. {"id": <task_id>}) which
+        # must not be confused with LiteLLM's own "id" field.
+        _is_message_method = method in ("message/send", "message/stream")
+        if params and _is_message_method:
             # extract any litellm params from the params - eg. 'guardrails'
             params_to_remove = []
             for key, value in params.items():
@@ -515,6 +577,28 @@ async def invoke_agent_a2a(  # noqa: PLR0915
                 user_api_key_dict=user_api_key_dict,
                 request_data=data,
                 proxy_logging_obj=proxy_logging_obj,
+            )
+        elif method in ("tasks/get", "tasks/cancel", "tasks/resubscribe"):
+            # Forward task-lifecycle JSON-RPC methods directly to the upstream
+            # agent.  These methods are part of the A2A spec but are not
+            # mediated by the Python A2A SDK client; a plain HTTP pass-through
+            # is the correct behaviour for a transparent proxy.
+            if not agent_url:
+                return _jsonrpc_error(
+                    request_id,
+                    -32000,
+                    f"Agent '{agent_id}' has no URL configured",
+                    500,
+                )
+            return await _forward_jsonrpc_to_agent(
+                agent_url=agent_url,
+                body={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": method,
+                    "params": params,
+                },
+                extra_headers=agent_extra_headers,
             )
         else:
             return _jsonrpc_error(request_id, -32601, f"Method '{method}' not found")

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -181,3 +181,329 @@ async def test_invoke_agent_a2a_adds_litellm_data():
         # Verify proxy_server_request was added
         assert "proxy_server_request" in captured_data
         assert captured_data["proxy_server_request"]["method"] == "POST"
+
+
+# ---------------------------------------------------------------------------
+# Tests for Bug 1: context_id auto-injection (LIT-2955)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_asend_message_no_context_id_injection_without_trace():
+    """
+    When trace_id is None and the caller did not set context_id, asend_message
+    must NOT inject a random UUID into the message.  Strict A2A agents reject
+    unknown contextId values (A2A spec §3.4.1 -32054 Session not found).
+    """
+    from litellm.a2a_protocol.main import asend_message
+
+    injected_context_ids = []
+
+    async def _mock_execute(a2a_client, request, **kwargs):
+        """Capture whatever context_id ends up on the message."""
+        msg = request.params.message
+        if isinstance(msg, dict):
+            injected_context_ids.append(msg.get("context_id"))
+        else:
+            injected_context_ids.append(getattr(msg, "context_id", None))
+        return MagicMock(
+            model_dump=MagicMock(
+                return_value={"jsonrpc": "2.0", "id": "r1", "result": {}}
+            )
+        )
+
+    mock_a2a_client = MagicMock()
+    mock_a2a_client._litellm_agent_card = None
+    mock_a2a_client.agent_card = None
+
+    # Build a minimal send-message request (as a mock so we don't need the SDK)
+    mock_message = {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "hi"}],
+        "messageId": "m1",
+    }
+    mock_params = MagicMock()
+    mock_params.message = mock_message
+    mock_request = MagicMock()
+    mock_request.id = "r1"
+    mock_request.params = mock_params
+
+    mock_response = MagicMock()
+    mock_response.model_dump = MagicMock(
+        return_value={"jsonrpc": "2.0", "id": "r1", "result": {}}
+    )
+
+    with (
+        patch(
+            "litellm.a2a_protocol.main._execute_a2a_send_with_retry",
+            new_callable=AsyncMock,
+            side_effect=_mock_execute,
+        ),
+        patch(
+            "litellm.a2a_protocol.main._get_a2a_model_info",
+            return_value="test-agent",
+        ),
+        patch(
+            "litellm.a2a_protocol.main.A2ARequestUtils.calculate_usage_from_request_response",
+            return_value=(0, 0, 0),
+        ),
+        patch(
+            "litellm.a2a_protocol.main.LiteLLMSendMessageResponse.from_a2a_response",
+            return_value=mock_response,
+        ),
+    ):
+        await asend_message(
+            a2a_client=mock_a2a_client,
+            request=mock_request,
+            litellm_params={},
+            # No litellm_logging_obj => trace_id will be None
+        )
+
+    # context_id must not have been injected
+    assert injected_context_ids == [
+        None
+    ], f"context_id was unexpectedly injected: {injected_context_ids}"
+
+
+@pytest.mark.asyncio
+async def test_asend_message_no_context_id_injection_even_with_logging_obj():
+    """
+    Even when a LiteLLM logging object with a trace_id IS present, asend_message
+    must NOT inject the trace_id as context_id.  context_id (A2A session) and
+    trace_id (LiteLLM distributed tracing) are distinct concepts; conflating them
+    breaks strict agents.
+    """
+    from litellm.a2a_protocol.main import asend_message
+
+    injected_context_ids = []
+
+    async def _capture(a2a_client, request, **kwargs):
+        msg = request.params.message
+        if isinstance(msg, dict):
+            injected_context_ids.append(msg.get("context_id"))
+        else:
+            injected_context_ids.append(getattr(msg, "context_id", None))
+        return MagicMock(
+            model_dump=MagicMock(
+                return_value={"jsonrpc": "2.0", "id": "r1", "result": {}}
+            )
+        )
+
+    mock_a2a_client = MagicMock()
+    mock_a2a_client._litellm_agent_card = None
+    mock_a2a_client.agent_card = None
+
+    mock_message = {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "hi"}],
+        "messageId": "m2",
+    }
+    mock_params = MagicMock()
+    mock_params.message = mock_message
+    mock_request = MagicMock()
+    mock_request.id = "r1"
+    mock_request.params = mock_params
+
+    mock_response = MagicMock()
+    mock_response.model_dump = MagicMock(
+        return_value={"jsonrpc": "2.0", "id": "r1", "result": {}}
+    )
+
+    _trace_id = "trace-abc-123"
+
+    # Build a mock logging_obj that carries litellm_trace_id
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_trace_id = _trace_id
+    mock_logging_obj.model_call_details = {}
+
+    with (
+        patch(
+            "litellm.a2a_protocol.main._execute_a2a_send_with_retry",
+            new_callable=AsyncMock,
+            side_effect=_capture,
+        ),
+        patch(
+            "litellm.a2a_protocol.main._get_a2a_model_info",
+            return_value="test-agent",
+        ),
+        patch(
+            "litellm.a2a_protocol.main.A2ARequestUtils.calculate_usage_from_request_response",
+            return_value=(0, 0, 0),
+        ),
+        patch(
+            "litellm.a2a_protocol.main.LiteLLMSendMessageResponse.from_a2a_response",
+            return_value=mock_response,
+        ),
+    ):
+        await asend_message(
+            a2a_client=mock_a2a_client,
+            request=mock_request,
+            litellm_params={},
+            litellm_logging_obj=mock_logging_obj,
+        )
+
+    # trace_id must NOT be injected as context_id even when a logging_obj is present
+    assert injected_context_ids == [
+        None
+    ], f"trace_id was unexpectedly injected as context_id: {injected_context_ids}"
+
+
+# ---------------------------------------------------------------------------
+# Tests for Bug 2: tasks/get pass-through (LIT-2955)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_a2a_tasks_get_forwarded():
+    """
+    tasks/get must be forwarded to the upstream agent URL and the response
+    returned to the caller.  Previously LiteLLM returned -32601 Method not found.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    expected_task = {
+        "jsonrpc": "2.0",
+        "id": "r2",
+        "result": {
+            "kind": "task",
+            "id": "task-uuid",
+            "status": {"state": "completed"},
+        },
+    }
+
+    mock_agent = MagicMock()
+    mock_agent.agent_id = "agent-uuid"
+    mock_agent.agent_name = "mock-agent"
+    mock_agent.agent_card_params = {
+        "url": "http://backend-agent:9999",
+        "name": "Mock Agent",
+    }
+    mock_agent.litellm_params = {}
+    mock_agent.static_headers = {}
+    mock_agent.extra_headers = []
+
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    mock_request.json = AsyncMock(
+        return_value={
+            "jsonrpc": "2.0",
+            "id": "r2",
+            "method": "tasks/get",
+            "params": {"id": "task-uuid"},
+        }
+    )
+
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-test",
+        user_id="user-1",
+        team_id="team-1",
+    )
+
+    mock_a2a_types = MagicMock()
+
+    async def mock_forward(agent_url, body, extra_headers=None):
+        """Simulate a successful upstream tasks/get response."""
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(content=expected_task)
+
+    with (
+        patch(
+            "litellm.proxy.agent_endpoints.a2a_endpoints._get_agent",
+            return_value=mock_agent,
+        ),
+        patch(
+            "litellm.proxy.agent_endpoints.a2a_endpoints._forward_jsonrpc_to_agent",
+            side_effect=mock_forward,
+        ) as mock_fwd,
+        patch(
+            "litellm.proxy.agent_endpoints.auth.agent_permission_handler.AgentRequestHandler.is_agent_allowed",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "litellm.proxy.common_request_processing.add_litellm_data_to_request",
+            side_effect=lambda data, **kw: data,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {},
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_config",
+            MagicMock(),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.version",
+            "1.0.0",
+        ),
+        patch.dict(
+            sys.modules,
+            {"a2a": MagicMock(), "a2a.types": mock_a2a_types},
+        ),
+        patch(
+            "litellm.a2a_protocol.main.A2A_SDK_AVAILABLE",
+            True,
+        ),
+    ):
+        from litellm.proxy.agent_endpoints.a2a_endpoints import invoke_agent_a2a
+
+        mock_fastapi_response = MagicMock()
+        result = await invoke_agent_a2a(
+            agent_id="agent-uuid",
+            request=mock_request,
+            fastapi_response=mock_fastapi_response,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+    # Verify the forward helper was called (not the -32601 error path)
+    mock_fwd.assert_called_once()
+    call_kwargs = mock_fwd.call_args
+    assert call_kwargs.kwargs["body"]["method"] == "tasks/get"
+    assert call_kwargs.kwargs["body"]["params"] == {"id": "task-uuid"}
+
+
+@pytest.mark.asyncio
+async def test_forward_jsonrpc_to_agent_success():
+    """
+    _forward_jsonrpc_to_agent must POST the body to the agent URL and
+    return its JSON response unchanged.
+    """
+    from fastapi.responses import JSONResponse
+
+    from litellm.proxy.agent_endpoints.a2a_endpoints import _forward_jsonrpc_to_agent
+
+    upstream_payload = {
+        "jsonrpc": "2.0",
+        "id": "r3",
+        "result": {"kind": "task", "id": "t1", "status": {"state": "completed"}},
+    }
+
+    mock_http_response = MagicMock()
+    mock_http_response.status_code = 200
+    mock_http_response.json = MagicMock(return_value=upstream_payload)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_http_response)
+
+    mock_handler = MagicMock()
+    mock_handler.client = mock_client
+
+    from litellm.proxy.agent_endpoints.a2a_endpoints import _forward_jsonrpc_to_agent
+
+    with patch(
+        "litellm.proxy.agent_endpoints.a2a_endpoints.get_async_httpx_client",
+        return_value=mock_handler,
+    ):
+        response = await _forward_jsonrpc_to_agent(
+            agent_url="http://agent:9999",
+            body={
+                "jsonrpc": "2.0",
+                "id": "r3",
+                "method": "tasks/get",
+                "params": {"id": "t1"},
+            },
+        )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

Fixes two A2A proxy bugs reported in LIT-2955.

### Bug 1: context_id auto-injection

**Before:** `asend_message` silently injected a random UUID as `context_id` into every outbound A2A message where the caller hadn't set one. Strict A2A agents (A2A spec §3.4.1) reject unknown `contextId` values with `-32054 Session not found`, breaking two-step flows and giving callers no way to opt out.

**After:** The proxy never modifies `context_id`. A2A session management (`context_id`) and LiteLLM distributed tracing (`trace_id`) are distinct concepts and must not be conflated. Callers who need a `context_id` must supply it themselves.

### Bug 2: tasks/get (and task lifecycle methods) not proxied

**Before:** Only `message/send` and `message/stream` were handled. Calling `tasks/get`, `tasks/cancel`, or `tasks/resubscribe` returned `-32601 Method not found`. This broke the standard A2A two-step flow (submit task → poll result) entirely.

**After:** A new `_forward_jsonrpc_to_agent()` helper forwards task-lifecycle JSON-RPC methods directly to the upstream agent URL. The `id` param in `tasks/get` was also getting incorrectly stripped by the litellm-param extraction logic (since `id` happens to be a LiteLLM param); this is now scoped to message-sending methods only.

## Changes

- `litellm/a2a_protocol/main.py`: Remove `context_id` injection block from `asend_message`
- `litellm/proxy/agent_endpoints/a2a_endpoints.py`:
  - Add `_forward_jsonrpc_to_agent()` helper (raw HTTP JSON-RPC pass-through)
  - Route `tasks/get`, `tasks/cancel`, `tasks/resubscribe` through the helper
  - Move litellm-param stripping to message-only methods to protect `tasks/*` params
  - Import `get_async_httpx_client`/`httpxSpecialProvider` at module level (per CLAUDE.md)
- `tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py`: Add 4 new tests covering both fixes

## Test plan

- [x] `test_asend_message_no_context_id_injection_without_trace` — verifies no UUID injected when no trace present
- [x] `test_asend_message_no_context_id_injection_even_with_logging_obj` — verifies trace_id is NOT used as context_id even with a logging obj
- [x] `test_invoke_agent_a2a_tasks_get_forwarded` — verifies tasks/get routes to forward helper
- [x] `test_forward_jsonrpc_to_agent_success` — verifies forward helper POSTs to agent and returns response
- [x] All 5 tests in the file pass (`uv run pytest tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py`)

Closes LIT-2955

🤖 Generated with [Claude Code](https://claude.com/claude-code)