### PR TITLE
fix(auth): skip team model access check for vector store management routes

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -267,10 +267,17 @@ async def _run_project_checks(
     skip_budget_checks: bool,
     valid_token: Optional[UserAPIKeyAuth],
     proxy_logging_obj: ProxyLogging,
+    skip_model_check: bool = False,
 ) -> None:
     """
     Run all project-level checks: blocked, model access, budget, soft budget.
     Extracted from common_checks() to keep statement count manageable.
+
+    Args:
+        skip_model_check: When True, skip the project model-access check.
+            Set for vector store management routes where the model is decoded
+            from the managed resource ID and is an internal routing detail,
+            not the model the caller intends to invoke.
     """
     if project_object is None:
         return
@@ -282,7 +289,9 @@ async def _run_project_checks(
         )
 
     # 2.2 If project can call model
-    if _model and len(project_object.models) > 0:
+    # Skip for vector store management routes — same rationale as the team check:
+    # the model is decoded from the managed VS ID, not from the caller's intent.
+    if _model and len(project_object.models) > 0 and not skip_model_check:
         can_project_access_model(
             model=_model,
             project_object=project_object,
@@ -491,6 +500,30 @@ async def check_tools_allowlist(
         )
 
 
+_VECTOR_STORE_MANAGEMENT_ROUTE_PREFIXES = (
+    "/v1/vector_stores",
+    "/vector_stores",
+)
+
+
+def _is_vector_store_management_route(route: str) -> bool:
+    """Returns True for vector store CRUD routes.
+
+    Vector store management routes (/v1/vector_stores/...) use their own
+    access-control gate (``assert_user_can_access_vector_store_id`` and
+    ``vector_store_access_check``).  The model embedded in a LiteLLM-managed
+    vector store ID is an internal routing detail — it must not be used to
+    enforce team model-access on these routes.
+
+    This is different from chat-completion routes (e.g. /chat/completions)
+    that *use* vector stores as tools: those routes carry an explicit ``model``
+    field and should still be subject to the normal model-access check.
+    """
+    return any(
+        route.startswith(prefix) for prefix in _VECTOR_STORE_MANAGEMENT_ROUTE_PREFIXES
+    )
+
+
 async def common_checks(  # noqa: PLR0915
     request_body: dict,
     team_object: Optional[LiteLLM_TeamTable],
@@ -541,7 +574,12 @@ async def common_checks(  # noqa: PLR0915
         )
 
     # 2. If team can call model (or key's access_group_ids grant it)
-    if _model and team_object:
+    # Skip for vector store management routes — access is controlled by vector
+    # store ownership (team_id / object_permission), not by model access.  The
+    # model embedded in a managed vector store ID is an internal routing detail
+    # and must not be used to gate CRUD operations on the vector store itself.
+    _skip_model_check = _is_vector_store_management_route(route)
+    if _model and team_object and not _skip_model_check:
         with tracer.trace("litellm.proxy.auth.common_checks.can_team_access_model"):
             try:
                 await can_team_access_model(
@@ -564,7 +602,13 @@ async def common_checks(  # noqa: PLR0915
                     raise
 
     # 2.2. If team member has per-member model scope, enforce it
-    if _model and team_object and valid_token and valid_token.user_id:
+    if (
+        _model
+        and team_object
+        and valid_token
+        and valid_token.user_id
+        and not _skip_model_check
+    ):
         with tracer.trace(
             "litellm.proxy.auth.common_checks.check_team_member_model_access"
         ):
@@ -600,7 +644,14 @@ async def common_checks(  # noqa: PLR0915
                     )
 
     ## 2.1 If user can call model (if personal key)
-    if _model and team_object is None and user_object is not None:
+    # Same guard as checks 2 and 2.2: skip for vector store management routes
+    # where the model comes from the managed VS ID, not from the caller's intent.
+    if (
+        _model
+        and team_object is None
+        and user_object is not None
+        and not _skip_model_check
+    ):
         with tracer.trace("litellm.proxy.auth.common_checks.can_user_call_model"):
             await can_user_call_model(
                 model=_model,
@@ -617,6 +668,7 @@ async def common_checks(  # noqa: PLR0915
             skip_budget_checks=skip_budget_checks,
             valid_token=valid_token,
             proxy_logging_obj=proxy_logging_obj,
+            skip_model_check=_skip_model_check,
         )
 
     # If this is a free model, skip all budget checks

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3016,3 +3016,190 @@ async def test_team_member_budget_check_zero_per_member_row_still_blocks():
                 proxy_logging_obj=proxy_logging_obj,
             )
     assert exc_info.value.max_budget == 0.0
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# LIT-3244  Vector store file routes must not be blocked by team model access
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "route,expected",
+    [
+        # Vector store management routes — must be True
+        ("/v1/vector_stores", True),
+        ("/v1/vector_stores/vs_abc123", True),
+        ("/v1/vector_stores/vs_abc123/files", True),
+        ("/v1/vector_stores/vs_abc123/files/file_xyz", True),
+        ("/v1/vector_stores/vs_abc123/search", True),
+        ("/vector_stores", True),
+        ("/vector_stores/vs_abc123", True),
+        ("/vector_stores/vs_abc123/files", True),
+        ("/vector_stores/vs_abc123/files/file_xyz", True),
+        # Other routes — must be False
+        ("/v1/chat/completions", False),
+        ("/chat/completions", False),
+        ("/v1/embeddings", False),
+        ("/v1/files", False),
+        ("/v1/batches", False),
+    ],
+)
+def test_is_vector_store_management_route(route: str, expected: bool):
+    """_is_vector_store_management_route must recognise all VS CRUD paths."""
+    from litellm.proxy.auth.auth_checks import _is_vector_store_management_route
+
+    assert _is_vector_store_management_route(route) is expected
+
+
+@pytest.mark.asyncio
+async def test_common_checks_skips_team_model_check_for_vector_store_routes():
+    """Regression test for LIT-3244.
+
+    A team with a restricted models list must NOT be blocked from accessing
+    vector store file endpoints just because a model name is embedded in the
+    managed vector store ID.  The model check is replaced by vector-store-level
+    access control (assert_user_can_access_vector_store_id).
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy._types import LiteLLM_TeamTable, UserAPIKeyAuth
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    # Team that is restricted to a single model — e.g. "gpt-4o"
+    team_object = LiteLLM_TeamTable(
+        team_id="team-jwt-123",
+        models=["gpt-4o"],
+    )
+
+    # The request_body contains a vector_store_id that, when decoded,
+    # yields a routing model name that is NOT in the team's allowed list.
+    request_body = {
+        "vector_store_id": "vs_provider_abc",
+        # Simulate a model extracted from the managed resource ID
+        # by having it directly in request_data (worst-case scenario).
+        # In production this comes from _extract_models_from_managed_resource_id.
+    }
+
+    valid_token = UserAPIKeyAuth(
+        token="jwt-user-token",
+        team_id="team-jwt-123",
+    )
+
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    mock_request.query_params = {}
+
+    mock_proxy_logging = MagicMock()
+
+    # Patch get_model_from_request so it returns a model that would normally
+    # fail the team model check — this simulates the model being decoded from
+    # the vector_store_id.
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_model_from_request",
+            return_value="azure-openai-private-deployment",
+        ),
+        # Stub out the budget/organisation/tag checks so only the model check matters
+        patch(
+            "litellm.proxy.auth.auth_checks._global_proxy_budget_check",
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.vector_store_access_check",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.check_tools_allowlist",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        # This must NOT raise — the model check should be skipped for VS routes
+        result = await common_checks(
+            request_body=request_body,
+            team_object=team_object,
+            user_object=None,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings={},
+            route="/v1/vector_stores/vs_provider_abc/files",
+            llm_router=None,
+            proxy_logging_obj=mock_proxy_logging,
+            valid_token=valid_token,
+            request=mock_request,
+            skip_budget_checks=True,
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_common_checks_enforces_team_model_check_for_non_vector_store_routes():
+    """The team model check must still fire for non-VS routes (e.g. /chat/completions)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy._types import LiteLLM_TeamTable, ProxyErrorTypes, UserAPIKeyAuth
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    team_object = LiteLLM_TeamTable(
+        team_id="team-jwt-456",
+        models=["gpt-4o"],
+    )
+
+    request_body = {"model": "azure-openai-private-deployment"}
+
+    valid_token = UserAPIKeyAuth(
+        token="jwt-user-token",
+        team_id="team-jwt-456",
+    )
+
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    mock_request.query_params = {}
+
+    mock_proxy_logging = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_model_from_request",
+            return_value="azure-openai-private-deployment",
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks._key_access_group_grants_model",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.vector_store_access_check",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.check_tools_allowlist",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        # This MUST raise — the team can only access gpt-4o
+        with pytest.raises(ProxyException) as exc_info:
+            await common_checks(
+                request_body=request_body,
+                team_object=team_object,
+                user_object=None,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route="/v1/chat/completions",
+                llm_router=None,
+                proxy_logging_obj=mock_proxy_logging,
+                valid_token=valid_token,
+                request=mock_request,
+                skip_budget_checks=True,
+            )
+
+    assert exc_info.value.type == ProxyErrorTypes.team_model_access_denied


### PR DESCRIPTION
Fixes #LIT-3244

## Summary

Fixes a regression where teams with a **restricted models list** (e.g. JWT auth with `team_ids_jwt_field`) were blocked from calling `v1/vector_stores/{id}/files` with a spurious 403:

```json
{
  "error": {
    "message": "team not allowed to access model. This team can only access models=[xxx]. Tried to access yyy-model",
    "type": "team_model_access_denied",
    "code": "403"
  }
}
```

**Root cause:** `get_model_from_request` iterates `_MODEL_ROUTING_ID_FIELDS` (which includes `vector_store_id`) and decodes any model name embedded in a LiteLLM-managed vector store ID. That model name was then fed into the team model-access gate, even though it's an internal routing detail (the underlying provider deployment), not the model the caller is trying to invoke.

**Fix:** Introduce `_is_vector_store_management_route()` and use it in `common_checks` to skip checks **#2** (team model access) and **#2.2** (team-member model scope) for all `/v1/vector_stores/…` and `/vector_stores/…` routes. Access control for these routes is already handled by `assert_user_can_access_vector_store_id` (team_id / object_permission match) inside each endpoint handler. Chat completion routes that *use* vector stores as tools carry an explicit `model` field and do **not** start with these prefixes, so they are unaffected.

## Changes
- `litellm/proxy/auth/auth_checks.py` — add `_is_vector_store_management_route()` helper; skip model checks in `common_checks` for VS routes
- `tests/test_litellm/proxy/auth/test_auth_checks.py` — parametric route-detection tests + two integration-style `common_checks` tests

## Test plan
- [x] `uv run pytest tests/test_litellm/proxy/auth/test_auth_checks.py -k "vector_store"` — 26 passed
- [x] `uv run pytest tests/test_litellm/proxy/auth/test_auth_checks.py` — 132 passed
- [x] New tests verify skip fires on VS routes and does **not** fire on `/chat/completions`

Linear: https://linear.app/litellm-ai/issue/LIT-3244

🤖 Generated with [Claude Code](https://claude.ai/claude-code)