### PR TITLE
[Fix] Responses bridge: normalize function tools and drop unsupported tool types

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -10,10 +10,28 @@ from openai.types.responses.response_create_params import ResponseInputParam
 from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
 
+from litellm._logging import verbose_logger
 from litellm.caching import InMemoryCache
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
+)
+
+
+# Responses-API-only tool types that have no Chat Completions equivalent.
+# Downstream chat-completions providers (DeepSeek, GLM/Z.AI, MiniMax, ...) reject
+# them with "unknown variant" errors. The bridge drops them so the surrounding
+# `function` and `mcp` tools still reach the provider.
+_RESPONSES_ONLY_TOOL_TYPES: frozenset = frozenset(
+    {
+        "custom",
+        "shell",
+        "file_search",
+        "code_interpreter",
+        "image_generation",
+        "computer_use_preview",
+        "local_shell",
+    }
 )
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -1366,17 +1384,42 @@ class LiteLLMCompletionResponsesConfig:
                 )
             elif tool.get("type") == "function":
                 typed_tool = cast(FunctionToolParam, tool)
+                # Function tools arrive in two shapes:
+                #   Responses-API spec: ``{"type": "function", "name": ..., "parameters": ...}``
+                #   Chat-Completion-nested (Codex / Vercel SDK): ``{"type": "function",
+                #       "function": {"name": ..., "parameters": ...}}``
+                # Read each field from the top level, falling back to the nested
+                # ``function`` object so we never lose the name / parameters
+                # depending on which shape the caller sent.
+                nested_function: Dict[str, Any] = (
+                    typed_tool.get("function")  # type: ignore[assignment]
+                    if isinstance(typed_tool.get("function"), dict)
+                    else {}
+                )
+                name = typed_tool.get("name") or nested_function.get("name") or ""
+                description = (
+                    typed_tool.get("description")
+                    or nested_function.get("description")
+                    or ""
+                )
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
-                parameters = dict(typed_tool.get("parameters", {}) or {})
+                parameters = dict(
+                    typed_tool.get("parameters")
+                    or nested_function.get("parameters")
+                    or {}
+                )
                 if not parameters or "type" not in parameters:
                     parameters["type"] = "object"
+                strict = typed_tool.get("strict")
+                if strict is None:
+                    strict = nested_function.get("strict")
                 chat_completion_tool: Dict[str, Any] = {
                     "type": "function",
                     "function": {
-                        "name": typed_tool.get("name") or "",
-                        "description": typed_tool.get("description") or "",
+                        "name": name,
+                        "description": description,
                         "parameters": parameters,
-                        "strict": typed_tool.get("strict", False) or False,
+                        "strict": bool(strict) if strict is not None else False,
                     },
                 }
                 if tool.get("cache_control"):
@@ -1389,6 +1432,18 @@ class LiteLLMCompletionResponsesConfig:
                     chat_completion_tool["input_examples"] = tool.get("input_examples")  # type: ignore
                 chat_completion_tools.append(
                     cast(ChatCompletionToolParam, chat_completion_tool)
+                )
+            elif tool.get("type") in _RESPONSES_ONLY_TOOL_TYPES:
+                # Responses-API-only tool types (custom, shell, file_search,
+                # code_interpreter, image_generation, computer_use_preview,
+                # local_shell) have no Chat Completions equivalent. Downstream
+                # providers (DeepSeek, GLM/Z.AI, MiniMax) reject them with
+                # ``unknown variant``. Drop them silently with a debug log;
+                # the assistant simply will not have access to those tools.
+                verbose_logger.debug(
+                    "responses-bridge: dropping unsupported tool type '%s' "
+                    "with no Chat Completions equivalent",
+                    tool.get("type"),
                 )
             else:
                 chat_completion_tools.append(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -16,23 +16,6 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
 )
