### PR TITLE
fix(proxy): stream raw bytes for streamGenerateContent, skip SSE wrapping

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1328,6 +1328,18 @@ class ProxyBaseLLMRequestProcessing:
                             status_code=response.status_code,  # type: ignore[union-attr]
                             headers=custom_headers,
                         )
+                elif route_type == "agenerate_content_stream":
+                    if self._is_streaming_response(response):
+                        if asyncio.iscoroutine(response):
+                            generator = await response
+                        else:
+                            generator = response
+
+                        return StreamingResponse(
+                            content=generator,  # type: ignore[arg-type]
+                            status_code=status.HTTP_200_OK,
+                            headers=custom_headers,
+                        )
                 elif route_type == "anthropic_messages":
                     # Check if response is actually a streaming response (async generator)
                     # Non-streaming responses (dict) should be returned directly

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_raw_bytes.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_raw_bytes.py
@@ -1,0 +1,140 @@
+"""
+Regression tests for https://github.com/BerriAI/litellm/issues/28777
+
+The streamGenerateContent endpoint must return raw JSON bytes from Gemini,
+not SSE-wrapped 'data: {...}' format. The google-genai SDK parses raw JSON
+and raises UnknownApiResponseError on the SSE 'data: ' prefix.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+GEMINI_STREAM_CHUNKS = [
+    b'[{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]},"finishReason":"STOP"}]}]\n',
+    b'[{"candidates":[{"content":{"role":"model","parts":[{"text":" world"}]},"finishReason":"STOP"}]}]\n',
+]
+
+
+class FakeGeminiStreamingIterator:
+    """Mimics AsyncGoogleGenAIGenerateContentStreamingIterator: yields raw bytes,
+    has _hidden_params dict."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = list(chunks)
+        self._index = 0
+        self._hidden_params = {"additional_headers": {}}
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
+def test_streaming_response_detected_for_async_iterator():
+    """_is_streaming_response must recognize the Gemini streaming iterator."""
+    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+
+    processor = ProxyBaseLLMRequestProcessing(data={"model": "test", "stream": True})
+    fake_iter = FakeGeminiStreamingIterator(GEMINI_STREAM_CHUNKS)
+    assert processor._is_streaming_response(fake_iter) is True
+
+
+@pytest.mark.asyncio
+async def test_agenerate_content_stream_returns_raw_streaming_response():
+    """base_process_llm_request with route_type='agenerate_content_stream' must
+    return a StreamingResponse that passes raw bytes through — no SSE wrapping."""
+    from starlette.responses import StreamingResponse
+
+    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+
+    fake_response = FakeGeminiStreamingIterator(GEMINI_STREAM_CHUNKS)
+
+    processor = ProxyBaseLLMRequestProcessing(
+        data={"model": "gemini-2.0-flash", "stream": True}
+    )
+
+    fake_logging_obj = MagicMock()
+    fake_logging_obj.litellm_call_id = "test-call-id"
+    fake_logging_obj._on_deferred_stream_complete = None
+    fake_logging_obj._defer_async_logging = False
+
+    fake_proxy_logging = AsyncMock()
+    fake_proxy_logging.during_call_hook = AsyncMock()
+    fake_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value={})
+    fake_proxy_logging.update_request_status = AsyncMock()
+
+    fake_fastapi_response = MagicMock()
+    fake_fastapi_response.headers = {}
+
+    fake_user_api_key_dict = MagicMock()
+    fake_user_api_key_dict.token = "sk-test"
+    fake_user_api_key_dict.key_alias = None
+    fake_user_api_key_dict.allowed_model_region = ""
+
+    async def fake_route_request(**kwargs):
+        """Simulates route_request returning a coroutine whose result is the
+        streaming iterator (matching the real call chain: await route_request()
+        returns a coroutine, then asyncio.gather awaits it)."""
+
+        async def _inner():
+            return fake_response
+
+        return _inner()
+
+    with (
+        patch.object(
+            processor,
+            "common_processing_pre_call_logic",
+            new_callable=AsyncMock,
+            return_value=(processor.data, fake_logging_obj),
+        ),
+        patch.object(
+            processor,
+            "_has_post_call_guardrails",
+            return_value=False,
+        ),
+        patch(
+            "litellm.proxy.common_request_processing.route_request",
+            new=fake_route_request,
+        ),
+    ):
+        result = await processor.base_process_llm_request(
+            request=MagicMock(),
+            fastapi_response=fake_fastapi_response,
+            user_api_key_dict=fake_user_api_key_dict,
+            route_type="agenerate_content_stream",
+            proxy_logging_obj=fake_proxy_logging,
+            llm_router=None,
+            general_settings={},
+            proxy_config=MagicMock(),
+            select_data_generator=None,
+            model="gemini-2.0-flash",
+        )
+
+    assert isinstance(
+        result, StreamingResponse
+    ), f"Expected StreamingResponse, got {type(result).__name__}"
+
+    collected = b""
+    async for chunk in result.body_iterator:
+        if isinstance(chunk, str):
+            collected += chunk.encode()
+        else:
+            collected += chunk
+
+    assert (
+        b"data: " not in collected
+    ), f"Raw Gemini bytes must not be SSE-wrapped. Got: {collected[:120]!r}"
+    assert b'"candidates"' in collected
+    for expected_chunk in GEMINI_STREAM_CHUNKS:
+        assert expected_chunk in collected


### PR DESCRIPTION
## Relevant issues

Fixes #28777

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The `agenerate_content_stream` route type in `base_process_llm_request` fell through to the default `select_data_generator` path, which wraps every streaming chunk in SSE `data: {...}\n\n` format. The google-genai SDK (v2.0.0+) expects raw JSON from Gemini's `streamGenerateContent` endpoint and raises `UnknownApiResponseError` when it encounters the `data: ` prefix.

### Root cause

In `common_request_processing.py`, the streaming response dispatch has explicit branches for `allm_passthrough_route` (raw bytes) and `anthropic_messages` (SSE), but `agenerate_content_stream` had no branch and fell through to the default SSE-wrapping path.

### Fix

Added an `agenerate_content_stream` branch (mirroring the existing `allm_passthrough_route` pattern) that returns a `StreamingResponse` streaming raw bytes directly, bypassing SSE wrapping.

### Files changed

- `litellm/proxy/common_request_processing.py` — 12 lines added: new branch for `agenerate_content_stream` route type
- `tests/test_litellm/proxy/google_endpoints/test_stream_generate_content_raw_bytes.py` — 2 regression tests verifying raw bytes pass through without SSE wrapping

## Screenshots / Proof of Fix

**Before (bug):** Streaming chunks wrapped as `data: [{"candidates":...}]\n\n` — google-genai SDK fails with `UnknownApiResponseError: Failed to parse response as JSON`

**After (fix):** Raw JSON bytes `[{"candidates":...}]\n` streamed directly — google-genai SDK parses successfully