### PR TITLE
docs: fix broken cosign overview link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
 
 ### Verify Docker Image Signatures
 
-All LiteLLM Docker images published to GHCR are signed with [cosign](https://docs.sigstore.dev/cosign/overview/). Every release is signed with the same key introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0).
+All LiteLLM Docker images published to GHCR are signed with [cosign](https://docs.sigstore.dev/cosign/signing/overview/). Every release is signed with the same key introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0).
 
 **Verify using the pinned commit hash (recommended):**
 


### PR DESCRIPTION
## Relevant issues

N/A — minor docs link fix.

## Linear ticket

N/A.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  > Not applicable: change is a single-character URL path fragment in `README.md`. No code path is touched, no test target exists. Happy to add one if maintainers prefer a different convention for docs-only fixes.
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  > N/A for README-only change.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
  > Will request after PR opens.

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Old link returns 404, new link returns 200:

```
$ curl -sI https://docs.sigstore.dev/cosign/overview/         | head -1
HTTP/2 404
$ curl -sI https://docs.sigstore.dev/cosign/signing/overview/ | head -1
HTTP/2 200
```

## Type

📖 Documentation

## Changes

The cosign overview page on `docs.sigstore.dev/cosign/overview/` now 404s — the Sigstore docs site reorganized cosign content under `cosign/signing/overview/`. Updated the link in the "Verify Docker Image Signatures" section of `README.md` so the reference is reachable again.

Single-line change, `README.md` only. The neighboring commit-pinned link (to the `cosign.pub` introduction) is unchanged because it still resolves correctly.
