### PR TITLE
feat(bedrock-batch): propagate embedding endpoint through batch responses

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -108,10 +108,9 @@ class BaseConfig(ABC):
         return type_to_response_format_param(response_format=response_format)
 
     def is_thinking_enabled(self, non_default_params: dict) -> bool:
-        return (
-            (non_default_params.get("thinking") or {}).get("type") == "enabled"
-            or non_default_params.get("reasoning_effort") is not None
-        )
+        return (non_default_params.get("thinking") or {}).get(
+            "type"
+        ) == "enabled" or non_default_params.get("reasoning_effort") is not None
 
     def is_max_tokens_in_request(self, non_default_params: dict) -> bool:
         """

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -245,10 +245,17 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
 
         # Prefer the endpoint the caller explicitly set; fall back to the
         # model-id heuristic so embedding batches don't get mislabelled as
-        # chat completions when `original_batch_request` is missing.
-        resolved_endpoint = original_request.get(
-            "endpoint"
-        ) or self._infer_openai_endpoint_from_model_id(model)
+        # chat completions when `original_batch_request` is missing. We
+        # check `is not None` rather than truthiness so a caller passing
+        # an empty string keeps that explicit signal instead of being
+        # silently overridden by the heuristic - the heuristic only runs
+        # when the field is genuinely absent.
+        explicit_endpoint = original_request.get("endpoint")
+        resolved_endpoint = (
+            explicit_endpoint
+            if explicit_endpoint is not None
+            else self._infer_openai_endpoint_from_model_id(model)
+        )
 
         # Create LiteLLM batch object
         return LiteLLMBatch(

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -286,8 +286,7 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
     @staticmethod
     def _infer_openai_endpoint_from_model_id(model_id: Optional[str]) -> str:
         """
-        Best-effort mapping of a Bedrock model id to the OpenAI endpoint
-        the batch job represents.
+        Map a Bedrock model id to the OpenAI endpoint the batch job represents.
 
         Used when we cannot read the original `endpoint` field off
         `litellm_params` (the retrieve path is the main case: by the time
@@ -295,15 +294,39 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
         request body, and the AWS GetModelInvocationJob response only
         exposes the model id).
 
