### PR TITLE
fix(proxy): wire use_chat_completions_url_for_anthropic_messages from…

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4177,6 +4177,10 @@ class ProxyConfig:
                     verbose_proxy_logger.debug(
                         f"{blue_color_code} Enabled JSON logging via config{reset_color_code}"
                     )
+                elif key == "use_chat_completions_url_for_anthropic_messages":
+                    litellm.use_chat_completions_url_for_anthropic_messages = bool(
+                        value
+                    )
                 else:
                     verbose_proxy_logger.debug(
                         f"{blue_color_code} setting litellm.{key}={value}{reset_color_code}"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4178,8 +4178,11 @@ class ProxyConfig:
                         f"{blue_color_code} Enabled JSON logging via config{reset_color_code}"
                     )
                 elif key == "use_chat_completions_url_for_anthropic_messages":
-                    litellm.use_chat_completions_url_for_anthropic_messages = bool(
-                        value
+                    litellm.use_chat_completions_url_for_anthropic_messages = (
+                        value is True
+                    )
+                    verbose_proxy_logger.debug(
+                        f"{blue_color_code} setting litellm.use_chat_completions_url_for_anthropic_messages={value is True}{reset_color_code}"
                     )
                 else:
                     verbose_proxy_logger.debug(

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -316,3 +316,46 @@ async def test_json_logs_calls_turn_on_json():
         # Cleanup
         os.unlink(temp_file_path)
         litellm.json_logs = False
+
+
+@pytest.mark.asyncio
+async def test_use_chat_completions_url_for_anthropic_messages_loaded_from_litellm_settings():
+    """
+    use_chat_completions_url_for_anthropic_messages: true in litellm_settings must be
+    applied to litellm.use_chat_completions_url_for_anthropic_messages during proxy startup.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/28756.
+    """
+    import litellm
+    import tempfile
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4o", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "use_chat_completions_url_for_anthropic_messages": True
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    original = litellm.use_chat_completions_url_for_anthropic_messages
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=None,
+            config_file_path=temp_file_path,
+        )
+        assert litellm.use_chat_completions_url_for_anthropic_messages is True
+    finally:
+        os.unlink(temp_file_path)
+        litellm.use_chat_completions_url_for_anthropic_messages = original

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -673,3 +673,42 @@ async def test_async_wrapper_sets_presanitized_and_sanitizes_once():
     assert spy.call_count == 1
     assert captured["presanitized"] is True
     assert [b["type"] for b in captured["messages"][0]["content"]] == ["tool_use"]
+
+
+def test__should_not_route_to_responses_api_when_use_chat_completions_url_set():
+    """
+    When litellm.use_chat_completions_url_for_anthropic_messages is True, openai-provider
+    requests must go through chat/completions, not the Responses API.
+    """
+    import litellm
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        _should_route_to_responses_api,
+    )
+
+    original = litellm.use_chat_completions_url_for_anthropic_messages
+    try:
+        litellm.use_chat_completions_url_for_anthropic_messages = True
+        assert _should_route_to_responses_api("openai") is False
+    finally:
+        litellm.use_chat_completions_url_for_anthropic_messages = original
+
+
+def test__should_route_to_responses_api_default_behavior():
+    """
+    Without the opt-out flag, openai provider must use the Responses API path and
+    non-openai providers must not.
+    """
+    import litellm
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        _should_route_to_responses_api,
+    )
+
+    original = litellm.use_chat_completions_url_for_anthropic_messages
+    try:
+        litellm.use_chat_completions_url_for_anthropic_messages = False
+        assert _should_route_to_responses_api("openai") is True
+        assert _should_route_to_responses_api("anthropic") is False
+        assert _should_route_to_responses_api("azure") is False
+        assert _should_route_to_responses_api(None) is False
+    finally:
+        litellm.use_chat_completions_url_for_anthropic_messages = original


### PR DESCRIPTION
## Relevant issues

Fixes #28756

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
All 3 new tests pass locally -
<img width="2555" height="381" alt="1" src="https://github.com/user-attachments/assets/45a0a223-6956-4e1d-98cd-2264f957d785" />


## Type

🐛 Bug Fix
✅ Test

## Changes
_should_route_to_responses_api() in litellm/llms/anthropic/experimental_pass_through/messages/handler.py checks litellm.use_chat_completions_url_for_anthropic_messages to decide whether an openai/-prefixed backend routes through the Responses API or chat/completions. The attribute was only initialized from the env var LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES. Setting use_chat_completions_url_for_anthropic_messages: true under litellm_settings in the proxy config YAML had no effect because the litellm_settings loop in proxy_server.py had no explicit branch for this key. The raw YAML value flowed through the generic setattr catch-all without bool() coercion and without test coverage.

Added an explicit elif key == "use_chat_completions_url_for_anthropic_messages": branch that applies bool(value) to the module attribute. Two unit tests cover _should_route_to_responses_api (opt-out flag active, and default routing). One proxy config integration test writes a temp YAML with this key in litellm_settings, calls load_config, and asserts the module attribute is set. The integration test follows the same pattern as test_json_logs_calls_turn_on_json.