### PR TITLE
feat(proxy): allow use_redis_transaction_buffer without redis cache

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -888,16 +888,26 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 
         asyncio.create_task(_run_pw_migration())
 
+    ## use_redis_transaction_buffer: fall back to a standalone Redis (REDIS_* env)
+    ## when the proxy cache backend is not Redis ##
+    transaction_buffer_redis_cache = redis_usage_cache
+    if transaction_buffer_redis_cache is None:
+        transaction_buffer_redis_cache = (
+            ProxyStartupEvent._get_transaction_buffer_redis_cache(
+                general_settings=general_settings
+            )
+        )
+
     ProxyStartupEvent._initialize_startup_logging(
         llm_router=llm_router,
         proxy_logging_obj=proxy_logging_obj,
-        redis_usage_cache=redis_usage_cache,
+        redis_usage_cache=transaction_buffer_redis_cache,
     )
 
     ## Validate use_redis_transaction_buffer requires Redis cache ##
     ProxyStartupEvent._validate_redis_transaction_buffer_config(
         general_settings=general_settings,
-        redis_usage_cache=redis_usage_cache,
+        redis_usage_cache=transaction_buffer_redis_cache,
     )
 
     ## SEMANTIC TOOL FILTER ##
@@ -7248,14 +7258,46 @@ class ProxyStartupEvent:
         if _use_redis_transaction_buffer and redis_usage_cache is None:
             raise ValueError(
                 "`use_redis_transaction_buffer` is enabled in general_settings "
-                "but no Redis cache is configured. This will cause spend updates "
+                "but no Redis is configured. This will cause spend updates "
                 "to not be tracked. Add a Redis cache in litellm_settings:\n\n"
                 "litellm_settings:\n"
                 "  cache: true\n"
                 "  cache_params:\n"
                 "    type: redis\n"
-                "    url: os.environ/REDIS_URL\n"
+                "    url: os.environ/REDIS_URL\n\n"
+                "or set REDIS_* environment variables (e.g. REDIS_HOST, "
+                "REDIS_PORT, REDIS_PASSWORD, or REDIS_URL) to use a standalone "
+                "Redis for the transaction buffer."
             )