-        Returns `/v1/embeddings` iff the lowercased model id contains
-        "embed" (covers `amazon.titan-embed-text-v2:0`,
-        `amazon.titan-embed-image-v1`, `amazon.nova-2-multimodal-embeddings-v1:0`,
-        `cohere.embed-english-v3`, ARN forms thereof). Otherwise defaults
-        to `/v1/chat/completions` so the existing chat batches continue to
-        report the same endpoint they always have.
+        Resolution order:
+          1. `model_prices_and_context_window.json` via `litellm.get_model_info`.
+             This is the project-wide source of truth: every current Bedrock
+             embedding model is registered with `"mode": "embedding"`, so
+             future additions get classified automatically once their entry
+             lands - no code change here is required.
+          2. Substring fallback (`"embed" in model_id.lower()`) for ids the
+             registry can't resolve. This catches cross-region inference
+             profile prefixes (e.g. `us.amazon.titan-embed-text-v2:0`) and
+             Bedrock ARN forms, neither of which `get_model_info` handles
+             today.
+          3. Default to `/v1/chat/completions` for everything else, so the
+             existing chat batches keep the endpoint they always reported.
         """
         if not model_id:
             return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
+
+        try:
+            from litellm import get_model_info
+
+            info = get_model_info(model_id)
+            mode = (info or {}).get("mode")
+            if mode == "embedding":
+                return BedrockBatchesConfig._OPENAI_EMBEDDINGS_ENDPOINT
+            if mode:
+                # Registry knows the mode and it's not embedding - trust it.
+                return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
+        except Exception:
+            # `get_model_info` raises for ids it can't normalize (ARN forms,
+            # cross-region profile prefixes, unreleased models). Fall through
+            # to the substring fallback rather than misclassifying.
+            pass
+
         if "embed" in model_id.lower():
             return BedrockBatchesConfig._OPENAI_EMBEDDINGS_ENDPOINT
         return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -243,11 +243,18 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
         # Get original request data from litellm_params if available
         original_request = litellm_params.get("original_batch_request", {})
 
+        # Prefer the endpoint the caller explicitly set; fall back to the
+        # model-id heuristic so embedding batches don't get mislabelled as
+        # chat completions when `original_batch_request` is missing.
+        resolved_endpoint = original_request.get(
+            "endpoint"
+        ) or self._infer_openai_endpoint_from_model_id(model)
+
         # Create LiteLLM batch object
         return LiteLLMBatch(
             id=job_arn,  # Use ARN as the batch ID
             object="batch",
-            endpoint=original_request.get("endpoint", "/v1/chat/completions"),
+            endpoint=resolved_endpoint,
             errors=None,
             input_file_id=original_request.get("input_file_id", ""),
             completion_window=original_request.get("completion_window", "24h"),
@@ -268,6 +275,38 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
                 original_request.get("metadata", {})
             ),
         )
+
+    # OpenAI endpoints we can route a Bedrock batch job to. Kept as constants
+    # so the inference helper below can be extended without scattering string
+    # literals; today AWS supports CreateModelInvocationJob for chat and
+    # embedding workloads, both surfaced as OpenAI-shaped endpoints.
+    _OPENAI_CHAT_ENDPOINT = "/v1/chat/completions"
+    _OPENAI_EMBEDDINGS_ENDPOINT = "/v1/embeddings"
+
+    @staticmethod
+    def _infer_openai_endpoint_from_model_id(model_id: Optional[str]) -> str:
+        """
+        Best-effort mapping of a Bedrock model id to the OpenAI endpoint
+        the batch job represents.
+
+        Used when we cannot read the original `endpoint` field off
+        `litellm_params` (the retrieve path is the main case: by the time
+        a caller polls `GET /batches/{id}` we no longer have the create
+        request body, and the AWS GetModelInvocationJob response only
+        exposes the model id).
+
+        Returns `/v1/embeddings` iff the lowercased model id contains
+        "embed" (covers `amazon.titan-embed-text-v2:0`,
+        `amazon.titan-embed-image-v1`, `amazon.nova-2-multimodal-embeddings-v1:0`,
+        `cohere.embed-english-v3`, ARN forms thereof). Otherwise defaults
+        to `/v1/chat/completions` so the existing chat batches continue to
+        report the same endpoint they always have.
+        """
+        if not model_id:
+            return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
+        if "embed" in model_id.lower():
+            return BedrockBatchesConfig._OPENAI_EMBEDDINGS_ENDPOINT
+        return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
 
     @staticmethod
     def _get_openai_compatible_batch_metadata(metadata: Any) -> Dict[str, str]:
@@ -543,10 +582,17 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
             response_data, raw_response
         )
 
+        # GetModelInvocationJob doesn't echo the OpenAI endpoint, so infer
+        # from the Bedrock modelId surfaced on the response. The `model`
+        # parameter is preferred when the caller passed it through.
+        resolved_endpoint = self._infer_openai_endpoint_from_model_id(
+            model or response_data.get("modelId")
+        )
+
         return LiteLLMBatch(
             id=job_arn,
             object="batch",
-            endpoint="/v1/chat/completions",
+            endpoint=resolved_endpoint,
             errors=errors,
             input_file_id=input_file_id,
             completion_window="24h",

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -284,6 +284,29 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
     _OPENAI_EMBEDDINGS_ENDPOINT = "/v1/embeddings"
 
     @staticmethod
+    def _lookup_registry_mode(model_id: str) -> Optional[str]:
+        """
+        Read `mode` for `model_id` from `model_prices_and_context_window.json`.
+
+        Returns the mode string (e.g. `"embedding"`, `"chat"`) when the
+        registry knows the id, or `None` when `get_model_info` raises
+        (ARN forms, cross-region inference profile prefixes, unreleased
+        models). Isolating this means the dispatch logic in
+        `_infer_openai_endpoint_from_model_id` stays linear and the
+        registry-vs-fallback split is unit-testable on its own.
+        """
+        try:
+            from litellm import get_model_info
+
+            info = get_model_info(model_id)
+        except Exception:
+            return None
+        if not isinstance(info, dict):
+            return None
+        mode = info.get("mode")
+        return mode if isinstance(mode, str) and mode else None
+
+    @staticmethod
     def _infer_openai_endpoint_from_model_id(model_id: Optional[str]) -> str:
         """
         Map a Bedrock model id to the OpenAI endpoint the batch job represents.
@@ -295,7 +318,7 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
         exposes the model id).
 
         Resolution order:
