### PR TITLE
Refresh Perplexity model pricing and metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26028,16 +26028,16 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "input_cost_per_token": 3e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8000,
-        "max_tokens": 8000,
-        "output_cost_per_token": 1.5e-05,
+        "input_cost_per_token": 5e-07,
+        "max_input_tokens": 1048576,
+        "max_tokens": 65536,
+        "output_cost_per_token": 3e-06,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.014,
             "search_context_size_low": 0.006,
             "search_context_size_medium": 0.01
-        }
+        },
+        "cache_read_input_token_cost": 5e-08
     },
     "perplexity/preset/pro-search": {
         "litellm_provider": "perplexity",
@@ -26045,16 +26045,16 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "input_cost_per_token": 3e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8000,
-        "max_tokens": 8000,
-        "output_cost_per_token": 1.5e-05,
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.022,
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.018
-        }
+        },
+        "cache_read_input_token_cost": 1.25e-07
     },
     "perplexity/preset/deep-research": {
         "litellm_provider": "perplexity",
@@ -26062,18 +26062,17 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "citation_cost_per_token": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "max_input_tokens": 128000,
+        "input_cost_per_token": 1.75e-06,
+        "max_input_tokens": 272000,
         "max_tokens": 128000,
-        "output_cost_per_reasoning_token": 3e-06,
-        "output_cost_per_token": 8e-06,
+        "output_cost_per_token": 1.4e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.005,
             "search_context_size_low": 0.005,
             "search_context_size_medium": 0.005
         },
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "cache_read_input_token_cost": 1.75e-07
     },
     "perplexity/preset/advanced-deep-research": {
         "litellm_provider": "perplexity",
@@ -26081,18 +26080,17 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "citation_cost_per_token": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "max_input_tokens": 128000,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
         "max_tokens": 128000,
-        "output_cost_per_reasoning_token": 3e-06,
-        "output_cost_per_token": 8e-06,
+        "output_cost_per_token": 2.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.005,
             "search_context_size_low": 0.005,
             "search_context_size_medium": 0.005
         },
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "cache_read_input_token_cost": 5e-07
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25726,7 +25726,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 1.4e-06
+        "output_cost_per_token": 1.4e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/codellama-70b-instruct": {
         "input_cost_per_token": 7e-07,
@@ -25735,7 +25736,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/llama-2-70b-chat": {
         "input_cost_per_token": 7e-07,
@@ -25744,7 +25746,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/llama-3.1-70b-instruct": {
         "input_cost_per_token": 1e-06,
