### PR TITLE
fix(ui): allow renaming a credential after creation (LIT-2074)

### DIFF
--- a/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Providers } from "../provider_info_helpers";
 import { CredentialItem } from "../networking";
@@ -117,7 +118,46 @@ describe("EditCredentialModal", () => {
     await waitFor(() => {
       const credentialNameInput = screen.getByLabelText("Credential Name:") as HTMLInputElement;
       expect(credentialNameInput.value).toBe("test-credential");
-      expect(credentialNameInput.disabled).toBe(true);
+      // LIT-2074: credential name must stay editable so admins can rename
+      // a credential after creation.
+      expect(credentialNameInput.disabled).toBe(false);
     });
+  });
+
+  it("should allow renaming the credential and pass the new name to onUpdateCredential", async () => {
+    const queryClient = createQueryClient();
+    const onCancel = vi.fn();
+    const onUpdateCredential = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditCredentialModal
+          open={true}
+          onCancel={onCancel}
+          onUpdateCredential={onUpdateCredential}
+          uploadProps={mockUploadProps}
+          existingCredential={mockCredential}
+        />
+      </QueryClientProvider>,
+    );
+
+    const credentialNameInput = (await screen.findByLabelText(
+      "Credential Name:",
+    )) as HTMLInputElement;
+    expect(credentialNameInput.disabled).toBe(false);
+
+    // Replace the existing name with a new one.
+    await user.clear(credentialNameInput);
+    await user.type(credentialNameInput, "test-credential-renamed");
+
+    await user.click(screen.getByRole("button", { name: /update credential/i }));
+
+    await waitFor(() => {
+      expect(onUpdateCredential).toHaveBeenCalledTimes(1);
+    });
+    expect(onUpdateCredential.mock.calls[0][0].credential_name).toBe(
+      "test-credential-renamed",
+    );
   });
 });

--- a/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx
@@ -76,10 +76,7 @@ export default function EditCredentialsModal({
           rules={[{ required: true, message: "Credential name is required" }]}
           initialValue={existingCredential?.credential_name}
         >
-          <TextInput
-            placeholder="Enter a friendly name for these credentials"
-            disabled={existingCredential?.credential_name ? true : false}
-          />
+          <TextInput placeholder="Enter a friendly name for these credentials" />
         </Form.Item>
 
         {/* Provider Selection */}

--- a/ui/litellm-dashboard/src/components/model_add/credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.tsx
@@ -64,7 +64,12 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ uploadProps }) => {
       },
     };
 
-    await credentialUpdateCall(accessToken, values.credential_name, newCredential);
+    // PATCH /credentials/{credential_name} looks up the row by its existing
+    // name, so route the request to the credential's ORIGINAL name. The new
+    // name (if changed) is carried in newCredential.credential_name in the
+    // request body and the backend swaps the DB + in-memory entry over to it.
+    const originalCredentialName = selectedCredential?.credential_name ?? values.credential_name;
+    await credentialUpdateCall(accessToken, originalCredentialName, newCredential);
     NotificationsManager.success("Credential updated successfully");
     setIsUpdateModalOpen(false);
     await refetchCredentials();


### PR DESCRIPTION
## What
Lets admins rename a credential after it has been created. Today the Edit Credential modal hard-disables the credential name input, so the only way to "rename" is to delete the credential and create a new one — which loses any models referencing it. The backend `PATCH /credentials/{credential_name}` endpoint already supports rename (`update_db_credential` updates the name, and the in-memory `litellm.credential_list` rebuild handles the old→new key swap), so this is a UI-only unlock plus a small routing fix.

Linear: [LIT-2074](https://linear.app/litellm-ai/issue/LIT-2074/feat-be-able-to-edit-name-of-a-credential-after-creation) (Swietelsky)

## Change
- `ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx` — drop the `disabled={existingCredential?.credential_name ? true : false}` on the credential-name `<TextInput>` so the field is editable when an existing credential is loaded.
- `ui/litellm-dashboard/src/components/model_add/credentials.tsx` — in `handleUpdateCredential`, route the PATCH to the credential's **original** name (`selectedCredential.credential_name`) so the backend lookup still finds the row when the user changes the name; the new name travels in the request body and the existing backend rename path takes it from there.
- `ui/litellm-dashboard/src/components/model_add/EditCredentialModal.test.tsx` — flip the assertion that pinned `disabled=true` and add a test that the renamed value is propagated to `onUpdateCredential`.

## Evidence

### Backend rename round-trip (curl against a running proxy)

The before/after shows *both* sides of the fix:

1. **Why the routing change matters** — if the UI just sent the new name in the URL (which is what `values.credential_name` was doing before this PR), the PATCH 404s because the row is still keyed on the original name.
2. **The fix** — addressing PATCH to the original name, with the new name in the body, succeeds, and `GET /credentials` confirms the rename persisted.

```text
==[1] create the credential ==
{"success":true,"message":"Credential created successfully"}

==[2] list before ==
{
    "credentials": [
        {
            "credential_name": "openai-credential-v1",
            "credential_values": { "api_key": "sk****34" },
            "credential_info": { "custom_llm_provider": "openai" }
        }
    ]
}

==[3] UI BUG flow (PATCHing to the NEW name path — what the unfixed UI does after a rename) ==
$ curl -X PATCH /credentials/openai-credential-v2  -d '{"credential_name":"openai-credential-v2", ...}'
{"message":"Credential not found in DB.","openai_code":404, ...}

==[4] FIXED flow (PATCH path = ORIGINAL name, body carries NEW name) ==
$ curl -X PATCH /credentials/openai-credential-v1  -d '{"credential_name":"openai-credential-v2", ...}'
{"success":true,"message":"Credential updated successfully"}

==[5] list after ==
{
    "credentials": [
        {
            "credential_name": "openai-credential-v2",
            "credential_values": { "api_key": "sk****34" },
            "credential_info": { "custom_llm_provider": "openai" }
        }
    ]
}
```

### UI rendering (vitest, jsdom)

The added test mounts the real `EditCredentialModal` against `mockCredential` and verifies:

- `credentialNameInput.disabled === false` — the name input is now editable when editing an existing credential.
- Typing a new name into the input and clicking **Update Credential** propagates `credential_name: "test-credential-renamed"` to `onUpdateCredential`.

```text
$ npx vitest run src/components/model_add/EditCredentialModal.test.tsx
 ✓ src/components/model_add/EditCredentialModal.test.tsx (3 tests)
   ✓ should render
   ✓ should render initial values
   ✓ should allow renaming the credential and pass the new name to onUpdateCredential

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

(`credentials.test.tsx` — the existing CredentialsPanel suite — also still passes: 6/6.)

### Note on live UI screenshots

I built the UI in the sandbox and brought up the proxy + admin UI to capture before/after screenshots of the Edit Credential modal, but the sandbox is shared with other concurrent agents and kept switching git branches / clobbering builds out from under me, so the screenshots that landed are not trustworthy as runtime evidence of *this* commit. The backend curl above is the actual exercised behavior on a running proxy, and the vitest test renders the real React component and asserts on the resulting DOM — together they cover both halves of the change (UI render + API routing).

## Risk
Small. Backend already supports rename, no schema/migration changes, all existing assertions either pass or were explicitly updated. Renaming a credential will no longer match models that reference it by name (`litellm_credential_name`) — that mismatch already exists in the data model and is out of scope for this PR (see `_hydrate_litellm_credential_name`); admins doing a rename today are expected to update referencing models themselves.