-          1. `model_prices_and_context_window.json` via `litellm.get_model_info`.
+          1. `model_prices_and_context_window.json` via `_lookup_registry_mode`.
              This is the project-wide source of truth: every current Bedrock
              embedding model is registered with `"mode": "embedding"`, so
              future additions get classified automatically once their entry
@@ -311,21 +334,12 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
         if not model_id:
             return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
 
-        try:
-            from litellm import get_model_info
-
-            info = get_model_info(model_id)
-            mode = (info or {}).get("mode")
-            if mode == "embedding":
-                return BedrockBatchesConfig._OPENAI_EMBEDDINGS_ENDPOINT
-            if mode:
-                # Registry knows the mode and it's not embedding - trust it.
-                return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
-        except Exception:
-            # `get_model_info` raises for ids it can't normalize (ARN forms,
-            # cross-region profile prefixes, unreleased models). Fall through
-            # to the substring fallback rather than misclassifying.
-            pass
+        registry_mode = BedrockBatchesConfig._lookup_registry_mode(model_id)
+        if registry_mode == "embedding":
+            return BedrockBatchesConfig._OPENAI_EMBEDDINGS_ENDPOINT
+        if registry_mode is not None:
+            # Registry knows the mode and it's not embedding - trust it.
+            return BedrockBatchesConfig._OPENAI_CHAT_ENDPOINT
 
         if "embed" in model_id.lower():
             return BedrockBatchesConfig._OPENAI_EMBEDDINGS_ENDPOINT

--- a/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
@@ -340,3 +340,43 @@ class TestRegistryDrivenClassification:
             )
             == "/v1/chat/completions"
         )
+
+
+class TestLookupRegistryMode:
+    """Direct tests for the extracted `_lookup_registry_mode` helper.
+
+    Pinning this separately lets us assert the registry-vs-fallback split
+    in isolation, instead of inferring it from end-to-end endpoint output.
+    """
+
+    def test_returns_mode_when_registry_resolves(self, mocker):
+        mocker.patch("litellm.get_model_info", return_value={"mode": "embedding"})
+        assert (
+            BedrockBatchesConfig._lookup_registry_mode("amazon.titan-embed-text-v2:0")
+            == "embedding"
+        )
+
+    def test_returns_none_when_registry_raises(self, mocker):
+        mocker.patch("litellm.get_model_info", side_effect=Exception("not mapped"))
+        assert BedrockBatchesConfig._lookup_registry_mode("anything") is None
+
+    def test_returns_none_when_registry_returns_non_dict(self, mocker):
+        # Defensive: get_model_info isn't supposed to return non-dict but if
+        # it ever does we treat it the same as 'not mapped' rather than
+        # crashing the batch transformer.
+        mocker.patch("litellm.get_model_info", return_value="not a dict")
+        assert BedrockBatchesConfig._lookup_registry_mode("anything") is None
+
+    def test_returns_none_when_mode_missing(self, mocker):
+        mocker.patch("litellm.get_model_info", return_value={})
+        assert BedrockBatchesConfig._lookup_registry_mode("anything") is None
+
+    def test_returns_none_when_mode_is_empty_string(self, mocker):
+        mocker.patch("litellm.get_model_info", return_value={"mode": ""})
+        assert BedrockBatchesConfig._lookup_registry_mode("anything") is None
+
+    def test_returns_none_when_mode_is_non_string(self, mocker):
+        # If a malformed registry entry has a non-string mode we don't trust
+        # it and fall through to the substring heuristic.
+        mocker.patch("litellm.get_model_info", return_value={"mode": 42})
+        assert BedrockBatchesConfig._lookup_registry_mode("anything") is None

--- a/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
@@ -190,6 +190,29 @@ class TestTransformCreateBatchResponseEndpoint:
         )
         assert batch.endpoint == "/v1/chat/completions"
 
