### PR TITLE
Mark xAI models retiring on 2026-05-15

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -35979,7 +35979,8 @@
         "supports_prompt_caching": true,
         "supports_response_schema": false,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-3-beta": {
         "cache_read_input_token_cost": 7.5e-07,
@@ -36178,7 +36179,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-fast-non-reasoning": {
         "cache_read_input_token_cost": 5e-08,
@@ -36195,7 +36197,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-0709": {
         "input_cost_per_token": 3e-06,
@@ -36211,7 +36214,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-latest": {
         "input_cost_per_token": 3e-06,
@@ -36269,7 +36273,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-1-fast-reasoning-latest": {
         "cache_read_input_token_cost": 5e-08,
@@ -36290,7 +36295,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-1-fast-non-reasoning": {
         "cache_read_input_token_cost": 5e-08,
@@ -36310,7 +36316,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-1-fast-non-reasoning-latest": {
         "cache_read_input_token_cost": 5e-08,
@@ -36330,7 +36337,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4.20-multi-agent-beta-0309": {
         "cache_read_input_token_cost": 2e-07,
@@ -36481,7 +36489,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-code-fast-1-0825": {
         "cache_read_input_token_cost": 2e-08,
@@ -36496,7 +36505,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-vision-beta": {
         "input_cost_per_image": 5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -35863,7 +35863,8 @@
         "supports_prompt_caching": true,
         "supports_response_schema": false,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-3-beta": {
         "cache_read_input_token_cost": 7.5e-07,
@@ -36062,7 +36063,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-fast-non-reasoning": {
         "cache_read_input_token_cost": 5e-08,
@@ -36079,7 +36081,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-0709": {
         "input_cost_per_token": 3e-06,
@@ -36095,7 +36098,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-latest": {
         "input_cost_per_token": 3e-06,
@@ -36153,7 +36157,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-1-fast-reasoning-latest": {
         "cache_read_input_token_cost": 5e-08,
@@ -36174,7 +36179,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-1-fast-non-reasoning": {
         "cache_read_input_token_cost": 5e-08,
@@ -36194,7 +36200,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4-1-fast-non-reasoning-latest": {
         "cache_read_input_token_cost": 5e-08,
@@ -36214,7 +36221,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-4.20-multi-agent-beta-0309": {
         "cache_read_input_token_cost": 2e-07,
@@ -36365,7 +36373,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-code-fast-1-0825": {
         "cache_read_input_token_cost": 2e-08,
@@ -36380,7 +36389,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2026-05-15"
     },
     "xai/grok-vision-beta": {
         "input_cost_per_image": 5e-06,


### PR DESCRIPTION
## Summary

Tag the xAI models retiring per [docs.x.ai May-15 retirement notice](https://docs.x.ai/developers/migration/may-15-retirement) with `deprecation_date: 2026-05-15`.

After 2026-05-15, requests to these slugs auto-redirect to a `grok-4.3` variant; callers are billed at `grok-4.3` rates ($1.25 / $2.50 per 1M tokens) regardless of which retired slug they invoke.

### Models tagged

| Retiring slug | Redirects to |
|---|---|
| `xai/grok-4-1-fast-reasoning{,-latest}` | `grok-4.3` (low effort) |
| `xai/grok-4-1-fast-non-reasoning{,-latest}` | `grok-4.3` (none) |
| `xai/grok-4-fast-reasoning` | `grok-4.3` (low effort) |
| `xai/grok-4-fast-non-reasoning` | `grok-4.3` (none) |
| `xai/grok-4-0709` | `grok-4.3` (low effort) |
| `xai/grok-code-fast-1{,-0825}` | `grok-build-0.1` |
| `xai/grok-3` | `grok-4.3` (none) |

### Out of scope
- Third-party hosts of these models (`azure_ai/*`, `oci/*`, `vercel_ai_gateway/*`, `perplexity/xai/*`) run their own retirement schedules and are left alone.
- The `grok-3` retirement list explicitly names only the base slug — `grok-3-mini`, `grok-3-fast`, `grok-3-beta`, `grok-3-latest`, etc. are not listed by xAI, so they're untouched.

## Test plan
- [x] `python ci_cd/check_files_match.py` reports the two JSONs match.
- [x] `json.load()` parses both files cleanly.