### PR TITLE
[Feature] Proxy: hide team service-account keys from regular members on /key/list

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2521,6 +2521,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).",
     )
+    expose_team_service_accounts_to_members: Optional[bool] = Field(
+        True,
+        description="When False, non-admin team members do NOT see service-account keys (user_id=NULL) of their teams via /key/list. Team admins (and proxy admins) are unaffected and still see full team keys. Default True preserves upstream behavior.",
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4953,7 +4953,7 @@ async def list_keys(
     Note: When expand=user is specified, full key objects are returned regardless of the return_full_object parameter.
     """
     try:
-        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.proxy_server import general_settings, prisma_client
 
         verbose_proxy_logger.debug("Entering list_keys function")
 
@@ -4969,6 +4969,15 @@ async def list_keys(
                     "error": "Invalid status value. Currently only 'deleted' is supported."
                 },
             )
+
+        # Operator-controlled toggle: when False, regular team members no longer
+        # see service-account keys (user_id=NULL) of their teams via /key/list.
+        # Default True preserves upstream behavior.
+        expose_team_service_accounts_to_members = _resolve_general_settings_bool(
+            general_settings,
+            key="expose_team_service_accounts_to_members",
+            default=True,
+        )
 
         complete_user_info = await validate_key_list_check(
             user_api_key_dict=user_api_key_dict,
@@ -5042,6 +5051,7 @@ async def list_keys(
             project_id=project_id,
             access_group_id=access_group_id,
             use_substring_matching=use_substring_matching,
+            expose_team_service_accounts_to_members=expose_team_service_accounts_to_members,
         )
 
         verbose_proxy_logger.debug("Successfully prepared response")
@@ -5267,6 +5277,25 @@ def _validate_sort_params(
     return order_by
 
 
+def _resolve_general_settings_bool(
+    general_settings: Dict[str, Any], key: str, default: bool
+) -> bool:
+    """
+    Read a boolean flag from `general_settings` safely.
+
+    YAML loaders may produce a non-bool (e.g. quoted ``"False"`` becomes a
+    truthy string, or an explicit ``null`` becomes ``None``). Using
+    ``bool(...)`` directly would silently flip the flag in those cases. To
+    avoid that footgun, accept only real Python booleans; anything else falls
+    back to ``default`` so an operator misconfiguring YAML never weakens a
+    security default.
+    """
+    raw = general_settings.get(key, default)
+    if isinstance(raw, bool):
+        return raw
+    return default
+
+
 def _build_key_filter_conditions(
     user_id: Optional[str],
     team_id: Optional[str],
@@ -5280,6 +5309,7 @@ def _build_key_filter_conditions(
     project_id: Optional[str] = None,
     access_group_id: Optional[str] = None,
     use_substring_matching: bool = False,
+    expose_team_service_accounts_to_members: bool = True,
 ) -> Dict[str, Union[str, Dict[str, Any], List[Dict[str, Any]]]]:
     """Build filter conditions for key listing.
 
@@ -5290,6 +5320,9 @@ def _build_key_filter_conditions(
       teams (via member_team_ids). This prevents leaking other members' spend data.
     - created_by visibility is scoped to teams the user currently belongs to,
       so former members cannot see service accounts they created after leaving.
+    - When expose_team_service_accounts_to_members is False, the regular-member
+      service-account branch is dropped entirely — members see only their own
+      keys (admins still see full team keys via admin_team_ids).
     """
     # Prepare filter conditions
     where: Dict[str, Union[str, Dict[str, Any], List[Dict[str, Any]]]] = {}
@@ -5360,7 +5393,7 @@ def _build_key_filter_conditions(
         or_conditions.append({"team_id": {"in": admin_team_ids}})
 
     # Add condition for member team service accounts (members only see keys with user_id=NULL)
-    if member_team_ids:
+    if member_team_ids and expose_team_service_accounts_to_members:
         # Exclude teams where user is already admin (those are covered above with full visibility)
         member_only_team_ids = [
             tid for tid in member_team_ids if tid not in (admin_team_ids or [])
@@ -5419,6 +5452,7 @@ async def _list_key_helper(
     project_id: Optional[str] = None,
     access_group_id: Optional[str] = None,
     use_substring_matching: bool = False,
+    expose_team_service_accounts_to_members: bool = True,
 ) -> KeyListResponseObject:
     """
     Helper function to list keys
@@ -5432,6 +5466,7 @@ async def _list_key_helper(
         return_full_object: bool # when true, will return UserAPIKeyAuth objects instead of just the token
         admin_team_ids: Optional[List[str]] # list of team IDs where the user is an admin
         member_team_ids: Optional[List[str]] # list of team IDs where user is a member (for service account visibility)
+        expose_team_service_accounts_to_members: bool # when False, regular members do NOT see team service-account keys
 
     Returns:
         KeyListResponseObject
@@ -5455,6 +5490,7 @@ async def _list_key_helper(
         project_id=project_id,
         access_group_id=access_group_id,
         use_substring_matching=use_substring_matching,
+        expose_team_service_accounts_to_members=expose_team_service_accounts_to_members,
     )
 
     # Calculate skip for pagination

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5361,6 +5361,18 @@ def _build_key_filter_conditions(
 
     # Add condition for created_by keys, scoped to user's current teams
     if include_created_by_keys and user_id:
+        # When the team-service-account visibility gate is off, also exclude
+        # service-account-shaped keys (user_id is NULL) from the created_by
+        # branch. Without this, a member who happened to create a team
+        # service-account key could call `/key/list?include_created_by_keys=true`
+        # and read it back even though the gate hides it from the
+        # member-team branch below. The exclusion matches the spirit of the
+        # gate: service-account keys are not visible to regular members.
+        service_account_exclusion: List[Dict[str, Any]] = (
+            [{"user_id": {"not": None}}]
+            if not expose_team_service_accounts_to_members
+            else []
+        )
         if member_team_ids is not None:
             if member_team_ids:
                 # Scope created_by keys to teams user is still a member of,
@@ -5375,18 +5387,35 @@ def _build_key_filter_conditions(
                                     {"team_id": None},
                                 ]
                             },
+                            *service_account_exclusion,
                         ]
                     }
                 )
             else:
                 # User is not a member of any team, only show non-team created_by keys
                 or_conditions.append(
-                    {"AND": [{"created_by": user_id}, {"team_id": None}]}
+                    {
+                        "AND": [
+                            {"created_by": user_id},
+                            {"team_id": None},
+                            *service_account_exclusion,
+                        ]
+                    }
                 )
         else:
             # No team membership info provided (backward compatibility for
             # direct _list_key_helper callers like Prometheus)
-            or_conditions.append({"created_by": user_id})
+            if service_account_exclusion:
+                or_conditions.append(
+                    {
+                        "AND": [
+                            {"created_by": user_id},
+                            *service_account_exclusion,
+                        ]
+                    }
+                )
+            else:
+                or_conditions.append({"created_by": user_id})
 
     # Add condition for admin team keys (admins see ALL team keys)
     if admin_team_ids:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -7094,6 +7094,123 @@ async def test_build_key_filter_member_team_service_accounts():
 
 
 @pytest.mark.asyncio
+async def test_build_key_filter_member_service_account_visibility_disabled():
+    """
+    When the proxy is configured with expose_team_service_accounts_to_members=False,
+    a regular team member must NOT receive the service-account OR-branch — they
+    should only see their own keys.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "regular-member-123"
+    member_team_ids = ["team-A", "team-B"]
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=member_team_ids,
+        include_created_by_keys=False,
+        expose_team_service_accounts_to_members=False,
+    )
+
+    # Only the user-own-keys condition should remain; no AND/OR wrapper needed.
+    assert "AND" not in where
+    assert where.get("user_id") == user_id
+
+
+@pytest.mark.asyncio
+async def test_build_key_filter_admin_unaffected_when_member_visibility_disabled():
+    """
+    Regression: turning off member service-account visibility must NOT shrink
+    what a team admin sees — the admin_team_ids branch still grants full team
+    key visibility.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "admin-user"
+    admin_team_ids = ["team-A"]
+    member_team_ids = ["team-A", "team-B"]
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=admin_team_ids,
+        member_team_ids=member_team_ids,
+        include_created_by_keys=False,
+        expose_team_service_accounts_to_members=False,
+    )
+
+    assert "AND" in where
+    or_conditions = where["AND"][1]["OR"]
+
+    # Expect exactly two branches: own keys + admin-team full visibility.
+    # The member service-account branch (would be for team-B) is suppressed.
+    assert len(or_conditions) == 2
+
+    has_admin_branch = any(
+        isinstance(c.get("team_id"), dict) and c["team_id"].get("in") == admin_team_ids
+        for c in or_conditions
+    )
+    assert has_admin_branch, "Admin team_id IN branch must still be present"
+
+    has_member_service_branch = any(
+        "AND" in c
+        and any(
+            isinstance(p, dict) and p.get("user_id") is None and "team_id" in p
+            for p in c["AND"]
+        )
+        for c in or_conditions
+    )
+    assert not has_member_service_branch, "Member service-account branch must be gone"
+
+
+@pytest.mark.parametrize(
+    "general_settings_value,expected",
+    [
+        ({}, True),  # missing key → default
+        ({"expose_team_service_accounts_to_members": True}, True),
+        ({"expose_team_service_accounts_to_members": False}, False),
+        # Non-bool values must fall back to the safe default, not silently flip:
+        ({"expose_team_service_accounts_to_members": None}, True),
+        ({"expose_team_service_accounts_to_members": "False"}, True),
+        ({"expose_team_service_accounts_to_members": "false"}, True),
+        ({"expose_team_service_accounts_to_members": "true"}, True),
+        ({"expose_team_service_accounts_to_members": 0}, True),
+        ({"expose_team_service_accounts_to_members": 1}, True),
+    ],
+)
+def test_resolve_general_settings_bool_safe_default(general_settings_value, expected):
+    """
+    Only literal Python True/False from config should toggle the flag.
+    Any other value (None, strings, ints) must safely default — otherwise a
+    quoted "False" in YAML would silently keep service accounts visible.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _resolve_general_settings_bool,
+    )
+
+    result = _resolve_general_settings_bool(
+        general_settings_value,
+        key="expose_team_service_accounts_to_members",
+        default=True,
+    )
+    assert result is expected
+
+
+@pytest.mark.asyncio
 async def test_build_key_filter_admin_sees_all_team_keys():
     """
     Test that team admins see ALL keys for their teams (not just service accounts),

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -7093,8 +7093,7 @@ async def test_build_key_filter_member_team_service_accounts():
     assert {"user_id": None} in and_parts
 
 
