### PR TITLE
[Feature] Responses bridge: resolve item_reference inputs to previous_response_id

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -12,12 +12,58 @@ from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
 from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
+from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
 )
 from litellm.types.utils import ModelResponse
+
+
+def _resolve_item_references_to_previous_response_id(
+    request_input: Union[str, ResponseInputParam, None],
+) -> Optional[str]:
+    """When a Responses API client sends prior turn items as opaque
+    ``item_reference`` entries (``@ai-sdk/openai`` with default ``store: true``
+    does this), resolve them to the original ``previous_response_id`` so the
+    existing session handler can rebuild conversation history.
+
+    Scans the input list for items of type ``item_reference``, decodes the
+    most recent one through the envelope codec, and returns the result in the
+    ``resp_<env>`` form that ``async_responses_api_session_handler`` already
+    accepts. Returns ``None`` when no decodable references are present.
+    """
+    if not isinstance(request_input, list):
+        return None
+    refs = [
+        item
+        for item in request_input
+        if isinstance(item, dict) and item.get("type") == "item_reference"
+    ]
+    if not refs:
+        return None
+    for ref in reversed(refs):
+        decoded = ResponsesAPIRequestUtils._decode_item_envelope(ref.get("id", ""))
+        if decoded:
+            return decoded
+    return None
+
+
+def _strip_item_references(
+    request_input: Union[str, ResponseInputParam, None],
+) -> Union[str, ResponseInputParam, None]:
+    """Filter ``item_reference`` items out of the input list so the standard
+    message transformer does not see opaque references it cannot inline.
+    Non-list inputs pass through unchanged.
+    """
+    if not isinstance(request_input, list):
+        return request_input
+    return [
+        item
+        for item in request_input
+        if not (isinstance(item, dict) and item.get("type") == "item_reference")
+    ]
 
 
 class LiteLLMCompletionTransformationHandler:
@@ -99,6 +145,22 @@ class LiteLLMCompletionTransformationHandler:
         previous_response_id: Optional[str] = responses_api_request.get(
             "previous_response_id"
         )
+        # When the caller did not supply ``previous_response_id`` explicitly,
+        # try to derive it from any ``item_reference`` entries in the input.
+        # Vercel ``@ai-sdk/openai`` with default ``store: true`` sends prior
+        # turn items as references instead of inlining them, so without this
+        # the bridge would treat each turn as a fresh conversation.
+        if not previous_response_id:
+            resolved = _resolve_item_references_to_previous_response_id(request_input)
+            if resolved:
+                previous_response_id = resolved
+                request_input = _strip_item_references(request_input)
+                litellm_completion_request[
+                    "messages"
+                ] = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+                    input=request_input,
+                    responses_api_request=responses_api_request,
+                )
         if previous_response_id:
             litellm_completion_request = await LiteLLMCompletionResponsesConfig.async_responses_api_session_handler(
                 previous_response_id=previous_response_id,

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -244,15 +244,21 @@ class ResponsesAPIRequestUtils:
         prefix: str,
         custom_llm_provider: Optional[str],
         model_id: Optional[str],
+        item_position: Optional[int] = None,
     ) -> str:
         """Wrap a raw upstream id (e.g. ``chatcmpl-*``) as ``rs_<env>`` or
         ``msg_<env>`` so the value carries the same response_id payload as
         ``response.id`` but with an item-type prefix that clients recognize.
 
-        The envelope reuses
-        :meth:`_build_responses_api_response_id` and swaps the leading
-        ``resp_`` for the requested item prefix, so the result round-trips
-        through :meth:`_decode_item_envelope` plus
+        ``item_position`` distinguishes multiple items of the same type that
+        share a response_id (e.g. parallel ``n>1`` choices). The position is
+        appended as ``.{n}`` after the base64 payload and stripped by
+        :meth:`_decode_item_envelope` before the inner payload reaches the
+        existing response-id decoder.
+
+        The envelope reuses :meth:`_build_responses_api_response_id` and swaps
+        the leading ``resp_`` for the requested item prefix, so the result
+        round-trips through :meth:`_decode_item_envelope` plus
         :meth:`_decode_responses_api_response_id` back to ``raw_response_id``.
         """
         resp_form = ResponsesAPIRequestUtils._build_responses_api_response_id(
@@ -260,21 +266,32 @@ class ResponsesAPIRequestUtils:
             model_id=model_id,
             response_id=raw_response_id,
         )
