### PR TITLE
refactor: mask credential fields in proxy settings GET responses

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -157,11 +157,21 @@ def mask_sensitive_keys(
     Unlike :meth:`SensitiveDataMasker.mask_dict`, this does exact key-name
     matching (not segment matching), so callers explicitly enumerate which
     fields to mask. Non-string and None values are passed through unchanged.
+
+    Values shorter than ``visible_prefix + visible_suffix`` (8 by default)
+    fall outside :meth:`SensitiveDataMasker._mask_value`'s partial-reveal
+    range and are replaced with a fixed-length all-mask string, so a short
+    credential is never returned verbatim.
     """
     masked: Dict[str, Any] = {}
+    mask_char = _default_masker.mask_char
+    min_visible = _default_masker.visible_prefix + _default_masker.visible_suffix
     for key, value in data.items():
         if value is not None and key in sensitive_fields and isinstance(value, str):
-            masked[key] = _default_masker._mask_value(value)
+            if len(value) < min_visible:
+                masked[key] = mask_char * len(value) if value else value
+            else:
+                masked[key] = _default_masker._mask_value(value)
         else:
             masked[key] = value
     return masked

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -146,6 +146,27 @@ class SensitiveDataMasker:
         return masked_data
 
 
+_default_masker = SensitiveDataMasker()
+
+
+def mask_sensitive_keys(
+    data: Dict[str, Any], sensitive_fields: Set[str]
+) -> Dict[str, Any]:
+    """Return a new dict with values masked for keys listed in ``sensitive_fields``.
+
+    Unlike :meth:`SensitiveDataMasker.mask_dict`, this does exact key-name
+    matching (not segment matching), so callers explicitly enumerate which
+    fields to mask. Non-string and None values are passed through unchanged.
+    """
+    masked: Dict[str, Any] = {}
+    for key, value in data.items():
+        if value is not None and key in sensitive_fields and isinstance(value, str):
+            masked[key] = _default_masker._mask_value(value)
+        else:
+            masked[key] = value
+    return masked
+
+
 # Usage example:
 """
 masker = SensitiveDataMasker()

--- a/litellm/proxy/management_endpoints/cache_settings_endpoints.py
+++ b/litellm/proxy/management_endpoints/cache_settings_endpoints.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
+from litellm.litellm_core_utils.sensitive_data_masker import mask_sensitive_keys
 from litellm.proxy._types import (
     AUDIT_ACTIONS,
     LiteLLM_AuditLogs,
@@ -33,6 +34,10 @@ from litellm.types.management_endpoints import (
 )
 
 router = APIRouter()
+
+# Cache fields holding credentials. Masked on read so plaintext Redis /
+# Sentinel passwords never leave the server in a GET response.
+_CACHE_SENSITIVE_FIELDS: set = {"password", "sentinel_password"}
 
 
 _REDACTED_VALUE = "***REDACTED***"
@@ -295,7 +300,11 @@ async def get_cache_settings(
                     else:
                         decrypted_settings["redis_type"] = "node"
 
-                current_values = decrypted_settings
+                # Mask credential fields so the GET response never carries
+                # plaintext Redis / Sentinel passwords off the server.
+                current_values = mask_sensitive_keys(
+                    decrypted_settings, _CACHE_SENSITIVE_FIELDS
+                )
 
         # Update field values with current values
         for field in cache_fields:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -241,7 +241,10 @@ from litellm.litellm_core_utils.core_helpers import (
 )
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
+from litellm.litellm_core_utils.sensitive_data_masker import (
+    SensitiveDataMasker,
+    mask_sensitive_keys,
+)
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.proxy._types import *
@@ -14634,6 +14637,11 @@ async def get_config():  # noqa: PLR0915
                 )
             )
 
+        # Credentials in the alerting block: the webhook URL (full Slack
+        # incoming-webhook URL is itself a credential) and the SMTP password.
+        # Masked on read so plaintext never reaches the UI.
+        _alerting_sensitive_vars = {"SLACK_WEBHOOK_URL", "SMTP_PASSWORD"}
+
         # Check if slack alerting is on
         _alerting = _general_settings.get("alerting", [])
         alerting_data = []
@@ -14653,6 +14661,9 @@ async def get_config():  # noqa: PLR0915
                         value=env_variable, key=_var
                     )
                     _slack_env_vars[_var] = _decrypted_value
