### PR TITLE
Preserve input_file blocks in Responses tool output lowering

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1581,13 +1581,14 @@ def convert_to_gemini_tool_call_result(  # noqa: PLR0915
                 elif content_type in ("file", "input_file"):
                     # Extract file for inline_data (for tool results with PDF, audio, video, etc.)
                     file_data = content.get("file_data", "")
+                    file_id = content.get("file_id", "")
                     if not file_data:
                         file_content = content.get("file", {})
-                        file_data = (
-                            file_content.get("file_data", "")
-                            if isinstance(file_content, dict)
-                            else file_content if isinstance(file_content, str) else ""
-                        )
+                        if isinstance(file_content, dict):
+                            file_data = file_content.get("file_data", "")
+                            file_id = file_content.get("file_id", "") or file_id
+                        elif isinstance(file_content, str):
+                            file_data = file_content
 
                     if file_data:
                         # Convert file to base64 blob format for Gemini
@@ -1605,6 +1606,10 @@ def convert_to_gemini_tool_call_result(  # noqa: PLR0915
                             verbose_logger.warning(
                                 f"Failed to process file in tool response: {e}"
                             )
+                    elif file_id:
+                        if content_str:
+                            content_str += "\n"
+                        content_str += json.dumps(content)
     name: Optional[str] = message.get("name", "")  # type: ignore
 
     # Recover name from last message with tool calls

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1047,10 +1047,11 @@ class LiteLLMCompletionResponsesConfig:
 
             Some clients/adapters send:
             - output: [{"type": "input_text", "text": "..."}, {"type": "input_image", ...}]
+            - output: [{"type": "input_text", "text": "..."}, {"type": "input_file", ...}]
 
             For chat tool messages we normalize to either:
             - string (preferred)
-            - list of {"type": "text"|"image_url", ...} blocks (for multimodal tool outputs)
+            - list of {"type": "text"|"image_url"|"file", ...} blocks (for multimodal/file tool outputs)
             """
             if output is None:
                 return ""
@@ -1085,10 +1086,16 @@ class LiteLLMCompletionResponsesConfig:
                                     "image_url": {"url": image_url_val},
                                 }
                             )
+                    elif part_type == "input_file":
+                        normalized_blocks.append(
+                            LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
+                                part
+                            )
+                        )
 
-                # Prefer structured blocks if we have images; otherwise return a string.
-                if any(b.get("type") == "image_url" for b in normalized_blocks):
-                    # Ensure we include any accumulated text as text blocks too
+                # Prefer structured blocks if we have non-text content; otherwise return a string.
+                if any(b.get("type") != "text" for b in normalized_blocks):
+                    # Ensure we include any accumulated text as text blocks too.
                     return normalized_blocks
                 if text_acc:
                     return "".join(text_acc)
@@ -1225,7 +1232,8 @@ class LiteLLMCompletionResponsesConfig:
         Transform a Responses API input_file item to a Chat Completion file item
 
         Args:
-            item: Dictionary containing input_file type with file_id, file_data, and/or file_url
+            item: Dictionary containing input_file type with file_id, file_data,
+                filename, and/or file_url
 
         Returns:
             Dictionary with transformed file structure for Chat Completion
@@ -1236,6 +1244,8 @@ class LiteLLMCompletionResponsesConfig:
             file_dict["file_id"] = file_id
         if item.get("file_data"):
             file_dict["file_data"] = item["file_data"]
+        if item.get("filename"):
+            file_dict["filename"] = item["filename"]
 
         new_item: Dict[str, Any] = {"type": "file", "file": file_dict}
         if "cache_control" in item:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_gemini_file_refs.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_gemini_file_refs.py
@@ -1,0 +1,51 @@
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    convert_to_gemini_tool_call_result,
+)
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+
+
+def test_gemini_tool_result_preserves_file_id_only_file_block():
+    """
+    Responses input_file blocks without inline file_data should still keep their
+    file_id when converted through Gemini tool-result handling.
+    """
+
+    messages = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+        tool_call_output={
+            "type": "function_call_output",
+            "call_id": "call_file_ref",
+            "output": [
+                {
+                    "type": "input_file",
+                    "file_id": "files/report-123",
+                    "filename": "report.pdf",
+                }
+            ],
+        }
+    )
+    last_message_with_tool_calls = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_file_ref",
+                "type": "function",
+                "index": 0,
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+    }
+
+    result = convert_to_gemini_tool_call_result(
+        message=messages[0],
+        last_message_with_tool_calls=last_message_with_tool_calls,
+    )
+
+    assert isinstance(result, dict)
+    assert result["function_response"]["name"] == "read_file"
+    assert result["function_response"]["response"] == {
+        "type": "file",
+        "file": {"file_id": "files/report-123", "filename": "report.pdf"},
+    }

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
@@ -30,6 +30,65 @@ def test_function_call_output_list_input_text_is_converted_to_tool_string_conten
     assert msg["content"] == "hello world"
 
 
+def test_function_call_output_list_input_file_is_preserved_as_tool_content():
+    out = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+        tool_call_output={
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [
+                {"type": "input_text", "text": "Read the attached PDF."},
+                {
+                    "type": "input_file",
+                    "filename": "invoice.pdf",
+                    "file_data": "data:application/pdf;base64,JVBERi0xLjQK",
+                },
+            ],
+        }
+    )
+
+    assert len(out) == 1
+    msg = out[0]
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "call_1"
+    assert msg["content"] == [
+        {"type": "text", "text": "Read the attached PDF."},
+        {
+            "type": "file",
+            "file": {
+                "file_data": "data:application/pdf;base64,JVBERi0xLjQK",
+                "filename": "invoice.pdf",
+            },
+        },
+    ]
+
+
+def test_function_call_output_list_input_file_only_is_preserved_as_tool_content():
+    out = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
+        tool_call_output={
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [
+                {
+                    "type": "input_file",
+                    "file_id": "file-abc123",
+                    "filename": "report.pdf",
+                },
+            ],
+        }
+    )
+
+    assert len(out) == 1
+    msg = out[0]
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "call_1"
+    assert msg["content"] == [
+        {
+            "type": "file",
+            "file": {"file_id": "file-abc123", "filename": "report.pdf"},
+        },
+    ]
+
+
 def test_function_call_output_string_passthrough():
     out = LiteLLMCompletionResponsesConfig._transform_responses_api_tool_call_output_to_chat_completion_message(
         tool_call_output={


### PR DESCRIPTION
## What

Preserve `input_file` content parts when lowering Responses API `function_call_output.output` arrays to Chat Completions tool-message content.

The existing normalizer already kept text-like blocks and image blocks, but `input_file` parts fell through and were dropped. This reuses the existing `_transform_input_file_item_to_file_item` helper and returns structured content whenever a non-text block is present.

This also preserves `filename` on file blocks and keeps file-id-only tool outputs from being lowered to empty Gemini tool responses.

Fixes #28232.

## Tests

- `uv run pytest tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_gemini_file_refs.py tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py::test_convert_tool_response_with_input_file_type tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py::test_convert_tool_response_with_nested_file_object -q`
- `uv run ruff check litellm/litellm_core_utils/prompt_templates/factory.py litellm/responses/litellm_completion_transformation/transformation.py tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_gemini_file_refs.py`

Note: collecting the whole `tests/test_litellm/responses/litellm_completion_transformation` directory in this local checkout currently requires additional optional/proxy deps; it stopped on missing `orjson` before running unrelated tests.