@@ -25753,7 +25756,8 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 1e-06
+        "output_cost_per_token": 1e-06,
+        "deprecation_date": "2025-02-22"
     },
     "perplexity/llama-3.1-8b-instruct": {
         "input_cost_per_token": 2e-07,
@@ -25762,7 +25766,8 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2e-07
+        "output_cost_per_token": 2e-07,
+        "deprecation_date": "2025-02-22"
     },
     "perplexity/mistral-7b-instruct": {
         "input_cost_per_token": 7e-08,
@@ -25771,7 +25776,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/mixtral-8x7b-instruct": {
         "input_cost_per_token": 7e-08,
@@ -25780,7 +25786,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-70b-chat": {
         "input_cost_per_token": 7e-07,
@@ -25789,7 +25796,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-70b-online": {
         "input_cost_per_request": 0.005,
@@ -25799,7 +25807,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-7b-chat": {
         "input_cost_per_token": 7e-08,
@@ -25808,7 +25817,8 @@
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-7b-online": {
         "input_cost_per_request": 0.005,
@@ -25818,7 +25828,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/sonar": {
         "input_cost_per_token": 1e-06,
@@ -25858,7 +25869,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 1.8e-06
+        "output_cost_per_token": 1.8e-06,
+        "deprecation_date": "2024-08-12"
     },
     "perplexity/sonar-medium-online": {
         "input_cost_per_request": 0.005,
@@ -25868,7 +25880,8 @@
         "max_output_tokens": 12000,
         "max_tokens": 12000,
         "mode": "chat",
-        "output_cost_per_token": 1.8e-06
+        "output_cost_per_token": 1.8e-06,
+        "deprecation_date": "2024-08-12"
     },
     "perplexity/sonar-pro": {
         "input_cost_per_token": 3e-06,
@@ -25898,7 +25911,8 @@
             "search_context_size_medium": 0.008
         },
         "supports_reasoning": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2025-12-15"
     },
     "perplexity/sonar-reasoning-pro": {
         "input_cost_per_token": 2e-06,
@@ -25922,7 +25936,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-08-12"
     },
     "perplexity/sonar-small-online": {
         "input_cost_per_request": 0.005,
@@ -25932,7 +25947,8 @@
         "max_output_tokens": 12000,
         "max_tokens": 12000,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-08-12"
     },
     "publicai/swiss-ai/apertus-8b-instruct": {
         "input_cost_per_token": 0.0,
@@ -26011,119 +26027,221 @@
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.014,
+            "search_context_size_low": 0.006,
+            "search_context_size_medium": 0.01
+        }
     },
     "perplexity/preset/pro-search": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.022,
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.018
+        }
     },
     "perplexity/preset/deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "citation_cost_per_token": 2e-06,
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_reasoning_token": 3e-06,
+        "output_cost_per_token": 8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
+        "supports_reasoning": true
     },
     "perplexity/preset/advanced-deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "citation_cost_per_token": 2e-06,
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_reasoning_token": 3e-06,
+        "output_cost_per_token": 8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
+        "supports_reasoning": true
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 1.75e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1.4e-05,
+        "cache_read_input_token_cost": 1.75e-07
     },
     "perplexity/openai/gpt-5.1": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "cache_read_input_token_cost": 1.25e-07
     },
     "perplexity/openai/gpt-5-mini": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2e-06,
+        "cache_read_input_token_cost": 2.5e-08
     },
     "perplexity/anthropic/claude-opus-4-6": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "cache_read_input_token_cost": 5e-07
     },
     "perplexity/anthropic/claude-opus-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 2.5e-05,
+        "cache_read_input_token_cost": 5e-07
     },
     "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1.5e-05,
+        "cache_read_input_token_cost": 3e-07
     },
     "perplexity/anthropic/claude-haiku-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 5e-06,
+        "cache_read_input_token_cost": 1e-07
     },
     "perplexity/google/gemini-3-pro-preview": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-04-01"
     },
     "perplexity/google/gemini-3-flash-preview": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "output_cost_per_token": 3e-06,
+        "cache_read_input_token_cost": 5e-08
     },
     "perplexity/google/gemini-2.5-pro": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-02-01"
     },
     "perplexity/google/gemini-2.5-flash": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-02-01"
     },
     "perplexity/xai/grok-4-1-fast-non-reasoning": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-04-01"
     },
     "perplexity/perplexity/sonar": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-06,
+        "cache_read_input_token_cost": 6.25e-08
     },
     "perplexity/pplx-embed-v1-0.6b": {
         "input_cost_per_token": 4e-09,
@@ -37521,5 +37639,230 @@
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
+    },
+    "perplexity/pplx-embed-context-v1-0.6b": {
+        "input_cost_per_token": 8e-09,
+        "litellm_provider": "perplexity",
+        "max_input_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1024
+    },
+    "perplexity/pplx-embed-context-v1-4b": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "perplexity",
+        "max_input_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 2560
+    },
+    "perplexity/anthropic/claude-opus-4-7": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 5e-07
+    },
+    "perplexity/anthropic/claude-sonnet-4-6": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 3e-07
+    },
+    "perplexity/openai/gpt-5.5": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 5e-07
+    },
+    "perplexity/openai/gpt-5.4": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-06,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2.5e-07
+    },
+    "perplexity/openai/gpt-5.4-mini": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 7.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 4.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 0.0
+    },
+    "perplexity/openai/gpt-5.4-nano": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.25e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 0.0
+    },
+    "perplexity/openai/gpt-5": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 1.25e-07
+    },
+    "perplexity/google/gemini-3.1-pro-preview": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/google/gemini-3.1-flash-lite": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2.5e-08
+    },
+    "perplexity/google/gemini-3.1-flash-lite-preview": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2.5e-08
+    },
+    "perplexity/google/gemini-3.5-flash": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.5e-06,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 9e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 1.5e-07
+    },
+    "perplexity/xai/grok-4.3": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/xai/grok-4.20-reasoning": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/xai/grok-4.20-non-reasoning": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": false,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/xai/grok-4.20-multi-agent": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/nvidia/nemotron-3-super-120b-a12b": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true
     }
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -26028,16 +26028,16 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "input_cost_per_token": 3e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8000,
-        "max_tokens": 8000,
-        "output_cost_per_token": 1.5e-05,
+        "input_cost_per_token": 5e-07,
+        "max_input_tokens": 1048576,
+        "max_tokens": 65536,
+        "output_cost_per_token": 3e-06,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.014,
             "search_context_size_low": 0.006,
             "search_context_size_medium": 0.01
