### PR TITLE
fix(otel): normalize list guardrail_mode to tuple in _emit_once dedupe key (LIT-3299)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -907,7 +907,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             spans_logged = {}
             _otel_internal["spans_logged"] = spans_logged
 
-        dedupe_key = (self.__class__.__name__, id(self), *scope)
+        # Normalize any list elements in scope to tuples so the composed key
+        # is always hashable. guardrail_mode is stored as a list when multiple
+        # lifecycle hooks are configured (e.g. ["pre_call", "post_call"]), and
+        # using a raw list as a dict key raises TypeError: unhashable type: list.
+        hashable_scope = tuple(tuple(s) if isinstance(s, list) else s for s in scope)
+        dedupe_key = (self.__class__.__name__, id(self), *hashable_scope)
         if spans_logged.get(dedupe_key) is True:
             return False
 

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4604,6 +4604,44 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         self.assertTrue(otel._emit_once(kwargs, "success"))
         self.assertFalse(otel._emit_once(kwargs, "success"))
 
+    def test_emit_once_list_guardrail_mode_does_not_raise(self):
+        """Regression test for LIT-3299.
+
+        When guardrail_mode is a list (e.g. ["pre_call", "post_call"]) it must
+        not raise ``TypeError: unhashable type: list`` — the list should be
+        normalised to a tuple before being used as part of the dict key.
+        """
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        list_mode = ["pre_call", "post_call"]
+        # Must not raise TypeError
+        result_first = otel._emit_once(
+            kwargs, "guardrail", "block-code", 1.0, list_mode
+        )
+        self.assertTrue(result_first, "First call with list mode must return True")
+        result_second = otel._emit_once(
+            kwargs, "guardrail", "block-code", 1.0, list_mode
+        )
+        self.assertFalse(
+            result_second,
+            "Second call with identical list mode must be deduped (return False)",
+        )
+
+    def test_emit_once_list_mode_dedupes_against_equivalent_tuple(self):
+        """A list-valued scope and the equivalent tuple must share the same
+        dedupe slot (both representations refer to the same guardrail entry)."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        list_mode = ["pre_call", "post_call"]
+        tuple_mode = ("pre_call", "post_call")
+        # First call with list
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "g1", 1.0, list_mode))
+        # Equivalent tuple call must be deduped
+        self.assertFalse(
+            otel._emit_once(kwargs, "guardrail", "g1", 1.0, tuple_mode),
+            "Equivalent tuple form must share the dedupe slot of the list form",
+        )
+
     def test_handle_success_emits_single_litellm_request_span_on_double_call(self):
         """Sync + async callback paths firing for the same kwargs must
         result in exactly one litellm_request span."""


### PR DESCRIPTION
## Summary

- **Bug**: When a guardrail is configured with a list-valued `mode` (e.g. `["pre_call", "post_call"]`), every request that triggers the guardrail returned HTTP 500 with `TypeError: unhashable type: list`.
- **Root cause**: `_emit_once()` in `opentelemetry.py` constructs a `dedupe_key` tuple from scope args and stores it as a dict key. When `guardrail_mode` is a `list`, the list cannot be used as a dict key (lists are unhashable).
- **Fix**: Normalize any list elements in `scope` to tuples before constructing `dedupe_key`, making it always hashable. A list and its equivalent tuple are treated as the same dedupe slot (same guardrail entry).

Closes https://github.com/BerriAI/litellm/issues/28486
Linear: [LIT-3299](https://linear.app/litellm/issue/LIT-3299)

## Changes

**`litellm/integrations/opentelemetry.py`** — `_emit_once()`:
```python
# Before
dedupe_key = (self.__class__.__name__, id(self), *scope)

# After  
hashable_scope = tuple(tuple(s) if isinstance(s, list) else s for s in scope)
dedupe_key = (self.__class__.__name__, id(self), *hashable_scope)
```

**`tests/test_litellm/integrations/test_opentelemetry.py`** — two new regression tests in `TestOpenTelemetrySpanDedupe`:
- `test_emit_once_list_guardrail_mode_does_not_raise` — verifies a list-valued mode no longer raises `TypeError`
- `test_emit_once_list_mode_dedupes_against_equivalent_tuple` — verifies a list and equivalent tuple share the same dedupe slot

## Test plan

- [x] `uv run pytest tests/test_litellm/integrations/test_opentelemetry.py::TestOpenTelemetrySpanDedupe -v` — all 12 tests pass
- [x] New regression tests reproduce the crash before the fix and pass after

No UI surface changes.