### PR TITLE
fix(team_endpoints): include budget table when fetching org for limit checks

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -986,6 +986,7 @@ async def new_team(  # noqa: PLR0915
                 org_id=data.organization_id,
                 user_api_key_cache=user_api_key_cache,
                 prisma_client=prisma_client,
+                include_budget_table=True,
             )
             if org_table is None:
                 raise HTTPException(
@@ -1752,6 +1753,7 @@ async def update_team(  # noqa: PLR0915
                 org_id=org_id_to_check,
                 user_api_key_cache=user_api_key_cache,
                 prisma_client=prisma_client,
+                include_budget_table=True,
             )
             if org_table is not None:
                 await _check_org_team_limits(


### PR DESCRIPTION
## Problem

`get_org_object` has an `include_budget_table` parameter that defaults to `False`. Both call sites that feed into `_check_org_team_limits` — `/team/new` and `/team/update` — were calling it without setting this flag, so `org_table.litellm_budget_table` was always `None` at the point of validation.

This silently disabled every check inside `_check_org_team_limits`:

- `max_budget` comparison → no-op (`litellm_budget_table is None`)
- `tpm_limit` / `rpm_limit` direct comparison → no-op
- `guaranteed_throughput` aggregate guard (`check_org_team_rpm_tpm_limits`) → `entity_rpm_limit = None` → no-op

The Phase 4 F7 test suite (`test_f7_coverage_closeout.py`) already documents this as "currently dead because the call site doesn't include `include_budget_table=True`".

## Fix

Pass `include_budget_table=True` at both call sites in `new_team` and `update_team`.

```python
# Before
org_table = await get_org_object(
    org_id=data.organization_id,
    user_api_key_cache=user_api_key_cache,
    prisma_client=prisma_client,
)

# After
org_table = await get_org_object(
    org_id=data.organization_id,
    user_api_key_cache=user_api_key_cache,
    prisma_client=prisma_client,
    include_budget_table=True,
)
```

## Test plan

- [ ] Create an org with `max_budget`, `tpm_limit`, `rpm_limit` set
- [ ] Attempt to create a team under that org exceeding each limit → expect 400
- [ ] Attempt to create a team with `tpm_limit_type="guaranteed_throughput"` that would over-allocate the org → expect 400
- [ ] Existing tests in `tests/proxy_behavior/management/` pass without modification