-        return f"{prefix}_" + resp_form[len("resp_") :]
+        suffix = "" if item_position is None else f".{item_position}"
+        return f"{prefix}_" + resp_form[len("resp_") :] + suffix
 
     @staticmethod
     def _decode_item_envelope(item_id: str) -> Optional[str]:
         """Decode ``rs_<env>`` / ``msg_<env>`` back to the ``resp_<env>`` form
         that :meth:`_decode_responses_api_response_id` understands.
 
-        Returns ``None`` on missing prefix or empty input. All other validation
-        is delegated to the existing response-id decoder.
+        Returns ``None`` on missing prefix, empty input, or an empty payload
+        after the prefix (``"msg_"`` / ``"rs_"``). Strips the optional
+        ``.{position}`` item-position suffix before returning, so the inner
+        base64 payload is the same regardless of which item the envelope
+        belonged to.
         """
         if not item_id:
             return None
         for prefix in ("rs_", "msg_"):
             if item_id.startswith(prefix):
-                return "resp_" + item_id[len(prefix) :]
+                payload = item_id[len(prefix) :]
+                # Strip optional ".{position}" suffix used to disambiguate
+                # multiple items of the same type sharing a response_id.
+                if "." in payload:
+                    payload = payload.rsplit(".", 1)[0]
+                if not payload:
+                    return None
+                return "resp_" + payload
         return None
 
     @staticmethod
@@ -299,6 +316,7 @@ class ResponsesAPIRequestUtils:
         if not output:
             return response
 
+        message_position = 0
         for item in output:
             if isinstance(item, dict):
                 item_type = item.get("type")
@@ -313,17 +331,24 @@ class ResponsesAPIRequestUtils:
                 or current_id.startswith("rs_")
                 or current_id.startswith("encitem_")
             ):
+                message_position += 1
                 continue
+            # ``item_position`` keeps each message item's id distinct when a
+            # response carries multiple ``message`` items sharing a single
+            # response_id (parallel ``n>1`` choices). All ids still decode to
+            # the same response_id payload via :meth:`_decode_item_envelope`.
             new_id = ResponsesAPIRequestUtils._encode_item_envelope(
                 raw_response_id,
                 prefix="msg",
                 custom_llm_provider=custom_llm_provider,
                 model_id=model_id,
+                item_position=message_position,
             )
             if isinstance(item, dict):
                 item["id"] = new_id
             else:
                 item.id = new_id
+            message_position += 1
         return response
 
     @staticmethod

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -218,6 +218,15 @@ class ResponsesAPIRequestUtils:
         else:
             responses_api_response.id = updated_id
 
