### PR TITLE
test(bedrock): fail loudly on unentitled cells; mock image-gen

### DIFF
--- a/tests/batches_tests/test_bedrock_files_and_batches.py
+++ b/tests/batches_tests/test_bedrock_files_and_batches.py
@@ -42,9 +42,6 @@ async def test_async_create_file():
     )
 
 
-@pytest.mark.skip(
-    reason="Bedrock batch inference (model-invocation-job) is not authorized on AWS account 941277531214 (requires an AWS support case); re-enable once batch access is granted"
-)
 @pytest.mark.asyncio()
 async def test_async_file_and_batch():
     """

--- a/tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py
+++ b/tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -43,6 +44,9 @@ from litellm.llms.bedrock.image_generation.image_handler import (
     BedrockImagePreparedRequest,
 )
 from litellm.llms.bedrock.common_utils import BedrockError
+
+# Base64 placeholder used for mocked Bedrock image responses (a 1x1 PNG).
+_MOCK_BEDROCK_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
 
 @pytest.mark.parametrize(
@@ -527,21 +531,35 @@ def test_backward_compatibility_regular_nova_model():
     assert result["imageGenerationConfig"]["cfg_scale"] == 7
 
 
-@pytest.mark.skip(
-    reason="amazon.titan-image-generator is legacy-gated and unavailable on AWS account 941277531214"
-)
 def test_amazon_titan_image_gen():
-    """Test Amazon Titan image generation with cost tracking."""
-    from litellm import image_generation
+    """Test Amazon Titan image generation with cost tracking.
+
+    The Bedrock CI account is not entitled to amazon.titan-image-generator, so
+    the network call is mocked and only the transform + cost-tracking path is
+    exercised.
+    """
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
     # Use v2 as v1 has reached end of life
     model_id = "bedrock/amazon.titan-image-generator-v2:0"
 
-    response = litellm.image_generation(
-        model=model_id,
-        prompt="A serene mountain landscape at sunset with a lake reflection",
-        aws_region_name="us-east-1",
-    )
+    mock_payload = {"images": [_MOCK_BEDROCK_IMAGE_B64]}
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_payload
+    mock_response.text = json.dumps(mock_payload)
+    mock_response.headers = {}
+
+    client = HTTPHandler()
+    with patch.object(client, "post", return_value=mock_response):
+        response = litellm.image_generation(
+            model=model_id,
+            prompt="A serene mountain landscape at sunset with a lake reflection",
+            aws_region_name="us-east-1",
+            aws_access_key_id="fake-access-key-id",
+            aws_secret_access_key="fake-secret-access-key",
+            client=client,
+        )
 
     print(f"response cost: {response._hidden_params['response_cost']}")
 

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -7,7 +7,6 @@ import sys
 import traceback
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
@@ -136,9 +135,51 @@ class TestVertexAIGeminiImageGeneration(BaseImageGenTest):
         }
 
 
-@pytest.mark.skip(
-    reason="amazon.nova-canvas-v1:0 is legacy-gated and unavailable on AWS account 941277531214"
-)
+# Base64 placeholder used for mocked Bedrock image responses (a 1x1 PNG).
+_MOCK_BEDROCK_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+
+async def _assert_mocked_bedrock_image_generation(call_args: dict) -> None:
+    """Run ``aimage_generation`` with the Bedrock HTTP call mocked.
+
+    The CI account is not entitled to Nova Canvas, so the network call is
+    replaced with a canned Bedrock response. This keeps the request transform,
+    response transform, and cost-tracking path under test without live access.
+    """
+    mock_payload = {"images": [_MOCK_BEDROCK_IMAGE_B64]}
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_payload
+    mock_response.text = json.dumps(mock_payload)
+    mock_response.headers = {}
+
+    custom_logger = TestCustomLogger()
+    litellm.logging_callback_manager._reset_all_callbacks()
+    litellm.callbacks = [custom_logger]
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        response = await litellm.aimage_generation(
+            **call_args,
+            prompt="A image of a otter",
+            aws_access_key_id="fake-access-key-id",
+            aws_secret_access_key="fake-secret-access-key",
+        )
+
+    await asyncio.sleep(1)
+
+    assert custom_logger.standard_logging_payload is not None
+    assert custom_logger.standard_logging_payload["response_cost"] is not None
+    assert custom_logger.standard_logging_payload["response_cost"] > 0
+    assert response.data is not None
+    for d in response.data:
+        assert isinstance(d, Image)
+        assert d.b64_json is not None or d.url is not None
+
+
 class TestBedrockNovaCanvasTextToImage(BaseImageGenTest):
     def get_base_image_generation_call_args(self) -> dict:
         litellm.in_memory_llm_clients_cache = InMemoryCache()
@@ -151,10 +192,13 @@ class TestBedrockNovaCanvasTextToImage(BaseImageGenTest):
             "aws_region_name": "us-east-1",
         }
 
+    @pytest.mark.asyncio(scope="module")
+    async def test_basic_image_generation(self):
+        await _assert_mocked_bedrock_image_generation(
+            self.get_base_image_generation_call_args()
+        )
 
-@pytest.mark.skip(
-    reason="amazon.nova-canvas-v1:0 is legacy-gated and unavailable on AWS account 941277531214"
-)
+
 class TestBedrockNovaCanvasColorGuidedGeneration(BaseImageGenTest):
     def get_base_image_generation_call_args(self) -> dict:
         litellm.in_memory_llm_clients_cache = InMemoryCache()
@@ -167,6 +211,12 @@ class TestBedrockNovaCanvasColorGuidedGeneration(BaseImageGenTest):
             "colorGuidedGenerationParams": {"colors": ["#FFFFFF"]},
             "aws_region_name": "us-east-1",
         }
+
+    @pytest.mark.asyncio(scope="module")
+    async def test_basic_image_generation(self):
+        await _assert_mocked_bedrock_image_generation(
+            self.get_base_image_generation_call_args()
+        )
 
 
 class TestOpenAIGPTImage1(BaseImageGenTest):

--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -21,7 +21,7 @@ class ModelEntry:
     extra_params: Tuple[Tuple[str, str], ...] = field(default_factory=tuple)
     required_env: FrozenSet[str] = field(default_factory=frozenset)
     caps: FrozenSet[str] = field(default_factory=frozenset)
-    skip_reason: Optional[str] = None
+    fail_reason: Optional[str] = None
 
     def params(self) -> Dict[str, str]:
         return dict(self.extra_params)
@@ -205,10 +205,11 @@ BEDROCK_CONVERSE_MODELS: Tuple[ModelEntry, ...] = (
         extra_params=(("aws_region_name", "us-east-1"),),
         required_env=_BEDROCK_REQ,
         caps=_CAPS_OPUS_4_7,
-        skip_reason=(
+        fail_reason=(
             "claude-opus-4-7 is not entitled on the Bedrock CI account "
             "941277531214 (model access requires an AWS Sales request, not "
-            "self-serve); remove this skip_reason once access is granted"
+            "self-serve); this cell fails on purpose so it stays loud in CI — "
+            "remove this fail_reason once access is granted"
         ),
     ),
     ModelEntry(

--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -163,12 +163,12 @@ async def test_reasoning_effort_grid(
     cell: CellExpectation,
     wire_capture,
 ) -> None:
-    if model.skip_reason:
-        pytest.skip(model.skip_reason)
-
     skip_reason = _required_env_missing(model)
     if skip_reason:
         pytest.skip(skip_reason)
+
+    if model.fail_reason:
+        pytest.fail(model.fail_reason)
 
     if route_name == "bedrock_invoke_messages":
         status, exc = await _call_messages(model, effort)

--- a/tests/openai_endpoints_tests/test_bedrock_batches_api.py
+++ b/tests/openai_endpoints_tests/test_bedrock_batches_api.py
@@ -10,9 +10,6 @@ client = OpenAI(
 BEDROCK_BATCH_MODEL = "bedrock/batch-us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
-@pytest.mark.skip(
-    reason="Bedrock batch inference (model-invocation-job) is not authorized on AWS account 941277531214 (requires an AWS support case); re-enable once batch access is granted"
-)
 @pytest.mark.asyncio
 async def test_bedrock_batches_api():
     """


