### PR TITLE
test(ci): add tests/ci_models.py — env-var-driven CI model name registry (LIT-2650)

### DIFF
--- a/tests/README.MD
+++ b/tests/README.MD
@@ -7,3 +7,41 @@ To make it easier to contribute and map what behavior is tested,
 we've started mapping the litellm directory in `tests/test_litellm`
 
 This folder can only run mock tests.
+
+## Overriding CI model names
+
+The most-frequently used model identifiers in this test suite are exposed
+as env-var-driven constants in [`tests/ci_models.py`](./ci_models.py). When
+a provider deprecates a model, every test that imports the constant can be
+swapped to the new identifier without a code change:
+
+```bash
+# Run with defaults.
+pytest tests/llm_translation/
+
+# Override one model name -- every test that imports the constant
+# (e.g. GPT_4O) picks up the new value:
+CI_MODEL_GPT_4O="gpt-4o-2024-08-06" pytest tests/llm_translation/
+
+# Inspect every constant + its current resolved value:
+python -m tests.ci_models
+```
+
+To use these constants in a test, import them from ``tests.ci_models``:
+
+```python
+from tests.ci_models import GPT_4O, CLAUDE_SONNET_4_5
+
+response = litellm.completion(model=GPT_4O, messages=...)
+```
+
+For model names without a dedicated constant, use :func:`get_ci_model`:
+
+```python
+from tests.ci_models import get_ci_model
+
+model = get_ci_model("CI_MODEL_MY_MODEL", default="anthropic/claude-haiku")
+```
+
+See `tests/ci_models.py` for the full list of constants and the
+environment-variable names that override them.