+        responses_api_response = (
+            ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+                response=responses_api_response,
+                raw_response_id=response_id,
+                custom_llm_provider=custom_llm_provider,
+                model_id=model_id,
+            )
+        )
+
         if litellm_metadata.get("encrypted_content_affinity_enabled"):
             responses_api_response = (
                 ResponsesAPIRequestUtils._update_encrypted_content_item_ids_in_response(
@@ -227,6 +236,95 @@ class ResponsesAPIRequestUtils:
             )
 
         return responses_api_response
+
+    @staticmethod
+    def _encode_item_envelope(
+        raw_response_id: str,
+        *,
+        prefix: str,
+        custom_llm_provider: Optional[str],
+        model_id: Optional[str],
+    ) -> str:
+        """Wrap a raw upstream id (e.g. ``chatcmpl-*``) as ``rs_<env>`` or
+        ``msg_<env>`` so the value carries the same response_id payload as
+        ``response.id`` but with an item-type prefix that clients recognize.
+
+        The envelope reuses
+        :meth:`_build_responses_api_response_id` and swaps the leading
+        ``resp_`` for the requested item prefix, so the result round-trips
+        through :meth:`_decode_item_envelope` plus
+        :meth:`_decode_responses_api_response_id` back to ``raw_response_id``.
+        """
+        resp_form = ResponsesAPIRequestUtils._build_responses_api_response_id(
+            custom_llm_provider=custom_llm_provider,
+            model_id=model_id,
+            response_id=raw_response_id,
+        )
+        return f"{prefix}_" + resp_form[len("resp_") :]
+
+    @staticmethod
+    def _decode_item_envelope(item_id: str) -> Optional[str]:
+        """Decode ``rs_<env>`` / ``msg_<env>`` back to the ``resp_<env>`` form
+        that :meth:`_decode_responses_api_response_id` understands.
+
+        Returns ``None`` on missing prefix or empty input. All other validation
+        is delegated to the existing response-id decoder.
+        """
+        if not item_id:
+            return None
+        for prefix in ("rs_", "msg_"):
+            if item_id.startswith(prefix):
+                return "resp_" + item_id[len(prefix) :]
+        return None
+
+    @staticmethod
+    def _envelope_encode_output_item_ids(
+        response: Union["ResponsesAPIResponse", Dict[str, Any]],
+        raw_response_id: str,
+        custom_llm_provider: Optional[str],
+        model_id: Optional[str],
+    ) -> Union["ResponsesAPIResponse", Dict[str, Any]]:
+        """Rewrite output item IDs that leak raw upstream forms (e.g.
+        ``chatcmpl-*``) as ``msg_<env>`` so downstream clients see a stable,
+        item-typed identifier instead of a chat-completions artifact.
+
+        Only items whose ``id`` is missing or does not already start with the
+        expected typed prefix (``msg_``, ``rs_``, ``encitem_``) are rewritten.
+        Function-call items keep their ``call_id``-based id (untouched).
+        """
+        if isinstance(response, dict):
+            output = response.get("output")
+        else:
+            output = getattr(response, "output", None)
+        if not output:
+            return response
+
+        for item in output:
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                current_id = item.get("id")
+            else:
+                item_type = getattr(item, "type", None)
+                current_id = getattr(item, "id", None)
+            if item_type != "message":
+                continue
+            if isinstance(current_id, str) and (
+                current_id.startswith("msg_")
+                or current_id.startswith("rs_")
+                or current_id.startswith("encitem_")
+            ):
+                continue
+            new_id = ResponsesAPIRequestUtils._encode_item_envelope(
+                raw_response_id,
+                prefix="msg",
+                custom_llm_provider=custom_llm_provider,
+                model_id=model_id,
+            )
+            if isinstance(item, dict):
+                item["id"] = new_id
+            else:
+                item.id = new_id
+        return response
 
     @staticmethod
     def _build_encrypted_item_id(model_id: str, item_id: str) -> str:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_item_reference_resolver.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_item_reference_resolver.py
@@ -1,0 +1,255 @@
+"""Tests for ``item_reference`` resolution in the Responses API bridge.
+
+Vercel ``@ai-sdk/openai`` with default ``store: true`` sends prior turn items
+as opaque ``item_reference`` entries instead of inlining their content:
+
+    input=[
+        {"type": "item_reference", "id": "rs_<envelope>"},  # prior reasoning
+        {"type": "item_reference", "id": "msg_<envelope>"}, # prior message
+        {"role": "user", "content": "next message"}
+    ]
+
+Without resolution the bridge drops the references silently and the
+conversation degrades to a single-turn fresh request. The handler now
+decodes the envelope (introduced in the message-item id wrapping change),
+sets ``previous_response_id``, and falls through to the existing session
+handler that rebuilds the conversation from SpendLogs.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.responses.litellm_completion_transformation.handler import (
+    LiteLLMCompletionTransformationHandler,
+    _resolve_item_references_to_previous_response_id,
+    _strip_item_references,
+)
+from litellm.responses.utils import ResponsesAPIRequestUtils
+
+
+def _encode_msg(raw_response_id: str) -> str:
+    return ResponsesAPIRequestUtils._encode_item_envelope(
+        raw_response_id,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id=None,
+    )
+
+
+def _encode_rs(raw_response_id: str) -> str:
+    return ResponsesAPIRequestUtils._encode_item_envelope(
+        raw_response_id,
+        prefix="rs",
+        custom_llm_provider="hosted_vllm",
+        model_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_item_references_to_previous_response_id (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_none_for_string_input():
+    assert _resolve_item_references_to_previous_response_id("hello") is None
+
+
+def test_resolve_returns_none_when_no_references():
+    request_input = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    assert _resolve_item_references_to_previous_response_id(request_input) is None
+
+
+def test_resolve_decodes_msg_envelope():
+    envelope = _encode_msg("chatcmpl-abc")
+    request_input = [
+        {"type": "item_reference", "id": envelope},
+        {"role": "user", "content": "next"},
+    ]
+    resolved = _resolve_item_references_to_previous_response_id(request_input)
+    assert resolved is not None
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(resolved)
+    assert decoded["response_id"] == "chatcmpl-abc"
+
+
+def test_resolve_decodes_rs_envelope():
+    envelope = _encode_rs("chatcmpl-xyz")
+    request_input = [
+        {"type": "item_reference", "id": envelope},
+        {"role": "user", "content": "next"},
+    ]
+    resolved = _resolve_item_references_to_previous_response_id(request_input)
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(resolved)
+    assert decoded["response_id"] == "chatcmpl-xyz"
+
+
+def test_resolve_picks_most_recent_when_multiple_references():
+    """When the input has multiple references, the most recent (last in list)
+    wins so the resolved response_id points at the latest assistant turn.
+    """
+    older = _encode_msg("chatcmpl-older")
+    newer = _encode_msg("chatcmpl-newer")
+    request_input = [
+        {"type": "item_reference", "id": older},
+        {"role": "user", "content": "x"},
+        {"type": "item_reference", "id": newer},
+        {"role": "user", "content": "y"},
+    ]
+    resolved = _resolve_item_references_to_previous_response_id(request_input)
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(resolved)
+    assert decoded["response_id"] == "chatcmpl-newer"
+
+
+def test_resolve_returns_none_for_malformed_envelopes():
+    request_input = [
+        {"type": "item_reference", "id": "not-an-envelope"},
+        {"type": "item_reference", "id": ""},
+    ]
+    assert _resolve_item_references_to_previous_response_id(request_input) is None
+
+
+# ---------------------------------------------------------------------------
+# _strip_item_references (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_removes_only_item_references():
+    request_input = [
+        {"type": "item_reference", "id": "rs_xxx"},
+        {"role": "user", "content": "hello"},
+        {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+        {"type": "item_reference", "id": "msg_yyy"},
+    ]
+    stripped = _strip_item_references(request_input)
+    assert stripped == [
+        {"role": "user", "content": "hello"},
+        {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+    ]
+
+
+def test_strip_passes_through_string_input():
+    assert _strip_item_references("hello") == "hello"
+
+
+def test_strip_passes_through_none():
+    assert _strip_item_references(None) is None
+
+
+def test_strip_returns_empty_list_when_all_references():
+    stripped = _strip_item_references(
+        [
+            {"type": "item_reference", "id": "rs_a"},
+            {"type": "item_reference", "id": "msg_b"},
+        ]
+    )
+    assert stripped == []
+
+
+# ---------------------------------------------------------------------------
+# Handler integration: async_response_api_handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_handler_resolves_item_reference_and_calls_session_handler():
+    """When `previous_response_id` is absent but item_references decode to a
+    valid response_id, the handler delegates to the existing session handler
+    with the resolved id and the stripped input.
+    """
+    envelope = _encode_msg("chatcmpl-prior")
+    request_input = [
+        {"type": "item_reference", "id": envelope},
+        {"role": "user", "content": "next question"},
+    ]
+
+    with patch(
+        "litellm.responses.litellm_completion_transformation.handler.LiteLLMCompletionResponsesConfig.async_responses_api_session_handler",
+        new_callable=AsyncMock,
+    ) as mock_session_handler, patch(
+        "litellm.acompletion", new_callable=AsyncMock
+    ) as mock_acompletion:
+        mock_session_handler.side_effect = (
+            lambda previous_response_id, litellm_completion_request: litellm_completion_request
+        )
+        # Make acompletion raise so we exit before the response transformation;
+        # we only want to confirm the session handler was reached with the
+        # decoded id.
+        mock_acompletion.side_effect = RuntimeError("stop here")
+
+        handler = LiteLLMCompletionTransformationHandler()
+        with pytest.raises(RuntimeError, match="stop here"):
+            await handler.async_response_api_handler(
+                litellm_completion_request={"messages": [], "model": "vllm/x"},
+                request_input=request_input,
+                responses_api_request={},
+            )
+
+    assert mock_session_handler.await_count == 1
+    call_kwargs = mock_session_handler.await_args.kwargs
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        call_kwargs["previous_response_id"]
+    )
+    assert decoded["response_id"] == "chatcmpl-prior"
+
+
+@pytest.mark.asyncio
+async def test_async_handler_explicit_previous_response_id_wins_over_references():
+    """If both an explicit `previous_response_id` and item_references are
+    present, the explicit value wins so existing callers keep their behavior.
+    """
+    envelope = _encode_msg("chatcmpl-from-ref")
+    request_input = [
+        {"type": "item_reference", "id": envelope},
+        {"role": "user", "content": "next"},
+    ]
+
+    with patch(
+        "litellm.responses.litellm_completion_transformation.handler.LiteLLMCompletionResponsesConfig.async_responses_api_session_handler",
+        new_callable=AsyncMock,
+    ) as mock_session_handler, patch(
+        "litellm.acompletion", new_callable=AsyncMock
+    ) as mock_acompletion:
+        mock_session_handler.side_effect = (
+            lambda previous_response_id, litellm_completion_request: litellm_completion_request
+        )
+        mock_acompletion.side_effect = RuntimeError("stop here")
+
+        handler = LiteLLMCompletionTransformationHandler()
+        with pytest.raises(RuntimeError):
+            await handler.async_response_api_handler(
+                litellm_completion_request={"messages": [], "model": "vllm/x"},
+                request_input=request_input,
+                responses_api_request={"previous_response_id": "explicit-id"},
+            )
+
+    assert (
+        mock_session_handler.await_args.kwargs["previous_response_id"] == "explicit-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_handler_no_resolution_when_no_references_or_explicit_id():
+    """No `previous_response_id`, no item_references → session handler is not
+    called; the request goes through with whatever messages were already
+    built.
+    """
+    with patch(
+        "litellm.responses.litellm_completion_transformation.handler.LiteLLMCompletionResponsesConfig.async_responses_api_session_handler",
+        new_callable=AsyncMock,
+    ) as mock_session_handler, patch(
+        "litellm.acompletion", new_callable=AsyncMock
+    ) as mock_acompletion:
+        mock_acompletion.side_effect = RuntimeError("stop here")
+
+        handler = LiteLLMCompletionTransformationHandler()
+        with pytest.raises(RuntimeError):
+            await handler.async_response_api_handler(
+                litellm_completion_request={"messages": [], "model": "vllm/x"},
+                request_input=[{"role": "user", "content": "hi"}],
+                responses_api_request={},
+            )
+
+    assert mock_session_handler.await_count == 0

--- a/tests/test_litellm/responses/test_item_envelope_encoding.py
+++ b/tests/test_litellm/responses/test_item_envelope_encoding.py
@@ -66,15 +66,46 @@ def test_decode_item_envelope_returns_none_for_empty_input():
     assert ResponsesAPIRequestUtils._decode_item_envelope("") is None
 
 
-def test_decode_item_envelope_empty_payload_is_resp_passthrough():
-    """A ``msg_`` prefix with no payload decodes to ``resp_``, which the
-    response-id decoder treats as raw passthrough rather than crashing.
+def test_decode_item_envelope_returns_none_for_empty_payload():
+    """A degenerate ``msg_`` or ``rs_`` prefix with no payload must decode to
+    ``None`` so callers (e.g. the item_reference resolver) can fall through
+    to first-turn behavior instead of propagating an empty response_id to
+    the session handler.
     """
-    result = ResponsesAPIRequestUtils._decode_item_envelope("msg_")
-    assert result == "resp_"
-    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(result)
-    assert decoded["custom_llm_provider"] is None
-    assert decoded["model_id"] is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("msg_") is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("rs_") is None
+
+
+def test_encode_decode_round_trip_with_item_position():
+    """Distinct item positions yield distinct encoded ids but decode back to
+    the same response_id payload.
+    """
+    raw = "chatcmpl-multi"
+    first = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id="m-1",
+        item_position=0,
+    )
+    second = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id="m-1",
+        item_position=1,
+    )
+    assert first != second
+    assert first.endswith(".0")
+    assert second.endswith(".1")
+    for envelope in (first, second):
+        decoded_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(envelope)
+        decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+            decoded_resp_form
+        )
+        assert decoded["response_id"] == raw
+        assert decoded["custom_llm_provider"] == "hosted_vllm"
+        assert decoded["model_id"] == "m-1"
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +183,53 @@ def test_envelope_encode_skips_encitem_prefixed_message_id():
         model_id=None,
     )
     assert encoded.output[0]["id"] == "encitem_abc123"
