### PR TITLE
fix(helm): drop main- prefix from default image tag

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -24,7 +24,7 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.80.12
+appVersion: v1.85.1
 
 annotations:
   org.opencontainers.image.source: "https://github.com/BerriAI/litellm"

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: {{ include "litellm.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HOST

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }} 
       containers:
         - name: prisma-migrations
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: ghcr.io/berriai/litellm-database
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  # tag: "main-latest"
+  # tag: "v1.85.1"
   tag: ""
 
 imagePullSecrets: []

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: ghcr.io/berriai/litellm-database
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  # tag: "v1.85.1"
+  # tag: "latest"
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

Users installing the helm chart get `ImagePullBackOff` because the default image tag is rendered as `main-<AppVersion>` (e.g. `ghcr.io/berriai/litellm-database:main-1.85.1`), and the current release pipeline does not publish tags with a `main-` prefix.

## What's changing

- **`templates/deployment.yaml`** + **`templates/migrations-job.yaml`** — default image tag changes from `(printf "main-%s" .Chart.AppVersion)` to `.Chart.AppVersion`.
- **`Chart.yaml`** — `appVersion` bumped from the stale `v1.80.12` (not on GHCR/DockerHub in any form) to `v1.85.1` (the current latest stable, published as both `v1.85.1` and `1.85.1` on both registries). Without this bump, local-checkout `helm install` users still 404 even after the template fix.
- **`values.yaml`** — commented tag-override example updated from `main-latest` to `v1.85.1` to match reality.

## Why the release pipeline doesn't need to change

The release pipeline packages the chart with `helm package --version <semver> --app-version <semver>` — which only rewrites the `version:` and `appVersion:` fields in `Chart.yaml`. Templates are bundled byte-for-byte from this repo. Every release since `1.84.0` publishes both `vX.Y.Z` and `X.Y.Z` to GHCR + DockerHub, so the bare `.Chart.AppVersion` default resolves on both the packaged-chart path (renders `:1.85.1`) and the local-checkout path (renders `:v1.85.1`).

## Verification

Locally with `helm template` against the modified chart:

- Unpackaged (uses in-tree `Chart.yaml`): renders `image: "ghcr.io/berriai/litellm-database:v1.85.1"` ✓
- After `helm package --app-version 1.85.1` (simulating the release pipeline): renders `image: "ghcr.io/berriai/litellm-database:1.85.1"` ✓

Both tags confirmed present on GHCR via manifest probe. `helm lint` clean. No existing helm unit test asserts on the old `main-` default path (image refs in `*_tests.yaml` all explicitly `set: image.tag=test`).

```
yunengjiang@Mac vibrant-dirac-bdd819 % git checkout litellm_/vibrant-dirac-bdd819
Already on 'litellm_/vibrant-dirac-bdd819'
Your branch is up to date with 'origin/litellm_/vibrant-dirac-bdd819'.
yunengjiang@Mac vibrant-dirac-bdd819 % helm version --short
v4.2.0+g0646808
yunengjiang@Mac vibrant-dirac-bdd819 % helm lint ./deploy/charts/litellm-helm

==> Linting ./deploy/charts/litellm-helm
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
yunengjiang@Mac vibrant-dirac-bdd819 % helm dependency build ./deploy/charts/litellm-helm 2>/dev/null
Saving 2 charts
Downloading postgresql from repo oci://registry-1.docker.io/bitnamicharts
Downloading redis from repo oci://registry-1.docker.io/bitnamicharts
Deleting outdated charts
yunengjiang@Mac vibrant-dirac-bdd819 % helm template litellm ./deploy/charts/litellm-helm | grep -E 'litellm-database:'
          image: "ghcr.io/berriai/litellm-database:v1.85.1"
          image: "ghcr.io/berriai/litellm-database:v1.85.1"
yunengjiang@Mac vibrant-dirac-bdd819 % helm template litellm ./deploy/charts/litellm-helm --set image.tag=latest | grep -E 'litellm-database:'
          image: "ghcr.io/berriai/litellm-database:latest"
          image: "ghcr.io/berriai/litellm-database:latest"

```