### PR TITLE
Fix null token rollups in daily activity aggregation

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -696,16 +696,35 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     """Build a SpendMetrics directly from one already-aggregated rollup row."""
+    spend = 0 if record.spend is None else record.spend
+    prompt_tokens = 0 if record.prompt_tokens is None else record.prompt_tokens
+    completion_tokens = (
+        0 if record.completion_tokens is None else record.completion_tokens
+    )
+    cache_read_input_tokens = (
+        0 if record.cache_read_input_tokens is None else record.cache_read_input_tokens
+    )
+    cache_creation_input_tokens = (
+        0
+        if record.cache_creation_input_tokens is None
+        else record.cache_creation_input_tokens
+    )
+    api_requests = 0 if record.api_requests is None else record.api_requests
+    successful_requests = (
+        0 if record.successful_requests is None else record.successful_requests
+    )
+    failed_requests = 0 if record.failed_requests is None else record.failed_requests
+
     return SpendMetrics(
-        spend=record.spend,
-        prompt_tokens=record.prompt_tokens,
-        completion_tokens=record.completion_tokens,
-        total_tokens=record.prompt_tokens + record.completion_tokens,
-        cache_read_input_tokens=record.cache_read_input_tokens,
-        cache_creation_input_tokens=record.cache_creation_input_tokens,
-        api_requests=record.api_requests,
-        successful_requests=record.successful_requests,
-        failed_requests=record.failed_requests,
+        spend=spend,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        api_requests=api_requests,
+        successful_requests=successful_requests,
+        failed_requests=failed_requests,
     )
 
 

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -696,24 +696,18 @@ _GROUP_DATE_ENDPOINT_API_KEY = 30  # 0b0011110
 
 def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     """Build a SpendMetrics directly from one already-aggregated rollup row."""
-    spend = 0 if record.spend is None else record.spend
-    prompt_tokens = 0 if record.prompt_tokens is None else record.prompt_tokens
-    completion_tokens = (
-        0 if record.completion_tokens is None else record.completion_tokens
-    )
-    cache_read_input_tokens = (
-        0 if record.cache_read_input_tokens is None else record.cache_read_input_tokens
-    )
-    cache_creation_input_tokens = (
-        0
-        if record.cache_creation_input_tokens is None
-        else record.cache_creation_input_tokens
-    )
-    api_requests = 0 if record.api_requests is None else record.api_requests
-    successful_requests = (
-        0 if record.successful_requests is None else record.successful_requests
-    )
-    failed_requests = 0 if record.failed_requests is None else record.failed_requests
+
+    def _zero_if_none(value: Any) -> Any:
+        return 0 if value is None else value
+
+    spend = _zero_if_none(record.spend)
+    prompt_tokens = _zero_if_none(record.prompt_tokens)
+    completion_tokens = _zero_if_none(record.completion_tokens)
+    cache_read_input_tokens = _zero_if_none(record.cache_read_input_tokens)
+    cache_creation_input_tokens = _zero_if_none(record.cache_creation_input_tokens)
+    api_requests = _zero_if_none(record.api_requests)
+    successful_requests = _zero_if_none(record.successful_requests)
+    failed_requests = _zero_if_none(record.failed_requests)
 
     return SpendMetrics(
         spend=spend,

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -231,6 +231,77 @@ async def test_get_daily_activity_aggregated_with_endpoint_breakdown():
 
 
 @pytest.mark.asyncio
+async def test_get_daily_activity_aggregated_handles_null_token_rollups():
+    """Test that aggregated activity treats NULL token sums as zero."""
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+
+    base = {
+        "api_key": None,
+        "model": None,
+        "model_group": None,
+        "custom_llm_provider": None,
+        "mcp_namespaced_tool_name": None,
+        "cache_read_input_tokens": None,
+        "cache_creation_input_tokens": None,
+        "api_requests": 1,
+        "successful_requests": 1,
+        "failed_requests": 0,
+        "spend": 0.0,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+    }
+    mock_rows = [
+        {
+            **base,
+            "date": "2024-01-01",
+            "endpoint": "/v1/chat/completions",
+            "group_level": 62,
+        },
+        {
+            **base,
+            "date": "2024-01-01",
+            "endpoint": None,
+            "group_level": 63,
+        },
+        {
+            **base,
+            "date": None,
+            "endpoint": None,
+            "group_level": 127,
+        },
+    ]
+
+    mock_prisma.db.query_raw = AsyncMock(return_value=mock_rows)
+
+    result = await get_daily_activity_aggregated(
+        prisma_client=mock_prisma,
+        table_name="litellm_dailyuserspend",
+        entity_id_field="user_id",
+        entity_id=None,
+        entity_metadata_field=None,
+        start_date="2024-01-01",
+        end_date="2024-01-01",
+        model=None,
+        api_key=None,
+    )
+
+    assert result.metadata.total_prompt_tokens == 0
+    assert result.metadata.total_completion_tokens == 0
+    assert result.metadata.total_tokens == 0
+
+    daily_data = result.results[0]
+    assert daily_data.metrics.prompt_tokens == 0
+    assert daily_data.metrics.completion_tokens == 0
+    assert daily_data.metrics.total_tokens == 0
+
+    endpoint = daily_data.breakdown.endpoints["/v1/chat/completions"]
+    assert endpoint.metrics.prompt_tokens == 0
+    assert endpoint.metrics.completion_tokens == 0
+    assert endpoint.metrics.total_tokens == 0
+
+
+@pytest.mark.asyncio
 async def test_get_api_key_metadata_returns_active_key_metadata():
     """Test that get_api_key_metadata should return metadata for active keys."""
     mock_prisma = MagicMock()


### PR DESCRIPTION
## Relevant issues

Fixes #28858

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Added a regression test covering NULL daily activity aggregate rollups.

## Type

Bug Fix
Test

## Changes

- normalize nullable daily activity rollup metrics to zero before constructing response metrics
- cover NULL prompt, completion, cache, and request-count rollups in `/user/daily/activity/aggregated`

## Tests

- `uv run --group proxy-dev --extra proxy pytest tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py -q`
