### PR TITLE
chore(release): cherry-pick #28519 (non_root npm fix) into patch/1.86.0

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -24,7 +24,8 @@ RUN for i in 1 2 3; do \
         curl \
         openssl \
         libsndfile \
-        nodejs && break || sleep 5; \
+        nodejs \
+        npm && break || sleep 5; \
     done
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \


### PR DESCRIPTION
## Summary
- Cherry-picks [#28519](https://github.com/BerriAI/litellm/pull/28519) (`f1abe03ed6`) onto `patch/1.86.0` to unblock the v1.86.0-stable `Dockerfile.non_root` build.
- Without `npm` on `PATH`, prisma-python falls back to a nodeenv-bootstrapped node that fails to load `libatomic.so.1` on Wolfi, causing `prisma generate` to exit 127 (see [project-releaser run #26349890283](https://github.com/BerriAI/project-releaser/actions/runs/26349890283/job/77566901827)).
- Fix is already on `litellm_internal_staging`; v1.86.0-rc.1 was cut before it landed.

## Test plan
- [ ] Re-trigger the project-releaser non_root build off `patch/1.86.0` and confirm `prisma generate` succeeds.