-        }
+        },
+        "cache_read_input_token_cost": 5e-08
     },
     "perplexity/preset/pro-search": {
         "litellm_provider": "perplexity",
@@ -26045,16 +26045,16 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "input_cost_per_token": 3e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8000,
-        "max_tokens": 8000,
-        "output_cost_per_token": 1.5e-05,
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.022,
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.018
-        }
+        },
+        "cache_read_input_token_cost": 1.25e-07
     },
     "perplexity/preset/deep-research": {
         "litellm_provider": "perplexity",
@@ -26062,18 +26062,17 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "citation_cost_per_token": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "max_input_tokens": 128000,
+        "input_cost_per_token": 1.75e-06,
+        "max_input_tokens": 272000,
         "max_tokens": 128000,
-        "output_cost_per_reasoning_token": 3e-06,
-        "output_cost_per_token": 8e-06,
+        "output_cost_per_token": 1.4e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.005,
             "search_context_size_low": 0.005,
             "search_context_size_medium": 0.005
         },
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "cache_read_input_token_cost": 1.75e-07
     },
     "perplexity/preset/advanced-deep-research": {
         "litellm_provider": "perplexity",
@@ -26081,18 +26080,17 @@
         "supports_web_search": true,
         "supports_preset": true,
         "supports_function_calling": true,
-        "citation_cost_per_token": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "max_input_tokens": 128000,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
         "max_tokens": 128000,
-        "output_cost_per_reasoning_token": 3e-06,
-        "output_cost_per_token": 8e-06,
+        "output_cost_per_token": 2.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.005,
             "search_context_size_low": 0.005,
             "search_context_size_medium": 0.005
         },
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "cache_read_input_token_cost": 5e-07
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25726,7 +25726,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 1.4e-06
+        "output_cost_per_token": 1.4e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/codellama-70b-instruct": {
         "input_cost_per_token": 7e-07,
@@ -25735,7 +25736,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/llama-2-70b-chat": {
         "input_cost_per_token": 7e-07,
@@ -25744,7 +25746,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/llama-3.1-70b-instruct": {
         "input_cost_per_token": 1e-06,
