### PR TITLE
fix(proxy/auth): honour user_api_key_cache_ttl for management-object writes (LIT-3338)

### DIFF
--- a/litellm/proxy/common_utils/user_api_key_cache.py
+++ b/litellm/proxy/common_utils/user_api_key_cache.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.dual_cache import DualCache
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
 
 T = TypeVar("T", bound=BaseModel)
@@ -132,7 +133,40 @@ class UserApiKeyCache(DualCache):
             return None
         return decoded
 
+    def _coerce_management_object_ttl(self, kwargs: dict) -> None:
+        """Honour ``general_settings.user_api_key_cache_ttl`` for management-object writes.
+
+        LIT-3338: ``auth_checks.py`` writes management objects (key, team, user,
+        budget, vector store, permission) with an explicit
+        ``ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` (the well-known
+        60s fallback constant). That explicit ttl always wins over the cache
+        instance's own ``default_in_memory_ttl``, which ``proxy_server.py``
+        *does* correctly update from ``general_settings.user_api_key_cache_ttl``
+        at startup via ``update_cache_ttl``. The user's configured TTL is
+        therefore silently capped at 60s.
+
+        Treat ``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` as a sentinel
+        meaning "use the cache's configured default TTL". If the cache's
+        ``default_in_memory_ttl`` was customised away from the constant (i.e.
+        the user actually set ``user_api_key_cache_ttl``), substitute it in.
+        Otherwise the value is identical and behaviour is unchanged.
+
+        Mutates ``kwargs`` in place; no-op when ``ttl`` is not the sentinel.
+        """
+        ttl = kwargs.get("ttl")
+        if ttl is None:
+            return
+        if ttl != DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL:
+            return
+        configured = self.default_in_memory_ttl
+        if configured is None:
+            return
+        if configured == DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL:
+            return
+        kwargs["ttl"] = configured
+
     def set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
+        self._coerce_management_object_ttl(kwargs)
         model_type = cast(Optional[Type[BaseModel]], kwargs.pop("model_type", None))
         payload = CacheCodec.serialize(value, model_type=model_type)
         return super().set_cache(
@@ -140,6 +174,7 @@ class UserApiKeyCache(DualCache):
         )
 
     async def async_set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