### PR DESCRIPTION
## Summary

Layers on top of `litellm_migrate_aws_to_941277531214`. Where the new CI account (`941277531214`) is not entitled to a model/feature, this keeps the gap **visible** rather than silently green:

- **reasoning-effort grid (`claude-opus-4-7`)** — renamed `ModelEntry.skip_reason` → `fail_reason` and moved the check after the env gate. The Bedrock Opus 4.7 cells now `pytest.fail` with a clear reason when AWS creds are present (loud in CI), and still skip when creds are absent (local dev).
- **Bedrock batch inference** (`test_async_file_and_batch`, `test_bedrock_batches_api`) — skips removed so they run and fail until batch access is granted.
- **Image generation** (`amazon.titan-image-generator`, `amazon.nova-canvas-v1:0`) — the Bedrock HTTP call is mocked with a canned response (+ fake AWS creds), so the request transform, response transform, and cost-tracking path stay under test without live model access.

## Test plan

- [x] `tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py::test_amazon_titan_image_gen` passes (mocked)
- [x] `TestBedrockNovaCanvasTextToImage` / `TestBedrockNovaCanvasColorGuidedGeneration` pass (mocked)
- [x] opus-4-7 grid cell fails with the entitlement message when AWS creds are set; skips when they are not
- [ ] Bedrock batch tests run (and fail until access granted) against the new account in CI

https://claude.ai/code/session_01MT7SWDnXUjv6e6EPG7BDjT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes: skips removed, intentional failures, and HTTP mocks—no production Bedrock or auth logic modified.
> 
> **Overview**
> Bedrock CI tests no longer **skip** when the account lacks entitlement; gaps stay visible in CI while image paths stay covered via mocks.
> 
> **Reasoning-effort grid:** `ModelEntry.skip_reason` is renamed to `fail_reason`, checked after the env gate. Bedrock Opus 4.7 cells **`pytest.fail`** with an entitlement message when AWS creds are set, and still skip when creds are missing.
> 
> **Batch inference:** Skips are removed from `test_async_file_and_batch` and `test_bedrock_batches_api` so live Bedrock batch/file flows run (and fail) until batch access is granted.
> 
> **Image generation:** Titan and Nova Canvas tests mock the Bedrock HTTP response (1×1 PNG base64 + fake AWS keys) so request/response transforms and cost tracking are exercised without live model access; Nova Canvas adds shared `_assert_mocked_bedrock_image_generation` and explicit `test_basic_image_generation` overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2754a87cceb52538700a0aa5422a9194cf247e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->