+
+
+def test_envelope_encode_multiple_message_items_get_distinct_ids():
+    """When a response carries multiple ``message`` items (parallel ``n>1``
+    choices), each rewritten id must be distinct so downstream clients can
+    address them individually. All ids still decode to the same response_id
+    payload via :meth:`_decode_item_envelope`.
+    """
+    response = ResponsesAPIResponse(
+        id="chatcmpl-multi",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[
+            {"type": "message", "id": "chatcmpl-multi"},
+            {"type": "message", "id": "chatcmpl-multi"},
+            {"type": "message", "id": "chatcmpl-multi"},
+        ],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-multi",
+        custom_llm_provider="hosted_vllm",
+        model_id=None,
+    )
+    ids = [item["id"] for item in encoded.output]
+    assert len(set(ids)) == 3
+    for new_id in ids:
+        assert new_id.startswith("msg_")
+        resp_form = ResponsesAPIRequestUtils._decode_item_envelope(new_id)
+        decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+            resp_form
+        )
+        assert decoded["response_id"] == "chatcmpl-multi"
 
 
 def test_envelope_encode_leaves_function_call_items_untouched():

--- a/tests/test_litellm/responses/test_item_envelope_encoding.py
+++ b/tests/test_litellm/responses/test_item_envelope_encoding.py
@@ -1,0 +1,249 @@
+"""Tests for envelope-encoded output item IDs in Responses API responses.
+
+When the Responses API bridge fronts a chat-completions provider, message
+output items historically inherit the upstream ``chatcmpl-*`` id from the
+chat-completion response. Clients that follow the OpenAI Responses spec
+expect typed prefixes (``msg_*``, ``rs_*``) and break when they receive an
+``chatcmpl-*`` id (e.g. Vercel AI SDK 6.x "text part {id} not found").
+
+These tests cover the envelope codec helpers and the integration into
+``_update_responses_api_response_id_with_model_id``.
+"""
+
+from litellm.responses.utils import ResponsesAPIRequestUtils
+from litellm.types.llms.openai import ResponsesAPIResponse
+
+
+# ---------------------------------------------------------------------------
+# Envelope codec (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_round_trip_chatcmpl_id():
+    raw = "chatcmpl-abc123"
+    envelope = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="msg",
+        custom_llm_provider="hosted_vllm",
+        model_id="m-1",
+    )
+    assert envelope.startswith("msg_")
+    decoded_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(envelope)
+    assert decoded_resp_form is not None
+    assert decoded_resp_form.startswith("resp_")
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        decoded_resp_form
+    )
+    assert decoded["response_id"] == raw
+    assert decoded["custom_llm_provider"] == "hosted_vllm"
+    assert decoded["model_id"] == "m-1"
+
+
+def test_encode_decode_round_trip_reasoning_prefix():
+    raw = "chatcmpl-xyz789"
+    envelope = ResponsesAPIRequestUtils._encode_item_envelope(
+        raw,
+        prefix="rs",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert envelope.startswith("rs_")
+    decoded_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(envelope)
+    assert decoded_resp_form is not None
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        decoded_resp_form
+    )
+    assert decoded["response_id"] == raw
+
+
+def test_decode_item_envelope_returns_none_for_missing_prefix():
+    assert ResponsesAPIRequestUtils._decode_item_envelope("chatcmpl-abc") is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("encitem_abc") is None
+    assert ResponsesAPIRequestUtils._decode_item_envelope("resp_abc") is None
+
+
+def test_decode_item_envelope_returns_none_for_empty_input():
+    assert ResponsesAPIRequestUtils._decode_item_envelope("") is None
+
+
+def test_decode_item_envelope_empty_payload_is_resp_passthrough():
+    """A ``msg_`` prefix with no payload decodes to ``resp_``, which the
+    response-id decoder treats as raw passthrough rather than crashing.
+    """
+    result = ResponsesAPIRequestUtils._decode_item_envelope("msg_")
+    assert result == "resp_"
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(result)
+    assert decoded["custom_llm_provider"] is None
+    assert decoded["model_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# _envelope_encode_output_item_ids
+# ---------------------------------------------------------------------------
+
+
+def _resp_with_message_id(message_id: str) -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="chatcmpl-abc",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[{"type": "message", "id": message_id}],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+
+
+def test_envelope_encode_rewrites_chatcmpl_message_id():
+    response = _resp_with_message_id("chatcmpl-abc")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider="hosted_vllm",
+        model_id=None,
+    )
+    new_id = encoded.output[0]["id"]
+    assert new_id.startswith("msg_")
+    # Verify round-trip
+    resp_form = ResponsesAPIRequestUtils._decode_item_envelope(new_id)
+    decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(resp_form)
+    assert decoded["response_id"] == "chatcmpl-abc"
+
+
+def test_envelope_encode_skips_already_prefixed_message_id():
+    response = _resp_with_message_id("msg_existing")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "msg_existing"
+
+
+def test_envelope_encode_skips_rs_prefixed_message_id():
+    response = _resp_with_message_id("rs_hash123")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "rs_hash123"
+
+
+def test_envelope_encode_skips_encitem_prefixed_message_id():
+    response = _resp_with_message_id("encitem_abc123")
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "encitem_abc123"
+
+
+def test_envelope_encode_leaves_function_call_items_untouched():
+    """function_call items keep their call_id-based id."""
+    response = ResponsesAPIResponse(
+        id="chatcmpl-abc",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[
+            {"type": "function_call", "id": "chatcmpl-fc", "call_id": "call_xyz"},
+            {"type": "message", "id": "chatcmpl-abc"},
+        ],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output[0]["id"] == "chatcmpl-fc"
+    assert encoded.output[1]["id"].startswith("msg_")
+
+
+def test_envelope_encode_handles_empty_output():
+    response = ResponsesAPIResponse(
+        id="chatcmpl-abc",
+        object="response",
+        created_at=0,
+        model="hosted_vllm/test-model",
+        output=[],
+        parallel_tool_calls=False,
+        temperature=0,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text={},
+        truncation=None,
+        usage=None,
+        user=None,
+    )
+    encoded = ResponsesAPIRequestUtils._envelope_encode_output_item_ids(
+        response=response,
+        raw_response_id="chatcmpl-abc",
+        custom_llm_provider=None,
+        model_id=None,
+    )
+    assert encoded.output == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: _update_responses_api_response_id_with_model_id
+# ---------------------------------------------------------------------------
+
+
+def test_update_responses_api_response_id_rewrites_message_item_id():
+    """The full update_responses_api_response_id flow wraps both the top-level
+    response.id AND each message item id whose value is a raw chatcmpl-* form.
+    """
+    response = _resp_with_message_id("chatcmpl-abc")
+    updated = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+        responses_api_response=response,
+        custom_llm_provider="hosted_vllm",
+        litellm_metadata={"model_info": {"id": "deploy-1"}},
+    )
+    assert updated.id.startswith("resp_")
+    assert updated.output[0]["id"].startswith("msg_")
+    # The message id and the response id encode the SAME response_id payload
+    msg_resp_form = ResponsesAPIRequestUtils._decode_item_envelope(
+        updated.output[0]["id"]
+    )
+    msg_decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        msg_resp_form
+    )
+    resp_decoded = ResponsesAPIRequestUtils._decode_responses_api_response_id(
+        updated.id
+    )
+    assert msg_decoded["response_id"] == resp_decoded["response_id"] == "chatcmpl-abc"