+            _slack_env_vars = mask_sensitive_keys(
+                _slack_env_vars, _alerting_sensitive_vars
+            )
 
             _alerting_types = proxy_logging_obj.slack_alerting_instance.alert_types
             _all_alert_types = (
@@ -14689,6 +14700,7 @@ async def get_config():  # noqa: PLR0915
                 # decode + decrypt the value
                 _decrypted_value = decrypt_value_helper(value=env_variable, key=_var)
                 _email_env_vars[_var] = _decrypted_value
+        _email_env_vars = mask_sensitive_keys(_email_env_vars, _alerting_sensitive_vars)
 
         alerting_data.append(
             {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -992,6 +992,15 @@ _OPENAPI_HTTP_METHODS = {
 }
 
 
+# Credentials surfaced by `/get/config/callbacks` in the alerting block: the
+# full Slack incoming-webhook URL is itself a credential, and the SMTP
+# password is a service password. Masked on read so plaintext never reaches
+# the UI. Kept here at module scope to match the analogous
+# `_SSO_SENSITIVE_FIELDS` / `_CACHE_SENSITIVE_FIELDS` constants in the SSO
+# and cache endpoint files.
+_ALERTING_SENSITIVE_VARS: Set[str] = {"SLACK_WEBHOOK_URL", "SMTP_PASSWORD"}
+
+
 def _strip_operation_id_method_suffix(operation_id: str) -> str:
     base, separator, suffix = operation_id.rpartition("_")
     if separator and suffix in _OPENAPI_HTTP_METHODS:
@@ -14637,11 +14646,6 @@ async def get_config():  # noqa: PLR0915
                 )
             )
 
-        # Credentials in the alerting block: the webhook URL (full Slack
-        # incoming-webhook URL is itself a credential) and the SMTP password.
-        # Masked on read so plaintext never reaches the UI.
-        _alerting_sensitive_vars = {"SLACK_WEBHOOK_URL", "SMTP_PASSWORD"}
-
         # Check if slack alerting is on
         _alerting = _general_settings.get("alerting", [])
         alerting_data = []
@@ -14662,7 +14666,7 @@ async def get_config():  # noqa: PLR0915
                     )
                     _slack_env_vars[_var] = _decrypted_value
             _slack_env_vars = mask_sensitive_keys(
-                _slack_env_vars, _alerting_sensitive_vars
+                _slack_env_vars, _ALERTING_SENSITIVE_VARS
             )
 
             _alerting_types = proxy_logging_obj.slack_alerting_instance.alert_types
@@ -14700,7 +14704,7 @@ async def get_config():  # noqa: PLR0915
                 # decode + decrypt the value
                 _decrypted_value = decrypt_value_helper(value=env_variable, key=_var)
                 _email_env_vars[_var] = _decrypted_value