--- a/tests/ci_models.py
+++ b/tests/ci_models.py
@@ -1,0 +1,162 @@
+"""
+Centralized CI model identifiers, resolved at import time from environment
+variables with sensible defaults.
+
+Many tests in this repository pass a literal model identifier directly to
+``litellm.completion`` / ``litellm.embedding`` (e.g. ``model="gpt-4"``).
+When a provider deprecates a model, every hardcoded reference must be
+updated across the suite -- a noisy, error-prone code change for what is
+operationally a config swap.
+
+This module centralizes the common CI model names so the swap becomes a
+single environment-variable override at CI invocation time::
+
+    # Default: tests use gpt-4o.
+    pytest tests/llm_translation/
+
+    # Swap every test that imports GPT_4O without touching code:
+    CI_MODEL_GPT_4O="gpt-4o-2024-08-06" pytest tests/llm_translation/
+
+Usage::
+
+    from tests.ci_models import GPT_4O, CLAUDE_SONNET_4_5, get_ci_model
+
+    response = litellm.completion(
+        model=GPT_4O,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    # For model names without a dedicated constant:
+    model = get_ci_model("CI_MODEL_MY_CUSTOM", default="anthropic/claude-haiku")
+
+Each constant ``X`` is resolved exactly once at module import as
+``os.environ.get("CI_MODEL_X", "<default>")``. Tests that need to flip the
+value mid-run should call :func:`get_ci_model` instead, which reads
+``os.environ`` on every call.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Set, Tuple
+
+_CI_MODEL_PREFIX = "CI_MODEL_"
+
+# (constant_name, env_var, default_model_id)
+#
+# Defaults reflect what these tests use today; keep them in sync with the
+# most-frequently hardcoded identifiers in the suite.
+_DEFAULTS: Tuple[Tuple[str, str, str], ...] = (
+    # ---- OpenAI chat ----
+    ("GPT_3_5_TURBO", "CI_MODEL_GPT_3_5_TURBO", "gpt-3.5-turbo"),
+    ("GPT_3_5_TURBO_INSTRUCT", "CI_MODEL_GPT_3_5_TURBO_INSTRUCT", "gpt-3.5-turbo-instruct"),
+    ("GPT_4", "CI_MODEL_GPT_4", "gpt-4"),
+    ("GPT_4O", "CI_MODEL_GPT_4O", "gpt-4o"),
+    ("GPT_4O_MINI", "CI_MODEL_GPT_4O_MINI", "gpt-4o-mini"),
+    ("GPT_4_1_MINI", "CI_MODEL_GPT_4_1_MINI", "gpt-4.1-mini"),
+    ("GPT_5", "CI_MODEL_GPT_5", "gpt-5"),
+    ("GPT_5_MINI", "CI_MODEL_GPT_5_MINI", "gpt-5-mini"),
+    ("GPT_5_4", "CI_MODEL_GPT_5_4", "gpt-5.4"),
+    ("GPT_5_5", "CI_MODEL_GPT_5_5", "gpt-5.5"),
+    # ---- OpenAI embeddings ----
+    ("TEXT_EMBEDDING_ADA_002", "CI_MODEL_TEXT_EMBEDDING_ADA_002", "text-embedding-ada-002"),
+    ("TEXT_EMBEDDING_3_SMALL", "CI_MODEL_TEXT_EMBEDDING_3_SMALL", "text-embedding-3-small"),
+    # ---- Azure (prefixed routes used in CI) ----
+    ("AZURE_GPT_4_1_MINI", "CI_MODEL_AZURE_GPT_4_1_MINI", "azure/gpt-4.1-mini"),
+    # ---- Anthropic ----
+    ("CLAUDE_SONNET_4_5", "CI_MODEL_CLAUDE_SONNET_4_5", "claude-sonnet-4-5-20250929"),
+    ("CLAUDE_SONNET_4", "CI_MODEL_CLAUDE_SONNET_4", "claude-sonnet-4-20250514"),
+    ("CLAUDE_3_5_SONNET", "CI_MODEL_CLAUDE_3_5_SONNET", "claude-3-5-sonnet-20240620"),
+    ("ANTHROPIC_CLAUDE_SONNET_4_5", "CI_MODEL_ANTHROPIC_CLAUDE_SONNET_4_5", "anthropic/claude-sonnet-4-5-20250929"),
+    # ---- Bedrock (Anthropic via Bedrock) ----
+    ("BEDROCK_CLAUDE_HAIKU_4_5", "CI_MODEL_BEDROCK_CLAUDE_HAIKU_4_5", "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+    ("ANTHROPIC_CLAUDE_HAIKU_4_5", "CI_MODEL_ANTHROPIC_CLAUDE_HAIKU_4_5", "anthropic.claude-haiku-4-5-20251001-v1:0"),
+    # ---- Google / Gemini ----
+    ("GEMINI_1_5_PRO", "CI_MODEL_GEMINI_1_5_PRO", "gemini-1.5-pro"),
+    ("GEMINI_2_5_FLASH", "CI_MODEL_GEMINI_2_5_FLASH", "gemini-2.5-flash"),
+    ("GEMINI_GEMINI_2_5_FLASH", "CI_MODEL_GEMINI_GEMINI_2_5_FLASH", "gemini/gemini-2.5-flash"),
+)
+
+
+def get_ci_model(env_var: str, default: str) -> str:
+    """Resolve a CI model identifier from an env var, falling back to ``default``.
+
+    Reads ``os.environ`` on every call (unlike the module-level constants,
+    which are resolved once at import).
+
+    Parameters
+    ----------
+    env_var:
+        Environment variable name to consult. Must start with the
+        ``CI_MODEL_`` prefix so the override is discoverable via
+        ``env | grep ^CI_MODEL_``.
+    default:
+        Model identifier to return if ``env_var`` is unset or empty.
+
+    Returns
+    -------
+    str
+        The resolved model identifier.
+
+    Raises
+    ------
+    ValueError
+        If ``env_var`` does not start with ``CI_MODEL_``.
+    """
+    if not env_var.startswith(_CI_MODEL_PREFIX):
+        raise ValueError(
+            f"CI model env var must start with {_CI_MODEL_PREFIX!r}; "
+            f"got {env_var!r}"
+        )
+    value = os.environ.get(env_var)
+    if not value:
+        return default
+    return value
+
+
+def _populate_module_constants() -> None:
+    """Resolve every entry in ``_DEFAULTS`` and bind it on this module."""
+    module = sys.modules[__name__]
+    seen_constants: Set[str] = set()
+    seen_env_vars: Set[str] = set()
+    for constant_name, env_var, default in _DEFAULTS:
+        if constant_name in seen_constants:
+            raise RuntimeError(
+                f"Duplicate constant name in _DEFAULTS: {constant_name!r}"
+            )
+        if env_var in seen_env_vars:
+            raise RuntimeError(
+                f"Duplicate env var in _DEFAULTS: {env_var!r}"
+            )
+        if not env_var.startswith(_CI_MODEL_PREFIX):
+            raise RuntimeError(
+                f"Env var for {constant_name!r} must start with "
+                f"{_CI_MODEL_PREFIX!r}; got {env_var!r}"
+            )
+        seen_constants.add(constant_name)
+        seen_env_vars.add(env_var)
+        setattr(module, constant_name, get_ci_model(env_var, default))
+
+
+_populate_module_constants()
+
+
+def _format_table() -> str:
+    """Return a fixed-width table of (constant, env_var, default, current)."""
+    rows = [("Constant", "Environment variable", "Default", "Current")]
+    rows.extend(
+        (cn, ev, d, os.environ.get(ev, d) or d)
+        for cn, ev, d in _DEFAULTS
+    )
+    widths = [max(len(r[i]) for r in rows) for i in range(4)]
+    lines = []
+    for i, r in enumerate(rows):
+        lines.append("  ".join(c.ljust(widths[k]) for k, c in enumerate(r)))
+        if i == 0:
+            lines.append("  ".join("-" * w for w in widths))
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(_format_table())

--- a/tests/test_litellm/test_ci_models.py
+++ b/tests/test_litellm/test_ci_models.py
@@ -10,17 +10,28 @@ from typing import Iterator
 import pytest
 
 
-@pytest.fixture
-def fresh_ci_models(monkeypatch: pytest.MonkeyPatch) -> Iterator[object]:
-    """Return a freshly-imported ``tests.ci_models`` module.
+@pytest.fixture(autouse=True)
+def _clean_ci_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every ``CI_MODEL_*`` env var before each test.
 
