### PR TITLE
[Feature] Responses bridge: extract <think> tags from chat-completions content as reasoning

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -72,6 +72,7 @@ class LiteLLMCompletionTransformationHandler:
                 chat_completion_response=litellm_completion_response,
                 request_input=input,
                 responses_api_request=responses_api_request,
+                litellm_metadata=kwargs.get("litellm_metadata", {}),
             )
 
             return responses_api_response
@@ -120,6 +121,7 @@ class LiteLLMCompletionTransformationHandler:
                 chat_completion_response=litellm_completion_response,
                 request_input=request_input,
                 responses_api_request=responses_api_request,
+                litellm_metadata=kwargs.get("litellm_metadata", {}),
             )
 
             return responses_api_response

--- a/litellm/responses/litellm_completion_transformation/think_tag_parser.py
+++ b/litellm/responses/litellm_completion_transformation/think_tag_parser.py
@@ -1,0 +1,139 @@
+"""Inline ``<think>...</think>`` extraction for chat-completions content streams.
+
+Used by the Responses API bridge when a chat-completions provider emits its
+reasoning as ``<think>...</think>`` blocks embedded in the regular ``content``
+field instead of populating the canonical ``reasoning_content`` field. Known
+offenders include sglang's ``--reasoning-parser minimax-append-think``
+(broken per sgl-project/sglang#15508), some MiniMax / DeepSeek-R1 deployments,
+Fireworks AI streaming, and Kimi K2 via NVIDIA NIM.
+
+The parser feeds character chunks (as they arrive from upstream stream
+deltas) through a small state machine and yields a list of typed segments
+the caller can map to OpenAI Responses API stream events:
+
+    ("text", "...")              -> response.output_text.delta
+    ("reasoning_open", None)     -> response.output_item.added (type=reasoning)
+    ("reasoning", "...")         -> response.reasoning_summary_text.delta
+    ("reasoning_close", None)    -> response.output_item.done (type=reasoning)
+
+Robustness contract:
+
+- Tags may be split across feeds (e.g. ``<thi`` then ``nk>``); the parser
+  buffers only the minimum trailing bytes that are themselves a valid prefix
+  of the next-expected tag.
+- A ``<think>`` without a closing ``</think>`` flushes the remaining buffer
+  as reasoning when ``flush()`` is called at stream end.
+- A buffer ending mid-open-tag (e.g. ``"hello <thi"``) flushes as plain
+  text - partial open tags do not transition state.
+- Unmatched ``</think>`` outside of an open block is plain text.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+OPEN_TAG = "<think>"
+CLOSE_TAG = "</think>"
+
+Segment = Tuple[str, Optional[str]]
+
+
+def _partial_prefix_len(buf: str, target: str) -> int:
+    """Length of the longest suffix of ``buf`` that is a strict prefix of ``target``.
+
+    Returns 0 when no overlap. Used to hold only the bytes that *could* become
+    a split tag on the next feed; everything earlier is safe to emit.
+    """
+    max_check = min(len(buf), len(target) - 1)
+    for k in range(max_check, 0, -1):
+        if buf.endswith(target[:k]):
+            return k
+    return 0
+
+
+class ThinkTagParser:
+    def __init__(self) -> None:
+        self._buf: str = ""
+        self._in_think: bool = False
+
+    def feed(self, chunk: str) -> List[Segment]:
+        """Process a content chunk, return ordered segments to emit."""
+        if not chunk:
+            return []
+        self._buf += chunk
+        return self._drain(final=False)
+
+    def flush(self) -> List[Segment]:
+        """Drain anything still buffered at stream end.
+
+        If we are still inside a ``<think>`` block, the unclosed remainder is
+        emitted as reasoning (and a synthetic close event is fired) so the
+        stream stays well-formed even if the model truncated.
+        """
+        return self._drain(final=True)
+
+    def _drain(self, final: bool) -> List[Segment]:
+        out: List[Segment] = []
+        while True:
+            if self._in_think:
+                idx = self._buf.find(CLOSE_TAG)
+                if idx >= 0:
+                    if idx > 0:
+                        out.append(("reasoning", self._buf[:idx]))
+                    self._buf = self._buf[idx + len(CLOSE_TAG) :]
+                    self._in_think = False
+                    out.append(("reasoning_close", None))
+                    continue
+                if final:
+                    if self._buf:
+                        out.append(("reasoning", self._buf))
+                        self._buf = ""
+                    out.append(("reasoning_close", None))
+                    return out
+                hold = _partial_prefix_len(self._buf, CLOSE_TAG)
+                if len(self._buf) > hold:
+                    emit = self._buf[: len(self._buf) - hold]
+                    self._buf = self._buf[len(self._buf) - hold :]
+                    if emit:
+                        out.append(("reasoning", emit))
+                return out
+            else:
+                idx = self._buf.find(OPEN_TAG)
+                if idx >= 0:
+                    if idx > 0:
+                        out.append(("text", self._buf[:idx]))
+                    self._buf = self._buf[idx + len(OPEN_TAG) :]
+                    self._in_think = True
+                    out.append(("reasoning_open", None))
+                    continue
+                if final:
+                    if self._buf:
+                        out.append(("text", self._buf))
+                        self._buf = ""
+                    return out
+                hold = _partial_prefix_len(self._buf, OPEN_TAG)
+                if len(self._buf) > hold:
+                    emit = self._buf[: len(self._buf) - hold]
+                    self._buf = self._buf[len(self._buf) - hold :]
+                    if emit:
+                        out.append(("text", emit))
+                return out
+
+
+def extract_think_from_text(content: str) -> Tuple[str, str]:
+    """Non-streaming helper: split an entire content string into reasoning
+    (concatenated across all ``<think>`` blocks) and remaining message text.
+
+    Used by ``transform_chat_completion_response_to_responses_api_response``
+    when the bridge processes a non-streamed completion.
+    """
+    p = ThinkTagParser()
+    segments = p.feed(content) + p.flush()
+    reasoning_parts: List[str] = []
+    text_parts: List[str] = []
+    for kind, value in segments:
+        if kind == "reasoning" and value:
+            reasoning_parts.append(value)
+        elif kind == "text" and value:
+            text_parts.append(value)
+    return "".join(reasoning_parts), "".join(text_parts)

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1647,6 +1647,11 @@ class LiteLLMCompletionResponsesConfig:
         ``reasoning_content`` field and replace ``content`` with the cleaned
         text. Downstream extractors then produce the correct output items.
 
+        When the entire ``content`` was wrapped in ``<think>`` tags (so the
+        cleaned text is empty), ``message.content`` is set to ``None`` instead
+        of ``""`` so that ``_extract_message_output_items`` can skip emitting
+        a blank assistant message item alongside the reasoning item.
+
         No-op when ``reasoning_content`` is already set (native field wins) or
         when ``content`` contains no ``<think>`` tag.
         """