-        _email_env_vars = mask_sensitive_keys(_email_env_vars, _alerting_sensitive_vars)
+        _email_env_vars = mask_sensitive_keys(_email_env_vars, _ALERTING_SENSITIVE_VARS)
 
         alerting_data.append(
             {

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -9,6 +9,7 @@ from pydantic.fields import FieldInfo
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.sensitive_data_masker import mask_sensitive_keys
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.types.proxy.management_endpoints.ui_sso import (
@@ -18,6 +19,16 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
 )
 
 router = APIRouter()
+
+# SSO secret fields returned by /get/sso_settings. These are masked on read so
+# the UI can show "(set)" without ever transporting the plaintext OAuth secret
+# off the server, matching the write-once + masked-on-read contract used for
+# the HashiCorp Vault config override.
+_SSO_SENSITIVE_FIELDS: Set[str] = {
+    "google_client_secret",
+    "microsoft_client_secret",
+    "generic_client_secret",
+}
 
 
 class IPAddress(BaseModel):
@@ -728,8 +739,9 @@ async def get_sso_settings():
 
     schema = TypeAdapter(SSOConfig).json_schema(by_alias=True)
 
-    # Convert to dict for response
-    sso_dict = sso_config.model_dump()
+    # Convert to dict for response, masking OAuth client secrets so plaintext
+    # is never sent to the UI.
+    sso_dict = mask_sensitive_keys(sso_config.model_dump(), _SSO_SENSITIVE_FIELDS)
 
     # Add descriptions to the response
     result = {

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -360,11 +360,15 @@ class TestProxySettingEndpoints:
         assert "proxy_base_url" in values
         assert "user_email" in values
 
-        # Verify values match our mock config
+        # Verify non-secret values match our mock config. OAuth client
+        # secrets are masked on read so the GET response never carries
+        # plaintext credentials.
         assert values["google_client_id"] == "test_google_client_id"
-        assert values["google_client_secret"] == "test_google_client_secret"
+        assert values["google_client_secret"] != "test_google_client_secret"
+        assert "*" in values["google_client_secret"]
         assert values["microsoft_client_id"] == "test_microsoft_client_id"
-        assert values["microsoft_client_secret"] == "test_microsoft_client_secret"
+        assert values["microsoft_client_secret"] != "test_microsoft_client_secret"
+        assert "*" in values["microsoft_client_secret"]
         assert values["proxy_base_url"] == "https://example.com"
         assert values["user_email"] == "admin@example.com"
 
@@ -1321,10 +1325,12 @@ class TestProxySettingEndpoints:
         assert "values" in data
         assert "field_schema" in data
 
-        # Verify decrypted values are returned
+        # Verify decrypted values are returned. OAuth client secrets are
+        # masked on read so plaintext is never sent to the UI.
         values = data["values"]
         assert values["google_client_id"] == "decrypted_google_id"
-        assert values["google_client_secret"] == "decrypted_google_secret"
+        assert values["google_client_secret"] != "decrypted_google_secret"
+        assert "*" in values["google_client_secret"]
         assert values["microsoft_client_id"] == "decrypted_microsoft_id"
         assert values["proxy_base_url"] == "https://decrypted.example.com"
 


### PR DESCRIPTION
Brings the SSO settings, cache settings, and email/Slack alerting view in `/get/config/callbacks` in line with the HashiCorp Vault config-override pattern, so persisted credentials are not transported back to the UI in plaintext.

### What the code now does
- `/get/sso_settings` masks `google_client_secret`, `microsoft_client_secret`, `generic_client_secret` before returning the response.
- `/cache/settings` GET masks Redis `password` and `sentinel_password` in `current_values`.
- `/get/config/callbacks` masks `SLACK_WEBHOOK_URL` and `SMTP_PASSWORD` in the Slack / email alerting block.
- New module-level `mask_sensitive_keys` helper in `litellm/litellm_core_utils/sensitive_data_masker.py` does exact-key-name masking using the existing `SensitiveDataMasker._mask_value`. The HashiCorp Vault config-override already follows the same shape; this generalizes the helper.

### Test plan
- `uv run pytest tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py tests/test_litellm/proxy/management_endpoints/test_cache_settings_endpoints.py tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py tests/test_litellm/proxy/auth/test_route_checks.py tests/test_litellm/proxy/auth/test_admin_viewer_handler_access.py` — 341 passed.
- Two stale assertions in `test_proxy_setting_endpoints.py` were updated to expect the masked OAuth client secret rather than the plaintext value.
- Ran a live curl matrix against a local proxy as both PROXY_ADMIN and PROXY_ADMIN_VIEW_ONLY. Non-secret fields (`client_id`, `microsoft_tenant`, cache `host` / `username`, SMTP host / username) still round-trip; secret fields come back masked.