+    def test_create_response_preserves_explicit_empty_endpoint(self):
+        """Explicit empty-string endpoint is preserved, not replaced by heuristic.
+
+        Pins the `is not None` semantics: only a missing `endpoint` key
+        falls through to the model-id heuristic. An explicitly-provided
+        empty string keeps that explicit signal so an upstream caller
+        that means 'no endpoint' isn't silently overridden.
+        """
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Submitted",
+            }
+        )
+        batch = config.transform_create_batch_response(
+            model="amazon.titan-embed-text-v2:0",
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={"original_batch_request": {"endpoint": ""}},
+        )
+        assert batch.endpoint == ""
+
 
 class TestTransformRetrieveBatchResponseEndpoint:
     """The retrieve path has no original request to read from, so it must

--- a/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
@@ -278,3 +278,65 @@ class TestTransformRetrieveBatchResponseEndpoint:
             litellm_params={},
         )
         assert batch.endpoint == "/v1/chat/completions"
+
+
+class TestRegistryDrivenClassification:
+    """The model registry (`model_prices_and_context_window.json`) is the
+    source of truth - these tests pin that we use it, not just substring
+    matching, for canonical Bedrock model ids."""
+
+    def test_registry_classifies_known_embed_id(self, mocker):
+        """get_model_info short-circuits the substring fallback for known ids."""
+        mocked = mocker.patch(
+            "litellm.get_model_info", return_value={"mode": "embedding"}
+        )
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "amazon.titan-embed-text-v2:0"
+            )
+            == "/v1/embeddings"
+        )
+        mocked.assert_called_once_with("amazon.titan-embed-text-v2:0")
+
+    def test_registry_chat_mode_wins_even_if_name_contains_embed_word(self, mocker):
+        """Hypothetical model whose name has 'embed' but registry says chat
+        must NOT route to embeddings - registry wins over substring."""
+        mocker.patch("litellm.get_model_info", return_value={"mode": "chat"})
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "some.embed-themed-chat-v1:0"
+            )
+            == "/v1/chat/completions"
+        )
+
+    def test_substring_fallback_used_when_registry_raises(self, mocker):
+        """For unmapped ids (ARN forms, cross-region profiles) we keep the
+        old substring heuristic so embedding batches still get routed."""
+        mocker.patch("litellm.get_model_info", side_effect=Exception("not mapped"))
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "us.amazon.titan-embed-text-v2:0"
+            )
+            == "/v1/embeddings"
+        )
+
+    def test_substring_fallback_chat_default_when_registry_raises(self, mocker):
+        """Unmapped id without 'embed' marker -> chat (preserves prior behavior)."""
+        mocker.patch("litellm.get_model_info", side_effect=Exception("not mapped"))
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "arn:aws:bedrock:us-east-1:123:custom-model/some-llm"
+            )
+            == "/v1/chat/completions"
+        )
+
+    def test_registry_no_mode_field_falls_back_to_substring(self, mocker):
+        """Registry returns info dict without a `mode` key -> substring path."""
+        mocker.patch("litellm.get_model_info", return_value={})
+        # No 'embed' in name -> chat
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "anthropic.claude-3-5-sonnet-20240620-v1:0"
+            )
+            == "/v1/chat/completions"
+        )

--- a/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py
@@ -1,0 +1,280 @@
+"""
+Tests for BedrockBatchesConfig endpoint propagation.
+
+Before these changes, both `transform_create_batch_response` and
+`transform_retrieve_batch_response` reported `endpoint="/v1/chat/completions"`
+unconditionally, which mis-labelled embedding batches and broke OpenAI
+clients that introspect the batch object.
+
+The new helper `_infer_openai_endpoint_from_model_id` is a best-effort
+mapper used as a fallback when the caller didn't (or couldn't) pass the
+original `endpoint` through `litellm_params["original_batch_request"]`.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.bedrock.batches.transformation import BedrockBatchesConfig
+
+
+class TestInferOpenaiEndpointFromModelId:
+    """Direct tests for the static inference helper."""
+
+    def test_titan_v2_text_embed_routes_to_embeddings(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "amazon.titan-embed-text-v2:0"
+            )
+            == "/v1/embeddings"
+        )
+
+    def test_titan_multimodal_embed_routes_to_embeddings(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "amazon.titan-embed-image-v1"
+            )
+            == "/v1/embeddings"
+        )
+
+    def test_nova_multimodal_embed_routes_to_embeddings(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "amazon.nova-2-multimodal-embeddings-v1:0"
+            )
+            == "/v1/embeddings"
+        )
+
+    def test_cohere_embed_routes_to_embeddings(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "cohere.embed-english-v3"
+            )
+            == "/v1/embeddings"
+        )
+
+    def test_arn_form_embed_routes_to_embeddings(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "arn:aws:bedrock:us-east-1:123:foundation-model/amazon.titan-embed-text-v2:0"
+            )
+            == "/v1/embeddings"
+        )
+
+    def test_anthropic_chat_routes_to_chat_completions(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "anthropic.claude-3-5-sonnet-20240620-v1:0"
+            )
+            == "/v1/chat/completions"
+        )
+
+    def test_cross_region_inference_profile_chat_routes_to_chat(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+            )
+            == "/v1/chat/completions"
+        )
+
+    def test_nova_chat_routes_to_chat_completions(self):
+        # Nova Pro is a chat model, not an embedding model; the name has
+        # no "embed" so we must NOT misclassify it.
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "us.amazon.nova-pro-v1:0"
+            )
+            == "/v1/chat/completions"
+        )
+
+    def test_none_model_defaults_to_chat(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(None)
+            == "/v1/chat/completions"
+        )
+
+    def test_empty_model_defaults_to_chat(self):
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id("")
+            == "/v1/chat/completions"
+        )
+
+    def test_case_insensitive_matching(self):
+        # AWS model ids are lowercase but defensive coercion shouldn't hurt.
+        assert (
+            BedrockBatchesConfig._infer_openai_endpoint_from_model_id(
+                "AMAZON.TITAN-EMBED-TEXT-V2:0"
+            )
+            == "/v1/embeddings"
+        )
+
+
+class TestTransformCreateBatchResponseEndpoint:
+    """End-to-end checks that the create-batch response carries the right endpoint."""
+
+    @staticmethod
+    def _mock_raw_response(payload):
+        m = MagicMock()
+        m.json.return_value = payload
+        return m
+
+    def test_create_response_uses_original_request_endpoint_when_set(self):
+        """Explicit endpoint on the original request wins over the heuristic."""
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Submitted",
+            }
+        )
+        batch = config.transform_create_batch_response(
+            model="amazon.titan-embed-text-v2:0",
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={"original_batch_request": {"endpoint": "/v1/embeddings"}},
+        )
+        assert batch.endpoint == "/v1/embeddings"
+
+    def test_create_response_falls_back_to_model_inference_for_embed(self):
+        """Without `original_batch_request.endpoint`, infer from model id."""
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Submitted",
+            }
+        )
+        batch = config.transform_create_batch_response(
+            model="amazon.titan-embed-text-v2:0",
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+        assert batch.endpoint == "/v1/embeddings"
+
+    def test_create_response_chat_default_when_no_signal(self):
+        """No endpoint and no embed marker in model id -> chat completions."""
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Submitted",
+            }
+        )
+        batch = config.transform_create_batch_response(
+            model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+        assert batch.endpoint == "/v1/chat/completions"
+
+    def test_create_response_chat_when_model_is_none_but_request_says_chat(self):
+        """If model is None but original request says chat, that wins."""
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Submitted",
+            }
+        )
+        batch = config.transform_create_batch_response(
+            model=None,
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={
+                "original_batch_request": {"endpoint": "/v1/chat/completions"}
+            },
+        )
+        assert batch.endpoint == "/v1/chat/completions"
+
+
+class TestTransformRetrieveBatchResponseEndpoint:
+    """The retrieve path has no original request to read from, so it must
+    infer the endpoint from the AWS response's modelId."""
+
+    @staticmethod
+    def _mock_raw_response(payload):
+        m = MagicMock()
+        m.json.return_value = payload
+        m.status_code = 200
+        return m
+
+    def test_retrieve_response_infers_embeddings_from_modelid(self):
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Completed",
+                "modelId": "amazon.titan-embed-text-v2:0",
+                "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in.jsonl"}},
+                "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out/"}},
+            }
+        )
+        batch = config.transform_retrieve_batch_response(
+            model=None,
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+        assert batch.endpoint == "/v1/embeddings"
+
+    def test_retrieve_response_infers_chat_from_modelid(self):
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Completed",
+                "modelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in.jsonl"}},
+                "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out/"}},
+            }
+        )
+        batch = config.transform_retrieve_batch_response(
+            model=None,
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+        assert batch.endpoint == "/v1/chat/completions"
+
+    def test_retrieve_response_model_arg_wins_over_response_modelid(self):
+        """If the caller passed `model`, prefer it over the AWS payload."""
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Completed",
+                # AWS-reported model is chat; caller-supplied model is embed.
+                "modelId": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in.jsonl"}},
+                "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out/"}},
+            }
+        )
+        batch = config.transform_retrieve_batch_response(
+            model="amazon.titan-embed-text-v2:0",
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+        assert batch.endpoint == "/v1/embeddings"
+
+    def test_retrieve_response_defaults_to_chat_when_no_modelid(self):
+        config = BedrockBatchesConfig()
+        raw = self._mock_raw_response(
+            {
+                "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+                "status": "Submitted",
+                "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in.jsonl"}},
+                "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out/"}},
+            }
+        )
+        batch = config.transform_retrieve_batch_response(
+            model=None,
+            raw_response=raw,
+            logging_obj=MagicMock(),
+            litellm_params={},
+        )
+        assert batch.endpoint == "/v1/chat/completions"


