### PR TITLE
fix(bedrock/agentcore): optionally forward multimodal content blocks in InvokeAgentRuntime payload

### DIFF
--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -218,8 +218,20 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         - Qualifier goes as query parameter
         - Only the payload goes in the request body
 
+        Payload shape:
+        - ``prompt`` is always present and contains the text-only flatten of the
+          last message's content (existing behavior).
+        - ``content`` is added ONLY when the ``forward_multimodal_content`` litellm
+          param is truthy AND the last message's ``content`` is a list containing a
+          non-text block (e.g. ``image_url``, ``file``, ``input_audio``). The list is
+          forwarded verbatim so the agent's ``@app.entrypoint`` handler can parse the
+          OpenAI-shaped multimodal blocks. This is opt-in because an AgentCore agent
+          must be explicitly written to read ``payload["content"]``; by default the
+          payload stays byte-identical to the legacy ``{"prompt": "..."}`` shape.
+
         Returns:
-            dict: Payload dict containing the prompt
+            dict: Payload dict containing the prompt and (optionally) the OpenAI
+            content list.
         """
         verbose_logger.debug(
             f"AgentCore transform_request - optional_params keys: {list(optional_params.keys())}"
@@ -230,6 +242,18 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
         # Create the payload - this is what goes in the body (raw JSON)
         payload: dict = {"prompt": prompt}
+
+        # Opt-in: when forward_multimodal_content is set, forward the OpenAI content
+        # list verbatim under "content" so an attachment-aware agent can read the raw
+        # blocks (image_url, file, etc.). Default off keeps the payload byte-identical
+        # to the legacy {"prompt": "..."} shape for agents that only read the prompt.
+        if self._should_forward_multimodal_content(optional_params, litellm_params):
+            last_content = messages[-1].get("content")
+            if isinstance(last_content, list) and any(
+                isinstance(block, dict) and block.get("type") not in (None, "text")
+                for block in last_content
+            ):
+                payload["content"] = last_content
 
         # Get or generate session ID - this goes in the header
         runtime_session_id = self._get_runtime_session_id(optional_params)
@@ -245,6 +269,29 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
         verbose_logger.debug(f"PAYLOAD: {payload}")
         return payload
+
+    @staticmethod
+    def _should_forward_multimodal_content(
+        optional_params: dict, litellm_params: dict
+    ) -> bool:
+        """Whether to forward raw OpenAI content blocks under ``payload["content"]``.
+
+        Opt-in via the ``forward_multimodal_content`` litellm param (default ``False``)
+        because AgentCore agents must be explicitly written to read the field. The
+        value may arrive as a bool or a config/env string ("true", "1", ...). Checks
+        ``optional_params`` first (where other AgentCore params land), then
+        ``litellm_params``.
+        """
+        for source in (optional_params, litellm_params):
+            if not isinstance(source, dict):
+                continue
+            value = source.get("forward_multimodal_content")
+            if value is None:
+                continue
+            if isinstance(value, str):
+                return value.strip().lower() in ("1", "true", "yes", "on")
+            return bool(value)
+        return False
 
     def _extract_sse_json(self, line: str) -> Optional[Dict]:
         """Extract and parse JSON from an SSE data line."""

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -253,7 +253,9 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 isinstance(block, dict) and block.get("type") not in (None, "text")
                 for block in last_content
             ):
-                payload["content"] = last_content
+                # Copy so the payload never aliases messages[-1]["content"]; shallow,
+                # not deep, to avoid cloning large base64 media on the request path.
+                payload["content"] = list(last_content)
 
         # Get or generate session ID - this goes in the header
         runtime_session_id = self._get_runtime_session_id(optional_params)

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -5,6 +5,7 @@ Tests:
 - Accept header fix (sign_request sets Accept: application/json, text/event-stream)
 - JSON response parsing fallback chain (_parse_json_response supports multiple schemas)
 - Streaming Content-Type fallback (JSON responses converted to single-chunk streams)
+- Multimodal content preservation (transform_request forwards OpenAI content blocks)
 """
 
 import json
@@ -389,3 +390,225 @@ class TestAgentCoreStreamingJsonFallback:
                     client=client,
                     api_key="test-jwt-token",
                 )