+
+    @staticmethod
+    def _get_transaction_buffer_redis_cache(
+        general_settings: dict,
+    ) -> Optional[RedisCache]:
+        """
+        Builds a standalone Redis cache from REDIS_* environment variables so
+        use_redis_transaction_buffer can run when the proxy cache backend is not
+        Redis (e.g. disk, s3).
+
+        Returns None when the buffer is disabled or no Redis env vars are set.
+        """
+        from litellm._redis import _redis_kwargs_from_environment
+        from litellm.secret_managers.main import str_to_bool
+
+        _use_redis_transaction_buffer: Optional[Union[bool, str]] = (
+            general_settings.get("use_redis_transaction_buffer", False)
+        )
+        if isinstance(_use_redis_transaction_buffer, str):
+            _use_redis_transaction_buffer = str_to_bool(_use_redis_transaction_buffer)
+
+        if not _use_redis_transaction_buffer:
+            return None
+
+        redis_env_kwargs = _redis_kwargs_from_environment()
+        if not redis_env_kwargs:
+            return None
+
+        return RedisCache(**redis_env_kwargs)
 
     @classmethod
     async def _initialize_semantic_tool_filter(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7279,7 +7279,8 @@ class ProxyStartupEvent:
         use_redis_transaction_buffer can run when the proxy cache backend is not
         Redis (e.g. disk, s3).
 
-        Returns None when the buffer is disabled or no Redis env vars are set.
+        Returns None when the buffer is disabled, or when no Redis host or url
+        is set in the environment.
         """
         from litellm._redis import _redis_kwargs_from_environment
         from litellm.secret_managers.main import str_to_bool
@@ -7294,7 +7295,7 @@ class ProxyStartupEvent:
             return None
 
         redis_env_kwargs = _redis_kwargs_from_environment()
-        if not redis_env_kwargs:
+        if "host" not in redis_env_kwargs and "url" not in redis_env_kwargs:
             return None
 
         return RedisCache(**redis_env_kwargs)

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_redis_update_buffer.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_redis_update_buffer.py
@@ -342,3 +342,35 @@ def test_get_transaction_buffer_redis_cache_none_without_redis_env():
             general_settings={"use_redis_transaction_buffer": True},
         )
     assert result is None
+
+
+def test_get_transaction_buffer_redis_cache_none_without_host_or_url():
+    """
+    A REDIS_* var that is not a connection target (e.g. REDIS_SOCKET_TIMEOUT) must not
+    trigger a build. Without a host or url, get_redis_client raises, so return None and
+    let startup validation surface the config error instead of crashing.
+    """
+    with patch(
+        "litellm._redis._redis_kwargs_from_environment",
+        return_value={"socket_timeout": 5.0},
+    ):
+        result = ProxyStartupEvent._get_transaction_buffer_redis_cache(
+            general_settings={"use_redis_transaction_buffer": True},
+        )
+    assert result is None
+
+
+def test_get_transaction_buffer_redis_cache_parses_string_flag(monkeypatch):
+    """
+    use_redis_transaction_buffer accepts a string value (e.g. from env/YAML); "true"
+    is parsed to a bool before the standalone cache is built.
+    """
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+
+    with patch("litellm.proxy.proxy_server.RedisCache") as mock_redis_cache:
+        result = ProxyStartupEvent._get_transaction_buffer_redis_cache(
+            general_settings={"use_redis_transaction_buffer": "true"},
+        )
+
+    mock_redis_cache.assert_called_once()
+    assert result is mock_redis_cache.return_value

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_redis_update_buffer.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_redis_update_buffer.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,7 +11,6 @@ sys.path.insert(
 
 from litellm.proxy.db.db_transaction_queue.redis_update_buffer import RedisUpdateBuffer
 from litellm.proxy.proxy_server import ProxyStartupEvent
-from litellm.types.caching import RedisPipelineRpushOperation
 
 
 @pytest.fixture
@@ -305,3 +304,41 @@ def test_validate_redis_transaction_buffer_passes_when_disabled():
         general_settings={},
         redis_usage_cache=None,
     )
+
+
+def test_get_transaction_buffer_redis_cache_builds_from_env(monkeypatch):
+    """
+    When use_redis_transaction_buffer=true, a standalone RedisCache is built from
+    REDIS_* environment variables so the buffer works without a Redis cache backend.
+    """
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+
+    with patch("litellm.proxy.proxy_server.RedisCache") as mock_redis_cache:
+        result = ProxyStartupEvent._get_transaction_buffer_redis_cache(
+            general_settings={"use_redis_transaction_buffer": True},
+        )
+
+    mock_redis_cache.assert_called_once()
+    assert mock_redis_cache.call_args.kwargs["host"] == "localhost"
+    assert result is mock_redis_cache.return_value
+
+
+def test_get_transaction_buffer_redis_cache_none_when_disabled():
+    """When use_redis_transaction_buffer is not enabled, no standalone cache is built."""
+    result = ProxyStartupEvent._get_transaction_buffer_redis_cache(
+        general_settings={},
+    )
+    assert result is None
+
+
+def test_get_transaction_buffer_redis_cache_none_without_redis_env():
+    """
+    When use_redis_transaction_buffer=true but no REDIS_* env vars are set,
+    no standalone cache is built (startup validation then raises the config error).
+    """
+    with patch("litellm._redis._redis_kwargs_from_environment", return_value={}):
+        result = ProxyStartupEvent._get_transaction_buffer_redis_cache(
+            general_settings={"use_redis_transaction_buffer": True},
+        )
+    assert result is None


### PR DESCRIPTION
## Relevant issues

Fixes #28606

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The buffer path has no external dependency, new unit tests passing locally:
<img width="2247" height="496" alt="1" src="https://github.com/user-attachments/assets/6c6d1c5f-dc35-4b81-a09a-603692054a88" />


## Type

🆕 New Feature

## Changes
`use_redis_transaction_buffer` needs a Redis connection to buffer spend transactions before committing them to the database. The only Redis handle the proxy builds at startup is `redis_usage_cache`, and that is populated only when the litellm cache backend is Redis (when `litellm.cache.cache` is a `RedisCache`). With a disk, s3, or in-memory cache, `redis_usage_cache` stays `None`, `_validate_redis_transaction_buffer_config` raises, and the proxy fails to start. That blocks the case in #28606 where the operator wants the buffer to run against a Redis instance that is separate from the cache.

This PR adds a standalone Redis path for the buffer. `_get_transaction_buffer_redis_cache` builds a `RedisCache` from the standard `REDIS_*` environment variables through `_redis_kwargs_from_environment` when `use_redis_transaction_buffer` is enabled and no Redis cache is configured. It returns None when the buffer is disabled or no Redis host or url is set in the environment, so a deployment without a real Redis connection still hits the existing validation error.

At startup the resolved cache flows through the existing path (`_initialize_startup_logging`, `startup_event`, `update_values`), which attaches it to the transaction buffer, the pod lock manager, and the internal usage cache. The module-level `redis_usage_cache` is only read here, so behavior outside the transaction buffer path is unchanged when the cache backend is not Redis.

The startup validation error now also points to the `REDIS_*` environment variables as a way to configure Redis for the buffer.

Tests added in `tests/test_litellm/proxy/db/db_transaction_queue/test_redis_update_buffer.py`:
- `test_get_transaction_buffer_redis_cache_builds_from_env` builds the cache from `REDIS_HOST` / `REDIS_PORT`.
- `test_get_transaction_buffer_redis_cache_none_when_disabled` returns `None` when the buffer is off.
- `test_get_transaction_buffer_redis_cache_none_without_redis_env` returns `None` when no `REDIS_*` variables are set.