### PR DESCRIPTION
## Relevant issues

- Fixes #26167 — Responses API bridged backend (Anthropic) multi-turn tool calls fail
- Fixes #26529 — OpenAI-proxy streaming for Claude breaks AI SDK 6.x multi-step tool calls

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — 13 new unit + integration tests in `test_item_reference_resolver.py`
- [x] My PR passes all unit tests — `tests/test_litellm/responses/litellm_completion_transformation/` (105 tests) green locally
- [x] My PR's scope is as isolated as possible — single resolver + strip helper + one wire-in point
- [ ] Greptile review pending

## ⚠️ Stacked on #28692 — read this first

**This PR is stacked on #28692** and uses `ResponsesAPIRequestUtils._decode_item_envelope` introduced there. My branch is based on `feat/responses-bridge-envelope-item-ids`, so the GitHub diff against `main` includes both #28692's files (`responses/utils.py`, `test_item_envelope_encoding.py`) AND this PR's own files (`handler.py`, `test_item_reference_resolver.py`). The new work in *this* PR is just the latter two.

**Recommended merge path:**

1. Review and merge #28692 (smaller, foundational).
2. I will rebase this branch onto `main`; the GitHub diff will then collapse to the two files unique to this PR.

If you prefer one bundled PR I am happy to close this and push the combined diff onto #28692 — they were originally separated to keep each scope-isolated, but they were always intended to merge together.

