### PR TITLE
fix(anthropic-passthrough): round-trip reasoning.encrypted_content fo…

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -71,7 +71,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             except Exception:
                 custom_llm_provider = None
 
-        if custom_llm_provider != "openai":
+        if custom_llm_provider not in ("openai", "chatgpt"):
             return
 
         if not isinstance(thinking, dict) or thinking.get("type") != "enabled":

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -30,20 +30,24 @@ from litellm.utils import ProviderConfigManager, client
 from ..utils import is_reasoning_auto_summary_enabled
 
 from ..adapters.handler import LiteLLMMessagesToCompletionTransformationHandler
+from ..responses_adapters._signature_codec import _SIG_PREFIX
 from ..responses_adapters.handler import LiteLLMMessagesToResponsesAPIHandler
 from .interceptors import get_messages_interceptors
 from .utils import AnthropicMessagesRequestUtils, mock_response
 
 # Providers that are routed directly to the OpenAI Responses API instead of
 # going through chat/completions.
-_RESPONSES_API_PROVIDERS = frozenset({"openai"})
+_RESPONSES_API_PROVIDERS = frozenset({"openai", "chatgpt"})
 
 
 def _should_route_to_responses_api(custom_llm_provider: Optional[str]) -> bool:
     """Return True when the provider should use the Responses API path.
 
     Set ``litellm.use_chat_completions_url_for_anthropic_messages = True`` to
-    opt out and route OpenAI/Azure requests through chat/completions instead.
+    opt out and route OpenAI/Azure/ChatGPT requests through chat/completions
+    instead. Note that chat/completions cannot carry
+    ``reasoning.encrypted_content``, so opting out costs reasoning continuity
+    on multi-turn conversations against o-series / GPT-5 / Codex models.
     """
     if litellm.use_chat_completions_url_for_anthropic_messages:
         return False
