### PR TITLE
fix(otel): add litellm_metadata fallback to fix broken span hierarchy on /v1/messages

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -763,8 +763,15 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         """
         from opentelemetry import trace as _trace
 
+        # Guardrail info may be in "metadata" or "litellm_metadata" depending
+        # on the endpoint (see LITELLM_METADATA_ROUTES).
         metadata = (request_data or {}).get("metadata") or {}
         guardrail_information = metadata.get("standard_logging_guardrail_information")
+        if not guardrail_information:
+            metadata = (request_data or {}).get("litellm_metadata") or {}
+            guardrail_information = metadata.get(
+                "standard_logging_guardrail_information"
+            )
         if not guardrail_information:
             return
 
@@ -982,6 +989,14 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         litellm_params = kwargs.get("litellm_params", {}) or {}
         _metadata = litellm_params.get("metadata", {}) or {}
         proxy_span = _metadata.get("litellm_parent_otel_span", None)
+
+        # Fallback to litellm_metadata for /v1/messages and other
+        # LITELLM_METADATA_ROUTES where the span is stored under a
+        # different key.  Fixes: https://github.com/BerriAI/litellm/issues/27934
+        if proxy_span is None:
+            _litellm_metadata = litellm_params.get("litellm_metadata", {}) or {}
+            proxy_span = _litellm_metadata.get("litellm_parent_otel_span", None)
+
         if (
             proxy_span is not None
             and getattr(proxy_span, "name", None) == LITELLM_PROXY_REQUEST_SPAN_NAME
@@ -2609,6 +2624,15 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         traceparent = headers.get("traceparent", None)
         _metadata = litellm_params.get("metadata", {}) or {}
         parent_otel_span = _metadata.get("litellm_parent_otel_span", None)
+
+        # On /v1/messages and other LITELLM_METADATA_ROUTES the parent span
+        # is stored under litellm_params["litellm_metadata"] instead of
+        # litellm_params["metadata"].  If the primary lookup missed, check
+        # the alternative key so the span hierarchy stays intact.
+        # Fixes: https://github.com/BerriAI/litellm/issues/27934
+        if parent_otel_span is None:
+            _litellm_metadata = litellm_params.get("litellm_metadata", {}) or {}
+            parent_otel_span = _litellm_metadata.get("litellm_parent_otel_span", None)
 
         # Priority 1: Explicit parent span from metadata
         if parent_otel_span is not None:

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1262,7 +1262,6 @@ class TestOpenTelemetry(unittest.TestCase):
             ) as mock_get_headers,
             patch.object(otel, "_get_tracer_with_dynamic_headers") as mock_get_tracer,
         ):
-
             # Test case 1: With dynamic headers
             mock_get_headers.return_value = {
                 "arize-space-id": "test-space",
@@ -2642,7 +2641,7 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
                 # Verify parent span is still recording after each call
                 self.assertTrue(
                     parent_span.is_recording(),
-                    f"External span should still be recording after completion #{i+1}",
+                    f"External span should still be recording after completion #{i + 1}",
                 )
 
         # Verify all spans have the same trace_id
@@ -5142,3 +5141,160 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
         span, exp = self._span()
         otel.set_preprocessing_duration_attribute(span, None)
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
+
+
+class TestGetSpanContextLitellmMetadataFallback(unittest.TestCase):
+    """
+    Tests for _get_span_context() falling back to litellm_metadata.
+
+    On /v1/messages (Anthropic Messages API) and other LITELLM_METADATA_ROUTES,
+    litellm_parent_otel_span is stored in litellm_params["litellm_metadata"]
+    instead of litellm_params["metadata"].  _get_span_context() must check
+    both locations.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/27934
+    """
+
+    def test_fallback_to_litellm_metadata(self):
+        """When metadata has no span but litellm_metadata does, use it."""
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        parent_span = tracer.start_span("proxy-parent")
+
+        otel = OpenTelemetry()
+        kwargs = {
+            "litellm_params": {
+                "metadata": {},  # no span here
+                "litellm_metadata": {
+                    "litellm_parent_otel_span": parent_span,
+                },
+            },
+        }
+
+        ctx, _ = otel._get_span_context(kwargs)
+        self.assertIsNotNone(ctx)
+        parent_span.end()
+
+    def test_primary_metadata_still_preferred(self):
+        """When metadata has the span, litellm_metadata is not checked."""
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        primary_span = tracer.start_span("primary")
+        fallback_span = tracer.start_span("fallback")
+
+        otel = OpenTelemetry()
+        kwargs = {
+            "litellm_params": {
+                "metadata": {
+                    "litellm_parent_otel_span": primary_span,
+                },
+                "litellm_metadata": {
+                    "litellm_parent_otel_span": fallback_span,
+                },
+            },
+        }
+
+        ctx, _ = otel._get_span_context(kwargs)
+        self.assertIsNotNone(ctx)
+        # Context should contain the primary span, not the fallback
+        from opentelemetry import trace
+
+        span_from_ctx = trace.get_current_span(ctx)
+        self.assertIs(span_from_ctx, primary_span)
+        primary_span.end()
+        fallback_span.end()
+
+    def test_no_span_in_either_metadata(self):
+        """When neither metadata dict has the span, fall through."""
+        otel = OpenTelemetry()
+        kwargs = {
+            "litellm_params": {
+                "metadata": {},
+                "litellm_metadata": {},
+            },
+        }
+        ctx, span = otel._get_span_context(kwargs)
+        # Should not crash; returns some context (possibly None/default)
+        # The important thing is no exception is raised
+
+
+class TestEndProxySpanLitellmMetadataFallback(unittest.TestCase):
+    """
+    Tests for _end_proxy_span_from_kwargs() falling back to litellm_metadata.
+    """
+
+    def test_end_proxy_span_from_litellm_metadata(self):
+        """Proxy span in litellm_metadata should be found and closed."""
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        proxy_span = tracer.start_span("Received Proxy Server Request")
+
+        otel = OpenTelemetry()
+        kwargs = {
+            "litellm_params": {
+                "metadata": {},  # no span here
+                "litellm_metadata": {
+                    "litellm_parent_otel_span": proxy_span,
+                },
+            },
+        }
+        otel._end_proxy_span_from_kwargs(kwargs, datetime.now())
+        # Span should have been ended
+        self.assertFalse(proxy_span.is_recording())
+
+
+class TestEmitGuardrailSpansLitellmMetadataFallback(unittest.TestCase):
+    """
+    Tests for _emit_guardrail_spans_from_request_data() checking
+    litellm_metadata when metadata has no guardrail information.
+    """
+
+    def test_guardrail_info_from_litellm_metadata(self):
+        """Guardrail info in litellm_metadata should be found."""
+        otel = OpenTelemetry()
+        otel.tracer = MagicMock()
+        mock_span = MagicMock()
+        otel.tracer.start_span = MagicMock(return_value=mock_span)
+
+        request_data = {
+            "metadata": {},  # no guardrail info here
+            "litellm_metadata": {
+                "standard_logging_guardrail_information": [
+                    {
+                        "guardrail_name": "test-guard",
+                        "guardrail_mode": "pre_call",
+                        "start_time": 1000.0,
+                        "end_time": 1001.0,
+                    }
+                ],
+            },
+        }
+
+        otel._emit_guardrail_spans_from_request_data(
+            request_data=request_data, parent_span=None
+        )
+
+        # Should have called _create_guardrail_span (via the constructed kwargs)
+        # which uses the tracer to start a span
+        self.assertTrue(otel.tracer.start_span.called)


### PR DESCRIPTION
## Summary

Fixes #27934

On `/v1/messages` and other `LITELLM_METADATA_ROUTES`, `litellm_parent_otel_span` is stored in `litellm_params["litellm_metadata"]` instead of `litellm_params["metadata"]`. When the Anthropic request body contains a native `metadata` field (e.g. `{"user_id": "..."}`), `litellm_params["metadata"]` gets overwritten with that native metadata and the parent OTel span is lost — resulting in orphaned root spans with different `trace_id`s.

This PR adds fallback checks to `litellm_metadata` in three methods:

| Method | What changed |
|--------|-------------|
| `_get_span_context()` | Fallback to `litellm_params["litellm_metadata"]` when `litellm_parent_otel_span` not found in `litellm_params["metadata"]` |
| `_end_proxy_span_from_kwargs()` | Same fallback so the proxy span gets closed on the success path |
| `_emit_guardrail_spans_from_request_data()` | Check `litellm_metadata` for guardrail info on LITELLM_METADATA_ROUTES |

## Changes

- `litellm/integrations/opentelemetry.py` — 24 lines added (3 fallback checks)
- `tests/test_litellm/integrations/test_opentelemetry.py` — 6 new unit tests

## Testing

```bash
uv run pytest tests/test_litellm/integrations/test_opentelemetry.py -x -vv
# 226 passed
```

### Local Jaeger verification

Ran litellm proxy locally with OTel exporting to Jaeger. Sent `/v1/messages` requests with native `metadata` field in the request body.

**Before:** Spans have different `trace_id`s — orphaned hierarchy.  
**After:** All spans share the same `trace_id` with correct parent-child nesting:

```
Received Proxy Server Request
  ├── auth                          [OK]
  ├── proxy_pre_call                [OK]
  └── litellm_request               [OK]
       └── raw_gen_ai_request       [OK]
```