### PR TITLE
fix(customer_endpoints): restrict /customer/daily/activity to admin-only

### DIFF
--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -883,14 +883,6 @@ async def get_customer_daily_activity(
     """
     Get daily activity for specific organizations or all accessible organizations.
     """
-    from litellm.proxy.proxy_server import prisma_client
-
-    if prisma_client is None:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": CommonProxyErrors.db_not_connected_error.value},
-        )
-
     if (
         user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN
         and user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
@@ -902,6 +894,14 @@ async def get_customer_daily_activity(
                     user_api_key_dict.user_role
                 )
             },
+        )
+
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
 
     # Parse comma-separated ids

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -891,6 +891,19 @@ async def get_customer_daily_activity(
             detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
 
+    if (
+        user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN
+        and user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error": "Admin-only endpoint. Your user role={}".format(
+                    user_api_key_dict.user_role
+                )
+            },
+        )
+
     # Parse comma-separated ids
     end_user_ids_list = end_user_ids.split(",") if end_user_ids else None
     exclude_end_user_ids_list: Optional[List[str]] = None

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -409,3 +409,101 @@ async def test_get_customer_daily_activity_with_end_user_aliases(monkeypatch):
         "end-user-1": {"alias": "Customer One"},
         "end-user-2": {"alias": "Customer Two"},
     }
+
+
+@pytest.mark.asyncio
+async def test_get_customer_daily_activity_non_admin_is_rejected(monkeypatch):
+    """
+    Security regression: any non-admin caller must receive 401 from
+    /customer/daily/activity and /end_user/daily/activity.
+
+    Before this fix, the endpoint performed no role check. A caller with
+    user_role=INTERNAL_USER could omit end_user_ids, causing entity_id=None
+    to flow into get_daily_activity where the SQL builder treats it as no
+    filter — returning every tenant's spend across the full
+    LiteLLM_DailyEndUserSpend table.
+
+    LiteLLM_EndUserTable has no per-tenant ownership column, so non-admin
+    scoping is not possible. The correct fix is admin-only, matching the
+    existing /customer/list gate.
+    """
+    from litellm.proxy.management_endpoints import customer_endpoints
+    from litellm.proxy.management_endpoints.customer_endpoints import (
+        get_customer_daily_activity,
+    )
+
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    get_daily_activity_mock = AsyncMock()
+    monkeypatch.setattr(
+        customer_endpoints, "get_daily_activity", get_daily_activity_mock
+    )
+
+    non_admin_key = UserAPIKeyAuth(
+        user_id="regular-user-abc",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_customer_daily_activity(
+            end_user_ids=None,
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            page=1,
+            page_size=10,
+            exclude_end_user_ids=None,
+            user_api_key_dict=non_admin_key,
+        )
+
+    assert exc_info.value.status_code == 401
+    assert "Admin-only endpoint" in str(exc_info.value.detail)
+    get_daily_activity_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_customer_daily_activity_service_account_key_is_rejected(monkeypatch):
+    """
+    Security regression: service-account keys (user_id=None, role=INTERNAL_USER)
+    must be rejected at the admin gate before reaching get_daily_activity.
+
+    A service-account key with end_user_ids omitted is the worst-case caller:
+    entity_id=None and no user identity to scope by — the SQL builder would
+    return the full LiteLLM_DailyEndUserSpend table with no WHERE clause.
+    """
+    from litellm.proxy.management_endpoints import customer_endpoints
+    from litellm.proxy.management_endpoints.customer_endpoints import (
+        get_customer_daily_activity,
+    )
+
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    get_daily_activity_mock = AsyncMock()
+    monkeypatch.setattr(
+        customer_endpoints, "get_daily_activity", get_daily_activity_mock
+    )
+
+    service_account_key = UserAPIKeyAuth(
+        user_id=None,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_customer_daily_activity(
+            end_user_ids=None,
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            page=1,
+            page_size=10,
+            exclude_end_user_ids=None,
+            user_api_key_dict=service_account_key,
+        )
+
+    assert exc_info.value.status_code == 401
+    assert "Admin-only endpoint" in str(exc_info.value.detail)
+    get_daily_activity_mock.assert_not_called()


### PR DESCRIPTION
## Relevant issues
Fixes #28570

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
<img width="2547" height="759" alt="1" src="https://github.com/user-attachments/assets/031b9e25-01d2-416d-8dc1-bf0618442805" />

## Type

🐛 Bug Fix
✅ Test

## Changes
`/customer/daily/activity` (and its alias `/end_user/daily/activity`) had no role check. Any authenticated caller (including service-account keys with `user_id=None`) could omit `end_user_ids` and receive daily spend, token counts, and model breakdown for every end-user across all tenants.

When `end_user_ids` is omitted, `end_user_ids_list = None` flows into `get_daily_activity(entity_id=None, ...)`. The `_build_where_conditions` helper treats `entity_id=None` as no filter, so the query reads the full `LiteLLM_DailyEndUserSpend` table with no WHERE clause.

The same disclosure shape was fixed for `/user/daily/activity` in 0f98f375, that endpoint allows non-admins to scope to their own `user_id`. That scoping is not available here: `LiteLLM_EndUserTable` has no per-tenant ownership column, so there is no safe non-admin path. The correct fix is admin-only, matching the existing `/customer/list` endpoint which already blocks non-admins for the same reason.

Two tests added to `tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py`:

`test_get_customer_daily_activity_non_admin_is_rejected` - INTERNAL_USER caller gets 401; `get_daily_activity` tripwire confirms it is never reached
`test_get_customer_daily_activity_service_account_key_is_rejected` - same for service-account keys (`user_id=None`), the worst-case caller since `entity_id=None` would produce a completely unfiltered query.