### PR TITLE
fix(anthropic): align adapter response id with call id

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -309,6 +309,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         **kwargs,
     ) -> Union[AnthropicMessagesResponse, AsyncIterator]:
         """Handle non-Anthropic models asynchronously using the adapter"""
+        litellm_call_id = cast(Optional[str], kwargs.get("litellm_call_id"))
         (
             completion_kwargs,
             tool_name_mapping,
@@ -338,6 +339,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                     completion_response,
                     model=model,
                     tool_name_mapping=tool_name_mapping,
+                    litellm_call_id=litellm_call_id,
                 )
             )
             if transformed_stream is not None:
@@ -347,6 +349,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             anthropic_response = ANTHROPIC_ADAPTER.translate_completion_output_params(
                 cast(ModelResponse, completion_response),
                 tool_name_mapping=tool_name_mapping,
+                litellm_call_id=litellm_call_id,
             )
             if anthropic_response is not None:
                 return anthropic_response
@@ -395,6 +398,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 **kwargs,
             )
 
+        litellm_call_id = cast(Optional[str], kwargs.get("litellm_call_id"))
         (
             completion_kwargs,
             tool_name_mapping,
@@ -424,6 +428,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                     completion_response,
                     model=model,
                     tool_name_mapping=tool_name_mapping,
+                    litellm_call_id=litellm_call_id,
                 )
             )
             if transformed_stream is not None:
@@ -433,6 +438,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             anthropic_response = ANTHROPIC_ADAPTER.translate_completion_output_params(
                 cast(ModelResponse, completion_response),
                 tool_name_mapping=tool_name_mapping,
+                litellm_call_id=litellm_call_id,
             )
             if anthropic_response is not None:
                 return anthropic_response

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -48,11 +48,16 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         completion_stream: Any,
         model: str,
         tool_name_mapping: Optional[Dict[str, str]] = None,
+        litellm_call_id: Optional[str] = None,
     ):
         super().__init__(completion_stream)
         self.model = model
+        self.litellm_call_id = litellm_call_id
         # Mapping of truncated tool names to original names (for OpenAI's 64-char limit)
         self.tool_name_mapping = tool_name_mapping or {}
+
+    def _get_message_id(self) -> str:
+        return self.litellm_call_id or "msg_{}".format(uuid.uuid4())
 
     def _create_initial_usage_delta(self) -> UsageDelta:
         """
@@ -90,7 +95,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     {
                         "type": "message_start",
                         "message": {
-                            "id": "msg_{}".format(uuid.uuid4()),
+                            "id": self._get_message_id(),
                             "type": "message",
                             "role": "assistant",
                             "content": [],
@@ -230,7 +235,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     {
                         "type": "message_start",
                         "message": {
-                            "id": "msg_{}".format(uuid.uuid4()),
+                            "id": self._get_message_id(),
                             "type": "message",
                             "role": "assistant",
                             "content": [],

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -195,6 +195,7 @@ class AnthropicAdapter:
         self,
         response: ModelResponse,
         tool_name_mapping: Optional[Dict[str, str]] = None,
+        litellm_call_id: Optional[str] = None,
     ) -> Optional[AnthropicMessagesResponse]:
         """
         Translate OpenAI response to Anthropic format.
@@ -204,10 +205,13 @@ class AnthropicAdapter:
             tool_name_mapping: Optional mapping of truncated tool names to original names.
                               Used to restore original names for tools that exceeded
                               OpenAI's 64-char limit.
+            litellm_call_id: Optional LiteLLM call ID to use as the Anthropic response ID
+                             for spend log correlation.
         """
         return LiteLLMAnthropicMessagesAdapter().translate_openai_response_to_anthropic(
             response=response,
             tool_name_mapping=tool_name_mapping,
+            litellm_call_id=litellm_call_id,
         )
 
     def translate_completion_output_params_streaming(
@@ -215,6 +219,7 @@ class AnthropicAdapter:
         completion_stream: Any,
         model: str,
         tool_name_mapping: Optional[Dict[str, str]] = None,
+        litellm_call_id: Optional[str] = None,
     ) -> Union[AsyncIterator[bytes], None]:
         """
         Translate OpenAI streaming response to Anthropic format.
@@ -223,11 +228,14 @@ class AnthropicAdapter:
             completion_stream: The OpenAI streaming response
             model: The model name
             tool_name_mapping: Optional mapping of truncated tool names to original names.
