### PR TITLE
fix(hiddenlayer): correct 'reponse' typo in debug log messages

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py
@@ -258,7 +258,7 @@ class HiddenlayerGuardrail(CustomGuardrail):
             response.raise_for_status()
             result = response.json()
 
-            verbose_proxy_logger.debug(f"Hiddenlayer reponse: {result}")
+            verbose_proxy_logger.debug(f"Hiddenlayer response: {result}")
 
             return result
         except HTTPStatusError as e:
@@ -282,7 +282,7 @@ class HiddenlayerGuardrail(CustomGuardrail):
             response.raise_for_status()
             result = response.json()
 
-            verbose_proxy_logger.debug(f"Hiddenlayer reponse: {result}")
+            verbose_proxy_logger.debug(f"Hiddenlayer response: {result}")
             return result
 
     @staticmethod
@@ -483,7 +483,7 @@ class HiddenlayerGuardrailV2(CustomGuardrail):
             )
             response.raise_for_status()
 
-            verbose_proxy_logger.debug(f"Hiddenlayer reponse: {response}")
+            verbose_proxy_logger.debug(f"Hiddenlayer response: {response}")
 
             return response
         except HTTPStatusError as e:
@@ -506,7 +506,7 @@ class HiddenlayerGuardrailV2(CustomGuardrail):
 
             response.raise_for_status()
 
-            verbose_proxy_logger.debug(f"Hiddenlayer reponse: {response}")
+            verbose_proxy_logger.debug(f"Hiddenlayer response: {response}")
             return response
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes a small typo in the HiddenLayer guardrail integration: `"Hiddenlayer reponse"` -> `"Hiddenlayer response"` in four `verbose_proxy_logger.debug()` calls in `litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py`.

Only debug-log strings are touched; behavior is unchanged.

## Changes

- 4 occurrences of `reponse` -> `response` in debug log f-strings (lines 261, 285, 486, 509).

## Test plan

- [x] No behavior change; affects only log output text.
- [x] `grep -n "reponse" litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py` returns no matches.