### PR TITLE
fix(spend_tracking): skip SpendLogs for proxy-internal health checks (LIT-2457)

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -11,6 +11,7 @@ from litellm.litellm_core_utils.core_helpers import (
     get_litellm_metadata_from_kwargs,
 )
 from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.auth_checks import (
     get_key_object,
@@ -72,6 +73,15 @@ class _ProxyDBLogger(CustomLogger):
         elif request_route is not None and not (
             RouteChecks.is_llm_api_route(route=request_route)
             or RouteChecks.is_info_route(route=request_route)
+        ):
+            return
+
+        # Skip DB writes for proxy-internal health-check failures (LIT-2457).
+        if _is_litellm_internal_health_check_call(
+            user_api_key=user_api_key_dict.api_key,
+            user_id=user_api_key_dict.user_id,
+            team_id=user_api_key_dict.team_id,
+            end_user_id=user_api_key_dict.end_user_id,
         ):
             return
 
@@ -409,6 +419,30 @@ class _ProxyDBLogger(CustomLogger):
         return
 
 
+def _is_litellm_internal_health_check_call(
+    user_api_key: Optional[str],
+    user_id: Optional[str],
+    team_id: Optional[str],
+    end_user_id: Optional[str],
+) -> bool:
+    """
+    Return True when any spend-attribution identifier matches the sentinel
+    used by the proxy's background/manual health check service account
+    (see ``HealthCheckHelpers._update_model_params_with_health_check_tracking_information``
+    and ``UserAPIKeyAuth.get_litellm_internal_health_check_user_api_key_auth``).
+
+    Health-check requests should not produce SpendLogs rows or move budget
+    counters — they are synthetic calls issued by the proxy itself.
+    """
+    sentinel = LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
+    return (
+        user_api_key == sentinel
+        or user_id == sentinel
+        or team_id == sentinel
+        or end_user_id == sentinel
+    )
+
+
 def _should_track_cost_callback(
     user_api_key: Optional[str],
     user_id: Optional[str],
@@ -421,6 +455,15 @@ def _should_track_cost_callback(
 
     # don't run track cost callback if user opted into disabling spend
     if ProxyUpdateSpend.disable_spend_updates() is True:
+        return False
+
+    # don't run track cost callback for proxy-internal health checks (LIT-2457)
+    if _is_litellm_internal_health_check_call(
+        user_api_key=user_api_key,
+        user_id=user_id,
+        team_id=team_id,
+        end_user_id=end_user_id,
+    ):
         return False
 
     if (

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1067,3 +1067,153 @@ async def test_failure_hook_drops_error_information_traceback_when_env_set(
     assert "traceback" not in error_information
     assert error_information["error_class"] == "RuntimeError"
     assert error_information["error_message"] == "boom-with-traceback"
+
+
+# ---------------------------------------------------------------------------
+# LIT-2457: background/manual health checks must not produce SpendLogs rows.
+#
+# Health check requests go through ``ahealth_check``, which stamps
+# ``LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME`` onto the synthetic
+# ``UserAPIKeyAuth`` and the per-call metadata
+# (see ``HealthCheckHelpers._update_model_params_with_health_check_tracking_information``).
+# The success path goes through ``_should_track_cost_callback`` and the
+# failure path goes through ``async_post_call_failure_hook``. Both must
+# short-circuit before any DB write.
+# ---------------------------------------------------------------------------
+
+
+def test_should_track_cost_callback_skips_internal_health_check_service_account():
+    """The success-path gate must return False when any spend-attribution
+    identifier matches the proxy-internal health-check sentinel."""
+    from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
+    from litellm.proxy.hooks.proxy_track_cost_callback import (
+        _is_litellm_internal_health_check_call,
+        _should_track_cost_callback,
+    )
+
+    sentinel = LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
+
+    # The shape produced by
+    # ``HealthCheckHelpers._update_model_params_with_health_check_tracking_information``
+    # is: api_key == team_id == sentinel, user_id is None, end_user_id is None.
+    assert _is_litellm_internal_health_check_call(
+        user_api_key=sentinel,
+        user_id=None,
+        team_id=sentinel,
+        end_user_id=None,
+    )
+    assert (
+        _should_track_cost_callback(
+            user_api_key=sentinel,
+            user_id=None,
+            team_id=sentinel,
+            end_user_id=None,
+        )
+        is False
+    )
+
+    # A regular call (real hashed token, normal team_id) must still be tracked.
+    assert not _is_litellm_internal_health_check_call(
+        user_api_key="hashed-real-key",
+        user_id="user-1",
+        team_id="team-1",
+        end_user_id=None,
+    )
+    assert (
+        _should_track_cost_callback(
+            user_api_key="hashed-real-key",
+            user_id="user-1",
+            team_id="team-1",
+            end_user_id=None,
+        )
+        is True
+    )
+
+    # Defensive: the sentinel showing up in *any* identifier slot is enough
+    # to skip — guards against future refactors that move the sentinel onto
+    # user_id / end_user_id.
+    for slot in ("user_api_key", "user_id", "team_id", "end_user_id"):
+        kwargs = {
+            "user_api_key": None,
+            "user_id": None,
+            "team_id": None,
+            "end_user_id": None,
+            slot: sentinel,
+        }
+        assert _is_litellm_internal_health_check_call(**kwargs), slot
+        assert _should_track_cost_callback(**kwargs) is False, slot
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_skips_internal_health_check_service_account():
+    """The failure-path hook must skip the DB write when the
+    ``UserAPIKeyAuth`` is the synthetic health-check service account."""
+    from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
+
+    logger = _ProxyDBLogger()
+    health_check_user_api_key_dict = (
+        UserAPIKeyAuth.get_litellm_internal_health_check_user_api_key_auth()
+    )
+    assert (
+        health_check_user_api_key_dict.api_key
+        == LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
+    )
+
+    request_data = {
+        "model": "fake-openai-endpoint",
+        "messages": [{"role": "user", "content": "health check"}],
+        "metadata": {},
+    }
+    original_exception = Exception("upstream-down")
+
+    # Patch proxy_server / update_database so any call is observable.
+    with patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj"
+    ) as mock_proxy_logging_obj:
+        mock_db_writer = AsyncMock()
+        mock_proxy_logging_obj.db_spend_update_writer = mock_db_writer
+
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=original_exception,
+            user_api_key_dict=health_check_user_api_key_dict,
+        )
+
+        mock_db_writer.update_database.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_still_writes_for_real_keys():
+    """Sanity check that the health-check guard didn't accidentally
+    suppress the failure DB write for normal user keys."""
+    logger = _ProxyDBLogger()
+    real_user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-real-key",
+        key_alias="real-alias",
+        user_id="user-1",
+        team_id="team-1",
+        team_alias="team-alias",
+        end_user_id=None,
+        org_id=None,
+    )
+
+    request_data = {
+        "model": "fake-openai-endpoint",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {},
+    }
+    original_exception = Exception("upstream-down")
+
+    with patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj"
+    ) as mock_proxy_logging_obj:
+        mock_db_writer = AsyncMock()
+        mock_proxy_logging_obj.db_spend_update_writer = mock_db_writer
+
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=original_exception,
+            user_api_key_dict=real_user_api_key_dict,
+        )
+
+        mock_db_writer.update_database.assert_called_once()


