### PR TITLE
fix(proxy/auth): honour general_settings.user_api_key_cache_ttl for management-object cache writes

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -945,7 +945,7 @@ async def get_default_end_user_budget(
             key=cache_key,
             value=_budget_obj,
             model_type=LiteLLM_BudgetTable,
-            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            ttl=_management_object_cache_ttl(user_api_key_cache),
         )
 
         return _budget_obj
@@ -1001,7 +1001,7 @@ async def get_team_member_default_budget(
         await user_api_key_cache.async_set_cache(
             key=cache_key,
             value=budget_record.dict(),
-            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            ttl=_management_object_cache_ttl(user_api_key_cache),
         )
 
         return LiteLLM_BudgetTable(**budget_record.dict())
@@ -1599,7 +1599,7 @@ async def get_user_object(
             key=user_id,
             value=_response,
             model_type=LiteLLM_UserTable,
-            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            ttl=_management_object_cache_ttl(user_api_key_cache),
         )
 
         # save to db access time
@@ -1617,6 +1617,31 @@ async def get_user_object(
         )
 
 
+def _management_object_cache_ttl(user_api_key_cache: UserApiKeyCache) -> float:
+    """
+    TTL (in seconds) for management-object cache writes.
+
+    ``user_api_key_cache.default_in_memory_ttl`` is the source of truth: it is
+    initialised to ``UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value`` (60s)
+    at proxy startup and then overridden by
+    ``general_settings.user_api_key_cache_ttl`` when the user configures one
+    (see ``proxy_server.py``'s ``user_api_key_cache.update_cache_ttl(...)``
+    call).
+
+    Reading it here keeps every management-object cache write
+    (``_cache_management_object`` and friends) in sync with the user's
+    configured TTL, instead of hard-coding
+    ``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` and silently capping the
+    cache at 60s. Falls back to ``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL``
+    only when the cache exposes no default (e.g. a bare cache constructed in a
+    test).
+    """
+    configured = getattr(user_api_key_cache, "default_in_memory_ttl", None)
+    if configured is not None:
+        return float(configured)
+    return float(DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
+
+
 async def _cache_management_object(
     key: str,
     value: Union[BaseModel, Dict[str, Any]],
@@ -1628,13 +1653,15 @@ async def _cache_management_object(
     """
     Persist management objects via ``UserApiKeyCache`` (in-memory + optional Redis).
 
-    ``UserApiKeyCache`` serializes with ``model_type`` so Redis and in-memory stay aligned.
+    ``UserApiKeyCache`` serializes with ``model_type`` so Redis and in-memory
+    stay aligned. The TTL honours ``general_settings.user_api_key_cache_ttl``
+    when configured; see :func:`_management_object_cache_ttl`.
     """
     await user_api_key_cache.async_set_cache(
         key=key,
         value=value,
         model_type=model_type,
-        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        ttl=_management_object_cache_ttl(user_api_key_cache),
     )
 
 
@@ -2508,7 +2535,7 @@ async def get_object_permission(
             key=key,
             value=_perm_obj,
             model_type=LiteLLM_ObjectPermissionTable,
-            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            ttl=_management_object_cache_ttl(user_api_key_cache),
         )
 
         return _perm_obj
@@ -2573,7 +2600,7 @@ async def get_managed_vector_store_rows_by_uuids(
             key=key,
             value=cached_obj,
             model_type=LiteLLM_ManagedVectorStoresTable,
-            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            ttl=_management_object_cache_ttl(user_api_key_cache),
         )
         result.append(cached_obj)
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3016,3 +3016,98 @@ async def test_team_member_budget_check_zero_per_member_row_still_blocks():
                 proxy_logging_obj=proxy_logging_obj,
             )
     assert exc_info.value.max_budget == 0.0
+
+
+
+# ---------------------------------------------------------------------------
+# LIT-3338: general_settings.user_api_key_cache_ttl must be honoured for the
+# management-object caches (key, team, user, budget, vector store, permission).
+# Before the fix, _cache_management_object (and several call sites) hard-coded
+# ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL=60, so a
+# `user_api_key_cache_ttl: 300` config was silently capped at 60s.
+# ---------------------------------------------------------------------------
+class TestUserApiKeyCacheTTLHonoured:
+    """Regression coverage for LIT-3338."""
+
+    def _make_cache(self, configured_ttl):
+        """Build a UserApiKeyCache the way proxy_server.py does at startup."""
+        from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+        cache = UserApiKeyCache(default_in_memory_ttl=60)
+        if configured_ttl is not None:
+            cache.update_cache_ttl(
+                default_in_memory_ttl=configured_ttl,
+                default_redis_ttl=configured_ttl,
+            )
+        return cache
+
+    @pytest.mark.asyncio
+    async def test_configured_ttl_is_used_for_key_object(self):
+        """user_api_key_cache_ttl=300 -> cached key entry expires in ~300s, not 60s."""
+        import time
+
+        from litellm.proxy.auth.auth_checks import _cache_key_object
+
+        cache = self._make_cache(configured_ttl=300)
+        hashed = "hashed-token-lit-3338"
+        auth = UserAPIKeyAuth(token=hashed, api_key=hashed)
+
+        before = time.time()
+        await _cache_key_object(
+            hashed_token=hashed,
+            user_api_key_obj=auth,
+            user_api_key_cache=cache,
+            proxy_logging_obj=None,
+        )
+        expiry = cache.in_memory_cache.ttl_dict.get(hashed)
+        assert expiry is not None, "key object was not cached"
+        ttl_actual = expiry - before
+        # Allow a few seconds of slack for slow CI runners.
+        assert (
+            295 <= ttl_actual <= 305
+        ), f"expected ~300s TTL, got {ttl_actual:.1f}s (LIT-3338 regression)"
+
+    @pytest.mark.asyncio
+    async def test_default_ttl_unchanged_when_unconfigured(self):
+        """When user_api_key_cache_ttl is NOT set, the historical 60s TTL still wins."""
+        import time
+
+        from litellm.proxy.auth.auth_checks import _cache_key_object
+
+        cache = self._make_cache(configured_ttl=None)
+        hashed = "hashed-token-default"
+        auth = UserAPIKeyAuth(token=hashed, api_key=hashed)
+
+        before = time.time()
+        await _cache_key_object(
+            hashed_token=hashed,
+            user_api_key_obj=auth,
+            user_api_key_cache=cache,
+            proxy_logging_obj=None,
+        )
+        ttl_actual = cache.in_memory_cache.ttl_dict[hashed] - before
+        assert 55 <= ttl_actual <= 65, (
+            f"default TTL drifted: got {ttl_actual:.1f}s, expected ~60s"
+        )
+
+    def test_helper_prefers_cache_default(self):
+        """`_management_object_cache_ttl` reads cache.default_in_memory_ttl when set."""
+        from litellm.proxy.auth.auth_checks import _management_object_cache_ttl
+
+        cache = self._make_cache(configured_ttl=300)
+        assert _management_object_cache_ttl(cache) == 300.0
+
+    def test_helper_falls_back_when_cache_has_no_default(self):
+        """When the cache exposes no default (bare DualCache in a test), fall back."""
+        from litellm.caching.dual_cache import DualCache
+        from litellm.constants import (
+            DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        )
+        from litellm.proxy.auth.auth_checks import _management_object_cache_ttl
+
+        bare = DualCache()
+        bare.default_in_memory_ttl = None  # simulate a cache with no configured TTL
+        assert (
+            _management_object_cache_ttl(bare)
+            == float(DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
+        )


### PR DESCRIPTION
Fixes [LIT-3338](https://linear.app/litellm-ai/issue/LIT-3338/user-api-key-cache-ttl-is-ignored-for-api-key-auth).

## What

Customer report (NVIDIA, Pylon #4339): `general_settings.user_api_key_cache_ttl: 300` is silently ignored — cache entries for the API-key auth path still expire at the default 60s, defeating the operator's attempt to soften DB-load.

## Root cause

`_cache_management_object()` and five other call sites in `litellm/proxy/auth/auth_checks.py` write to the cache with an explicit `ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL` (= 60). That explicit override always wins over the cache's `default_in_memory_ttl`, which `proxy_server.py:4244` *does* correctly set from `general_settings.user_api_key_cache_ttl` at startup. So the user setting is read at startup, applied to the cache object as the new default, then ignored by every management-object cache write.

## Fix

Add a small helper:

```python
def _management_object_cache_ttl(user_api_key_cache: UserApiKeyCache) -> float:
    configured = getattr(user_api_key_cache, "default_in_memory_ttl", None)
    if configured is not None:
        return float(configured)
    return float(DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
```

and use it at the 6 call sites that previously hard-coded the constant (`_cache_management_object` itself + 5 direct callers for budget / team-member-default-budget / user / object-permission / managed-vector-store caches).

This preserves the historical 60s default for deployments that haven't configured `user_api_key_cache_ttl`, and honours the configured value when set.

## Evidence

Reproducer drives the exact runtime path — `get_key_object → _cache_key_object → _cache_management_object` — with a `UserApiKeyCache` set up the way `proxy_server.py` sets it up when `general_settings.user_api_key_cache_ttl: 300` is configured (init at 60s via `UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value`, then `cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)` per `proxy_server.py:4244`).

**BEFORE → fix → AFTER**, captured against upstream main `06f6cfc5ae`:

![lit3338-evidence](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit3338/lit3338-evidence.png)

Same output as text for accessibility:

```
[1/3] BEFORE — clean main @ 06f6cfc5ae
general_settings.user_api_key_cache_ttl: 300s
actual TTL stored in user_api_key_cache:  60.0s
RESULT: BUG (got 60s, expected 300s)

[2/3] Apply fix → fix applied

[3/3] AFTER — fix applied
general_settings.user_api_key_cache_ttl: 300s
actual TTL stored in user_api_key_cache:  300.0s
RESULT: OK (matches configured TTL)

Default-TTL regression check (no user_api_key_cache_ttl configured)
cache.default_in_memory_ttl: 60
cache entry expires in: 60.0s (expected ~60s)
PASS: default TTL unchanged.
```

The full proxy was also booted with this config (`general_settings.user_api_key_cache_ttl: 300`), `/health/readiness` returned 200, and the auth-check path was exercised end-to-end through `/v1/chat/completions` (returns 401 due to dummy upstream key, after the auth path ran and `_cache_key_object` was called) and `/key/info` (200).

## Tests

Four new unit tests in `tests/test_litellm/proxy/auth/test_auth_checks.py::TestUserApiKeyCacheTTLHonoured`:

```
test_configured_ttl_is_used_for_key_object PASSED
test_default_ttl_unchanged_when_unconfigured PASSED
test_helper_falls_back_when_cache_has_no_default PASSED
test_helper_prefers_cache_default PASSED
============================== 4 passed in 7.33s ==============================
```

## Scope

This PR only touches `_cache_management_object` and the 5 direct call sites in `auth_checks.py` that share `user_api_key_cache`. Two other files have the same pattern with the same `user_api_key_cache` (`litellm/proxy/auth/handle_jwt.py` and `litellm/proxy/_experimental/mcp_server/mcp_server_manager.py`) — kept out of this PR to keep the blast radius small; happy to follow up if reviewers want them in the same change.

cc @shivam @harish (NVIDIA tracker)