### PR TITLE
feat(arize): route Phoenix traces via per-project TracerProviders

### DIFF
--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -1,5 +1,7 @@
 import os
-from typing import TYPE_CHECKING, Any, Optional, Union
+import threading
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from litellm._logging import verbose_logger
 from litellm.integrations.arize import _utils
@@ -8,8 +10,10 @@ from litellm.types.integrations.arize_phoenix import ArizePhoenixConfig
 
 if TYPE_CHECKING:
     from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SpanProcessor
     from opentelemetry.trace import Span as _Span
     from opentelemetry.trace import SpanKind
+    from opentelemetry.trace import Tracer
 
     from litellm.integrations.opentelemetry import OpenTelemetry as _OpenTelemetry
     from litellm.integrations.opentelemetry import (
@@ -21,20 +25,27 @@ if TYPE_CHECKING:
     OpenTelemetryConfig = _OpenTelemetryConfig
     Span = Union[_Span, Any]
     OpenTelemetry = _OpenTelemetry
+    LITELLM_TRACER_NAME: str
 else:
     Protocol = Any
     OpenTelemetryConfig = Any
     Span = Any
+    Tracer = Any
     TracerProvider = Any
     SpanKind = Any
-    # Import OpenTelemetry at runtime
+    SpanProcessor = Any
     try:
-        from litellm.integrations.opentelemetry import OpenTelemetry
+        from litellm.integrations.opentelemetry import (
+            LITELLM_TRACER_NAME,
+            OpenTelemetry,
+        )
     except ImportError:
+        LITELLM_TRACER_NAME = "litellm"
         OpenTelemetry = None  # type: ignore
 
 
 ARIZE_HOSTED_PHOENIX_ENDPOINT = "https://otlp.arize.com/v1/traces"
+_MAX_PROJECT_PROVIDERS = 64
 
 
 class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
@@ -48,36 +59,141 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
 
     def _init_tracing(self, tracer_provider):
         """
-        Override to always create a *private* TracerProvider for Arize Phoenix.
+        Override to create per-project TracerProviders (LRU-cached) for Arize Phoenix.
 
         The base ``OpenTelemetry._init_tracing`` falls back to the global
         TracerProvider when one already exists.  That causes whichever
         integration initialises second to silently reuse the first one's
         exporter, so spans only reach one destination.
-
-        By creating our own provider we guarantee Arize Phoenix always gets
-        its own exporter pipeline, regardless of initialisation order.
         """
-        from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.trace import SpanKind
 
         if tracer_provider is not None:
-            # Explicitly supplied (e.g. in tests) — honour it.
-            self.tracer = tracer_provider.get_tracer("litellm")
+            self._use_injected_tracer_provider = True
+            self._shared_span_processor = None
+            self.tracer = tracer_provider.get_tracer(LITELLM_TRACER_NAME)
             self.span_kind = SpanKind
             return
 
-        # Always create a dedicated provider — never touch the global one.
-        provider = TracerProvider(resource=self._get_litellm_resource(self.config))
-        provider.add_span_processor(self._get_span_processor())
-        self.tracer = provider.get_tracer("litellm")
+        self._use_injected_tracer_provider = False
+        self._project_providers: OrderedDict[str, TracerProvider] = OrderedDict()
+        self._project_providers_lock = threading.Lock()
+        self._shared_span_processor = self._get_span_processor()
         self.span_kind = SpanKind
+
+        default_project = self._resolve_project_name({})
+        self.tracer = self._get_tracer_for(default_project)
         verbose_logger.debug(
-            "ArizePhoenixLogger: Created dedicated TracerProvider "
-            "(endpoint=%s, exporter=%s)",
+            "ArizePhoenixLogger: Initialized per-project TracerProvider cache "
+            "(default_project=%s, endpoint=%s, exporter=%s)",
+            default_project,
             self.config.endpoint,
             self.config.exporter,
         )
+
+    def flush_tracer_providers(self) -> None:
+        """
+        Flush all cached per-project providers and the shared span processor.
+
+        Call on graceful proxy shutdown. Do not call on LRU eviction — in-flight
+        spans may still reference evicted providers.
+        """
+        if getattr(self, "_use_injected_tracer_provider", False):
+            return
+
+        shared_processor = getattr(self, "_shared_span_processor", None)
+        if shared_processor is not None:
+            try:
+                shared_processor.force_flush()
+            except Exception as e:
+                verbose_logger.debug(
+                    "ArizePhoenixLogger: shared span processor force_flush failed: %s",
+                    e,
+                )
+
+        with getattr(self, "_project_providers_lock", threading.Lock()):
+            providers = list(getattr(self, "_project_providers", {}).values())
+
+        for provider in providers:
+            try:
+                provider.force_flush()
+            except Exception as e:
+                verbose_logger.debug(
+                    "ArizePhoenixLogger: TracerProvider force_flush failed: %s", e
+                )
+
+    def _get_litellm_resource_for_project(self, project_name: str):
+        """
+        Build an OTEL Resource with project routing attrs that win over env detector.
+
+        Phoenix uses ``openinference.project.name``; Arize AX uses ``model_id`` and
+        ``service.name``. Project attrs are merged last so OTEL_RESOURCE_ATTRIBUTES
+        from init does not pin every provider to one project.
+        """
+        from opentelemetry.sdk.resources import OTELResourceDetector, Resource
+
+        project_attributes: dict[str, str] = {
+            "openinference.project.name": project_name,
+            "model_id": project_name,
+            "service.name": project_name,
+        }
+        deployment_environment = getattr(self.config, "deployment_environment", None)
+        if deployment_environment is not None:
+            project_attributes["deployment.environment"] = deployment_environment
+
+        env_resource = OTELResourceDetector().detect()
+        project_resource = Resource.create(project_attributes)  # type: ignore[arg-type]
+        return env_resource.merge(project_resource)
+
+    def _build_tracer_provider_for_project(self, project_name: str) -> TracerProvider:
+        """Create a TracerProvider for *project_name* (caller holds no cache lock)."""
+        from opentelemetry.sdk.trace import TracerProvider
+
+        provider = TracerProvider(
+            resource=self._get_litellm_resource_for_project(project_name)
+        )
+        provider.add_span_processor(self._shared_span_processor)
+        return provider
+
+    def _get_tracer_for(self, project_name: str) -> Tracer:
+        """Return a tracer for *project_name*, creating/caching a provider on miss."""
+        if getattr(self, "_use_injected_tracer_provider", False):
+            return self.tracer
+
+        with self._project_providers_lock:
+            if project_name in self._project_providers:
+                self._project_providers.move_to_end(project_name)
+                return self._project_providers[project_name].get_tracer(
+                    LITELLM_TRACER_NAME
+                )
+
+        # OTELResourceDetector().detect() is synchronous; build outside the lock so
+        # concurrent requests for other projects are not blocked on cache misses.
+        new_provider = self._build_tracer_provider_for_project(project_name)
+
+        with self._project_providers_lock:
+            if project_name in self._project_providers:
+                self._project_providers.move_to_end(project_name)
+                return self._project_providers[project_name].get_tracer(
+                    LITELLM_TRACER_NAME
+                )
+
+            if len(self._project_providers) >= _MAX_PROJECT_PROVIDERS:
+                self._project_providers.popitem(last=False)
+
+            self._project_providers[project_name] = new_provider
+            return new_provider.get_tracer(LITELLM_TRACER_NAME)
+
+    def _resolve_tracer_for_kwargs(self, kwargs: dict) -> Tuple[str, Tracer]:
+        """Resolve project name once and return the matching tracer."""
+        project_name = self._resolve_project_name(kwargs)
+        return project_name, self._get_tracer_for(project_name)
+
+    def get_tracer_to_use_for_request(self, kwargs: dict) -> Tracer:
+        """Route guardrail/raw-request spans to the same per-project tracer as the request."""
+        if getattr(self, "_use_injected_tracer_provider", False):
+            return self.tracer
+        return self._resolve_tracer_for_kwargs(kwargs)[1]
 
     def _init_otel_logger_on_litellm_proxy(self):
         """
@@ -93,56 +209,108 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
 
     @staticmethod
     def set_arize_phoenix_attributes(span: Span, kwargs, response_obj):
-        from litellm.integrations.opentelemetry_utils.base_otel_llm_obs_attributes import (
-            safe_set_attribute,
-        )
-
         _utils.set_attributes(span, kwargs, response_obj, ArizeOTELAttributes)
-
-        # Dynamic project name: check metadata first, then fall back to env var config
-        dynamic_project_name = ArizePhoenixLogger._get_dynamic_project_name(kwargs)
-        if dynamic_project_name:
-            safe_set_attribute(span, "openinference.project.name", dynamic_project_name)
-        else:
-            # Fall back to static config from env var
-            config = ArizePhoenixLogger.get_arize_phoenix_config()
-            if config.project_name:
-                safe_set_attribute(
-                    span, "openinference.project.name", config.project_name
-                )
-
         return
 
     @staticmethod
-    def _get_dynamic_project_name(kwargs) -> Optional[str]:
-        """
-        Retrieve dynamic Phoenix project name from request metadata.
+    def _normalize_project_name(name: Optional[str]) -> Optional[str]:
+        if name is None:
+            return None
+        normalized = str(name).strip()
+        return normalized if normalized else None
 
-        Users can set `metadata.phoenix_project_name` in their request to route
-        traces to different Phoenix projects dynamically.
-        """
-        standard_logging_payload = kwargs.get("standard_logging_object")
-        if isinstance(standard_logging_payload, dict):
-            metadata = standard_logging_payload.get("metadata")
+    @staticmethod
+    def _iter_metadata_dicts_from_kwargs(kwargs: dict):
+        """Yield request metadata dicts; standard_logging_object before litellm_params."""
+        for key in ("standard_logging_object", "litellm_params"):
+            found_key = kwargs.get(key)
+            if not isinstance(found_key, dict):
+                continue
+            metadata = found_key.get("metadata")
             if isinstance(metadata, dict):
-                project_name = metadata.get("phoenix_project_name")
-                if project_name:
-                    return str(project_name)
+                yield metadata
 
-        # Also check litellm_params.metadata for SDK usage
+    @staticmethod
+    def _is_proxy_request(kwargs: dict) -> bool:
+        """True when the call is routed through the LiteLLM proxy."""
         litellm_params = kwargs.get("litellm_params")
-        if isinstance(litellm_params, dict):
-            metadata = litellm_params.get("metadata") or {}
-        else:
-            metadata = {}
-        if isinstance(metadata, dict):
-            project_name = metadata.get("phoenix_project_name")
-            if project_name:
-                return str(project_name)
+        if isinstance(litellm_params, dict) and litellm_params.get(
+            "proxy_server_request"
+        ):
+            return True
 
+        for metadata in ArizePhoenixLogger._iter_metadata_dicts_from_kwargs(kwargs):
+            if isinstance(metadata.get("user_api_key_auth_metadata"), dict):
+                return True
+        return False
+
+    @staticmethod
+    def _project_from_metadata_dict(
+        metadata: dict, metadata_key: str, *, proxy_mode: bool
+    ) -> Optional[str]:
+        """
+        Read a Phoenix project field from proxy/SDK metadata.
+
+        On the proxy, only ``user_api_key_auth_metadata`` (team/key config) may
+        select the project. SDK callers may still set project fields directly on
+        ``metadata``.
+        """
+        auth_metadata = metadata.get("user_api_key_auth_metadata")
+        if isinstance(auth_metadata, dict):
+            project = ArizePhoenixLogger._normalize_project_name(
+                auth_metadata.get(metadata_key)
+            )
+            if project:
+                return project
+
+        if not proxy_mode:
+            return ArizePhoenixLogger._normalize_project_name(
+                metadata.get(metadata_key)
+            )
         return None
 
-    def _get_phoenix_context(self, kwargs):
+    @staticmethod
+    def _metadata_project_from_kwargs(kwargs: dict, metadata_key: str) -> Optional[str]:
+        proxy_mode = ArizePhoenixLogger._is_proxy_request(kwargs)
+        for metadata in ArizePhoenixLogger._iter_metadata_dicts_from_kwargs(kwargs):
+            project = ArizePhoenixLogger._project_from_metadata_dict(
+                metadata, metadata_key, proxy_mode=proxy_mode
+            )
+            if project:
+                return project
+        return None
+
+    @staticmethod
+    def _resolve_project_name(kwargs: dict) -> str:
+        """
+        Resolve the target Phoenix/Arize project for this request.
+
+        Proxy priority: ``user_api_key_auth_metadata.phoenix_project_name_override``,
+        ``user_api_key_auth_metadata.phoenix_project_name``, env, then ``default``.
+        SDK priority: request metadata fields, then env, then ``default``.
+        """
+        override = ArizePhoenixLogger._metadata_project_from_kwargs(
+            kwargs, "phoenix_project_name_override"
+        )
+        if override:
+            return override
+
+        phoenix_name = ArizePhoenixLogger._metadata_project_from_kwargs(
+            kwargs, "phoenix_project_name"
+        )
+        if phoenix_name:
+            return phoenix_name
+
+        env_name = ArizePhoenixLogger._normalize_project_name(
+            os.environ.get("PHOENIX_PROJECT_NAME")
+            or os.environ.get("ARIZE_PROJECT_NAME")
+        )
+        if env_name:
+            return env_name
+
+        return "default"
+
+    def _get_phoenix_context(self, kwargs, tracer: Optional[Tracer] = None):
         """
         Build a trace context for Phoenix's dedicated TracerProvider.
 
@@ -159,11 +327,13 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
         """
         from opentelemetry import trace
 
+        if tracer is None:
+            tracer = self._resolve_tracer_for_kwargs(kwargs)[1]
+
         litellm_params = kwargs.get("litellm_params", {}) or {}
         proxy_server_request = litellm_params.get("proxy_server_request", {}) or {}
         headers = proxy_server_request.get("headers", {}) or {}
 
-        # Propagate distributed trace context if the caller sent a traceparent
         traceparent_ctx = (
             self.get_traceparent_from_header(headers=headers)
             if headers.get("traceparent")
@@ -173,10 +343,8 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
         is_proxy_mode = bool(proxy_server_request)
 
         if is_proxy_mode:
-            # Create a parent span on Phoenix's own tracer so both parent
-            # and child are exported to Phoenix.
             start_time_val = kwargs.get("start_time", kwargs.get("api_call_start_time"))
-            parent_span = self.tracer.start_span(
+            parent_span = tracer.start_span(
                 name="litellm_proxy_request",
                 start_time=(
                     self._to_ns(start_time_val) if start_time_val is not None else None
@@ -187,100 +355,73 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
             ctx = trace.set_span_in_context(parent_span)
             return ctx, parent_span
 
-        # SDK mode — no parent span needed
         return traceparent_ctx, None
 
     def _handle_success(self, kwargs, response_obj, start_time, end_time):
-        """
-        Override to always create spans on ArizePhoenixLogger's dedicated TracerProvider.
+        self._handle_phoenix_trace(
+            kwargs, response_obj, start_time, end_time, success=True
+        )
 
-        The base class's ``_get_span_context`` would find the parent span created by
-        the ``otel`` callback on the *global* TracerProvider.  That span is invisible
-        in Phoenix (different exporter pipeline), so we ignore it and build our own
-        hierarchy via ``_get_phoenix_context``.
-        """
+    def _handle_failure(self, kwargs, response_obj, start_time, end_time):
+        self._handle_phoenix_trace(
+            kwargs, response_obj, start_time, end_time, success=False
+        )
+
+    def _handle_phoenix_trace(
+        self,
+        kwargs,
+        response_obj,
+        start_time,
+        end_time,
+        *,
+        success: bool,
+    ):
         from opentelemetry.trace import Status, StatusCode
 
         verbose_logger.debug(
-            "ArizePhoenixLogger: Logging kwargs: %s, OTEL config settings=%s",
+            "ArizePhoenixLogger: %s - kwargs: %s, OTEL config settings=%s",
+            "success" if success else "failure",
             kwargs,
             self.config,
         )
 
-        ctx, parent_span = self._get_phoenix_context(kwargs)
+        _project_name, tracer = self._resolve_tracer_for_kwargs(kwargs)
+        ctx, parent_span = self._get_phoenix_context(kwargs, tracer=tracer)
 
-        # Create litellm_request span (child of our parent when in proxy mode)
-        span = self.tracer.start_span(
+        status = Status(StatusCode.OK if success else StatusCode.ERROR)
+
+        span = tracer.start_span(
             name=self._get_span_name(kwargs),
             start_time=self._to_ns(start_time),
             context=ctx,
         )
-        span.set_status(Status(StatusCode.OK))
+        span.set_status(status)
         self.set_attributes(span, kwargs, response_obj)
+        if not success:
+            self._record_exception_on_span(span=span, kwargs=kwargs)
 
-        # Raw-request sub-span (if enabled) — must be created before
-        # ending the parent span so the hierarchy is valid.
         self._maybe_log_raw_request(kwargs, response_obj, start_time, end_time, span)
         span.end(end_time=self._to_ns(end_time))
 
-        # Guardrail span
         self._create_guardrail_span(kwargs=kwargs, context=ctx)
 
-        # Annotate and close our proxy parent span
         if parent_span is not None:
-            parent_span.set_status(Status(StatusCode.OK))
+            parent_span.set_status(status)
             self.set_attributes(parent_span, kwargs, response_obj)
+            if not success:
+                self._record_exception_on_span(span=parent_span, kwargs=kwargs)
             parent_span.end(end_time=self._to_ns(end_time))
 
-        # Metrics & cost recording
         self._record_metrics(kwargs, response_obj, start_time, end_time)
 
-        # Semantic logs
         if self.config.enable_events:
             self._emit_semantic_logs(kwargs, response_obj, span)
-
-    def _handle_failure(self, kwargs, response_obj, start_time, end_time):
-        """
-        Override to always create failure spans on ArizePhoenixLogger's dedicated
-        TracerProvider.  Mirrors ``_handle_success`` but sets ERROR status.
-        """
-        from opentelemetry.trace import Status, StatusCode
-
-        verbose_logger.debug(
-            "ArizePhoenixLogger: Failure - Logging kwargs: %s, OTEL config settings=%s",
-            kwargs,
-            self.config,
-        )
-
-        ctx, parent_span = self._get_phoenix_context(kwargs)
-
-        # Create litellm_request span (child of our parent when in proxy mode)
-        span = self.tracer.start_span(
-            name=self._get_span_name(kwargs),
-            start_time=self._to_ns(start_time),
-            context=ctx,
-        )
-        span.set_status(Status(StatusCode.ERROR))
-        self.set_attributes(span, kwargs, response_obj)
-        self._record_exception_on_span(span=span, kwargs=kwargs)
-        span.end(end_time=self._to_ns(end_time))
-
-        # Guardrail span
-        self._create_guardrail_span(kwargs=kwargs, context=ctx)
-
-        # Annotate and close our proxy parent span
-        if parent_span is not None:
-            parent_span.set_status(Status(StatusCode.ERROR))
-            self.set_attributes(parent_span, kwargs, response_obj)
-            self._record_exception_on_span(span=parent_span, kwargs=kwargs)
-            parent_span.end(end_time=self._to_ns(end_time))
 
     @staticmethod
     def get_arize_phoenix_config() -> ArizePhoenixConfig:
         """
         Retrieves the Arize Phoenix configuration based on environment variables.
         Returns:
-            ArizePhoenixConfig: A Pydantic model containing Arize Phoenix configuration.
         """
         api_key = os.environ.get("PHOENIX_API_KEY", None)
 
@@ -295,18 +436,15 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
         protocol: Protocol = "otlp_http"
 
         if collector_endpoint:
-            # Parse the endpoint to determine protocol
             if collector_endpoint.startswith("grpc://") or (
                 ":4317" in collector_endpoint and "/v1/traces" not in collector_endpoint
             ):
                 endpoint = collector_endpoint
                 protocol = "otlp_grpc"
             else:
-                # Phoenix Cloud endpoints (app.phoenix.arize.com) include the space in the URL
                 if "app.phoenix.arize.com" in collector_endpoint:
                     endpoint = collector_endpoint
                     protocol = "otlp_http"
-                # For other HTTP endpoints, ensure they have the correct path
                 elif "/v1/traces" not in collector_endpoint:
                     if collector_endpoint.endswith("/v1"):
                         endpoint = collector_endpoint + "/traces"
@@ -318,7 +456,6 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
                     endpoint = collector_endpoint
                 protocol = "otlp_http"
         else:
-            # If no endpoint specified, self hosted phoenix
             endpoint = "http://localhost:6006/v1/traces"
             protocol = "otlp_http"
             verbose_logger.debug(
@@ -329,12 +466,11 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
         if api_key is not None:
             otlp_auth_headers = f"Authorization=Bearer {api_key}"
         elif "app.phoenix.arize.com" in endpoint:
-            # Phoenix Cloud requires an API key
             raise ValueError(
                 "PHOENIX_API_KEY must be set when using Phoenix Cloud (app.phoenix.arize.com)."
             )
 
-        project_name = os.environ.get("PHOENIX_PROJECT_NAME", "default")
+        project_name = os.environ.get("PHOENIX_PROJECT_NAME") or "default"
 
         return ArizePhoenixConfig(
             otlp_auth_headers=otlp_auth_headers,
@@ -342,8 +478,6 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
             endpoint=endpoint,
             project_name=project_name,
         )
-
-    ## cannot suppress additional proxy server spans, removed previous methods.
 
     async def async_health_check(self):
         config = self.get_arize_phoenix_config()

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3905,31 +3905,6 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 endpoint=arize_phoenix_config.endpoint,
                 headers=arize_phoenix_config.otlp_auth_headers,
             )
-            if arize_phoenix_config.project_name:
-                existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
-                # Add openinference.project.name attribute
-                if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
-                    )
-                else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={arize_phoenix_config.project_name}"
-                    )
-
-            # Set Phoenix project name from environment variable
-            phoenix_project_name = os.environ.get("PHOENIX_PROJECT_NAME", None)
-            if phoenix_project_name:
-                existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
-                # Add openinference.project.name attribute
-                if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={phoenix_project_name}"
-                    )
-                else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={phoenix_project_name}"
-                    )
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -213,6 +213,7 @@ _EXTRA_BANNED_OBSERVABILITY_PARAMS: FrozenSet[str] = frozenset(
     {
         "posthog_api_url",
         "phoenix_project_name",
+        "phoenix_project_name_override",
         "wandb_api_key",
         "weave_project_id",
     }

--- a/tests/test_litellm/integrations/arize/test_arize_phoenix.py
+++ b/tests/test_litellm/integrations/arize/test_arize_phoenix.py
@@ -7,7 +7,6 @@ from litellm.integrations.arize.arize_phoenix import (
     ArizePhoenixConfig,
     ArizePhoenixLogger,
 )
-from litellm.integrations.arize._utils import ArizeOTELAttributes
 
 
 class TestArizePhoenixConfig(unittest.TestCase):
@@ -217,44 +216,147 @@ def test_get_arize_phoenix_config_expection_on_missing_api_key(monkeypatch, env_
 
 
 # ---------------------------------------------------------------------------
-# Dynamic project naming from metadata
+# Per-project routing via Resource (not span attributes)
 # ---------------------------------------------------------------------------
 
 
-class TestGetDynamicProjectName:
-    """Tests for _get_dynamic_project_name extraction logic."""
+class TestResolveProjectName:
+    """Tests for _resolve_project_name priority chain."""
 
-    def test_extracts_from_standard_logging_object_metadata(self):
+    def test_extracts_phoenix_name_from_standard_logging_object_metadata(self):
         kwargs = {
             "standard_logging_object": {
                 "metadata": {"phoenix_project_name": "my-project"},
             }
         }
-        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) == "my-project"
+        assert ArizePhoenixLogger._resolve_project_name(kwargs) == "my-project"
 
-    def test_extracts_from_litellm_params_metadata(self):
+    def test_extracts_phoenix_name_from_litellm_params_metadata(self):
         kwargs = {
             "litellm_params": {
                 "metadata": {"phoenix_project_name": "sdk-project"},
             }
         }
-        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) == "sdk-project"
+        assert ArizePhoenixLogger._resolve_project_name(kwargs) == "sdk-project"
 
-    def test_returns_none_when_no_metadata(self):
-        assert ArizePhoenixLogger._get_dynamic_project_name({}) is None
+    @patch.dict("os.environ", {"PHOENIX_PROJECT_NAME": "env-project"}, clear=False)
+    def test_falls_back_to_phoenix_env_when_no_metadata(self):
+        assert ArizePhoenixLogger._resolve_project_name({}) == "env-project"
+
+    @patch.dict(
+        "os.environ",
+        {"ARIZE_PROJECT_NAME": "arize-env", "PHOENIX_PROJECT_NAME": ""},
+        clear=False,
+    )
+    def test_falls_back_to_arize_env_when_phoenix_unset(self):
+        assert ArizePhoenixLogger._resolve_project_name({}) == "arize-env"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_falls_back_to_default_when_no_metadata_or_env(self):
+        assert ArizePhoenixLogger._resolve_project_name({}) == "default"
+
+    def test_phoenix_override_beats_phoenix_metadata(self):
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "phoenix_project_name_override": "override-proj",
+                    "phoenix_project_name": "phoenix-proj",
+                },
+            }
+        }
+        assert ArizePhoenixLogger._resolve_project_name(kwargs) == "override-proj"
+
+    def test_whitespace_only_metadata_falls_through_to_default(self):
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {"phoenix_project_name_override": "   "},
+            }
+        }
+        with patch.dict("os.environ", {}, clear=True):
+            assert ArizePhoenixLogger._resolve_project_name(kwargs) == "default"
+
+    def test_strips_whitespace_from_project_name(self):
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {"phoenix_project_name": "  trimmed  "},
+            }
+        }
+        assert ArizePhoenixLogger._resolve_project_name(kwargs) == "trimmed"
 
     def test_non_dict_standard_logging_object_does_not_raise(self):
-        """isinstance(dict) guard prevents AttributeError on non-dict payloads."""
         kwargs = {"standard_logging_object": "not-a-dict"}
-        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) is None
+        with patch.dict("os.environ", {}, clear=True):
+            assert ArizePhoenixLogger._resolve_project_name(kwargs) == "default"
+
+    def test_resolves_override_from_user_api_key_auth_metadata(self):
+        kwargs = {
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name_override": "claude-code",
+                    },
+                },
+            },
+        }
+        with patch.dict("os.environ", {}, clear=True):
+            assert ArizePhoenixLogger._resolve_project_name(kwargs) == "claude-code"
+
+    def test_resolves_phoenix_name_from_user_api_key_auth_metadata(self):
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project",
+                    },
+                },
+            },
+        }
+        with patch.dict("os.environ", {}, clear=True):
+            assert ArizePhoenixLogger._resolve_project_name(kwargs) == "team-project"
+
+    def test_proxy_ignores_client_metadata_when_auth_metadata_set(self):
+        kwargs = {
+            "litellm_params": {
+                "proxy_server_request": {
+                    "url": "/v1/chat/completions",
+                    "method": "POST",
+                    "headers": {},
+                },
+                "metadata": {
+                    "phoenix_project_name_override": "attacker-project",
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name_override": "team-project",
+                    },
+                },
+            },
+        }
+        with patch.dict("os.environ", {}, clear=True):
+            assert ArizePhoenixLogger._resolve_project_name(kwargs) == "team-project"
+
+    def test_proxy_without_auth_metadata_falls_back_to_env(self):
+        kwargs = {
+            "litellm_params": {
+                "proxy_server_request": {
+                    "url": "/v1/chat/completions",
+                    "method": "POST",
+                    "headers": {},
+                },
+                "metadata": {"phoenix_project_name": "attacker-project"},
+            },
+        }
+        with patch.dict(
+            "os.environ", {"PHOENIX_PROJECT_NAME": "env-project"}, clear=True
+        ):
+            assert ArizePhoenixLogger._resolve_project_name(kwargs) == "env-project"
 
 
-class TestDynamicProjectNameOnSpan:
-    """set_arize_phoenix_attributes sets openinference.project.name on the span."""
+class TestProjectNameNotOnSpan:
+    """Project routing uses Resource on TracerProvider, not span attributes."""
 
-    @patch.dict("os.environ", {"PHOENIX_PROJECT_NAME": "env-fallback"}, clear=False)
     @patch("litellm.integrations.arize._utils.set_attributes")
-    def test_dynamic_name_sets_span_attribute(self, _mock_set_attrs):
+    def test_set_arize_phoenix_attributes_does_not_set_project_on_span(
+        self, _mock_set_attrs
+    ):
         span = MagicMock()
         kwargs = {
             "standard_logging_object": {
@@ -263,19 +365,467 @@ class TestDynamicProjectNameOnSpan:
         }
         ArizePhoenixLogger.set_arize_phoenix_attributes(span, kwargs, response_obj=None)
 
-        span.set_attribute.assert_called_once_with(
-            "openinference.project.name", "dynamic-proj"
+        for call in span.set_attribute.call_args_list:
+            assert call[0][0] != "openinference.project.name"
+
+
+class TestPerProjectTracerProviderCache:
+    """Spans for different projects use different Resources on export."""
+
+    def test_different_metadata_routes_to_different_resource(self):
+        from datetime import datetime
+
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
         )
 
-    @patch.dict("os.environ", {"PHOENIX_PROJECT_NAME": "env-project"}, clear=False)
-    @patch("litellm.integrations.arize._utils.set_attributes")
-    def test_falls_back_to_env_var_when_no_dynamic_name(self, _mock_set_attrs):
-        span = MagicMock()
-        ArizePhoenixLogger.set_arize_phoenix_attributes(span, {}, response_obj=None)
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
 
-        span.set_attribute.assert_called_once_with(
-            "openinference.project.name", "env-project"
+        exporter = InMemorySpanExporter()
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=exporter),
+            callback_name="arize_phoenix",
         )
+
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 1)
+
+        logger._handle_success(
+            {
+                "standard_logging_object": {
+                    "metadata": {"phoenix_project_name": "project-a"},
+                },
+            },
+            response_obj={},
+            start_time=start,
+            end_time=end,
+        )
+        logger._handle_success(
+            {
+                "standard_logging_object": {
+                    "metadata": {"phoenix_project_name": "project-b"},
+                },
+            },
+            response_obj={},
+            start_time=start,
+            end_time=end,
+        )
+
+        spans = exporter.get_finished_spans()
+        project_names = {
+            s.resource.attributes.get("openinference.project.name") for s in spans
+        }
+        assert "project-a" in project_names
+        assert "project-b" in project_names
+
+    def test_shared_span_processor_created_once_at_init(self):
+        from litellm.integrations.opentelemetry import (
+            OpenTelemetry,
+            OpenTelemetryConfig,
+        )
+
+        mock_processor = MagicMock()
+        with patch.object(
+            OpenTelemetry, "_get_span_processor", return_value=mock_processor
+        ) as mock_get_processor:
+            logger = ArizePhoenixLogger(
+                config=OpenTelemetryConfig(exporter=MagicMock()),
+                callback_name="arize_phoenix",
+            )
+            assert mock_get_processor.call_count == 1
+            assert logger._shared_span_processor is mock_processor
+
+            logger._project_providers.clear()
+            logger._get_tracer_for("project-a")
+            logger._get_tracer_for("project-b")
+            assert mock_get_processor.call_count == 1
+
+    def test_lru_eviction_does_not_shutdown_provider(self):
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=MagicMock()),
+            callback_name="arize_phoenix",
+        )
+        logger._project_providers.clear()
+
+        logger._get_tracer_for("project-0")
+        evicted_provider = logger._project_providers["project-0"]
+        shutdown_mock = MagicMock()
+        evicted_provider.shutdown = shutdown_mock  # type: ignore[method-assign]
+
+        for i in range(1, 65):
+            logger._get_tracer_for(f"project-{i}")
+
+        assert len(logger._project_providers) == 64
+        assert "project-0" not in logger._project_providers
+        assert "project-64" in logger._project_providers
+        shutdown_mock.assert_not_called()
+
+    def test_flush_tracer_providers_force_flushes_shared_processor(self):
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=MagicMock()),
+            callback_name="arize_phoenix",
+        )
+        mock_processor = MagicMock()
+        logger._shared_span_processor = mock_processor
+        mock_provider = MagicMock()
+        logger._project_providers["proj"] = mock_provider
+
+        logger.flush_tracer_providers()
+
+        mock_processor.force_flush.assert_called_once()
+        mock_provider.force_flush.assert_called_once()
+
+
+class TestGetLitellmResourceForProject:
+    """Resource attrs used by Phoenix OSS and Arize AX for project routing."""
+
+    def test_project_attrs_win_over_otel_resource_attributes_env(self):
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=MagicMock()),
+            callback_name="arize_phoenix",
+        )
+
+        with patch.dict(
+            "os.environ",
+            {
+                "OTEL_RESOURCE_ATTRIBUTES": "openinference.project.name=env-pinned,model_id=env-model"
+            },
+            clear=False,
+        ):
+            resource = logger._get_litellm_resource_for_project("dynamic-proj")
+
+        assert resource.attributes["openinference.project.name"] == "dynamic-proj"
+        assert resource.attributes["model_id"] == "dynamic-proj"
+        assert resource.attributes["service.name"] == "dynamic-proj"
+
+    @patch.dict("os.environ", {"OTEL_DEPLOYMENT_ENVIRONMENT": "staging"}, clear=False)
+    def test_preserves_deployment_environment_from_config(self):
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(
+                exporter=MagicMock(), deployment_environment="staging"
+            ),
+            callback_name="arize_phoenix",
+        )
+        resource = logger._get_litellm_resource_for_project("my-proj")
+        assert resource.attributes.get("deployment.environment") == "staging"
+
+
+class TestTracerResolutionAndCache:
+    """_resolve_tracer_for_kwargs, get_tracer_to_use_for_request, provider cache."""
+
+    def test_get_tracer_to_use_for_request_matches_resolve_tracer(self):
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=MagicMock()),
+            callback_name="arize_phoenix",
+        )
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {"phoenix_project_name": "same-proj"},
+            }
+        }
+        project_name, _ = logger._resolve_tracer_for_kwargs(kwargs)
+        tracer_from_request = logger.get_tracer_to_use_for_request(kwargs)
+        assert project_name == "same-proj"
+        assert "same-proj" in logger._project_providers
+        assert logger._resolve_project_name(kwargs) == project_name
+        assert tracer_from_request is not None
+
+    def test_cache_reuses_provider_for_same_project(self):
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=MagicMock()),
+            callback_name="arize_phoenix",
+        )
+        logger._project_providers.clear()
+
+        logger._get_tracer_for("cached-proj")
+        provider_first = logger._project_providers["cached-proj"]
+
+        logger._get_tracer_for("cached-proj")
+        provider_second = logger._project_providers["cached-proj"]
+
+        assert provider_first is provider_second
+        assert len(logger._project_providers) == 1
+
+    def test_parallel_cache_miss_for_same_project_inserts_once(self):
+        import threading
+
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=MagicMock()),
+            callback_name="arize_phoenix",
+        )
+        logger._project_providers.clear()
+
+        build_calls: list[str] = []
+        real_build = logger._build_tracer_provider_for_project
+
+        def tracking_build(project_name: str):
+            build_calls.append(project_name)
+            return real_build(project_name)
+
+        barrier = threading.Barrier(10)
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                logger._get_tracer_for("race-proj")
+            except Exception as exc:
+                errors.append(exc)
+
+        with patch.object(
+            logger,
+            "_build_tracer_provider_for_project",
+            side_effect=tracking_build,
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(10)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert not errors
+        assert len(logger._project_providers) == 1
+        assert "race-proj" in logger._project_providers
+        assert len(build_calls) >= 1
+
+    def test_injected_tracer_provider_bypasses_project_cache(self):
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=exporter),
+            callback_name="arize_phoenix",
+            tracer_provider=provider,
+        )
+
+        assert getattr(logger, "_use_injected_tracer_provider", False) is True
+        assert not hasattr(logger, "_project_providers") or not getattr(
+            logger, "_project_providers", None
+        )
+
+        tracer_a = logger._get_tracer_for("any-project")
+        tracer_b = logger.get_tracer_to_use_for_request(
+            {"standard_logging_object": {"metadata": {"phoenix_project_name": "x"}}}
+        )
+        assert tracer_a is logger.tracer
+        assert tracer_b is logger.tracer
+
+    def test_flush_tracer_providers_noop_for_injected_provider(self):
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=exporter),
+            callback_name="arize_phoenix",
+            tracer_provider=provider,
+        )
+        logger.flush_tracer_providers()
+        exporter.shutdown()
+
+    def test_standard_logging_metadata_wins_over_litellm_params(self):
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {"phoenix_project_name_override": "from-logging"},
+            },
+            "litellm_params": {
+                "metadata": {"phoenix_project_name_override": "from-params"},
+            },
+        }
+        assert ArizePhoenixLogger._resolve_project_name(kwargs) == "from-logging"
+
+
+class TestPhoenixTraceHandling:
+    """_handle_success / _handle_failure span export behavior."""
+
+    def test_handle_failure_sets_error_status_on_request_span(self):
+        from datetime import datetime
+
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+        from opentelemetry.trace import StatusCode
+
+        from litellm.integrations.opentelemetry import (
+            LITELLM_REQUEST_SPAN_NAME,
+            OpenTelemetryConfig,
+        )
+
+        exporter = InMemorySpanExporter()
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=exporter),
+            callback_name="arize_phoenix",
+        )
+
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 1)
+
+        logger._handle_failure(
+            {
+                "standard_logging_object": {
+                    "metadata": {"phoenix_project_name": "fail-proj"},
+                },
+                "exception": Exception("boom"),
+            },
+            response_obj=None,
+            start_time=start,
+            end_time=end,
+        )
+
+        spans = exporter.get_finished_spans()
+        request_spans = [s for s in spans if s.name == LITELLM_REQUEST_SPAN_NAME]
+        assert len(request_spans) == 1
+        assert request_spans[0].status.status_code == StatusCode.ERROR
+        assert (
+            request_spans[0].resource.attributes.get("openinference.project.name")
+            == "fail-proj"
+        )
+
+    def test_proxy_mode_parent_and_child_share_trace_id(self):
+        from datetime import datetime
+
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from litellm.integrations.opentelemetry import (
+            LITELLM_REQUEST_SPAN_NAME,
+            OpenTelemetryConfig,
+        )
+
+        exporter = InMemorySpanExporter()
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=exporter),
+            callback_name="arize_phoenix",
+        )
+
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 1)
+
+        logger._handle_success(
+            {
+                "litellm_params": {
+                    "proxy_server_request": {
+                        "url": "/chat/completions",
+                        "method": "POST",
+                        "headers": {},
+                    },
+                    "metadata": {
+                        "user_api_key_auth_metadata": {
+                            "phoenix_project_name_override": "proxy-proj",
+                        },
+                    },
+                },
+            },
+            response_obj={},
+            start_time=start,
+            end_time=end,
+        )
+
+        spans = exporter.get_finished_spans()
+        span_names = {s.name for s in spans}
+        assert "litellm_proxy_request" in span_names
+        assert LITELLM_REQUEST_SPAN_NAME in span_names
+
+        trace_ids = {s.context.trace_id for s in spans}
+        assert len(trace_ids) == 1
+        for span in spans:
+            assert (
+                span.resource.attributes.get("openinference.project.name")
+                == "proxy-proj"
+            )
+
+    def test_override_routes_all_spans_to_one_project_in_single_request(self):
+        from datetime import datetime
+
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from litellm.integrations.opentelemetry import OpenTelemetryConfig
+
+        exporter = InMemorySpanExporter()
+        logger = ArizePhoenixLogger(
+            config=OpenTelemetryConfig(exporter=exporter),
+            callback_name="arize_phoenix",
+        )
+
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 1)
+
+        logger._handle_success(
+            {
+                "standard_logging_object": {
+                    "metadata": {
+                        "user_api_key_auth_metadata": {
+                            "phoenix_project_name_override": "unified-proj",
+                        },
+                    },
+                },
+                "litellm_params": {
+                    "proxy_server_request": {
+                        "url": "/v1/chat/completions",
+                        "method": "POST",
+                        "headers": {},
+                    },
+                },
+            },
+            response_obj={"id": "resp-1"},
+            start_time=start,
+            end_time=end,
+        )
+
+        for span in exporter.get_finished_spans():
+            assert (
+                span.resource.attributes.get("openinference.project.name")
+                == "unified-proj"
+            )
+            assert span.resource.attributes.get("model_id") == "unified-proj"
+
+
+class TestGetArizePhoenixConfigProjectName:
+    @patch.dict(
+        "os.environ", {"PHOENIX_PROJECT_NAME": "phoenix-config-proj"}, clear=True
+    )
+    def test_project_name_from_phoenix_env(self):
+        config = ArizePhoenixLogger.get_arize_phoenix_config()
+        assert config.project_name == "phoenix-config-proj"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_project_name_defaults_when_env_unset(self):
+        config = ArizePhoenixLogger.get_arize_phoenix_config()
+        assert config.project_name == "default"
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -1644,6 +1644,7 @@ class TestObservabilityCallbackBans:
             "braintrust_api_key",
             "braintrust_project",
             "phoenix_project_name",
+            "phoenix_project_name_override",
             "wandb_api_key",
             "weave_project_id",
             "gcs_bucket_name",
@@ -1675,6 +1676,7 @@ class TestObservabilityCallbackBans:
             "posthog_api_url",
             "braintrust_project",
             "phoenix_project_name",
+            "phoenix_project_name_override",
         ],
     )
     def test_observability_field_in_metadata_dict_is_rejected(


### PR DESCRIPTION
## Summary

Reopens and rewrites [#28439](https://github.com/BerriAI/litellm/pull/28439) with the security feedback addressed.

- Route Arize Phoenix traces using **per-project LRU-cached `TracerProvider`s** with project-scoped OTEL `Resource` attributes (`openinference.project.name`, `model_id`, `service.name`) instead of span-level overrides.
- Resolve project names from **`user_api_key_auth_metadata`** (team/key config on the proxy) so admins can assign Phoenix projects per team or virtual key.
- **Do not allow client-supplied** `metadata.phoenix_project_name` / `metadata.phoenix_project_name_override` on the proxy — those fields remain on the request-body ban list so callers cannot redirect traces into arbitrary Phoenix projects.
- SDK (non-proxy) callers can still set project fields directly in `litellm_params.metadata`.
- Remove init-time mutation of `OTEL_RESOURCE_ATTRIBUTES` in `litellm_logging.py` (project routing is now per-provider).

## Security change vs #28439

The prior PR allowed client metadata to override team/key routing (flagged by veria-ai). This version only reads project routing from `user_api_key_auth_metadata` when the request is proxy-scoped; direct client metadata is ignored in that mode and blocked at the auth gate.

Configure routing on teams/keys, e.g.:

```json
{
  "metadata": {
    "phoenix_project_name_override": "my-team-project"
  }
}
```

## Test plan

- [x] `uv run pytest tests/test_litellm/integrations/arize/test_arize_phoenix.py -v`
- [x] `uv run pytest tests/test_litellm/proxy/auth/test_auth_utils.py -v`
- [ ] Manual QA: assign `phoenix_project_name_override` on a team/key and confirm traces land in the expected Phoenix project

## Proof

Manual QA from the original PR: https://www.loom.com/share/36861e84cf8f4107bc7f066f1bedf782

## Type

🆕 New Feature
🐛 Bug Fix


Made with [Cursor](https://cursor.com)