@@ -25753,7 +25756,8 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 1e-06
+        "output_cost_per_token": 1e-06,
+        "deprecation_date": "2025-02-22"
     },
     "perplexity/llama-3.1-8b-instruct": {
         "input_cost_per_token": 2e-07,
@@ -25762,7 +25766,8 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2e-07
+        "output_cost_per_token": 2e-07,
+        "deprecation_date": "2025-02-22"
     },
     "perplexity/mistral-7b-instruct": {
         "input_cost_per_token": 7e-08,
@@ -25771,7 +25776,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/mixtral-8x7b-instruct": {
         "input_cost_per_token": 7e-08,
@@ -25780,7 +25786,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-70b-chat": {
         "input_cost_per_token": 7e-07,
@@ -25789,7 +25796,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-70b-online": {
         "input_cost_per_request": 0.005,
@@ -25799,7 +25807,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-06
+        "output_cost_per_token": 2.8e-06,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-7b-chat": {
         "input_cost_per_token": 7e-08,
@@ -25808,7 +25817,8 @@
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/pplx-7b-online": {
         "input_cost_per_request": 0.005,
@@ -25818,7 +25828,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-03-15"
     },
     "perplexity/sonar": {
         "input_cost_per_token": 1e-06,
@@ -25858,7 +25869,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 1.8e-06
+        "output_cost_per_token": 1.8e-06,
+        "deprecation_date": "2024-08-12"
     },
     "perplexity/sonar-medium-online": {
         "input_cost_per_request": 0.005,
@@ -25868,7 +25880,8 @@
         "max_output_tokens": 12000,
         "max_tokens": 12000,
         "mode": "chat",
-        "output_cost_per_token": 1.8e-06
+        "output_cost_per_token": 1.8e-06,
+        "deprecation_date": "2024-08-12"
     },
     "perplexity/sonar-pro": {
         "input_cost_per_token": 3e-06,
@@ -25898,7 +25911,8 @@
             "search_context_size_medium": 0.008
         },
         "supports_reasoning": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2025-12-15"
     },
     "perplexity/sonar-reasoning-pro": {
         "input_cost_per_token": 2e-06,
@@ -25922,7 +25936,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-08-12"
     },
     "perplexity/sonar-small-online": {
         "input_cost_per_request": 0.005,
@@ -25932,7 +25947,8 @@
         "max_output_tokens": 12000,
         "max_tokens": 12000,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07
+        "output_cost_per_token": 2.8e-07,
+        "deprecation_date": "2024-08-12"
     },
     "publicai/swiss-ai/apertus-8b-instruct": {
         "input_cost_per_token": 0.0,
@@ -26011,119 +26027,221 @@
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.014,
+            "search_context_size_low": 0.006,
+            "search_context_size_medium": 0.01
+        }
     },
     "perplexity/preset/pro-search": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.022,
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.018
+        }
     },
     "perplexity/preset/deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "citation_cost_per_token": 2e-06,
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_reasoning_token": 3e-06,
+        "output_cost_per_token": 8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
+        "supports_reasoning": true
     },
     "perplexity/preset/advanced-deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_preset": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "citation_cost_per_token": 2e-06,
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_reasoning_token": 3e-06,
+        "output_cost_per_token": 8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
+        "supports_reasoning": true
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 1.75e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1.4e-05,
+        "cache_read_input_token_cost": 1.75e-07
     },
     "perplexity/openai/gpt-5.1": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "cache_read_input_token_cost": 1.25e-07
     },
     "perplexity/openai/gpt-5-mini": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2e-06,
+        "cache_read_input_token_cost": 2.5e-08
     },
     "perplexity/anthropic/claude-opus-4-6": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "cache_read_input_token_cost": 5e-07
     },
     "perplexity/anthropic/claude-opus-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 2.5e-05,
+        "cache_read_input_token_cost": 5e-07
     },
     "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1.5e-05,
+        "cache_read_input_token_cost": 3e-07
     },
     "perplexity/anthropic/claude-haiku-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 5e-06,
+        "cache_read_input_token_cost": 1e-07
     },
     "perplexity/google/gemini-3-pro-preview": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-04-01"
     },
     "perplexity/google/gemini-3-flash-preview": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "input_cost_per_token": 5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "output_cost_per_token": 3e-06,
+        "cache_read_input_token_cost": 5e-08
     },
     "perplexity/google/gemini-2.5-pro": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-02-01"
     },
     "perplexity/google/gemini-2.5-flash": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-02-01"
     },
     "perplexity/xai/grok-4-1-fast-non-reasoning": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "deprecation_date": "2026-04-01"
     },
     "perplexity/perplexity/sonar": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-06,