+
+
+class TestAgentCoreMultimodalContent:
+    """Tests for transform_request forwarding OpenAI multimodal content blocks.
+
+    AgentCore Runtime is schemaless on the agent side — the agent author's
+    @app.entrypoint handler parses whatever JSON arrives. transform_request
+    only emits {"prompt": "<text>"} by default and drops image_url, file, and
+    other non-text blocks.
+
+    When the ``forward_multimodal_content`` litellm param is set, the OpenAI
+    content list is forwarded verbatim under a "content" field whenever the last
+    message contains a non-text block. This is opt-in: an agent must be written
+    to read payload["content"]. Without the flag, the payload is byte-identical
+    to the legacy {"prompt": "..."} shape.
+    """
+
+    @pytest.fixture
+    def config(self):
+        return AmazonAgentCoreConfig()
+
+    @pytest.fixture
+    def transform_kwargs(self):
+        """Default kwargs — forwarding is OFF (no opt-in flag)."""
+        return {
+            "model": "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:111111111111:runtime/test_agent",
+            "optional_params": {},
+            "litellm_params": {},
+            "headers": {},
+        }
+
+    @pytest.fixture
+    def opted_in_kwargs(self, transform_kwargs):
+        """Kwargs with the opt-in flag set in optional_params."""
+        return {
+            **transform_kwargs,
+            "optional_params": {"forward_multimodal_content": True},
+        }
+
+    def test_string_content_payload_byte_identical_to_legacy(
+        self, config, transform_kwargs
+    ):
+        """String content → exactly {"prompt": "<text>"}, no extra fields."""
+        messages = [{"role": "user", "content": "hello agent"}]
+        payload = config.transform_request(messages=messages, **transform_kwargs)
+        assert payload == {"prompt": "hello agent"}
+
+    def test_file_block_not_forwarded_by_default(self, config, transform_kwargs):
+        """Default (no opt-in flag): file blocks are NOT forwarded — backward compat."""
+        content = [
+            {"type": "text", "text": "summarize this report"},
+            {
+                "type": "file",
+                "file": {
+                    "filename": "report.pdf",
+                    "file_data": "data:application/pdf;base64,JVBERi0xLjQK",
+                },
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        payload = config.transform_request(messages=messages, **transform_kwargs)
+        assert payload == {"prompt": "summarize this report"}
+        assert "content" not in payload
+
+    def test_text_only_list_content_no_content_field(self, config, opted_in_kwargs):
+        """All-text content list → no "content" field even when opted in."""
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello agent"}],
+            }
+        ]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+        assert payload == {"prompt": "hello agent"}
+        assert "content" not in payload
+
+    def test_file_data_block_passthrough(self, config, opted_in_kwargs):
+        """Opted in: a file block → "content" carries the original list verbatim."""
+        content = [
+            {"type": "text", "text": "summarize this report"},
+            {
+                "type": "file",
+                "file": {
+                    "filename": "report.pdf",
+                    "file_data": "data:application/pdf;base64,JVBERi0xLjQK",
+                },
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+        assert payload["prompt"] == "summarize this report"
+        # The list is forwarded verbatim — same identity, same contents.
+        assert payload["content"] is content
+
+    def test_image_url_block_passthrough(self, config, opted_in_kwargs):
+        """Opted in: an image_url block → "content" carries it verbatim."""
+        content = [
+            {"type": "text", "text": "what is in this image?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+        assert payload["prompt"] == "what is in this image?"
+        assert payload["content"] is content
+
+    def test_mixed_text_and_files_payload_shape(self, config, opted_in_kwargs):
+        """Opted in: text + file + image → both "prompt" (text-only) and "content"."""
+        content = [
+            {"type": "text", "text": "first sentence."},
+            {
+                "type": "file",
+                "file": {
+                    "filename": "report.pdf",
+                    "file_data": "data:application/pdf;base64,JVBERi0xLjQK",
+                },
+            },
+            {"type": "text", "text": "second sentence."},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+        # prompt is the text-only flatten produced by convert_content_list_to_str.
+        assert "first sentence." in payload["prompt"]
+        assert "second sentence." in payload["prompt"]
+        assert "JVBERi0xLjQK" not in payload["prompt"]
+        assert "iVBORw0KGgo=" not in payload["prompt"]
+        # content carries every block in original order.
+        assert payload["content"] == content
+
+    def test_only_last_message_content_preserved(self, config, opted_in_kwargs):
+        """Opted in: file blocks in earlier messages don't trigger "content" — last only."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "context"},
+                    {
+                        "type": "file",
+                        "file": {
+                            "filename": "old.pdf",
+                            "file_data": "data:application/pdf;base64,Zm9v",
+                        },
+                    },
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "follow-up question with no files"},
+        ]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+        assert payload == {"prompt": "follow-up question with no files"}
+        assert "content" not in payload
+
+    def test_unknown_non_text_block_type_passthrough(self, config, opted_in_kwargs):
+        """Opted in: unknown block types (e.g. input_audio) flow through."""
+        content = [
+            {"type": "text", "text": "transcribe this"},
+            {
+                "type": "input_audio",
+                "input_audio": {"data": "U29tZUF1ZGlvQnl0ZXM=", "format": "wav"},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+        assert payload["prompt"] == "transcribe this"
+        assert payload["content"] is content
+
+    def test_forward_flag_as_string_true(self, config, transform_kwargs):
+        """The opt-in flag accepts config/env string values like "true"."""
+        content = [
+            {"type": "text", "text": "hi"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        kwargs = {
+            **transform_kwargs,
+            "optional_params": {"forward_multimodal_content": "true"},
+        }
+        payload = config.transform_request(messages=messages, **kwargs)
+        assert payload["content"] is content
+
+    def test_forward_flag_false_explicit(self, config, transform_kwargs):
+        """Explicit falsy flag → no content field."""
+        content = [
+            {"type": "text", "text": "hi"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        kwargs = {
+            **transform_kwargs,
+            "optional_params": {"forward_multimodal_content": False},
+        }
+        payload = config.transform_request(messages=messages, **kwargs)
+        assert "content" not in payload
+
+    def test_forward_flag_via_litellm_params(self, config, transform_kwargs):
+        """The opt-in flag is also honored when set in litellm_params."""
+        content = [
+            {"type": "text", "text": "hi"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        kwargs = {
+            **transform_kwargs,
+            "litellm_params": {"forward_multimodal_content": True},
+        }
+        payload = config.transform_request(messages=messages, **kwargs)
+        assert payload["content"] is content

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -481,8 +481,9 @@ class TestAgentCoreMultimodalContent:
         messages = [{"role": "user", "content": content}]
         payload = config.transform_request(messages=messages, **opted_in_kwargs)
         assert payload["prompt"] == "summarize this report"
-        # The list is forwarded verbatim — same identity, same contents.
-        assert payload["content"] is content
+        # Contents forwarded verbatim, but as a distinct list (no aliasing).
+        assert payload["content"] == content
+        assert payload["content"] is not content
 
     def test_image_url_block_passthrough(self, config, opted_in_kwargs):
         """Opted in: an image_url block → "content" carries it verbatim."""
@@ -496,7 +497,8 @@ class TestAgentCoreMultimodalContent:
         messages = [{"role": "user", "content": content}]
         payload = config.transform_request(messages=messages, **opted_in_kwargs)
         assert payload["prompt"] == "what is in this image?"
-        assert payload["content"] is content
+        assert payload["content"] == content
+        assert payload["content"] is not content
 
     def test_mixed_text_and_files_payload_shape(self, config, opted_in_kwargs):
         """Opted in: text + file + image → both "prompt" (text-only) and "content"."""
@@ -524,6 +526,25 @@ class TestAgentCoreMultimodalContent:
         assert "iVBORw0KGgo=" not in payload["prompt"]
         # content carries every block in original order.
         assert payload["content"] == content
+
+    def test_forwarded_content_does_not_alias_message(self, config, opted_in_kwargs):
+        """Regression: the forwarded list is a shallow copy, so mutating the
+        returned payload before serialization must not leak back into the caller's
+        messages[-1]["content"]."""
+        content = [
+            {"type": "text", "text": "describe this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ]
+        messages = [{"role": "user", "content": content}]
+        payload = config.transform_request(messages=messages, **opted_in_kwargs)
+
+        payload["content"].append({"type": "text", "text": "injected"})
+
+        assert len(messages[-1]["content"]) == 2
+        assert {"type": "text", "text": "injected"} not in messages[-1]["content"]
 
     def test_only_last_message_content_preserved(self, config, opted_in_kwargs):
         """Opted in: file blocks in earlier messages don't trigger "content" — last only."""
@@ -560,7 +581,8 @@ class TestAgentCoreMultimodalContent:
         messages = [{"role": "user", "content": content}]
         payload = config.transform_request(messages=messages, **opted_in_kwargs)
         assert payload["prompt"] == "transcribe this"
-        assert payload["content"] is content
+        assert payload["content"] == content
+        assert payload["content"] is not content
 
     def test_forward_flag_as_string_true(self, config, transform_kwargs):
         """The opt-in flag accepts config/env string values like "true"."""
@@ -577,7 +599,8 @@ class TestAgentCoreMultimodalContent:
             "optional_params": {"forward_multimodal_content": "true"},
         }
         payload = config.transform_request(messages=messages, **kwargs)
-        assert payload["content"] is content
+        assert payload["content"] == content
+        assert payload["content"] is not content
 
     def test_forward_flag_false_explicit(self, config, transform_kwargs):
         """Explicit falsy flag → no content field."""
@@ -611,4 +634,5 @@ class TestAgentCoreMultimodalContent:
             "litellm_params": {"forward_multimodal_content": True},
         }
         payload = config.transform_request(messages=messages, **kwargs)
-        assert payload["content"] is content
+        assert payload["content"] == content
+        assert payload["content"] is not content


### PR DESCRIPTION
## Relevant issues

<!-- No existing issue tracked; happy to file one if maintainers prefer. -->

## Pre-Submission checklist

- [x] Added testing in `tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py` (12 multimodal cases incl. default-off, opt-in, string flag, litellm_params fallback, and a shared-reference regression).
- [x] Affected-file unit tests pass (`uv run pytest .../agentcore/test_agentcore_transformation.py` → 32 passed). Full `make test-unit` not run locally (`boto3`/`botocore` absent in my env); draft so CI runs it.
- [x] Scope isolated to one method (`transform_request`) + a helper + tests.
- [ ] Greptile review (after CI green).

## Type

🐛 Bug Fix / 🆕 opt-in enhancement

## Changes

### Problem

`AmazonAgentCoreConfig.transform_request` builds the AgentCore body via
`convert_content_list_to_str(messages[-1])`, which keeps only `text` blocks and silently
drops every other OpenAI block type (`image_url`, `file`, `input_audio`, …). Any
OpenAI-compatible client that sends multimodal content to a `bedrock/agentcore/...` model
(e.g. LibreChat "Upload to Provider") loses the file/image before it reaches the agent.

### Fix (opt-in)

Add a `forward_multimodal_content` litellm param (**default `False`**). When truthy **and**
the last message's `content` is a list containing a non-text block, the original OpenAI
content list is forwarded verbatim under a new `content` field, alongside the existing
`prompt`. An attachment-aware AgentCore agent reads `payload["content"]`; agents that don't
are unaffected.

```python
if self._should_forward_multimodal_content(optional_params, litellm_params):
    last_content = messages[-1].get("content")
    if isinstance(last_content, list) and any(
        isinstance(b, dict) and b.get("type") not in (None, "text") for b in last_content
    ):
        payload["content"] = list(last_content)
```

The flag is read from `optional_params` (where other AgentCore params land) with a
`litellm_params` fallback, and accepts a bool or a config/env string (`"true"`, `"1"`, …).

### Why opt-in / why this shape

AgentCore Runtime is schemaless on the agent side — the agent's `@app.entrypoint` parses
arbitrary JSON up to 100 MB ([docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-invoke-agent.html)).
Forwarding is therefore gated behind an explicit flag: an agent must be written to read the
new field. The forwarded value is the verbatim OpenAI content list (not a re-invented
schema) — LiteLLM is an OpenAI-compatible proxy, so emitting OpenAI shapes is consistent and
the agent owns any translation to its model's native format (e.g. Bedrock Converse).

### Backward compatibility

Default off → payload is **byte-identical** to the legacy `{"prompt": "<text>"}` shape.
`convert_content_list_to_str` is untouched (used by ~17 other providers). No change for any
existing agent.

### Review follow-up

`payload["content"]` forwards `list(last_content)` rather than the original list, so the returned payload never aliases `messages[-1]["content"]` and a caller that mutates the payload before serialization cannot affect the request messages. The copy is shallow on purpose; the block dicts stay shared because a deep copy would clone potentially large base64 media on the request path, and the flagged risk was the shared list itself. `test_forwarded_content_does_not_alias_message` appends to `payload["content"]` and asserts `messages[-1]["content"]` is untouched, so it fails against the old direct-assignment code and passes now

### Test plan

`TestAgentCoreMultimodalContent` (12 cases): default-off (file block → no `content`,
backward-compat regression guard); opted-in file/image/mixed/unknown-block passthrough;
all-text list → no `content` even when opted in; last-message-only scope; string `"true"`
flag; explicit `False`; flag via `litellm_params`; shared-reference regression. All 32 tests
in the file pass.

### Usage

```yaml
model_list:
  - model_name: my-agentcore-agent
    litellm_params:
      model: bedrock/agentcore/arn:aws:bedrock-agentcore:...:runtime/my-agent
      forward_multimodal_content: true
```