### PR DESCRIPTION
## Summary

The proxy's background and manual `/health` checks go through `litellm.ahealth_check`, which stamps the `LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME` sentinel onto the synthetic `UserAPIKeyAuth` and per-call metadata (see `HealthCheckHelpers._update_model_params_with_health_check_tracking_information`).

`_PROXY_track_cost_callback` then treats these synthetic calls like regular traffic: every health-checked deployment produces one `LiteLLM_SpendLogs` row per cycle (`api_key=team_id=litellm-internal-health-check`, `request_tags=["litellm-internal-health-check"]`, `spend=0.0`). Over a long-running deployment this is the bulk of the noise customers asked us to stop writing (LIT-2457 — the original ticket comment was *"something like a spendlog cleanup job will resolve it"*; better to never write the rows in the first place).

## Fix

`litellm/proxy/hooks/proxy_track_cost_callback.py`:

1. New helper `_is_litellm_internal_health_check_call(...)` returns `True` when **any** spend-attribution identifier (`user_api_key`, `user_id`, `team_id`, `end_user_id`) equals `LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME`. Centralized so both gates use the same predicate.
2. `_should_track_cost_callback` (success path) short-circuits to `False` when the helper matches — no SpendLogs row, no budget counter movement.
3. `async_post_call_failure_hook` (failure path) short-circuits before the DB write when the `UserAPIKeyAuth` is the health-check service account — same reasoning applies when a health-checked deployment is down.

