### PR TITLE
test(bedrock): swap legacy claude-3/3.5 model strings for 4.5 inference profiles

### DIFF
--- a/tests/litellm_utils_tests/test_litellm_overhead.py
+++ b/tests/litellm_utils_tests/test_litellm_overhead.py
@@ -14,7 +14,6 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import litellm
 
-
 # Fake Vertex AI Gemini response for mocking
 FAKE_VERTEX_GEMINI_RESPONSE = {
     "candidates": [
@@ -82,7 +81,7 @@ async def _vertex_ai_mocks():
         "bedrock/mistral.mistral-7b-instruct-v0:2",
         "openai/gpt-4o",
         "openai/self_hosted",
-        "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+        "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "vertex_ai/gemini-1.5-flash",
     ],
 )
@@ -147,7 +146,7 @@ async def test_litellm_overhead_non_streaming(model):
     [
         "bedrock/mistral.mistral-7b-instruct-v0:2",
         "openai/gpt-4o",
-        "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+        "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "openai/self_hosted",
     ],
 )

--- a/tests/local_testing/test_function_calling.py
+++ b/tests/local_testing/test_function_calling.py
@@ -49,7 +49,7 @@ def get_current_weather(location, unit="fahrenheit"):
         "mistral/mistral-large-latest",
         "claude-haiku-4-5-20251001",
         "gemini/gemini-2.5-flash-lite",
-        "anthropic.claude-3-sonnet-20240229-v1:0",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
     ],
 )
 @pytest.mark.flaky(retries=3, delay=1)
@@ -267,7 +267,6 @@ def test_aaparallel_function_call_with_anthropic_thinking(model):
 
 from litellm.types.utils import ChatCompletionMessageToolCall, Function, Message
 
-
 _PARALLEL_TOOL_HISTORY_MESSAGES = [
     {
         "role": "user",
@@ -303,7 +302,7 @@ _PARALLEL_TOOL_HISTORY_MESSAGES = [
     [
         # Bedrock Converse still requires modify_params to inject the dummy tool.
         (
-            "anthropic.claude-3-sonnet-20240229-v1:0",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             _PARALLEL_TOOL_HISTORY_MESSAGES,
             True,
         ),
@@ -314,7 +313,7 @@ _PARALLEL_TOOL_HISTORY_MESSAGES = [
             False,
         ),
         (
-            "anthropic.claude-3-sonnet-20240229-v1:0",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             [
                 {
                     "role": "user",
@@ -579,7 +578,7 @@ def test_groq_parallel_function_call():
 @pytest.mark.parametrize(
     "model",
     [
-        "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+        "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
     ],
 )
 def test_passing_tool_result_as_list(model):

--- a/tests/test_openai_endpoints.py
+++ b/tests/test_openai_endpoints.py
@@ -446,7 +446,7 @@ async def test_chat_completion_anthropic_structured_output():
     client = AsyncOpenAI(api_key="sk-1234", base_url="http://0.0.0.0:4000")
 
     res = await client.beta.chat.completions.parse(
-        model="bedrock/us.anthropic.claude-3-sonnet-20240229-v1:0",
+        model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         messages=messages,
         response_format=EventsList,
         timeout=60,


### PR DESCRIPTION
## Issue
Several Bedrock live-API tests on CCI are failing with `ValidationException: Operation not allowed` (HTTP 400). Per the [Bedrock model lifecycle table](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html), the pinned model IDs entered the *Legacy → public extended access* phase months ago and our CCI AWS account has lost on-demand access:

| Model | Legacy date | Public extended access | EOL |
|---|---|---|---|
| `anthropic.claude-3-5-haiku-20241022-v1:0` | 2025-12-19 | 2026-03-19 | 2026-06-19 |
| `anthropic.claude-3-sonnet-20240229-v1:0` | 2026-01-30 | 2026-04-30 | 2026-07-30 |

## Change
Replace with the current-gen Anthropic inference profiles already in use elsewhere in the suite:

- `claude-3-5-haiku-20241022-v1:0` → `us.claude-haiku-4-5-20251001-v1:0`
- `claude-3-sonnet-20240229-v1:0` → `us.claude-sonnet-4-5-20250929-v1:0`

Both targets are still **Active** on Bedrock and are already exercised by other tests (`test_anthropic_messages_prompt_caching.py`, `test_health_check.py`, `test_users.py`).

## Affected tests
- `tests/litellm_utils_tests/test_litellm_overhead.py` — `test_litellm_overhead_non_streaming`, `test_litellm_overhead_stream`
- `tests/local_testing/test_function_calling.py` — `test_aaparallel_function_call`, `test_parallel_function_call_anthropic_error_msg`, `test_passing_tool_result_as_list`
- `tests/test_openai_endpoints.py` — `test_chat_completion_anthropic_structured_output`

## Out of scope (different root causes, separate diagnosis needed)
- `test_bedrock_embedding_titan*` — Titan embed v1/v2 are still Active; failures are intermittent (already labeled FLAKY in CCI)
- `test_demo_tokens_as_input_to_embeddings_fails_for_titan` — asserts a Bedrock error-message string; would need verification against the live error text
- `test_prompt_caching_returns_cache_read_tokens_on_second_call` / `test_prompt_caching_streaming_second_call_returns_cache_read` — already pinned to Sonnet 4.5 (Active); not lifecycle-related
- `test_bedrock_batches_api` / `test_async_file_and_batch` — separate `'account is not authorized'` error specific to Bedrock batch entitlements

## Test plan
CCI run on this branch — affected jobs are `litellm_utils_testing`, `local_testing`, and `test_openai_endpoints`.