### PR DESCRIPTION
## Relevant issues

Companion to #28865 (Titan v2 embedding JSONL input transform). That PR makes embedding JSONL records produce a valid Bedrock modelInput; this PR makes the resulting `LiteLLMBatch` object correctly report `endpoint=\"/v1/embeddings\"` to OpenAI clients that introspect it.

Reopens the use case from #15506. Supersedes #28863, which was opened against `main` (wrong base) and accumulated force-pushes / close-reopen churn while we fixed up the base + addressed Greptile feedback. This PR is the clean, rebased version against `litellm_oss_branch`.

## Problem

`BedrockBatchesConfig.transform_create_batch_response` and `transform_retrieve_batch_response` both hardcoded `endpoint=\"/v1/chat/completions\"`. For an embedding batch the create path could read `original_batch_request.endpoint` but defaulted to chat-completions when the caller didn't set it; the retrieve path had no fallback at all because it has no original request to read from.

## Changes vs `litellm_oss_branch`

- `litellm/llms/bedrock/batches/transformation.py`
  - New static helper `_lookup_registry_mode` reads `mode` for a model id from `model_prices_and_context_window.json` via `litellm.get_model_info`. Returns the mode string when the registry knows the id and the entry has a non-empty string mode, else `None`. Catches the failure modes: registry raises, registry returns a non-dict, registry returns a dict without (or with empty / non-string) `mode`.
  - New static helper `_infer_openai_endpoint_from_model_id` returns `/v1/embeddings` when the registry says `mode == \"embedding\"`. Falls back to substring (`\"embed\" in model_id.lower()`) for ids the registry can't resolve - this catches cross-region inference profile prefixes (e.g. `us.amazon.titan-embed-text-v2:0`) and Bedrock ARN forms, neither of which `get_model_info` handles today. Otherwise defaults to `/v1/chat/completions`.
  - `transform_create_batch_response` now prefers `original_batch_request.endpoint` from `litellm_params` and falls back to the heuristic instead of hardcoded chat-completions.
  - `transform_retrieve_batch_response` replaces the hardcoded value with the same heuristic, fed from the caller-supplied `model` argument or the `modelId` AWS returns on GetModelInvocationJob.

