### PR TITLE
feat(proxy): FIPS-compliant encryption and password hashing

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -255,6 +255,7 @@ class KeyManagementRoutes(str, enum.Enum):
 
     # team spend-log viewing
     SPEND_LOGS = "/spend/logs"
+    SPEND_LOGS_V2 = "/spend/logs/v2"
 
 
 class LiteLLMRoutes(enum.Enum):
@@ -548,6 +549,7 @@ class LiteLLMRoutes(enum.Enum):
         KeyManagementRoutes.TEAM_KEY_BULK_UPDATE.value,
         KeyManagementRoutes.TEAM_DAILY_ACTIVITY.value,
         KeyManagementRoutes.SPEND_LOGS.value,
+        KeyManagementRoutes.SPEND_LOGS_V2.value,
         KeyManagementRoutes.KEY_RESET_SPEND.value,
         KeyManagementRoutes.KEY_ALIASES.value,
     ]
@@ -599,6 +601,7 @@ class LiteLLMRoutes(enum.Enum):
         "/spend/tags",
         "/spend/calculate",
         "/spend/logs",
+        "/spend/logs/v2",
         "/spend/logs/ui",
         "/spend/logs/session/ui",
         "/cost/estimate",

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -30,6 +30,7 @@ from litellm.proxy.management_endpoints.ui_sso import (
 )
 from litellm.proxy.utils import (
     PrismaClient,
+    _is_fips_mode,
     get_server_root_path,
     hash_password,
     verify_password,
@@ -43,8 +44,6 @@ async def _rehash_password_if_needed(user_id: str, password: str, stored: str) -
 
     In FIPS mode the current algorithm is PBKDF2-HMAC-SHA256; otherwise scrypt.
     """
-    from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
-
     if _is_fips_mode():
         if stored.startswith("pbkdf2:"):
             return

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -39,9 +39,19 @@ from litellm.types.proxy.ui_sso import ReturnedUITokenObject
 
 
 async def _rehash_password_if_needed(user_id: str, password: str, stored: str) -> None:
-    """Rehash legacy password (SHA256) to scrypt on successful login."""
-    if stored.startswith("scrypt:"):
-        return
+    """Rehash legacy password (SHA256 or scrypt) to the current algorithm on successful login.
+
+    In FIPS mode the current algorithm is PBKDF2-HMAC-SHA256; otherwise scrypt.
+    """
+    from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
+
+    if _is_fips_mode():
+        if stored.startswith("pbkdf2:"):
+            return
+    else:
+        if stored.startswith("scrypt:"):
+            return
+
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is not None:

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -4,6 +4,15 @@ from typing import Literal, Optional
 
 from litellm._logging import verbose_proxy_logger
 
+# Prefix used to identify AES-256-GCM encrypted values (FIPS-compliant).
+# Values without this prefix are treated as legacy nacl-encrypted.
+_AES_GCM_PREFIX = "aes256gcm:"
+
+
+def _is_fips_mode() -> bool:
+    """Return True when LITELLM_FIPS_MODE is set to a truthy value."""
+    return os.getenv("LITELLM_FIPS_MODE", "").lower() in ("true", "1", "yes")
+
 
 def _get_salt_key():
     from litellm.proxy.proxy_server import master_key
@@ -16,11 +25,50 @@ def _get_salt_key():
     return salt_key
 
 
+def _encrypt_aes_gcm(value: str, signing_key: str) -> bytes:
+    """Encrypt *value* with AES-256-GCM using a SHA-256 derived key.
+
+    Returns: nonce (12 B) + ciphertext + auth-tag (16 B).
+    Uses the ``cryptography`` library which delegates to OpenSSL and is
+    FIPS-compliant when the underlying OpenSSL build is FIPS-enabled.
+    """
+    import hashlib
+
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    key = hashlib.sha256(signing_key.encode()).digest()
+    nonce = os.urandom(12)
+    aesgcm = AESGCM(key)
+    ciphertext = aesgcm.encrypt(nonce, value.encode("utf-8"), None)
+    return nonce + ciphertext
+
+
+def _decrypt_aes_gcm(data: bytes, signing_key: str) -> str:
+    """Decrypt AES-256-GCM ciphertext produced by :func:`_encrypt_aes_gcm`."""
+    import hashlib
+
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    if len(data) < 12:
+        raise ValueError("AES-GCM ciphertext too short")
+
+    key = hashlib.sha256(signing_key.encode()).digest()
+    nonce, ciphertext = data[:12], data[12:]
+    aesgcm = AESGCM(key)
+    return aesgcm.decrypt(nonce, ciphertext, None).decode("utf-8")
+
+
 def encrypt_value_helper(value: str, new_encryption_key: Optional[str] = None):
     signing_key = new_encryption_key or _get_salt_key()
 
     try:
         if isinstance(value, str):
+            if _is_fips_mode():
+                encrypted_bytes = _encrypt_aes_gcm(value, signing_key)  # type: ignore
+                return _AES_GCM_PREFIX + base64.urlsafe_b64encode(
+                    encrypted_bytes
+                ).decode("utf-8")
+
             encrypted_value = encrypt_value(value=value, signing_key=signing_key)  # type: ignore
             # Use urlsafe_b64encode for URL-safe base64 encoding (replaces + with - and / with _)
             encrypted_value = base64.urlsafe_b64encode(encrypted_value).decode("utf-8")
@@ -46,6 +94,13 @@ def decrypt_value_helper(
 
     try:
         if isinstance(value, str):
+            if value.startswith(_AES_GCM_PREFIX):
+                # AES-256-GCM encrypted value (FIPS-compliant path)
+                b64_part = value[len(_AES_GCM_PREFIX) :]
+                encrypted_bytes = base64.urlsafe_b64decode(b64_part)
+                return _decrypt_aes_gcm(encrypted_bytes, signing_key)  # type: ignore
+
+            # Legacy nacl-encrypted value
             # Try URL-safe base64 decoding first (new format)
             # Fall back to standard base64 decoding for backwards compatibility (old format)
             try:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -64,6 +64,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.auth_checks import (
+    _cache_team_object,
     allowed_route_check_inside_route,
     can_org_access_model,
     get_org_object,
@@ -128,6 +129,33 @@ def _sanitize_for_log(value: Any) -> str:
     except Exception:
         text = repr(value)
     return text.replace("\r", "").replace("\n", "")
+
+
+async def _refresh_cached_team(
+    team_row: Any,
+    user_api_key_cache: Any,
+    proxy_logging_obj: Any,
+) -> None:
+    """
+    Refresh the in-memory cached team object after a DB write.
+
+    Every endpoint that mutates `litellm_teamtable` must call this so the
+    cached `LiteLLM_TeamTableCachedObj` used by `common_checks` stays in
+    sync. Without this, subsequent auth checks read a stale team and can
+    403 on permissions the DB has already granted (or, symmetrically,
+    keep granting permissions the DB has already revoked).
+
+    `team_row` is the Prisma row returned by `update`/`find_unique` on
+    `litellm_teamtable`. It is converted to `LiteLLM_TeamTableCachedObj`
+    via `model_dump()` to match the cache shape `_cache_team_object`
+    expects.
+    """
+    await _cache_team_object(
+        team_id=team_row.team_id,
+        team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
 
 
 async def _verify_team_access(
@@ -1591,7 +1619,6 @@ async def update_team(  # noqa: PLR0915
     ```
     """
     try:
-        from litellm.proxy.auth.auth_checks import _cache_team_object
         from litellm.proxy.proxy_server import (
             litellm_proxy_admin_name,
             llm_router,
@@ -1861,7 +1888,13 @@ async def update_team(  # noqa: PLR0915
             await prisma_client.db.litellm_teamtable.update(
                 where={"team_id": data.team_id},
                 data=updated_kv,
-                include={"litellm_model_table": True},  # type: ignore
+                # `object_permission` is included so `_refresh_cached_team`
+                # doesn't write a cached team with the relation nulled out —
+                # see team_model_add for the full rationale.
+                include={
+                    "litellm_model_table": True,
+                    "object_permission": True,
+                },  # type: ignore
             )
         )
 
@@ -1874,9 +1907,8 @@ async def update_team(  # noqa: PLR0915
         verbose_proxy_logger.info(
             "Successfully updated team - %s, info", team_row.team_id
         )
-        await _cache_team_object(
-            team_id=team_row.team_id,
-            team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
+        await _refresh_cached_team(
+            team_row=team_row,
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )
@@ -4569,7 +4601,11 @@ async def team_model_add(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail={"error": "No db connected"})
@@ -4603,9 +4639,21 @@ async def team_model_add(
         )
 
     updated_models = add_new_models_to_team(team_obj=team_obj, new_models=data.models)
-    # Update team
+    # Update team. `include` mirrors the relations the auth path consumes
+    # off the cached team object so that `_refresh_cached_team` doesn't
+    # null them out — see object_permission_utils.validate_key_search_tools_against_team
+    # and the MCP/agent authz paths, which treat a missing object_permission
+    # as "no team-level restriction".
     updated_team = await prisma_client.db.litellm_teamtable.update(
-        where={"team_id": data.team_id}, data={"models": updated_models}
+        where={"team_id": data.team_id},
+        data={"models": updated_models},
+        include={"object_permission": True},  # type: ignore
+    )
+
+    await _refresh_cached_team(
+        team_row=updated_team,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return updated_team
@@ -4640,7 +4688,11 @@ async def team_model_delete(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail={"error": "No db connected"})
@@ -4679,9 +4731,17 @@ async def team_model_delete(
     # Remove specified models
     updated_models = [m for m in current_models if m not in data.models]
 
-    # Update team
+    # Update team. See team_model_add for the rationale on `include`.
     updated_team = await prisma_client.db.litellm_teamtable.update(
-        where={"team_id": data.team_id}, data={"models": updated_models}
+        where={"team_id": data.team_id},
+        data={"models": updated_models},
+        include={"object_permission": True},  # type: ignore
+    )
+
+    await _refresh_cached_team(
+        team_row=updated_team,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return updated_team

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5074,6 +5074,11 @@ def hash_token(token: str):
     return hashed_token
 
 
+def _is_fips_mode() -> bool:
+    """Return True when LITELLM_FIPS_MODE is set to a truthy value."""
+    return os.getenv("LITELLM_FIPS_MODE", "").lower() in ("true", "1", "yes")
+
+
 def hash_password(password: str) -> str:
     """Hash a password.
 
@@ -5089,9 +5094,6 @@ def hash_password(password: str) -> str:
     """
     import base64
     import hashlib
-    import os
-
-    from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
 
     salt = os.urandom(16)
     if _is_fips_mode():

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5075,21 +5075,54 @@ def hash_token(token: str):
 
 
 def hash_password(password: str) -> str:
-    """Hash a password using scrypt with a random salt."""
+    """Hash a password.
+
+    Uses PBKDF2-HMAC-SHA256 when ``LITELLM_FIPS_MODE`` is enabled (FIPS 140-2/3
+    compliant via Python's ``hashlib`` which delegates to OpenSSL).  Falls back
+    to scrypt in non-FIPS environments for stronger brute-force resistance.
+
+    Format:
+      * FIPS mode  → ``pbkdf2:<base64(salt + dk)>``  (16-byte salt, 32-byte dk,
+        600 000 iterations of HMAC-SHA256)
+      * Default    → ``scrypt:<base64(salt + dk)>``  (16-byte salt, 32-byte dk,
+        n=16384, r=8, p=1)
+    """
     import base64
     import hashlib
     import os
 
+    from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
+
     salt = os.urandom(16)
+    if _is_fips_mode():
+        dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 600_000, dklen=32)
+        return "pbkdf2:" + base64.b64encode(salt + dk).decode()
+
     dk = hashlib.scrypt(password.encode(), salt=salt, n=16384, r=8, p=1, dklen=32)
     return "scrypt:" + base64.b64encode(salt + dk).decode()
 
 
 def verify_password(password: str, stored: str) -> bool:
-    """Verify a password against a stored hash. Supports scrypt and SHA256."""
+    """Verify a password against a stored hash.
+
+    Supports pbkdf2 (FIPS-compliant), scrypt, and SHA256 (legacy) formats.
+    On successful verification via SHA256 or scrypt while FIPS mode is active
+    the caller should re-hash with :func:`hash_password` on next login.
+    """
     import base64
     import hashlib
     import secrets
+
+    if stored.startswith("pbkdf2:"):
+        try:
+            raw = base64.b64decode(stored[7:])
+            salt, dk = raw[:16], raw[16:]
+            dk2 = hashlib.pbkdf2_hmac(
+                "sha256", password.encode(), salt, 600_000, dklen=32
+            )
+            return secrets.compare_digest(dk, dk2)
+        except Exception:
+            return False
 
     if stored.startswith("scrypt:"):
         try:
@@ -5101,6 +5134,7 @@ def verify_password(password: str, stored: str) -> bool:
             return secrets.compare_digest(dk, dk2)
         except Exception:
             return False
+
     # SHA256 fallback (not vulnerable to pass-the-hash: checks sha256(input) == stored)
     if len(stored) == 64 and all(c in "0123456789abcdef" for c in stored):
         return secrets.compare_digest(
@@ -5111,8 +5145,8 @@ def verify_password(password: str, stored: str) -> bool:
 
 async def migrate_passwords_to_scrypt_async(prisma_client) -> str:
     """
-    Migrate plaintext passwords in the DB to scrypt. SHA256 passwords
-    are left alone (they migrate on next login via the SHA256 fallback).
+    Migrate plaintext passwords in the DB to scrypt (or pbkdf2 in FIPS mode).
+    SHA256 passwords are left alone (they migrate on next login).
     Skips quickly if no plaintext passwords exist.
     """
     all_with_pw = await prisma_client.db.litellm_usertable.find_many(
@@ -5127,6 +5161,7 @@ async def migrate_passwords_to_scrypt_async(prisma_client) -> str:
         for u in all_with_pw
         if u.password
         and not u.password.startswith("scrypt:")
+        and not u.password.startswith("pbkdf2:")
         and not _is_sha256_hex(u.password)
     ]
     if not plaintext_users:

--- a/tests/test_litellm/proxy/auth/test_fips_compliance.py
+++ b/tests/test_litellm/proxy/auth/test_fips_compliance.py
@@ -1,0 +1,466 @@
+"""Tests for FIPS-compliant encryption and password hashing.
+
+Covers:
+  - AES-256-GCM encryption/decryption (encrypt_decrypt_utils)
+  - PBKDF2-HMAC-SHA256 password hashing (proxy/utils)
+  - Backward-compatibility: decrypt legacy nacl values in non-FIPS mode
+  - Cross-format password verification (pbkdf2, scrypt, sha256)
+  - _rehash_password_if_needed triggers correctly in both modes
+"""
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_fips(monkeypatch, enabled: bool):
+    monkeypatch.setenv("LITELLM_FIPS_MODE", "true" if enabled else "false")
+
+
+# ---------------------------------------------------------------------------
+# AES-256-GCM low-level helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAesGcmHelpers:
+    def test_roundtrip(self):
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+            _decrypt_aes_gcm,
+            _encrypt_aes_gcm,
+        )
+
+        plaintext = "hello FIPS world"
+        signing_key = "my-secret-key"
+        ciphertext = _encrypt_aes_gcm(plaintext, signing_key)
+        assert isinstance(ciphertext, bytes)
+        assert _decrypt_aes_gcm(ciphertext, signing_key) == plaintext
+
+    def test_wrong_key_raises(self):
+        from cryptography.exceptions import InvalidTag
+
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+            _decrypt_aes_gcm,
+            _encrypt_aes_gcm,
+        )
+
+        ciphertext = _encrypt_aes_gcm("secret", "key-A")
+        with pytest.raises(InvalidTag):
+            _decrypt_aes_gcm(ciphertext, "key-B")
+
+    def test_nonce_is_random(self):
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import _encrypt_aes_gcm
+
+        c1 = _encrypt_aes_gcm("same", "key")
+        c2 = _encrypt_aes_gcm("same", "key")
+        # Different nonces → different ciphertexts
+        assert c1 != c2
+
+    def test_short_ciphertext_raises(self):
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import _decrypt_aes_gcm
+
+        with pytest.raises(ValueError, match="too short"):
+            _decrypt_aes_gcm(b"\x00" * 5, "key")
+
+    def test_unicode_roundtrip(self):
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+            _decrypt_aes_gcm,
+            _encrypt_aes_gcm,
+        )
+
+        plaintext = "pässwörd 🔐"
+        ct = _encrypt_aes_gcm(plaintext, "key")
+        assert _decrypt_aes_gcm(ct, "key") == plaintext
+
+
+# ---------------------------------------------------------------------------
+# encrypt_value_helper / decrypt_value_helper — FIPS mode
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptDecryptHelperFipsMode:
+    def test_fips_mode_uses_aes_gcm_prefix(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(encrypt_decrypt_utils, "_get_salt_key", lambda: "test-key")
+        result = encrypt_decrypt_utils.encrypt_value_helper("my-secret")
+        assert result.startswith("aes256gcm:")
+
+    def test_fips_mode_roundtrip(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(encrypt_decrypt_utils, "_get_salt_key", lambda: "test-key")
+        encrypted = encrypt_decrypt_utils.encrypt_value_helper("my-api-key")
+        decrypted = encrypt_decrypt_utils.decrypt_value_helper(
+            value=encrypted, key="any"
+        )
+        assert decrypted == "my-api-key"
+
+    def test_non_fips_uses_nacl_format(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(encrypt_decrypt_utils, "_get_salt_key", lambda: "test-key")
+        result = encrypt_decrypt_utils.encrypt_value_helper("my-secret")
+        assert not result.startswith("aes256gcm:")
+
+    def test_non_fips_roundtrip(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(encrypt_decrypt_utils, "_get_salt_key", lambda: "test-key")
+        encrypted = encrypt_decrypt_utils.encrypt_value_helper("hello")
+        decrypted = encrypt_decrypt_utils.decrypt_value_helper(
+            value=encrypted, key="any"
+        )
+        assert decrypted == "hello"
+
+    def test_decrypt_aes_gcm_values_in_non_fips_mode(self, monkeypatch):
+        """Values encrypted in FIPS mode can be decrypted in non-FIPS mode."""
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(
+            encrypt_decrypt_utils, "_get_salt_key", lambda: "shared-key"
+        )
+
+        # Encrypt with FIPS mode ON
+        _set_fips(monkeypatch, True)
+        encrypted = encrypt_decrypt_utils.encrypt_value_helper("cross-mode-value")
+
+        # Decrypt with FIPS mode OFF
+        _set_fips(monkeypatch, False)
+        decrypted = encrypt_decrypt_utils.decrypt_value_helper(
+            value=encrypted, key="any"
+        )
+        assert decrypted == "cross-mode-value"
+
+    def test_decrypt_nacl_values_in_fips_mode(self, monkeypatch):
+        """Legacy nacl-encrypted values can still be decrypted when FIPS mode is on."""
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(
+            encrypt_decrypt_utils, "_get_salt_key", lambda: "shared-key"
+        )
+
+        # Encrypt with FIPS mode OFF (nacl)
+        _set_fips(monkeypatch, False)
+        encrypted = encrypt_decrypt_utils.encrypt_value_helper("legacy-value")
+
+        # Decrypt with FIPS mode ON
+        _set_fips(monkeypatch, True)
+        decrypted = encrypt_decrypt_utils.decrypt_value_helper(
+            value=encrypted, key="any"
+        )
+        assert decrypted == "legacy-value"
+
+    def test_non_string_value_returned_unchanged(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(encrypt_decrypt_utils, "_get_salt_key", lambda: "test-key")
+        result = encrypt_decrypt_utils.encrypt_value_helper(123)  # type: ignore
+        assert result == 123
+
+    def test_decrypt_error_returns_none_by_default(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+        monkeypatch.setattr(encrypt_decrypt_utils, "_get_salt_key", lambda: "test-key")
+        result = encrypt_decrypt_utils.decrypt_value_helper(
+            value="notvalidbase64!!!", key="k"
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_fips_mode detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsFipsMode:
+    @pytest.mark.parametrize("val", ["true", "True", "TRUE", "1", "yes", "YES"])
+    def test_truthy_values(self, monkeypatch, val):
+        monkeypatch.setenv("LITELLM_FIPS_MODE", val)
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
+
+        assert _is_fips_mode() is True
+
+    @pytest.mark.parametrize("val", ["false", "0", "no", "", "off"])
+    def test_falsy_values(self, monkeypatch, val):
+        monkeypatch.setenv("LITELLM_FIPS_MODE", val)
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
+
+        assert _is_fips_mode() is False
+
+    def test_unset_defaults_to_false(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_FIPS_MODE", raising=False)
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import _is_fips_mode
+
+        assert _is_fips_mode() is False
+
+
+# ---------------------------------------------------------------------------
+# Password hashing — FIPS mode (PBKDF2)
+# ---------------------------------------------------------------------------
+
+
+class TestHashPasswordFipsMode:
+    def test_fips_mode_produces_pbkdf2_prefix(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password
+
+        result = hash_password("secret")
+        assert result.startswith("pbkdf2:")
+
+    def test_non_fips_mode_produces_scrypt_prefix(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.utils import hash_password
+
+        result = hash_password("secret")
+        assert result.startswith("scrypt:")
+
+    def test_pbkdf2_unique_salt_per_call(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password
+
+        h1 = hash_password("same")
+        h2 = hash_password("same")
+        assert h1 != h2
+
+    def test_pbkdf2_output_length(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password
+
+        h = hash_password("test")
+        # "pbkdf2:" (7) + base64(16+32=48 bytes) = 7 + 64 = 71
+        assert len(h) == 71
+
+    def test_pbkdf2_correct_password_verifies(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password, verify_password
+
+        h = hash_password("correct")
+        assert verify_password("correct", h) is True
+
+    def test_pbkdf2_wrong_password_fails(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password, verify_password
+
+        h = hash_password("correct")
+        assert verify_password("wrong", h) is False
+
+    def test_pbkdf2_empty_password(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password, verify_password
+
+        h = hash_password("")
+        assert verify_password("", h) is True
+        assert verify_password("notempty", h) is False
+
+    def test_pbkdf2_unicode_password(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password, verify_password
+
+        h = hash_password("pässwörd")
+        assert verify_password("pässwörd", h) is True
+        assert verify_password("password", h) is False
+
+
+# ---------------------------------------------------------------------------
+# verify_password — cross-format compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPasswordCrossFormat:
+    """Ensure verify_password handles all stored hash formats correctly."""
+
+    def test_verify_pbkdf2_format(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password, verify_password
+
+        h = hash_password("pw")
+        assert h.startswith("pbkdf2:")
+        assert verify_password("pw", h) is True
+
+    def test_verify_scrypt_format(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.utils import hash_password, verify_password
+
+        h = hash_password("pw")
+        assert h.startswith("scrypt:")
+        assert verify_password("pw", h) is True
+
+    def test_verify_sha256_fallback(self):
+        from litellm.proxy.utils import verify_password
+
+        stored = hashlib.sha256("oldpass".encode()).hexdigest()
+        assert verify_password("oldpass", stored) is True
+        assert verify_password("wrong", stored) is False
+
+    def test_verify_scrypt_hash_in_fips_mode(self, monkeypatch):
+        """Legacy scrypt hashes can still be verified even when FIPS mode is on."""
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.utils import hash_password
+
+        scrypt_hash = hash_password("mypassword")
+
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import verify_password
+
+        assert verify_password("mypassword", scrypt_hash) is True
+
+    def test_verify_pbkdf2_hash_in_non_fips_mode(self, monkeypatch):
+        """PBKDF2 hashes can be verified even when FIPS mode is off."""
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password
+
+        pbkdf2_hash = hash_password("mypassword")
+
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.utils import verify_password
+
+        assert verify_password("mypassword", pbkdf2_hash) is True
+
+    def test_invalid_pbkdf2_base64_rejected(self):
+        from litellm.proxy.utils import verify_password
+
+        assert verify_password("test", "pbkdf2:not-valid-base64!!!") is False
+
+    def test_no_plaintext_fallback(self):
+        from litellm.proxy.utils import verify_password
+
+        assert verify_password("plaintext", "plaintext") is False
+
+    def test_unknown_format_rejected(self):
+        from litellm.proxy.utils import verify_password
+
+        assert verify_password("test", "argon2:somehash") is False
+
+
+# ---------------------------------------------------------------------------
+# migrate_passwords_to_scrypt_async — includes pbkdf2 skip
+# ---------------------------------------------------------------------------
+
+
+class TestMigratePasswordsAsync:
+    @pytest.mark.asyncio
+    async def test_skips_pbkdf2_passwords(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.utils import hash_password, migrate_passwords_to_scrypt_async
+
+        pbkdf2_hash = hash_password("existing")
+        user = MagicMock()
+        user.password = pbkdf2_hash
+        user.user_id = "u1"
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_usertable.find_many = AsyncMock(return_value=[user])
+
+        result = await migrate_passwords_to_scrypt_async(prisma_client)
+        assert result == "No plaintext passwords found"
+        prisma_client.db.litellm_usertable.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_scrypt_passwords(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.utils import hash_password, migrate_passwords_to_scrypt_async
+
+        scrypt_hash = hash_password("existing")
+        user = MagicMock()
+        user.password = scrypt_hash
+        user.user_id = "u1"
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_usertable.find_many = AsyncMock(return_value=[user])
+
+        result = await migrate_passwords_to_scrypt_async(prisma_client)
+        assert result == "No plaintext passwords found"
+
+    @pytest.mark.asyncio
+    async def test_migrates_plaintext_passwords(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.utils import migrate_passwords_to_scrypt_async
+
+        user = MagicMock()
+        user.password = "plaintext_password"
+        user.user_id = "u2"
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_usertable.find_many = AsyncMock(return_value=[user])
+        prisma_client.db.litellm_usertable.update = AsyncMock()
+
+        result = await migrate_passwords_to_scrypt_async(prisma_client)
+        assert "Migrated 1" in result
+        prisma_client.db.litellm_usertable.update.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _rehash_password_if_needed
+# ---------------------------------------------------------------------------
+
+
+class TestRehashPasswordIfNeeded:
+    @pytest.mark.asyncio
+    async def test_no_rehash_when_pbkdf2_in_fips_mode(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.auth.login_utils import _rehash_password_if_needed
+
+        with patch("litellm.proxy.auth.login_utils.hash_password") as mock_hash:
+            await _rehash_password_if_needed("u1", "pw", "pbkdf2:somehash")
+            mock_hash.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_rehash_when_scrypt_in_non_fips_mode(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.auth.login_utils import _rehash_password_if_needed
+
+        with patch("litellm.proxy.auth.login_utils.hash_password") as mock_hash:
+            await _rehash_password_if_needed("u1", "pw", "scrypt:somehash")
+            mock_hash.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rehashes_sha256_to_scrypt_in_non_fips_mode(self, monkeypatch):
+        _set_fips(monkeypatch, False)
+        from litellm.proxy.auth.login_utils import _rehash_password_if_needed
+
+        sha256_stored = hashlib.sha256("pw".encode()).hexdigest()
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_usertable.update = AsyncMock()
+
+        # prisma_client is imported lazily inside the function from proxy_server
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma, create=True),
+            patch(
+                "litellm.proxy.auth.login_utils.hash_password",
+                return_value="scrypt:newhash",
+            ) as mock_hash,
+        ):
+            await _rehash_password_if_needed("u1", "pw", sha256_stored)
+            mock_hash.assert_called_once_with("pw")
+            mock_prisma.db.litellm_usertable.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rehashes_scrypt_to_pbkdf2_in_fips_mode(self, monkeypatch):
+        _set_fips(monkeypatch, True)
+        from litellm.proxy.auth.login_utils import _rehash_password_if_needed
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_usertable.update = AsyncMock()
+
+        # prisma_client is imported lazily inside the function from proxy_server
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma, create=True),
+            patch(
+                "litellm.proxy.auth.login_utils.hash_password",
+                return_value="pbkdf2:newhash",
+            ) as mock_hash,
+        ):
+            await _rehash_password_if_needed("u1", "pw", "scrypt:oldhash")
+            mock_hash.assert_called_once_with("pw")
+            mock_prisma.db.litellm_usertable.update.assert_called_once()

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -268,6 +268,47 @@ def test_mcp_management_routes_classified_as_management_not_llm_api(route):
     assert RouteChecks.is_management_route(route=route) is True
 
 
+def test_spend_logs_v2_classified_as_management_not_llm_api():
+    """Paginated spend logs are a management/spend read route, not an LLM API."""
+
+    assert RouteChecks.is_llm_api_route(route="/spend/logs/v2") is False
+    assert RouteChecks.is_management_route(route="/spend/logs/v2") is True
+
+
+def test_virtual_key_management_routes_allows_spend_logs_v2():
+    """Management virtual keys should be allowed to call the v2 spend logs endpoint."""
+
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        allowed_routes=["management_routes"],
+    )
+
+    result = RouteChecks.is_virtual_key_allowed_to_call_route(
+        route="/spend/logs/v2",
+        valid_token=valid_token,
+    )
+
+    assert result is True
+
+
+def test_virtual_key_llm_api_routes_denies_spend_logs_v2():
+    """AI API virtual keys should not gain spend-log access."""
+
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        allowed_routes=["llm_api_routes"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        RouteChecks.is_virtual_key_allowed_to_call_route(
+            route="/spend/logs/v2",
+            valid_token=valid_token,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "Virtual key is not allowed to call this route" in str(exc_info.value.detail)
+
+
 @pytest.mark.parametrize(
     "route",
     [
@@ -1322,6 +1363,7 @@ ADMIN_VIEWER_LOGS_PAGE_ROUTES = [
     "/cost/estimate",
     # Public spend logs / spend tracking routes that admin viewer should read
     "/spend/logs",
+    "/spend/logs/v2",
     "/spend/keys",
     "/spend/users",
     "/spend/tags",

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -1541,6 +1541,137 @@ def test_add_new_models_to_team_with_existing_models():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint_name",
+    ["team_model_add", "team_model_delete"],
+)
+async def test_team_model_add_delete_refresh_team_cache(endpoint_name):
+    """
+    Regression pin for LIT-3244 vector-store BYOK 403.
+
+    `team_model_add` and `team_model_delete` mutate `team.models` in the
+    DB. Without a cache refresh, the in-memory `LiteLLM_TeamTableCachedObj`
+    used by `common_checks` stays stale and team members 403 on a model
+    the DB has just granted (or, symmetrically, keep using a model the DB
+    has just revoked).
+
+    Pin: after the DB update, the endpoint must call `_cache_team_object`
+    with the updated team row so the cached team stays in sync.
+    """
+    from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import (
+        LitellmUserRoles,
+        TeamModelAddRequest,
+        TeamModelDeleteRequest,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        team_model_add,
+        team_model_delete,
+    )
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user_id"
+    )
+
+    existing_team = MagicMock()
+    existing_team.model_dump.return_value = {
+        "team_id": "team-1234",
+        "models": ["bedrock-claude-sonnet-4", "openai/*"],
+        "object_permission_id": "op-1234",
+        "object_permission": {
+            "object_permission_id": "op-1234",
+            "search_tools": ["allowed-tool-A"],
+        },
+    }
+
+    updated_team = MagicMock()
+    updated_team.team_id = "team-1234"
+    updated_team.model_dump.return_value = {
+        "team_id": "team-1234",
+        "models": ["bedrock-claude-sonnet-4", "openai/*", "team-byok-1"],
+        # The Prisma update must come back with `object_permission` populated
+        # (via `include={"object_permission": True}`), otherwise the cache
+        # write below would null it out — see LIT-3244 follow-up.
+        "object_permission_id": "op-1234",
+        "object_permission": {
+            "object_permission_id": "op-1234",
+            "search_tools": ["allowed-tool-A"],
+        },
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object"
+        ) as mock_cache_team,
+    ):
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=existing_team
+        )
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
+            return_value=updated_team
+        )
+        mock_cache_team.return_value = None
+
+        if endpoint_name == "team_model_add":
+            await team_model_add(
+                data=TeamModelAddRequest(team_id="team-1234", models=["team-byok-1"]),
+                http_request=mock_request,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+        else:
+            await team_model_delete(
+                data=TeamModelDeleteRequest(team_id="team-1234", models=["openai/*"]),
+                http_request=mock_request,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        # The pin: cache refresh must run with the updated team row.
+        assert mock_cache_team.await_count == 1, (
+            f"{endpoint_name} must call _cache_team_object exactly once "
+            f"after the DB update (LIT-3244 regression pin); "
+            f"got await_count={mock_cache_team.await_count}"
+        )
+        call_kwargs = mock_cache_team.await_args.kwargs
+        assert call_kwargs["team_id"] == "team-1234"
+        # The cached object must be built from the *updated* row, not the
+        # pre-mutation `existing_team` — that's the whole point. Both rows
+        # share team_id, so the only assertion that actually pins this is
+        # against the field that differs between them: `models`.
+        assert call_kwargs["team_table"].team_id == "team-1234"
+        assert call_kwargs["team_table"].models == [
+            "bedrock-claude-sonnet-4",
+            "openai/*",
+            "team-byok-1",
+        ]
+        # And the cached object MUST carry the `object_permission` relation
+        # (LIT-3244 follow-up). If the Prisma update were missing
+        # `include={"object_permission": True}`, the cached team would have
+        # object_permission=None, and downstream consumers like
+        # `validate_key_search_tools_against_team` would treat that as
+        # "no team-level restriction" and stop enforcing the team's
+        # search-tool allowlist on key issuance.
+        assert call_kwargs["team_table"].object_permission is not None
+        assert call_kwargs["team_table"].object_permission.search_tools == [
+            "allowed-tool-A"
+        ]
+        # Pin the Prisma call shape too — the regression is in *what the
+        # update returns*, so the contract that the update asks for
+        # `object_permission` belongs in this test.
+        update_call_kwargs = (
+            mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs
+        )
+        assert update_call_kwargs.get("include", {}).get("object_permission") is True
+
+
+@pytest.mark.asyncio
 async def test_update_team_team_member_budget_not_passed_to_db():
     """
     Test that 'team_member_budget' is never passed to prisma_client.db.litellm_teamtable.update
@@ -1568,7 +1699,9 @@ async def test_update_team_team_member_budget_not_passed_to_db():
         patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
         patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
         patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
-        patch("litellm.proxy.auth.auth_checks._cache_team_object") as mock_cache_team,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object"
+        ) as mock_cache_team,
         patch(
             "litellm.proxy.management_endpoints.team_endpoints.TeamMemberBudgetHandler.upsert_team_member_budget_table"
         ) as mock_upsert_budget,
@@ -1999,7 +2132,9 @@ async def test_update_team_with_team_member_budget_duration():
         patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
         patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
         patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
-        patch("litellm.proxy.auth.auth_checks._cache_team_object") as mock_cache_team,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object"
+        ) as mock_cache_team,
         patch(
             "litellm.proxy.management_endpoints.team_endpoints.TeamMemberBudgetHandler.upsert_team_member_budget_table"
         ) as mock_upsert_budget,

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -218,14 +218,83 @@ describe("provider_info_helpers", () => {
       expect(result).toEqual(["gpt-3.5-turbo", "gpt-4"]);
     });
 
-    it("should return models when litellm_provider includes the provider string", () => {
+    it("should return models whose litellm_provider is a prefix-anchored variant of the provider", () => {
       const modelMap = {
-        "custom-openai-model": { litellm_provider: "custom_openai_endpoint" },
-        "another-model": { litellm_provider: "openai" },
+        "anthropic-text-model": { litellm_provider: "anthropic_text" },
+        "claude-3-opus": { litellm_provider: "anthropic" },
+      };
+      const result = getProviderModels(Providers.Anthropic, modelMap);
+      expect(result).toContain("anthropic-text-model");
+      expect(result).toContain("claude-3-opus");
+    });
+
+    it("should not leak vertex_ai-anthropic_models into the Anthropic provider", () => {
+      const modelMap = {
+        "claude-3-opus": { litellm_provider: "anthropic" },
+        "vertex_ai/claude-3-5-sonnet": { litellm_provider: "vertex_ai-anthropic_models" },
+        "vertex_ai/claude-haiku-4-5": { litellm_provider: "vertex_ai-anthropic_models" },
+      };
+      const result = getProviderModels(Providers.Anthropic, modelMap);
+      expect(result).toEqual(["claude-3-opus"]);
+      expect(result).not.toContain("vertex_ai/claude-3-5-sonnet");
+      expect(result).not.toContain("vertex_ai/claude-haiku-4-5");
+    });
+
+    it("should not leak vertex_ai-openai_models into the OpenAI provider", () => {
+      const modelMap = {
+        "gpt-4": { litellm_provider: "openai" },
+        "vertex_ai/openai-something": { litellm_provider: "vertex_ai-openai_models" },
       };
       const result = getProviderModels(Providers.OpenAI, modelMap);
-      expect(result).toContain("custom-openai-model");
-      expect(result).toContain("another-model");
+      expect(result).toEqual(["gpt-4"]);
+      expect(result).not.toContain("vertex_ai/openai-something");
+    });
+
+    // Note on the next three tests: in production, AddModelForm passes the
+    // backend `provider` field (the provider_map *key*, e.g. "Vertex_AI",
+    // "Bedrock", "FireworksAI") into getProviderModels, not the Providers
+    // enum value. The `as Providers` cast in callers is misleading. We mirror
+    // the production shape here by passing the key directly.
+    it("should include all vertex_ai variants when called with 'Vertex_AI' provider key", () => {
+      const modelMap = {
+        "vertex_ai/gemini-pro": { litellm_provider: "vertex_ai" },
+        "vertex_ai/claude-3-5-sonnet": { litellm_provider: "vertex_ai-anthropic_models" },
+        "vertex_ai/text-bison": { litellm_provider: "vertex_ai-text-models" },
+        "vertex_ai_beta/something": { litellm_provider: "vertex_ai_beta" },
+        "anthropic-native": { litellm_provider: "anthropic" },
+      };
+      const result = getProviderModels("Vertex_AI" as Providers, modelMap);
+      expect(result).toContain("vertex_ai/gemini-pro");
+      expect(result).toContain("vertex_ai/claude-3-5-sonnet");
+      expect(result).toContain("vertex_ai/text-bison");
+      expect(result).toContain("vertex_ai_beta/something");
+      expect(result).not.toContain("anthropic-native");
+    });
+
+    it("should include bedrock variants (converse, mantle) when called with 'Bedrock' provider key", () => {
+      const modelMap = {
+        "bedrock-base": { litellm_provider: "bedrock" },
+        "bedrock-converse-model": { litellm_provider: "bedrock_converse" },
+        "bedrock-mantle-model": { litellm_provider: "bedrock_mantle" },
+        "openai-model": { litellm_provider: "openai" },
+      };
+      const result = getProviderModels("Bedrock" as Providers, modelMap);
+      expect(result).toContain("bedrock-base");
+      expect(result).toContain("bedrock-converse-model");
+      expect(result).toContain("bedrock-mantle-model");
+      expect(result).not.toContain("openai-model");
+    });
+
+    it("should include fireworks_ai-embedding-models when called with 'FireworksAI' provider key", () => {
+      const modelMap = {
+        "fireworks-base": { litellm_provider: "fireworks_ai" },
+        "fireworks-embed": { litellm_provider: "fireworks_ai-embedding-models" },
+        "openai-model": { litellm_provider: "openai" },
+      };
+      const result = getProviderModels("FireworksAI" as Providers, modelMap);
+      expect(result).toContain("fireworks-base");
+      expect(result).toContain("fireworks-embed");
+      expect(result).not.toContain("openai-model");
     });
 
     it("should filter out models with null values", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -389,7 +389,9 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
         const litellmProvider = (value as any)["litellm_provider"];
         if (
           litellmProvider === custom_llm_provider ||
-          (typeof litellmProvider === "string" && litellmProvider.includes(custom_llm_provider))
+          (typeof litellmProvider === "string" &&
+            (litellmProvider.startsWith(`${custom_llm_provider}_`) ||
+              litellmProvider.startsWith(`${custom_llm_provider}-`)))
         ) {
           providerModels.push(key);
         }


### PR DESCRIPTION
## Summary

Resolves LIT-3317 | Closes #16789

LiteLLM currently uses **pynacl** (libsodium / XSalsa20-Poly1305) for credential encryption and **scrypt** for password hashing. Neither algorithm is FIPS 140-2/3 approved, which blocks deployment in FIPS-restricted environments.

This PR adds full FIPS compliance via a single environment variable: `LITELLM_FIPS_MODE=true`.

### What changes

| Component | Default (unchanged) | FIPS mode (`LITELLM_FIPS_MODE=true`) |
|-----------|---------------------|---------------------------------------|
| Credential encryption | pynacl / XSalsa20-Poly1305 | AES-256-GCM via `cryptography` (OpenSSL) |
| Password hashing | scrypt | PBKDF2-HMAC-SHA256 (600 000 iterations, NIST SP 800-132) |
| Token hashing | SHA-256 (unchanged) | SHA-256 (unchanged — already FIPS-compliant) |

### Backward compatibility

- **Encryption**: Values written with pynacl are still readable in FIPS mode (no prefix → nacl path). New values written in FIPS mode carry an `aes256gcm:` prefix and are readable in non-FIPS mode too.
- **Passwords**: `verify_password` supports `pbkdf2:`, `scrypt:`, and legacy SHA-256 formats. On next login, `_rehash_password_if_needed` automatically upgrades to the current algorithm.
- `migrate_passwords_to_scrypt_async` skips already-hashed `pbkdf2:` passwords.

### No new dependencies

`cryptography` (already pinned at `46.0.7`) is used for AES-256-GCM. `hashlib.pbkdf2_hmac` is stdlib. `pynacl` is still present for reading legacy encrypted values.

---

## Behavioral test matrix

| Scenario | Input | FIPS mode | Expected |
|----------|-------|-----------|----------|
| Encrypt new value | any string | OFF | nacl ciphertext (no prefix) |
| Encrypt new value | any string | ON | `aes256gcm:<b64>` |
| Decrypt aes256gcm value | `aes256gcm:…` | OFF | ✅ plaintext |
| Decrypt nacl value | raw b64 | ON | ✅ plaintext (nacl fallback) |
| Decrypt nacl value | raw b64 | OFF | ✅ plaintext |
| Wrong signing key | any | any | ❌ raises `InvalidTag` |
| Ciphertext too short | <12 bytes | any | ❌ raises `ValueError` |
| Hash password | any | OFF | `scrypt:…` |
| Hash password | any | ON | `pbkdf2:…` |
| Verify correct password | `scrypt:…` | any | ✅ True |
| Verify correct password | `pbkdf2:…` | any | ✅ True |
| Verify correct password | SHA-256 hex | any | ✅ True (legacy) |
| Verify wrong password | any format | any | ❌ False |
| Verify plaintext | not-hashed | any | ❌ False (no plaintext fallback) |
| Verify scrypt in FIPS mode | `scrypt:…` | ON | ✅ True (cross-format) |
| Verify pbkdf2 in non-FIPS | `pbkdf2:…` | OFF | ✅ True (cross-format) |
| Rehash on login | `scrypt:…` | ON | upgrades to `pbkdf2:…` |
| Rehash on login | `pbkdf2:…` | ON | no-op |
| Rehash on login | SHA-256 hex | OFF | upgrades to `scrypt:…` |
| Rehash on login | `scrypt:…` | OFF | no-op |
| Migrate plaintext passwords | plaintext | any | migrated to current algorithm |
| Migrate scrypt/pbkdf2 passwords | already hashed | any | skipped |
| `LITELLM_FIPS_MODE` detection | `true`/`1`/`yes` | — | FIPS mode enabled |
| `LITELLM_FIPS_MODE` detection | `false`/`0`/unset | — | FIPS mode disabled |

**48 unit tests, all passing.**

## Test plan

- [x] `uv run pytest tests/test_litellm/proxy/auth/test_fips_compliance.py -v` → 48 passed
- [x] `uv run pytest tests/test_litellm/proxy/auth/test_password_hashing.py tests/test_litellm/proxy/auth/test_login_utils.py -v` → 27 passed (existing tests unchanged)
- [x] `uv run ruff check` → no issues
- [x] `uv run black` → no issues
- [x] Zero diff in `litellm/proxy/_experimental/out/`

https://claude.ai/code/session_01PfHdZL7eNSDDfJsv4Bcyx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHdZL7eNSDDfJsv4Bcyx1)_