### PR TITLE
[Fix] Responses bridge: translate developer role to system for non-OpenAI providers

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -980,9 +980,16 @@ class LiteLLMCompletionResponsesConfig:
             # Since guardrails skip None content anyway, we return empty list to exclude it from structured messages
             if content is None:
                 return []
+            # The Responses API uses ``developer`` as the equivalent of the
+            # Chat Completions ``system`` role. Non-OpenAI providers (vLLM,
+            # sglang, etc.) only recognize ``system``/``user``/``assistant``/
+            # ``tool`` and reject ``developer`` with "Unexpected message role".
+            role = input_item.get("role") or "user"
+            if role == "developer":
+                role = "system"
             return [
                 GenericChatCompletionMessage(
-                    role=input_item.get("role") or "user",
+                    role=role,
                     content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
                         content
                     ),

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -195,6 +195,7 @@ class LiteLLMCompletionResponsesConfig:
             "messages": LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
                 input=input,
                 responses_api_request=responses_api_request,
+                custom_llm_provider=custom_llm_provider,
             ),
             "model": model,
             "tool_choice": LiteLLMCompletionResponsesConfig._transform_tool_choice(
@@ -240,6 +241,7 @@ class LiteLLMCompletionResponsesConfig:
     def transform_responses_api_input_to_messages(
         input: Union[str, ResponseInputParam],
         responses_api_request: Union[ResponsesAPIOptionalRequestParams, dict],
+        custom_llm_provider: Optional[str] = None,
     ) -> List[
         Union[
             AllMessageValues,
@@ -271,6 +273,7 @@ class LiteLLMCompletionResponsesConfig:
         messages.extend(
             LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
                 input=input,
+                custom_llm_provider=custom_llm_provider,
             )
         )
 
@@ -351,6 +354,7 @@ class LiteLLMCompletionResponsesConfig:
     @staticmethod
     def _transform_response_input_param_to_chat_completion_message(
         input: Union[str, ResponseInputParam],
+        custom_llm_provider: Optional[str] = None,
     ) -> List[
         Union[
             AllMessageValues,
@@ -377,7 +381,8 @@ class LiteLLMCompletionResponsesConfig:
             existing_tool_call_ids: Set[str] = set()
             for _input in input:
                 chat_completion_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
-                    input_item=_input
+                    input_item=_input,
+                    custom_llm_provider=custom_llm_provider,
                 )
 
                 if LiteLLMCompletionResponsesConfig._is_input_item_function_call(
@@ -942,6 +947,7 @@ class LiteLLMCompletionResponsesConfig:
     @staticmethod
     def _transform_responses_api_input_item_to_chat_completion_message(
         input_item: Any,
+        custom_llm_provider: Optional[str] = None,
     ) -> List[
         Union[
             AllMessageValues,
@@ -984,8 +990,11 @@ class LiteLLMCompletionResponsesConfig:
             # Chat Completions ``system`` role. Non-OpenAI providers (vLLM,
             # sglang, etc.) only recognize ``system``/``user``/``assistant``/
             # ``tool`` and reject ``developer`` with "Unexpected message role".
+            # OpenAI's Chat Completions API distinguishes ``developer`` from
+            # ``system`` (higher trust priority for o-series models), so leave
+            # the role untouched when the downstream is OpenAI.
             role = input_item.get("role") or "user"
-            if role == "developer":
+            if role == "developer" and custom_llm_provider != "openai":
                 role = "system"
             return [
                 GenericChatCompletionMessage(

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1964,8 +1964,28 @@ class TestDeveloperRoleTranslation:
             ],
             responses_api_request={"store": False},
             extra_headers=None,
+            custom_llm_provider="hosted_vllm",
         )
         roles = [self._role(m) for m in result["messages"]]
         assert "developer" not in roles
         assert "system" in roles
+        assert "user" in roles
+
+    def test_developer_role_preserved_for_openai_provider(self):
+        """OpenAI's Chat Completions API distinguishes `developer` from
+        `system` (higher trust priority for o-series models). The bridge
+        must not collapse them when the downstream is OpenAI.
+        """
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="openai/gpt-5.4",
+            input=[
+                {"role": "developer", "content": "You are helpful."},
+                {"role": "user", "content": "Hi"},
+            ],
+            responses_api_request={"store": False},
+            extra_headers=None,
+            custom_llm_provider="openai",
+        )
+        roles = [self._role(m) for m in result["messages"]]
+        assert "developer" in roles
         assert "user" in roles

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1899,3 +1899,73 @@ class TestStreamingIDConsistency:
             else getattr(assistant_messages[0], "tool_calls", None)
         )
         assert tool_calls is not None and len(tool_calls) == 1
+
+
+class TestDeveloperRoleTranslation:
+    """The Responses API uses the ``developer`` role as the equivalent of the
+    Chat Completions ``system`` role. Non-OpenAI providers (vLLM, sglang, etc.)
+    only recognize ``system``/``user``/``assistant``/``tool`` and reject
+    ``developer`` with "Unexpected message role". The bridge must translate
+    ``developer`` to ``system`` so the downstream chat-completions call
+    succeeds.
+    """
+
+    def _role(self, msg):
+        return msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+
+    def test_developer_role_translates_to_system(self):
+        input_items = [
+            {"role": "developer", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+            input=input_items
+        )
+        roles = [self._role(m) for m in messages]
+        assert "system" in roles
+        assert "developer" not in roles
+        assert "user" in roles
+
+    def test_other_roles_passed_through_unchanged(self):
+        input_items = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+            input=input_items
+        )
+        roles = [self._role(m) for m in messages]
+        assert roles == ["system", "user", "assistant"]
+
+    def test_developer_role_with_structured_content_blocks(self):
+        input_items = [
+            {
+                "role": "developer",
+                "content": [
+                    {"type": "input_text", "text": "You are a helpful assistant."}
+                ],
+            }
+        ]
+        messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+            input=input_items
+        )
+        assert len(messages) == 1
+        assert self._role(messages[0]) == "system"
+
+    def test_full_request_transform_drops_developer_role_from_messages(self):
+        """End-to-end: request with `developer` role gets `system` in the
+        downstream chat-completions request."""
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="hosted_vllm/some-model",
+            input=[
+                {"role": "developer", "content": "You are helpful."},
+                {"role": "user", "content": "Hi"},
+            ],
+            responses_api_request={"store": False},
+            extra_headers=None,
+        )
+        roles = [self._role(m) for m in result["messages"]]
+        assert "developer" not in roles
+        assert "system" in roles
+        assert "user" in roles


### PR DESCRIPTION
## Relevant issues

- Fixes #24664 — Responses API → Chat Completions bridge does not translate `developer` role to `system` for non-OpenAI providers

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — 4 new tests in `test_litellm_completion_responses.py::TestDeveloperRoleTranslation`
- [x] My PR passes all unit tests — `test_litellm_completion_responses.py` (59 tests) green locally
- [x] My PR's scope is as isolated as possible — single role translation
- [ ] Greptile review pending

## Type

🐛 Bug Fix

## Changes

### Problem

The Responses API uses `developer` as the equivalent of the Chat Completions `system` role. When the bridge transforms an input item, the role is currently passed through unchanged:

```python
# litellm/responses/litellm_completion_transformation/transformation.py:
# _transform_responses_api_input_item_to_chat_completion_message

return [
    GenericChatCompletionMessage(
        role=input_item.get("role") or "user",  # "developer" passed through
        ...
    )
]
```

Non-OpenAI providers (vLLM, sglang, etc.) only recognize the canonical four chat-completions roles (`system`, `user`, `assistant`, `tool`) and reject `developer` with "Unexpected message role". This breaks any Responses API client built against the official spec — `@ai-sdk/openai` v2+ defaults to emitting `developer` for the system prompt, so any default Vercel AI SDK client hits this on first request.

### Solution

Translate `developer` → `system` at the same site the role is read:

```python
role = input_item.get("role") or "user"
if role == "developer":
    role = "system"
```

The `instructions` field is already translated to `system` correctly via `transform_instructions_to_system_message`; this PR closes the gap for input items that carry the role directly.

### Tests

`tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestDeveloperRoleTranslation` — 4 new tests:

- `test_developer_role_translates_to_system` — base case, mixed with a user message
- `test_other_roles_passed_through_unchanged` — `system`/`user`/`assistant` are not touched
- `test_developer_role_with_structured_content_blocks` — variant with `{type: input_text, text: ...}` content
- `test_full_request_transform_drops_developer_role_from_messages` — end-to-end through `transform_responses_api_request_to_chat_completion_request` so the assertion runs against the downstream chat-completions payload

### Scope

Out of scope for this PR (mentioned in the linked issue but separate):
- Stripping the `metadata` parameter from the downstream Chat Completions request. That is a separate fix to the request-shape transformation; left out so this PR remains scope-isolated to the role translation.
