### PR TITLE
feat: updated openrouter provider to map max level to xhigh

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -55,6 +55,10 @@ class OpenrouterConfig(OpenAIGPTConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
+        # OpenRouter expects "xhigh" instead of "max" for reasoning_effort.
+        if non_default_params.get("reasoning_effort") == "max":
+            non_default_params = {**non_default_params, "reasoning_effort": "xhigh"}
+
         mapped_openai_params = super().map_openai_params(
             non_default_params, optional_params, model, drop_params
         )

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -553,3 +553,68 @@ def test_openrouter_non_reasoning_models_do_not_add_reasoning_effort():
     )
 
     assert "reasoning_effort" not in supported_params
+
+
+def test_openrouter_reasoning_effort_max_maps_to_xhigh():
+    """
+    OpenRouter expects 'xhigh' instead of 'max' for reasoning_effort.
+    """
+    config = OpenrouterConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": "max"},
+        optional_params={},
+        model="openrouter/deepseek/deepseek-r1",
+        drop_params=False,
+    )
+
+    assert result["reasoning_effort"] == "xhigh"
+
+
+def test_openrouter_reasoning_effort_max_does_not_mutate_caller_dict():
+    """
+    map_openai_params must not mutate the caller-supplied non_default_params dict.
+    """
+    config = OpenrouterConfig()
+    original_params = {"reasoning_effort": "max"}
+
+    config.map_openai_params(
+        non_default_params=original_params,
+        optional_params={},
+        model="openrouter/deepseek/deepseek-r1",
+        drop_params=False,
+    )
+
+    assert original_params["reasoning_effort"] == "max"
+
+
+def test_openrouter_reasoning_effort_xhigh_passes_through():
+    """
+    reasoning_effort='xhigh' should be forwarded unchanged.
+    """
+    config = OpenrouterConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="openrouter/deepseek/deepseek-r1",
+        drop_params=False,
+    )
+
+    assert result["reasoning_effort"] == "xhigh"
+
+
+def test_openrouter_reasoning_effort_high_passes_through():
+    """
+    Non-max reasoning_effort values should be forwarded unchanged.
+    """
+    config = OpenrouterConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model="openrouter/deepseek/deepseek-r1",
+        drop_params=False,
+    )
+
+    assert result["reasoning_effort"] == "high"


### PR DESCRIPTION
DeepSeek V4 (Flash/Pro) are a constant nuisance among the different providers due to `max` canonically being the highest reasoning level. This differs from OpenAI conventions where `xhigh` is the highest reasoning level. Clients are expected to generally send `max` for these models.

There appears to be three stances among the providers:

- Some providers only accept `max` e.g., Ollama Cloud (tested via their OpenAI endpoints), OpenCode Go, etc.
- Some providers only accept `xhigh` e.g., OpenRouter, DeepInfra, etc.
- Some providers accept either `max` or `xhigh`, e.g., DeepSeek's official API.

So we have no consensus across providers. There's no way to abstract all these DeepSeek model providers with a single public model name via LiteLLM, since LiteLLM doesn't appear to have a callback to support provider level transformations (after routing is complete). 

This PR adds mapping from `max` to `xhigh` for the OpenRouter provider (and if this is good, I would like to apply the same change to the DeepInfra and OpenAI compatible provider).

OpenRouter internally maps from `xhigh` to `max` as required to their internal providers.

## Relevant issues

- None that I could find.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

In `OpenrouterConfig.map_openai_params()`, intercept `reasoning_effort="max"` and rewrite it to `xhigh` before delegating to the parent OpenAI transformation.
