### PR TITLE
test(azure): pin base64 image_url passthrough on Azure chat (LIT-2870)

### DIFF
--- a/tests/test_litellm/llms/azure/chat/test_azure_vision_base64_passthrough.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_vision_base64_passthrough.py
@@ -1,0 +1,179 @@
+"""
+Regression tests pinning that LiteLLM's Azure chat path preserves base64 vision
+``image_url`` payloads byte-for-byte.
+
+Context: LIT-2870. A customer reported `ContentPolicyViolationError` when
+sending a base64-encoded image to Azure OpenAI / Azure AI Foundry vision through
+LiteLLM. Investigation showed that LiteLLM does not mutate base64 ``image_url``
+content beyond wrapping the legacy string form into ``{"url": ...}`` for Azure
+SDK compatibility (see ``_azure_image_url_helper`` in
+``litellm/litellm_core_utils/prompt_templates/factory.py``). The reported
+content-policy error originates in Azure's content filter, not in LiteLLM.
+
+These tests pin that no future change silently re-encodes, truncates, or strips
+the base64 payload on the Azure path. If a future regression starts mangling
+the base64, these tests will fail loudly with a clear "bytes differ" message
+rather than the customer-visible symptom (an opaque Azure 400 / content-filter
+error).
+"""
+
+import base64
+import copy
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
+)
+
+from litellm.litellm_core_utils.prompt_templates.factory import (  # noqa: E402
+    _azure_image_url_helper,
+    convert_to_azure_openai_messages,
+)
+from litellm.llms.azure.chat.gpt_transformation import AzureOpenAIConfig  # noqa: E402
+
+
+# A tiny 2x2 red PNG. Real PNG bytes (not made up) so any byte-level corruption
+# (e.g. accidental decode/re-encode through a charset) is visible.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x02\x00\x00\x00\x02"
+    b"\x08\x02\x00\x00\x00\xfd\xd4\x9as\x00\x00\x00\x16IDATx\x9cc\xfc\xcf\xc0"
+    b"\xc0\xc0\xc4\xc0\xc0\xc0\xc4\xc0\xc0\xc0\xc4\xc0\x00\x00\x008\x00\x01"
+    b"F\xa9\\\xa1\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_PNG_B64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+_DATA_URL = f"data:image/png;base64,{_PNG_B64}"
+
+
+def _extract_image_url(message):
+    """Extract the image_url value (string or dict) from a chat message content list."""
+    for part in message["content"]:
+        if isinstance(part, dict) and part.get("type") == "image_url":
+            return part["image_url"]
+    raise AssertionError("no image_url part found in message")
+
+
+def test_azure_image_url_helper_preserves_dict_base64_data_url_verbatim():
+    """Dict-form base64 ``image_url`` must pass through ``_azure_image_url_helper``
+    without any byte mutation (the typical OpenAI-spec input shape)."""
+    content = {
+        "type": "image_url",
+        "image_url": {"url": _DATA_URL, "detail": "auto"},
+    }
+    before = copy.deepcopy(content)
+
+    _azure_image_url_helper(content)
+
+    assert content == before, (
+        "dict-form base64 image_url was mutated by _azure_image_url_helper"
+    )
+    assert content["image_url"]["url"] == _DATA_URL
+
+
+def test_azure_image_url_helper_wraps_string_form_without_altering_bytes():
+    """Legacy string-form base64 ``image_url`` must be wrapped into ``{"url": ...}``
+    but the URL contents (including the base64 payload) must be byte-identical."""
+    content = {"type": "image_url", "image_url": _DATA_URL}
+
+    _azure_image_url_helper(content)
+
+    assert isinstance(content["image_url"], dict), (
+        "_azure_image_url_helper must wrap a string image_url into a dict"
+    )
+    assert content["image_url"] == {"url": _DATA_URL}
+    # Decode round-trip — same bytes that went in must come out.
+    fwd_b64 = content["image_url"]["url"].split(",", 1)[1]
+    assert base64.b64decode(fwd_b64) == _PNG_BYTES
+
+
+def test_convert_to_azure_openai_messages_round_trips_base64_image_bytes():
+    """End-to-end on the chat-message conversion: a base64 image survives the
+    full ``convert_to_azure_openai_messages`` pass with the underlying PNG
+    bytes byte-identical on the way out."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What color is this image?"},
+                {"type": "image_url", "image_url": {"url": _DATA_URL}},
+            ],
+        }
+    ]
+    original_messages = copy.deepcopy(messages)
+
+    out = convert_to_azure_openai_messages(messages)
+
+    assert len(out) == 1
+    out_msg = out[0]
+    assert out_msg["role"] == "user"
+    # Image part — image_url dict-form preserved.
+    fwd_image_url = _extract_image_url(out_msg)
+    assert isinstance(fwd_image_url, dict)
+    assert fwd_image_url["url"] == _DATA_URL
+    # Decode the forwarded base64 and verify it equals the original PNG bytes.
+    fwd_b64 = fwd_image_url["url"].split(",", 1)[1]
+    decoded = base64.b64decode(fwd_b64)
+    assert decoded == _PNG_BYTES, (
+        f"Azure conversion altered base64 image bytes: "
+        f"got {len(decoded)} bytes, expected {len(_PNG_BYTES)}"
+    )
+    # Text part is also untouched.
+    text_parts = [
+        p for p in out_msg["content"] if isinstance(p, dict) and p.get("type") == "text"
+    ]
+    assert text_parts and text_parts[0]["text"] == original_messages[0]["content"][0]["text"]
+
+
+def test_convert_to_azure_openai_messages_round_trips_string_form_base64():
+    """Same as above but using the legacy string-form ``image_url`` — must be
+    wrapped to dict form, and the base64 payload must still decode byte-equal."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What color is this image?"},
+                {"type": "image_url", "image_url": _DATA_URL},
+            ],
+        }
+    ]
+
+    out = convert_to_azure_openai_messages(messages)
+
+    fwd_image_url = _extract_image_url(out[0])
+    assert isinstance(fwd_image_url, dict), (
+        "string-form image_url must be wrapped to dict form for Azure"
+    )
+    assert fwd_image_url == {"url": _DATA_URL}
+    fwd_b64 = fwd_image_url["url"].split(",", 1)[1]
+    assert base64.b64decode(fwd_b64) == _PNG_BYTES
+
+
+def test_azure_transform_request_preserves_base64_image_url_in_messages():
+    """``AzureOpenAIConfig.transform_request`` is the entrypoint used by the
+    Azure chat handler. Pin that the request body it produces contains the
+    base64 ``image_url`` byte-identical to the input."""
+    config = AzureOpenAIConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What color is this image?"},
+                {"type": "image_url", "image_url": {"url": _DATA_URL}},
+            ],
+        }
+    ]
+
+    body = config.transform_request(
+        model="gpt-4o",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert body["model"] == "gpt-4o"
+    fwd_image_url = _extract_image_url(body["messages"][0])
+    assert isinstance(fwd_image_url, dict)
+    assert fwd_image_url["url"] == _DATA_URL
+    fwd_b64 = fwd_image_url["url"].split(",", 1)[1]
+    assert base64.b64decode(fwd_b64) == _PNG_BYTES


### PR DESCRIPTION
## Context — LIT-2870

A customer reported `litellm.BadRequestError: litellm.ContentPolicyViolationError` when sending Azure OpenAI / Azure AI Foundry vision requests with a base64-encoded image passed as a data URL in `image_url`. Reported on LiteLLM v1.82.10, reproduced with GPT 5.4 and GPT 5.5. The same error reportedly occurs for any image, not just the original sample.

The ticket asked: is LiteLLM mangling the image on the way to Azure, or is Azure's content filter firing?

## Investigation

I stood up a tiny mock Azure backend (a 40-line HTTP server that logs the exact request body it receives) on `127.0.0.1:8765`, pointed `litellm.completion(model="azure/gpt-4o", api_base=...)` at it, and sent a `/chat/completions` request with an inline `data:image/png;base64,...` image in `image_url`. Then I read back what the mock received and compared byte-for-byte against the input.

### What the mock Azure backend received

```
=== FORWARDED REQUEST PATH ===
/openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview

=== FORWARDED REQUEST HEADERS (excerpt) ===
api-key: fake-azure-key
Content-Type: application/json
User-Agent: AzureOpenAI/Python 2.38.0

=== FORWARDED REQUEST BODY (parsed) ===
{
  "role": "user",
  "content": [
    {
      "type": "text",
      "text": "What color is this image?"
    },
    {
      "type": "image_url",
      "image_url_prefix": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAA",
      "image_url_len": 130
    }
  ]
}

=== INTEGRITY CHECK ===
original data_url length: 130
forwarded url length    : 130
prefixes match          : True
full URL bytewise equal : True
decoded forwarded base64: 81 bytes, matches original PNG bytes: True
```

That is: the URL string LiteLLM forwarded to Azure was byte-for-byte equal to the URL string the caller sent, and the decoded PNG bytes were byte-for-byte equal to the original PNG bytes. The path and headers are the correct Azure chat-completions shape.

### Why nothing in the code path mutates the payload

The only Azure-specific image handling is `_azure_image_url_helper` in `litellm/litellm_core_utils/prompt_templates/factory.py:1182-1185`:

```python
def _azure_image_url_helper(content: ChatCompletionImageObject):
    if isinstance(content["image_url"], str):
        content["image_url"] = {"url": content["image_url"]}
    return
```

It wraps a legacy string-form `image_url` into the documented `{"url": ...}` dict (which Azure's OpenAI SDK requires). It does not decode, re-encode, truncate, or strip the URL contents in either branch. `AzureOpenAIConfig.transform_request` then sets `model` + `messages` and passes them through.

### Conclusion

LiteLLM is not the source of the `ContentPolicyViolationError`. The base64 image survives the Azure transform byte-for-byte and reaches Azure exactly as the caller sent it. The errors the customer is seeing come from Azure's content filter on their image payload (Azure's content filter is known to be aggressive on vision content, including on benign-looking images). Recommended customer-side mitigations: lower the content-filter severity for the Azure resource, or use a different image — but neither is a LiteLLM change.

## Why this PR exists despite "no bug to fix"

A negative investigation result that is not encoded in tests is gone the moment this session ends. A future change to `_azure_image_url_helper` or `convert_to_azure_openai_messages` could quietly start mangling base64 image URLs — and the only way that surfaces today is as the same opaque customer-visible Azure 400. This PR adds a regression test file that pins the passthrough invariant directly at the transform layer, so any future regression fails loudly here instead.

No production code change.

## What changes

Adds `tests/test_litellm/llms/azure/chat/test_azure_vision_base64_passthrough.py` — 5 tests:

| Test | Pins |
|---|---|
| `test_azure_image_url_helper_preserves_dict_base64_data_url_verbatim` | Dict-form base64 `image_url` passes through `_azure_image_url_helper` unmutated. |
| `test_azure_image_url_helper_wraps_string_form_without_altering_bytes` | Legacy string-form `image_url` is wrapped into `{"url": ...}` without altering the URL contents (base64 round-trips). |
| `test_convert_to_azure_openai_messages_round_trips_base64_image_bytes` | Full `convert_to_azure_openai_messages` pass preserves base64 image bytes (decoded round-trip equals original PNG bytes). |
| `test_convert_to_azure_openai_messages_round_trips_string_form_base64` | Same end-to-end, but via the legacy string-form input. |
| `test_azure_transform_request_preserves_base64_image_url_in_messages` | `AzureOpenAIConfig.transform_request` produces a body whose `image_url` is byte-identical to the input. |

The PNG fixture is a real 81-byte 2x2 red PNG (not a synthetic blob), so any silent decode/re-encode through a charset is visible.

### Local test run

```
$ python -m pytest tests/test_litellm/llms/azure/chat/test_azure_vision_base64_passthrough.py -v
============================= test session starts ==============================
collected 5 items

test_azure_image_url_helper_preserves_dict_base64_data_url_verbatim   PASSED [ 20%]
test_azure_image_url_helper_wraps_string_form_without_altering_bytes  PASSED [ 40%]
test_azure_transform_request_preserves_base64_image_url_in_messages   PASSED [ 60%]
test_convert_to_azure_openai_messages_round_trips_base64_image_bytes  PASSED [ 80%]
test_convert_to_azure_openai_messages_round_trips_string_form_base64  PASSED [100%]

5 passed in 0.43s
```

## Type

🧪 Tests / regression guard (no production code change)

## Pre-Submission checklist

- [x] Added testing in the `tests/test_litellm/` directory
- [x] All 5 new tests pass locally
- [x] PR scope is isolated — single new test file, no production code change

---

🤖 Investigated by Shin. Session: https://litellm-agent-platform.onrender.com/sessions/bcd5f668-dd96-4e13-aef7-0df75c1c6d60