### PR TITLE
fix(anthropic): drop whitespace-only system messages (#28706)

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1619,8 +1619,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 system_prompt_indices.append(idx)
                 system_message_block = ChatCompletionSystemMessage(**message)
                 if isinstance(system_message_block["content"], str):
-                    # Skip empty text blocks - Anthropic API raises errors for empty text
-                    if not system_message_block["content"]:
+                    # Skip empty or whitespace-only text blocks - Anthropic API
+                    # raises errors for empty / whitespace-only text content.
+                    if not system_message_block["content"].strip():
                         continue
                     # Skip system messages containing x-anthropic-billing-header metadata
                     if system_message_block["content"].startswith(
@@ -1640,9 +1641,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     )
                 elif isinstance(message["content"], list):
                     for _content in message["content"]:
-                        # Skip empty text blocks - Anthropic API raises errors for empty text
+                        # Skip empty or whitespace-only text blocks - Anthropic API
+                        # raises errors for empty / whitespace-only text content.
                         text_value = _content.get("text")
-                        if _content.get("type") == "text" and not text_value:
+                        if _content.get("type") == "text" and (
+                            not text_value or not text_value.strip()
+                        ):
                             continue
                         # Skip system messages containing x-anthropic-billing-header metadata
                         if (

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1960,6 +1960,54 @@ def test_translate_system_message_preserves_cache_control():
     assert result[0]["cache_control"] == {"type": "ephemeral"}
 
 
+def test_translate_system_message_skips_whitespace_only_string_content():
+    """
+    Whitespace-only system content (e.g. "   ") must be dropped — Anthropic
+    rejects it with "system: text content blocks must contain non-whitespace
+    text", while OpenAI accepts it. The proxy should normalize across providers.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/28706
+    """
+    config = AnthropicConfig()
+
+    messages = [
+        {"role": "system", "content": "   "},
+        {"role": "user", "content": "say hi"},
+    ]
+
+    result = config.translate_system_message(messages)
+
+    assert len(result) == 0
+    assert all(m["role"] != "system" for m in messages)
+
+
+def test_translate_system_message_skips_whitespace_only_list_content():
+    """
+    Whitespace-only text blocks inside a list-form system message must be
+    filtered out, while sibling non-whitespace blocks are preserved.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/28706
+    """
+    config = AnthropicConfig()
+
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "   "},
+                {"type": "text", "text": "Valid content"},
+                {"type": "text", "text": "\n\t  "},
+            ],
+        },
+        {"role": "user", "content": "Hello"},
+    ]
+
+    result = config.translate_system_message(messages)
+
+    assert len(result) == 1
+    assert result[0]["text"] == "Valid content"
+
+
 # ============ Dynamic max_tokens Tests ============
 
 
@@ -2513,14 +2561,14 @@ def test_reasoning_effort_accepts_dict_shape_for_adaptive_model(reasoning_effort
     )
 
     # thinking must be set (adaptive for 4.6+)
-    assert "thinking" in result, (
-        f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
-    )
+    assert (
+        "thinking" in result
+    ), f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
     assert result["thinking"]["type"] == "adaptive"
     # output_config must carry the mapped effort
-    assert "output_config" in result, (
-        f"output_config missing for reasoning_effort={reasoning_effort_value!r}"
-    )
+    assert (
+        "output_config" in result
+    ), f"output_config missing for reasoning_effort={reasoning_effort_value!r}"
     assert result["output_config"]["effort"] == "low"
 
 
@@ -2532,7 +2580,9 @@ def test_reasoning_effort_accepts_dict_shape_for_adaptive_model(reasoning_effort
         {"effort": "low", "summary": "concise"},
     ],
 )
-def test_reasoning_effort_accepts_dict_shape_for_non_adaptive_model(reasoning_effort_value):
+def test_reasoning_effort_accepts_dict_shape_for_non_adaptive_model(
+    reasoning_effort_value,
+):
     """
     Non-adaptive (pre-4.6) branch: dict-shape reasoning_effort must still map
     to ``thinking.type='enabled'`` + ``budget_tokens``. ``output_config`` must
@@ -2547,9 +2597,9 @@ def test_reasoning_effort_accepts_dict_shape_for_non_adaptive_model(reasoning_ef
         drop_params=False,
     )
 
-    assert "thinking" in result, (
-        f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
-    )
+    assert (
+        "thinking" in result
+    ), f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
     assert result["thinking"]["type"] == "enabled"
     assert "budget_tokens" in result["thinking"]
     assert result["thinking"]["budget_tokens"] > 0
@@ -2582,12 +2632,12 @@ def test_reasoning_effort_unparseable_dict_is_dropped(bad_value):
         model="claude-sonnet-4-6-20260219",
         drop_params=False,
     )
-    assert "thinking" not in result, (
-        f"thinking should not be set for bad value {bad_value!r}"
-    )
-    assert "output_config" not in result, (
-        f"output_config should not be set for bad value {bad_value!r}"
-    )
+    assert (
+        "thinking" not in result
+    ), f"thinking should not be set for bad value {bad_value!r}"
+    assert (
+        "output_config" not in result
+    ), f"output_config should not be set for bad value {bad_value!r}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #28706.

When a client sends a whitespace-only system message (e.g. `"content": "   "`), LiteLLM was forwarding it to Anthropic, which rejects it with:

```
invalid_request_error: system: text content blocks must contain non-whitespace text
```

OpenAI accepts the same body. `drop_params: true` did not help because that flag drops unrecognized params, not message content.

`AnthropicConfig.translate_system_message` already tried to skip empty system content, but the guard was `if not content:` — a whitespace-only string is truthy in Python and slipped through.

## Changes

- `litellm/llms/anthropic/chat/transformation.py` — extend the existing skip in `translate_system_message` to also drop whitespace-only content in both the string and list-of-blocks branches.
- `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py` — two new unit tests covering the whitespace-only string case and the whitespace-only-inside-list case (alongside the existing empty-content tests).

If every system block is whitespace-only, no `system` field is set on the Anthropic request — the same outcome as if the caller had omitted the system message entirely.

## Test plan

- [x] `uv run pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py -k translate_system_message -v` — 6 passed (4 existing + 2 new)
- [x] `uv run black .` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
