### PR TITLE
fix(fireworks_ai): recursively strip unsupported JSON Schema fields from tool params

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -208,6 +208,33 @@ class FireworksAIConfig(OpenAIGPTConfig):
                 content["image_url"]["url"] = f"{url}#transform=inline"
         return content
 
+    @staticmethod
+    def _sanitize_tool_schema(node: Any) -> Any:
+        """Recursively strip JSON Schema keys that Fireworks AI's tool-parameter
+        validator rejects.
+
+        Fireworks rejects ``title`` anywhere in a tool's parameter schema and
+        rejects ``default`` when its value is ``None`` (Pydantic emits both by
+        default). The drop_params flag only strips top-level OpenAI params, not
+        nested fields inside tool schemas, so callers using Pydantic-generated
+        tool schemas (e.g. via MCP servers like Coralogix / DevRev) hit a 400:
+
+            JSON Schema not supported: could not understand the instance
+            {'default': None, 'title': 'Page Size'}
+
+        This helper walks the schema and removes those keys while preserving
+        non-null defaults and every other field.
+        """
+        if isinstance(node, dict):
+            return {
+                k: FireworksAIConfig._sanitize_tool_schema(v)
+                for k, v in node.items()
+                if k != "title" and not (k == "default" and v is None)
+            }
+        if isinstance(node, list):
+            return [FireworksAIConfig._sanitize_tool_schema(item) for item in node]
+        return node
+
     def _transform_tools(
         self, tools: List[OpenAIChatCompletionToolParam]
     ) -> List[OpenAIChatCompletionToolParam]:
@@ -219,6 +246,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
             params = function.get("parameters")
             if isinstance(params, dict):
                 unpack_legacy_defs(params)
+                function["parameters"] = self._sanitize_tool_schema(params)
         return tools
 
     def _transform_messages_helper(

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_schema_sanitize.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_schema_sanitize.py
@@ -1,0 +1,182 @@
+"""Tests for FireworksAIConfig tool-schema sanitization.
+
+Covers the regression where Fireworks AI rejects tool parameter schemas
+containing ``title`` or ``default: None`` (both auto-emitted by Pydantic) with
+a 400 "JSON Schema not supported" error. See issues #27821 and #28149.
+"""
+
+import copy
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.fireworks_ai.chat.transformation import FireworksAIConfig
+
+# --- _sanitize_tool_schema unit cases --------------------------------------
+
+
+def test_sanitize_strips_top_level_title():
+    schema = {"title": "PageRequest", "type": "object"}
+    assert FireworksAIConfig._sanitize_tool_schema(schema) == {"type": "object"}
+
+
+def test_sanitize_strips_default_none_only_keeps_other_defaults():
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer", "default": None},
+            "b": {"type": "integer", "default": 10},
+            "c": {"type": "string", "default": ""},
+        },
+    }
+    out = FireworksAIConfig._sanitize_tool_schema(schema)
+    assert "default" not in out["properties"]["a"]
+    assert out["properties"]["b"]["default"] == 10
+    # empty string is a legitimate non-null default and must survive
+    assert out["properties"]["c"]["default"] == ""
+
+
+def test_sanitize_recurses_into_nested_properties():
+    schema = {
+        "type": "object",
+        "properties": {
+            "page": {
+                "type": "object",
+                "title": "Page",
+                "properties": {
+                    "page_size": {
+                        "default": None,
+                        "title": "Page Size",
+                        "type": "integer",
+                    },
+                },
+            }
+        },
+    }
+    out = FireworksAIConfig._sanitize_tool_schema(schema)
+    assert "title" not in out["properties"]["page"]
+    assert "title" not in out["properties"]["page"]["properties"]["page_size"]
+    assert "default" not in out["properties"]["page"]["properties"]["page_size"]
+    assert out["properties"]["page"]["properties"]["page_size"]["type"] == "integer"
+
+
+def test_sanitize_recurses_into_array_items():
+    schema = {
+        "type": "array",
+        "items": {"type": "object", "title": "Item", "properties": {}},
+    }
+    out = FireworksAIConfig._sanitize_tool_schema(schema)
+    assert "title" not in out["items"]
+
+
+@pytest.mark.parametrize("keyword", ["anyOf", "allOf", "oneOf"])
+def test_sanitize_recurses_into_composition_keywords(keyword):
+    schema = {
+        keyword: [
+            {"type": "string", "title": "StringVariant"},
+            {"type": "integer", "default": None},
+        ]
+    }
+    out = FireworksAIConfig._sanitize_tool_schema(schema)
+    assert "title" not in out[keyword][0]
+    assert "default" not in out[keyword][1]
+    assert out[keyword][0]["type"] == "string"
+    assert out[keyword][1]["type"] == "integer"
+
+
+def test_sanitize_passthrough_for_non_container_values():
+    # Strings, ints, None should pass through unchanged
+    assert FireworksAIConfig._sanitize_tool_schema("hello") == "hello"
+    assert FireworksAIConfig._sanitize_tool_schema(42) == 42
+    assert FireworksAIConfig._sanitize_tool_schema(None) is None
+
+
+def test_sanitize_does_not_strip_keyed_title_inside_enum_values():
+    # 'title' should be stripped only as a key; if it appears as a string
+    # value (e.g. an enum entry), it must survive.
+    schema = {"type": "string", "enum": ["title", "subtitle", "body"]}
+    out = FireworksAIConfig._sanitize_tool_schema(schema)
+    assert out["enum"] == ["title", "subtitle", "body"]
+
+
+# --- _transform_tools integration cases ------------------------------------
+
+
+def test_transform_tools_sanitizes_parameters_and_keeps_strict_strip():
+    """End-to-end: Pydantic-shaped tool schema goes in, sanitized version
+    comes out, ``strict`` is still removed at the top level."""
+    config = FireworksAIConfig()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "list_pages",
+                "description": "List paginated results",
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "title": "ListPagesParams",
+                    "properties": {
+                        "page_size": {
+                            "default": None,
+                            "title": "Page Size",
+                            "type": "integer",
+                        },
+                        "cursor": {
+                            "default": None,
+                            "title": "Cursor",
+                            "type": "string",
+                        },
+                        "filters": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "title": "Filter",
+                                "properties": {
+                                    "field": {"type": "string", "title": "Field"},
+                                },
+                            },
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        }
+    ]
+
+    out = config._transform_tools(tools=copy.deepcopy(tools))
+
+    fn = out[0]["function"]
+    assert "strict" not in fn
+    params = fn["parameters"]
+    assert "title" not in params
+    # Top-level + nested + array-items all sanitized
+    assert "title" not in params["properties"]["page_size"]
+    assert "default" not in params["properties"]["page_size"]
+    assert "title" not in params["properties"]["cursor"]
+    assert "title" not in params["properties"]["filters"]["items"]
+    assert (
+        "title" not in params["properties"]["filters"]["items"]["properties"]["field"]
+    )
+    # Other fields preserved
+    assert params["properties"]["page_size"]["type"] == "integer"
+    assert params["properties"]["filters"]["type"] == "array"
+
+
+def test_transform_tools_noop_on_non_function_tools():
+    """Tools whose type is not 'function' should pass through unchanged."""
+    config = FireworksAIConfig()
+    tools = [{"type": "code_interpreter"}]
+    assert config._transform_tools(tools=copy.deepcopy(tools)) == tools
+
+
+def test_transform_tools_handles_function_with_no_parameters():
+    """Some MCP tools have no ``parameters`` field — must not KeyError."""
+    config = FireworksAIConfig()
+    tools = [{"type": "function", "function": {"name": "ping", "strict": True}}]
+    out = config._transform_tools(tools=copy.deepcopy(tools))
+    assert "strict" not in out[0]["function"]
+    assert "parameters" not in out[0]["function"]


