### PR TITLE
feat(enterprise): add RESEND_FROM_EMAIL for self-hosted Resend sends

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/resend_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/resend_email.py
@@ -19,12 +19,26 @@ RESEND_API_ENDPOINT = "https://api.resend.com/emails"
 
 
 class ResendEmailLogger(BaseEmailLogger):
+    """
+    Send emails using Resend's API.
+
+    Required env vars:
+    - RESEND_API_KEY
+
+    Optional env vars:
+    - RESEND_FROM_EMAIL: Override the default sender address. Must be on a
+      domain verified in your Resend account. When unset, falls back to the
+      `from_email` argument passed by the caller (which defaults to
+      `notifications@alerts.litellm.ai` and only works on LiteLLM Cloud).
+    """
+
     def __init__(self, internal_usage_cache=None, **kwargs):
         super().__init__(internal_usage_cache=internal_usage_cache, **kwargs)
         self.async_httpx_client = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.LoggingCallback
         )
         self.resend_api_key = os.getenv("RESEND_API_KEY")
+        self.resend_from_email = os.getenv("RESEND_FROM_EMAIL")
 
     async def send_email(
         self,
@@ -33,13 +47,14 @@ class ResendEmailLogger(BaseEmailLogger):
         subject: str,
         html_body: str,
     ):
+        sender_email = self.resend_from_email or from_email
         verbose_logger.debug(
-            f"Sending email from {from_email} to {to_email} with subject {subject}"
+            f"Sending email from {sender_email} to {to_email} with subject {subject}"
         )
         response = await self.async_httpx_client.post(
             url=RESEND_API_ENDPOINT,
             json={
-                "from": from_email,
+                "from": sender_email,
                 "to": to_email,
                 "subject": subject,
                 "html": html_body,

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_resend_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_resend_email.py
@@ -32,7 +32,11 @@ def clear_client_cache():
 
 @pytest.fixture
 def mock_env_vars():
-    with mock.patch.dict(os.environ, {"RESEND_API_KEY": "test_api_key"}):
+    # Set test API key and ensure RESEND_FROM_EMAIL is unset for isolation
+    # so tests can verify the default `from_email` argument is used.
+    patched = {"RESEND_API_KEY": "test_api_key"}
+    with mock.patch.dict(os.environ, patched):
+        os.environ.pop("RESEND_FROM_EMAIL", None)
         yield
 
 
@@ -87,7 +91,7 @@ async def test_send_email_success(mock_env_vars):
 async def test_send_email_missing_api_key():
     # Remove the API key from environment before initializing logger
     original_key = os.environ.pop("RESEND_API_KEY", None)
-    
+
     try:
         # Initialize the logger after removing the API key
         logger = ResendEmailLogger()
@@ -104,16 +108,19 @@ async def test_send_email_missing_api_key():
         mock_response.raise_for_status.return_value = None
         mock_response.status_code = 200
         mock_response.json.return_value = {"id": "test_email_id"}
-        
+
         mock_async_client = mock.AsyncMock()
         mock_async_client.post.return_value = mock_response
-        
+
         # Directly inject the mock client to bypass any caching
         logger.async_httpx_client = mock_async_client
 
         # Send email
         await logger.send_email(
-            from_email=from_email, to_email=to_email, subject=subject, html_body=html_body
+            from_email=from_email,
+            to_email=to_email,
+            subject=subject,
+            html_body=html_body,
         )
 
         # Verify the HTTP client was called with None as the API key
@@ -159,3 +166,62 @@ async def test_send_email_multiple_recipients(mock_env_vars):
     call_args = mock_async_client.post.call_args
     request_body = call_args[1]["json"]
     assert request_body["to"] == to_email
+
+
+@pytest.mark.asyncio
+async def test_send_email_uses_resend_from_email_override():
+    """RESEND_FROM_EMAIL overrides the caller-supplied from_email."""
+    with mock.patch.dict(
+        os.environ,
+        {
+            "RESEND_API_KEY": "test_api_key",
+            "RESEND_FROM_EMAIL": "alerts@my-verified-domain.com",
+        },
+    ):
+        logger = ResendEmailLogger()
+
+        mock_response = mock.Mock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "test_email_id"}
+        mock_response.raise_for_status.return_value = None
+
+        mock_async_client = mock.AsyncMock()
+        mock_async_client.post.return_value = mock_response
+        logger.async_httpx_client = mock_async_client
+
+        await logger.send_email(
+            from_email="notifications@alerts.litellm.ai",
+            to_email=["recipient@example.com"],
+            subject="Test Subject",
+            html_body="<p>Test email body</p>",
+        )
+
+        mock_async_client.post.assert_called_once()
+        request_body = mock_async_client.post.call_args[1]["json"]
+        assert request_body["from"] == "alerts@my-verified-domain.com"
+
+
+@pytest.mark.asyncio
+async def test_send_email_falls_back_to_argument_when_override_unset(mock_env_vars):
+    """When RESEND_FROM_EMAIL is unset, the caller-supplied from_email is used."""
+    logger = ResendEmailLogger()
+
+    mock_response = mock.Mock(spec=Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "test_email_id"}
+    mock_response.raise_for_status.return_value = None
+
+    mock_async_client = mock.AsyncMock()
+    mock_async_client.post.return_value = mock_response
+    logger.async_httpx_client = mock_async_client
+
+    await logger.send_email(
+        from_email="notifications@alerts.litellm.ai",
+        to_email=["recipient@example.com"],
+        subject="Test Subject",
+        html_body="<p>Test email body</p>",
+    )
+
+    mock_async_client.post.assert_called_once()
+    request_body = mock_async_client.post.call_args[1]["json"]
+    assert request_body["from"] == "notifications@alerts.litellm.ai"


### PR DESCRIPTION
Description
Adds optional RESEND_FROM_EMAIL support to ResendEmailLogger, matching the existing SendGrid pattern (SENDGRID_SENDER_EMAIL). Self-hosted installs can send from a domain verified in their own Resend account instead of the hardcoded LiteLLM default.

Cause
ResendEmailLogger always sent from notifications@alerts.litellm.ai (via BaseEmailLogger.DEFAULT_LITELLM_EMAIL). That address works on LiteLLM Cloud but fails on self-hosted setups — Resend returns 403 Forbidden when the sender domain isn't verified on the caller's account.

SendGrid already supports a custom sender via SENDGRID_SENDER_EMAIL; Resend had no equivalent.

Fix
Read RESEND_FROM_EMAIL in ResendEmailLogger.__init__
Resolve sender as RESEND_FROM_EMAIL or from_email before calling the Resend API
Preserve existing behavior when the env var is unset (falls back to notifications@alerts.litellm.ai)
Add unit tests for override and fallback paths
Usage:

RESEND_API_KEY=re_xxxx
RESEND_FROM_EMAIL=issues@berri.ai  # verified domain in Resend
Test plan

 uv run pytest tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_resend_email.py -v

 Restart proxy with RESEND_FROM_EMAIL set; create a key with "Send email" enabled and confirm delivery in Resend dashboard
 
 
<img width="1137" height="634" alt="Screenshot 2026-05-25 at 8 00 16 PM" src="https://github.com/user-attachments/assets/4be45cb1-2e68-483b-87b7-cb7d195aac23" />