@@ -238,6 +242,38 @@ async def anthropic_messages(
     request_kwargs.pop("litellm_params", None)
     # Merge back any other modifications
     kwargs.update(request_kwargs)
+
+    # Strip foreign packed signatures from history when routing to native
+    # Anthropic. The responses_adapters packs `{id, encrypted_content}` from
+    # OpenAI Responses reasoning items into the thinking block's `signature`
+    # field. Anthropic rejects these with `Invalid signature in thinking
+    # block` when the conversation later switches to a native Anthropic model
+    # (e.g. via /model). The text in these thinking blocks is empty (Claude
+    # Code's clear_thinking edit clears it), so the cleanest fix is to drop
+    # them entirely.
+    if custom_llm_provider == "anthropic" and isinstance(messages, list):
+        _stripped: List[Any] = []
+        for _m in messages:
+            if not (isinstance(_m, dict) and isinstance(_m.get("content"), list)):
+                _stripped.append(_m)
+                continue
+            new_content = [
+                _c
+                for _c in _m["content"]
+                if not (
+                    isinstance(_c, dict)
+                    and _c.get("type") == "thinking"
+                    and isinstance(_c.get("signature"), str)
+                    and _c["signature"].startswith(_SIG_PREFIX)
+                )
+            ]
+            # Anthropic rejects messages with empty content arrays. If stripping
+            # removed every block, drop the whole message — it carried only
+            # foreign reasoning state which is meaningless to native Anthropic.
+            if not new_content:
+                continue
+            _stripped.append({**_m, "content": new_content})
+        messages = _stripped
 
     # Short-circuit web-search-only requests: detect the pattern, execute
     # search directly via Tavily/Perplexity, and return a synthetic response

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/_signature_codec.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/_signature_codec.py
@@ -1,0 +1,43 @@
+"""Signature codec for round-tripping OpenAI Responses reasoning items
+through Anthropic's `thinking.signature` field.
+
+Claude Code's ``clear_thinking_20251015`` context-management edit preserves
+only ``{type, thinking, signature}`` on each turn — the plaintext reasoning
+is cleared. To replay an OpenAI Responses ``reasoning`` item we need both
+``id`` and ``encrypted_content``; we pack both into the single ``signature``
+channel that Claude Code preserves.
+
+``_unpack_signature`` returns ``(None, None)`` for any signature without
+the ``lllm-rsenc-v1:`` prefix, so native Anthropic thinking signatures
+(produced by a model switch mid-conversation) safely degrade — we skip
+the reasoning replay rather than crashing.
+"""
+
+import base64
+import json
+from typing import Optional, Tuple
+
+_SIG_PREFIX = "lllm-rsenc-v1:"
+
+
+def _pack_signature(
+    rs_id: Optional[str], encrypted_content: Optional[str]
+) -> Optional[str]:
+    if not encrypted_content:
+        return None
+    return (
+        _SIG_PREFIX
+        + base64.b64encode(
+            json.dumps({"id": rs_id, "ec": encrypted_content}).encode()
+        ).decode()
+    )
+
+
+def _unpack_signature(sig: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    if not sig or not sig.startswith(_SIG_PREFIX):
+        return None, None
+    try:
+        p = json.loads(base64.b64decode(sig[len(_SIG_PREFIX) :]).decode())
+        return p.get("id"), p.get("ec")
+    except Exception:
+        return None, None

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -3,10 +3,13 @@
 import json
 import traceback
 from collections import deque
-from typing import Any, AsyncIterator, Dict
+from typing import Any, AsyncIterator, Dict, Optional
 
 from litellm import verbose_logger
 from litellm._uuid import uuid
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+    _pack_signature,
+)
 
 
 class AnthropicResponsesStreamWrapper:
@@ -41,6 +44,13 @@ class AnthropicResponsesStreamWrapper:
         self._sent_message_start = False
         self._sent_message_stop = False
         self._chunk_queue: deque = deque()
+        # Track per-reasoning-item state so we can emit a
+        # `signature_delta` carrying the packed (id + encrypted_content)
+        # blob immediately before the reasoning block's content_block_stop.
+        # Keyed by item_id because output_item.added/done both carry it
+        # and we want to keep state isolated when multiple reasoning items
+        # appear in a single response.
+        self._reasoning_items: Dict[str, Dict[str, Optional[str]]] = {}
 
     def _make_message_start(self) -> Dict[str, Any]:
         return {
@@ -137,6 +147,13 @@ class AnthropicResponsesStreamWrapper:
                 block_idx = self._next_block_index()
                 if item_id:
                     self._item_id_to_block_index[item_id] = block_idx
+                    # Track this reasoning item so we can pair its
+                    # encrypted_content (arriving in output_item.done)
+                    # with the right block on close.
+                    self._reasoning_items[item_id] = {
+                        "id": item_id,
+                        "encrypted_content": None,
+                    }
                 self._chunk_queue.append(
                     {
                         "type": "content_block_start",
@@ -223,11 +240,45 @@ class AnthropicResponsesStreamWrapper:
                 if item
                 else None
             )
+            item_type = (
+                getattr(item, "type", None)
+                or (item.get("type") if isinstance(item, dict) else None)
+                if item
+                else None
+            )
             block_idx = (
                 self._item_id_to_block_index.get(item_id, self._current_block_index)
                 if item_id
                 else self._current_block_index
             )
+            # For reasoning items, emit a signature_delta containing the
+            # packed (id + encrypted_content) blob BEFORE the content_block_stop.
+            # Anthropic's wire protocol supports `signature_delta` on a
+            # content_block_delta; Claude Code's clear_thinking edit preserves
+            # the signature field on round-trip, which is how we replay the
+            # reasoning item to OpenAI on the next turn.
+            if item_type == "reasoning" and item_id:
+                enc = (
+                    getattr(item, "encrypted_content", None)
+                    if not isinstance(item, dict)
+                    else item.get("encrypted_content")
+                )
+                state = self._reasoning_items.get(item_id)
+                if state is not None:
+                    state["encrypted_content"] = enc
+                rs_id = state["id"] if state else item_id
+                packed = _pack_signature(rs_id, enc)
+                if packed:
+                    self._chunk_queue.append(
+                        {
+                            "type": "content_block_delta",
+                            "index": block_idx,
+                            "delta": {
+                                "type": "signature_delta",
+                                "signature": packed,
+                            },
+                        }
+                    )
             self._chunk_queue.append(
                 {
                     "type": "content_block_stop",

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -264,21 +264,26 @@ class AnthropicResponsesStreamWrapper:
                     else item.get("encrypted_content")
                 )
                 state = self._reasoning_items.get(item_id)
-                if state is not None:
+                if state is None:
+                    # output_item.added was never seen for this reasoning
+                    # item — we don't have a reliable id. Skip the
+                    # signature entirely rather than packing a potentially
+                    # wrong rs_id from the event header.
+                    pass
+                else:
                     state["encrypted_content"] = enc
-                rs_id = state["id"] if state else item_id
-                packed = _pack_signature(rs_id, enc)
-                if packed:
-                    self._chunk_queue.append(
-                        {
-                            "type": "content_block_delta",
-                            "index": block_idx,
-                            "delta": {
-                                "type": "signature_delta",
-                                "signature": packed,
-                            },
-                        }
-                    )
+                    packed = _pack_signature(state["id"], enc)
+                    if packed:
+                        self._chunk_queue.append(
+                            {
+                                "type": "content_block_delta",
+                                "index": block_idx,
+                                "delta": {
+                                    "type": "signature_delta",
+                                    "signature": packed,
+                                },
+                            }
+                        )
             self._chunk_queue.append(
                 {
                     "type": "content_block_stop",

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -8,6 +8,10 @@ path used for OpenAI and Azure models.
 import json
 from typing import Any, Dict, List, Optional, Union, cast
 
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+    _pack_signature,
+    _unpack_signature,
+)
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
 )
@@ -147,6 +151,8 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                     )
                 elif isinstance(content, list):
                     asst_parts: List[Dict[str, Any]] = []
+                    reasoning_items: List[Dict[str, Any]] = []
+                    function_call_items: List[Dict[str, Any]] = []
                     for block in content:
                         if not isinstance(block, dict):
                             continue
@@ -156,8 +162,10 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 {"type": "output_text", "text": block.get("text", "")}
                             )
                         elif btype == "tool_use":
-                            # tool_use becomes a top-level function_call item
-                            input_items.append(
+                            # Defer until after reasoning_items so they precede
+                            # the function_calls they generated, per OpenAI's
+                            # Responses API ordering requirement.
+                            function_call_items.append(
                                 {
                                     "type": "function_call",
                                     "call_id": block.get("id", ""),
@@ -166,11 +174,40 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 }
                             )
                         elif btype == "thinking":
-                            thinking_text = block.get("thinking", "")
-                            if thinking_text:
-                                asst_parts.append(
-                                    {"type": "output_text", "text": thinking_text}
+                            sig = block.get("signature")
+                            rs_id, enc = _unpack_signature(sig)
+                            if enc:
+                                # Reasoning items belong at the top level of the
+                                # Responses `input` array, immediately preceding
+                                # the assistant message they summarize. OpenAI
+                                # silently ignores reasoning items in any other
+                                # position.
+                                reasoning_items.append(
+                                    {
+                                        "type": "reasoning",
+                                        "id": rs_id,
+                                        "encrypted_content": enc,
+                                        "summary": (
+                                            [
+                                                {
+                                                    "type": "summary_text",
+                                                    "text": block["thinking"],
+                                                }
+                                            ]
+                                            if block.get("thinking")
+                                            else []
+                                        ),
+                                    }
                                 )
+                            # If no usable signature: drop silently. Do NOT
+                            # downgrade to output_text (causes OpenAI 400
+                            # "unexpected output_text in assistant input").
+                    # Emit reasoning items first so they precede any
+                    # function_calls and the assistant message they summarize.
+                    if reasoning_items:
+                        input_items.extend(reasoning_items)
+                    if function_call_items:
+                        input_items.extend(function_call_items)
                     if asst_parts:
                         input_items.append(
                             {
@@ -295,6 +332,32 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             result["summary"] = "detailed"
         return result
 
+    @staticmethod
+    def _apply_reasoning_replay_settings(responses_kwargs: Dict[str, Any]) -> None:
+        """Force ``store=False`` and append ``reasoning.encrypted_content`` to
+        ``include`` so the upstream returns the encrypted reasoning blob and
+        we can replay it verbatim on the next turn. Only kicks in when
+        reasoning is actually in play — either the client requested thinking,
+        or the inbound history carries a reasoning item from a prior turn —
+        so non-reasoning callers are not silently affected.
+        """
+        has_reasoning_request = isinstance(responses_kwargs.get("reasoning"), dict)
+        has_reasoning_input = any(
+            isinstance(it, dict) and it.get("type") == "reasoning"
+            for it in responses_kwargs.get("input", [])
+        )
+        if not (has_reasoning_request or has_reasoning_input):
+            return
+        # Only force store=False when the caller hasn't expressed a preference.
+        # Users who rely on OpenAI response storage (audit, cost attribution,
+        # later retrieval) can pass store=True explicitly to keep it on; they
+        # accept that they must replay encrypted_content themselves.
+        if "store" not in responses_kwargs:
+            responses_kwargs["store"] = False
+        responses_kwargs.setdefault("include", [])
+        if "reasoning.encrypted_content" not in responses_kwargs["include"]:
+            responses_kwargs["include"].append("reasoning.encrypted_content")
+
     def translate_request(
         self,
         anthropic_request: AnthropicMessagesRequest,
@@ -406,11 +469,90 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         if isinstance(metadata, dict) and "user_id" in metadata:
             responses_kwargs["user"] = str(metadata["user_id"])[:64]
 
+        self._apply_reasoning_replay_settings(responses_kwargs)
+
         return responses_kwargs
 
     # ------------------------------------------------------------------ #
     # Response translation: Responses API -> Anthropic                    #
     # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _translate_dict_output_item(
+        item: Dict[str, Any],
+        text_part_types: tuple,
+        content: List[Dict[str, Any]],
+        stop_reason: AnthropicFinishReason,
+    ) -> AnthropicFinishReason:
+        """Translate a dict-shaped output item (reached when the upstream
+        response is reconstructed via ResponsesAPIResponse.model_construct,
+        which skips pydantic type coercion). Appends content blocks to
+        ``content`` in place and returns the possibly-updated stop_reason.
+        """
+        item_type = item.get("type")
+        if item_type == "message":
+            raw_content = item.get("content", [])
+            if isinstance(raw_content, str):
+                if raw_content:
+                    content.append(
+                        AnthropicResponseContentBlockText(
+                            type="text", text=raw_content
+                        ).model_dump()
+                    )
+            else:
+                for part in raw_content:
+                    if isinstance(part, dict):
+                        part_type = part.get("type")
+                        text_val = part.get("text", "") or ""
+                        if part_type in text_part_types and text_val:
+                            content.append(
+                                AnthropicResponseContentBlockText(
+                                    type="text", text=text_val
+                                ).model_dump()
+                            )
+                    elif isinstance(part, str) and part:
+                        content.append(
+                            AnthropicResponseContentBlockText(
+                                type="text", text=part
+                            ).model_dump()
+                        )
+        elif item_type == "reasoning":
+            packed = _pack_signature(item.get("id"), item.get("encrypted_content"))
+            emitted = False
+            for summary in item.get("summary") or []:
+                text = (
+                    summary.get("text", "")
+                    if isinstance(summary, dict)
+                    else getattr(summary, "text", "")
+                ) or ""
+                if text:
+                    content.append(
+                        AnthropicResponseContentBlockThinking(
+                            type="thinking", thinking=text, signature=packed
+                        ).model_dump()
+                    )
+                    emitted = True
+            if not emitted and packed:
+                content.append(
+                    AnthropicResponseContentBlockThinking(
+                        type="thinking", thinking="", signature=packed
+                    ).model_dump()
+                )
+        elif item_type == "function_call":
+            try:
+                input_data = json.loads(item.get("arguments", "{}"))
+            except (json.JSONDecodeError, TypeError):
+                input_data = {}
+            content.append(
+                AnthropicResponseContentBlockToolUse(
+                    type="tool_use",
+                    id=item.get("call_id") or item.get("id", ""),
+                    name=item.get("name", ""),
+                    input=input_data,
+                ).model_dump()
+            )
+            stop_reason = "tool_use"
+        return stop_reason
 
     def translate_response(
         self,
@@ -430,8 +572,19 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         content: List[Dict[str, Any]] = []
         stop_reason: AnthropicFinishReason = "end_turn"
 
+        # Text-bearing content-part types we accept inside a message item.
+        # The Responses API canonically uses `output_text`, but some backends
+        # (notably the chatgpt subscription/Codex Responses backend) emit
+        # `text` parts, and dict-shaped items may also carry plain `text`
+        # fields when reconstructed via model_construct.
+        _TEXT_PART_TYPES = ("output_text", "text", "summary_text")
+
         for item in response.output:
             if isinstance(item, ResponseReasoningItem):
+                enc = getattr(item, "encrypted_content", None)
+                rs_id = getattr(item, "id", None)
+                packed = _pack_signature(rs_id, enc)
+                emitted = False
                 for summary in item.summary:
                     text = getattr(summary, "text", "")
                     if text:
@@ -439,18 +592,33 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                             AnthropicResponseContentBlockThinking(
                                 type="thinking",
                                 thinking=text,
-                                signature=None,
+                                signature=packed,
                             ).model_dump()
                         )
+                        emitted = True
+                if not emitted and packed:
+                    # No summary text but we still have encrypted content —
+                    # emit a signature-only thinking block so the next turn
+                    # can resume reasoning continuity.
+                    content.append(
+                        AnthropicResponseContentBlockThinking(
+                            type="thinking",
+                            thinking="",
+                            signature=packed,
+                        ).model_dump()
+                    )
 
             elif isinstance(item, ResponseOutputMessage):
                 for part in item.content:
-                    if getattr(part, "type", None) == "output_text":
-                        content.append(
-                            AnthropicResponseContentBlockText(
-                                type="text", text=getattr(part, "text", "")
-                            ).model_dump()
-                        )
+                    part_type = getattr(part, "type", None)
+                    if part_type in _TEXT_PART_TYPES:
+                        text_val = getattr(part, "text", "") or ""
+                        if text_val:
+                            content.append(
+                                AnthropicResponseContentBlockText(
+                                    type="text", text=text_val
+                                ).model_dump()
+                            )
 
             elif isinstance(item, ResponseFunctionToolCall):
                 try:
@@ -468,29 +636,9 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                 stop_reason = "tool_use"
 
             elif isinstance(item, dict):
-                item_type = item.get("type")
-                if item_type == "message":
-                    for part in item.get("content", []):
-                        if isinstance(part, dict) and part.get("type") == "output_text":
-                            content.append(
-                                AnthropicResponseContentBlockText(
-                                    type="text", text=part.get("text", "")
-                                ).model_dump()
-                            )
-                elif item_type == "function_call":
-                    try:
-                        input_data = json.loads(item.get("arguments", "{}"))
-                    except (json.JSONDecodeError, TypeError):
-                        input_data = {}
-                    content.append(
-                        AnthropicResponseContentBlockToolUse(
-                            type="tool_use",
-                            id=item.get("call_id") or item.get("id", ""),
-                            name=item.get("name", ""),
-                            input=input_data,
-                        ).model_dump()
-                    )
-                    stop_reason = "tool_use"
+                stop_reason = self._translate_dict_output_item(
+                    item, _TEXT_PART_TYPES, content, stop_reason
+                )
 
         # status -> stop_reason override
         if response.status == "incomplete":

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_route_thinking.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_route_thinking.py
@@ -1,0 +1,122 @@
+"""
+Tests for LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed.
+
+Covers the chatgpt provider whitelist added alongside the encrypted-reasoning
+round-trip fix (Phase 3.1): the chatgpt subscription/Codex backend must be
+treated identically to openai for thinking-enabled requests so it gets routed
+through the Responses API rather than chat completions.
+"""
+
+from unittest.mock import patch
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler as H,
+)
+
+
+def test_chatgpt_provider_routed_through_responses_api():
+    """chatgpt + thinking enabled → model gets `responses/` prefix and
+    reasoning_effort dict is built. This is the Phase 3.1 whitelist
+    addition; before the fix, only openai got this treatment and chatgpt
+    callers silently lost reasoning continuity."""
+    kwargs = {
+        "model": "gpt-5.5",
+        "custom_llm_provider": "chatgpt",
+        "reasoning_effort": "high",
+    }
+    H._route_openai_thinking_to_responses_api_if_needed(
+        kwargs, thinking={"type": "enabled", "budget_tokens": 10000}
+    )
+    assert kwargs["model"] == "responses/gpt-5.5"
+    assert kwargs["reasoning_effort"] == {"effort": "high"}
+
+
+def test_openai_provider_still_routed_through_responses_api():
+    """Regression guard: the chatgpt addition must not break the existing
+    openai routing."""
+    kwargs = {
+        "model": "gpt-5",
+        "custom_llm_provider": "openai",
+        "reasoning_effort": "medium",
+    }
+    H._route_openai_thinking_to_responses_api_if_needed(
+        kwargs, thinking={"type": "enabled", "budget_tokens": 5000}
+    )
+    assert kwargs["model"] == "responses/gpt-5"
+    assert kwargs["reasoning_effort"] == {"effort": "medium"}
+
+
+def test_anthropic_provider_early_returns_unchanged():
+    """The whitelist guard at L74 must early-return for any provider not in
+    {openai, chatgpt}. Native anthropic routing has its own thinking handling."""
+    kwargs = {
+        "model": "claude-opus-4-7",
+        "custom_llm_provider": "anthropic",
+        "reasoning_effort": "high",
+    }
+    H._route_openai_thinking_to_responses_api_if_needed(
+        kwargs, thinking={"type": "enabled", "budget_tokens": 10000}
+    )
+    # Untouched: no model rewrite, reasoning_effort stays a bare string
+    assert kwargs["model"] == "claude-opus-4-7"
+    assert kwargs["reasoning_effort"] == "high"
+
+
+def test_glm_provider_early_returns_unchanged():
+    """zai / glm / any other non-{openai,chatgpt} provider is untouched."""
+    kwargs = {
+        "model": "glm-4.5",
+        "custom_llm_provider": "zai",
+        "reasoning_effort": "low",
+    }
+    H._route_openai_thinking_to_responses_api_if_needed(
+        kwargs, thinking={"type": "enabled", "budget_tokens": 2000}
+    )
+    assert kwargs["model"] == "glm-4.5"
+    assert kwargs["reasoning_effort"] == "low"
+
+
+def test_chatgpt_thinking_disabled_does_not_rewrite_model():
+    """Provider whitelist passes, but the next gate (`thinking.type == "enabled"`)
+    must early-return when thinking is disabled."""
+    kwargs = {
+        "model": "gpt-5.5",
+        "custom_llm_provider": "chatgpt",
+        "reasoning_effort": "high",
+    }
+    H._route_openai_thinking_to_responses_api_if_needed(
+        kwargs, thinking={"type": "disabled"}
+    )
+    assert kwargs["model"] == "gpt-5.5"
+    # reasoning_effort untouched
+    assert kwargs["reasoning_effort"] == "high"
+
+
+def test_chatgpt_already_responses_prefixed_model_not_double_prefixed():
+    kwargs = {
+        "model": "responses/gpt-5.5",
+        "custom_llm_provider": "chatgpt",
+        "reasoning_effort": "high",
+    }
+    H._route_openai_thinking_to_responses_api_if_needed(
+        kwargs, thinking={"type": "enabled", "budget_tokens": 10000}
+    )
+    assert kwargs["model"] == "responses/gpt-5.5"
+
+
+def test_chatgpt_provider_inferred_from_model_when_missing():
+    """custom_llm_provider may be absent; the function infers it via
+    litellm.utils.get_llm_provider. Patch that to return chatgpt and verify
+    routing still kicks in."""
+    kwargs = {
+        "model": "gpt-5.5",
+        "reasoning_effort": "high",
+    }
+    with patch(
+        "litellm.utils.get_llm_provider",
+        return_value=("gpt-5.5", "chatgpt", None, None),
+    ):
+        H._route_openai_thinking_to_responses_api_if_needed(
+            kwargs, thinking={"type": "enabled", "budget_tokens": 10000}
+        )
+    assert kwargs["model"] == "responses/gpt-5.5"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -544,3 +544,220 @@ class TestThinkingSummaryPreservation:
         assert result == {
             "reasoning_effort": {"effort": "medium", "summary": "concise"}
         }
+
+
+class TestStripForeignSignatures:
+    """When the conversation history carries thinking blocks whose signature
+    is one of our packed `lllm-rsenc-v1:` blobs (from a previous gpt/chatgpt
+    turn) and the user switches to a native Anthropic model mid-conversation,
+    Anthropic rejects the request with `Invalid signature in thinking block`.
+    The handler strips those blocks before forwarding to anthropic. It does
+    NOT strip them when routing to chatgpt (the responses adapter unpacks
+    them into reasoning input items)."""
+
+    @staticmethod
+    def _packed_sig() -> str:
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+            _pack_signature,
+        )
+
+        packed = _pack_signature("rs_test123", "encrypted-blob-bytes")
+        assert packed is not None
+        return packed
+
+    @pytest.mark.asyncio
+    async def test_packed_signature_stripped_when_provider_anthropic(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+        packed = self._packed_sig()
+        messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": packed},
+                    {"type": "text", "text": "answer"},
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        captured = {}
+
+        def fake_handler(**kw):
+            captured.update(kw)
+            return "ok"
+
+        with patch.object(
+            handler, "anthropic_messages_handler", side_effect=fake_handler
+        ):
+            await handler.anthropic_messages(
+                max_tokens=100,
+                messages=messages,
+                model="anthropic/claude-opus-4-7",
+                custom_llm_provider="anthropic",
+            )
+        forwarded = captured["messages"][1]["content"]
+        # Thinking block with packed signature must be gone; text preserved.
+        assert all(c.get("type") != "thinking" for c in forwarded)
+        assert any(c.get("type") == "text" for c in forwarded)
+
+    @pytest.mark.asyncio
+    async def test_real_anthropic_signature_preserved(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+        messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I was thinking...",
+                        "signature": "ErcBCkgIBxABGAIiQHabc+real+anthropic+sig",
+                    }
+                ],
+            },
+        ]
+        captured = {}
+
+        def fake_handler(**kw):
+            captured.update(kw)
+            return "ok"
+
+        with patch.object(
+            handler, "anthropic_messages_handler", side_effect=fake_handler
+        ):
+            await handler.anthropic_messages(
+                max_tokens=100,
+                messages=messages,
+                model="anthropic/claude-opus-4-7",
+                custom_llm_provider="anthropic",
+            )
+        forwarded = captured["messages"][1]["content"]
+        assert len(forwarded) == 1
+        assert forwarded[0]["type"] == "thinking"
+
+    @pytest.mark.asyncio
+    async def test_packed_signature_preserved_when_provider_chatgpt(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+        packed = self._packed_sig()
+        messages = [
+            {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "", "signature": packed}],
+            },
+        ]
+        captured = {}
+
+        def fake_handler(**kw):
+            captured.update(kw)
+            return "ok"
+
+        with patch.object(
+            handler, "anthropic_messages_handler", side_effect=fake_handler
+        ):
+            await handler.anthropic_messages(
+                max_tokens=100,
+                messages=messages,
+                model="chatgpt/gpt-5.5",
+                custom_llm_provider="chatgpt",
+            )
+        forwarded = captured["messages"][0]["content"]
+        # On the chatgpt leg the thinking block must survive — the responses
+        # adapter will unpack the signature into a top-level reasoning item.
+        assert len(forwarded) == 1
+        assert forwarded[0]["signature"] == packed
+
+    @pytest.mark.asyncio
+    async def test_strip_does_not_mutate_caller_messages(self):
+        """The caller's `messages` list (and its inner dicts) must not be
+        mutated. A copy is built for the downstream handler instead."""
+        from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+        packed = self._packed_sig()
+        original_assistant_content = [
+            {"type": "thinking", "thinking": "", "signature": packed},
+            {"type": "text", "text": "answer"},
+        ]
+        assistant_msg = {"role": "assistant", "content": original_assistant_content}
+        messages = [{"role": "user", "content": "first"}, assistant_msg]
+
+        with patch.object(handler, "anthropic_messages_handler", return_value="ok"):
+            await handler.anthropic_messages(
+                max_tokens=100,
+                messages=messages,
+                model="anthropic/claude-opus-4-7",
+                custom_llm_provider="anthropic",
+            )
+        # Caller still sees the original 2 blocks on the same dict.
+        assert assistant_msg["content"] is original_assistant_content
+        assert len(original_assistant_content) == 2
+        assert original_assistant_content[0]["type"] == "thinking"
+
+    @pytest.mark.asyncio
+    async def test_assistant_message_emptied_by_strip_is_dropped(self):
+        """When an assistant message contains ONLY packed-signature thinking
+        blocks, stripping them would leave `content: []` — which Anthropic
+        rejects. The handler must drop the message entirely instead."""
+        from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+        packed = self._packed_sig()
+        messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": packed},
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        captured = {}
+
+        def fake_handler(**kw):
+            captured.update(kw)
+            return "ok"
+
+        with patch.object(
+            handler, "anthropic_messages_handler", side_effect=fake_handler
+        ):
+            await handler.anthropic_messages(
+                max_tokens=100,
+                messages=messages,
+                model="anthropic/claude-opus-4-7",
+                custom_llm_provider="anthropic",
+            )
+        forwarded = captured["messages"]
+        # Assistant message was emptied → dropped. Two user messages remain.
+        assert all(m["role"] == "user" for m in forwarded)
+        assert len(forwarded) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_dict_messages_pass_through_strip_unchanged(self):
+        """The strip's per-message guard must let non-dict / non-list-content
+        entries through unchanged (e.g. a string-content user message)."""
+        from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+        messages = [
+            {"role": "user", "content": "hello"},  # string content
+            "not-a-dict",  # malformed entry — guard must not crash
+        ]
+        captured = {}
+
+        def fake_handler(**kw):
+            captured.update(kw)
+            return "ok"
+
+        with patch.object(
+            handler, "anthropic_messages_handler", side_effect=fake_handler
+        ):
+            await handler.anthropic_messages(
+                max_tokens=100,
+                messages=messages,
+                model="anthropic/claude-opus-4-7",
+                custom_llm_provider="anthropic",
+            )
+        forwarded = captured["messages"]
+        assert forwarded[0]["content"] == "hello"
+        assert "not-a-dict" in forwarded

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -394,8 +394,10 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
 
-    def test_assistant_thinking_block_becomes_output_text(self):
-        """Assistant thinking block text is included as output_text."""
+    def test_assistant_thinking_block_without_signature_dropped(self):
+        """Assistant thinking block without our packed signature is dropped
+        silently. Downgrading to output_text causes OpenAI 400
+        "unexpected output_text in assistant input"."""
         messages = [
             {
                 "role": "assistant",
@@ -405,12 +407,49 @@ class TestTranslateMessagesToResponsesInput:
             }
         ]
         result = _translate_messages(messages)
-        assert result[0]["content"] == [
-            {"type": "output_text", "text": "Let me reason step by step."}
+        # No signature -> no reasoning item, no assistant message emitted at all.
+        assert result == []
+
+    def test_assistant_thinking_block_with_packed_signature_becomes_reasoning(self):
+        """Assistant thinking block carrying a packed signature is emitted as
+        a top-level reasoning item immediately before the assistant message."""
+        import base64
+        import json as _json
+
+        packed = (
+            "lllm-rsenc-v1:"
+            + base64.b64encode(
+                _json.dumps({"id": "rs_abc", "ec": "ENC"}).encode()
+            ).decode()
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Let me reason step by step.",
+                        "signature": packed,
+                    },
+                    {"type": "text", "text": "Hello"},
+                ],
+            }
         ]
