### PR TITLE
fix(ui): route API Reference back to query-param page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -30,9 +30,7 @@ function withBase(path: string): string {
  *
  * Key = legacy page id used in leftnav, Value = route segment under (dashboard)/
  */
-const MIGRATED_PAGES: Record<string, string> = {
-  "api-reference": "api-reference",
-};
+const MIGRATED_PAGES: Record<string, string> = {};
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
   const router = useRouter();

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -551,7 +551,7 @@ function CreateKeyPageContent() {
                     <AdminPanel
                       proxySettings={proxySettings}
                     />
-                  ) : page == "api_ref" ? (
+                  ) : page == "api_ref" || page == "api-reference" ? (
                     <APIReferenceView proxySettings={proxySettings} />
                   ) : page == "logging-and-alerts" ? (
                     <Settings userID={userID} userRole={userRole} accessToken={accessToken} premiumUser={premiumUser} />

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import APIReferenceView from "@/app/(dashboard)/api-reference/APIReferenceView";
 import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import OldModelDashboard from "@/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView";
 import PlaygroundPage from "@/app/(dashboard)/playground/page";
@@ -73,10 +74,7 @@ interface ProxySettings {
  * When a user visits ?page=<key>, they are redirected to /ui/<value>.
  * Add entries here as pages are migrated from the if/else chain to path-based routes.
  */
-const LEGACY_REDIRECTS: Record<string, string> = {
-  api_ref: "api-reference",
-  "api-reference": "api-reference",
-};
+const LEGACY_REDIRECTS: Record<string, string> = {};
 
 function CreateKeyPageContent() {
   const [userRole, setUserRole] = useState("");
@@ -553,6 +551,8 @@ function CreateKeyPageContent() {
                     <AdminPanel
                       proxySettings={proxySettings}
                     />
+                  ) : page == "api_ref" ? (
+                    <APIReferenceView proxySettings={proxySettings} />
                   ) : page == "logging-and-alerts" ? (
                     <Settings userID={userID} userRole={userRole} accessToken={accessToken} premiumUser={premiumUser} />
                   ) : page == "budgets" ? (

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -49,12 +49,9 @@ const { Sider } = Layout;
 /**
  * Pages migrated to path-based routing under (dashboard)/.
  * Key = legacy page id, Value = route segment.
- * Keep in sync with MIGRATED_PAGES in (dashboard)/layout.tsx and
- * LEGACY_REDIRECTS in app/page.tsx.
+ * Keep in sync with MIGRATED_PAGES in (dashboard)/layout.tsx.
  */
-const MIGRATED_PAGES: Record<string, string> = {
-  "api-reference": "api-reference",
-};
+const MIGRATED_PAGES: Record<string, string> = {};
 
 /** Build an absolute href for a migrated page, respecting base URL + serverRootPath. */
 function migratedHref(routeSegment: string): string {
@@ -295,8 +292,8 @@ const menuGroups: MenuGroup[] = [
     groupLabel: "DEVELOPER TOOLS",
     items: [
       {
-        key: "api-reference",
-        page: "api-reference",
+        key: "api_ref",
+        page: "api_ref",
         label: "API Reference",
         icon: <ApiOutlined />,
       },

--- a/ui/litellm-dashboard/src/components/page_metadata.ts
+++ b/ui/litellm-dashboard/src/components/page_metadata.ts
@@ -27,7 +27,7 @@ export const pageDescriptions: Record<string, string> = {
   projects: "Manage projects within teams",
   "access-groups": "Manage access groups for role-based permissions",
   budgets: "Set and monitor spending budgets",
-  "api-reference": "Browse API documentation and endpoints",
+  api_ref: "Browse API documentation and endpoints",
   "model-hub-table": "Explore available AI models and providers",
   "learning-resources": "Access tutorials and documentation",
   caching: "Configure response caching settings",


### PR DESCRIPTION
## Summary

The API Reference page was migrated from query-param routing (`?page=api_ref`) to a path-based route at `/ui/api-reference`. In practice the path-based variant resolves `proxySettings` via a page-local `useProxySettings` hook that doesn't match what the root `app/page.tsx` passes everywhere else, so the page rendered with the wrong base URL / API doc base. Move API Reference back to the query-param render branch and leave the migration scaffolding (`LEGACY_REDIRECTS`, `MIGRATED_PAGES`) in place — empty — for future page migrations.

## What changed

- `leftnav.tsx` — menu item back to `page: "api_ref"`; drop the entry from `MIGRATED_PAGES` (map kept empty).
- `app/page.tsx` — restore the `page == "api_ref" ? <APIReferenceView .../> : ...` render branch and the `APIReferenceView` import; drop both `api_ref` and `api-reference` entries from `LEGACY_REDIRECTS` (map kept empty).
- `(dashboard)/layout.tsx` — drop the entry from `MIGRATED_PAGES` (map kept empty).
- `page_metadata.ts` — key back to `api_ref`.

The `(dashboard)/api-reference/page.tsx` route and the `useProxySettings` hook are left in place untouched; they're just no longer routed to by the sidebar.

## Test plan
- [x] Click "API Reference" in the leftnav — lands on `/ui?page=api_ref` and renders the page with the correct base URL.
- [x] Old bookmarks to `/ui/api-reference` still load (the route file remains; only sidebar routing changed).
- [x] Other migration-targeted maps still compile/work with empty entries.