+        self._coerce_management_object_ttl(kwargs)
         model_type = cast(Optional[Type[BaseModel]], kwargs.pop("model_type", None))
         payload = CacheCodec.serialize(value, model_type=model_type)
         return await super().async_set_cache(

--- a/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py
+++ b/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py
@@ -22,8 +22,18 @@ from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 
 
 def _make_cache(configured_ttl):
-    """Build a UserApiKeyCache the way ``proxy_server.py`` does at startup."""
-    cache = UserApiKeyCache(default_in_memory_ttl=60)
+    """Build a UserApiKeyCache the way ``proxy_server.py`` does at startup.
+
+    Initialise with ``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` (same
+    value the production initialiser uses) so the sentinel equality guard in
+    ``_coerce_management_object_ttl`` sees a matching ``default_in_memory_ttl``
+    when no user TTL has been configured. Hardcoding 60 here would drift if
+    the constant is customised via env var, producing misleading regression
+    results.
+    """
+    cache = UserApiKeyCache(
+        default_in_memory_ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+    )
     if configured_ttl is not None:
         cache.update_cache_ttl(
             default_in_memory_ttl=configured_ttl,
@@ -56,7 +66,8 @@ async def test_configured_ttl_overrides_management_object_constant():
 
 @pytest.mark.asyncio
 async def test_default_ttl_unchanged_when_unconfigured():
-    """No ``user_api_key_cache_ttl`` set -> entries keep the historical 60s TTL.
+    """No ``user_api_key_cache_ttl`` set -> entries keep the historical default
+    TTL (``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL``, normally 60s).
     Regression guard against accidentally widening the cache for everyone."""
     import time
 
@@ -69,8 +80,9 @@ async def test_default_ttl_unchanged_when_unconfigured():
         ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
     )
     ttl_actual = cache.in_memory_cache.ttl_dict["lit-3338-default-key"] - before
-    assert 55 <= ttl_actual <= 65, (
-        f"default 60s TTL drifted to {ttl_actual:.1f}s (LIT-3338 regression)"
+    expected = DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+    assert expected - 5 <= ttl_actual <= expected + 5, (
+        f"default {expected}s TTL drifted to {ttl_actual:.1f}s (LIT-3338 regression)"
     )
 
 
@@ -82,15 +94,22 @@ async def test_explicit_non_management_ttl_is_not_coerced():
 
     cache = _make_cache(configured_ttl=300)
 
+    # Pick an arbitrary ttl that is provably not the management sentinel.
+    non_sentinel_ttl = DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL // 2 + 1
+    assert non_sentinel_ttl != DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+
     before = time.time()
     await cache.async_set_cache(
-        key="lit-3338-explicit-30",
+        key="lit-3338-explicit-non-sentinel",
         value={"ok": True},
-        ttl=30,
+        ttl=non_sentinel_ttl,
     )
-    ttl_actual = cache.in_memory_cache.ttl_dict["lit-3338-explicit-30"] - before
-    assert 25 <= ttl_actual <= 35, (
-        f"explicit ttl=30 was coerced to {ttl_actual:.1f}s -- caller intent broken"
+    ttl_actual = (
+        cache.in_memory_cache.ttl_dict["lit-3338-explicit-non-sentinel"] - before
+    )
+    assert non_sentinel_ttl - 5 <= ttl_actual <= non_sentinel_ttl + 5, (
+        f"explicit ttl={non_sentinel_ttl} was coerced to {ttl_actual:.1f}s "
+        f"-- caller intent broken"
     )
 
 

--- a/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py
+++ b/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py
@@ -1,0 +1,113 @@
+"""LIT-3338: ``general_settings.user_api_key_cache_ttl`` must be honoured for the
+management-object cache writes from ``auth_checks.py`` (key, team, user, budget,
+vector store, permission).
+
+Before the fix, those call sites passed an explicit
+``ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` (60s) that silently capped
+the user's configured ``user_api_key_cache_ttl`` at 60s, even though
+``proxy_server.py`` had already pushed the user value into the cache via
+``update_cache_ttl``.
+
+The fix in ``UserApiKeyCache`` treats the constant as a sentinel meaning "use
+the cache's configured default" and substitutes ``default_in_memory_ttl`` when
+the user has overridden it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+
+def _make_cache(configured_ttl):
+    """Build a UserApiKeyCache the way ``proxy_server.py`` does at startup."""
+    cache = UserApiKeyCache(default_in_memory_ttl=60)
+    if configured_ttl is not None:
+        cache.update_cache_ttl(
+            default_in_memory_ttl=configured_ttl,
+            default_redis_ttl=configured_ttl,
+        )
+    return cache
+
+
+@pytest.mark.asyncio
+async def test_configured_ttl_overrides_management_object_constant():
+    """``user_api_key_cache_ttl: 300`` -> entries written with the management
+    constant honour the configured 300s TTL."""
+    import time
+
+    cache = _make_cache(configured_ttl=300)
+
+    before = time.time()
+    await cache.async_set_cache(
+        key="lit-3338-key-1",
+        value={"ok": True},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    expiry = cache.in_memory_cache.ttl_dict.get("lit-3338-key-1")
+    assert expiry is not None, "value was not cached in-memory"
+    ttl_actual = expiry - before
+    assert 295 <= ttl_actual <= 305, (
+        f"expected ~300s TTL, got {ttl_actual:.1f}s (LIT-3338 regression)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_ttl_unchanged_when_unconfigured():
+    """No ``user_api_key_cache_ttl`` set -> entries keep the historical 60s TTL.
+    Regression guard against accidentally widening the cache for everyone."""
+    import time
+
+    cache = _make_cache(configured_ttl=None)
+
+    before = time.time()
+    await cache.async_set_cache(
+        key="lit-3338-default-key",
+        value={"ok": True},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    ttl_actual = cache.in_memory_cache.ttl_dict["lit-3338-default-key"] - before
+    assert 55 <= ttl_actual <= 65, (
+        f"default 60s TTL drifted to {ttl_actual:.1f}s (LIT-3338 regression)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_non_management_ttl_is_not_coerced():
+    """Other callers passing an explicit ttl that is NOT the management constant
+    must be passed through untouched."""
+    import time
+
+    cache = _make_cache(configured_ttl=300)
+
+    before = time.time()
+    await cache.async_set_cache(
+        key="lit-3338-explicit-30",
+        value={"ok": True},
+        ttl=30,
+    )
+    ttl_actual = cache.in_memory_cache.ttl_dict["lit-3338-explicit-30"] - before
+    assert 25 <= ttl_actual <= 35, (
+        f"explicit ttl=30 was coerced to {ttl_actual:.1f}s -- caller intent broken"
+    )
+
+
+def test_sync_set_cache_also_coerces_management_object_constant():
+    """Sync path must mirror async path so callers that use ``set_cache``
+    receive the same TTL coercion."""
+    import time
+
+    cache = _make_cache(configured_ttl=300)
+
+    before = time.time()
+    cache.set_cache(
+        key="lit-3338-sync-key",
+        value={"ok": True},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    ttl_actual = cache.in_memory_cache.ttl_dict["lit-3338-sync-key"] - before
+    assert 295 <= ttl_actual <= 305, (
+        f"sync path didn't honour configured TTL: got {ttl_actual:.1f}s"
+    )


### PR DESCRIPTION
## Summary

Customer report (NVIDIA, Pylon #4339): `general_settings.user_api_key_cache_ttl: 300` is silently ignored — `user_api_key_auth` cached entries still expire after 60s.

Linear: [LIT-3338](https://linear.app/litellm-ai/issue/LIT-3338/user-api-key-cache-ttl-is-ignored-for-api-key-auth)

## Root cause

`auth_checks._cache_management_object()` (and 5 other call sites: budget, team member budget, user, vector store, permission) write to:

```python
user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
```

That explicit `ttl=60` always wins over the cache's own `default_in_memory_ttl`, which `proxy_server.py` *does* correctly update from `general_settings.user_api_key_cache_ttl` at startup via `user_api_key_cache.update_cache_ttl(...)`. So the user setting is read at startup, written onto the cache object as the new default, and then ignored by every management-object cache write.

## Fix

In `UserApiKeyCache`, treat `DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL` as a **sentinel** meaning "use the cache's configured default TTL". When a caller passes that exact constant **and** the cache's `default_in_memory_ttl` has been customised away from the constant (i.e. the user actually configured `user_api_key_cache_ttl`), substitute the configured value. Otherwise behaviour is unchanged — the constant collapses to itself.

```python
def _coerce_management_object_ttl(self, kwargs: dict) -> None:
    ttl = kwargs.get("ttl")
    if ttl is None or ttl != DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL:
        return
    configured = self.default_in_memory_ttl
    if configured is None or configured == DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL:
        return
    kwargs["ttl"] = configured
```

Applied to both `set_cache` and `async_set_cache` on `UserApiKeyCache` (sync + async paths kept symmetric).

### Why coerce in the cache layer instead of editing the 6 call sites

* Single touch-point — no risk of missing a future call site that uses the same management constant.
* No-op when the user hasn't configured `user_api_key_cache_ttl` (cache's default still equals the constant, substitution branch skipped).
* Pass-through for other callers passing arbitrary explicit ttls (e.g. tag cache writes — covered by a regression test).

## Evidence

### Reproducer drives the exact code path from the report

`_cache_key_object → _cache_management_object → user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)`, with `UserApiKeyCache` configured the same way `proxy_server.py` does at startup with `general_settings.user_api_key_cache_ttl: 300`.

#### BEFORE (clean `main` @ `0d5040f` — current HEAD, no fix)
```
Driving _cache_key_object -> _cache_management_object -> async_set_cache(ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL):
  configured_ttl=300s  -> actual TTL stored: 60.0s   ← BUG
  configured_ttl=None  -> actual TTL stored: 60.0s
RESULT: FAIL (LIT-3338 reproduced on clean main)
```

#### AFTER (this branch)
```
Driving _cache_key_object -> _cache_management_object -> async_set_cache(ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL):
  configured_ttl=300s  -> actual TTL stored: 300.0s  ← FIXED
  configured_ttl=None  -> actual TTL stored: 60.0s   ← default preserved
RESULT: PASS — LIT-3338 fixed; default unchanged
```

### Unit tests (4 new, all passing)

```
tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py::test_configured_ttl_overrides_management_object_constant PASSED
tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py::test_default_ttl_unchanged_when_unconfigured PASSED
tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py::test_explicit_non_management_ttl_is_not_coerced PASSED
tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_lit3338.py::test_sync_set_cache_also_coerces_management_object_constant PASSED
============================== 4 passed in 11.95s ==============================
```

Covers:
1. **Customer scenario** — `user_api_key_cache_ttl=300` → cache entry expires in ~300s.
2. **Regression guard** — no `user_api_key_cache_ttl` set → default 60s preserved.
3. **Pass-through** — explicit `ttl=30` (or any non-sentinel value) is NOT coerced.
4. **Sync path** — `set_cache` mirrors `async_set_cache`.

## Reviewer notes

- Diff is intentionally narrow: 35 lines on `user_api_key_cache.py` (one private helper + 2 one-line callers in `set_cache` / `async_set_cache`) + a new 113-line test file. No changes to `auth_checks.py`.
- The 6 management-object call sites in `auth_checks.py` are unchanged; they keep passing the constant as a documented "management default" marker, and the cache now honours user config when that marker shows up.

Agent session: https://litellm-agent-platform.onrender.com/sessions/ad8cf1f7-6188-4a01-a41b-0e3231f483e3
Supersedes #28818 (closed — that one was empty due to a prior session's commit only adding a patch artifact file, no real code change).