+        "cache_read_input_token_cost": 6.25e-08
     },
     "perplexity/pplx-embed-v1-0.6b": {
         "input_cost_per_token": 4e-09,
@@ -37521,5 +37639,230 @@
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true,
         "supports_pdf_input": true
+    },
+    "perplexity/pplx-embed-context-v1-0.6b": {
+        "input_cost_per_token": 8e-09,
+        "litellm_provider": "perplexity",
+        "max_input_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1024
+    },
+    "perplexity/pplx-embed-context-v1-4b": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "perplexity",
+        "max_input_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 2560
+    },
+    "perplexity/anthropic/claude-opus-4-7": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 5e-07
+    },
+    "perplexity/anthropic/claude-sonnet-4-6": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 3e-07
+    },
+    "perplexity/openai/gpt-5.5": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 5e-07
+    },
+    "perplexity/openai/gpt-5.4": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-06,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2.5e-07
+    },
+    "perplexity/openai/gpt-5.4-mini": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 7.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 4.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 0.0
+    },
+    "perplexity/openai/gpt-5.4-nano": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.25e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 0.0
+    },
+    "perplexity/openai/gpt-5": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 1.25e-07
+    },
+    "perplexity/google/gemini-3.1-pro-preview": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/google/gemini-3.1-flash-lite": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2.5e-08
+    },
+    "perplexity/google/gemini-3.1-flash-lite-preview": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2.5e-08
+    },
+    "perplexity/google/gemini-3.5-flash": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.5e-06,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "responses",
+        "output_cost_per_token": 9e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 1.5e-07
+    },
+    "perplexity/xai/grok-4.3": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/xai/grok-4.20-reasoning": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/xai/grok-4.20-non-reasoning": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": false,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/xai/grok-4.20-multi-agent": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true,
+        "cache_read_input_token_cost": 2e-07
+    },
+    "perplexity/nvidia/nemotron-3-super-120b-a12b": {
+        "litellm_provider": "perplexity",
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_web_search": true
     }
 }


### PR DESCRIPTION
## Summary

Sync every entry under the `perplexity` provider in `model_prices_and_context_window.json` (+ backup) against Perplexity's published docs:
- [Pricing](https://docs.perplexity.ai/getting-started/pricing)
- [Sonar models](https://docs.perplexity.ai/docs/sonar/models)
- [Agent API models](https://docs.perplexity.ai/docs/agent-api/models)

### What changed
- **Native Sonar** (`sonar`, `sonar-pro`, `sonar-reasoning-pro`, `sonar-deep-research`): refreshed per-token + per-query search-context pricing.
- **`sonar-reasoning`**: tagged `deprecation_date: 2025-12-15` (retired in favor of `sonar-reasoning-pro`).
- **Legacy native models** (Llama/Mistral/CodeLlama/`pplx-*`/`sonar-small|medium-*`): added `deprecation_date`.
- **Existing Agent API proxied entries** (`perplexity/openai/*`, `perplexity/anthropic/*`, `perplexity/google/*`, `perplexity/perplexity/sonar`): filled in token + cache pricing + context windows. Corrected `supports_reasoning` on Claude 4.x / GPT-5.x / Gemini-3 entries.
- **Stale Agent API entries** no longer listed by Perplexity (`gemini-2.5-*`, `gemini-3-pro-preview`, `grok-4-1-fast-non-reasoning`): tagged `deprecation_date`.
- **Presets** (`fast-search`, `pro-search`, `deep-research`, `advanced-deep-research`): added token + search-context pricing.
- **New entries** (16): `claude-opus-4-7`, `claude-sonnet-4-6`, `gpt-5`/`5.4`/`5.4-mini`/`5.4-nano`/`5.5`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite{,-preview}`, `gemini-3.5-flash`, `grok-4.3`, `grok-4.20-{reasoning,non-reasoning,multi-agent}`, `nvidia/nemotron-3-super-120b-a12b`, `pplx-embed-context-v1-{0.6b,4b}`.

### Out of scope
No source code changed. Both JSON files updated in lockstep so `ci_cd/check_files_match.py` passes.

## Test plan
- [x] `python ci_cd/check_files_match.py` reports the two JSONs match.
- [x] `python -c "import json; json.load(open('model_prices_and_context_window.json'))"` parses cleanly.
- [x] Spot-check a few entries via `litellm.model_cost["perplexity/sonar-pro"]` etc. return expected pricing.