-
-
-# Responses-API-only tool types that have no Chat Completions equivalent.
-# Downstream chat-completions providers (DeepSeek, GLM/Z.AI, MiniMax, ...) reject
-# them with "unknown variant" errors. The bridge drops them so the surrounding
-# `function` and `mcp` tools still reach the provider.
-_RESPONSES_ONLY_TOOL_TYPES: frozenset = frozenset(
-    {
-        "custom",
-        "shell",
-        "file_search",
-        "code_interpreter",
-        "image_generation",
-        "computer_use_preview",
-        "local_shell",
-    }
-)
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionImageObject,
@@ -77,6 +60,22 @@ from litellm.types.utils import (
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
+
+# Responses-API-only tool types that have no Chat Completions equivalent.
+# Downstream chat-completions providers (DeepSeek, GLM/Z.AI, MiniMax, ...) reject
+# them with "unknown variant" errors. The bridge drops them so the surrounding
+# `function` and `mcp` tools still reach the provider.
+_RESPONSES_ONLY_TOOL_TYPES: frozenset = frozenset(
+    {
+        "custom",
+        "shell",
+        "file_search",
+        "code_interpreter",
+        "image_generation",
+        "computer_use_preview",
+        "local_shell",
+    }
+)
 
 
 class ChatCompletionSession(TypedDict, total=False):
@@ -1438,9 +1437,10 @@ class LiteLLMCompletionResponsesConfig:
                 # code_interpreter, image_generation, computer_use_preview,
                 # local_shell) have no Chat Completions equivalent. Downstream
                 # providers (DeepSeek, GLM/Z.AI, MiniMax) reject them with
-                # ``unknown variant``. Drop them silently with a debug log;
-                # the assistant simply will not have access to those tools.
-                verbose_logger.debug(
+                # ``unknown variant``. Drop them with an info-level log so
+                # operators can see the loss in production without raising
+                # the verbose-logger threshold.
+                verbose_logger.info(
                     "responses-bridge: dropping unsupported tool type '%s' "
                     "with no Chat Completions equivalent",
                     tool.get("type"),

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1268,6 +1268,90 @@ class TestToolTransformation:
         assert "properties" in result_tool["function"]["parameters"]
         assert result_tool["function"]["parameters"]["properties"]["arg"]["type"] == "string"
 
+    def test_transform_function_tool_with_chat_completion_nested_shape(self):
+        """Codex / Vercel AI SDK send function tools in chat-completion form:
+        ``{"type": "function", "function": {"name": ..., ...}}``. The bridge
+        must read the name from the nested ``function`` object, not only from
+        the top level.
+        """
+        nested_tool = {
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+                "strict": True,
+            },
+        }
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[nested_tool]
+        )
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["type"] == "function"
+        assert result_tool["function"]["name"] == "read"
+        assert result_tool["function"]["description"] == "read a file"
+        assert result_tool["function"]["parameters"]["properties"]["path"]["type"] == "string"
+        assert result_tool["function"]["strict"] is True
+
+    def test_transform_function_tool_prefers_top_level_name_over_nested(self):
+        """If both top-level and nested names are present, top-level wins
+        (matches the OpenAI Responses spec FunctionToolParam shape)."""
+        tool = {
+            "type": "function",
+            "name": "top_level_name",
+            "function": {"name": "nested_name"},
+            "parameters": {"type": "object"},
+        }
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[tool]
+        )
+        assert result_tools[0]["function"]["name"] == "top_level_name"
+
+    def test_transform_drops_responses_only_tool_types(self):
+        """Tool types that exist only in the Responses API (custom, shell,
+        file_search, code_interpreter, image_generation,
+        computer_use_preview, local_shell) have no Chat Completions
+        equivalent and are rejected by downstream providers (DeepSeek,
+        GLM/Z.AI, MiniMax). The bridge drops them so the surrounding
+        ``function`` and ``mcp`` tools still reach the provider.
+        """
+        tools = [
+            {"type": "custom", "name": "shell", "description": "run shell"},
+            {"type": "shell", "name": "exec"},
+            {"type": "file_search"},
+            {"type": "code_interpreter"},
+            {"type": "image_generation"},
+            {"type": "computer_use_preview"},
+            {"type": "local_shell"},
+            {
+                "type": "function",
+                "name": "kept",
+                "parameters": {"type": "object"},
+            },
+        ]
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        assert len(result_tools) == 1
+        assert result_tools[0]["type"] == "function"
+        assert result_tools[0]["function"]["name"] == "kept"
+
+    def test_transform_preserves_unrecognized_types_for_pass_through(self):
+        """Tools without an explicit ``type`` (e.g. Vertex AI
+        ``{"code_execution": {}}``) continue to pass through as-is.
+        Only the explicit Responses-API-only types are dropped."""
+        vertex_tool = {"code_execution": {}}
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[vertex_tool]
+        )
+        assert len(result_tools) == 1
+        assert result_tools[0] == vertex_tool
+
 
 class TestUsageTransformation:
     """Test cases for usage transformation from Chat Completion to Responses API format"""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1352,6 +1352,39 @@ class TestToolTransformation:
         assert len(result_tools) == 1
         assert result_tools[0] == vertex_tool
 
