### PR TITLE
feat(helm): split per-component ServiceAccounts for gateway, backend, and UI

### DIFF
--- a/helm/litellm/templates/_helpers.tpl
+++ b/helm/litellm/templates/_helpers.tpl
@@ -56,16 +56,34 @@ app.kubernetes.io/component: ui
 {{- end -}}
 
 {{/*
-Shared ServiceAccount name used by all three component Deployments. When
-`serviceAccount.create` is true and `serviceAccount.name` is empty, default
-to the chart fullname. When `create` is false, fall back to the provided
-name or the namespace's `default` SA.
+Per-component ServiceAccount name helpers.
+
+Each component (gateway, backend, ui) has its own SA config under
+.Values.serviceAccounts.<component>. When `create` is true and `name` is
+empty the chart defaults to "<release>-litellm-<component>". When `create`
+is false the chart uses the provided name, or the namespace `default` SA.
 */}}
-{{- define "litellm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-{{ default (include "litellm.fullname" .) .Values.serviceAccount.name }}
+{{- define "litellm.gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccounts.gateway.create -}}
+{{ default (include "litellm.gateway.fullname" .) .Values.serviceAccounts.gateway.name }}
 {{- else -}}
-{{ default "default" .Values.serviceAccount.name }}
+{{ default "default" .Values.serviceAccounts.gateway.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "litellm.backend.serviceAccountName" -}}
+{{- if .Values.serviceAccounts.backend.create -}}
+{{ default (include "litellm.backend.fullname" .) .Values.serviceAccounts.backend.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccounts.backend.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "litellm.ui.serviceAccountName" -}}
+{{- if .Values.serviceAccounts.ui.create -}}
+{{ default (include "litellm.ui.fullname" .) .Values.serviceAccounts.ui.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccounts.ui.name }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- include "litellm.backend.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "litellm.backend.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.backend.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         {{- include "litellm.backend.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "litellm.serviceAccountName" . }}
+      serviceAccountName: {{ include "litellm.backend.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         {{- include "litellm.gateway.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "litellm.serviceAccountName" . }}
+      serviceAccountName: {{ include "litellm.gateway.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- include "litellm.gateway.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "litellm.gateway.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.gateway.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/templates/migrations-job.yaml
+++ b/helm/litellm/templates/migrations-job.yaml
@@ -28,7 +28,7 @@ spec:
         app.kubernetes.io/component: migrations
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "litellm.serviceAccountName" . }}
+      serviceAccountName: {{ include "litellm.backend.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/templates/serviceaccount.yaml
+++ b/helm/litellm/templates/serviceaccount.yaml
@@ -1,4 +1,6 @@
+{{- $prev := false -}}
 {{- if .Values.serviceAccounts.gateway.create -}}
+{{- $prev = true }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,7 +15,10 @@ metadata:
 automountServiceAccountToken: {{ .Values.serviceAccounts.gateway.automount }}
 {{- end }}
 {{- if .Values.serviceAccounts.backend.create }}
+{{- if $prev }}
 ---
+{{- end }}
+{{- $prev = true }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -28,7 +33,9 @@ metadata:
 automountServiceAccountToken: {{ .Values.serviceAccounts.backend.automount }}
 {{- end }}
 {{- if .Values.serviceAccounts.ui.create }}
+{{- if $prev }}
 ---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/litellm/templates/serviceaccount.yaml
+++ b/helm/litellm/templates/serviceaccount.yaml
@@ -1,13 +1,44 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccounts.gateway.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "litellm.serviceAccountName" . }}
+  name: {{ include "litellm.gateway.serviceAccountName" . }}
   labels:
     {{- include "litellm.commonLabels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+    app.kubernetes.io/component: gateway
+  {{- with .Values.serviceAccounts.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.serviceAccounts.gateway.automount }}
+{{- end }}
+{{- if .Values.serviceAccounts.backend.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "litellm.backend.serviceAccountName" . }}
+  labels:
+    {{- include "litellm.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  {{- with .Values.serviceAccounts.backend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccounts.backend.automount }}
+{{- end }}
+{{- if .Values.serviceAccounts.ui.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "litellm.ui.serviceAccountName" . }}
+  labels:
+    {{- include "litellm.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+  {{- with .Values.serviceAccounts.ui.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccounts.ui.automount }}
 {{- end }}

--- a/helm/litellm/templates/ui/deployment.yaml
+++ b/helm/litellm/templates/ui/deployment.yaml
@@ -19,7 +19,8 @@ spec:
       labels:
         {{- include "litellm.ui.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "litellm.serviceAccountName" . }}
+      serviceAccountName: {{ include "litellm.ui.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.ui.automount }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -14,16 +14,33 @@ ingress:
   host: ""        # optional; if set, becomes the rule's host
   tls: []
 
-# Shared ServiceAccount used by all three component Deployments. Set
-# `create: true` to have the chart provision it (e.g. when wiring an EKS
-# Pod Identity association by SA name). Set `name` to use an existing SA
-# (chart-created or out-of-band). When both are empty / false, pods run
-# with the namespace's `default` SA.
-serviceAccount:
-  create: false
-  automount: true
-  annotations: {}
-  name: ""
+# Per-component ServiceAccounts for gateway, backend, and ui.
+#
+# Each section mirrors the old shared serviceAccount shape. Set `create:
+# true` to have the chart provision the SA (useful for EKS Pod Identity /
+# GKE Workload Identity annotations). Set `name` to bind an existing SA.
+# When both are unset the component pod runs with the namespace `default` SA.
+#
+# The UI SA deliberately defaults to `automount: false` — the static nginx
+# container does not need the K8s API and should not carry a projected
+# ServiceAccount token that a compromised container could use to call the
+# cloud-provider metadata service or the K8s API.
+serviceAccounts:
+  gateway:
+    create: false
+    automount: true
+    annotations: {}
+    name: ""
+  backend:
+    create: false
+    automount: true
+    annotations: {}
+    name: ""
+  ui:
+    create: false
+    automount: false
+    annotations: {}
+    name: ""
 
 # Pre-install / pre-upgrade Helm hook that runs `prisma migrate deploy`
 # against the writer database, creating the LiteLLM schema (tables that


### PR DESCRIPTION
## Summary

Resolves LIT-3171

The Helm chart previously used a single shared `serviceAccount` for all three component deployments (gateway, backend, UI). This means any IRSA / Workload Identity annotation placed on that SA — intended only for the data-plane components — was also inherited by the static UI container. A compromised UI pod could then call the cloud-provider metadata service with those credentials and read secrets (master key, DB password, provider API keys) it has no business accessing.

This PR splits the shared SA into three per-component service accounts (`serviceAccounts.gateway`, `serviceAccounts.backend`, `serviceAccounts.ui`) and sets `automount: false` by default for the UI, so no projected token is present in the UI container at all.

> **Note:** Both Terraform stacks (GCP Cloud Run and AWS ECS) already have this split in place — the GCP stack uses a dedicated `<name>-ui-runtime` service account with zero IAM bindings, and the AWS stack uses a dedicated `ui_task` IAM role with no `rds-db:connect` / S3 / Secrets Manager policies. This PR closes the same gap in the Helm chart.

### Changes

| File | Change |
|------|--------|
| `helm/litellm/values.yaml` | Replace `serviceAccount` (singular) with `serviceAccounts.gateway/backend/ui`; UI defaults to `automount: false` |
| `helm/litellm/templates/_helpers.tpl` | Replace `litellm.serviceAccountName` with `litellm.gateway/backend/ui.serviceAccountName` helpers |
| `helm/litellm/templates/serviceaccount.yaml` | Create up to three separate ServiceAccount objects with component labels |
| `helm/litellm/templates/gateway/deployment.yaml` | Use `litellm.gateway.serviceAccountName` |
| `helm/litellm/templates/backend/deployment.yaml` | Use `litellm.backend.serviceAccountName` |
| `helm/litellm/templates/ui/deployment.yaml` | Use `litellm.ui.serviceAccountName` + explicit `automountServiceAccountToken: false` on pod spec |
| `helm/litellm/templates/migrations-job.yaml` | Share the backend SA (migrations needs the same DB write access) |

## Behavioral Test Matrix

| Scenario | `serviceAccounts.*.create` | `serviceAccounts.*.name` | Expected SA name in pod spec | SA object created? | `automountServiceAccountToken` on UI pod |
|---|---|---|---|---|---|
| All defaults (no SA) | `false` / `false` / `false` | `""` / `""` / `""` | `default` for all | No | `false` |
| Named existing SA for gateway | `false` | `"irsa-gw"` | `irsa-gw` | No | n/a |
| Named existing SA for backend | `false` | `"irsa-be"` | `irsa-be` | No | n/a |
| Named existing SA for UI | `false` | `"ui-sa"` | `ui-sa` | No | `false` |
| Chart creates gateway SA (no name override) | `true` | `""` | `<release>-litellm-gateway` | Yes, gateway SA | n/a |
| Chart creates backend SA (no name override) | `true` | `""` | `<release>-litellm-backend` | Yes, backend SA | n/a |
| Chart creates UI SA (no name override) | `true` | `""` | `<release>-litellm-ui` | Yes, UI SA with `automountServiceAccountToken: false` | `false` |
| Chart creates gateway SA with name override | `true` | `"my-gw"` | `my-gw` | Yes, named `my-gw` | n/a |
| Gateway & UI use different SAs simultaneously | gateway `create: true`, UI `name: "ui-sa"` | — | gateway: `<release>-litellm-gateway`, UI: `ui-sa` | Only gateway SA created | `false` |
| All three created simultaneously | `true` / `true` / `true` | `""` / `""` / `""` | Three separate SA names | Three SA objects, separated by `---` | `false` |
| Migrations job SA follows backend | gateway `create: true`, backend `create: true` | — | Migrations job uses same SA as backend | — | n/a |
| UI automount overridden to `true` | any | any | any | any | `true` (operator opt-in) |

## Migration guide (breaking change)

Users who had `serviceAccount:` in their custom `values.yaml` must rename it:

```yaml
# Before
serviceAccount:
  create: true
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123:role/litellm

# After
serviceAccounts:
  gateway:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::123:role/litellm-gateway
  backend:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::123:role/litellm-backend
  ui:
    create: false   # UI gets no cloud-provider role
```

https://claude.ai/code/session_01QPy362WnjmEpeNuJaPUqmF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPy362WnjmEpeNuJaPUqmF)_