### PR TITLE
[Fix] Responses bridge: wrap chatcmpl-* message item IDs with msg_ envelope

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -244,15 +244,21 @@ class ResponsesAPIRequestUtils:
         prefix: str,
         custom_llm_provider: Optional[str],
         model_id: Optional[str],
+        item_position: Optional[int] = None,
     ) -> str:
         """Wrap a raw upstream id (e.g. ``chatcmpl-*``) as ``rs_<env>`` or
         ``msg_<env>`` so the value carries the same response_id payload as
         ``response.id`` but with an item-type prefix that clients recognize.
 
-        The envelope reuses
-        :meth:`_build_responses_api_response_id` and swaps the leading
-        ``resp_`` for the requested item prefix, so the result round-trips
-        through :meth:`_decode_item_envelope` plus
+        ``item_position`` distinguishes multiple items of the same type that
+        share a response_id (e.g. parallel ``n>1`` choices). The position is
+        appended as ``.{n}`` after the base64 payload and stripped by
+        :meth:`_decode_item_envelope` before the inner payload reaches the
+        existing response-id decoder.
+
+        The envelope reuses :meth:`_build_responses_api_response_id` and swaps
+        the leading ``resp_`` for the requested item prefix, so the result
+        round-trips through :meth:`_decode_item_envelope` plus
         :meth:`_decode_responses_api_response_id` back to ``raw_response_id``.
         """
         resp_form = ResponsesAPIRequestUtils._build_responses_api_response_id(
@@ -260,21 +266,32 @@ class ResponsesAPIRequestUtils:
             model_id=model_id,
             response_id=raw_response_id,
         )
-        return f"{prefix}_" + resp_form[len("resp_") :]
+        suffix = "" if item_position is None else f".{item_position}"
+        return f"{prefix}_" + resp_form[len("resp_") :] + suffix
 
     @staticmethod
     def _decode_item_envelope(item_id: str) -> Optional[str]:
         """Decode ``rs_<env>`` / ``msg_<env>`` back to the ``resp_<env>`` form
         that :meth:`_decode_responses_api_response_id` understands.
 
-        Returns ``None`` on missing prefix or empty input. All other validation
-        is delegated to the existing response-id decoder.
+        Returns ``None`` on missing prefix, empty input, or an empty payload
+        after the prefix (``"msg_"`` / ``"rs_"``). Strips the optional
+        ``.{position}`` item-position suffix before returning, so the inner
+        base64 payload is the same regardless of which item the envelope
+        belonged to.
         """
         if not item_id:
             return None
         for prefix in ("rs_", "msg_"):
             if item_id.startswith(prefix):
-                return "resp_" + item_id[len(prefix) :]
+                payload = item_id[len(prefix) :]
+                # Strip optional ".{position}" suffix used to disambiguate
+                # multiple items of the same type sharing a response_id.
+                if "." in payload:
+                    payload = payload.rsplit(".", 1)[0]
+                if not payload:
+                    return None
+                return "resp_" + payload
         return None
 
     @staticmethod
@@ -299,6 +316,7 @@ class ResponsesAPIRequestUtils:
         if not output:
             return response
 
+        message_position = 0
         for item in output:
             if isinstance(item, dict):
                 item_type = item.get("type")
@@ -313,17 +331,24 @@ class ResponsesAPIRequestUtils:
                 or current_id.startswith("rs_")
                 or current_id.startswith("encitem_")
             ):
+                message_position += 1
                 continue
+            # ``item_position`` keeps each message item's id distinct when a
+            # response carries multiple ``message`` items sharing a single
+            # response_id (parallel ``n>1`` choices). All ids still decode to
+            # the same response_id payload via :meth:`_decode_item_envelope`.
             new_id = ResponsesAPIRequestUtils._encode_item_envelope(
                 raw_response_id,
                 prefix="msg",
                 custom_llm_provider=custom_llm_provider,
                 model_id=model_id,
+                item_position=message_position,
             )
             if isinstance(item, dict):
                 item["id"] = new_id
             else:
                 item.id = new_id
+            message_position += 1
         return response
 
     @staticmethod

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -218,6 +218,15 @@ class ResponsesAPIRequestUtils:
         else:
             responses_api_response.id = updated_id
 
