### PR TITLE
fix(proxy): LiteLLM_TeamMembership.litellm_budget_table missing default causes ValidationError → 401 (#28689)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3886,7 +3886,7 @@ class LiteLLM_TeamMembership(LiteLLMPydanticObjectBase):
     # Union so Pydantic picks Full when data has server-managed fields
     # (/team/info) and Base when callers/tests construct with only
     # user-settable fields.
-    litellm_budget_table: Optional[Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]]
+    litellm_budget_table: Optional[Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]] = None
 
     def safe_get_team_member_rpm_limit(self) -> Optional[int]:
         if self.litellm_budget_table is not None:

--- a/tests/test_litellm/proxy/auth/test_team_member_budget.py
+++ b/tests/test_litellm/proxy/auth/test_team_member_budget.py
@@ -436,3 +436,35 @@ async def test_team_member_budget_check_personal_key_not_team():
         # Should pass and get_team_membership should not be called
         assert result is True
         mock_get_team_membership.assert_not_called()
+
+
+def test_team_membership_without_budget_table_deserializes():
+    """Regression test for issue #28689.
+
+    When a user's budget_id is set to null via /team/member_update,
+    the Prisma join returns a membership row without a litellm_budget_table key.
+    Before the fix, LiteLLM_TeamMembership had no default on litellm_budget_table,
+    causing Pydantic to raise ``ValidationError: Field required`` on every
+    subsequent auth check (→ 401 for all requests by that user).
+    """
+    # Simulates CacheCodec.deserialize processing a membership whose
+    # budget_id was nulled out — litellm_budget_table key is absent.
+    membership = LiteLLM_TeamMembership(
+        user_id="test-user",
+        team_id="test-team",
+        budget_id=None,
+        # litellm_budget_table intentionally omitted
+    )
+    assert membership.litellm_budget_table is None
+    assert membership.safe_get_team_member_rpm_limit() is None
+    assert membership.safe_get_team_member_tpm_limit() is None
+
+
+def test_team_membership_explicit_none_budget_table():
+    """litellm_budget_table=None can also be passed explicitly (e.g. from JSON null)."""
+    membership = LiteLLM_TeamMembership(
+        user_id="test-user",
+        team_id="test-team",
+        litellm_budget_table=None,
+    )
+    assert membership.litellm_budget_table is None


### PR DESCRIPTION
## Problem

Closes #28689.

`LiteLLM_TeamMembership.litellm_budget_table` was declared as:

```python
litellm_budget_table: Optional[Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]]
```

In **Pydantic v2**, `Optional[T]` *without* a default value is a **required** field — it must be present in the input data; it does **not** default to `None`.

When a user's `budget_id` is set to `null` via `/team/member_update`, the Prisma join returns a membership row with no `litellm_budget_table` key. Pydantic then raises:

```
ValidationError: 1 validation error for LiteLLM_TeamMembership
litellm_budget_table
  Field required [type=missing, ...]
```

This propagates through `common_checks` → every request from that user returns **401 Unauthorized**.

## Fix

One-line change — give the field an explicit `= None` default:

```python
litellm_budget_table: Optional[Union[LiteLLM_BudgetTableFull, LiteLLM_BudgetTable]] = None
```

## Tests

Added two regression tests to `tests/test_litellm/proxy/auth/test_team_member_budget.py`:

- `test_team_membership_without_budget_table_deserializes` — omits `litellm_budget_table` entirely (as Prisma would when `budget_id=null`); asserts model instantiates cleanly and `safe_get_team_member_*_limit()` helpers return `None`.
- `test_team_membership_explicit_none_budget_table` — passes `litellm_budget_table=None` explicitly (JSON `null` path); same assertions.