- `tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py` (new)
  - 11 direct tests for `_infer_openai_endpoint_from_model_id`: Titan v2 text, Titan multimodal, Nova multimodal embeddings, Cohere Embed, ARN form, Anthropic chat, cross-region chat profile, Nova chat, None, empty, case-insensitive.
  - 4 create-batch tests: explicit override wins, model-id fallback for embed, chat default when no signal, model=None with original_request.endpoint=chat.
  - 4 retrieve-batch tests: embed via AWS modelId, chat via AWS modelId, caller `model` arg wins over AWS modelId, default-chat when neither present.
  - 5 registry-driven tests: registry classifies known embed id, registry chat mode wins over substring \"embed\" in name, substring fallback used when registry raises, substring fallback chat default when registry raises, no mode field falls back to substring.
  - 6 isolated `_lookup_registry_mode` tests: returns mode when resolves, returns None on raise / non-dict / missing mode / empty mode / non-string mode.

## What this does NOT change

- The actual batch processing path is unchanged. AWS Bedrock's `CreateModelInvocationJob` is endpoint-agnostic at the wire level: only the `modelId` and the JSONL `modelInput` schema vary. So this PR is metadata fidelity, not feature unlock; #28865 is the schema fix.
- The output-file transform (Bedrock `modelOutput` -> OpenAI batch embedding response shape) is intentionally not in this PR. It will be a follow-up so the schema-specific risk stays isolated.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on `make test-unit` (30/30 in `tests/test_litellm/llms/bedrock/batches/test_endpoint_inference.py` plus 9 existing tests in `test_batch_metadata_sanitization.py`)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem (endpoint propagation in batch response transformers)
- [ ] I will request `@greptileai` review after opening this PR

## Type

New Feature