+        responses_api_response = (
+            ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+                response=responses_api_response,
+                raw_response_id=response_id,
+                custom_llm_provider=custom_llm_provider,
+                model_id=model_id,
+            )
+        )
+
         if litellm_metadata.get("encrypted_content_affinity_enabled"):
             responses_api_response = (
                 ResponsesAPIRequestUtils._update_encrypted_content_item_ids_in_response(
@@ -227,6 +236,95 @@ class ResponsesAPIRequestUtils:
             )
 
         return responses_api_response
+
+    @staticmethod
+    def _encode_item_envelope(
+        raw_response_id: str,
+        *,
+        prefix: str,
+        custom_llm_provider: Optional[str],
+        model_id: Optional[str],
+    ) -> str:
+        """Wrap a raw upstream id (e.g. ``chatcmpl-*``) as ``rs_<env>`` or
+        ``msg_<env>`` so the value carries the same response_id payload as
+        ``response.id`` but with an item-type prefix that clients recognize.
+
+        The envelope reuses
+        :meth:`_build_responses_api_response_id` and swaps the leading
+        ``resp_`` for the requested item prefix, so the result round-trips
+        through :meth:`_decode_item_envelope` plus
+        :meth:`_decode_responses_api_response_id` back to ``raw_response_id``.
+        """
+        resp_form = ResponsesAPIRequestUtils._build_responses_api_response_id(
+            custom_llm_provider=custom_llm_provider,
+            model_id=model_id,
+            response_id=raw_response_id,
+        )
+        return f"{prefix}_" + resp_form[len("resp_") :]
+
+    @staticmethod
+    def _decode_item_envelope(item_id: str) -> Optional[str]:
+        """Decode ``rs_<env>`` / ``msg_<env>`` back to the ``resp_<env>`` form
+        that :meth:`_decode_responses_api_response_id` understands.
+
+        Returns ``None`` on missing prefix or empty input. All other validation
+        is delegated to the existing response-id decoder.
+        """
+        if not item_id:
+            return None
+        for prefix in ("rs_", "msg_"):
+            if item_id.startswith(prefix):
+                return "resp_" + item_id[len(prefix) :]
+        return None
+
+    @staticmethod
+    def _envelope_encode_output_item_ids(
+        response: Union["ResponsesAPIResponse", Dict[str, Any]],
+        raw_response_id: str,
+        custom_llm_provider: Optional[str],
+        model_id: Optional[str],
+    ) -> Union["ResponsesAPIResponse", Dict[str, Any]]:
+        """Rewrite output item IDs that leak raw upstream forms (e.g.
+        ``chatcmpl-*``) as ``msg_<env>`` so downstream clients see a stable,
+        item-typed identifier instead of a chat-completions artifact.
+
+        Only items whose ``id`` is missing or does not already start with the
+        expected typed prefix (``msg_``, ``rs_``, ``encitem_``) are rewritten.
+        Function-call items keep their ``call_id``-based id (untouched).
+        """
+        if isinstance(response, dict):
+            output = response.get("output")
+        else:
+            output = getattr(response, "output", None)
+        if not output:
+            return response
+
+        for item in output:
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                current_id = item.get("id")
+            else:
+                item_type = getattr(item, "type", None)
+                current_id = getattr(item, "id", None)
+            if item_type != "message":
+                continue
+            if isinstance(current_id, str) and (
+                current_id.startswith("msg_")
+                or current_id.startswith("rs_")
+                or current_id.startswith("encitem_")
+            ):
+                continue
+            new_id = ResponsesAPIRequestUtils._encode_item_envelope(
+                raw_response_id,
+                prefix="msg",
+                custom_llm_provider=custom_llm_provider,
+                model_id=model_id,
+            )
+            if isinstance(item, dict):
+                item["id"] = new_id
+            else:
+                item.id = new_id
+        return response
 
     @staticmethod
     def _build_encrypted_item_id(model_id: str, item_id: str) -> str:

--- a/tests/test_litellm/responses/test_item_envelope_encoding.py
+++ b/tests/test_litellm/responses/test_item_envelope_encoding.py
@@ -66,15 +66,46 @@ def test_decode_item_envelope_returns_none_for_empty_input():
     assert ResponsesAPIRequestUtils._decode_item_envelope("") is None
 
 
-def test_decode_item_envelope_empty_payload_is_resp_passthrough():
-    """A ``msg_`` prefix with no payload decodes to ``resp_``, which the
-    response-id decoder treats as raw passthrough rather than crashing.
+def test_decode_item_envelope_returns_none_for_empty_payload():
+    """A degenerate ``msg_`` or ``rs_`` prefix with no payload must decode to
+    ``None`` so callers (e.g. the item_reference resolver) can fall through
+    to first-turn behavior instead of propagating an empty response_id to
+    the session handler.
     """
-    result = ResponsesAPIRequestUtils._decode_item_envelope("msg_")
-    assert result == "resp_"
-    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(result)
-    assert decoded["custom_llm_provider"] is None
-    assert decoded["model_id"] is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("msg_") is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("rs_") is None
+
+
+def test_encode_decode_round_trip_with_item_position():
+    """Distinct item positions yield distinct encoded ids but decode back to
+    the same response_id payload.
+    """
+    raw = "chatcmpl-multi"
+    first = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id="m-1",
+        item_position=0,
+    )
+    second = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id="m-1",
+        item_position=1,
+    )
+    assert first != second
+    assert first.endswith(".0")
+    assert second.endswith(".1")
+    for envelope in (first, second):
+        decoded_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(envelope)
+        decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+            decoded_resp_form
+        )
+        assert decoded["response_id"] == raw
+        assert decoded["custom_llm_provider"] == "hosted_vllm"
+        assert decoded["model_id"] == "m-1"
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +183,53 @@ def test_envelope_encode_skips_encitem_prefixed_message_id():
         model_id=None,
     )
     assert encoded.output[0]["id"] == "encitem_abc123"
+
+
+def test_envelope_encode_multiple_message_items_get_distinct_ids():
+    """When a response carries multiple ``message`` items (parallel ``n>1``
+    choices), each rewritten id must be distinct so downstream clients can
+    address them individually. All ids still decode to the same response_id
+    payload via :meth:`_decode_item_envelope`.
+    """
+    response = ResponsesAPIResponse(
+        id="chatcmpl-multi",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[
+            {"type": "message", "id": "chatcmpl-multi"},
+            {"type": "message", "id": "chatcmpl-multi"},
+            {"type": "message", "id": "chatcmpl-multi"},
+        ],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-multi",
+        custom_llm_provider="hosted_vllm",
+        model_id=None,
+    )
+    ids = [item["id"] for item in encoded.output]
+    assert len(set(ids)) == 3
+    for new_id in ids:
+        assert new_id.startswith("msg_")
+        resp_form = ResponsesAPIRequestUtils._decode_item_envelope(new_id)
+        decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+            resp_form
+        )
+        assert decoded["response_id"] == "chatcmpl-multi"
 
 
 def test_envelope_encode_leaves_function_call_items_untouched():

--- a/tests/test_litellm/responses/test_item_envelope_encoding.py
+++ b/tests/test_litellm/responses/test_item_envelope_encoding.py
@@ -1,0 +1,249 @@
+"""Tests for envelope-encoded output item IDs in Responses API responses.
+
+When the Responses API bridge fronts a chat-completions provider, message
+output items historically inherit the upstream ``chatcmpl-*`` id from the
+chat-completion response. Clients that follow the OpenAI Responses spec
+expect typed prefixes (``msg_*``, ``rs_*``) and break when they receive an
+``chatcmpl-*`` id (e.g. Vercel AI SDK 6.x "text part {id} not found").
+
+These tests cover the envelope codec helpers and the integration into
+``_update_responses_api_response_id_with_model_id``.
+"""
+
+from litellm.responses.utils import ResponsesAPIRequestUtils
+from litellm.types.llms.openai import ResponsesAPIResponse
+
+
+# ---------------------------------------------------------------------------
+# Envelope codec (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_round_trip_chatcmpl_id():
+    raw = "chatcmpl-abc123"
+    envelope = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id="m-1",
+    )
+    assert envelope.startswith("msg_")
+    decoded_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(envelope)
+    assert decoded_resp_form is not None
+    assert decoded_resp_form.startswith("resp_")
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        decoded_resp_form
+    )
+    assert decoded["response_id"] == raw
+    assert decoded["custom_llm_provider"] == "hosted_vllm"
+    assert decoded["model_id"] == "m-1"
+
+
+def test_encode_decode_round_trip_reasoning_prefix():
+    raw = "chatcmpl-xyz789"
+    envelope = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="rs",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert envelope.startswith("rs_")
+    decoded_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(envelope)
+    assert decoded_resp_form is not None
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        decoded_resp_form
+    )
+    assert decoded["response_id"] == raw
+
+
+def test_decode_item_envelope_returns_none_for_missing_prefix():
+    assert ResponsesAPIRequestUtils._decode_item_envelope("chatcmpl-abc") is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("encitem_abc") is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("resp_abc") is None
+
+
+def test_decode_item_envelope_returns_none_for_empty_input():
+    assert ResponsesAPIRequestUtils._decode_item_envelope("") is None
+
+
+def test_decode_item_envelope_empty_payload_is_resp_passthrough():
+    """A ``msg_`` prefix with no payload decodes to ``resp_``, which the
+    response-id decoder treats as raw passthrough rather than crashing.
+    """
+    result = ResponsesAPIRequestUtils._decode_item_envelope("msg_")
+    assert result == "resp_"
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(result)
+    assert decoded["custom_llm_provider"] is None
+    assert decoded["model_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# _envelope_encode_output_item_ids
+# ---------------------------------------------------------------------------
+
+
+def _resp_with_message_id(message_id: str) -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="chatcmpl-abc",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[{"type": "message", "id": message_id}],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+
+
+def test_envelope_encode_rewrites_chatcmpl_message_id():
+    response = _resp_with_message_id("chatcmpl-abc")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider="hosted_vllm",
+        model_id=None,
+    )
+    new_id = encoded.output[0]["id"]
+    assert new_id.startswith("msg_")
+    # Verify round-trip
+    resp_form = ResponsesAPIRequestUtils._decode_item_envelope(new_id)
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(resp_form)
+    assert decoded["response_id"] == "chatcmpl-abc"
+
+
+def test_envelope_encode_skips_already_prefixed_message_id():
+    response = _resp_with_message_id("msg_existing")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "msg_existing"
+
+
+def test_envelope_encode_skips_rs_prefixed_message_id():
+    response = _resp_with_message_id("rs_hash123")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "rs_hash123"
+
+
+def test_envelope_encode_skips_encitem_prefixed_message_id():
+    response = _resp_with_message_id("encitem_abc123")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "encitem_abc123"
+
+
+def test_envelope_encode_leaves_function_call_items_untouched():
+    """function_call items keep their call_id-based id."""
+    response = ResponsesAPIResponse(
+        id="chatcmpl-abc",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[
+            {"type": "function_call", "id": "chatcmpl-fc", "call_id": "call_xyz"},
+            {"type": "message", "id": "chatcmpl-abc"},
+        ],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "chatcmpl-fc"
+    assert encoded.output[1]["id"].startswith("msg_")
+
+
+def test_envelope_encode_handles_empty_output():
+    response = ResponsesAPIResponse(
+        id="chatcmpl-abc",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: _update_responses_api_response_id_with_model_id
+# ---------------------------------------------------------------------------
+
+
+def test_update_responses_api_response_id_rewrites_message_item_id():
+    """The full update_responses_api_response_id flow wraps both the top-level
+    response.id AND each message item id whose value is a raw chatcmpl-* form.
+    """
+    response = _resp_with_message_id("chatcmpl-abc")
+    updated = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+        responses_api_response=response,
+        custom_llm_provider="hosted_vllm",
+        litellm_metadata={"model_info": {"id": "deploy-1"}},
+    )
+    assert updated.id.startswith("resp_")
+    assert updated.output[0]["id"].startswith("msg_")
+    # The message id and the response id encode the SAME response_id payload
+    msg_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(
+        updated.output[0]["id"]
+    )
+    msg_decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        msg_resp_form
+    )
+    resp_decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        updated.id
+    )
+    assert msg_decoded["response_id"] == resp_decoded["response_id"] == "chatcmpl-abc"


### PR DESCRIPTION
## Relevant issues

- Fixes #27333 — `/v1/responses` can replay `chatcmpl-*` message IDs into OpenAI Responses during cross-provider handoffs
- Fixes #27671 — Responses API streaming bridge: multi-step Anthropic tool calls emit text-delta with unregistered `chatcmpl-` ID
- Related to #26529 — OpenAI-proxy streaming for Claude breaks AI SDK 6.x multi-step tool calls: "text part {id} not found" (covers the non-streaming half; streaming follow-up TBD)

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — 12 new unit + integration tests in `tests/test_litellm/responses/test_item_envelope_encoding.py`
- [x] My PR passes all unit tests — `tests/test_litellm/responses/` (214 tests) green locally
- [x] My PR's scope is as isolated as possible — single envelope codec + one integration point in the existing post-processor
- [ ] Greptile review pending

## Type

🐛 Bug Fix

## Changes

### Problem

When the Responses API bridge fronts a chat-completions provider, message output items inherit the upstream `chatcmpl-*` id directly:

```python
# litellm/responses/litellm_completion_transformation/transformation.py:_extract_message_output_items
message_output_items.append(
    GenericResponseOutputItem(
        type="message",
        id=chat_completion_response.id,  # "chatcmpl-abc"
        ...
    )
)
```

Clients that follow the OpenAI Responses spec expect typed prefixes (`msg_*`, `rs_*`) on output item ids. Raw `chatcmpl-*` ids break them:

- **Vercel AI SDK 6.x** — fails with `text part {id} not found` on multi-step tool calls (#26529)
- **Streaming bridge** — surfaces unregistered `chatcmpl-` ids in `response.output_text.delta` events (#27671)
- **Cross-provider handoff** — bridge responses can replay `chatcmpl-*` ids back into OpenAI's `previous_response_id` path (#27333)

### Solution

Envelope codec on `ResponsesAPIRequestUtils` that wraps raw upstream ids as `msg_<base64-payload>` using the same payload format as the existing `_build_responses_api_response_id` envelope:

```
chatcmpl-abc123  →  msg_<base64("litellm:custom_llm_provider:X;model_id:Y;response_id:chatcmpl-abc123")>
```

The encoded form round-trips via `_decode_item_envelope` + the existing `_decode_responses_api_response_id` decoder back to the original `chatcmpl-abc123`, so the bridge does not lose any routing information.

### Implementation

Three new static methods on `ResponsesAPIRequestUtils`:

- `_encode_item_envelope(raw_response_id, prefix, custom_llm_provider, model_id)` — reuses `_build_responses_api_response_id` and swaps `resp_` for the requested item prefix (`msg`/`rs`).
- `_decode_item_envelope(item_id)` — returns the `resp_<env>` form so the existing response-id decoder handles the inner payload validation. Returns `None` on missing prefix or empty input.
- `_envelope_encode_output_item_ids(response, raw_response_id, custom_llm_provider, model_id)` — walks the response output and rewrites only message items whose id is raw (does NOT already start with `msg_`, `rs_`, or `encitem_`). Function-call items and already-prefixed items are left untouched.

Hooked into `_update_responses_api_response_id_with_model_id` so the same post-processor that wraps `response.id` now also wraps message item ids — giving downstream clients consistent typed envelopes across both fields. No new opt-in flag; the change is transparent for any caller that treats item ids as opaque (the OpenAI Responses spec contract).

### Linked / follow-up PR

A follow-up PR will reuse the same envelope codec to resolve `item_reference` input items back to `previous_response_id` — needed for `@ai-sdk/openai` clients running with default `store: true` who send opaque references on multi-turn instead of inlining prior assistant content. That work depends directly on `_decode_item_envelope` from this PR and is best merged together.

### Tests

`tests/test_litellm/responses/test_item_envelope_encoding.py` — 12 tests:

- **Codec round-trip** (2): encode → `_decode_item_envelope` → `_decode_responses_api_response_id` returns original `(response_id, custom_llm_provider, model_id)` tuple, for both `msg_` and `rs_` prefixes.
- **Decode edge cases** (3): missing prefix returns `None`, empty input returns `None`, empty payload (`msg_`) decodes to `resp_` (delegated to existing decoder).
- **Selective rewriting** (4): rewrites raw `chatcmpl-*` message ids, skips `msg_*`/`rs_*`/`encitem_*` already-prefixed ids.
- **Function-call passthrough** (1): `function_call` items keep their original id.
- **Empty output** (1): no-op when `response.output` is empty.
- **Integration** (1): full `_update_responses_api_response_id_with_model_id` round-trip; `response.id` and message item id both encode the same response_id payload.

### Known limitations (Greptile feedback)

- **Multiple message items in one response share the same `msg_<envelope>`.** This preserves the pre-existing behavior (all message items already shared `chatcmpl-*` as their id) and is not a regression. The bridge currently emits at most one message item per response in production paths (Vercel AI SDK / opencode / Cursor all send `n=1`). Adding a per-item index to the envelope is straightforward and can land as a separate spec-compliance follow-up if a real client needs to distinguish parallel choices.
- **Unconditional rewrite, no opt-in flag.** Output item ids are documented as opaque per the OpenAI Responses API spec, so any client that pinned to the `chatcmpl-*` shape was relying on undocumented behavior. The change is transparent for spec-conformant clients and is the only way to surface the bug fix by default.
