### PR TITLE
feat(provider): add deAPI — OpenAI-compatible embeddings, image, and audio

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -114,5 +114,17 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "deapi": {
+    "base_url": "https://oai.deapi.ai/v1",
+    "api_key_env": "DEAPI_API_KEY",
+    "api_base_env": "DEAPI_API_BASE",
+    "supported_endpoints": [
+      "/v1/embeddings",
+      "/v1/images/generations",
+      "/v1/images/edits",
+      "/v1/audio/speech",
+      "/v1/audio/transcriptions"
+    ]
   }
 }

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -707,6 +707,24 @@
         "interactions": true
       }
     },
+    "deapi": {
+      "display_name": "deAPI (`deapi`)",
+      "url": "https://docs.litellm.ai/docs/providers/deapi",
+      "endpoints": {
+        "chat_completions": false,
+        "messages": false,
+        "responses": false,
+        "embeddings": true,
+        "image_generations": true,
+        "image_edits": true,
+        "audio_transcriptions": true,
+        "audio_speech": true,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "deepgram": {
       "display_name": "Deepgram (`deepgram`)",
       "url": "https://docs.litellm.ai/docs/providers/deepgram",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -760,6 +760,24 @@
         "interactions": true
       }
     },
+    "deapi": {
+      "display_name": "deAPI (`deapi`)",
+      "url": "https://docs.litellm.ai/docs/providers/deapi",
+      "endpoints": {
+        "chat_completions": false,
+        "messages": false,
+        "responses": false,
+        "embeddings": true,
+        "image_generations": true,
+        "image_edits": true,
+        "audio_transcriptions": true,
+        "audio_speech": true,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "deepgram": {
       "display_name": "Deepgram (`deepgram`)",
       "url": "https://docs.litellm.ai/docs/providers/deepgram",

--- a/tests/litellm/test_deapi_integration.py
+++ b/tests/litellm/test_deapi_integration.py
@@ -1,0 +1,60 @@
+"""
+Live-call integration tests for the deAPI provider.
+
+These tests make real network calls to https://oai.deapi.ai and are
+intentionally placed outside `tests/test_litellm/llms/openai_like/`
+(which is mock-only). They are skipped by default and only run when
+DEAPI_API_KEY is set in the environment.
+"""
+
+import os
+import sys
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, workspace_path)
+
+import litellm
+
+
+class TestDeAPIIntegration:
+    """Live-call integration tests (skipped unless DEAPI_API_KEY is set)."""
+
+    def test_deapi_embedding_basic(self):
+        """End-to-end embedding call against deAPI (requires DEAPI_API_KEY)."""
+        if not os.environ.get("DEAPI_API_KEY"):
+            if pytest:
+                pytest.skip("DEAPI_API_KEY not set")
+            return
+
+        response = litellm.embedding(
+            model="deapi/Bge_M3_FP16",
+            input="hello world",
+        )
+
+        assert response is not None
+        assert hasattr(response, "data")
+        assert len(response.data) > 0
+        assert hasattr(response.data[0], "embedding")
+        assert isinstance(response.data[0].embedding, list)
+        assert len(response.data[0].embedding) > 0
+
+    def test_deapi_image_generation_basic(self):
+        """End-to-end image generation call (requires DEAPI_API_KEY)."""
+        if not os.environ.get("DEAPI_API_KEY"):
+            if pytest:
+                pytest.skip("DEAPI_API_KEY not set")
+            return
+
+        response = litellm.image_generation(
+            model="deapi/Flux1schnell",
+            prompt="a small red square",
+        )
+
+        assert response is not None
+        assert hasattr(response, "data")
+        assert len(response.data) > 0

--- a/tests/test_litellm/llms/openai_like/test_deapi.py
+++ b/tests/test_litellm/llms/openai_like/test_deapi.py
@@ -1,0 +1,96 @@
+"""
+Tests for deAPI provider configuration and integration.
+
+deAPI is a non-chat OpenAI-compatible provider serving embeddings,
+image generation/edits, and audio (TTS + transcription).
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, workspace_path)
+
+import litellm
+
+
+class TestDeAPIProviderConfig:
+    """Test deAPI provider configuration (mock-only, no live calls)."""
+
+    def test_deapi_json_config_exists(self):
+        """deAPI is registered in providers.json with the expected base_url/env."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("deapi")
+
+        cfg = JSONProviderRegistry.get("deapi")
+        assert cfg is not None
+        assert cfg.base_url == "https://oai.deapi.ai/v1"
+        assert cfg.api_key_env == "DEAPI_API_KEY"
+        assert cfg.api_base_env == "DEAPI_API_BASE"
+
+    def test_deapi_supported_endpoints(self):
+        """supported_endpoints declares the non-chat endpoints deAPI serves."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        cfg = JSONProviderRegistry.get("deapi")
+        endpoints = set(cfg.supported_endpoints)
+
+        assert "/v1/embeddings" in endpoints
+        assert "/v1/images/generations" in endpoints
+        assert "/v1/images/edits" in endpoints
+        assert "/v1/audio/speech" in endpoints
+        assert "/v1/audio/transcriptions" in endpoints
+        # deAPI does not serve chat completions
+        assert "/v1/chat/completions" not in endpoints
+        assert "/v1/responses" not in endpoints
+
+    def test_deapi_provider_resolution(self):
+        """get_llm_provider resolves deapi/<model> to base_url + provider slug."""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="deapi/Bge_M3_FP16",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "Bge_M3_FP16"
+        assert provider == "deapi"
+        assert api_base == "https://oai.deapi.ai/v1"
+
+    def test_deapi_api_key_env_resolution(self):
+        """DEAPI_API_KEY env var is read when no explicit key is passed."""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        with patch.dict(os.environ, {"DEAPI_API_KEY": "dpn-sk-test-key"}):
+            _, _, api_key, _ = get_llm_provider(
+                model="deapi/Bge_M3_FP16",
+                custom_llm_provider=None,
+                api_base=None,
+                api_key=None,
+            )
+            assert api_key == "dpn-sk-test-key"
+
+    def test_deapi_does_not_advertise_responses_api(self):
+        """JSON registry should NOT report Responses API support for deAPI."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.supports_responses_api("deapi") is False
+
+
+if __name__ == "__main__":
+    test = TestDeAPIProviderConfig()
+    test.test_deapi_json_config_exists()
+    test.test_deapi_supported_endpoints()
+    test.test_deapi_provider_resolution()
+    test.test_deapi_api_key_env_resolution()
+    test.test_deapi_does_not_advertise_responses_api()
+    print("All config tests passed.")


### PR DESCRIPTION
## Summary

Adds **deAPI** as an OpenAI-compatible provider via the JSON-only path (no Python code required, mirrors PR #24294 AIHubMix pattern).

deAPI is a decentralized inference platform serving open-source AI models at `https://oai.deapi.ai/v1`. This PR registers it for non-chat modalities:

- **Embeddings** (BGE M3)
- **Image generation** (FLUX.1 Schnell, FLUX.2 Klein, Z-Image-Turbo, Z-Anime)
- **Image edits** (FLUX.2 Klein img2img, Qwen-Image-Edit)
- **Audio speech / TTS** (Kokoro, Chatterbox, Qwen3 TTS)
- **Audio transcriptions** (Whisper Large V3)

Companion docs PR forthcoming to `BerriAI/litellm-docs` adding `docs/providers/deapi.md` and the corresponding `sidebars.js` entry — link will be posted as a comment once opened.

## Notes for reviewers (pre-empting likely questions)

- **`chat_completions: false`** — deAPI does not serve chat by design. This is the first `openai_like` JSON provider with chat disabled. Happy to flip if you prefer the existing convention; the JSON registry's routing for non-chat endpoints works regardless.
- **Updated `provider_endpoints_support_backup.json`** in addition to the root file. The backup is loaded at runtime by `/public/model_hub` (see `litellm/proxy/public_endpoints/public_endpoints.py:146`). Editing both keeps deAPI visible in the model hub UI on merge. Happy to drop if you'd prefer the AIHubMix pattern (root-only).
- **`supported_endpoints` field** on the providers.json entry lists the exact endpoints deAPI implements (`/v1/embeddings`, `/v1/images/generations`, `/v1/images/edits`, `/v1/audio/speech`, `/v1/audio/transcriptions`). This documents intent for non-chat providers; the field is part of `SimpleProviderConfig` schema in `json_loader.py`.

## Files

- `litellm/llms/openai_like/providers.json` — provider registration with `supported_endpoints`
- `provider_endpoints_support.json` — endpoint capability matrix (root)
- `litellm/provider_endpoints_support_backup.json` — runtime mirror used by `/public/model_hub`
- `tests/test_litellm/llms/openai_like/test_deapi.py` — provider config + routing tests (5 mock-only + 2 integration tests skip-if-no-key)

## Validation

- `python3 tests/code_coverage_tests/check_provider_folders_documented.py` PASS
- All 3 JSON files parse cleanly (`json.load` clean)
- Root + backup support entries byte-identical
- Branch rebased onto current `main` (`06f6cfc5ae`)

## Test key

Maintainers: happy to share a deAPI test API key (`dpn-sk-...` with $5+ credit) by DM for end-to-end verification of the live endpoints.

cc @ishaan-jaff @krrishdholakia