@@ -1664,7 +1669,7 @@ class LiteLLMCompletionResponsesConfig:
             if not reasoning:
                 continue
             message.reasoning_content = reasoning
-            message.content = cleaned
+            message.content = cleaned if cleaned else None
 
     @staticmethod
     def transform_chat_completion_response_to_responses_api_response(
@@ -1976,23 +1981,31 @@ class LiteLLMCompletionResponsesConfig:
                     choice=choice,
                 )
                 message_output_items.extend(image_generation_items)
-            else:
-                # Regular message output
-                message_output_items.append(
-                    GenericResponseOutputItem(
-                        type="message",
-                        id=chat_completion_response.id,
-                        status=LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
-                            choice.finish_reason
-                        ),
-                        role=choice.message.role,
-                        content=[
-                            LiteLLMCompletionResponsesConfig._transform_chat_message_to_response_output_text(
-                                choice.message
-                            )
-                        ],
-                    )
+                continue
+            # When reasoning was lifted out of `content` (e.g. by
+            # `_apply_think_tag_split_in_place`) and nothing remains, skip the
+            # message item so clients don't render a blank assistant turn
+            # alongside the reasoning item.
+            content = getattr(choice.message, "content", None)
+            has_reasoning = bool(getattr(choice.message, "reasoning_content", None))
+            if not content and has_reasoning:
+                continue
+            # Regular message output
+            message_output_items.append(
+                GenericResponseOutputItem(
+                    type="message",
+                    id=chat_completion_response.id,
+                    status=LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
+                        choice.finish_reason
+                    ),
+                    role=choice.message.role,
+                    content=[
+                        LiteLLMCompletionResponsesConfig._transform_chat_message_to_response_output_text(
+                            choice.message
+                        )
+                    ],
                 )