-    The module resolves its constants at import time, so any test that wants
-    to observe an env-var override must re-import the module after setting
-    the env var. We also remove any leftover ``CI_MODEL_*`` env vars so
-    tests are independent of the surrounding environment.
+    Without this, any ``CI_MODEL_*`` set in the surrounding CI environment
+    (which is exactly the environment this module is meant to support) can
+    poison the default-value assertions in tests that don't use the
+    ``fresh_ci_models`` fixture.
     """
     for key in [k for k in os.environ if k.startswith("CI_MODEL_")]:
         monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def fresh_ci_models() -> Iterator[object]:
+    """Return a freshly-imported ``tests.ci_models`` module.
+
+    The module resolves its constants at import time, so any test that
+    wants to observe an env-var override must re-import the module after
+    setting the env var. ``_clean_ci_model_env`` (autouse, module-wide)
+    ensures the outer environment doesn't leak into the import.
+    """
     sys.modules.pop("tests.ci_models", None)
     module = importlib.import_module("tests.ci_models")
     yield module
@@ -66,7 +77,8 @@ class TestEnvOverride:
         ci_models = importlib.import_module("tests.ci_models")
         try:
             assert ci_models.GPT_4O == "gpt-4o-2024-08-06"
-            # Unrelated constants are untouched.
+            # Unrelated constants are untouched (autouse fixture above
+            # guarantees no stray CI_MODEL_GPT_4 from the outer env).
             assert ci_models.GPT_4 == "gpt-4"
         finally:
             sys.modules.pop("tests.ci_models", None)

--- a/tests/test_litellm/test_ci_models.py
+++ b/tests/test_litellm/test_ci_models.py
@@ -1,0 +1,136 @@
+"""Tests for ``tests/ci_models.py`` -- the CI model name registry."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from typing import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def fresh_ci_models(monkeypatch: pytest.MonkeyPatch) -> Iterator[object]:
+    """Return a freshly-imported ``tests.ci_models`` module.
+
+    The module resolves its constants at import time, so any test that wants
+    to observe an env-var override must re-import the module after setting
+    the env var. We also remove any leftover ``CI_MODEL_*`` env vars so
+    tests are independent of the surrounding environment.
+    """
+    for key in [k for k in os.environ if k.startswith("CI_MODEL_")]:
+        monkeypatch.delenv(key, raising=False)
+    sys.modules.pop("tests.ci_models", None)
+    module = importlib.import_module("tests.ci_models")
+    yield module
+    sys.modules.pop("tests.ci_models", None)
+
+
+class TestDefaults:
+    def test_known_constants_are_exposed(self, fresh_ci_models):
+        # Spot-check a representative sample of the constants we expose.
+        for name in (
+            "GPT_3_5_TURBO",
+            "GPT_4",
+            "GPT_4O",
+            "GPT_4O_MINI",
+            "GPT_5_MINI",
+            "CLAUDE_SONNET_4_5",
+            "CLAUDE_SONNET_4",
+            "BEDROCK_CLAUDE_HAIKU_4_5",
+            "GEMINI_2_5_FLASH",
+            "TEXT_EMBEDDING_ADA_002",
+        ):
+            assert hasattr(fresh_ci_models, name), f"missing constant {name!r}"
+            assert isinstance(getattr(fresh_ci_models, name), str)
+            assert getattr(fresh_ci_models, name), f"{name} resolved to empty string"
+
+    def test_defaults_match_well_known_identifiers(self, fresh_ci_models):
+        """Defaults should not silently drift; pin a few critical ones."""
+        assert fresh_ci_models.GPT_3_5_TURBO == "gpt-3.5-turbo"
+        assert fresh_ci_models.GPT_4 == "gpt-4"
+        assert fresh_ci_models.GPT_4O == "gpt-4o"
+        assert fresh_ci_models.GPT_4O_MINI == "gpt-4o-mini"
+        assert fresh_ci_models.CLAUDE_SONNET_4_5 == "claude-sonnet-4-5-20250929"
+        assert (
+            fresh_ci_models.BEDROCK_CLAUDE_HAIKU_4_5
+            == "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+
+class TestEnvOverride:
+    def test_env_var_overrides_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CI_MODEL_GPT_4O", "gpt-4o-2024-08-06")
+        sys.modules.pop("tests.ci_models", None)
+        ci_models = importlib.import_module("tests.ci_models")
+        try:
+            assert ci_models.GPT_4O == "gpt-4o-2024-08-06"
+            # Unrelated constants are untouched.
+            assert ci_models.GPT_4 == "gpt-4"
+        finally:
+            sys.modules.pop("tests.ci_models", None)
+
+    def test_empty_env_var_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CI_MODEL_GPT_4O", "")
+        sys.modules.pop("tests.ci_models", None)
+        ci_models = importlib.import_module("tests.ci_models")
+        try:
+            assert ci_models.GPT_4O == "gpt-4o"
+        finally:
+            sys.modules.pop("tests.ci_models", None)
+
+    def test_post_import_env_change_does_not_affect_constants(
+        self, fresh_ci_models, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Setting the env var AFTER import must not mutate already-resolved
+        # constants -- this is documented behaviour.
+        assert fresh_ci_models.GPT_4 == "gpt-4"
+        monkeypatch.setenv("CI_MODEL_GPT_4", "should-not-apply")
+        assert fresh_ci_models.GPT_4 == "gpt-4"
+
+
+class TestGetCiModel:
+    def test_returns_env_value_when_set(
+        self, monkeypatch: pytest.MonkeyPatch, fresh_ci_models
+    ):
+        monkeypatch.setenv("CI_MODEL_GPT_4O", "override-value")
+        assert (
+            fresh_ci_models.get_ci_model("CI_MODEL_GPT_4O", "fallback")
+            == "override-value"
+        )
+
+    def test_returns_default_when_unset(self, fresh_ci_models):
+        assert (
+            fresh_ci_models.get_ci_model("CI_MODEL_NEVER_SET", "fallback")
+            == "fallback"
+        )
+
+    def test_returns_default_when_empty(
+        self, monkeypatch: pytest.MonkeyPatch, fresh_ci_models
+    ):
+        monkeypatch.setenv("CI_MODEL_EMPTY", "")
+        assert (
+            fresh_ci_models.get_ci_model("CI_MODEL_EMPTY", "fallback")
+            == "fallback"
+        )
+
+    def test_reads_env_on_each_call(
+        self, monkeypatch: pytest.MonkeyPatch, fresh_ci_models
+    ):
+        # Unlike module-level constants, get_ci_model picks up changes to
+        # os.environ after import.
+        monkeypatch.setenv("CI_MODEL_DYNAMIC", "first")
+        assert fresh_ci_models.get_ci_model("CI_MODEL_DYNAMIC", "x") == "first"
+        monkeypatch.setenv("CI_MODEL_DYNAMIC", "second")
+        assert fresh_ci_models.get_ci_model("CI_MODEL_DYNAMIC", "x") == "second"
+
+    def test_rejects_env_var_missing_prefix(self, fresh_ci_models):
+        with pytest.raises(ValueError, match="CI_MODEL_"):
+            fresh_ci_models.get_ci_model("OTHER_VAR", "fallback")
+
+    def test_rejects_env_var_with_wrong_prefix(self, fresh_ci_models):
+        with pytest.raises(ValueError, match="CI_MODEL_"):
+            fresh_ci_models.get_ci_model("MY_MODEL", "fallback")

--- a/tests/test_litellm/test_exception_header_preservation.py
+++ b/tests/test_litellm/test_exception_header_preservation.py
@@ -20,6 +20,8 @@ from litellm.exceptions import (
     RateLimitError,
 )
 
+from tests.ci_models import GPT_4, GPT_4O_MINI
+
 
 class TestExceptionHeaderPreservation:
     """Test that exception classes preserve headers from provider responses."""
@@ -44,7 +46,7 @@ class TestExceptionHeaderPreservation:
         """BadRequestError should preserve headers from the provider response."""
         error = BadRequestError(
             message="Invalid request",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=mock_response_with_headers,
         )
@@ -60,7 +62,7 @@ class TestExceptionHeaderPreservation:
         """ContentPolicyViolationError should preserve headers from the provider response."""
         error = ContentPolicyViolationError(
             message="Content policy violation",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=mock_response_with_headers,
         )
@@ -75,7 +77,7 @@ class TestExceptionHeaderPreservation:
         """ContextWindowExceededError should preserve headers from the provider response."""
         error = ContextWindowExceededError(
             message="Context window exceeded",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=mock_response_with_headers,
         )
@@ -90,7 +92,7 @@ class TestExceptionHeaderPreservation:
         """ImageFetchError should preserve headers from the provider response."""
         error = ImageFetchError(
             message="Failed to fetch image",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=mock_response_with_headers,
         )
@@ -103,7 +105,7 @@ class TestExceptionHeaderPreservation:
         """BadRequestError should handle None response gracefully."""
         error = BadRequestError(
             message="Invalid request",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=None,
         )
@@ -116,7 +118,7 @@ class TestExceptionHeaderPreservation:
         """ContentPolicyViolationError should handle None response gracefully."""
         error = ContentPolicyViolationError(
             message="Content policy violation",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=None,
         )
@@ -128,7 +130,7 @@ class TestExceptionHeaderPreservation:
         """ContextWindowExceededError should handle None response gracefully."""
         error = ContextWindowExceededError(
             message="Context window exceeded",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=None,
         )
@@ -144,7 +146,7 @@ class TestExceptionMessageFormatting:
         """BadRequestError should format message with litellm prefix."""
         error = BadRequestError(
             message="test error",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
         )
 
@@ -155,7 +157,7 @@ class TestExceptionMessageFormatting:
         """ContentPolicyViolationError should format message with specific prefix."""
         error = ContentPolicyViolationError(
             message="test error",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
         )
 
@@ -166,7 +168,7 @@ class TestExceptionMessageFormatting:
         """ContextWindowExceededError should format message with specific prefix."""
         error = ContextWindowExceededError(
             message="test error",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
         )
 
@@ -183,7 +185,7 @@ class TestExceptionAttributes:
 
         error = ContentPolicyViolationError(
             message="test error",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             provider_specific_fields=provider_fields,
         )
@@ -198,14 +200,14 @@ class TestExceptionAttributes:
         """BadRequestError should set all expected attributes."""
         error = BadRequestError(
             message="test error",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             litellm_debug_info="debug info",
             max_retries=3,
             num_retries=1,
         )
 
-        assert error.model == "gpt-4"
+        assert error.model == GPT_4
         assert error.llm_provider == "azure"
         assert error.litellm_debug_info == "debug info"
         assert error.max_retries == 3
@@ -225,13 +227,13 @@ class TestExceptionAttributes:
         rate_limit_error = RateLimitError(
             message="Rate limit exceeded",
             llm_provider="openai",
-            model="gpt-4o-mini",
+            model=GPT_4O_MINI,
             response=original_resp,
         )
 
         midstream_error = MidStreamFallbackError(
             message="stream broke",
-            model="gpt-4o-mini",
+            model=GPT_4O_MINI,
             llm_provider="openai",
             original_exception=rate_limit_error,
         )
@@ -245,7 +247,7 @@ class TestExceptionAttributes:
         # With no original exception, should default to 503.
         midstream_fallback = MidStreamFallbackError(
             message="stream broke without original",
-            model="gpt-4o-mini",
+            model=GPT_4O_MINI,
             llm_provider="openai",
             original_exception=None,
         )
@@ -295,7 +297,7 @@ class TestProxyHeaderExtraction:
         )
         error = ContentPolicyViolationError(
             message="test",
-            model="gpt-4",
+            model=GPT_4,
             llm_provider="azure",
             response=mock_response,
         )


### PR DESCRIPTION
Fixes [LIT-2650](https://linear.app/litellm-ai/issue/LIT-2650/make-ci-model-names-configurable-via-environment-variables).

## Why

When a provider deprecates a model used in our tests, every hardcoded
reference (`model="gpt-4"`, etc.) has to be updated across the suite — a
noisy code change for what is operationally a config swap. Ryan flagged
this in #llms-engineering:

> making model names in cicd be env var so that updating deprecated
> models in ci doesnt require a code change through the tests that use them

## What

New module **`tests/ci_models.py`** that exposes the most-frequently
hardcoded model identifiers as constants resolved at import time from
`CI_MODEL_*` environment variables, falling back to today's defaults:

```python
from tests.ci_models import GPT_4O, CLAUDE_SONNET_4_5, get_ci_model

response = litellm.completion(model=GPT_4O, messages=...)
```

Now the swap is a single CLI override — no code change:

```bash
CI_MODEL_GPT_4O="gpt-4o-2024-08-06" pytest tests/llm_translation/
```

Initial registry covers **22 constants** for the most-used model families
in CI (gpt-3.5-turbo, gpt-4, gpt-4o*, gpt-5*, claude-sonnet-4*,
bedrock claude, gemini, text-embedding-*). Adding a new constant is a
single tuple entry in `_DEFAULTS`.

`get_ci_model(env_var, default)` is also exported for ad-hoc names that
don't warrant a dedicated constant. It reads `os.environ` on every call
(so tests that flip env vars mid-run pick up the change). The module
validates that every env var name starts with `CI_MODEL_` so overrides
are discoverable via `env | grep ^CI_MODEL_`.

## Worked example migration

`tests/test_litellm/test_exception_header_preservation.py` is migrated as
a representative example: 13 `model="gpt-4"` literals and 3
`model="gpt-4o-mini"` literals become `model=GPT_4` and
`model=GPT_4O_MINI`. The 15 tests in that file pass both with the
defaults and with the env-var override set.

The remaining suite isn't churned in this PR — the registry + worked
example are enough to start adopting the pattern in new and touched
tests. Bulk migration is a follow-up.

## Files

| File | Change |
| ---- | ------ |
| `tests/ci_models.py` | new — the registry (162 lines) |
| `tests/test_litellm/test_ci_models.py` | new — 11 unit tests for the registry |
| `tests/test_litellm/test_exception_header_preservation.py` | migrate 16 model literals to constants |
| `tests/README.MD` | document the env-var override workflow |

## Evidence

This change has no runtime surface (no HTTP endpoint, no UI, no metrics).
The evidence below shows the registry working under the test runner —
defaults match the prior hardcoded values and env-var overrides take
effect.

### A. Defaults (no env vars)

```
$ python -m tests.ci_models

Constant                     Environment variable                  Default                                              Current
---------------------------  ------------------------------------  ---------------------------------------------------  ---------------------------------------------------
GPT_3_5_TURBO                CI_MODEL_GPT_3_5_TURBO                gpt-3.5-turbo                                        gpt-3.5-turbo
GPT_3_5_TURBO_INSTRUCT       CI_MODEL_GPT_3_5_TURBO_INSTRUCT       gpt-3.5-turbo-instruct                               gpt-3.5-turbo-instruct
GPT_4                        CI_MODEL_GPT_4                        gpt-4                                                gpt-4
GPT_4O                       CI_MODEL_GPT_4O                       gpt-4o                                               gpt-4o
GPT_4O_MINI                  CI_MODEL_GPT_4O_MINI                  gpt-4o-mini                                          gpt-4o-mini
GPT_4_1_MINI                 CI_MODEL_GPT_4_1_MINI                 gpt-4.1-mini                                         gpt-4.1-mini
GPT_5                        CI_MODEL_GPT_5                        gpt-5                                                gpt-5
GPT_5_MINI                   CI_MODEL_GPT_5_MINI                   gpt-5-mini                                           gpt-5-mini
GPT_5_4                      CI_MODEL_GPT_5_4                      gpt-5.4                                              gpt-5.4
GPT_5_5                      CI_MODEL_GPT_5_5                      gpt-5.5                                              gpt-5.5
TEXT_EMBEDDING_ADA_002       CI_MODEL_TEXT_EMBEDDING_ADA_002       text-embedding-ada-002                               text-embedding-ada-002
TEXT_EMBEDDING_3_SMALL       CI_MODEL_TEXT_EMBEDDING_3_SMALL       text-embedding-3-small                               text-embedding-3-small
AZURE_GPT_4_1_MINI           CI_MODEL_AZURE_GPT_4_1_MINI           azure/gpt-4.1-mini                                   azure/gpt-4.1-mini
CLAUDE_SONNET_4_5            CI_MODEL_CLAUDE_SONNET_4_5            claude-sonnet-4-5-20250929                           claude-sonnet-4-5-20250929
CLAUDE_SONNET_4              CI_MODEL_CLAUDE_SONNET_4              claude-sonnet-4-20250514                             claude-sonnet-4-20250514
CLAUDE_3_5_SONNET            CI_MODEL_CLAUDE_3_5_SONNET            claude-3-5-sonnet-20240620                           claude-3-5-sonnet-20240620
ANTHROPIC_CLAUDE_SONNET_4_5  CI_MODEL_ANTHROPIC_CLAUDE_SONNET_4_5  anthropic/claude-sonnet-4-5-20250929                 anthropic/claude-sonnet-4-5-20250929
BEDROCK_CLAUDE_HAIKU_4_5     CI_MODEL_BEDROCK_CLAUDE_HAIKU_4_5     bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0  bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
ANTHROPIC_CLAUDE_HAIKU_4_5   CI_MODEL_ANTHROPIC_CLAUDE_HAIKU_4_5   anthropic.claude-haiku-4-5-20251001-v1:0             anthropic.claude-haiku-4-5-20251001-v1:0
GEMINI_1_5_PRO               CI_MODEL_GEMINI_1_5_PRO               gemini-1.5-pro                                       gemini-1.5-pro
GEMINI_2_5_FLASH             CI_MODEL_GEMINI_2_5_FLASH             gemini-2.5-flash                                     gemini-2.5-flash
GEMINI_GEMINI_2_5_FLASH      CI_MODEL_GEMINI_GEMINI_2_5_FLASH      gemini/gemini-2.5-flash                              gemini/gemini-2.5-flash
```

### B. With env-var override

```
$ CI_MODEL_GPT_4O=gpt-4o-2024-08-06 \
    CI_MODEL_CLAUDE_SONNET_4_5=claude-sonnet-4-5-future \
    python -m tests.ci_models | grep -E 'GPT_4O |CLAUDE_SONNET_4_5 |GPT_4 '

GPT_4                        CI_MODEL_GPT_4                        gpt-4                                                gpt-4
GPT_4O                       CI_MODEL_GPT_4O                       gpt-4o                                               gpt-4o-2024-08-06
CLAUDE_SONNET_4_5            CI_MODEL_CLAUDE_SONNET_4_5            claude-sonnet-4-5-20250929                           claude-sonnet-4-5-future
ANTHROPIC_CLAUDE_SONNET_4_5  CI_MODEL_ANTHROPIC_CLAUDE_SONNET_4_5  anthropic/claude-sonnet-4-5-20250929                 anthropic/claude-sonnet-4-5-20250929
```

Note: `GPT_4` and `ANTHROPIC_CLAUDE_SONNET_4_5` are correctly *not*
overridden — only the two env vars actually set get the new value.

### C. Unit tests for `tests.ci_models` — 11/11 PASS

```
$ pytest tests/test_litellm/test_ci_models.py -v

tests/test_litellm/test_ci_models.py::TestDefaults::test_defaults_match_well_known_identifiers PASSED [  9%]
tests/test_litellm/test_ci_models.py::TestEnvOverride::test_empty_env_var_falls_back_to_default PASSED [ 18%]
tests/test_litellm/test_ci_models.py::TestEnvOverride::test_env_var_overrides_default PASSED [ 27%]
tests/test_litellm/test_ci_models.py::TestDefaults::test_known_constants_are_exposed PASSED [ 36%]
tests/test_litellm/test_ci_models.py::TestEnvOverride::test_post_import_env_change_does_not_affect_constants PASSED [ 45%]
tests/test_litellm/test_ci_models.py::TestGetCiModel::test_reads_env_on_each_call PASSED [ 54%]
tests/test_litellm/test_ci_models.py::TestGetCiModel::test_rejects_env_var_missing_prefix PASSED [ 63%]
tests/test_litellm/test_ci_models.py::TestGetCiModel::test_rejects_env_var_with_wrong_prefix PASSED [ 72%]
tests/test_litellm/test_ci_models.py::TestGetCiModel::test_returns_default_when_empty PASSED [ 81%]
tests/test_litellm/test_ci_models.py::TestGetCiModel::test_returns_default_when_unset PASSED [ 90%]
tests/test_litellm/test_ci_models.py::TestGetCiModel::test_returns_env_value_when_set PASSED [100%]
======================== 11 passed, 2 warnings in 0.22s ========================
```

### D. Migrated `test_exception_header_preservation.py` — 15/15 PASS with defaults

```
$ pytest tests/test_litellm/test_exception_header_preservation.py

======================== 15 passed, 2 warnings in 0.23s ========================
```

### E. Migrated file — 15/15 PASS with env-var overrides set

```
$ CI_MODEL_GPT_4=gpt-4-0613 CI_MODEL_GPT_4O_MINI=gpt-4o-mini-2024-07-18 \
    pytest tests/test_litellm/test_exception_header_preservation.py

======================== 15 passed, 2 warnings in 0.20s ========================
```

The tests pass with the override applied because the test only cares
about exception structural behavior — the model name flows through as
data. That's exactly the case the registry is meant to insulate.

## Notes for reviewers

- Module-level constants are resolved at import time (the standard
  CI-config pattern). For tests that flip env vars mid-run, use
  `get_ci_model()` which reads `os.environ` on every call. The unit
  tests for `tests.ci_models` exercise both behaviors.
- Prefix validation (every env var must start with `CI_MODEL_`) raises
  `ValueError` from `get_ci_model()` and `RuntimeError` from
  `_populate_module_constants()`, so a typo in `_DEFAULTS` fails at
  import — not silently.
- Bulk migration of the rest of the suite is intentionally out of scope
  for this PR; the registry + worked example let other PRs adopt the
  pattern incrementally without churning unrelated diffs.

### Verification (ship-pr)
- change-type: `tests/ci_models.py`, `tests/test_litellm/test_ci_models.py`, `tests/test_litellm/test_exception_header_preservation.py`, `tests/README.MD` — all test-infra + docs, no runtime surface. Per ship-pr table: "Docs / types only, no executable behavior" → state explicitly that no runtime evidence applies.
- evidence present: PASS (5 fenced code blocks — A defaults table, B override demo, C/D/E pytest pass output). No HTTP/UI/metrics surface to capture.
- image sanity: N/A (no screenshots).
- image content matches caption: N/A (no screenshots).
- backend evidence from running system: N/A — no backend changes. The captured terminal output IS from running `python -m tests.ci_models` and `pytest` on the branch.
- hygiene: PASS — no external image hosts; diff is exactly the 4 intended files (`git diff --name-only` matches files table above).

Agent session: https://litellm-agent-platform.onrender.com/sessions/8d08260a-7a21-4600-90d8-64c89258b794
