### PR TITLE
test(streaming): tolerate Vertex 429 wrapped in MidStreamFallbackError

### DIFF
--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -993,6 +993,11 @@ def test_vertex_ai_stream(provider):
 
         except litellm.RateLimitError as e:
             pass
+        except litellm.exceptions.MidStreamFallbackError as e:
+            # Streaming 429s are wrapped in MidStreamFallbackError so the
+            # Router can fall back; treat as a transient rate-limit pass.
+            if not isinstance(e.original_exception, litellm.RateLimitError):
+                pytest.fail(f"Error occurred: {e}")
         except Exception as e:
             pytest.fail(f"Error occurred: {e}")
 


### PR DESCRIPTION
## What

`tests/local_testing/test_streaming.py::test_vertex_ai_stream[vertex_ai_beta]` is currently blocking CI when the live Vertex AI endpoint returns 429.

The test has a tolerance for rate limits:

```python
except litellm.RateLimitError as e:
    pass
```

…but streaming 429s are now (intentionally) wrapped in `MidStreamFallbackError` by `CustomStreamWrapper._handle_stream_fallback_error` so the Router can trigger a fallback. The bare `RateLimitError` catch no longer matches; the generic `except Exception → pytest.fail` fires instead.

## Change

Add a sibling `except litellm.exceptions.MidStreamFallbackError` clause that swallows the error **only** when `e.original_exception` is a `RateLimitError`, so the test still fails on unrelated streaming errors. Same pattern already used at `test_streaming.py:2925`.

## Test plan

`make test-unit` passes locally; the targeted test no longer fails on an upstream 429.