### PR TITLE
fix(bedrock): align toolUse/toolSpec names and allow hyphens

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3997,7 +3997,7 @@ def _convert_to_bedrock_tool_call_invoke(
         for tool in tool_calls:
             if "function" in tool:
                 tool_id = tool["id"]
-                name = tool["function"].get("name", "")
+                name = make_valid_bedrock_tool_name(tool["function"].get("name", ""))
                 arguments = tool["function"].get("arguments", "")
 
                 if not arguments or not arguments.strip():
@@ -5323,16 +5323,10 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
 
 
 def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
-    """
-    Replaces any invalid characters in the input tool name with underscores
-    and ensures the resulting string is a valid identifier for Bedrock tools
-    """
+    """Normalize tool names to Bedrock pattern [a-zA-Z0-9_-]+."""
 
     def replace_invalid(char):
-        """
-        Bedrock tool names only supports alpha-numeric characters and underscores
-        """
-        if char.isalnum() or char == "_":
+        if char.isalnum() or char in ("_", "-"):
             return char
         return "_"
 
@@ -5492,7 +5486,7 @@ def _bedrock_tools_pt(
             raw_name = f"litellm_unnamed_tool_{tool_idx}"
 
         # related issue: https://github.com/BerriAI/litellm/issues/5007
-        # Bedrock tool names must satisfy regular expression pattern: [a-zA-Z][a-zA-Z0-9_]* ensure this is true
+        # Bedrock tool names must satisfy pattern: [a-zA-Z0-9_-]+
         name = make_valid_bedrock_tool_name(input_tool_name=raw_name)
         if _tool_description:  # bedrock doesn't accept empty "" or None descriptions
             description = _tool_description

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5323,7 +5323,7 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
 
 
 def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
-    """Normalize tool names to Bedrock pattern [a-zA-Z0-9_-]+."""
+    """Normalize tool names to Bedrock pattern [a-zA-Z][a-zA-Z0-9_-]*."""
 
     def replace_invalid(char):
         if char.isalnum() or char in ("_", "-"):
@@ -5486,7 +5486,7 @@ def _bedrock_tools_pt(
             raw_name = f"litellm_unnamed_tool_{tool_idx}"
 
         # related issue: https://github.com/BerriAI/litellm/issues/5007
-        # Bedrock tool names must satisfy pattern: [a-zA-Z0-9_-]+
+        # Bedrock tool names must satisfy pattern: [a-zA-Z][a-zA-Z0-9_-]*
         name = make_valid_bedrock_tool_name(input_tool_name=raw_name)
         if _tool_description:  # bedrock doesn't accept empty "" or None descriptions
             description = _tool_description

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -30,6 +30,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     BedrockConverseMessagesProcessor,
     _bedrock_converse_messages_pt,
     _bedrock_tools_pt,
+    make_valid_bedrock_tool_name,
 )
 from litellm.llms.anthropic.chat.transformation import (
     DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
@@ -595,7 +596,9 @@ class AmazonConverseConfig(BaseConfig):
         elif isinstance(tool_choice, dict):
             # only supported for anthropic + mistral models - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
             specific_tool = SpecificToolChoiceBlock(
-                name=tool_choice.get("function", {}).get("name", "")
+                name=make_valid_bedrock_tool_name(
+                    tool_choice.get("function", {}).get("name", "")
+                )
             )
             return ToolChoiceValuesBlock(tool=specific_tool)
         else:

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -1062,7 +1062,7 @@ def test_bedrock_tools_pt_invalid_names():
     print("bedrock tools after prompt formatting=", result)
 
     assert len(result) == 2
-    assert result[0]["toolSpec"]["name"] == "a123_invalid_name"
+    assert result[0]["toolSpec"]["name"] == "a123-invalid_name"
     assert result[1]["toolSpec"]["name"] == "another_invalid_name"
 
 
@@ -1171,7 +1171,7 @@ def test_bedrock_tools_transformation_valid_params():
     assert isinstance(result, list)
     assert len(result) == 1
     assert "toolSpec" in result[0]
-    assert result[0]["toolSpec"]["name"] == "a123_invalid_name"
+    assert result[0]["toolSpec"]["name"] == "a123-invalid_name"
     assert result[0]["toolSpec"]["description"] == "Invalid name test"
     assert "inputSchema" in result[0]["toolSpec"]
     assert "json" in result[0]["toolSpec"]["inputSchema"]

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -10,10 +10,12 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     BedrockConverseMessagesProcessor,
     BedrockImageProcessor,
     _bedrock_converse_messages_pt,
+    _bedrock_tools_pt,
     _convert_to_bedrock_tool_call_invoke,
     _convert_to_bedrock_tool_call_result,
     anthropic_messages_pt,
     convert_to_gemini_tool_call_result,
+    make_valid_bedrock_tool_name,
     ollama_pt,
     sanitize_messages_for_tool_calling,
 )
@@ -2080,6 +2082,90 @@ def test_bedrock_tool_call_invoke_non_dict_arguments():
     result = _convert_to_bedrock_tool_call_invoke(tool_calls)
     assert len(result) == 1
     assert result[0]["toolUse"]["input"] == {}
+
+
+def test_make_valid_bedrock_tool_name_preserves_hyphens():
+    assert make_valid_bedrock_tool_name("my-tool") == "my-tool"
+    assert (
+        make_valid_bedrock_tool_name(
+            "CreateCaseKnowledgeArticle_foTWsqR6yDt-OnSsvR5e6Q"
+        )
+        == "CreateCaseKnowledgeArticle_foTWsqR6yDt-OnSsvR5e6Q"
+    )
+
+
+def test_bedrock_tool_name_sanitized_consistently_in_tools_and_tool_use():
+    """toolSpec and toolUse names must match after sanitization (issue #5007)."""
+    raw_name = "foo@bar"
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": raw_name,
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    tool_spec_name = _bedrock_tools_pt(tools)[0]["toolSpec"]["name"]
+
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": raw_name, "arguments": "{}"},
+        }
+    ]
+    tool_use_name = _convert_to_bedrock_tool_call_invoke(tool_calls)[0]["toolUse"][
+        "name"
+    ]
+
+    assert tool_spec_name == "foo_bar"
+    assert tool_use_name == tool_spec_name
+
+
+def test_bedrock_converse_messages_pt_tool_use_matches_tool_spec_hyphen_name():
+    """Hyphenated tool names are preserved and consistent in multi-turn history."""
+    tool_name = "my-tool"
+    messages = [
+        {"role": "user", "content": "call the tool"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_hyphen",
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+    translated = _bedrock_converse_messages_pt(
+        messages=messages, model="", llm_provider=""
+    )
+    tool_use_blocks = [
+        block
+        for msg in translated
+        for block in msg.get("content", [])
+        if "toolUse" in block
+    ]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0]["toolUse"]["name"] == tool_name
+
+    tool_spec_name = _bedrock_tools_pt(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "description": "test",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+    )[0]["toolSpec"]["name"]
+    assert tool_spec_name == tool_name
 
 
 def test_bedrock_tool_call_invoke_multiple_normal_tools():


### PR DESCRIPTION
## Summary
- Sanitize `toolUse.name` in message history via `make_valid_bedrock_tool_name` (same as `toolSpec.name`) so multi-turn Bedrock Converse requests no longer send mismatched names like `my_tool` vs `my-tool`.
- Allow hyphens in tool names per current Bedrock pattern `[a-zA-Z0-9_-]+`.
- Sanitize `tool_choice.function.name` for forced tool selection.

## Test plan
- [x] `pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py::test_bedrock_tool_name_sanitized_consistently_in_tools_and_tool_use`
- [x] `pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py::test_bedrock_converse_messages_pt_tool_use_matches_tool_spec_hyphen_name`
- [x] `pytest tests/llm_translation/test_bedrock_completion.py::test_bedrock_tools_pt_invalid_names`

<img width="1137" height="776" alt="image" src="https://github.com/user-attachments/assets/18bf3923-79db-4abb-82b2-e9fb52a69578" />
curl in litellm:
POST Request Sent from LiteLLM:
```
curl -X POST \
https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse \
-H 'Content-Type: application/json' -H 'Authorization: Be****0=' -H 'Content-Length: 636' \
-d '{"messages": [{"role": "user", "content": [{"text": "Use my-tool."}]}, {"role": "assistant", "content": [{"toolUse": {"input": {"location": "Boston"}, "name": "my-tool", "toolUseId": "call_abc123"}}]}, {"role": "user", "content": [{"toolResult": {"content": [{"text": "{\"temperature\": 72}"}], "toolUseId": "call_abc123"}}, {"text": "Summarize."}]}], "additionalModelRequestFields": {}, "system": [], "inferenceConfig": {}, "toolConfig": {"tools": [{"toolSpec": {"inputSchema": {"json": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}, "name": "my-tool", "description": "Example tool"}}]}}'

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Bedrock prompt/transformation changes with added regression tests; no auth, billing, or broad API surface impact.
> 
> **Overview**
> **Bedrock Converse tool naming** is aligned so `toolSpec`, `toolUse`, and forced `tool_choice` all go through the same `make_valid_bedrock_tool_name` normalization—fixing multi-turn failures where history used raw names (e.g. `my-tool`) while definitions used sanitized names (e.g. `my_tool`).
> 
> **Hyphens are kept** in valid names per Bedrock’s `[a-zA-Z][a-zA-Z0-9_-]*` pattern (previously hyphens were turned into underscores). Tests cover hyphen preservation, invalid-character sanitization parity between tools and tool calls, and converse message translation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200a8bd7f50ece3e8d455dc9ee11e74b9f67d58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->