### PR DESCRIPTION
Closes #27821. Also covers #28149 (MCP-framed duplicate).

## Summary

Fireworks AI's chat-completions API rejects tool parameter schemas containing `title` (anywhere) or `default: null` with a 400:

JSON Schema not supported: could not understand the instance {'default': None, 'title': 'Page Size'}


Pydantic auto-emits both fields by default, so any caller piping a Pydantic-generated tool schema through LiteLLM hits this — most commonly MCP servers (Coralogix, DevRev, Claude Code) and frameworks built on top of Pydantic. The existing `drop_params` flag only strips top-level OpenAI params, not nested fields inside tool schemas.

## Change

`FireworksAIConfig._sanitize_tool_schema` — a static recursive helper that walks the schema (dicts, lists, anyOf/allOf/oneOf, array items, nested properties) and removes `title` everywhere and `default` when its value is `None`, preserving every other field including non-null defaults.

`_transform_tools` now invokes the sanitizer on `function.parameters` for every function tool, alongside the existing `strict` top-level strip.

## Scope decisions

- **Fireworks-only**: the sanitizer lives on `FireworksAIConfig`, not in shared utils, so no other provider's tool schemas are touched.
- **Only the two fields Fireworks actually rejects** (`title`, `default: None`). Keeping the strip list small avoids accidentally dropping fields some other provider relies on if this code is later generalized.
- **Preserves non-null defaults** (`{"default": 10}` survives) so model behavior doesn't silently change for tools that use real defaults.
- **Preserves `"title"` when it appears as a string value** (e.g. inside an enum) — only the key is filtered.
- **No-op for tools without a `parameters` field** and for non-function tools.

## Verification

- `pytest tests/test_litellm/llms/fireworks_ai/` — **42 passed** (30 existing + 12 new).
- 12 new tests cover: top-level title strip, default:None strip preserving other defaults, recursion into nested properties / array items / anyOf / allOf / oneOf, passthrough for scalars/None, enum-value preservation, end-to-end `_transform_tools` integration, no-op cases.
- `black` formatted, no diff after format.

## Alternative

#28586 proposes the same fix with a wider scope and currently sits with several open CI items (290 files in diff, CodeQL flags, blocked Greptile gate). This PR is a tighter implementation in a **clean 2-file diff against main**. Either approach lands the fix...opening this in case maintainers prefer the smaller surface. Happy to defer to #28586 if it converges first.