## Type

🆕 New Feature (fixes spec-compat regression for Vercel `@ai-sdk/openai`)

## Changes

### Problem

When Vercel `@ai-sdk/openai` clients run with the default `store: true`, they send prior turn items as opaque `item_reference` entries instead of inlining their content:

```jsonc
{
  "input": [
    {"type": "item_reference", "id": "rs_<envelope>"},  // prior reasoning
    {"type": "item_reference", "id": "msg_<envelope>"}, // prior message
    {"role": "user", "content": "next message"}
  ]
}
```

The bridge previously dropped these references silently (the input transformer falls into the `else` branch and returns `[]` because `item_reference` has no `content`). The conversation degrades to a single-turn fresh request and users observe the assistant losing context across turns.

### Solution

Two pure helpers in `handler.py`:

- `_resolve_item_references_to_previous_response_id(request_input)` — scans the input list for `item_reference` entries, decodes each `rs_*`/`msg_*` envelope via `ResponsesAPIRequestUtils._decode_item_envelope` (from #28692), and returns the most recent decodable id in the `resp_<env>` form that `async_responses_api_session_handler` already accepts.
- `_strip_item_references(request_input)` — filters out `item_reference` entries so the standard message transformer does not see opaque references it cannot inline.

Wired into `async_response_api_handler` before the existing `previous_response_id` block:

```python
if not previous_response_id:
    resolved = _resolve_item_references_to_previous_response_id(request_input)
    if resolved:
        previous_response_id = resolved
        request_input = _strip_item_references(request_input)
        litellm_completion_request["messages"] = transform_responses_api_input_to_messages(...)

if previous_response_id:
    # existing session handler rebuilds conversation from SpendLogs
    ...
```

An explicit `previous_response_id` from the caller still wins (the resolver only runs when the field is absent), so existing semantics are preserved.

### Tests

`tests/test_litellm/responses/litellm_completion_transformation/test_item_reference_resolver.py` — 13 tests:

- **Resolver pure logic** (6): string-input passthrough, no-references returns None, `msg_` envelope decoded, `rs_` envelope decoded, most-recent reference wins on multiple, malformed envelopes return None.
- **Strip helper** (4): removes only `item_reference` entries, string passthrough, None passthrough, returns empty list when all entries are references.
- **Handler integration** (3): resolution success path delegates to existing session handler with the decoded id; explicit `previous_response_id` wins over references; no-references-no-id passthrough does NOT call the session handler.

### Out of scope

- **`NotFoundError` graceful fallback when an `item_reference` resolves to a deleted session.** The existing `previous_response_id` flow raises if the session lookup misses; for envelope-derived ids this could leak via timing/eviction. A follow-up PR will catch and fall back to first-turn behavior. Left out to keep this PR's scope tight.
- **Tool-call-id JSONB fallback for orphan `function_call_output` items.** Some SDK versions emit `function_call_output` without an `item_reference` to the parent assistant turn; resolving via raw JSONB lookup against `LiteLLM_SpendLogs.response.choices[0].message.tool_calls` is another follow-up. Left out because it introduces raw SQL that should be reviewed in isolation.