+            )
         return message_output_items
 
     @staticmethod

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1986,9 +1986,15 @@ class LiteLLMCompletionResponsesConfig:
             # `_apply_think_tag_split_in_place`) and nothing remains, skip the
             # message item so clients don't render a blank assistant turn
             # alongside the reasoning item.
+            #
+            # The check is intentionally `content is None` (not `not content`):
+            # providers that natively return reasoning_content alongside
+            # ``content=""`` (DeepSeek-R1, Qwen3) keep their existing message
+            # item. Only callers whose ``content`` was explicitly cleared to
+            # ``None`` by this module's think-tag splitter trigger the skip.
             content = getattr(choice.message, "content", None)
             has_reasoning = bool(getattr(choice.message, "reasoning_content", None))
-            if not content and has_reasoning:
+            if content is None and has_reasoning:
                 continue
             # Regular message output
             message_output_items.append(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -15,6 +15,9 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
 )
+from litellm.responses.litellm_completion_transformation.think_tag_parser import (
+    extract_think_from_text,
+)
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionImageObject,
@@ -1622,10 +1625,53 @@ class LiteLLMCompletionResponsesConfig:
         return tool_call_dict
 
     @staticmethod
+    def _should_parse_think_tags(litellm_metadata: Optional[dict]) -> bool:
+        """Opt-in flag: ``model_info.parse_think_tags = true`` enables the bridge
+        to extract ``<think>...</think>`` blocks from chat-completions ``content``
+        and surface them as Responses-API ``reasoning`` items.
+
+        Needed for providers that emit reasoning inline in ``content`` instead
+        of populating the canonical ``reasoning_content`` field (sglang's
+        ``--reasoning-parser minimax-append-think``, Fireworks AI streaming,
+        some MiniMax / DeepSeek-R1 / Kimi-K2 deployments).
+        """
+        if not litellm_metadata:
+            return False
+        model_info = litellm_metadata.get("model_info") or {}
+        return bool(model_info.get("parse_think_tags", False))
+
+    @staticmethod
+    def _apply_think_tag_split_in_place(choices: List[Choices]) -> None:
+        """For each choice whose message has ``<think>...</think>`` in ``content``
+        but no native ``reasoning_content``, lift the reasoning out into the
+        ``reasoning_content`` field and replace ``content`` with the cleaned
+        text. Downstream extractors then produce the correct output items.
+
+        No-op when ``reasoning_content`` is already set (native field wins) or
+        when ``content`` contains no ``<think>`` tag.
+        """
+        for choice in choices:
+            message = getattr(choice, "message", None)
+            if message is None:
+                continue
+            existing_reasoning = getattr(message, "reasoning_content", None)
+            if existing_reasoning:
+                continue
+            content = getattr(message, "content", None)
+            if not isinstance(content, str) or "<think>" not in content:
+                continue
+            reasoning, cleaned = extract_think_from_text(content)
+            if not reasoning:
+                continue
+            message.reasoning_content = reasoning
+            message.content = cleaned
+
+    @staticmethod
     def transform_chat_completion_response_to_responses_api_response(
         request_input: Union[str, ResponseInputParam],
         responses_api_request: ResponsesAPIOptionalRequestParams,
         chat_completion_response: Union[ModelResponse, dict],
+        litellm_metadata: Optional[dict] = None,
     ) -> ResponsesAPIResponse:
         """
         Transform a Chat Completion response into a Responses API response
@@ -1637,6 +1683,9 @@ class LiteLLMCompletionResponsesConfig:
         choices: List[Choices] = getattr(chat_completion_response, "choices", [])
         if choices and len(choices) > 0:
             finish_reason = choices[0].finish_reason
+
+        if LiteLLMCompletionResponsesConfig._should_parse_think_tags(litellm_metadata):
+            LiteLLMCompletionResponsesConfig._apply_think_tag_split_in_place(choices)
 
         responses_api_response: ResponsesAPIResponse = ResponsesAPIResponse(
             id=chat_completion_response.id,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py
@@ -362,3 +362,27 @@ def test_end_to_end_opt_in_disabled_passes_think_tags_through_to_content():
     assert len(message_items) == 1
     rendered_text = message_items[0]["content"][0]["text"]
     assert "<think>internal</think>" in rendered_text
+
+
+def test_native_reasoning_with_empty_string_content_still_emits_message_item():
+    """Regression guard: providers that natively populate reasoning_content
+    alongside ``content=""`` (DeepSeek-R1, Qwen3) must keep their message
+    output item. The skip path triggers only when ``content`` is explicitly
+    None (cleared by this module's think-tag splitter), not for empty strings
+    that the provider returned directly.
+    """
+    choice = _build_choice(content="")
+    choice.message.reasoning_content = "native reasoning from provider"
+    chat_response = ModelResponse(
+        id="chatcmpl-native",
+        choices=[choice],
+    )
+    responses_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="hi",
+        responses_api_request={},
+        chat_completion_response=chat_response,
+        litellm_metadata=None,
+    )
+    output_types = [item.get("type") for item in responses_response.output]
+    assert "reasoning" in output_types
+    assert "message" in output_types

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py
@@ -12,7 +12,7 @@ from litellm.responses.litellm_completion_transformation.think_tag_parser import
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
-from litellm.types.utils import Choices, Message
+from litellm.types.utils import Choices, Message, ModelResponse
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ def test_extract_think_multiple_blocks_concatenated():
 # ---------------------------------------------------------------------------
 
 
-def _build_choice(content: str, reasoning_content: str = "") -> Choices:
+def _build_choice(content: str) -> Choices:
     return Choices(
         finish_reason="stop",
         index=0,
@@ -286,3 +286,79 @@ def test_apply_think_tag_split_handles_multiple_choices():
     assert choice_b.message.content == "plain text, no tags"
     assert choice_c.message.reasoning_content == "r3"
     assert choice_c.message.content == "text3"
+
+
+def test_apply_think_tag_split_sets_content_to_none_when_entirely_reasoning():
+    """When the entire content is wrapped in <think> tags, the cleaned text
+    is empty. message.content must become None (not ``""``) so the downstream
+    message extractor can skip emitting a blank message item.
+    """
+    choice = _build_choice(content="<think>only reasoning, no answer</think>")
+    LiteLLMCompletionResponsesConfig._apply_think_tag_split_in_place([choice])
+    assert choice.message.reasoning_content == "only reasoning, no answer"
+    assert choice.message.content is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: transform_chat_completion_response_to_responses_api_response
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_no_blank_message_item_when_entire_content_is_think_block():
+    """Regression: when the model emits only a <think> block, the bridge must
+    not emit both a reasoning item AND a blank message item.
+    """
+    chat_response = ModelResponse(
+        id="chatcmpl-abc123",
+        choices=[_build_choice(content="<think>just thinking, no text reply</think>")],
+    )
+    responses_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="hello",
+        responses_api_request={},
+        chat_completion_response=chat_response,
+        litellm_metadata={"model_info": {"parse_think_tags": True}},
+    )
+    output_types = [item.get("type") for item in responses_response.output]
+    assert "reasoning" in output_types
+    assert "message" not in output_types
+
+
+def test_end_to_end_emits_both_reasoning_and_message_when_text_remains():
+    """When some text remains after extracting <think>, both items are emitted."""
+    chat_response = ModelResponse(
+        id="chatcmpl-xyz789",
+        choices=[
+            _build_choice(content="<think>internal reasoning</think>Hello there!")
+        ],
+    )
+    responses_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="hi",
+        responses_api_request={},
+        chat_completion_response=chat_response,
+        litellm_metadata={"model_info": {"parse_think_tags": True}},
+    )
+    output_types = [item.get("type") for item in responses_response.output]
+    assert output_types.count("reasoning") == 1
+    assert output_types.count("message") == 1
+
+
+def test_end_to_end_opt_in_disabled_passes_think_tags_through_to_content():
+    """When opt-in is off (the default), <think> tags remain in message text."""
+    chat_response = ModelResponse(
+        id="chatcmpl-def456",
+        choices=[_build_choice(content="<think>internal</think>Hello!")],
+    )
+    responses_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+        request_input="hi",
+        responses_api_request={},
+        chat_completion_response=chat_response,
+        litellm_metadata=None,
+    )
+    output_types = [item.get("type") for item in responses_response.output]
+    assert "reasoning" not in output_types
+    message_items = [
+        item for item in responses_response.output if item.get("type") == "message"
+    ]
+    assert len(message_items) == 1
+    rendered_text = message_items[0]["content"][0]["text"]
+    assert "<think>internal</think>" in rendered_text

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py
@@ -1,0 +1,288 @@
+"""Tests for ``<think>...</think>`` extraction in the Responses API bridge.
+
+Covers the pure state-machine parser plus the bridge integration that lifts
+extracted reasoning into ``message.reasoning_content`` so downstream output
+item extractors emit a proper Responses-API ``reasoning`` item.
+"""
+
+from litellm.responses.litellm_completion_transformation.think_tag_parser import (
+    ThinkTagParser,
+    extract_think_from_text,
+)
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+from litellm.types.utils import Choices, Message
+
+
+# ---------------------------------------------------------------------------
+# Pure parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_tags_passthrough():
+    p = ThinkTagParser()
+    out = p.feed("hello world")
+    assert out == [("text", "hello world")]
+
+
+def test_simple_think_block_complete():
+    p = ThinkTagParser()
+    out = p.feed("<think>thinking</think> answer")
+    assert out == [
+        ("reasoning_open", None),
+        ("reasoning", "thinking"),
+        ("reasoning_close", None),
+        ("text", " answer"),
+    ]
+
+
+def test_text_before_think_block():
+    p = ThinkTagParser()
+    out = p.feed("prefix <think>mid</think> suffix")
+    assert out == [
+        ("text", "prefix "),
+        ("reasoning_open", None),
+        ("reasoning", "mid"),
+        ("reasoning_close", None),
+        ("text", " suffix"),
+    ]
+
+
+def test_only_open_tag_buffers_for_next_chunk():
+    p = ThinkTagParser()
+    out = p.feed("hello <think>partial")
+    assert ("reasoning_open", None) in out
+    assert ("text", "hello ") in out
+    has_reasoning = any(kind == "reasoning" and text == "partial" for kind, text in out)
+    assert has_reasoning
+
+
+def test_split_open_tag_across_chunks():
+    p = ThinkTagParser()
+    out1 = p.feed("hello <thi")
+    out2 = p.feed("nk>thinking</think> bye")
+    combined = out1 + out2
+    text_segs = [t for kind, t in combined if kind == "text"]
+    reasoning_segs = [t for kind, t in combined if kind == "reasoning"]
+    assert "".join(text_segs) == "hello  bye"
+    assert "".join(reasoning_segs) == "thinking"
+    assert any(kind == "reasoning_open" for kind, _ in combined)
+    assert any(kind == "reasoning_close" for kind, _ in combined)
+
+
+def test_split_close_tag_across_chunks():
+    p = ThinkTagParser()
+    out1 = p.feed("<think>thinking</thi")
+    out2 = p.feed("nk> done")
+    combined = out1 + out2
+    text_segs = [t for kind, t in combined if kind == "text"]
+    reasoning_segs = [t for kind, t in combined if kind == "reasoning"]
+    assert "".join(text_segs) == " done"
+    assert "".join(reasoning_segs) == "thinking"
+
+
+def test_split_both_tags_byte_by_byte():
+    """Worst-case fragmentation: feed one char at a time."""
+    p = ThinkTagParser()
+    full = "before <think>secret</think> after"
+    combined: list = []
+    for ch in full:
+        combined.extend(p.feed(ch))
+    combined.extend(p.flush())
+    text_segs = [t for kind, t in combined if kind == "text"]
+    reasoning_segs = [t for kind, t in combined if kind == "reasoning"]
+    assert "".join(text_segs) == "before  after"
+    assert "".join(reasoning_segs) == "secret"
+
+
+def test_open_tag_without_close_at_stream_end():
+    """If stream ends with unclosed <think>, treat remainder as reasoning."""
+    p = ThinkTagParser()
+    out = p.feed("<think>open forever")
+    out += p.flush()
+    reasoning_segs = [t for kind, t in out if kind == "reasoning"]
+    assert "".join(reasoning_segs) == "open forever"
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert "".join(text_segs) == ""
+
+
+def test_close_tag_without_open_passthrough():
+    p = ThinkTagParser()
+    out = p.feed("</think> just text")
+    out += p.flush()
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert "".join(text_segs) == "</think> just text"
+    reasoning_segs = [t for kind, t in out if kind == "reasoning"]
+    assert reasoning_segs == []
+
+
+def test_multiple_think_blocks_in_one_response():
+    p = ThinkTagParser()
+    out = p.feed("<think>a</think> x <think>b</think> y")
+    out += p.flush()
+    reasoning_segs = [t for kind, t in out if kind == "reasoning"]
+    assert reasoning_segs == ["a", "b"]
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert "".join(text_segs) == " x  y"
+
+
+def test_empty_feed():
+    p = ThinkTagParser()
+    assert p.feed("") == []
+    assert p.flush() == []
+
+
+def test_flush_holds_pending_partial_open_as_text():
+    """If buffer ends mid-`<think>` and stream ends, treat the partial as text."""
+    p = ThinkTagParser()
+    out = p.feed("hello <thi")
+    out += p.flush()
+    assert not any(kind == "reasoning_open" for kind, _ in out)
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert "".join(text_segs) == "hello <thi"
+
+
+def test_consecutive_tags_no_gap():
+    p = ThinkTagParser()
+    out = p.feed("<think>a</think><think>b</think>")
+    out += p.flush()
+    reasoning_segs = [t for kind, t in out if kind == "reasoning"]
+    assert reasoning_segs == ["a", "b"]
+
+
+def test_empty_think_block():
+    p = ThinkTagParser()
+    out = p.feed("<think></think>hello")
+    out += p.flush()
+    opens = [k for k, _ in out if k == "reasoning_open"]
+    closes = [k for k, _ in out if k == "reasoning_close"]
+    assert len(opens) == 1
+    assert len(closes) == 1
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert "".join(text_segs) == "hello"
+
+
+def test_whitespace_preserved_verbatim_inside_think():
+    p = ThinkTagParser()
+    out = p.feed("<think>\n  multi-line\n  reasoning  \n</think>!")
+    out += p.flush()
+    reasoning_segs = [t for kind, t in out if kind == "reasoning"]
+    assert "".join(reasoning_segs) == "\n  multi-line\n  reasoning  \n"
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert "".join(text_segs) == "!"
+
+
+def test_non_ascii_content_inside_think():
+    """Non-ASCII (UTF-8 multi-byte) text inside think blocks survives intact."""
+    p = ThinkTagParser()
+    full = (
+        "<think>User is greeting in 日本語. Simple — no tool use needed.\n</think>"
+        "\n\nこんにちは!"
+    )
+    out = p.feed(full)
+    out += p.flush()
+    reasoning_segs = [t for kind, t in out if kind == "reasoning"]
+    text_segs = [t for kind, t in out if kind == "text"]
+    assert (
+        "".join(reasoning_segs)
+        == "User is greeting in 日本語. Simple — no tool use needed.\n"
+    )
+    assert "".join(text_segs) == "\n\nこんにちは!"
+
+
+# ---------------------------------------------------------------------------
+# extract_think_from_text (non-stream helper)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_think_no_tags():
+    reasoning, text = extract_think_from_text("plain text")
+    assert reasoning == ""
+    assert text == "plain text"
+
+
+def test_extract_think_single_block():
+    reasoning, text = extract_think_from_text("<think>thinking</think> answer")
+    assert reasoning == "thinking"
+    assert text == " answer"
+
+
+def test_extract_think_multiple_blocks_concatenated():
+    reasoning, text = extract_think_from_text(
+        "<think>step 1</think>middle<think>step 2</think>end"
+    )
+    assert reasoning == "step 1step 2"
+    assert text == "middleend"
+
+
+# ---------------------------------------------------------------------------
+# Bridge integration: _should_parse_think_tags + _apply_think_tag_split_in_place
+# ---------------------------------------------------------------------------
+
+
+def _build_choice(content: str, reasoning_content: str = "") -> Choices:
+    return Choices(
+        finish_reason="stop",
+        index=0,
+        message=Message(content=content, role="assistant"),
+    )
+
+
+def test_should_parse_think_tags_opt_in_via_model_info():
+    assert (
+        LiteLLMCompletionResponsesConfig._should_parse_think_tags(
+            {"model_info": {"parse_think_tags": True}}
+        )
+        is True
+    )
+    assert (
+        LiteLLMCompletionResponsesConfig._should_parse_think_tags(
+            {"model_info": {"parse_think_tags": False}}
+        )
+        is False
+    )
+    assert (
+        LiteLLMCompletionResponsesConfig._should_parse_think_tags({"model_info": {}})
+        is False
+    )
+    assert LiteLLMCompletionResponsesConfig._should_parse_think_tags({}) is False
+    assert LiteLLMCompletionResponsesConfig._should_parse_think_tags(None) is False
+
+
+def test_apply_think_tag_split_lifts_reasoning_into_field():
+    choice = _build_choice(content="<think>internal</think>hello")
+    LiteLLMCompletionResponsesConfig._apply_think_tag_split_in_place([choice])
+    assert choice.message.reasoning_content == "internal"
+    assert choice.message.content == "hello"
+
+
+def test_apply_think_tag_split_noop_when_no_think_tag():
+    choice = _build_choice(content="just hello, no tags here")
+    LiteLLMCompletionResponsesConfig._apply_think_tag_split_in_place([choice])
+    assert getattr(choice.message, "reasoning_content", None) in (None, "")
+    assert choice.message.content == "just hello, no tags here"
+
+
+def test_apply_think_tag_split_noop_when_reasoning_already_set():
+    """Native reasoning_content wins; opt-in must not overwrite."""
+    choice = _build_choice(content="<think>ignored</think>hello")
+    choice.message.reasoning_content = "native reasoning"
+    LiteLLMCompletionResponsesConfig._apply_think_tag_split_in_place([choice])
+    assert choice.message.reasoning_content == "native reasoning"
+    assert choice.message.content == "<think>ignored</think>hello"
+
+
+def test_apply_think_tag_split_handles_multiple_choices():
+    choice_a = _build_choice(content="<think>r1</think>text1")
+    choice_b = _build_choice(content="plain text, no tags")
+    choice_c = _build_choice(content="<think>r3</think>text3")
+    LiteLLMCompletionResponsesConfig._apply_think_tag_split_in_place(
+        [choice_a, choice_b, choice_c]
+    )
+    assert choice_a.message.reasoning_content == "r1"
+    assert choice_a.message.content == "text1"
+    assert getattr(choice_b.message, "reasoning_content", None) in (None, "")
+    assert choice_b.message.content == "plain text, no tags"
+    assert choice_c.message.reasoning_content == "r3"
+    assert choice_c.message.content == "text3"


### PR DESCRIPTION
## Relevant issues

- Related to #24253 — `reasoning_content` not parsed from raw `<think>` tags for nvidia_nim/minimax-m2.5
- Related to #26326 — Fireworks AI streaming leaks `<think>` tags into `content`
- Related to #22392 — MiniMax streaming reasoning not surfaced

This PR addresses the **non-streaming** path. A follow-up will wire the same parser into the streaming iterator.

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — 24 new unit tests covering the parser state machine + the bridge integration
- [x] My PR passes all unit tests on `make test-unit` — `tests/test_litellm/responses/litellm_completion_transformation/` (116 tests) green locally
- [x] My PR's scope is as isolated as possible — single, focused feature with one opt-in flag
- [ ] Greptile review pending (will request after this PR is open)

## Type

🆕 New Feature

## Changes

### Problem

Some chat-completions providers emit reasoning inline as `<think>...</think>` blocks in the `content` field instead of populating the canonical `reasoning_content` field. When the Responses API bridge fronts these providers, the reasoning leaks into the assistant's user-visible content as raw `<think>` tags:

- sglang `--reasoning-parser minimax-append-think` (broken per [sgl-project/sglang#15508](https://github.com/sgl-project/sglang/issues/15508))
- Fireworks AI streaming responses
- Some MiniMax / DeepSeek-R1 / Kimi-K2 deployments via NVIDIA NIM

Clients that consume the Responses API (opencode CLI, Cursor IDE, Vercel AI SDK) do not strip these tags either, so end users see them verbatim in the assistant text.

### Solution

Opt-in `<think>` tag extractor in the bridge:

1. **New module** `litellm/responses/litellm_completion_transformation/think_tag_parser.py`
   - Pure state-machine parser, no external dependencies
   - `ThinkTagParser` for streaming (handles split tags across feeds, unclosed blocks at stream end, partial open tags)
   - `extract_think_from_text` non-streaming helper

2. **Bridge integration** in `transformation.py`:
   - `_should_parse_think_tags(litellm_metadata)` reads `model_info.parse_think_tags`
   - `_apply_think_tag_split_in_place(choices)` lifts reasoning into `message.reasoning_content` before existing output-item extractors run
   - Native `reasoning_content`, when populated by the provider, always wins (no double extraction)

3. **`handler.py`** threads `litellm_metadata` to the transform on both sync + async paths

### Opt-in

```yaml
model_list:
  - model_name: my-minimax
    litellm_params:
      model: hosted_vllm/MiniMaxAI/MiniMax-M2.7
      api_base: https://...
    model_info:
      parse_think_tags: true   # NEW
```

When the flag is unset (the default), behavior is unchanged.

### Tests

`tests/test_litellm/responses/litellm_completion_transformation/test_think_tag_parser.py` — 24 tests:

- **Parser state machine** (18 tests): no-tags passthrough, complete block, text-before, partial open buffers, split open/close across chunks, byte-by-byte fragmentation, unclosed at stream end, unmatched close, multiple blocks, empty feed, mid-open flush, consecutive blocks, empty block, whitespace preservation, non-ASCII UTF-8
- **Bridge integration** (6 tests): opt-in flag matrix, lift reasoning into field, no-op when no `<think>`, no-op when native `reasoning_content` already set, multi-choice handling