+            litellm_call_id: Optional LiteLLM call ID to use as the Anthropic message ID
+                             for spend log correlation.
         """
         anthropic_wrapper = AnthropicStreamWrapper(
             completion_stream=completion_stream,
             model=model,
             tool_name_mapping=tool_name_mapping,
+            litellm_call_id=litellm_call_id,
         )
         # Return the SSE-wrapped version for proper event formatting
         return anthropic_wrapper.async_anthropic_sse_wrapper()
@@ -1342,6 +1350,7 @@ class LiteLLMAnthropicMessagesAdapter:
         self,
         response: ModelResponse,
         tool_name_mapping: Optional[Dict[str, str]] = None,
+        litellm_call_id: Optional[str] = None,
     ) -> AnthropicMessagesResponse:
         """
         Translate OpenAI response to Anthropic format.
@@ -1351,6 +1360,8 @@ class LiteLLMAnthropicMessagesAdapter:
             tool_name_mapping: Optional mapping of truncated tool names to original names.
                               Used to restore original names for tools that exceeded
                               OpenAI's 64-char limit.
+            litellm_call_id: Optional LiteLLM call ID to use as the Anthropic response ID
+                             for spend log correlation.
         """
         ## translate content block
         anthropic_content = self._translate_openai_content_to_anthropic(
@@ -1386,7 +1397,7 @@ class LiteLLMAnthropicMessagesAdapter:
             anthropic_usage["cache_read_input_tokens"] = cached_tokens
 
         translated_obj = AnthropicMessagesResponse(
-            id=response.id,
+            id=litellm_call_id or response.id,
             type="message",
             role="assistant",
             model=response.model or "unknown-model",

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -10,6 +10,9 @@ sys.path.insert(0, os.path.abspath("../../../../.."))
 from litellm.litellm_core_utils.prompt_templates.factory import (
     THOUGHT_SIGNATURE_SEPARATOR,
 )
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     OPENAI_MAX_TOOL_NAME_LENGTH,
     LiteLLMAnthropicMessagesAdapter,
@@ -510,6 +513,176 @@ def test_translate_openai_response_to_anthropic_text_and_tool_calls():
     assert anthropic_content[1]["id"] == "call_tool_combo"
     assert anthropic_content[1]["input"] == {"location": "Paris"}
     assert anthropic_response.get("stop_reason") == "tool_use"
+
+
+def test_translate_openai_response_to_anthropic_uses_litellm_call_id():
+    """Anthropic adapter responses should be queryable by spend log request_id."""
+    openai_response = ModelResponse(
+        id="chatcmpl_backend_id",
+        model="gpt-4o-mini",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                message=Message(role="assistant", content="hello"),
+            )
+        ],
+        usage=Usage(prompt_tokens=5, completion_tokens=2),
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_response = adapter.translate_openai_response_to_anthropic(
+        response=openai_response,
+        litellm_call_id="litellm-call-123",
+    )
+
+    assert anthropic_response.get("id") == "litellm-call-123"
+
+
+def test_translate_openai_response_to_anthropic_preserves_backend_id_without_call_id():
+    """Direct adapter callers without a LiteLLM call ID keep the previous fallback."""
+    openai_response = ModelResponse(
+        id="chatcmpl_backend_id",
+        model="gpt-4o-mini",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                message=Message(role="assistant", content="hello"),
+            )
+        ],
+        usage=Usage(prompt_tokens=5, completion_tokens=2),
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_response = adapter.translate_openai_response_to_anthropic(
+        response=openai_response
+    )
+
+    assert anthropic_response.get("id") == "chatcmpl_backend_id"
+
+
+def test_anthropic_messages_handler_uses_litellm_call_id(monkeypatch):
+    """The public non-Anthropic adapter handler should return the spend log request ID."""
+    import litellm
+
+    backend_response = ModelResponse(
+        id="chatcmpl_backend_id",
+        model="gpt-4o-mini",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                message=Message(role="assistant", content="hello"),
+            )
+        ],
+        usage=Usage(prompt_tokens=5, completion_tokens=2),
+    )
+
+    def mock_completion(**kwargs):
+        assert kwargs["litellm_call_id"] == "litellm-handler-123"
+        return backend_response
+
+    monkeypatch.setattr(litellm, "completion", mock_completion)
+
+    anthropic_response = (
+        LiteLLMMessagesToCompletionTransformationHandler.anthropic_messages_handler(
+            model="gpt-4o-mini",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hello"}],
+            litellm_call_id="litellm-handler-123",
+        )
+    )
+
+    assert anthropic_response.get("id") == "litellm-handler-123"
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_uses_litellm_call_id(monkeypatch):
+    """Async Anthropic adapter responses should also match spend log request_id."""
+    import litellm
+
+    backend_response = ModelResponse(
+        id="chatcmpl_async_backend_id",
+        model="gpt-4o-mini",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                message=Message(role="assistant", content="hello"),
+            )
+        ],
+        usage=Usage(prompt_tokens=5, completion_tokens=2),
+    )
+
+    async def mock_acompletion(**kwargs):
+        assert kwargs["litellm_call_id"] == "litellm-async-handler-123"
+        return backend_response
+
+    monkeypatch.setattr(litellm, "acompletion", mock_acompletion)
+
+    anthropic_response = await LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(
+        model="gpt-4o-mini",
+        max_tokens=10,
+        messages=[{"role": "user", "content": "hello"}],
+        litellm_call_id="litellm-async-handler-123",
+    )
+
+    assert anthropic_response.get("id") == "litellm-async-handler-123"
+
+
+def test_anthropic_stream_wrapper_uses_litellm_call_id_for_message_start():
+    from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+        AnthropicStreamWrapper,
+    )
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4o-mini",
+        litellm_call_id="litellm-stream-123",
+    )
+
+    event = next(wrapper)
+
+    assert event["type"] == "message_start"
+    assert event["message"]["id"] == "litellm-stream-123"
+
+
+def test_anthropic_stream_wrapper_generates_message_id_without_call_id():
+    from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+        AnthropicStreamWrapper,
+    )
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4o-mini",
+    )
+
+    event = next(wrapper)
+
+    assert event["type"] == "message_start"
+    assert event["message"]["id"].startswith("msg_")
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_stream_wrapper_uses_litellm_call_id_for_message_start():
+    from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+        AnthropicStreamWrapper,
+    )
+
+    class EmptyAsyncIterator:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=EmptyAsyncIterator(),
+        model="gpt-4o-mini",
+        litellm_call_id="litellm-async-stream-123",
+    )
+
+    event = await wrapper.__anext__()
+
+    assert event["type"] == "message_start"
+    assert event["message"]["id"] == "litellm-async-stream-123"
 
 
 def test_translate_streaming_openai_chunk_to_anthropic_with_partial_json():


### PR DESCRIPTION
## Relevant issues

Fixes #28568

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This is a backend adapter bug fix. The issue was that Anthropic `/v1/messages` responses for non-Anthropic backends used IDs that did not match LiteLLM spend log `request_id` values.

Validation run locally:

```bash
uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py -q
# 76 passed

uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters -q
# 89 passed

uv run black --check litellm/llms/anthropic/experimental_pass_through/adapters/handler.py litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
# 4 files would be left unchanged

uv run ruff check litellm/llms/anthropic/experimental_pass_through/adapters/handler.py litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
# All checks passed

uv run mypy litellm/llms/anthropic/experimental_pass_through/adapters/handler.py litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py --ignore-missing-imports
# Success: no issues found in 3 source files

git diff --check
# no output
```

Repository-wide validation notes:

- `make lint` currently fails before reaching this PR's code because repo-wide Black reports 13 unrelated enterprise files would be reformatted under `litellm/proxy/enterprise/litellm_enterprise/...`.
- `make test-unit` was attempted and reached `7041 passed, 77 skipped` before stopping on two failures outside this patch:
  - `tests/test_litellm/llms/custom_httpx/test_http_handler.py::test_get_httpx_client_applies_float_timeout_without_mocking_handler`
  - `tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py::TestDeprecatedKeyLookupDbE2E::test_deprecated_key_grace_period_cache_hit_path`

## Type

🐛 Bug Fix
✅ Test

## Changes

- Propagate `litellm_call_id` through the Anthropic `/v1/messages` non-Anthropic adapter path.
- Use `litellm_call_id` as the Anthropic response ID for non-streaming adapter responses.
- Use `litellm_call_id` as the streaming `message_start.message.id`.
- Preserve existing fallback behavior when no `litellm_call_id` is available.
- Add focused tests for sync, async, streaming, and fallback ID behavior.