### PR TITLE
docs(helm): clarify which helm chart to use; add README to experimental helm/litellm (fixes #28619)

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -1,8 +1,15 @@
-# Helm Chart for LiteLLM
+# Helm Chart for LiteLLM (stable / monolithic)
 
 > [!IMPORTANT]
-> This is community maintained, Please make an issue if you run into a bug
+> This is the **stable, community-maintained, monolithic** Helm chart and is the recommended starting point for most users. Please make an issue if you run into a bug.
 > We recommend using [Docker or Kubernetes for production deployments](https://docs.litellm.ai/docs/proxy/prod)
+
+> [!NOTE]
+> **Which chart should I use?** This repo currently ships two charts:
+> - **`deploy/charts/litellm-helm/`** (this chart) — single-Deployment, community-maintained, stable. Use this unless you specifically need the microservices split below.
+> - **`helm/litellm/`** — experimental microservices-split chart maintained by the LiteLLM team. See the [microservices helm guide](https://docs.litellm.ai/docs/proxy/microservices_helm) for guidance. The associated container images are dev-only releases (see [BerriAI packages](https://github.com/orgs/BerriAI/packages?repo_name=litellm)).
+>
+> See [#28619](https://github.com/BerriAI/litellm/issues/28619) for the discussion that prompted this clarification.
 
 ## Prerequisites
 

--- a/helm/litellm/README.md
+++ b/helm/litellm/README.md
@@ -1,0 +1,23 @@
+# Helm Chart for LiteLLM (experimental, microservices split)
+
+> [!WARNING]
+> **This chart is experimental.** It splits a LiteLLM deployment into multiple microservices (proxy, UI, etc.) and is maintained by the LiteLLM team. The associated container images are published as **dev-only releases** (see the [BerriAI packages page](https://github.com/orgs/BerriAI/packages?repo_name=litellm) for available `litellm/ch*` images) and are **not** the same as the stable `docker.litellm.ai/berriai/litellm` image used by the monolithic chart.
+>
+> For production use, prefer the stable monolithic chart at [`deploy/charts/litellm-helm/`](../../deploy/charts/litellm-helm/) until this chart's images move out of dev-only status.
+
+## Which chart should I use?
+
+| Chart | Status | Maintainer | Use when |
+|---|---|---|---|
+| [`deploy/charts/litellm-helm/`](../../deploy/charts/litellm-helm/) | **Stable** | Community + LiteLLM team | Default for most users; production-ready single-Deployment. |
+| `helm/litellm/` (this chart) | **Experimental** | LiteLLM team | You need a microservices split deployment and are comfortable running dev-only container images. |
+
+See the [microservices helm guide](https://docs.litellm.ai/docs/proxy/microservices_helm) for deployment instructions and the planned architecture.
+
+## Background
+
+This README was added in response to [#28619](https://github.com/BerriAI/litellm/issues/28619), which flagged that two helm charts existed in the repository with no documentation explaining when to use which one. The clarification here mirrors the maintainer's comment on that issue.
+
+## Status / stability tracking
+
+When this chart graduates from experimental and its container images receive stable releases, this README should be updated to reflect the new status and the canonical chart recommendation may shift.


### PR DESCRIPTION
Issue #28619 flagged that this repo ships two helm charts with no in-tree documentation explaining when to use which one. @yassin-berriai clarified the difference in a comment, but that information lives in the issue thread rather than alongside the charts themselves — so an operator browsing the repo still has to find the issue to know which chart to pick.

This PR moves the maintainer's clarification into the chart READMEs so the answer is visible at the point of use.

## What changed (docs-only, 2 files)

- **`deploy/charts/litellm-helm/README.md`** — retitled as "stable / monolithic" and added a "Which chart should I use?" callout pointing at `helm/litellm/` for users who specifically need the microservices split. Mirrors the maintainer guidance from #28619.
- **`helm/litellm/README.md`** (new file) — was previously absent, so anyone landing on this chart had no way to know it was experimental + dev-only. Now states the experimental status, links to the [microservices helm guide](https://docs.litellm.ai/docs/proxy/microservices_helm), notes that the associated container images are dev-only releases, and recommends the stable chart for production.

## No behavior change

- No template / values / chart code changes.
- Both charts retain identical install behavior; users following existing docs land on the same chart they always did.
- The "Which chart?" table in both READMEs gives users a consistent decision matrix.

## When to revisit

If `helm/litellm/` graduates from experimental and its container images get stable releases, both READMEs should be updated to flip the recommendation. Flagged in the experimental README under "Status / stability tracking".

Fixes #28619