+    def test_transform_function_tool_nested_strict_falls_back_when_top_level_missing(
+        self,
+    ):
+        """When the top-level lacks ``strict`` and the nested ``function`` object
+        provides it, the nested value is used."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "fn",
+                "parameters": {"type": "object"},
+                "strict": True,
+            },
+        }
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[tool]
+        )
+        assert result_tools[0]["function"]["strict"] is True
+
+    def test_transform_function_tool_with_explicit_strict_false_top_level(self):
+        """An explicit top-level ``strict=False`` is honoured (not overridden by
+        a nested ``strict=True``)."""
+        tool = {
+            "type": "function",
+            "name": "fn",
+            "parameters": {"type": "object"},
+            "strict": False,
+            "function": {"strict": True},
+        }
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=[tool]
+        )
+        assert result_tools[0]["function"]["strict"] is False
+
 
 class TestUsageTransformation:
     """Test cases for usage transformation from Chat Completion to Responses API format"""


### PR DESCRIPTION
## Relevant issues

- Fixes #27276 — Responses API → Chat Completions bridge drops tool names and forwards unsupported tool types (custom, shell)

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — 4 new tests in `TestToolTransformation`
- [x] My PR passes all unit tests — `TestToolTransformation` (18 tests, 14 existing + 4 new) green locally
- [x] My PR's scope is as isolated as possible — single transform function, two narrowly-scoped bug fixes
- [ ] Greptile review pending

## Type

🐛 Bug Fix

## Changes

### Problem

Two bugs in `transform_responses_api_tools_to_chat_completion_tools` break the bridge for real client payloads against non-OpenAI providers (DeepSeek, GLM/Z.AI, MiniMax):

**Bug 1 — Function tool names lost when nested under `function`.** Codex / Vercel AI SDK send function tools in chat-completion shape even on Responses API requests:

```jsonc
{"type": "function", "function": {"name": "read", "parameters": {...}}}
```

The bridge previously read `name` only from the top level:

```python
"name": typed_tool.get("name") or "",  # returns "" when name is nested under "function"
```

Downstream providers reject with `Invalid 'tools[0].function.name': empty string`.

**Bug 2 — Responses-API-only tool types forwarded as-is.** The fallback `else` branch passes unrecognized types through unchanged:

```python
else:
    chat_completion_tools.append(
        cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool)
    )
```

Tool types that exist only in the Responses API (`custom`, `shell`, `file_search`, `code_interpreter`, `image_generation`, `computer_use_preview`, `local_shell`) have no Chat Completions equivalent. Downstream providers reject them: `tools[0].type: unknown variant 'custom', expected 'function'`.

### Solution

**Bug 1 fix.** Read function tool fields from both the top level and the nested `function` object so both Responses API and Chat Completion shapes round-trip cleanly. Top level wins when both are populated (matches the spec `FunctionToolParam` shape):

```python
nested_function = typed_tool.get("function") if isinstance(typed_tool.get("function"), dict) else {}
name = typed_tool.get("name") or nested_function.get("name") or ""
description = typed_tool.get("description") or nested_function.get("description") or ""
parameters = dict(typed_tool.get("parameters") or nested_function.get("parameters") or {})
strict = typed_tool.get("strict")
if strict is None:
    strict = nested_function.get("strict")
```

**Bug 2 fix.** Drop tool entries whose `type` is in an explicit set of Responses-only types. Tools without a `type` field (Vertex AI `{"code_execution": {}}`, etc.) keep their pass-through behavior — only the explicit Responses-API-only types are dropped:

```python
_RESPONSES_ONLY_TOOL_TYPES = frozenset({
    "custom", "shell", "file_search", "code_interpreter",
    "image_generation", "computer_use_preview", "local_shell",
})

elif tool.get("type") in _RESPONSES_ONLY_TOOL_TYPES:
    verbose_logger.debug(
        "responses-bridge: dropping unsupported tool type '%s' ...", tool.get("type")
    )
else:
    chat_completion_tools.append(...)  # vertex / unknown pass-through unchanged
```

### Tests

`tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestToolTransformation` — 4 new tests:

- `test_transform_function_tool_with_chat_completion_nested_shape` — name/description/parameters/strict all read from nested `function` object when top level is empty.
- `test_transform_function_tool_prefers_top_level_name_over_nested` — top level wins when both populated (Responses API spec precedence).
- `test_transform_drops_responses_only_tool_types` — all 7 unsupported types dropped, surrounding `function` tool preserved.
- `test_transform_preserves_unrecognized_types_for_pass_through` — Vertex AI `{"code_execution": {}}` regression guard.

All 14 pre-existing `TestToolTransformation` tests still pass unchanged.
