### PR TITLE
feat(oci): add xai.grok-4.3 model metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26296,6 +26296,25 @@
         "supports_function_calling": true,
         "supports_response_schema": false
     },
+    "oci/xai.grok-4.3": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "litellm_provider": "oci",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "source": "https://docs.oracle.com/en-us/iaas/Content/generative-ai/xai-grok-4-3.htm",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_vision": true
+    },
     "oci/xai.grok-code-fast-1": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "oci",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -26438,6 +26438,25 @@
         "supports_function_calling": true,
         "supports_response_schema": false
     },
+    "oci/xai.grok-4.3": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "litellm_provider": "oci",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "source": "https://docs.oracle.com/en-us/iaas/Content/generative-ai/xai-grok-4-3.htm",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_vision": true
+    },
     "oci/xai.grok-code-fast-1": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "oci",

--- a/tests/test_litellm/test_oci_xai_grok_4_3_model_metadata.py
+++ b/tests/test_litellm/test_oci_xai_grok_4_3_model_metadata.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+
+def test_oci_xai_grok_4_3_model_info():
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    model = "oci/xai.grok-4.3"
+    info = model_cost.get(model)
+    assert (
+        info is not None
+    ), f"{model} not found in model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "oci"
+    assert info["mode"] == "chat"
+
+    assert info["input_cost_per_token"] == 1.25e-06
+    assert info["output_cost_per_token"] == 2.5e-06
+    assert info["cache_read_input_token_cost"] == 2e-07
+
+    assert info["input_cost_per_token_above_200k_tokens"] == 2.5e-06
+    assert info["output_cost_per_token_above_200k_tokens"] == 5e-06
+    assert info["cache_read_input_token_cost_above_200k_tokens"] == 4e-07
+
+    assert info["max_input_tokens"] == 1000000
+    assert info["max_output_tokens"] == 1000000
+    assert info["max_tokens"] == 1000000
+
+    assert info["supports_function_calling"] is True
+    assert info["supports_vision"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_response_schema"] is False
+
+
+def test_oci_xai_grok_4_3_backup_matches_main():
+    """Ensure the bundled model cost map stays in sync with the canonical file."""
+    repo_root = Path(__file__).parents[2]
+    main_path = repo_root / "model_prices_and_context_window.json"
+    backup_path = repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+
+    with open(main_path) as f:
+        main_cost = json.load(f)
+    with open(backup_path) as f:
+        backup_cost = json.load(f)
+
+    model = "oci/xai.grok-4.3"
+    assert backup_cost.get(model) == main_cost.get(
+        model
+    ), f"{model} differs between main and backup model cost maps"


### PR DESCRIPTION
## Relevant issues

N/A — model is already listed as supported in the OCI provider docs
(BerriAI/litellm-docs#197, merged 2026-05-23), this PR only adds the
matching entry to the model cost catalog so the proxy UI surfaces it
and spend tracking attributes cost correctly.

## Linear ticket

N/A (external contributor)

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/test_oci_xai_grok_4_3_model_metadata.py`
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible — only adds the `oci/xai.grok-4.3` entry to the model cost catalog (and its backup) + a metadata regression test
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Summary

Oracle Cloud Infrastructure Generative AI has launched the **xAI Grok
4.3** model — a reasoning model with a 1M-token context window (shared
between prompt and response) and a knowledge cutoff of December 2025.
The model id `xai.grok-4.3` is already listed as supported in the OCI
provider docs (link below), but the model cost catalog does not yet
have an entry for it, so it does not appear in the proxy UI "Add Model"
dropdown and spend is attributed to the default rate.

This PR adds `oci/xai.grok-4.3` to both
`model_prices_and_context_window.json` and the bundled
`litellm/model_prices_and_context_window_backup.json`, with pricing and
capability metadata sourced from Oracle's public documentation and
pricing API.

## Pricing (PAY_AS_YOU_GO)

Sourced from the Oracle public pricing API
(`https://apexapps.oracle.com/pls/apex/cetools/api/v1/products/`,
SKUs B112080-B112085):

| Dimension              | ≤200K context | >200K context |
| ---------------------- | ------------- | ------------- |
| Input  / 1M tokens     | $1.25         | $2.50         |
| Output / 1M tokens     | $2.50         | $5.00         |
| Cached input / 1M tok. | $0.20         | $0.40         |

## Capability flags

Per the OCI Grok 4.3 model documentation
(<https://docs.oracle.com/en-us/iaas/Content/generative-ai/xai-grok-4-3.htm>):

| Flag                        | Value | Source                                  |
| --------------------------- | ----- | --------------------------------------- |
| `supports_function_calling` | true  | "Function Calling: Yes, through the API." |
| `supports_vision`           | true  | "Multimodal support: Input text and images and get a text output." |
| `supports_prompt_caching`   | true  | "Cached Input Tokens: Yes"              |
| `supports_reasoning`        | true  | "reasoning model designed for complex … tasks" |
| `supports_response_schema`  | false | Consistent with other OCI Grok entries  |
| `max_input_tokens`          | 1,000,000 | "Context Length: 1 million tokens"  |
| `max_output_tokens`         | 1,000,000 | API has no separate output-only limit beyond the shared context (playground cap of 131,000 does not apply to API) |
| `max_tokens`                | 1,000,000 | Same shared context window |

## Sources

- xAI Grok 4.3 on OCI: <https://docs.oracle.com/en-us/iaas/Content/generative-ai/xai-grok-4-3.htm>
- OCI Generative AI supported models: <https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm>
- OCI public price list: <https://www.oracle.com/cloud/price-list/#genai>
- Pattern reference: #27154 (`xai/grok-4.3` entry, merged 2026-05-07)

## Testing

- `tests/test_litellm/test_oci_xai_grok_4_3_model_metadata.py` covers:
  - All pricing, capability, and context-window fields on `oci/xai.grok-4.3`
  - The main + backup catalog files agree on this entry
- Both tests pass locally.