### PR TITLE
Fix tiered pricing schema for cache creation cost

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -939,6 +939,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                             },
                             "input_cost_per_token": {"type": "number"},
                             "output_cost_per_token": {"type": "number"},
+                            "cache_creation_input_token_cost": {"type": "number"},
                             "cache_read_input_token_cost": {"type": "number"},
                             "output_cost_per_reasoning_token": {"type": "number"},
                             "max_results_range": {
@@ -956,6 +957,23 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
             "additionalProperties": False,
         },
     }
+
+    validate(
+        {
+            "tiered-cache-creation-regression": {
+                "tiered_pricing": [
+                    {
+                        "range": [0, 128000],
+                        "input_cost_per_token": 0.0000008,
+                        "output_cost_per_token": 0.000002,
+                        "cache_creation_input_token_cost": 0.000001,
+                        "cache_read_input_token_cost": 0.0000002,
+                    }
+                ],
+            }
+        },
+        INTENDED_SCHEMA,
+    )
 
     prod_json = os.path.join(
         os.path.dirname(__file__), "..", "..", "model_prices_and_context_window.json"


### PR DESCRIPTION
## What\n- Allow tiered pricing entries in model_prices_and_context_window.json to include cache_creation_input_token_cost\n- Add a small regression validation for tiered cache creation/read pricing together\n\n## Why\nIssue #28844 reports that adding Qwen tiered pricing with cache_creation_input_token_cost fails the model map schema validation even though top-level model pricing already supports cache creation cost and tiered pricing already supports cache_read_input_token_cost.\n\n## Verification\n- git diff --check\n- python3 AST parse for tests/test_litellm/test_utils.py\n\nCould not run the targeted pytest locally because this environment is missing the tokenizers package required during litellm import.