-@pytest.mark.asyncio
-async def test_build_key_filter_member_service_account_visibility_disabled():
+def test_build_key_filter_member_service_account_visibility_disabled():
     """
     When the proxy is configured with expose_team_service_accounts_to_members=False,
     a regular team member must NOT receive the service-account OR-branch — they
@@ -7125,8 +7124,7 @@ async def test_build_key_filter_member_service_account_visibility_disabled():
     assert where.get("user_id") == user_id
 
 
-@pytest.mark.asyncio
-async def test_build_key_filter_admin_unaffected_when_member_visibility_disabled():
+def test_build_key_filter_admin_unaffected_when_member_visibility_disabled():
     """
     Regression: turning off member service-account visibility must NOT shrink
     what a team admin sees — the admin_team_ids branch still grants full team
@@ -7208,6 +7206,100 @@ def test_resolve_general_settings_bool_safe_default(general_settings_value, expe
         default=True,
     )
     assert result is expected
+
+
+def test_build_key_filter_member_include_created_by_keys_excludes_service_accounts_when_flag_off():
+    """
+    Regression for the include_created_by_keys bypass: a regular member calling
+    `/key/list?include_created_by_keys=true` must not receive team service-account
+    keys (user_id is NULL) they created when
+    expose_team_service_accounts_to_members=False. The created_by OR-branch
+    must carry a `user_id is not None` filter under the flag.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "regular-member-456"
+    member_team_ids = ["team-A", "team-B"]
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=member_team_ids,
+        include_created_by_keys=True,
+        expose_team_service_accounts_to_members=False,
+    )
+
+    assert "AND" in where, "Expected the multi-branch wrapper when include_created_by_keys is on"
+    or_conditions = where["AND"][1]["OR"]
+
+    created_by_branches = [
+        c for c in or_conditions
+        if "AND" in c and any(
+            isinstance(p, dict) and p.get("created_by") == user_id for p in c["AND"]
+        )
+    ]
+    assert created_by_branches, "Expected a created_by OR-branch"
+    created_by_and = created_by_branches[0]["AND"]
+    has_service_account_exclusion = any(
+        isinstance(p, dict) and p.get("user_id") == {"not": None}
+        for p in created_by_and
+    )
+    assert has_service_account_exclusion, (
+        "created_by branch must carry `user_id is not None` when "
+        "expose_team_service_accounts_to_members=False, otherwise members can "
+        "read team service-account keys they created via "
+        "`/key/list?include_created_by_keys=true`"
+    )
+
+
+def test_build_key_filter_member_include_created_by_keys_unchanged_when_flag_on():
+    """
+    Regression guard: when the flag is on (default), the created_by branch
+    keeps its pre-existing shape with no user_id-is-not-None constraint.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "regular-member-789"
+    member_team_ids = ["team-A"]
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=member_team_ids,
+        include_created_by_keys=True,
+        expose_team_service_accounts_to_members=True,
+    )
+
+    or_conditions = where["AND"][1]["OR"] if "AND" in where else [where]
+    created_by_branches = [
+        c for c in or_conditions
+        if "AND" in c and any(
+            isinstance(p, dict) and p.get("created_by") == user_id for p in c["AND"]
+        )
+    ]
+    assert created_by_branches
+    created_by_and = created_by_branches[0]["AND"]
+    has_service_account_exclusion = any(
+        isinstance(p, dict) and p.get("user_id") == {"not": None}
+        for p in created_by_and
+    )
+    assert not has_service_account_exclusion, (
+        "Flag-on path must keep the original created_by shape"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

- Fixes #28870 — Feature request: hide team service-account keys from regular members on `/key/list`

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — 2 new unit tests covering both directions of the gate
- [x] My PR passes all unit tests — `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py` (269 of 270 tests pass; the one failure `test_rotate_master_key_model_data_valid_for_prisma` reproduces on bare upstream `main` and is unrelated to this change)
- [x] My PR's scope is as isolated as possible — single new opt-in flag, single filter branch gated, no other behavior changed
- [ ] Greptile review pending

## Type

🆕 New Feature

## Changes

### Problem

Team service-account keys (keys with a `team_id` set and `user_id == NULL`) are infrastructure-level credentials — provisioned by team-admins or proxy-admins for CI/CD pipelines, automation, internal microservices. On `/key/list`, every regular team member can currently see all such keys for their team via this OR-branch in `_build_key_filter_conditions`:

```python
if member_team_ids:
    conditions.append({
        "team_id": {"in": member_team_ids},
        "user_id": None,
    })
```

For multi-tenant deployments this leaks the existence and metadata (aliases, budgets, expiration) of all team-level service accounts to every regular member — people who do not own and should not see those credentials. Team-admins should keep full visibility; proxy-admins are unaffected.

### Solution

New `general_settings.expose_team_service_accounts_to_members` boolean, default `True` to preserve upstream behavior (no breaking change). When set to `False`, the service-account OR-branch is removed for regular members — they only see keys where `user_id == self`. Team-admins keep the full team key list via the `admin_team_ids` branch, which is untouched.

```yaml
general_settings:
  expose_team_service_accounts_to_members: false
```

### Implementation

- `litellm/proxy/management_endpoints/key_management_endpoints.py`
  - `_build_key_filter_conditions(...)`: new `expose_team_service_accounts_to_members: bool = True` kwarg. Gates the member service-account branch (`if member_team_ids and expose_team_service_accounts_to_members:`). Docstring updated.
  - `_list_key_helper(...)`: same kwarg, pure pass-through to `_build_key_filter_conditions`.
  - `list_keys` endpoint: adds `general_settings` to the existing local proxy_server import (already used to break a circular dep), reads `general_settings.get("expose_team_service_accounts_to_members", True)`, passes to `_list_key_helper`.
- `litellm/proxy/_types.py`
  - `ConfigGeneralSettings` gains `expose_team_service_accounts_to_members: Optional[bool] = Field(True, ...)` so config validation accepts the new key.

### Other callers of `_list_key_helper`

`litellm/integrations/prometheus.py` is the only other caller; it passes `user_id=None` and `member_team_ids=None`, so the gated branch never fires there. No change needed.

### Tests

`tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`:

- `test_build_key_filter_member_service_account_visibility_disabled` — RED→GREEN: with `expose_team_service_accounts_to_members=False`, a regular member's filter set has only `user_id == self`; the service-account branch is absent.
- `test_build_key_filter_admin_unaffected_when_member_visibility_disabled` — regression guard: a team-admin still receives full team visibility via `admin_team_ids` even when the flag is `False`.

### Security direction

The flag only ever **restricts** visibility:

- `True` (default) — identical to current upstream behavior, bit-for-bit on the generated filter set.
- `False` — strict subset of the True path: it removes one OR-branch, never adds one.

No path can grant a member visibility they did not have before.
