### PR TITLE
fix: don't drop functionCall parts when Gemini returns safety finishR…

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2556,17 +2556,28 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         _candidates = completion_response.get("candidates")
         if _candidates and len(_candidates) > 0:
-            content_policy_violations = (
-                VertexGeminiConfig().get_flagged_finish_reasons()
+            # Check if the candidate contains functionCall parts.
+            # Gemini may return a safety finishReason alongside valid functionCall data;
+            # in that case we must NOT short-circuit to content_filter,
+            # since _process_candidates and _check_finish_reason correctly
+            # extract tool_calls and return "tool_calls" as the finish reason.
+            candidate_parts = _candidates[0].get("content", {}).get("parts", [])
+            has_function_call = any(
+                "functionCall" in part for part in candidate_parts
             )
-            if (
-                "finishReason" in _candidates[0]
-                and _candidates[0]["finishReason"] in content_policy_violations.keys()
-            ):
-                return self._handle_content_policy_violation(
-                    model_response=model_response,
-                    completion_response=completion_response,
+            if not has_function_call:
+                content_policy_violations = (
+                    VertexGeminiConfig().get_flagged_finish_reasons()
                 )
+                if (
+                    "finishReason" in _candidates[0]
+                    and _candidates[0]["finishReason"]
+                    in content_policy_violations.keys()
+                ):
+                    return self._handle_content_policy_violation(
+                        model_response=model_response,
+                        completion_response=completion_response,
+                    )
 
         model_response.choices = []
         response_id = completion_response.get("responseId")


### PR DESCRIPTION
Title: fix: don't drop functionCall parts when Gemini returns safety finishReason

  Description:

  ## Summary
  When Gemini returns a candidate with both `functionCall` parts and a
  safety-related `finishReason` (SAFETY, RECITATION, etc.), LiteLLM was
  unconditionally short-circuiting to `_handle_content_policy_violation`,
  which returns `finish_reason="content_filter"` with null `tool_calls`.

  This discards valid function call data — the safety flag is about why
  generation stopped, not about the generated content being invalid.

  The fix checks whether the first candidate's parts contain `functionCall`
  before entering the content policy violation path. When function calls
  are present, processing continues to `_process_candidates`, which
  correctly extracts `tool_calls` and `_check_finish_reason` returns
  `"tool_calls"` as the finish reason (matching OpenAI API semantics).

  ## Changes
  - `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`:
    In `_transform_google_generate_content_to_openai_model_response`, move

  ## Changes
  - `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`:
    In `_transform_google_generate_content_to_openai_model_response`, move
    the content policy violation check behind a `has_function_call` guard.

  ## Type
  🐛 Bug Fix