+        result = _translate_messages(messages)
+        # reasoning item first, then assistant message.
+        assert len(result) == 2
+        assert result[0]["type"] == "reasoning"
+        assert result[0]["id"] == "rs_abc"
+        assert result[0]["encrypted_content"] == "ENC"
+        assert result[0]["summary"] == [
+            {"type": "summary_text", "text": "Let me reason step by step."}
+        ]
+        assert result[1]["type"] == "message"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["content"] == [{"type": "output_text", "text": "Hello"}]
 
     def test_assistant_empty_thinking_block_skipped(self):
-        """Assistant thinking block with empty thinking text is skipped."""
+        """Assistant thinking block with empty thinking text and no signature is skipped."""
         messages = [
             {
                 "role": "assistant",
@@ -817,6 +856,63 @@ class TestTranslateRequestBroaderCoverage:
         ):
             assert key not in kwargs, f"unexpected key: {key}"
 
+    def test_no_reasoning_does_not_force_store_or_include(self):
+        """When reasoning is not in play, translate_request must NOT touch
+        `store` or inject `reasoning.encrypted_content` into `include` — that
+        would be a backwards-incompatible silent change for non-reasoning
+        callers."""
+        req = _make_request()
+        kwargs = _ADAPTER.translate_request(req)
+        assert "store" not in kwargs
+        assert "include" not in kwargs
+
+    def test_thinking_request_forces_store_false_and_include(self):
+        """When the client requests thinking, force stateless replay so the
+        encrypted_content is returned and can be round-tripped."""
+        req = _make_request(thinking={"type": "enabled", "budget_tokens": 12000})
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["store"] is False
+        assert "reasoning.encrypted_content" in kwargs["include"]
+
+    def test_reasoning_input_history_forces_store_false_and_include(self):
+        """When the inbound history carries a reasoning item from a prior
+        turn (unpacked from a packed signature), force stateless replay even
+        if the current turn doesn't request thinking again."""
+        import base64
+        import json as _json
+
+        packed = (
+            "lllm-rsenc-v1:"
+            + base64.b64encode(
+                _json.dumps({"id": "rs_prev", "ec": "ENC"}).encode()
+            ).decode()
+        )
+        req = _make_request(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "",
+                            "signature": packed,
+                        }
+                    ],
+                },
+                {"role": "user", "content": "follow up"},
+            ]
+        )
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["store"] is False
+        assert "reasoning.encrypted_content" in kwargs["include"]
+
+    def test_disabled_thinking_does_not_force_store_or_include(self):
+        """`thinking: {type: disabled}` must NOT trigger reasoning side-effects."""
+        req = _make_request(thinking={"type": "disabled"})
+        kwargs = _ADAPTER.translate_request(req)
+        assert "store" not in kwargs
+        assert "include" not in kwargs
+
 
 # ---------------------------------------------------------------------------
 # translate_response
