### PR TITLE
fix(base_llm): make is_thinking_enabled tolerant of non-dict thinking values (#28576)

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -14,7 +14,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 import httpx
@@ -108,8 +107,14 @@ class BaseConfig(ABC):
         return type_to_response_format_param(response_format=response_format)
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
+        if not non_default_params:
+            return False
+        thinking = non_default_params.get("thinking")
+        thinking_type_enabled = (
+            isinstance(thinking, dict) and thinking.get("type") == "enabled"
+        )
         return (
-            non_default_params.get("thinking", {}).get("type") == "enabled"
+            thinking_type_enabled
             or non_default_params.get("reasoning_effort") is not None
         )
 
@@ -137,8 +142,11 @@ class BaseConfig(ABC):
             "max_tokens" not in non_default_params
             and "max_completion_tokens" not in non_default_params
         ):
-            thinking_token_budget = cast(dict, optional_params["thinking"]).get(
-                "budget_tokens", None
+            thinking = optional_params.get("thinking")
+            thinking_token_budget = (
+                thinking.get("budget_tokens", None)
+                if isinstance(thinking, dict)
+                else None
             )
             if thinking_token_budget is not None:
                 optional_params["max_tokens"] = (

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2513,14 +2513,14 @@ def test_reasoning_effort_accepts_dict_shape_for_adaptive_model(reasoning_effort
     )
 
     # thinking must be set (adaptive for 4.6+)
-    assert "thinking" in result, (
-        f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
-    )
+    assert (
+        "thinking" in result
+    ), f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
     assert result["thinking"]["type"] == "adaptive"
     # output_config must carry the mapped effort
-    assert "output_config" in result, (
-        f"output_config missing for reasoning_effort={reasoning_effort_value!r}"
-    )
+    assert (
+        "output_config" in result
+    ), f"output_config missing for reasoning_effort={reasoning_effort_value!r}"
     assert result["output_config"]["effort"] == "low"
 
 
@@ -2532,7 +2532,9 @@ def test_reasoning_effort_accepts_dict_shape_for_adaptive_model(reasoning_effort
         {"effort": "low", "summary": "concise"},
     ],
 )
-def test_reasoning_effort_accepts_dict_shape_for_non_adaptive_model(reasoning_effort_value):
+def test_reasoning_effort_accepts_dict_shape_for_non_adaptive_model(
+    reasoning_effort_value,
+):
     """
     Non-adaptive (pre-4.6) branch: dict-shape reasoning_effort must still map
     to ``thinking.type='enabled'`` + ``budget_tokens``. ``output_config`` must
@@ -2547,9 +2549,9 @@ def test_reasoning_effort_accepts_dict_shape_for_non_adaptive_model(reasoning_ef
         drop_params=False,
     )
 
-    assert "thinking" in result, (
-        f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
-    )
+    assert (
+        "thinking" in result
+    ), f"thinking missing for reasoning_effort={reasoning_effort_value!r}"
     assert result["thinking"]["type"] == "enabled"
     assert "budget_tokens" in result["thinking"]
     assert result["thinking"]["budget_tokens"] > 0
@@ -2582,12 +2584,12 @@ def test_reasoning_effort_unparseable_dict_is_dropped(bad_value):
         model="claude-sonnet-4-6-20260219",
         drop_params=False,
     )
-    assert "thinking" not in result, (
-        f"thinking should not be set for bad value {bad_value!r}"
-    )
-    assert "output_config" not in result, (
-        f"output_config should not be set for bad value {bad_value!r}"
-    )
+    assert (
+        "thinking" not in result
+    ), f"thinking should not be set for bad value {bad_value!r}"
+    assert (
+        "output_config" not in result
+    ), f"output_config should not be set for bad value {bad_value!r}"
 
 
 @pytest.mark.parametrize(
@@ -4864,3 +4866,69 @@ def test_sanitize_tool_names_in_request_no_tools_is_noop():
     forward, reverse = AnthropicConfig._sanitize_tool_names_in_request({"tools": []})
     assert forward == {}
     assert reverse == {}
+
+
+# ============ is_thinking_enabled None Safety (issue #28576) ============
+
+
+@pytest.mark.parametrize(
+    "thinking_value",
+    [
+        None,
+        "enabled",  # non-dict primitive value
+        123,
+        ["enabled"],
+    ],
+)
+def test_is_thinking_enabled_handles_non_dict_thinking(thinking_value):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/28576
+
+    `is_thinking_enabled` must not crash when ``non_default_params['thinking']``
+    exists with a non-dict value (most importantly ``None``). Previously the
+    chained ``.get("thinking", {}).get("type")`` call raised
+    ``AttributeError: 'NoneType' object has no attribute 'get'`` because
+    ``dict.get(key, default)`` only returns the default when the key is missing,
+    not when the value is ``None``.
+    """
+    config = AnthropicConfig()
+    assert config.is_thinking_enabled({"thinking": thinking_value}) is False
+
+
+def test_is_thinking_enabled_with_enabled_dict_returns_true():
+    config = AnthropicConfig()
+    assert config.is_thinking_enabled({"thinking": {"type": "enabled"}}) is True
+
+
+def test_is_thinking_enabled_with_reasoning_effort_returns_true_even_if_thinking_none():
+    """reasoning_effort still triggers thinking even when 'thinking' key is None."""
+    config = AnthropicConfig()
+    assert (
+        config.is_thinking_enabled({"thinking": None, "reasoning_effort": "high"})
+        is True
+    )
+
+
+def test_is_thinking_enabled_empty_or_none_params():
+    config = AnthropicConfig()
+    assert config.is_thinking_enabled({}) is False
+    assert config.is_thinking_enabled(None) is False
+
+
+def test_update_optional_params_with_thinking_tokens_handles_none_thinking():
+    """
+    Regression test: update_optional_params_with_thinking_tokens must not crash
+    when optional_params['thinking'] is None. This is the path that originally
+    surfaced the AttributeError in issue #28576 via
+    AnthropicConfig.map_openai_params -> update_optional_params_with_thinking_tokens.
+    """
+    config = AnthropicConfig()
+    optional_params = {"thinking": None}
+    non_default_params = {}
+    # Should not raise
+    config.update_optional_params_with_thinking_tokens(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+    )
+    # No max_tokens should be injected because thinking is not actually enabled
+    assert "max_tokens" not in optional_params


### PR DESCRIPTION
## Title

`fix(base_llm): make is_thinking_enabled tolerant of non-dict thinking values (#28576)`

## Relevant issues

Fixes #28576

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

`BaseConfig.is_thinking_enabled` previously did:

```python
non_default_params.get("thinking", {}).get("type") == "enabled"
```

`dict.get(key, default)` only returns the default when the key is **missing**. If `"thinking"` is present with an explicit `None` value (which the LiteLLM internal pipeline sometimes sets when routing OpenAI-compatible requests to Anthropic-backed models), `.get("thinking", {})` returns `None` and the chained `.get("type")` raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This crashed any OpenAI-compatible request routed to an Anthropic-backed model via the proxy. The error surfaced to clients as a generic 500 / `litellm.APIConnectionError` with no actionable hint.

Traceback from the original report:

```
File ".../litellm/llms/base_llm/chat/transformation.py", line 114, in is_thinking_enabled
    non_default_params.get("thinking", {}).get("type") == "enabled"
AttributeError: 'NoneType' object has no attribute 'get'
```

### Root cause

Two related call sites in `litellm/llms/base_llm/chat/transformation.py` assumed `optional_params["thinking"]` is always either missing or a `dict`, but that contract is not enforced anywhere upstream:

1. `is_thinking_enabled` — chained `.get` on a possibly-`None` value.
2. `update_optional_params_with_thinking_tokens` — blindly `cast(dict, optional_params["thinking"])`, which would still crash even if `is_thinking_enabled` was made True via `reasoning_effort` while `thinking` was still `None`.

### Fix

- Guard `is_thinking_enabled` so any non-`dict` `thinking` value (`None`, `str`, `int`, `list`, …) is treated as "not enabled". `reasoning_effort` still independently enables thinking.
- Make `update_optional_params_with_thinking_tokens` look up `budget_tokens` only when `optional_params["thinking"]` is actually a dict.

### Tests

Added 8 regression tests in `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py`:

- Parametrized: `thinking=None` (the original repro), `"enabled"` string, `int`, `list` — all return `False`
- `thinking={"type":"enabled"}` returns `True`
- `thinking=None` + `reasoning_effort="high"` still returns `True`
- `is_thinking_enabled({})` and `is_thinking_enabled(None)` return `False`
- `update_optional_params_with_thinking_tokens` with `optional_params={"thinking": None}` does not crash and does not inject `max_tokens`

### Verification

```
$ uv run pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
237 passed in 2.99s   # 8 new + 229 existing
$ uv run pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -k thinking
10 passed             # Bedrock also calls is_thinking_enabled
$ uv run black .
```