Regular user traffic is untouched.

## Evidence (real proxy, real requests)

### BEFORE — clean `main`, one `GET /health` call

```
$ curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:56289/health
{"healthy_endpoints":[{...,"model":"openai/fake","model_id":"2213b2e9-..."}], "healthy_count":1, "unhealthy_count":0}

$ sleep 4 && curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:56289/spend/logs | jq 'length, .[0] | {api_key, team_id, model, request_tags, spend}'
1
{
  "api_key": "litellm-internal-health-check",
  "team_id": "litellm-internal-health-check",
  "model": "fake",
  "request_tags": ["litellm-internal-health-check"],
  "spend": 0.0
}
```

→ One synthetic health-check SpendLogs row written per `/health` call.

### AFTER — this branch, same proxy + DB, two `/health` calls

```
$ # State going in: only the 1 pre-existing row from the BEFORE run remains in the DB.
$ curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:45289/spend/logs | jq length
1

$ curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:45289/health > /dev/null
$ curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:45289/health > /dev/null
$ sleep 5
$ curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:45289/spend/logs | jq length
1   # still 1 — neither /health produced a new SpendLogs row
```

### Regression check — real user traffic still produces SpendLogs

```
$ NEW_KEY=$(curl -s -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -X POST http://127.0.0.1:45289/key/generate \
    -d '{"models":["fake-openai-endpoint"]}' | jq -r .key)

$ # Real chat completion from that virtual key
$ curl -s -H "Authorization: Bearer $NEW_KEY" -H "Content-Type: application/json" \
    -X POST http://127.0.0.1:45289/v1/chat/completions \
    -d '{"model":"fake-openai-endpoint","messages":[{"role":"user","content":"hi"}]}' > /dev/null

$ sleep 6 && curl -s -H "Authorization: Bearer sk-1234" http://127.0.0.1:45289/spend/logs | jq 'length, [.[] | {api_key: (.api_key[0:20]+"..."), model, tags: .request_tags}]'
3
[
  {"api_key": "03c6c9a889e5a56da161...", "model": "openai/fake", "tags": ["User-Agent: curl/8.14.1"]},
  {"api_key": "litellm_proxy_master...", "model": "openai/fake", "tags": ["User-Agent: curl/8.14.1"]},
  {"api_key": "litellm-internal-hea...", "model": "fake",       "tags": ["litellm-internal-health-check"]}
]
```

The 3rd row is the pre-existing pre-fix health-check entry; the 2 new rows are real master-key + virtual-key calls (both still tracked normally). The 2 `/health` calls fired on the fixed branch added zero rows.

## Tests

Added 3 regression tests in `tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py`:

- `test_should_track_cost_callback_skips_internal_health_check_service_account` — covers the new helper across every identifier slot and confirms the success-path gate returns `False` for the sentinel and `True` for a real call.
- `test_async_post_call_failure_hook_skips_internal_health_check_service_account` — the failure-path hook skips `update_database` when the `UserAPIKeyAuth` is from `get_litellm_internal_health_check_user_api_key_auth()`.
- `test_async_post_call_failure_hook_still_writes_for_real_keys` — sanity check that real user keys still trigger the failure DB write.

All 28 tests in the file pass:

```
$ python3 -m pytest tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
============================== 28 passed in 7.52s ==============================
```

## Diff note

The first commit on this branch (`fix(spend_tracking): ...`) shows a large line count in the GitHub UI because my tooling normalized the file's CRLF line endings to LF on push. Use `git diff -w --ignore-all-space` to see the actual functional change — only ~43 lines added to `litellm/proxy/hooks/proxy_track_cost_callback.py` (one import, one helper, two short-circuit blocks). Happy to re-push as a clean CRLF-preserving commit if preferred.

Ticket: [LIT-2457](https://linear.app/litellm-ai/issue/LIT-2457/bug-do-not-save-health-check-data-in-table)
Agent session: https://litellm-agent-platform.onrender.com/sessions/4bbca5a9-80df-400b-8215-8ccc1b4d0410