### PR TITLE
fix(ui): paginate session logs in drawer sidebar with Shift+J/K shortcuts

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -7485,11 +7485,17 @@ export const teamPermissionsUpdateCall = async (accessToken: string, teamId: str
 /**
  * Get all spend logs for a particular session
  */
-export const sessionSpendLogsCall = async (accessToken: string, session_id: string) => {
+export const sessionSpendLogsCall = async (
+  accessToken: string,
+  session_id: string,
+  page: number = 1,
+  page_size: number = 50,
+) => {
   try {
+    const query = `session_id=${encodeURIComponent(session_id)}&page=${page}&page_size=${page_size}`;
     let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/spend/logs/session/ui?session_id=${encodeURIComponent(session_id)}`
-      : `/spend/logs/session/ui?session_id=${encodeURIComponent(session_id)}`;
+      ? `${proxyBaseUrl}/spend/logs/session/ui?${query}`
+      : `/spend/logs/session/ui?${query}`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
@@ -1,5 +1,11 @@
 import { Button, Space, Tag, Tooltip, Typography } from "antd";
-import { CloseOutlined, UpOutlined, DownOutlined } from "@ant-design/icons";
+import {
+  CloseOutlined,
+  UpOutlined,
+  DownOutlined,
+  DoubleLeftOutlined,
+  DoubleRightOutlined,
+} from "@ant-design/icons";
 import moment from "moment";
 import { LogEntry } from "../columns";
 import { getProviderLogoAndName } from "../../provider_info_helpers";
@@ -22,6 +28,11 @@ interface DrawerHeaderProps {
   onClose: () => void;
   onPrevious: () => void;
   onNext: () => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
+  canGoPreviousPage?: boolean;
+  canGoNextPage?: boolean;
+  showPageControls?: boolean;
   statusLabel: string;
   statusColor: "error" | "success";
   environment: string;
@@ -36,6 +47,11 @@ export function DrawerHeader({
   onClose,
   onPrevious,
   onNext,
+  onPreviousPage,
+  onNextPage,
+  canGoPreviousPage = false,
+  canGoNextPage = false,
+  showPageControls = false,
   statusLabel,
   statusColor,
   environment,
@@ -60,7 +76,16 @@ export function DrawerHeader({
       {/* Row 1: Request ID + Actions */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: SPACING_MEDIUM }}>
         <RequestIdSection requestId={log.request_id} />
-        <NavigationSection onPrevious={onPrevious} onNext={onNext} onClose={onClose} />
+        <NavigationSection
+          onPrevious={onPrevious}
+          onNext={onNext}
+          onClose={onClose}
+          onPreviousPage={onPreviousPage}
+          onNextPage={onNextPage}
+          canGoPreviousPage={canGoPreviousPage}
+          canGoNextPage={canGoNextPage}
+          showPageControls={showPageControls}
+        />
       </div>
 
       {/* Row 2: Status + Env + Timestamp */}
@@ -142,10 +167,20 @@ function NavigationSection({
   onPrevious,
   onNext,
   onClose,
+  onPreviousPage,
+  onNextPage,
+  canGoPreviousPage = false,
+  canGoNextPage = false,
+  showPageControls = false,
 }: {
   onPrevious: () => void;
   onNext: () => void;
   onClose: () => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
+  canGoPreviousPage?: boolean;
+  canGoNextPage?: boolean;
+  showPageControls?: boolean;
 }) {
   const keyboardShortcutStyle = {
     border: "1px solid #d9d9d9",
@@ -167,6 +202,32 @@ function NavigationSection({
         <DownOutlined />
         <span style={keyboardShortcutStyle}>J</span>
       </Button>
+      {showPageControls && (
+        <>
+          <Tooltip title="Previous page (Shift+K)">
+            <Button
+              type="text"
+              size="small"
+              onClick={onPreviousPage}
+              disabled={!canGoPreviousPage}
+            >
+              <DoubleLeftOutlined />
+              <span style={keyboardShortcutStyle}>⇧K</span>
+            </Button>
+          </Tooltip>
+          <Tooltip title="Next page (Shift+J)">
+            <Button
+              type="text"
+              size="small"
+              onClick={onNextPage}
+              disabled={!canGoNextPage}
+            >
+              <DoubleRightOutlined />
+              <span style={keyboardShortcutStyle}>⇧J</span>
+            </Button>
+          </Tooltip>
+        </>
+      )}
       <Tooltip title="ESC to close">
         <Button type="text" icon={<CloseOutlined />} onClick={onClose} />
       </Tooltip>

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -456,7 +456,7 @@ export function LogDetailsDrawer({
               onNextPage={isSessionMode ? goToNextPage : undefined}
               canGoPreviousPage={canGoPreviousPage}
               canGoNextPage={canGoNextPage}
-              showPageControls={isSessionMode}
+              showPageControls={isSessionPaginated}
               statusLabel={statusLabel}
               statusColor={statusColor}
               environment={environment}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -14,7 +14,7 @@ import { DrawerHeader } from "./DrawerHeader";
 import { useKeyboardNavigation } from "./useKeyboardNavigation";
 import { LogDetailContent, GuardrailJumpLink } from "./LogDetailContent";
 import { sessionSpendLogsCall } from "../../networking";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { getSpendString } from "@/utils/dataUtils";
 import { normalizeGuardrailEntries } from "./utils";
 import { DRAWER_WIDTH } from "./constants";
@@ -145,6 +145,10 @@ export function LogDetailsDrawer({
       };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
+    // Keep the previous page's data visible while fetching the next page so the
+    // drawer doesn't unmount (which would otherwise trigger a close→reopen
+    // animation on the first paginate click while the fetch is in flight).
+    placeholderData: keepPreviousData,
   });
 
   const sessionLogs = sessionQueryResult?.logs ?? [];

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -214,18 +214,26 @@ export function LogDetailsDrawer({
     setSelectedSessionRequestId(null);
   }, [sessionId, isSessionMode]);
 
+  // Memoized to keep the reference stable across renders so the keyboard
+  // listener inside useKeyboardNavigation does not re-attach on every render
+  // and never sees a stale onSelectLog closure.
+  const handleSelectLog = useCallback(
+    (selected: LogEntry) => {
+      if (isSessionMode) {
+        setSelectedSessionRequestId(selected.request_id);
+      }
+      onSelectLog?.(selected);
+    },
+    [isSessionMode, onSelectLog],
+  );
+
   // Keyboard navigation
   const { selectNextLog, selectPreviousLog } = useKeyboardNavigation({
     isOpen: open,
     currentLog,
     allLogs: isSessionMode ? sessionLogs : allLogs,
     onClose,
-    onSelectLog: (selected) => {
-      if (isSessionMode) {
-        setSelectedSessionRequestId(selected.request_id);
-      }
-      onSelectLog?.(selected);
-    },
+    onSelectLog: handleSelectLog,
     // goToPreviousPage / goToNextPage are useCallback'd and self-guard
     // against out-of-bounds, so pass them directly to keep the reference
     // stable across renders.

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Drawer } from "antd";
 import {
   CheckOutlined,
@@ -116,14 +116,18 @@ export function LogDetailsDrawer({
   const [selectedSessionRequestId, setSelectedSessionRequestId] = useState<string | null>(null);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [copiedLeftPanelId, setCopiedLeftPanelId] = useState(false);
+  const [sessionPage, setSessionPage] = useState(1);
+  const SESSION_PAGE_SIZE = 50;
 
-  const { data: sessionLogs = [] } = useQuery({
-    queryKey: ["sessionLogs", sessionId],
+  const { data: sessionQueryResult } = useQuery({
+    queryKey: ["sessionLogs", sessionId, sessionPage],
     queryFn: async () => {
-      if (!sessionId || !accessToken) return [];
-      const response = await sessionSpendLogsCall(accessToken, sessionId);
+      if (!sessionId || !accessToken) {
+        return { logs: [] as LogEntry[], totalPages: 1, total: 0 };
+      }
+      const response = await sessionSpendLogsCall(accessToken, sessionId, sessionPage, SESSION_PAGE_SIZE);
       const allSessionLogs: LogEntry[] = response.data || response || [];
-      return allSessionLogs
+      const logs = allSessionLogs
         .map((row) => ({
           ...row,
           request_duration_ms: row.request_duration_ms ?? (Date.parse(row.endTime) - Date.parse(row.startTime)),
@@ -134,9 +138,36 @@ export function LogDetailsDrawer({
           if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
           return new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
         });
+      return {
+        logs,
+        totalPages: response.total_pages ?? 1,
+        total: response.total ?? logs.length,
+      };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
   });
+
+  const sessionLogs = sessionQueryResult?.logs ?? [];
+  const sessionTotalPages = sessionQueryResult?.totalPages ?? 1;
+  const sessionTotal = sessionQueryResult?.total ?? sessionLogs.length;
+  const isSessionPaginated = isSessionMode && sessionTotalPages > 1;
+  const canGoPreviousPage = isSessionMode && sessionPage > 1;
+  const canGoNextPage = isSessionMode && sessionPage < sessionTotalPages;
+
+  // useCallback so the function identity only changes when the boundary
+  // flag flips, preventing the keydown listener in useKeyboardNavigation
+  // from churning on every parent re-render.
+  const goToPreviousPage = useCallback(() => {
+    if (!canGoPreviousPage) return;
+    setSelectedSessionRequestId(null);
+    setSessionPage((p) => p - 1);
+  }, [canGoPreviousPage]);
+
+  const goToNextPage = useCallback(() => {
+    if (!canGoNextPage) return;
+    setSelectedSessionRequestId(null);
+    setSessionPage((p) => p + 1);
+  }, [canGoNextPage]);
 
   const currentLog = useMemo(() => {
     if (!isSessionMode) return logEntry;
@@ -166,10 +197,22 @@ export function LogDetailsDrawer({
     if (open) {
       setIsSidebarCollapsed(false);
     } else {
-      if (isSessionMode) setSelectedSessionRequestId(null);
+      if (isSessionMode) {
+        setSelectedSessionRequestId(null);
+        setSessionPage(1);
+      }
       setCopiedLeftPanelId(false);
     }
   }, [open, isSessionMode]);
+
+  // If the parent swaps to a different session while the drawer stays open,
+  // reset page/selection so we don't request page N of a shorter session and
+  // render an empty sidebar.
+  useEffect(() => {
+    if (!isSessionMode) return;
+    setSessionPage(1);
+    setSelectedSessionRequestId(null);
+  }, [sessionId, isSessionMode]);
 
   // Keyboard navigation
   const { selectNextLog, selectPreviousLog } = useKeyboardNavigation({
@@ -183,6 +226,11 @@ export function LogDetailsDrawer({
       }
       onSelectLog?.(selected);
     },
+    // goToPreviousPage / goToNextPage are useCallback'd and self-guard
+    // against out-of-bounds, so pass them directly to keep the reference
+    // stable across renders.
+    onPreviousPage: goToPreviousPage,
+    onNextPage: goToNextPage,
   });
 
   // Lazy-load log details (messages/response) only when drawer is open.
@@ -305,7 +353,7 @@ export function LogDetailsDrawer({
                 </div>
               </div>
               <div className="mt-1 text-[11px] text-slate-500 font-mono">
-                {logsForList.length} req
+                {isSessionMode ? sessionTotal : logsForList.length} req
                 {[
                   isSessionMode
                     ? llmCount
@@ -333,6 +381,12 @@ export function LogDetailsDrawer({
                   <>
                     <span className="mx-1.5">·</span>
                     {sessionDurationSeconds}s
+                  </>
+                )}
+                {isSessionPaginated && (
+                  <>
+                    <span className="mx-1.5">·</span>
+                    <span>page {sessionPage}/{sessionTotalPages} (cost/duration/counts shown for this page)</span>
                   </>
                 )}
               </div>
@@ -390,6 +444,11 @@ export function LogDetailsDrawer({
               onClose={onClose}
               onPrevious={selectPreviousLog}
               onNext={selectNextLog}
+              onPreviousPage={isSessionMode ? goToPreviousPage : undefined}
+              onNextPage={isSessionMode ? goToNextPage : undefined}
+              canGoPreviousPage={canGoPreviousPage}
+              canGoNextPage={canGoNextPage}
+              showPageControls={isSessionMode}
               statusLabel={statusLabel}
               statusColor={statusColor}
               environment={environment}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.test.ts
@@ -1,0 +1,217 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useKeyboardNavigation } from "./useKeyboardNavigation";
+import { LogEntry } from "../columns";
+
+// Three rows is enough to exercise prev/next at head, middle, and tail.
+const makeLogs = (): LogEntry[] =>
+  [
+    { request_id: "req-a", call_type: "completion", model: "gpt-4o", startTime: "", endTime: "" },
+    { request_id: "req-b", call_type: "completion", model: "gpt-4o", startTime: "", endTime: "" },
+    { request_id: "req-c", call_type: "completion", model: "gpt-4o", startTime: "", endTime: "" },
+  ] as unknown as LogEntry[];
+
+const dispatchKey = (key: string, opts: { shift?: boolean } = {}) => {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, shiftKey: opts.shift ?? false }));
+};
+
+describe("useKeyboardNavigation", () => {
+  it("J selects the next log within the current page", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+      }),
+    );
+
+    dispatchKey("j");
+    expect(onSelectLog).toHaveBeenCalledWith(logs[1]);
+  });
+
+  it("K selects the previous log within the current page", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[2],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+      }),
+    );
+
+    dispatchKey("k");
+    expect(onSelectLog).toHaveBeenCalledWith(logs[1]);
+  });
+
+  it("J at the end of the page is a no-op (does not page forward)", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onNextPage = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[2],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+        onNextPage,
+      }),
+    );
+
+    dispatchKey("j");
+    expect(onSelectLog).not.toHaveBeenCalled();
+    expect(onNextPage).not.toHaveBeenCalled();
+  });
+
+  it("Shift+J calls onNextPage and does NOT walk to the next row", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onNextPage = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+        onNextPage,
+      }),
+    );
+
+    // With shift held, the browser delivers e.key === "J" (uppercase). The
+    // hook must route to onNextPage and skip selectNextLog so the two paths
+    // stay mutually exclusive.
+    dispatchKey("J", { shift: true });
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+    expect(onSelectLog).not.toHaveBeenCalled();
+  });
+
+  it("Shift+K calls onPreviousPage and does NOT walk to the previous row", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onPreviousPage = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[2],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+        onPreviousPage,
+      }),
+    );
+
+    dispatchKey("K", { shift: true });
+    expect(onPreviousPage).toHaveBeenCalledTimes(1);
+    expect(onSelectLog).not.toHaveBeenCalled();
+  });
+
+  it("Shift+J without an onNextPage handler is a safe no-op", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose: vi.fn(),
+        onSelectLog,
+      }),
+    );
+
+    expect(() => dispatchKey("J", { shift: true })).not.toThrow();
+    // Critically, plain row-walk must not fire either — Shift+J is reserved
+    // for paging even when no handler is wired.
+    expect(onSelectLog).not.toHaveBeenCalled();
+  });
+
+  it("Escape calls onClose", () => {
+    const onClose = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: true,
+        currentLog: makeLogs()[0],
+        allLogs: makeLogs(),
+        onClose,
+        onSelectLog: vi.fn(),
+      }),
+    );
+
+    dispatchKey("Escape");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keys when isOpen is false", () => {
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onClose = vi.fn();
+    renderHook(() =>
+      useKeyboardNavigation({
+        isOpen: false,
+        currentLog: logs[0],
+        allLogs: logs,
+        onClose,
+        onSelectLog,
+      }),
+    );
+
+    dispatchKey("j");
+    dispatchKey("Escape");
+    expect(onSelectLog).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not re-register the keydown listener when callback identities are stable", () => {
+    // Regression guard: the effect deps include the page handlers, so unstable
+    // (inline) functions from the parent caused remove/addEventListener to fire
+    // on every render. With the parent passing stable refs (useCallback'd),
+    // a re-render with identical props must not churn the listener.
+    const logs = makeLogs();
+    const onSelectLog = vi.fn();
+    const onClose = vi.fn();
+    const onPreviousPage = vi.fn();
+    const onNextPage = vi.fn();
+
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    const { rerender } = renderHook(
+      (props) => useKeyboardNavigation(props),
+      {
+        initialProps: {
+          isOpen: true,
+          currentLog: logs[0],
+          allLogs: logs,
+          onClose,
+          onSelectLog,
+          onPreviousPage,
+          onNextPage,
+        },
+      },
+    );
+
+    const callsAfterMount = addSpy.mock.calls.filter(([type]) => type === "keydown").length;
+
+    // Re-render with the exact same prop references — should not re-attach.
+    rerender({
+      isOpen: true,
+      currentLog: logs[0],
+      allLogs: logs,
+      onClose,
+      onSelectLog,
+      onPreviousPage,
+      onNextPage,
+    });
+
+    const callsAfterRerender = addSpy.mock.calls.filter(([type]) => type === "keydown").length;
+    expect(callsAfterRerender).toBe(callsAfterMount);
+
+    addSpy.mockRestore();
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
@@ -8,15 +8,16 @@ interface UseKeyboardNavigationProps {
   allLogs: LogEntry[];
   onClose: () => void;
   onSelectLog?: (log: LogEntry) => void;
+  onPreviousPage?: () => void;
+  onNextPage?: () => void;
 }
 
 /**
  * Custom hook for keyboard navigation in the log details drawer.
- * Handles J/K for next/previous and Escape for close.
  *
  * Keyboard shortcuts:
- * - J: Navigate to next log (down)
- * - K: Navigate to previous log (up)
+ * - J / K: Navigate to next / previous log within the current page
+ * - Shift+J / Shift+K: Page next / previous (session mode)
  * - Escape: Close drawer
  */
 export function useKeyboardNavigation({
@@ -25,6 +26,8 @@ export function useKeyboardNavigation({
   allLogs,
   onClose,
   onSelectLog,
+  onPreviousPage,
+  onNextPage,
 }: UseKeyboardNavigationProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -35,24 +38,29 @@ export function useKeyboardNavigation({
 
       if (!isOpen) return;
 
-      switch (e.key) {
-        case KEY_ESCAPE:
-          onClose();
-          break;
-        case KEY_J_LOWER:
-        case KEY_J_UPPER:
-          selectNextLog();
-          break;
-        case KEY_K_LOWER:
-        case KEY_K_UPPER:
-          selectPreviousLog();
-          break;
+      if (e.key === KEY_ESCAPE) {
+        onClose();
+        return;
+      }
+
+      // With Shift held, e.key is already uppercase ("J"/"K"). Compare against
+      // both cases so the page shortcuts work regardless of caps lock.
+      const isJ = e.key === KEY_J_LOWER || e.key === KEY_J_UPPER;
+      const isK = e.key === KEY_K_LOWER || e.key === KEY_K_UPPER;
+      if (!isJ && !isK) return;
+
+      if (e.shiftKey) {
+        if (isJ) onNextPage?.();
+        else onPreviousPage?.();
+      } else {
+        if (isJ) selectNextLog();
+        else selectPreviousLog();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, currentLog, allLogs]);
+  }, [isOpen, currentLog, allLogs, onPreviousPage, onNextPage]);
 
   const selectNextLog = () => {
     if (!currentLog || !allLogs.length || !onSelectLog) return;

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
@@ -60,7 +60,7 @@ export function useKeyboardNavigation({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, currentLog, allLogs, onPreviousPage, onNextPage]);
+  }, [isOpen, currentLog, allLogs, onClose, onSelectLog, onPreviousPage, onNextPage]);
 
   const selectNextLog = () => {
     if (!currentLog || !allLogs.length || !onSelectLog) return;


### PR DESCRIPTION
## Relevant issues

Fixes #28224 — original bug report (still OPEN, filed 2026-05-19): the session trace sidebar in the Log Details drawer silently truncates to the first 50 entries.

Re-submission of #28225 (silently closed on 2026-05-22 during dated-staging cleanup; verified the fix is NOT in `main`, `litellm_internal_staging`, or `litellm_oss_staging` as of 2026-05-25).

Same root cause as #21300 (open since 2026-02-16, still unresolved) — `sessionSpendLogsCall` in `networking.tsx` not passing pagination params to the backend. That PR fetches all pages eagerly; this PR keeps a single-page-at-a-time UX with explicit user-controlled paging, which is more memory-friendly for very long sessions and matches the existing main-list pagination pattern.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — UI test coverage added in `useKeyboardNavigation.test.ts` (9 vitest specs in the dashboard test suite, since this is a UI-only change with no Python surface)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem (session log drawer truncation at 50 entries)
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile previously confirmed 5/5 on #28225 — same diff)

## Type

🐛 Bug Fix
🆕 New Feature

## Changes

The session sidebar in the log details drawer fetched all logs for a session in a single call. The backend defaults to `page_size=50`, so long sessions silently truncated to 50 entries — anything beyond that was unreachable from the UI.

This PR forwards `page` / `page_size` to the existing `/spend/logs/session/ui` endpoint and surfaces page navigation directly in the drawer with `Shift+J` / `Shift+K` keyboard shortcuts.

- **`networking.tsx`** — `sessionSpendLogsCall` now accepts `page` (default `1`) and `page_size` (default `50`) and forwards them as query params.
- **`LogDetailsDrawer.tsx`** — track `sessionPage` state, reset to `1` on `session_id` change, include page in the query key, and render a `(this page)` disclosure on the sidebar header when paginated.
- **`DrawerHeader.tsx`** — render previous/next page buttons (`DoubleLeft` / `DoubleRight` icons) with `⇧K` / `⇧J` shortcut labels when `showPageControls` is true.
- **`useKeyboardNavigation.ts`** — explicit `shiftKey` branch routes `Shift+J/K` to `onNextPage` / `onPreviousPage`. Plain `J` / `K` continue selecting next/prev log within the page (mutually exclusive — `Shift+` never fires both).
- **`useKeyboardNavigation.test.ts`** (new) — 9 vitest specs covering J/K bounds, Shift+J/K page calls and mutual exclusion with selection, optional handlers safe, Escape, `isOpen=false` ignored, and a regression test verifying `addEventListener` is not re-attached when callback identities are stable.