### PR TITLE
fix(terraform/aws): make db_bootstrap_sql output idempotent (LIT-3173)

### DIFF
--- a/terraform/litellm/aws/outputs.tf
+++ b/terraform/litellm/aws/outputs.tf
@@ -43,12 +43,17 @@ output "db_master_password_secret_arn" {
   value       = aws_secretsmanager_secret.db_master_password.arn
 }
 
-# Pre-baked SQL to run once as the master user, creating the IAM-authed
-# application user that gateway/backend/migration tasks will authenticate as.
+# Pre-baked SQL to run as the master user — idempotent, so safe to re-run.
+# bootstrap.tf executes this automatically on `terraform apply` via a
+# local-exec provisioner; expose it here for break-glass manual re-runs.
 output "db_bootstrap_sql" {
-  description = "Run this once as the master DB user (after the first apply) to create the IAM-authed app user."
+  description = "Idempotent SQL to run as the Aurora master user to create (or re-create) the IAM-authed app user. bootstrap.tf runs this automatically; use as a break-glass manual re-run."
   value       = <<-SQL
-    CREATE USER ${var.db_username};
+    DO $$
+    BEGIN
+      CREATE USER ${var.db_username};
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
     GRANT rds_iam TO ${var.db_username};
     GRANT ALL PRIVILEGES ON DATABASE ${var.db_name} TO ${var.db_username};
     GRANT ALL ON SCHEMA public TO ${var.db_username};


### PR DESCRIPTION
## Summary

- Fixes the `db_bootstrap_sql` output in `terraform/litellm/aws/outputs.tf` to use idempotent SQL

The break-glass `db_bootstrap_sql` output previously used a bare `CREATE USER` which would fail with `ERROR: role already exists` on any re-run. This aligns the output with the idempotent SQL that `bootstrap.tf` already uses in its `local-exec` provisioner (`DO $$ BEGIN CREATE USER ... EXCEPTION WHEN duplicate_object THEN NULL; END $$;`).

Resolves LIT-3173

## Behavioral test matrix

| Scenario | Before fix | After fix |
|---|---|---|
| Run `db_bootstrap_sql` on a fresh Aurora cluster | ✅ Creates user successfully | ✅ Creates user successfully |
| Re-run `db_bootstrap_sql` on an existing cluster (break-glass scenario) | ❌ `ERROR: role "litellm_app" already exists` | ✅ Silently skips `CREATE USER`, re-grants privileges (no-op) |
| `terraform apply` auto-bootstrap (bootstrap.tf local-exec) | ✅ Always idempotent (unaffected by this change) | ✅ Always idempotent (unchanged) |

## Test plan

- [ ] `terraform output db_bootstrap_sql` now outputs `DO $$ BEGIN CREATE USER ... END $$;` syntax
- [ ] Executing the output SQL twice against the same cluster succeeds both times
- [ ] `bootstrap.tf` behaviour is unchanged (uses `local.bootstrap_sql` not this output)

https://claude.ai/code/session_01N6myMC1QzDj2NtpqfACDPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6myMC1QzDj2NtpqfACDPn)_