### PR TITLE
chore(release): cherry-pick #28284 and #28683 into patch/1.86.0

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -4,11 +4,15 @@ from typing import Dict, List, Optional, Set
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
 from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
-from litellm.types.router import LiteLLM_Params
+from litellm.types.router import CredentialLiteLLMParams, LiteLLM_Params
 from litellm.utils import get_valid_models
+
+
+_CREDENTIAL_LITELLM_PARAM_FIELDS = set(CredentialLiteLLMParams.model_fields)
 
 
 def _check_wildcard_routing(model: str) -> bool:
@@ -178,6 +182,7 @@ def get_complete_model_list(
     model_access_groups: Dict[str, List[str]] = {},
     include_model_access_groups: Optional[bool] = False,
     only_model_access_groups: Optional[bool] = False,
+    team_id: Optional[str] = None,
 ) -> List[str]:
     """Logic for returning complete model list for a given key + team pair"""
 
@@ -222,11 +227,35 @@ def get_complete_model_list(
         unique_models=unique_models,
         return_wildcard_routes=return_wildcard_routes,
         llm_router=llm_router,
+        team_id=team_id,
     )
 
     complete_model_list = unique_models + all_wildcard_models
 
     return complete_model_list
+
+
+def _hydrate_litellm_credential_name(
+    litellm_params: Optional[LiteLLM_Params],
+) -> Optional[LiteLLM_Params]:
+    if litellm_params is None or litellm_params.litellm_credential_name is None:
+        return litellm_params
+
+    credential_values = CredentialAccessor.get_credential_values(
+        litellm_params.litellm_credential_name
+    )
+    if not credential_values:
+        return litellm_params
+
+    litellm_params = litellm_params.model_copy()
+    for key, value in credential_values.items():
+        if (
+            key in _CREDENTIAL_LITELLM_PARAM_FIELDS
+            and getattr(litellm_params, key, None) is None
+        ):
+            setattr(litellm_params, key, value)
+    litellm_params.litellm_credential_name = None
+    return litellm_params
 
 
 def get_known_models_from_wildcard(
@@ -247,7 +276,7 @@ def get_known_models_from_wildcard(
     else:
         provider = wildcard_provider_prefix
 
-    # get all known provider models
+    litellm_params = _hydrate_litellm_credential_name(litellm_params)
 
     wildcard_models = get_provider_models(
         provider=provider, litellm_params=litellm_params
@@ -285,6 +314,7 @@ def _get_wildcard_models(
     unique_models: List[str],
     return_wildcard_routes: Optional[bool] = False,
     llm_router: Optional[Router] = None,
+    team_id: Optional[str] = None,
 ) -> List[str]:
     models_to_remove = set()
     all_wildcard_models = []
@@ -297,7 +327,9 @@ def _get_wildcard_models(
 
             ## get litellm params from model
             if llm_router is not None:
-                model_list = llm_router.get_model_list(model_name=model)
+                model_list = llm_router.get_model_list(
+                    model_name=model, team_id=team_id
+                )
                 if model_list:
                     for router_model in model_list:
                         wildcard_models = get_known_models_from_wildcard(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -64,6 +64,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.auth_checks import (
+    _cache_team_object,
     allowed_route_check_inside_route,
     can_org_access_model,
     get_org_object,
@@ -126,6 +127,33 @@ def _sanitize_for_log(value: Any) -> str:
     except Exception:
         text = repr(value)
     return text.replace("\r", "").replace("\n", "")
+
+
+async def _refresh_cached_team(
+    team_row: Any,
+    user_api_key_cache: Any,
+    proxy_logging_obj: Any,
+) -> None:
+    """
+    Refresh the in-memory cached team object after a DB write.
+
+    Every endpoint that mutates `litellm_teamtable` must call this so the
+    cached `LiteLLM_TeamTableCachedObj` used by `common_checks` stays in
+    sync. Without this, subsequent auth checks read a stale team and can
+    403 on permissions the DB has already granted (or, symmetrically,
+    keep granting permissions the DB has already revoked).
+
+    `team_row` is the Prisma row returned by `update`/`find_unique` on
+    `litellm_teamtable`. It is converted to `LiteLLM_TeamTableCachedObj`
+    via `model_dump()` to match the cache shape `_cache_team_object`
+    expects.
+    """
+    await _cache_team_object(
+        team_id=team_row.team_id,
+        team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
 
 
 async def _verify_team_access(
@@ -1580,7 +1608,6 @@ async def update_team(  # noqa: PLR0915
     ```
     """
     try:
-        from litellm.proxy.auth.auth_checks import _cache_team_object
         from litellm.proxy.proxy_server import (
             litellm_proxy_admin_name,
             llm_router,
@@ -1843,7 +1870,13 @@ async def update_team(  # noqa: PLR0915
             await prisma_client.db.litellm_teamtable.update(
                 where={"team_id": data.team_id},
                 data=updated_kv,
-                include={"litellm_model_table": True},  # type: ignore
+                # `object_permission` is included so `_refresh_cached_team`
+                # doesn't write a cached team with the relation nulled out —
+                # see team_model_add for the full rationale.
+                include={
+                    "litellm_model_table": True,
+                    "object_permission": True,
+                },  # type: ignore
             )
         )
 
@@ -1856,9 +1889,8 @@ async def update_team(  # noqa: PLR0915
         verbose_proxy_logger.info(
             "Successfully updated team - %s, info", team_row.team_id
         )
-        await _cache_team_object(
-            team_id=team_row.team_id,
-            team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
+        await _refresh_cached_team(
+            team_row=team_row,
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )
@@ -4553,7 +4585,11 @@ async def team_model_add(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail={"error": "No db connected"})
@@ -4587,9 +4623,21 @@ async def team_model_add(
         )
 
     updated_models = add_new_models_to_team(team_obj=team_obj, new_models=data.models)
-    # Update team
+    # Update team. `include` mirrors the relations the auth path consumes
+    # off the cached team object so that `_refresh_cached_team` doesn't
+    # null them out — see object_permission_utils.validate_key_search_tools_against_team
+    # and the MCP/agent authz paths, which treat a missing object_permission
+    # as "no team-level restriction".
     updated_team = await prisma_client.db.litellm_teamtable.update(
-        where={"team_id": data.team_id}, data={"models": updated_models}
+        where={"team_id": data.team_id},
+        data={"models": updated_models},
+        include={"object_permission": True},  # type: ignore
+    )
+
+    await _refresh_cached_team(
+        team_row=updated_team,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return updated_team
@@ -4624,7 +4672,11 @@ async def team_model_delete(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail={"error": "No db connected"})
@@ -4663,9 +4715,17 @@ async def team_model_delete(
     # Remove specified models
     updated_models = [m for m in current_models if m not in data.models]
 
-    # Update team
+    # Update team. See team_model_add for the rationale on `include`.
     updated_team = await prisma_client.db.litellm_teamtable.update(
-        where={"team_id": data.team_id}, data={"models": updated_models}
+        where={"team_id": data.team_id},
+        data={"models": updated_models},
+        include={"object_permission": True},  # type: ignore
+    )
+
+    await _refresh_cached_team(
+        team_row=updated_team,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return updated_team

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6068,6 +6068,8 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
     )
 
+    effective_team_id = team_id or user_api_key_dict.team_id
+
     # Get complete model list
     all_models = get_complete_model_list(
         key_models=key_models,
@@ -6080,6 +6082,7 @@ async def get_available_models_for_user(
         model_access_groups=model_access_groups,
         include_model_access_groups=include_model_access_groups,
         only_model_access_groups=only_model_access_groups,
+        team_id=effective_team_id,
     )
 
     return all_models

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -249,3 +249,241 @@ def test_get_complete_model_list_byok_wildcard_expansion():
     assert len(result) > 0
     assert all(m.startswith("openai/") for m in result)
     assert "openai/*" not in result
+
+
+def test_get_complete_model_list_expands_team_scoped_wildcard_with_stored_credential(
+    monkeypatch,
+):
+    """
+    Team-scoped BYOK wildcard deployments are stored under an internal model_name,
+    with the public wildcard name in model_info.team_public_model_name.
+    """
+    import litellm
+    from litellm import Router
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    from litellm.types.utils import CredentialItem
+
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="openai-credential",
+                credential_info={"provider": "openai"},
+                credential_values={
+                    "api_key": "stored-openai-key",
+                    "api_base": "https://example.openai.test/v1",
+                },
+            )
+        ],
+    )
+
+    captured_params = {}
+
+    def fake_get_provider_models(provider, litellm_params=None):
+        captured_params["provider"] = provider
+        captured_params["api_key"] = litellm_params.api_key
+        captured_params["api_base"] = litellm_params.api_base
+        captured_params["credential_name"] = litellm_params.litellm_credential_name
+        return ["gpt-4o"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_get_provider_models)
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "model_name_team-1_generated",
+                "litellm_params": {
+                    "model": "openai/*",
+                    "custom_llm_provider": "openai",
+                    "litellm_credential_name": "openai-credential",
+                },
+                "model_info": {
+                    "team_id": "team-1",
+                    "team_public_model_name": "openai/*",
+                },
+            }
+        ]
+    )
+
+    result = get_complete_model_list(
+        key_models=[],
+        team_models=["openai/*"],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        llm_router=router,
+        team_id="team-1",
+    )
+
+    assert "openai/gpt-4o" in result
+    assert captured_params == {
+        "provider": "openai",
+        "api_key": "stored-openai-key",
+        "api_base": "https://example.openai.test/v1",
+        "credential_name": None,
+    }
+
+
+def test_wildcard_credential_hydration_preserves_deployment_params(
+    monkeypatch,
+):
+    import litellm
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+    from litellm.types.utils import CredentialItem
+
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="openai-credential",
+                credential_info={"provider": "openai"},
+                credential_values={
+                    "api_key": "stored-openai-key",
+                    "api_version": "credential-version",
+                    "model": "openai/wrong-model",
+                    "unexpected_field": "unexpected-value",
+                },
+            )
+        ],
+    )
+
+    captured_params = {}
+
+    def fake_get_provider_models(provider, litellm_params=None):
+        captured_params["provider"] = provider
+        captured_params["model"] = litellm_params.model
+        captured_params["api_key"] = litellm_params.api_key
+        captured_params["api_version"] = litellm_params.api_version
+        captured_params["credential_name"] = litellm_params.litellm_credential_name
+        captured_params["has_unexpected_field"] = hasattr(
+            litellm_params, "unexpected_field"
+        )
+        return ["gpt-4o"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_get_provider_models)
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="openai/*",
+        litellm_params=LiteLLM_Params(
+            model="openai/*",
+            custom_llm_provider="openai",
+            api_version="deployment-version",
+            litellm_credential_name="openai-credential",
+        ),
+    )
+
+    assert result == ["openai/gpt-4o"]
+    assert captured_params == {
+        "provider": "openai",
+        "model": "openai/*",
+        "api_key": "stored-openai-key",
+        "api_version": "deployment-version",
+        "credential_name": None,
+        "has_unexpected_field": False,
+    }
+
+
+def test_wildcard_credential_hydration_preserves_missing_credential_name(
+    monkeypatch,
+):
+    import litellm
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    from litellm.types.router import LiteLLM_Params
+
+    monkeypatch.setattr(litellm, "credential_list", [])
+
+    captured_params = {}
+
+    def fake_get_provider_models(provider, litellm_params=None):
+        captured_params["provider"] = provider
+        captured_params["api_key"] = litellm_params.api_key
+        captured_params["credential_name"] = litellm_params.litellm_credential_name
+        return ["gpt-4o"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_get_provider_models)
+
+    result = get_known_models_from_wildcard(
+        wildcard_model="openai/*",
+        litellm_params=LiteLLM_Params(
+            model="openai/*",
+            custom_llm_provider="openai",
+            api_key=None,
+            litellm_credential_name="missing-credential",
+        ),
+    )
+
+    assert result == ["openai/gpt-4o"]
+    assert captured_params == {
+        "provider": "openai",
+        "api_key": None,
+        "credential_name": "missing-credential",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_for_user_expands_query_team_wildcard(
+    monkeypatch,
+):
+    import litellm
+    from litellm import Router
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.utils import get_available_models_for_user
+    from litellm.types.utils import CredentialItem
+
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="openai-credential",
+                credential_info={"provider": "openai"},
+                credential_values={"api_key": "stored-openai-key"},
+            )
+        ],
+    )
+
+    def fake_get_provider_models(provider, litellm_params=None):
+        assert litellm_params.api_key == "stored-openai-key"
+        assert litellm_params.litellm_credential_name is None
+        return ["gpt-4o-mini"]
+
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_get_provider_models)
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "model_name_team-1_generated",
+                "litellm_params": {
+                    "model": "openai/*",
+                    "custom_llm_provider": "openai",
+                    "litellm_credential_name": "openai-credential",
+                },
+                "model_info": {
+                    "team_id": "team-1",
+                    "team_public_model_name": "openai/*",
+                },
+            }
+        ]
+    )
+
+    result = await get_available_models_for_user(
+        user_api_key_dict=UserAPIKeyAuth(
+            api_key="sk-test",
+            models=[],
+            team_id="team-1",
+            team_models=["openai/*"],
+        ),
+        llm_router=router,
+        general_settings={},
+        user_model=None,
+        team_id="team-1",
+    )
+
+    assert "openai/gpt-4o-mini" in result

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -1541,6 +1541,137 @@ def test_add_new_models_to_team_with_existing_models():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint_name",
+    ["team_model_add", "team_model_delete"],
+)
+async def test_team_model_add_delete_refresh_team_cache(endpoint_name):
+    """
+    Regression pin for LIT-3244 vector-store BYOK 403.
+
+    `team_model_add` and `team_model_delete` mutate `team.models` in the
+    DB. Without a cache refresh, the in-memory `LiteLLM_TeamTableCachedObj`
+    used by `common_checks` stays stale and team members 403 on a model
+    the DB has just granted (or, symmetrically, keep using a model the DB
+    has just revoked).
+
+    Pin: after the DB update, the endpoint must call `_cache_team_object`
+    with the updated team row so the cached team stays in sync.
+    """
+    from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import (
+        LitellmUserRoles,
+        TeamModelAddRequest,
+        TeamModelDeleteRequest,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        team_model_add,
+        team_model_delete,
+    )
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user_id"
+    )
+
+    existing_team = MagicMock()
+    existing_team.model_dump.return_value = {
+        "team_id": "team-1234",
+        "models": ["bedrock-claude-sonnet-4", "openai/*"],
+        "object_permission_id": "op-1234",
+        "object_permission": {
+            "object_permission_id": "op-1234",
+            "search_tools": ["allowed-tool-A"],
+        },
+    }
+
+    updated_team = MagicMock()
+    updated_team.team_id = "team-1234"
+    updated_team.model_dump.return_value = {
+        "team_id": "team-1234",
+        "models": ["bedrock-claude-sonnet-4", "openai/*", "team-byok-1"],
+        # The Prisma update must come back with `object_permission` populated
+        # (via `include={"object_permission": True}`), otherwise the cache
+        # write below would null it out — see LIT-3244 follow-up.
+        "object_permission_id": "op-1234",
+        "object_permission": {
+            "object_permission_id": "op-1234",
+            "search_tools": ["allowed-tool-A"],
+        },
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object"
+        ) as mock_cache_team,
+    ):
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=existing_team
+        )
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
+            return_value=updated_team
+        )
+        mock_cache_team.return_value = None
+
+        if endpoint_name == "team_model_add":
+            await team_model_add(
+                data=TeamModelAddRequest(team_id="team-1234", models=["team-byok-1"]),
+                http_request=mock_request,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+        else:
+            await team_model_delete(
+                data=TeamModelDeleteRequest(team_id="team-1234", models=["openai/*"]),
+                http_request=mock_request,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        # The pin: cache refresh must run with the updated team row.
+        assert mock_cache_team.await_count == 1, (
+            f"{endpoint_name} must call _cache_team_object exactly once "
+            f"after the DB update (LIT-3244 regression pin); "
+            f"got await_count={mock_cache_team.await_count}"
+        )
+        call_kwargs = mock_cache_team.await_args.kwargs
+        assert call_kwargs["team_id"] == "team-1234"
+        # The cached object must be built from the *updated* row, not the
+        # pre-mutation `existing_team` — that's the whole point. Both rows
+        # share team_id, so the only assertion that actually pins this is
+        # against the field that differs between them: `models`.
+        assert call_kwargs["team_table"].team_id == "team-1234"
+        assert call_kwargs["team_table"].models == [
+            "bedrock-claude-sonnet-4",
+            "openai/*",
+            "team-byok-1",
+        ]
+        # And the cached object MUST carry the `object_permission` relation
+        # (LIT-3244 follow-up). If the Prisma update were missing
+        # `include={"object_permission": True}`, the cached team would have
+        # object_permission=None, and downstream consumers like
+        # `validate_key_search_tools_against_team` would treat that as
+        # "no team-level restriction" and stop enforcing the team's
+        # search-tool allowlist on key issuance.
+        assert call_kwargs["team_table"].object_permission is not None
+        assert call_kwargs["team_table"].object_permission.search_tools == [
+            "allowed-tool-A"
+        ]
+        # Pin the Prisma call shape too — the regression is in *what the
+        # update returns*, so the contract that the update asks for
+        # `object_permission` belongs in this test.
+        update_call_kwargs = (
+            mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs
+        )
+        assert update_call_kwargs.get("include", {}).get("object_permission") is True
+
+
+@pytest.mark.asyncio
 async def test_update_team_team_member_budget_not_passed_to_db():
     """
     Test that 'team_member_budget' is never passed to prisma_client.db.litellm_teamtable.update
@@ -1568,7 +1699,9 @@ async def test_update_team_team_member_budget_not_passed_to_db():
         patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
         patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
         patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
-        patch("litellm.proxy.auth.auth_checks._cache_team_object") as mock_cache_team,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object"
+        ) as mock_cache_team,
         patch(
             "litellm.proxy.management_endpoints.team_endpoints.TeamMemberBudgetHandler.upsert_team_member_budget_table"
         ) as mock_upsert_budget,
@@ -1999,7 +2132,9 @@ async def test_update_team_with_team_member_budget_duration():
         patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
         patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
         patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
-        patch("litellm.proxy.auth.auth_checks._cache_team_object") as mock_cache_team,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object"
+        ) as mock_cache_team,
         patch(
             "litellm.proxy.management_endpoints.team_endpoints.TeamMemberBudgetHandler.upsert_team_member_budget_table"
         ) as mock_upsert_budget,


### PR DESCRIPTION
## Summary
Cherry-picks onto `patch/1.86.0` for the 1.86.0 stable release.

- [#28284](https://github.com/BerriAI/litellm/pull/28284) — fix(proxy): hydrate wildcard discovery credentials (picked from rollup #28419, SHA `37ef8d9059`)
- [#28683](https://github.com/BerriAI/litellm/pull/28683) — fix(team): refresh team cache on team_model_add/delete (LIT-3244) (SHA `5f73ad4fe7`)

## Test plan
- [ ] CI green on `patch/1.86.0`