### PR TITLE
fix(black_forest_labs): fix polling URL subdomain rejection and missing response transform args

### DIFF
--- a/litellm/llms/black_forest_labs/common_utils.py
+++ b/litellm/llms/black_forest_labs/common_utils.py
@@ -40,10 +40,10 @@ def assert_bfl_polling_url(polling_url: str) -> None:
     parsed = urlparse(polling_url)
     host = (parsed.hostname or "").lower()
 
-    if parsed.scheme not in ("https", "http"):
+    if parsed.scheme != "https":
         raise BlackForestLabsError(
             status_code=502,
-            message="Rejected polling URL: scheme is not allowed",
+            message="Rejected polling URL: scheme must be https",
         )
 
     if host != _BFL_REGISTERED_DOMAIN and not host.endswith(

--- a/litellm/llms/black_forest_labs/common_utils.py
+++ b/litellm/llms/black_forest_labs/common_utils.py
@@ -5,6 +5,7 @@ Common utilities, constants, and error handling for Black Forest Labs API.
 """
 
 from typing import Dict
+from urllib.parse import urlparse
 
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
@@ -17,6 +18,42 @@ class BlackForestLabsError(BaseLLMException):
 
 # API Constants
 DEFAULT_API_BASE = "https://api.bfl.ai"
+
+# BFL uses regional subdomains (e.g. gateway.bfl.ai) for polling URLs that
+# differ from the submission host (api.bfl.ai). We validate against the
+# registered domain rather than doing a strict same-origin check.
+_BFL_REGISTERED_DOMAIN = "bfl.ai"
+
+
+def assert_bfl_polling_url(polling_url: str) -> None:
+    """Validate that a polling URL points to a BFL-controlled host.
+
+    BFL returns polling URLs on subdomains like ``gateway.bfl.ai`` that differ
+    from the submission host ``api.bfl.ai``. A strict same-origin check would
+    reject these legitimate URLs. Instead we verify the host is ``bfl.ai`` or
+    any subdomain of it, which keeps the SSRF guarantee (credentials only go
+    to BFL-controlled infrastructure) without false-positives on regional hosts.
+
+    Raises:
+        BlackForestLabsError: If the polling URL scheme or host is not trusted.
+    """
+    parsed = urlparse(polling_url)
+    host = (parsed.hostname or "").lower()
+
+    if parsed.scheme not in ("https", "http"):
+        raise BlackForestLabsError(
+            status_code=502,
+            message="Rejected polling URL: scheme is not allowed",
+        )
+
+    if host != _BFL_REGISTERED_DOMAIN and not host.endswith(
+        "." + _BFL_REGISTERED_DOMAIN
+    ):
+        raise BlackForestLabsError(
+            status_code=502,
+            message="Rejected polling URL: host is not within the bfl.ai domain",
+        )
+
 
 # Polling configuration
 DEFAULT_POLLING_INTERVAL = 1.5  # seconds

--- a/litellm/llms/black_forest_labs/image_edit/handler.py
+++ b/litellm/llms/black_forest_labs/image_edit/handler.py
@@ -15,7 +15,10 @@ import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.url_utils import SSRFError, assert_same_origin
+from litellm.litellm_core_utils.url_utils import (
+    SSRFError,
+    assert_same_origin,
+)  # noqa: F401 — kept for other callers
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
@@ -29,6 +32,7 @@ from ..common_utils import (
     DEFAULT_MAX_POLLING_TIME,
     DEFAULT_POLLING_INTERVAL,
     BlackForestLabsError,
+    assert_bfl_polling_url,
 )
 from .transformation import BlackForestLabsImageEditConfig
 
@@ -332,16 +336,11 @@ class BlackForestLabsImageEdit:
                 message="No polling_url in BFL response",
             )
 
-        # Reject cross-origin polling URLs — the ``x-key`` auth header
-        # would otherwise leak to whatever URL the upstream returns.
-        # VERIA-51.
-        try:
-            assert_same_origin(polling_url, str(initial_response.request.url))
-        except SSRFError as ssrf_err:
-            raise BlackForestLabsError(
-                status_code=502,
-                message=f"Rejected polling URL: {ssrf_err}",
-            )
+        # Reject polling URLs that don't belong to BFL-controlled infrastructure.
+        # BFL uses regional subdomains (e.g. gateway.bfl.ai) that differ from the
+        # submission host (api.bfl.ai), so we validate against the registered
+        # domain rather than doing a strict same-origin check. VERIA-51.
+        assert_bfl_polling_url(polling_url)
 
         # Get just the auth header for polling
         polling_headers = {"x-key": headers.get("x-key", "")}
@@ -428,16 +427,11 @@ class BlackForestLabsImageEdit:
                 message="No polling_url in BFL response",
             )
 
-        # Reject cross-origin polling URLs — the ``x-key`` auth header
-        # would otherwise leak to whatever URL the upstream returns.
-        # VERIA-51.
-        try:
-            assert_same_origin(polling_url, str(initial_response.request.url))
-        except SSRFError as ssrf_err:
-            raise BlackForestLabsError(
-                status_code=502,
-                message=f"Rejected polling URL: {ssrf_err}",
-            )
+        # Reject polling URLs that don't belong to BFL-controlled infrastructure.
+        # BFL uses regional subdomains (e.g. gateway.bfl.ai) that differ from the
+        # submission host (api.bfl.ai), so we validate against the registered
+        # domain rather than doing a strict same-origin check. VERIA-51.
+        assert_bfl_polling_url(polling_url)
 
         # Get just the auth header for polling
         polling_headers = {"x-key": headers.get("x-key", "")}

--- a/litellm/llms/black_forest_labs/image_edit/handler.py
+++ b/litellm/llms/black_forest_labs/image_edit/handler.py
@@ -15,10 +15,6 @@ import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.url_utils import (
-    SSRFError,
-    assert_same_origin,
-)  # noqa: F401 — kept for other callers
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,

--- a/litellm/llms/black_forest_labs/image_generation/handler.py
+++ b/litellm/llms/black_forest_labs/image_generation/handler.py
@@ -15,7 +15,10 @@ import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.url_utils import SSRFError, assert_same_origin
+from litellm.litellm_core_utils.url_utils import (
+    SSRFError,
+    assert_same_origin,
+)  # noqa: F401 — kept for other callers
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
@@ -29,6 +32,7 @@ from ..common_utils import (
     DEFAULT_MAX_POLLING_TIME,
     DEFAULT_POLLING_INTERVAL,
     BlackForestLabsError,
+    assert_bfl_polling_url,
 )
 from .transformation import BlackForestLabsImageGenerationConfig
 
@@ -318,16 +322,11 @@ class BlackForestLabsImageGeneration:
                 message="No polling_url in BFL response",
             )
 
-        # Reject cross-origin polling URLs — the ``x-key`` auth header
-        # would otherwise leak to whatever URL the upstream returns.
-        # VERIA-51.
-        try:
-            assert_same_origin(polling_url, str(initial_response.request.url))
-        except SSRFError as ssrf_err:
-            raise BlackForestLabsError(
-                status_code=502,
-                message=f"Rejected polling URL: {ssrf_err}",
-            )
+        # Reject polling URLs that don't belong to BFL-controlled infrastructure.
+        # BFL uses regional subdomains (e.g. gateway.bfl.ai) that differ from the
+        # submission host (api.bfl.ai), so we validate against the registered
+        # domain rather than doing a strict same-origin check. VERIA-51.
+        assert_bfl_polling_url(polling_url)
 
         # Get just the auth header for polling
         polling_headers = {"x-key": headers.get("x-key", "")}
@@ -414,16 +413,11 @@ class BlackForestLabsImageGeneration:
                 message="No polling_url in BFL response",
             )
 
-        # Reject cross-origin polling URLs — the ``x-key`` auth header
-        # would otherwise leak to whatever URL the upstream returns.
-        # VERIA-51.
-        try:
-            assert_same_origin(polling_url, str(initial_response.request.url))
-        except SSRFError as ssrf_err:
-            raise BlackForestLabsError(
-                status_code=502,
-                message=f"Rejected polling URL: {ssrf_err}",
-            )
+        # Reject polling URLs that don't belong to BFL-controlled infrastructure.
+        # BFL uses regional subdomains (e.g. gateway.bfl.ai) that differ from the
+        # submission host (api.bfl.ai), so we validate against the registered
+        # domain rather than doing a strict same-origin check. VERIA-51.
+        assert_bfl_polling_url(polling_url)
 
         # Get just the auth header for polling
         polling_headers = {"x-key": headers.get("x-key", "")}

--- a/litellm/llms/black_forest_labs/image_generation/handler.py
+++ b/litellm/llms/black_forest_labs/image_generation/handler.py
@@ -176,6 +176,10 @@ class BlackForestLabsImageGeneration:
             raw_response=final_response,
             model_response=model_response,
             logging_obj=logging_obj,
+            request_data=data,
+            optional_params=optional_params,
+            litellm_params=litellm_params_dict,
+            encoding=None,
         )
 
     async def async_image_generation(
@@ -278,6 +282,10 @@ class BlackForestLabsImageGeneration:
             raw_response=final_response,
             model_response=model_response,
             logging_obj=logging_obj,
+            request_data=data,
+            optional_params=optional_params,
+            litellm_params=litellm_params_dict,
+            encoding=None,
         )
 
     def _poll_for_result_sync(

--- a/litellm/llms/black_forest_labs/image_generation/handler.py
+++ b/litellm/llms/black_forest_labs/image_generation/handler.py
@@ -15,10 +15,6 @@ import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.url_utils import (
-    SSRFError,
-    assert_same_origin,
-)  # noqa: F401 — kept for other callers
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,

--- a/tests/test_litellm/llms/black_forest_labs/test_bfl_common_utils.py
+++ b/tests/test_litellm/llms/black_forest_labs/test_bfl_common_utils.py
@@ -1,0 +1,66 @@
+"""
+Tests for Black Forest Labs common_utils — specifically assert_bfl_polling_url.
+
+BFL uses regional subdomains (e.g. gateway.bfl.ai) for polling URLs that
+differ from the submission host (api.bfl.ai). These tests verify that the
+domain-aware check accepts legitimate BFL subdomains while still rejecting
+off-domain URLs.
+"""
+
+import pytest
+
+from litellm.llms.black_forest_labs.common_utils import (
+    BlackForestLabsError,
+    assert_bfl_polling_url,
+)
+
+
+class TestAssertBflPollingUrl:
+    # --- should pass ---
+
+    def test_exact_registered_domain(self):
+        assert_bfl_polling_url("https://bfl.ai/v1/get_result?id=abc")
+
+    def test_api_subdomain(self):
+        assert_bfl_polling_url("https://api.bfl.ai/v1/get_result?id=abc")
+
+    def test_gateway_subdomain(self):
+        # BFL uses gateway.bfl.ai for polling — this was the original bug trigger
+        assert_bfl_polling_url("https://gateway.bfl.ai/v1/get_result?id=abc")
+
+    def test_regional_subdomain(self):
+        assert_bfl_polling_url("https://eu.api.bfl.ai/v1/get_result?id=abc")
+
+    def test_deep_subdomain(self):
+        assert_bfl_polling_url("https://region.gateway.bfl.ai/poll?id=xyz")
+
+    def test_http_scheme_allowed(self):
+        # http is permitted (not ideal, but matches allowed_schemes in url_utils)
+        assert_bfl_polling_url("http://api.bfl.ai/v1/get_result?id=abc")
+
+    # --- should raise BlackForestLabsError ---
+
+    def test_rejects_off_domain(self):
+        with pytest.raises(BlackForestLabsError, match="host is not within"):
+            assert_bfl_polling_url("https://evil.com/steal-key")
+
+    def test_rejects_lookalike_domain(self):
+        with pytest.raises(BlackForestLabsError, match="host is not within"):
+            assert_bfl_polling_url("https://notbfl.ai/v1/get_result?id=abc")
+
+    def test_rejects_bfl_ai_as_suffix_only(self):
+        # "fakebfl.ai" must not match — the check is on registered domain boundary
+        with pytest.raises(BlackForestLabsError, match="host is not within"):
+            assert_bfl_polling_url("https://fakebfl.ai/v1/get_result?id=abc")
+
+    def test_rejects_bfl_in_path(self):
+        with pytest.raises(BlackForestLabsError, match="host is not within"):
+            assert_bfl_polling_url("https://evil.com/bfl.ai/steal")
+
+    def test_rejects_ftp_scheme(self):
+        with pytest.raises(BlackForestLabsError, match="scheme is not allowed"):
+            assert_bfl_polling_url("ftp://api.bfl.ai/v1/get_result?id=abc")
+
+    def test_rejects_javascript_scheme(self):
+        with pytest.raises(BlackForestLabsError, match="scheme is not allowed"):
+            assert_bfl_polling_url("javascript://api.bfl.ai/alert(1)")

--- a/tests/test_litellm/llms/black_forest_labs/test_bfl_common_utils.py
+++ b/tests/test_litellm/llms/black_forest_labs/test_bfl_common_utils.py
@@ -4,7 +4,7 @@ Tests for Black Forest Labs common_utils — specifically assert_bfl_polling_url
 BFL uses regional subdomains (e.g. gateway.bfl.ai) for polling URLs that
 differ from the submission host (api.bfl.ai). These tests verify that the
 domain-aware check accepts legitimate BFL subdomains while still rejecting
-off-domain URLs.
+off-domain and non-HTTPS URLs.
 """
 
 import pytest
@@ -34,11 +34,12 @@ class TestAssertBflPollingUrl:
     def test_deep_subdomain(self):
         assert_bfl_polling_url("https://region.gateway.bfl.ai/poll?id=xyz")
 
-    def test_http_scheme_allowed(self):
-        # http is permitted (not ideal, but matches allowed_schemes in url_utils)
-        assert_bfl_polling_url("http://api.bfl.ai/v1/get_result?id=abc")
-
     # --- should raise BlackForestLabsError ---
+
+    def test_rejects_http_scheme(self):
+        # HTTP must be rejected — x-key would be forwarded in plaintext
+        with pytest.raises(BlackForestLabsError, match="scheme must be https"):
+            assert_bfl_polling_url("http://api.bfl.ai/v1/get_result?id=abc")
 
     def test_rejects_off_domain(self):
         with pytest.raises(BlackForestLabsError, match="host is not within"):
@@ -58,9 +59,9 @@ class TestAssertBflPollingUrl:
             assert_bfl_polling_url("https://evil.com/bfl.ai/steal")
 
     def test_rejects_ftp_scheme(self):
-        with pytest.raises(BlackForestLabsError, match="scheme is not allowed"):
+        with pytest.raises(BlackForestLabsError, match="scheme must be https"):
             assert_bfl_polling_url("ftp://api.bfl.ai/v1/get_result?id=abc")
 
     def test_rejects_javascript_scheme(self):
-        with pytest.raises(BlackForestLabsError, match="scheme is not allowed"):
+        with pytest.raises(BlackForestLabsError, match="scheme must be https"):
             assert_bfl_polling_url("javascript://api.bfl.ai/alert(1)")


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

1. Polling URL mismatch error for flux model with BFL provider:
```
{
	"error": {
		"message": "litellm.APIConnectionError: Black_forest_labsException - Rejected polling URL: Origin mismatch on host. Received Model Group=flux-pro\nAvailable Model Group Fallbacks=None",
		"type": null,
		"param": null,
		"code": "500"
	}
}
```

BFL official request/response screenshot where it returned polling url with having diff. regional sub domain:

<img width="1549" height="372" alt="image" src="https://github.com/user-attachments/assets/55d6e5ef-deae-4756-891b-c481f8f89b16" />
 
2. After polling url mismatch fix error of transform_image_generation_response missing fields.

```
{
	"error": {
		"message": "litellm.APIConnectionError: BlackForestLabsImageGenerationConfig.transform_image_generation_response() missing 4 required positional arguments: 'request_data', 'optional_params', 'litellm_params', and 'encoding'\nTraceback (most recent call last):\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/images/main.py\", line 127, in aimage_generation\n    response = await init_response  # type: ignore\n               ^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/llms/black_forest_labs/image_generation/handler.py\", line 272, in async_image_generation\n    return self.config.transform_image_generation_response(\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        model=model,\n        ^^^^^^^^^^^^\n    ...<2 lines>...\n        logging_obj=logging_obj,\n        ^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\nTypeError: BlackForestLabsImageGenerationConfig.transform_image_generation_response() missing 4 required positional arguments: 'request_data', 'optional_params', 'litellm_params', and 'encoding'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/router.py\", line 6032, in async_function_with_retries\n    response = await self.make_call(original_function, *args, **kwargs)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/router.py\", line 6200, in make_call\n    response = await response\n               ^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/router.py\", line 3428, in _aimage_generation\n    raise e\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/router.py\", line 3415, in _aimage_generation\n    response = await response\n               ^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/utils.py\", line 2099, in wrapper_async\n    raise e\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/utils.py\", line 1898, in wrapper_async\n    result = await original_function(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/images/main.py\", line 137, in aimage_generation\n    raise exception_type(\n          ~~~~~~~~~~~~~~^\n        model=model,\n        ^^^^^^^^^^^^\n    ...<3 lines>...\n        extra_kwargs=kwargs,\n        ^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 2466, in exception_type\n    raise e\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 2441, in exception_type\n    raise APIConnectionError(\n    ...<9 lines>...\n    )\nlitellm.exceptions.APIConnectionError: litellm.APIConnectionError: BlackForestLabsImageGenerationConfig.transform_image_generation_response() missing 4 required positional arguments: 'request_data', 'optional_params', 'litellm_params', and 'encoding'\nTraceback (most recent call last):\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/images/main.py\", line 127, in aimage_generation\n    response = await init_response  # type: ignore\n               ^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/llms/black_forest_labs/image_generation/handler.py\", line 272, in async_image_generation\n    return self.config.transform_image_generation_response(\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        model=model,\n        ^^^^^^^^^^^^\n    ...<2 lines>...\n        logging_obj=logging_obj,\n        ^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\nTypeError: BlackForestLabsImageGenerationConfig.transform_image_generation_response() missing 4 required positional arguments: 'request_data', 'optional_params', 'litellm_params', and 'encoding'\n\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/images/main.py\", line 127, in aimage_generation\n    response = await init_response  # type: ignore\n               ^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.13/site-packages/litellm/llms/black_forest_labs/image_generation/handler.py\", line 272, in async_image_generation\n    return self.config.transform_image_generation_response(\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        model=model,\n        ^^^^^^^^^^^^\n    ...<2 lines>...\n        logging_obj=logging_obj,\n        ^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\nTypeError: BlackForestLabsImageGenerationConfig.transform_image_generation_response() missing 4 required positional arguments: 'request_data', 'optional_params', 'litellm_params', and 'encoding'\n. Received Model Group=flux-pro\nAvailable Model Group Fallbacks=None",
		"type": null,
		"param": null,
		"code": "500"
	}
}
```
After all Fix:
<img width="1550" height="856" alt="image" src="https://github.com/user-attachments/assets/7013cffa-9970-4cec-84f9-25610f5497f4" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

## Summary

  Fixes two bugs that prevented Black Forest Labs image generation from working end-to-end in the LiteLLM proxy.

  ### Bug 1 — Polling URL rejected on valid BFL subdomains

  **File:** `litellm/llms/black_forest_labs/common_utils.py`, `image_generation/handler.py`, `image_edit/handler.py`

  BFL's API submits jobs to `api.bfl.ai` but returns a `polling_url` on  a different subdomain (e.g. `gateway.bfl.ai`). The existing code called  `assert_same_origin(polling_url, initial_request_url)` which enforces  **exact host equality** — so `api.bfl.ai != gateway.bfl.ai` and every  request failed immediately after submission with:

  Black_forest_labsException - Rejected polling URL: Origin mismatch on host

  **Fix:** Added `assert_bfl_polling_url()` in `common_utils.py` that validates the host is `bfl.ai` or any subdomain of it (`*.bfl.ai`).  The SSRF protection from VERIA-51 is preserved — the `x-key` header  can only be forwarded to BFL-controlled infrastructure. The check is  now on the registered domain boundary rather than an exact host match.

  ### Bug 2 — `transform_image_generation_response` called with missing args

  **File:** `litellm/llms/black_forest_labs/image_generation/handler.py`

  Both the sync and async paths called:
  ```python
  self.config.transform_image_generation_response(
      model=model,
      raw_response=final_response,
      model_response=model_response,
      logging_obj=logging_obj,
  )
```

But the method signature (inherited from BaseImageGenerationConfig) requires 4 additional positional arguments: request_data, optional_params, litellm_params, encoding. This raised a TypeError after successful polling, meaning no image was ever returned even if the BFL job completed successfully.

Fix: Both call sites now pass the missing args — data, optional_params, litellm_params_dict (all already in scope at that point), and encoding=None.