### PR TITLE
test(model_prices): allow audio_transcription_config in schema

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -706,6 +706,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "cache_read_input_audio_token_cost": {"type": "number"},
                 "cache_read_input_token_cost_per_audio_token": {"type": "number"},
                 "cache_read_input_image_token_cost": {"type": "number"},
+                "audio_transcription_config": {"type": "string"},
                 "deprecation_date": {"type": "string"},
                 "input_cost_per_audio_per_second": {"type": "number"},
                 "input_cost_per_audio_per_second_above_128k_tokens": {"type": "number"},


### PR DESCRIPTION
## Title

test(model_prices): allow audio_transcription_config in schema

## Relevant issues

n/a — unblocks unrelated PRs failing on `test_aaamodel_prices_and_context_window_json_is_valid`.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] I have added a screenshot of my new test passing locally

## Type

🧪 Tests

## Changes

`test_aaamodel_prices_and_context_window_json_is_valid` validates [model_prices_and_context_window.json](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) against an inline JSON schema with `additionalProperties: false`. PR #27482 added the `azure/speech/azure-stt` entry with a new `audio_transcription_config` field but did not extend the schema, so the test now fails on every branch built on top of staging.

This adds `audio_transcription_config` to the schema as a string property — one-line whitelist, no behavior change.

## Test plan

Validated the updated schema against the current `model_prices_and_context_window.json` via `jsonschema.validate` — passes.