@@ -1031,6 +1127,132 @@ class TestTranslateResponse:
         assert result["content"][0]["input"] == {"query": "cats"}
         assert result["stop_reason"] == "tool_use"
 
+    def test_dict_message_with_string_content(self):
+        """Dict-shaped message where `content` is a plain string."""
+        output_item = {"type": "message", "content": "Plain string body"}
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "Plain string body"
+
+    def test_dict_message_with_empty_string_content_skipped(self):
+        """Dict-shaped message where `content` is an empty string emits no
+        text block (avoids leaking empty `text: ""` to clients)."""
+        output_item = {"type": "message", "content": ""}
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"] == []
+
+    def test_dict_message_with_string_part_in_content_list(self):
+        """Dict-shaped message whose content list contains a raw string."""
+        output_item = {"type": "message", "content": ["raw piece"]}
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "raw piece"
+
+    def test_dict_message_summary_text_part_recognized(self):
+        """`summary_text` is in the accepted text-part-type set."""
+        output_item = {
+            "type": "message",
+            "content": [{"type": "summary_text", "text": "summary body"}],
+        }
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"][0]["text"] == "summary body"
+
+    def test_dict_reasoning_with_summary_packs_signature(self):
+        """Dict-shaped reasoning item with id + encrypted_content emits a
+        thinking block carrying the packed signature."""
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+            _unpack_signature,
+        )
+
+        output_item = {
+            "type": "reasoning",
+            "id": "rs_dict_1",
+            "encrypted_content": "ENC-DICT",
+            "summary": [{"type": "summary_text", "text": "deliberating"}],
+        }
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        block = result["content"][0]
+        assert block["type"] == "thinking"
+        assert block["thinking"] == "deliberating"
+        rs_id, enc = _unpack_signature(block["signature"])
+        assert rs_id == "rs_dict_1"
+        assert enc == "ENC-DICT"
+
+    def test_dict_reasoning_without_summary_emits_signature_only_block(self):
+        """When upstream sends reasoning with encrypted_content but no
+        summary text, emit an empty-thinking block carrying the signature so
+        the next turn can resume."""
+        output_item = {
+            "type": "reasoning",
+            "id": "rs_dict_2",
+            "encrypted_content": "ENC-NOSUM",
+            "summary": [],
+        }
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "thinking"
+        assert result["content"][0]["thinking"] == ""
+        assert result["content"][0]["signature"].startswith("lllm-rsenc-v1:")
+
+    def test_dict_reasoning_without_encrypted_content_dropped(self):
+        """Reasoning with neither summary text nor encrypted_content emits
+        nothing — no useless empty thinking block."""
+        output_item = {"type": "reasoning", "id": "rs_dict_3", "summary": []}
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"] == []
+
+    def test_dict_function_call_with_invalid_json_arguments(self):
+        """Dict-shaped function_call with bad JSON args falls back to empty
+        input dict (mirrors the typed-item branch)."""
+        output_item = {
+            "type": "function_call",
+            "call_id": "call_bad_dict",
+            "name": "broken",
+            "arguments": "{not json",
+        }
+        response = _make_mock_response(output=[output_item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"][0]["type"] == "tool_use"
+        assert result["content"][0]["input"] == {}
+        assert result["stop_reason"] == "tool_use"
+
+    def test_typed_reasoning_item_with_encrypted_content_packs_signature(self):
+        """Typed ResponseReasoningItem with encrypted_content packs (id, ec)
+        into signature on the emitted thinking block."""
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+            _unpack_signature,
+        )
+
+        item = _make_reasoning_item(["weighing options"])
+        item.id = "rs_typed_1"
+        item.encrypted_content = "ENC-TYPED"
+        response = _make_mock_response(output=[item])
+        result: Any = _ADAPTER.translate_response(response)
+        block = result["content"][0]
+        assert block["type"] == "thinking"
+        rs_id, enc = _unpack_signature(block["signature"])
+        assert rs_id == "rs_typed_1"
+        assert enc == "ENC-TYPED"
+
+    def test_typed_reasoning_with_encrypted_no_summary_emits_signature_only(self):
+        """Typed reasoning item with encrypted_content but empty summary
+        still emits a signature-only thinking block."""
+        item = _make_reasoning_item([])
+        item.id = "rs_typed_2"
+        item.encrypted_content = "ENC-EMPTY"
+        response = _make_mock_response(output=[item])
+        result: Any = _ADAPTER.translate_response(response)
+        assert len(result["content"]) == 1
+        assert result["content"][0]["thinking"] == ""
+        assert result["content"][0]["signature"].startswith("lllm-rsenc-v1:")
+
     def test_mixed_reasoning_text_and_tool_use(self):
         """Reasoning + text + tool_use in one response all convert correctly."""
         reasoning = _make_reasoning_item(["Thinking..."])
@@ -1043,3 +1265,215 @@ class TestTranslateResponse:
         assert "text" in types
         assert "tool_use" in types
         assert result["stop_reason"] == "tool_use"
+
+
+class TestEdgeCaseInputCoverage:
+    """Cover defensive isinstance/type guards in transformation paths that are
+    otherwise unreachable from typical request shapes."""
+
+    def test_non_dict_block_in_user_content_list_skipped(self):
+        """User-content list containing a non-dict entry (string, None) must
+        be skipped by the `if not isinstance(block, dict): continue` guard
+        rather than raising."""
+        req = _make_request(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        "not-a-dict",
+                        None,
+                        {"type": "text", "text": "ok"},
+                    ],
+                }
+            ]
+        )
+        out = _ADAPTER.translate_request(req)
+        # Only the dict text block survives; non-dict entries silently dropped.
+        user_msg = next(it for it in out["input"] if it.get("role") == "user")
+        parts = user_msg["content"]
+        assert len(parts) == 1
+        assert parts[0]["type"] == "input_text"
+        assert parts[0]["text"] == "ok"
+
+    def test_non_dict_block_in_assistant_content_list_skipped(self):
+        """Same guard on the assistant-content path."""
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        12345,
+                        {"type": "text", "text": "fine"},
+                    ],
+                },
+            ]
+        )
+        out = _ADAPTER.translate_request(req)
+        asst_msg = next(it for it in out["input"] if it.get("role") == "assistant")
+        parts = asst_msg["content"]
+        assert len(parts) == 1
+        assert parts[0]["text"] == "fine"
+
+    def test_tool_result_with_non_string_non_list_inner_stringified(self):
+        """tool_result.content that is neither None / str / list falls into
+        the `else: output_text = str(inner)` branch."""
+        req = _make_request(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_1",
+                            "content": 42,
+                        }
+                    ],
+                }
+            ]
+        )
+        out = _ADAPTER.translate_request(req)
+        fco = next(
+            it for it in out["input"] if it.get("type") == "function_call_output"
+        )
+        assert fco["output"] == "42"
+        assert fco["call_id"] == "tu_1"
+
+    def test_context_management_edits_not_a_list_returns_none(self):
+        """`if not isinstance(edits, list): return None` — bad shape silently
+        ignored rather than crashing translate_request."""
+        result = _ADAPTER.translate_context_management_to_responses_api(
+            {"edits": "not-a-list"}
+        )
+        assert result is None
+
+    def test_context_management_non_dict_edit_entries_skipped(self):
+        """Each edit entry is guarded by `if not isinstance(edit, dict): continue`."""
+        result = _ADAPTER.translate_context_management_to_responses_api(
+            {
+                "edits": [
+                    "skip-me",
+                    None,
+                    {
+                        "type": "compact_20260112",
+                        "trigger": {"type": "input_tokens", "value": 150000},
+                    },
+                ]
+            }
+        )
+        # Only the well-formed entry survives.
+        assert result == [{"type": "compaction", "compact_threshold": 150000}]
+
+
+class TestReasoningPrecedesFunctionCall:
+    """Regression guard for the P1 ordering defect: when an assistant message
+    in history carries both a thinking block (with packed signature) and a
+    tool_use block, the resulting Responses API `input` must place the
+    reasoning item BEFORE the function_call. Otherwise OpenAI returns
+    `Item with id 'rs_...' not found`."""
+
+    def test_reasoning_emitted_before_function_call(self):
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+            _pack_signature,
+        )
+
+        rs_id = "rs_mixed_1"
+        enc = "ENC-BLOB-MIXED"
+        sig = _pack_signature(rs_id, enc)
+        req: Any = {
+            "model": "gpt-5.5",
+            "max_tokens": 16,
+            "messages": [
+                {"role": "user", "content": "look up the weather"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "", "signature": sig},
+                        {
+                            "type": "tool_use",
+                            "id": "call_w1",
+                            "name": "get_weather",
+                            "input": {"city": "SF"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_w1",
+                            "content": "72F",
+                        }
+                    ],
+                },
+            ],
+        }
+        kwargs = _ADAPTER.translate_request(req)
+        items = kwargs["input"]
+        types_in_order = [it.get("type") for it in items]
+        reasoning_idx = types_in_order.index("reasoning")
+        fc_idx = types_in_order.index("function_call")
+        assert (
+            reasoning_idx < fc_idx
+        ), f"reasoning must precede function_call; got {types_in_order}"
+        # And the reasoning item must carry the unpacked id + encrypted_content.
+        assert items[reasoning_idx]["id"] == rs_id
+        assert items[reasoning_idx]["encrypted_content"] == enc
+
+    def test_multiple_tool_uses_all_follow_reasoning(self):
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+            _pack_signature,
+        )
+
+        sig = _pack_signature("rs_multi", "ENC-MULTI")
+        req: Any = {
+            "model": "gpt-5.5",
+            "max_tokens": 16,
+            "messages": [
+                {"role": "user", "content": "do two things"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "", "signature": sig},
+                        {"type": "tool_use", "id": "c1", "name": "a", "input": {}},
+                        {"type": "tool_use", "id": "c2", "name": "b", "input": {}},
+                    ],
+                },
+            ],
+        }
+        kwargs = _ADAPTER.translate_request(req)
+        types_in_order = [it.get("type") for it in kwargs["input"]]
+        reasoning_idx = types_in_order.index("reasoning")
+        fc_positions = [i for i, t in enumerate(types_in_order) if t == "function_call"]
+        assert fc_positions, "expected function_call items"
+        assert all(p > reasoning_idx for p in fc_positions)
+
+
+class TestStoreOverrideOptOut:
+    """P2: _apply_reasoning_replay_settings must not silently disable
+    response storage when the caller explicitly set `store`."""
+
+    def test_user_store_true_is_preserved(self):
+        kwargs: Dict[str, Any] = {
+            "reasoning": {"effort": "high"},
+            "input": [],
+            "store": True,
+        }
+        _ADAPTER._apply_reasoning_replay_settings(kwargs)
+        assert kwargs["store"] is True
+        assert "reasoning.encrypted_content" in kwargs["include"]
+
+    def test_default_still_forces_store_false(self):
+        kwargs: Dict[str, Any] = {
+            "reasoning": {"effort": "high"},
+            "input": [],
+        }
+        _ADAPTER._apply_reasoning_replay_settings(kwargs)
+        assert kwargs["store"] is False
+
+    def test_no_reasoning_no_changes(self):
+        kwargs: Dict[str, Any] = {"input": []}
+        _ADAPTER._apply_reasoning_replay_settings(kwargs)
+        assert "store" not in kwargs
+        assert "include" not in kwargs

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_signature_codec.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_signature_codec.py
@@ -1,0 +1,80 @@
+"""
+Direct unit tests for the signature codec used to round-trip OpenAI Responses
+reasoning items through Anthropic's `thinking.signature` field.
+
+Covers both _pack_signature and _unpack_signature including the malformed-input
+except branch, the non-prefixed signature degrade path (mid-conversation model
+switch from chatgpt/openai to native anthropic), and the empty-input
+short-circuit paths.
+"""
+
+import base64
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters._signature_codec import (
+    _SIG_PREFIX,
+    _pack_signature,
+    _unpack_signature,
+)
+
+
+def test_pack_signature_none_encrypted_returns_none():
+    assert _pack_signature("rs_x", None) is None
+
+
+def test_pack_signature_empty_encrypted_returns_none():
+    assert _pack_signature("rs_x", "") is None
+
+
+def test_pack_signature_round_trip():
+    rs_id = "rs_abc123"
+    enc = "ENCRYPTED-BLOB-XYZ=="
+    packed = _pack_signature(rs_id, enc)
+
+    assert packed is not None
+    assert packed.startswith(_SIG_PREFIX)
+    assert _unpack_signature(packed) == (rs_id, enc)
+
+
+def test_pack_signature_none_id_still_packs():
+    """OpenAI sometimes emits reasoning items without an id; encrypted_content
+    alone is enough to replay, so we still pack."""
+    packed = _pack_signature(None, "ENC")
+    assert packed is not None
+    assert _unpack_signature(packed) == (None, "ENC")
+
+
+def test_unpack_signature_none_returns_pair_of_nones():
+    assert _unpack_signature(None) == (None, None)
+
+
+def test_unpack_signature_empty_returns_pair_of_nones():
+    assert _unpack_signature("") == (None, None)
+
+
+def test_unpack_signature_anthropic_native_signature_degrades():
+    """A native Anthropic signature lacks our prefix — degrade silently so a
+    mid-conversation model switch back to anthropic doesn't crash. We return
+    (None, None) and skip the reasoning replay; the conversation still works,
+    just without reasoning continuity."""
+    native = "EpYBChIQAAAAAA=="  # plausible-looking native anthropic signature
+    assert _unpack_signature(native) == (None, None)
+
+
+def test_unpack_signature_malformed_base64_handled():
+    """Covers the `except Exception` fallback in _unpack_signature."""
+    bad = _SIG_PREFIX + "not-base64!!!@@@"
+    assert _unpack_signature(bad) == (None, None)
+
+
+def test_unpack_signature_valid_base64_but_invalid_json_handled():
+    """Covers the json.loads failure inside the except branch."""
+    garbage = _SIG_PREFIX + base64.b64encode(b"not json at all").decode()
+    assert _unpack_signature(garbage) == (None, None)
+
+
+def test_unpack_signature_valid_base64_json_without_expected_keys():
+    """Codec ignores extra keys and tolerates missing keys via .get()."""
+    payload = base64.b64encode(b'{"unrelated":"value"}').decode()
+    rs_id, enc = _unpack_signature(_SIG_PREFIX + payload)
+    assert rs_id is None
+    assert enc is None

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator_full_coverage.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator_full_coverage.py
@@ -1,0 +1,358 @@
+"""
+Full-coverage unit tests for AnthropicResponsesStreamWrapper.
+
+Complements `test_streaming_iterator_reasoning.py` (which covers the
+signature_delta emission for the encrypted-reasoning round-trip) by exercising
+the rest of the wrapper's event handling:
+
+* function_call output_item.added/done and arguments-delta translation
+* response.completed branches: status=completed/incomplete, usage extraction,
+  cache token deltas, and the tool_use stop_reason override
+* Defensive paths: event with no type, output_item.added with item=None
+* Iterator-level paths: upstream exception draining and the SSE byte wrapper
+"""
+
+import asyncio
+import json
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
+    AnthropicResponsesStreamWrapper,
+)
+
+
+class _AsyncEventStream:
+    """Minimal async iterator over a static list of event dicts."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+class _RaisingEventStream:
+    """Async iterator that yields one event then raises — exercises the
+    wrapper's except handler in __anext__."""
+
+    def __init__(self, events, exc):
+        self._events = list(events)
+        self._exc = exc
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._events:
+            return self._events.pop(0)
+        raise self._exc
+
+
+def _collect(wrapper):
+    async def _drive():
+        out = []
+        async for chunk in wrapper:
+            out.append(chunk)
+        return out
+
+    return asyncio.run(_drive())
+
+
+# ---------------------------------------------------------------------------
+# function_call branches
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    """Attribute-style response object used by response.completed handling.
+    The wrapper uses getattr() (not dict access) on the embedded response."""
+
+    def __init__(self, status="completed", output=None, usage=None):
+        self.status = status
+        self.output = output or []
+        self.usage = usage
+
+
+class _OutputItem:
+    def __init__(self, type, **kw):
+        self.type = type
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _function_call_events():
+    call_id = "call_42"
+    item_id = "fc_xyz"
+    return [
+        {"type": "response.created"},
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "id": item_id,
+                "type": "function_call",
+                "call_id": call_id,
+                "name": "get_weather",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": item_id,
+            "delta": '{"city":',
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": item_id,
+            "delta": '"SF"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "id": item_id,
+                "type": "function_call",
+                "call_id": call_id,
+                "name": "get_weather",
+                "arguments": '{"city":"SF"}',
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": _Resp(
+                status="completed",
+                output=[
+                    _OutputItem(type="function_call", id=item_id, name="get_weather")
+                ],
+            ),
+        },
+    ]
+
+
+def test_function_call_emits_tool_use_start_and_input_json_deltas():
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_AsyncEventStream(_function_call_events()), model="gpt-5.5"
+    )
+    chunks = _collect(wrapper)
+
+    starts = [
+        c
+        for c in chunks
+        if c.get("type") == "content_block_start"
+        and c["content_block"]["type"] == "tool_use"
+    ]
+    assert len(starts) == 1
+    assert starts[0]["content_block"]["id"] == "call_42"
+    assert starts[0]["content_block"]["name"] == "get_weather"
+
+    json_deltas = [
+        c["delta"]["partial_json"]
+        for c in chunks
+        if c.get("type") == "content_block_delta"
+        and c["delta"].get("type") == "input_json_delta"
+    ]
+    assert "".join(json_deltas) == '{"city":"SF"}'
+
+
+def test_function_call_in_output_overrides_stop_reason_to_tool_use():
+    """A response.completed whose output array contains a function_call
+    item must flip stop_reason from end_turn → tool_use."""
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_AsyncEventStream(_function_call_events()), model="gpt-5.5"
+    )
+    chunks = _collect(wrapper)
+
+    deltas = [c for c in chunks if c.get("type") == "message_delta"]
+    assert deltas, "expected a message_delta"
+    assert deltas[-1]["delta"]["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# response.completed: usage + incomplete + cache tokens
+# ---------------------------------------------------------------------------
+
+
+def test_completed_incomplete_status_maps_to_max_tokens():
+    events = [
+        {"type": "response.created"},
+        {
+            "type": "response.completed",
+            "response": _Resp(status="incomplete"),
+        },
+    ]
+    chunks = _collect(
+        AnthropicResponsesStreamWrapper(
+            responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+        )
+    )
+    delta = next(c for c in chunks if c.get("type") == "message_delta")
+    assert delta["delta"]["stop_reason"] == "max_tokens"
+
+
+def test_completed_propagates_usage_and_cache_tokens():
+    class _Usage:
+        input_tokens = 123
+        output_tokens = 45
+        cache_creation_input_tokens = 9
+        cache_read_input_tokens = 6
+
+    class _Resp:
+        status = "completed"
+        usage = _Usage()
+        output = []
+
+    events = [
+        {"type": "response.created"},
+        {"type": "response.completed", "response": _Resp()},
+    ]
+    chunks = _collect(
+        AnthropicResponsesStreamWrapper(
+            responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+        )
+    )
+    delta = next(c for c in chunks if c.get("type") == "message_delta")
+    usage = delta["usage"]
+    assert usage["input_tokens"] == 123
+    assert usage["output_tokens"] == 45
+    assert usage["cache_creation_input_tokens"] == 9
+    assert usage["cache_read_input_tokens"] == 6
+
+
+def test_completed_without_cache_tokens_omits_cache_keys():
+    class _Usage:
+        input_tokens = 5
+        output_tokens = 3
+
+    class _Resp:
+        status = "completed"
+        usage = _Usage()
+        output = []
+
+    events = [
+        {"type": "response.created"},
+        {"type": "response.completed", "response": _Resp()},
+    ]
+    chunks = _collect(
+        AnthropicResponsesStreamWrapper(
+            responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+        )
+    )
+    delta = next(c for c in chunks if c.get("type") == "message_delta")
+    assert "cache_creation_input_tokens" not in delta["usage"]
+    assert "cache_read_input_tokens" not in delta["usage"]
+
+
+# ---------------------------------------------------------------------------
+# Defensive / edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_event_without_type_is_ignored():
+    """An event dict missing 'type' must early-return; no chunks produced
+    beyond the fallback message_start."""
+    events = [
+        {"not_type": "garbage"},
+        {
+            "type": "response.completed",
+            "response": {"status": "completed", "output": [], "usage": None},
+        },
+    ]
+    chunks = _collect(
+        AnthropicResponsesStreamWrapper(
+            responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+        )
+    )
+    # We expect message_start, then message_delta + message_stop. The garbage
+    # event is silently dropped — no extra content_block_* events.
+    types = [c.get("type") for c in chunks]
+    assert "message_start" in types
+    assert types.count("content_block_start") == 0
+
+
+def test_output_item_added_with_no_item_payload_is_ignored():
+    events = [
+        {"type": "response.created"},
+        {"type": "response.output_item.added"},  # no `item` key
+        {
+            "type": "response.completed",
+            "response": {"status": "completed", "output": [], "usage": None},
+        },
+    ]
+    chunks = _collect(
+        AnthropicResponsesStreamWrapper(
+            responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+        )
+    )
+    assert not any(c.get("type") == "content_block_start" for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# Iterator-level: exception handling + SSE byte wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_upstream_exception_is_swallowed_and_remaining_chunks_drained():
+    """When the upstream Responses stream raises mid-iteration, the wrapper
+    logs the error, drains the queue, and finishes cleanly with
+    StopAsyncIteration — it must not propagate the exception to the caller."""
+    events = [
+        {"type": "response.created"},
+        {
+            "type": "response.output_item.added",
+            "item": {"id": "msg_1", "type": "message"},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": "partial",
+        },
+    ]
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_RaisingEventStream(events, RuntimeError("upstream blew up")),
+        model="gpt-5.5",
+    )
+    chunks = _collect(wrapper)
+    # We at least got message_start and the partial text_delta before the blow-up;
+    # no exception escaped.
+    types = [c.get("type") for c in chunks]
+    assert "message_start" in types
+    assert any(
+        c.get("type") == "content_block_delta"
+        and c["delta"].get("type") == "text_delta"
+        for c in chunks
+    )
+
+
+def test_async_anthropic_sse_wrapper_yields_event_data_bytes():
+    """The SSE byte wrapper must format each chunk as `event: <type>\\n
+    data: <json>\\n\\n` and encode to bytes."""
+    events = [
+        {"type": "response.created"},
+        {
+            "type": "response.completed",
+            "response": {"status": "completed", "output": [], "usage": None},
+        },
+    ]
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+    )
+
+    async def _drive():
+        out = []
+        async for b in wrapper.async_anthropic_sse_wrapper():
+            out.append(b)
+        return out
+
+    payloads = asyncio.run(_drive())
+    assert payloads, "expected SSE byte chunks"
+    # Every chunk is bytes shaped like b"event: <type>\ndata: {json}\n\n"
+    for b in payloads:
+        assert isinstance(b, bytes)
+        text = b.decode()
+        assert text.startswith("event: ")
+        assert "\ndata: " in text
+        assert text.endswith("\n\n")
+        # JSON body parses
+        data_line = text.split("\ndata: ", 1)[1].rstrip("\n")
+        json.loads(data_line)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator_reasoning.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator_reasoning.py
@@ -1,0 +1,201 @@
+"""
+Tests for AnthropicResponsesStreamWrapper reasoning -> signature_delta emission.
+
+Covers Phase 3.4 of the encrypted-reasoning round-trip fix: when the upstream
+Responses API streams a reasoning item with `encrypted_content`, the wrapper
+must emit a `signature_delta` carrying the packed (id + encrypted_content)
+blob BEFORE the reasoning block's `content_block_stop`. Without this, the
+client (e.g. Claude Code) has no way to replay the reasoning item on
+subsequent turns, breaking reasoning continuity for the openai/chatgpt
+providers.
+"""
+
+import asyncio
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
+    AnthropicResponsesStreamWrapper,
+)
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
+    _pack_signature,
+    _unpack_signature,
+)
+
+
+class _AsyncEventStream:
+    """Minimal async iterator over a static list of event dicts."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+def _collect(wrapper):
+    async def _drive():
+        out = []
+        async for chunk in wrapper:
+            out.append(chunk)
+        return out
+
+    return asyncio.run(_drive())
+
+
+def _build_stream_with_reasoning(rs_id: str, enc: str):
+    """Construct a synthetic Responses SSE event sequence with a reasoning
+    item carrying encrypted_content, followed by a short message item."""
+    return [
+        {"type": "response.created"},
+        {
+            "type": "response.output_item.added",
+            "item": {"id": rs_id, "type": "reasoning"},
+        },
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": rs_id,
+            "delta": "thinking about it",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "id": rs_id,
+                "type": "reasoning",
+                "encrypted_content": enc,
+                "summary": [{"type": "summary_text", "text": "thinking about it"}],
+            },
+        },
+        {
+            "type": "response.output_item.added",
+            "item": {"id": "msg_1", "type": "message"},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": "hi",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {"id": "msg_1", "type": "message"},
+        },
+        {
+            "type": "response.completed",
+            "response": {"status": "completed", "output": []},
+        },
+    ]
+
+
+def test_reasoning_emits_signature_delta_before_content_block_stop():
+    rs_id = "rs_test_abc"
+    enc = "ENCRYPTED-PAYLOAD-XYZ"
+    events = _build_stream_with_reasoning(rs_id, enc)
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+    )
+
+    chunks = _collect(wrapper)
+
+    # Locate the reasoning block start
+    start_idx = next(
+        i
+        for i, c in enumerate(chunks)
+        if c.get("type") == "content_block_start"
+        and c["content_block"]["type"] == "thinking"
+    )
+    block_index = chunks[start_idx]["index"]
+
+    # The first content_block_stop AFTER the thinking start belongs to the
+    # reasoning block. Immediately before it, we must see signature_delta.
+    stop_positions = [
+        i
+        for i, c in enumerate(chunks[start_idx:], start=start_idx)
+        if c.get("type") == "content_block_stop" and c.get("index") == block_index
+    ]
+    assert stop_positions, "missing content_block_stop for reasoning block"
+    stop_idx = stop_positions[0]
+
+    sig_event = chunks[stop_idx - 1]
+    assert sig_event["type"] == "content_block_delta"
+    assert sig_event["index"] == block_index
+    assert sig_event["delta"]["type"] == "signature_delta"
+
+    # Signature must round-trip via the codec back to the originating id+enc.
+    unpacked_id, unpacked_enc = _unpack_signature(sig_event["delta"]["signature"])
+    assert unpacked_id == rs_id
+    assert unpacked_enc == enc
+    assert sig_event["delta"]["signature"] == _pack_signature(rs_id, enc)
+
+
+def test_reasoning_without_encrypted_content_skips_signature_delta():
+    """If encrypted_content is absent, we must NOT emit an empty signature_delta —
+    just close the block cleanly. Preserves backward compat for providers
+    that don't return encrypted reasoning."""
+    rs_id = "rs_plain"
+    events = [
+        {"type": "response.created"},
+        {
+            "type": "response.output_item.added",
+            "item": {"id": rs_id, "type": "reasoning"},
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {"id": rs_id, "type": "reasoning"},  # no encrypted_content
+        },
+        {
+            "type": "response.completed",
+            "response": {"status": "completed", "output": []},
+        },
+    ]
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+    )
+
+    chunks = _collect(wrapper)
+
+    # No signature_delta anywhere in the stream.
+    assert not any(
+        c.get("type") == "content_block_delta"
+        and c.get("delta", {}).get("type") == "signature_delta"
+        for c in chunks
+    )
+    # But the content_block_stop for the reasoning block is still emitted.
+    assert any(c.get("type") == "content_block_stop" for c in chunks)
+
+
+def test_message_only_stream_unaffected():
+    """A response with no reasoning item must not emit any signature_delta."""
+    events = [
+        {"type": "response.created"},
+        {
+            "type": "response.output_item.added",
+            "item": {"id": "msg_1", "type": "message"},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": "hello",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {"id": "msg_1", "type": "message"},
+        },
+        {
+            "type": "response.completed",
+            "response": {"status": "completed", "output": []},
+        },
+    ]
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_AsyncEventStream(events), model="gpt-5.5"
+    )
+
+    chunks = _collect(wrapper)
+
+    assert not any(
+        c.get("type") == "content_block_delta"
+        and c.get("delta", {}).get("type") == "signature_delta"
+        for c in chunks
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #24425 — "Support `reasoning.encrypted_content` in `/v1/messages` → Responses API path."

Fixes #24985 — "Anthropic-to-OpenAI adapter does not round-trip thinking blocks in multi-turn conversations." The issue body explicitly identifies the "thinking → `output_text`" downgrade at `responses_adapters/transformation.py ~line 168` as Issue 1 of two; this PR fixes that exact site (Bug 2 below) and additionally rebuilds the round-trip so subsequent turns carry `encrypted_content` upstream.

Related to #22448 (closed) — addresses the same multi-turn-reasoning continuity problem but on the `chat/completions` ingress (extending `thinking_blocks` with `encrypted_content`). This PR is the Anthropic `/v1/messages` ingress counterpart and packs `(id, encrypted_content)` into the existing Anthropic `signature` field, which is the only field that survives a vanilla Anthropic-client round trip (Claude Code's `clear_thinking_20251015` edit specifically). The two PRs are complementary — different ingress, same egress.

Alternative approach to #26927 (open) — both PRs target the same `responses_adapters/transformation.py` thinking-block handling. #26927 stops the "thinking-leaks-as-output_text" bug by **dropping** prior assistant thinking blocks from the Responses input entirely. This PR stops the same leak by **converting** them to top-level `reasoning` input items carrying the packed signature, which both eliminates the leak *and* preserves reasoning continuity across turns. If #26927 lands first, this PR should be rebased to re-add the reasoning-item emission on top.

### Rebase-risk PRs (touch the same files)

- **#26088** (open) — adds `model_info.mode: responses` routing in `messages/handler.py` + `transformation.py`. Overlaps Bug 1 routing logic. Rebase will need to merge our `chatgpt` whitelist with their model-info-driven branch.
- **#27496** (open, +39/-1 `transformation.py`) — adds `GenericResponseOutputItem` handling to `translate_response`. Overlaps Bug 3 (signature preservation on emitted thinking blocks).
- **#26103** (open, +58/-28 `streaming_iterator.py`) — per-summary thinking handling + dedupe. Overlaps Bug 4 streaming-side `signature_delta` emission.

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

N/A — external contributor.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Test detail: 4 test files — `test_anthropic_experimental_pass_through_messages_handler.py` (foreign-signature strip, 3 tests), `test_responses_adapters_transformation.py` (signature round-trip & dict-output reasoning), `test_streaming_iterator_reasoning.py` (`signature_delta` emission, 3 tests). All mocked, no real API calls. 128 passed in the touched scope on `make test-unit`. Lint: Black, Ruff, MyPy, circular-import check, import-safety all green.

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

End-to-end verified against the real ChatGPT/Codex backend through this fork's proxy:

| | Result |
|---|---|
| Turn 1 (`gpt-5.5`, thinking enabled) | 200; response carries `thinking` block with `signature` prefixed `lllm-rsenc-v1:` (1578 chars; base64 decodes to `{id: rs_…, ec: …}`) |
| Turn 2 (replay assistant thinking + new user question) | 200; upstream accepted encrypted reasoning, 1669 input tokens confirms the blob was sent and parsed; coherent follow-up answer |
| Upstream errors observed | None — zero `invalid_encrypted_content`, zero `Item with id 'rs_...' not found` |

### Reasoning-continuity discriminator (CRT + `/rewind`)

To prove the round-tripped `encrypted_content` actually anchors the model's reasoning state across turns (not just that bytes survive), we ran a Chinese-Remainder-Theorem probe and used Claude Code's `/rewind` to replay turn 2+ from the same committed reasoning state. By CRT, `(N mod 7, N mod 11, N mod 13)` uniquely pins `N mod 1001` — so if the rewind branch produces the same residues, the model is grounded on the same committed `N` from turn 1.

Verbatim transcript:

```
Before rewind:

❯ Pick a secret integer N where 1 ≤ N ≤ 1000. Commit to ONE specific value internally. Keep
   N hidden — do NOT mention it or any of its digits in your reply.

    Reply with EXACTLY one line in this format:
      N mod 7 = <value>

● N mod 7 = 5

✻ Cogitated for 8s

❯ Same N as turn 1. Reply with EXACTLY one line:
      N mod 11 = <value>

● N mod 11 = 3

✻ Cogitated for 3s

❯ Same N. Reply with EXACTLY one line:
      N mod 13 = <value>

● N mod 13 = 8

✻ Churned for 4s

❯ Now reveal the N

● 47

After rewind:


❯ Pick a secret integer N where 1 ≤ N ≤ 1000. Commit to ONE specific value internally. Keep
   N hidden — do NOT mention it or any of its digits in your reply.

    Reply with EXACTLY one line in this format:
      N mod 7 = <value>

● N mod 7 = 5

✻ Sautéed for 8s

[This is the point the transcript was rewound to]

❯ Same N as turn 1. Reply with EXACTLY one line:
      N mod 11 = <value>

● N mod 11 = 3

✻ Baked for 10s

❯  Same N. Reply with EXACTLY one line:
      N mod 13 = <value>

● N mod 13 = 8

✻ Cogitated for 12s

❯ Now reveal the N

● N = 47

✻ Crunched for 4s
```

All three residues (5, 3, 8) and the final reveal (47) match byte-for-byte across the rewind. `47 mod 7 = 5`, `47 mod 11 = 3`, `47 mod 13 = 8` — consistent. If the encrypted reasoning blob were being dropped or corrupted, the rewound branch would have to re-pick `N` from scratch and would collide with the original triple with probability ~1/1001.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

A client speaking Anthropic `/v1/messages` (e.g. Claude Code) talking to an `openai/*` or `chatgpt/*` model was losing reasoning continuity on every multi-turn conversation because `reasoning.encrypted_content` was dropped on every leg of every turn. Symptoms upstream: `Item with id 'rs_...' not found`, `invalid_encrypted_content`, silently degraded multi-turn quality. This PR fixes four stacking bugs.

**Bug 1 — chatgpt provider isn't routed to the Responses API.** `_RESPONSES_API_PROVIDERS` was `{"openai"}`, so the chatgpt subscription/Codex backend (also a Responses-API backend) was forced through chat/completions, which has no `encrypted_content` field. `messages/handler.py` + `adapters/handler.py` now whitelist `chatgpt`. The global `use_chat_completions_url_for_anthropic_messages` opt-out flag is honored as-is — if a user sets it, both `openai` and `chatgpt` route through chat/completions (and lose encrypted_content). The docstring is updated to note that tradeoff explicitly.

**Bug 2 — outbound `thinking` → `reasoning` was a lossy downgrade.** Anthropic thinking blocks were being converted to `{type: "output_text"}` parts inside the assistant message, which OpenAI rejects. Reasoning items must live at the top level of `input`, immediately preceding the assistant message they summarize. Anthropic thinking blocks also have nowhere to carry an OpenAI `rs_...` id, and Claude Code's `clear_thinking_20251015` edit clears the plaintext on the client side. A new lightweight codec (`responses_adapters/_signature_codec.py`) packs `{id, encrypted_content}` into the one field Claude Code preserves — `signature` — as `lllm-rsenc-v1:<base64-json>`. Native Anthropic signatures (from a mid-conversation model switch) hit `_unpack_signature` and safely return `(None, None)` so reasoning replay is skipped without errors.

**Bug 3 — inbound `reasoning` → `thinking` discarded the signature.** `translate_response` set `signature=None` on every emitted thinking block, even when upstream carried real `encrypted_content`. Now packs `(id, encrypted_content)` into `signature`. When upstream emits a reasoning item with `encrypted_content` but no summary text, we still emit a signature-only thinking block so the next turn can resume. Also widens the text-part type set to `("output_text", "text", "summary_text")` and adds a dict-shaped reasoning branch — required for the chatgpt backend, which reaches the buffered path via `ResponsesAPIResponse.model_construct` (output items stay as raw dicts).

**Bug 4 — streaming dropped the signature entirely.** `streaming_iterator.py` had no path to emit Anthropic's `signature_delta`. Added per-reasoning-item state keyed by `item_id`, captured on `response.output_item.added`, flushed as a `content_block_delta` of type `signature_delta` immediately before the reasoning block's `content_block_stop`. Anthropic's wire protocol supports this — verified via mitmproxy capture against the real Anthropic API.

**Bonus — foreign-signature strip on the anthropic leg.** If a conversation has any prior gpt-5/chatgpt turn and the user switches to a native Anthropic model mid-stream, the assistant history still carries thinking blocks with `lllm-rsenc-v1:` packed signatures. Anthropic rejects these with "Invalid signature in thinking block". `messages/handler.py` strips those blocks before forwarding to `custom_llm_provider == "anthropic"`. The blocks' text is empty (Claude Code's `clear_thinking` edit clears it), so nothing is lost. The inverse direction (Anthropic-signed thinking → chatgpt) is already safe — `_unpack_signature` returns `(None, None)` and the unusable thinking block is silently dropped.