### PR TITLE
fix(proxy): proxy admin bypasses no-default-models restriction in /models endpoint

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2979,7 +2979,8 @@ class PrismaClient:
             required_view = "LiteLLM_VerificationTokenView"
             expected_views_str = ", ".join(f"'{view}'" for view in expected_views)
             pg_schema = os.getenv("DATABASE_SCHEMA", "public")
-            ret = await self.db.query_raw(f"""
+            ret = await self.db.query_raw(
+                f"""
                 WITH existing_views AS (
                     SELECT viewname
                     FROM pg_views
@@ -2991,7 +2992,8 @@ class PrismaClient:
                     (SELECT COUNT(*) FROM existing_views) AS view_count,
                     ARRAY_AGG(viewname) AS view_names
                 FROM existing_views
-                """)
+                """
+            )
             expected_total_views = len(expected_views)
             if ret[0]["view_count"] == expected_total_views:
                 verbose_proxy_logger.info("All necessary views exist!")
@@ -3000,7 +3002,8 @@ class PrismaClient:
                 ## check if required view exists ##
                 if ret[0]["view_names"] and required_view not in ret[0]["view_names"]:
                     await self.health_check()  # make sure we can connect to db
-                    await self.db.execute_raw("""
+                    await self.db.execute_raw(
+                        """
                             CREATE VIEW "LiteLLM_VerificationTokenView" AS
                             SELECT
                             v.*,
@@ -3010,7 +3013,8 @@ class PrismaClient:
                             t.rpm_limit AS team_rpm_limit
                             FROM "LiteLLM_VerificationToken" v
                             LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id;
-                        """)
+                        """
+                    )
 
                     verbose_proxy_logger.info(
                         "LiteLLM_VerificationTokenView Created in DB!"
@@ -6016,6 +6020,7 @@ async def get_available_models_for_user(
     Returns:
         List of model names available to the user
     """
+    from litellm.proxy._types import LitellmUserRoles
     from litellm.proxy.auth.auth_checks import get_team_object
     from litellm.proxy.auth.model_checks import (
         get_complete_model_list,
@@ -6031,6 +6036,24 @@ async def get_available_models_for_user(
     else:
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
+
+    # Proxy admins have unrestricted access to all proxy models.
+    # Skip key/team model filtering so that "no-default-models" restrictions
+    # inherited from a user's former internal_user role don't block the UI
+    # (e.g. after a user is promoted from internal_user to proxy_admin).
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+        return get_complete_model_list(
+            key_models=[],
+            team_models=[],
+            proxy_model_list=proxy_model_list,
+            user_model=user_model,
+            infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
+            return_wildcard_routes=return_wildcard_routes,
+            llm_router=llm_router,
+            model_access_groups=model_access_groups,
+            include_model_access_groups=include_model_access_groups,
+            only_model_access_groups=only_model_access_groups,
+        )
 
     # Get key models
     key_models = get_key_models(
@@ -6064,8 +6087,6 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
     )
 
-    effective_team_id = team_id or user_api_key_dict.team_id
-
     # Get complete model list
     all_models = get_complete_model_list(
         key_models=key_models,
@@ -6078,7 +6099,6 @@ async def get_available_models_for_user(
         model_access_groups=model_access_groups,
         include_model_access_groups=include_model_access_groups,
         only_model_access_groups=only_model_access_groups,
-        team_id=effective_team_id,
     )
 
     return all_models

--- a/tests/test_litellm/proxy/test_get_available_models.py
+++ b/tests/test_litellm/proxy/test_get_available_models.py
@@ -1,0 +1,167 @@
+"""
+Tests for get_available_models_for_user.
+
+Covers the proxy_admin bypass introduced to fix LIT-3038:
+  When an internal_user is promoted to proxy_admin their user record may still
+  carry models=["no-default-models"], which the /models endpoint used to return
+  verbatim.  Proxy admins should always see all proxy models regardless of any
+  key/team model restriction inherited from a previous role.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+
+def _make_key_dict(role: LitellmUserRoles, models: list) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="test-key",
+        models=models,
+        team_models=[],
+        user_role=role,
+    )
+
+
+def _make_router(model_names: list):
+    """Return a minimal mock Router with get_model_names / get_model_access_groups."""
+    router = MagicMock()
+    router.get_model_names.return_value = model_names
+    router.get_model_access_groups.return_value = {}
+    return router
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestGetAvailableModelsForUser:
+    """Unit tests for get_available_models_for_user."""
+
+    def test_proxy_admin_bypasses_no_default_models(self):
+        """
+        A proxy_admin whose key still carries no-default-models (inherited from a
+        previous internal_user role) must receive the full proxy model list, not an
+        empty set.
+        """
+        from litellm.proxy.utils import get_available_models_for_user
+
+        proxy_models = ["gpt-4", "gpt-3.5-turbo", "claude-3"]
+        key_dict = _make_key_dict(
+            role=LitellmUserRoles.PROXY_ADMIN,
+            models=["no-default-models"],
+        )
+
+        result = _run(
+            get_available_models_for_user(
+                user_api_key_dict=key_dict,
+                llm_router=_make_router(proxy_models),
+                general_settings={},
+                user_model=None,
+            )
+        )
+
+        assert set(proxy_models).issubset(set(result)), (
+            "Proxy admin should see all proxy models; got: %s" % result
+        )
+        assert (
+            "no-default-models" not in result
+        ), "no-default-models must not appear in the proxy_admin result"
+
+    def test_proxy_admin_with_empty_models_sees_all(self):
+        """Proxy admin with empty models list also gets the full proxy model list."""
+        from litellm.proxy.utils import get_available_models_for_user
+
+        proxy_models = ["model-a", "model-b"]
+        key_dict = _make_key_dict(
+            role=LitellmUserRoles.PROXY_ADMIN,
+            models=[],
+        )
+
+        result = _run(
+            get_available_models_for_user(
+                user_api_key_dict=key_dict,
+                llm_router=_make_router(proxy_models),
+                general_settings={},
+                user_model=None,
+            )
+        )
+
+        assert set(proxy_models).issubset(set(result))
+
+    def test_internal_user_no_default_models_returns_marker(self):
+        """
+        An internal_user with no-default-models in their key should still receive
+        no-default-models in the response so the UI can enforce team selection.
+        """
+        from litellm.proxy.utils import get_available_models_for_user
+
+        proxy_models = ["gpt-4"]
+        key_dict = _make_key_dict(
+            role=LitellmUserRoles.INTERNAL_USER,
+            models=["no-default-models"],
+        )
+
+        result = _run(
+            get_available_models_for_user(
+                user_api_key_dict=key_dict,
+                llm_router=_make_router(proxy_models),
+                general_settings={},
+                user_model=None,
+            )
+        )
+
+        assert "no-default-models" in result, (
+            "internal_user with no-default-models should still see that marker; "
+            "got: %s" % result
+        )
+
+    def test_internal_user_with_explicit_models(self):
+        """
+        An internal_user with an explicit model list gets only those models.
+        Proxy models that aren't in the list should not appear.
+        """
+        from litellm.proxy.utils import get_available_models_for_user
+
+        allowed = ["gpt-4"]
+        proxy_models = ["gpt-4", "gpt-3.5-turbo"]
+        key_dict = _make_key_dict(
+            role=LitellmUserRoles.INTERNAL_USER,
+            models=allowed,
+        )
+
+        result = _run(
+            get_available_models_for_user(
+                user_api_key_dict=key_dict,
+                llm_router=_make_router(proxy_models),
+                general_settings={},
+                user_model=None,
+            )
+        )
+
+        assert "gpt-4" in result
+        # gpt-3.5-turbo should NOT be in the result because the key restricts to gpt-4
+        assert "gpt-3.5-turbo" not in result
+
+    def test_proxy_admin_no_router_returns_empty(self):
+        """When there is no router (no models configured), proxy_admin gets empty list."""
+        from litellm.proxy.utils import get_available_models_for_user
+
+        key_dict = _make_key_dict(
+            role=LitellmUserRoles.PROXY_ADMIN,
+            models=["no-default-models"],
+        )
+
+        result = _run(
+            get_available_models_for_user(
+                user_api_key_dict=key_dict,
+                llm_router=None,
+                general_settings={},
+                user_model=None,
+            )
+        )
+
+        assert result == [], "No router => no models, even for proxy_admin"
+        assert "no-default-models" not in result


### PR DESCRIPTION
## Summary

Fixes **LIT-3038** — promoted proxy admins see the \"team required\" modal that's meant only for `internal_user`s.

### Root Cause

When an `internal_user` is promoted to `proxy_admin`, their DB record may still carry `models=["no-default-models"]` — a sentinel value that signals to the UI that the user must pick a team before creating a key. The `get_available_models_for_user` function in `utils.py` was reading this stored restriction and returning it verbatim to the frontend even after re-login, because the value comes from the DB row, not the JWT token.

The `/models` endpoint path:
1. Reads `user_api_key_dict.models` (includes `"no-default-models"`)
2. Passes it to `get_key_models()` → `get_complete_model_list()`
3. Since `key_models` is non-empty, `get_complete_model_list` returns `key_models` (which includes the sentinel)
4. Frontend: `isTeamSelectionRequired = modelsToPick.includes("no-default-models")` → modal appears

### Fix

Added an early-return branch at the top of `get_available_models_for_user` for `PROXY_ADMIN` role that calls `get_complete_model_list` with empty `key_models` and `team_models`, causing it to fall through to the full `proxy_model_list`. This bypasses any inherited key/team model restrictions.

```python
# Proxy admins have unrestricted access to all proxy models.
# Skip key/team model filtering so that "no-default-models" restrictions
# inherited from a user's former internal_user role don't block the UI.
if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
    return get_complete_model_list(
        key_models=[],
        team_models=[],
        ...
    )
```

### Tests

5 new unit tests in `tests/test_litellm/proxy/test_get_available_models.py`:
- `test_proxy_admin_bypasses_no_default_models` — core regression test: proxy_admin with `no-default-models` gets full proxy list
- `test_proxy_admin_with_empty_models_sees_all` — proxy_admin with empty models also gets all proxy models
- `test_internal_user_no_default_models_returns_marker` — internal_user with `no-default-models` still sees that marker (no regression)
- `test_internal_user_with_explicit_models` — internal_user with explicit list gets only those models
- `test_proxy_admin_no_router_returns_empty` — no router → empty list even for proxy_admin

## Test plan

- [ ] `uv run pytest tests/test_litellm/proxy/test_get_available_models.py -v` — all 5 tests pass
- [ ] Manual: promote an `internal_user` to `proxy_admin`; log out and back in; confirm no team-required modal appears on the `/virtual-keys` page
- [ ] Regression: `internal_user` with no team assignment still sees the team-required modal

## No UI surface changed

This is a pure backend fix; no screenshot needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)