### PR TITLE
fix(prometheus): per-(key, model) remaining tokens/requests always 9.22e18 under v3 limiter (LIT-2577)

### DIFF
--- a/tests/test_litellm/integrations/test_prometheus_virtual_key_remaining_v3.py
+++ b/tests/test_litellm/integrations/test_prometheus_virtual_key_remaining_v3.py
@@ -1,0 +1,288 @@
+"""
+Regression tests for LIT-2577 — Prometheus per-(API key, model) remaining
+RPM/TPM gauges returning `sys.maxsize` (~9.22e18) under the v3 rate limiter.
+
+The legacy v1 limiter writes the values into `metadata` under
+`litellm-key-remaining-{requests,tokens}-{model_group}`. The active v3 limiter
+(`parallel_request_limiter_v3.async_post_call_success_hook`) instead writes
+them to `response._hidden_params["additional_headers"]` under
+`x-ratelimit-{model_per_key,key}-remaining-{requests,tokens}`. `prometheus.py`
+must read both, otherwise the gauges always fall through to `sys.maxsize` when
+v3 is in use and Prometheus/DataDog dashboards become useless.
+
+See https://linear.app/litellm-ai/issue/LIT-2577.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.integrations.prometheus import (  # noqa: E402
+    PrometheusLogger,
+    _coerce_remaining_to_int,
+    _get_additional_headers_from_kwargs,
+    _get_remaining_value_from_v3_headers,
+)
+
+
+@pytest.fixture(scope="function")
+def prometheus_logger():
+    """Fresh PrometheusLogger so each test starts from a clean registry."""
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+    return PrometheusLogger()
+
+
+def _v3_kwargs(
+    model_group="gpt-4o",
+    remaining_requests=7,
+    remaining_tokens=1234,
+    descriptor="model_per_key",
+):
+    """
+    Build the kwargs shape `_set_virtual_key_rate_limit_metrics` sees when
+    `parallel_request_limiter_v3` produced the response.
+    """
+    return {
+        "model": model_group,
+        "litellm_params": {"metadata": {"model_group": model_group}},
+        "standard_logging_object": {
+            "hidden_params": {
+                "additional_headers": {
+                    f"x-ratelimit-{descriptor}-remaining-requests": remaining_requests,
+                    f"x-ratelimit-{descriptor}-remaining-tokens": remaining_tokens,
+                    f"x-ratelimit-{descriptor}-limit-requests": 100,
+                    f"x-ratelimit-{descriptor}-limit-tokens": 10000,
+                },
+            },
+        },
+    }
+
+
+class TestV3RemainingHeadersFallback:
+    """Cover the four code paths in `_set_virtual_key_rate_limit_metrics`."""
+
+    def test_v3_additional_headers_populate_per_key_per_model_gauges(
+        self, prometheus_logger
+    ):
+        """
+        Bug repro from LIT-2577: with metadata empty and v3 additional_headers
+        populated, the gauges must read from additional_headers — not fall
+        through to sys.maxsize.
+        """
+        kwargs = _v3_kwargs(remaining_requests=7, remaining_tokens=1234)
+
+        with patch.object(
+            prometheus_logger, "litellm_remaining_api_key_requests_for_model"
+        ) as req_gauge, patch.object(
+            prometheus_logger, "litellm_remaining_api_key_tokens_for_model"
+        ) as tok_gauge:
+            prometheus_logger._set_virtual_key_rate_limit_metrics(
+                user_api_key="hashed-key",
+                user_api_key_alias="alias",
+                kwargs=kwargs,
+                metadata={},
+                model_id="model-id",
+            )
+
+        req_gauge.labels.return_value.set.assert_called_once_with(7)
+        tok_gauge.labels.return_value.set.assert_called_once_with(1234)
+
+    def test_v3_key_scope_headers_used_when_model_per_key_absent(
+        self, prometheus_logger
+    ):
+        """
+        When only the broader `key` scope headers are present (per-key
+        cross-model limit), the gauges fall back to those.
+        """
+        kwargs = _v3_kwargs(
+            remaining_requests=42, remaining_tokens=555, descriptor="key"
+        )
+
+        with patch.object(
+            prometheus_logger, "litellm_remaining_api_key_requests_for_model"
+        ) as req_gauge, patch.object(
+            prometheus_logger, "litellm_remaining_api_key_tokens_for_model"
+        ) as tok_gauge:
+            prometheus_logger._set_virtual_key_rate_limit_metrics(
+                user_api_key="hashed-key",
+                user_api_key_alias="alias",
+                kwargs=kwargs,
+                metadata={},
+                model_id="model-id",
+            )
+
+        req_gauge.labels.return_value.set.assert_called_once_with(42)
+        tok_gauge.labels.return_value.set.assert_called_once_with(555)
+
+    def test_legacy_v1_metadata_takes_precedence_over_v3_headers(
+        self, prometheus_logger
+    ):
+        """
+        Back-compat: when both sources are present the v1 metadata values win,
+        preserving the pre-fix contract for the legacy limiter.
+        """
+        kwargs = _v3_kwargs(remaining_requests=7, remaining_tokens=1234)
+        metadata = {
+            "litellm-key-remaining-requests-gpt-4o": 99,
+            "litellm-key-remaining-tokens-gpt-4o": 8888,
+        }
+
+        with patch.object(
+            prometheus_logger, "litellm_remaining_api_key_requests_for_model"
+        ) as req_gauge, patch.object(
+            prometheus_logger, "litellm_remaining_api_key_tokens_for_model"
+        ) as tok_gauge:
+            prometheus_logger._set_virtual_key_rate_limit_metrics(
+                user_api_key="hashed-key",
+                user_api_key_alias="alias",
+                kwargs=kwargs,
+                metadata=metadata,
+                model_id="model-id",
+            )
+
+        req_gauge.labels.return_value.set.assert_called_once_with(99)
+        tok_gauge.labels.return_value.set.assert_called_once_with(8888)
+
+    def test_no_source_populated_still_emits_sys_maxsize(self, prometheus_logger):
+        """
+        With neither v1 metadata nor v3 additional_headers populated (no rate
+        limit configured for this key/model), preserve the historical
+        `sys.maxsize` sentinel.
+        """
+        import sys as _sys
+
+        kwargs = {
+            "model": "gpt-4o",
+            "litellm_params": {"metadata": {"model_group": "gpt-4o"}},
+            "standard_logging_object": {"hidden_params": {"additional_headers": {}}},
+        }
+
+        with patch.object(
+            prometheus_logger, "litellm_remaining_api_key_requests_for_model"
+        ) as req_gauge, patch.object(
+            prometheus_logger, "litellm_remaining_api_key_tokens_for_model"
+        ) as tok_gauge:
+            prometheus_logger._set_virtual_key_rate_limit_metrics(
+                user_api_key="hashed-key",
+                user_api_key_alias="alias",
+                kwargs=kwargs,
+                metadata={},
+                model_id="model-id",
+            )
+
+        req_gauge.labels.return_value.set.assert_called_once_with(_sys.maxsize)
+        tok_gauge.labels.return_value.set.assert_called_once_with(_sys.maxsize)
+
+    def test_partial_metadata_falls_back_to_v3_for_missing_field(
+        self, prometheus_logger
+    ):
+        """
+        If only one of the two metadata keys is set, the other still falls
+        back to additional_headers rather than to sys.maxsize.
+        """
+        kwargs = _v3_kwargs(remaining_requests=7, remaining_tokens=1234)
+        metadata = {
+            # only the requests metadata key — tokens must come from v3 headers
+            "litellm-key-remaining-requests-gpt-4o": 50,
+        }
+
+        with patch.object(
+            prometheus_logger, "litellm_remaining_api_key_requests_for_model"
+        ) as req_gauge, patch.object(
+            prometheus_logger, "litellm_remaining_api_key_tokens_for_model"
+        ) as tok_gauge:
+            prometheus_logger._set_virtual_key_rate_limit_metrics(
+                user_api_key="hashed-key",
+                user_api_key_alias="alias",
+                kwargs=kwargs,
+                metadata=metadata,
+                model_id="model-id",
+            )
+
+        req_gauge.labels.return_value.set.assert_called_once_with(50)
+        tok_gauge.labels.return_value.set.assert_called_once_with(1234)
+
+    def test_string_header_values_are_coerced_to_int(self, prometheus_logger):
+        """
+        Header values can be stringified upstream. The fix coerces with
+        `int(...)` so the gauge stays numeric.
+        """
+        kwargs = _v3_kwargs(remaining_requests="42", remaining_tokens="9930")
+
+        with patch.object(
+            prometheus_logger, "litellm_remaining_api_key_requests_for_model"
+        ) as req_gauge, patch.object(
+            prometheus_logger, "litellm_remaining_api_key_tokens_for_model"
+        ) as tok_gauge:
+            prometheus_logger._set_virtual_key_rate_limit_metrics(
+                user_api_key="hashed-key",
+                user_api_key_alias="alias",
+                kwargs=kwargs,
+                metadata={},
+                model_id="model-id",
+            )
+
+        req_gauge.labels.return_value.set.assert_called_once_with(42)
+        tok_gauge.labels.return_value.set.assert_called_once_with(9930)
+
+
+class TestPureHelpers:
+    """Direct coverage of the static helpers so they stay simple to reason about."""
+
+    def test_get_additional_headers_returns_empty_when_anything_missing(self):
+        assert _get_additional_headers_from_kwargs({}) == {}
+        assert _get_additional_headers_from_kwargs({"standard_logging_object": None}) == {}
+        assert (
+            _get_additional_headers_from_kwargs(
+                {"standard_logging_object": {"hidden_params": None}}
+            )
+            == {}
+        )
+        assert (
+            _get_additional_headers_from_kwargs(
+                {
+                    "standard_logging_object": {
+                        "hidden_params": {"additional_headers": None}
+                    }
+                }
+            )
+            == {}
+        )
+
+    def test_get_additional_headers_returns_the_dict(self):
+        headers = {"x-ratelimit-model_per_key-remaining-requests": 7}
+        kwargs = {
+            "standard_logging_object": {
+                "hidden_params": {"additional_headers": headers}
+            }
+        }
+        assert _get_additional_headers_from_kwargs(kwargs) == headers
+
+    def test_remaining_value_prefers_model_per_key_over_key(self):
+        headers = {
+            "x-ratelimit-model_per_key-remaining-requests": 5,
+            "x-ratelimit-key-remaining-requests": 99,
+        }
+        assert _get_remaining_value_from_v3_headers(headers, "requests") == 5
+
+    def test_remaining_value_falls_back_to_key_scope(self):
+        headers = {"x-ratelimit-key-remaining-tokens": 1234}
+        assert _get_remaining_value_from_v3_headers(headers, "tokens") == 1234
+
+    def test_remaining_value_returns_none_when_absent(self):
+        assert _get_remaining_value_from_v3_headers({}, "requests") is None
+
+    def test_coerce_remaining_handles_none_int_str_garbage(self):
+        import sys as _sys
+
+        assert _coerce_remaining_to_int(None) == _sys.maxsize
+        assert _coerce_remaining_to_int(7) == 7
+        assert _coerce_remaining_to_int("42") == 42
+        assert _coerce_remaining_to_int("not-a-number") == _sys.maxsize
+        assert _coerce_remaining_to_int(object()) == _sys.maxsize


### PR DESCRIPTION
## Linear ticket

Resolves [LIT-2577](https://linear.app/litellm-ai/issue/LIT-2577/bug-prometheus-remaining-rpmtpm-metrics-always-return-sysmaxsize-due).

## Type

🐛 Bug fix

## Problem

The Prometheus per-(API key, model) "remaining" gauges

- `litellm_remaining_api_key_requests_for_model`
- `litellm_remaining_api_key_tokens_for_model`

are emitted as `9223372036854775807` (`sys.maxsize` ≈ `9.22e18`) for every request that goes through the v3 parallel rate limiter, even when the proxy *does* know the real remaining RPM/TPM for the (key, model) pair. That makes Prometheus / DataDog dashboards useless for monitoring remaining capacity per virtual key.

Reported by a customer in Slack: > _"I tried to use these two metrics, but DataDog was constantly displaying '9e18', which appears to be `sys.maxsize`… the values are available, but under the keys `x-ratelimit-model_per_key-remaining-{tokens/requests}` in `hidden_params.additional_headers`."_

## Root cause

`PrometheusLogger._set_virtual_key_rate_limit_metrics` in `litellm/integrations/prometheus.py` only reads request `metadata`:

```python
remaining_requests = metadata.get(f"litellm-key-remaining-requests-{model_group}")
remaining_tokens   = metadata.get(f"litellm-key-remaining-tokens-{model_group}")
```

Those metadata keys are written by the **legacy v1** limiter (`litellm/proxy/hooks/parallel_request_limiter.py`).

The active **v3** limiter (`litellm/proxy/hooks/parallel_request_limiter_v3.py:async_post_call_success_hook`, around line 2805) writes the values to `response._hidden_params["additional_headers"]` under a different key scheme:

```python
prefix = f"x-ratelimit-{status['descriptor_key']}"   # e.g. "x-ratelimit-model_per_key"
_additional_headers[f"{prefix}-remaining-{status['rate_limit_type']}"] = status["limit_remaining"]
```

So under v3 the metadata lookup always misses, falls through to `sys.maxsize`, and Prometheus emits `9.22e18`.

## Fix

In `_set_virtual_key_rate_limit_metrics`:

1. First read the legacy `metadata["litellm-key-remaining-{requests,tokens}-{model_group}"]` (preserves the v1 path).
2. If either is missing, fall back to `kwargs["standard_logging_object"]["hidden_params"]["additional_headers"]` and read `x-ratelimit-model_per_key-remaining-{requests,tokens}` first, then `x-ratelimit-key-remaining-{requests,tokens}` (broader per-key cross-model scope).
3. If neither source has a value (no rate limit configured), preserve the historical `sys.maxsize` sentinel.
4. Coerce to `int` defensively — some serializers stringify numeric header values.

Three small static helpers (`_get_additional_headers_from_kwargs`, `_get_remaining_value_from_v3_headers`, `_coerce_remaining_to_int`) are added so the hot path stays trivially short and each helper is unit-testable on its own.

## Evidence — end-to-end against a running proxy

Configuration: proxy started locally with `callbacks: ["prometheus"]`, a `fake-mock` model registered (`mock_response: "hi there from mock"`), and a virtual key created with `model_rpm_limit={"fake-mock":100}` and `model_tpm_limit={"fake-mock":10000}`. The v3 limiter is the default; same proxy build, only `litellm/integrations/prometheus.py` changes between BEFORE and AFTER.

### BEFORE — clean `main`

Response headers from a real chat completion show the v3 limiter is correctly populating the per-(key, model) remaining values:

```
x-ratelimit-model_per_key-remaining-requests: 94
x-ratelimit-model_per_key-limit-requests: 100
x-ratelimit-model_per_key-remaining-tokens: 8825
x-ratelimit-model_per_key-limit-tokens: 10000
```

But scraping `/metrics` immediately after the same request:

```
litellm_remaining_api_key_requests_for_model{api_key_alias="ratelimit-test-key",hashed_api_key="a6efce5b51c89c92427f971091e71cc4a9935bb770d3d20dde37adb5379a9617",model="fake-mock",model_id="cfddf1a6-f898-42dc-8d8e-cd303364a02c"} 9.223372036854776e+18
litellm_remaining_api_key_tokens_for_model{api_key_alias="ratelimit-test-key",hashed_api_key="a6efce5b51c89c92427f971091e71cc4a9935bb770d3d20dde37adb5379a9617",model="fake-mock",model_id="cfddf1a6-f898-42dc-8d8e-cd303364a02c"}   9.223372036854776e+18
```

→ both gauges are `sys.maxsize` — the bug exactly as reported.

### AFTER — this branch

Same proxy, same model, same virtual key, same `model_rpm_limit=100` / `model_tpm_limit=10000`, same 5 driven requests:

```
litellm_remaining_api_key_requests_for_model{api_key_alias="ratelimit-test-key",hashed_api_key="a6efce5b51c89c92427f971091e71cc4a9935bb770d3d20dde37adb5379a9617",model="fake-mock",model_id="cfddf1a6-f898-42dc-8d8e-cd303364a02c"} 95.0
litellm_remaining_api_key_tokens_for_model{api_key_alias="ratelimit-test-key",hashed_api_key="a6efce5b51c89c92427f971091e71cc4a9935bb770d3d20dde37adb5379a9617",model="fake-mock",model_id="cfddf1a6-f898-42dc-8d8e-cd303364a02c"}   8855.0
```

→ both gauges now report the real remaining values from `additional_headers`. Same proxy build, only the prometheus.py changes between the two scrapes.

## Tests

`tests/test_litellm/integrations/test_prometheus_virtual_key_remaining_v3.py` (new) covers all four code paths and the helpers:

- `test_v3_additional_headers_populate_per_key_per_model_gauges` — the bug repro: metadata empty, v3 additional_headers populated → real values, not `sys.maxsize`.
- `test_v3_key_scope_headers_used_when_model_per_key_absent` — fall back to the broader `x-ratelimit-key-*` scope.
- `test_legacy_v1_metadata_takes_precedence_over_v3_headers` — back-compat: when both are present, v1 metadata wins.
- `test_no_source_populated_still_emits_sys_maxsize` — no rate limit configured → preserves the historical sentinel.
- `test_partial_metadata_falls_back_to_v3_for_missing_field` — partial v1 metadata → fall through field-by-field.
- `test_string_header_values_are_coerced_to_int` — defensive `int(...)` coercion.
- 5 direct tests of the three pure helpers.

```
$ python -m pytest tests/test_litellm/integrations/test_prometheus_virtual_key_remaining_v3.py -v
======================== 12 passed in 0.50s ========================
```

Existing prometheus tests continue to pass (no regression):

```
$ python -m pytest tests/test_litellm/integrations/test_prometheus_missing_metrics.py \
                   tests/test_litellm/integrations/test_prometheus_labels.py \
                   tests/test_litellm/integrations/test_prometheus_none_metadata.py -v
======================== 20 passed in 0.73s ========================
```

## prometheus.py diff — needs to be applied by a maintainer ⚠️

The new regression-test file `tests/test_litellm/integrations/test_prometheus_virtual_key_remaining_v3.py` is committed on this branch.

The corresponding `litellm/integrations/prometheus.py` edit (≈30 LOC) **could not be pushed via the GitHub MCP tooling available to me** — the file is ~163 KB and exceeded the tool-call inlining limit (this is the same blocker hit by ~13 prior shin-watcher sessions on this ticket; PR #27232 noted the same limit). The fix below was applied and validated end-to-end against the running proxy (see Evidence above); please apply the unified diff:

```diff
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1588,8 +1588,20 @@
             get_model_group_from_litellm_kwargs,
         )
 
-        # Set remaining rpm/tpm for API Key + model
-        # see parallel_request_limiter.py - variables are set there
+        # Set remaining rpm/tpm for API Key + model.
+        #
+        # The legacy parallel_request_limiter writes the per-(key, model)
+        # remaining values into request `metadata` under
+        #   litellm-key-remaining-{requests,tokens}-{model_group}
+        # The active parallel_request_limiter_v3 instead writes them into
+        # `response._hidden_params["additional_headers"]` (which is mirrored
+        # into `standard_logging_object.hidden_params.additional_headers`)
+        # under
+        #   x-ratelimit-{model_per_key,key}-remaining-{requests,tokens}
+        # We read from both so the gauges are populated regardless of which
+        # limiter is active. Without the v3 fallback the gauges always fall
+        # through to `sys.maxsize` (~9.22e18) under the v3 limiter, which
+        # makes Prometheus / DataDog dashboards useless. See LIT-2577.
         model_group = get_model_group_from_litellm_kwargs(kwargs)
         remaining_requests_variable_name = (
             f"litellm-key-remaining-requests-{model_group}"
@@ -1597,11 +1609,21 @@
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
 
         remaining_requests = metadata.get(remaining_requests_variable_name)
-        if remaining_requests is None:
-            remaining_requests = sys.maxsize
         remaining_tokens = metadata.get(remaining_tokens_variable_name)
-        if remaining_tokens is None:
-            remaining_tokens = sys.maxsize
+
+        if remaining_requests is None or remaining_tokens is None:
+            additional_headers = _get_additional_headers_from_kwargs(kwargs)
+            if remaining_requests is None:
+                remaining_requests = _get_remaining_value_from_v3_headers(
+                    additional_headers, "requests"
+                )
+            if remaining_tokens is None:
+                remaining_tokens = _get_remaining_value_from_v3_headers(
+                    additional_headers, "tokens"
+                )
+
+        remaining_requests = _coerce_remaining_to_int(remaining_requests)
+        remaining_tokens = _coerce_remaining_to_int(remaining_tokens)
 
         enum_values = UserAPIKeyLabelValues(
             hashed_api_key=user_api_key,
@@ -3950,6 +3972,66 @@
     return result
 
 
+def _get_additional_headers_from_kwargs(kwargs: dict) -> Dict[str, Any]:
+    """
+    Pull `additional_headers` out of `standard_logging_object.hidden_params`.
+
+    The v3 parallel rate limiter (`parallel_request_limiter_v3.py`) writes the
+    per-(key, model) remaining tokens/requests into this dict under keys like
+    `x-ratelimit-{model_per_key,key}-remaining-{requests,tokens}` (see
+    `parallel_request_limiter_v3.async_post_call_success_hook`). Returns an
+    empty dict on any missing layer so callers can `.get(...)` freely.
+    """
+    standard_logging_payload = kwargs.get("standard_logging_object") or {}
+    if not isinstance(standard_logging_payload, dict):
+        return {}
+    hidden_params = standard_logging_payload.get("hidden_params") or {}
+    if not isinstance(hidden_params, dict):
+        return {}
+    additional_headers = hidden_params.get("additional_headers") or {}
+    if not isinstance(additional_headers, dict):
+        return {}
+    return additional_headers
+
+
+def _get_remaining_value_from_v3_headers(
+    additional_headers: Dict[str, Any], suffix: str
+) -> Optional[Any]:
+    """
+    Read the per-(key, model) remaining value emitted by the v3 limiter.
+
+    Prefers the `model_per_key` scope (per-(key, model) limit) and falls back
+    to the broader `key` scope (per-key cross-model limit). `suffix` is
+    `"requests"` or `"tokens"`. Returns `None` when neither key is set so the
+    caller can fall through to `sys.maxsize` and preserve existing semantics
+    for keys with no rate limit configured.
+    """
+    for descriptor in ("model_per_key", "key"):
+        value = additional_headers.get(
+            f"x-ratelimit-{descriptor}-remaining-{suffix}"
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def _coerce_remaining_to_int(value: Any) -> int:
+    """
+    Coerce a remaining-RPM/TPM value to int, falling back to `sys.maxsize`.
+
+    Header values can arrive as ints, strings, or `None` depending on the
+    serializer in front of `_hidden_params`. `sys.maxsize` is the historical
+    sentinel for "no limit / unknown", emitted to Prometheus when neither the
+    v1 metadata path nor the v3 additional_headers path has a value.
+    """
+    if value is None:
+        return sys.maxsize
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return sys.maxsize
+
+
 def _get_combined_custom_metadata_from_standard_logging_payload(
     standard_logging_payload: Optional[dict],
 ) -> Dict[str, Any]:
```

## Risk

Low. The change is local to one function in one file. When neither source has a value the existing `sys.maxsize` sentinel is preserved, so behavior for keys with no rate limit configured is unchanged. The new helpers are pure and have direct unit-test coverage.

---

Agent session: https://litellm-agent-platform.onrender.com/sessions/91c2c1c9-7b2e-49e7-8f45-87313bd95056

🤖 Filed by shin.