### PR TITLE
fix(docker): use system Node in componentized builders + retry apk add

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,9 @@ COPY --from=uvbin /uv /uvx /usr/local/bin/
 # instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
 # (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
+      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break; \
+      [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
+      sleep 5; \
     done
 
 # UV_COMPILE_BYTECODE=1   precompiles .pyc at install time → faster cold start.
@@ -67,7 +69,9 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break || sleep 5; \
+      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break; \
+      [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
+      sleep 5; \
     done
 
 # wolfi-base ships an unprivileged `nonroot` account (UID/GID 65532) with

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,17 +12,32 @@ USER root
 
 COPY --from=uvbin /uv /uvx /usr/local/bin/
 
-RUN apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile
+# Install build deps. `nodejs`/`npm` are present so that `prisma generate`
+# below uses the Wolfi-built Node (PRISMA_USE_GLOBAL_NODE picks it up) rather
+# than letting prisma-client-py's nodeenv download "latest stable" Node from
+# nodejs.org. Without this, the build is a moving target — e.g. Node 26.2.0's
+# prebuilt linux binary added a runtime dep on `libatomic.so.1` that isn't in
+# the Wolfi builder, silently breaking `prisma generate` between releases.
+# Retry the install to ride out transient apk.cgr.dev mirror flakes on the
+# arm64 leg of multi-arch builds.
+RUN for i in 1 2 3; do \
+      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
+    done
 
-# UV_COMPILE_BYTECODE=1   precompiles .pyc at install time → faster cold start.
-# UV_LINK_MODE=copy       avoids hardlink warnings when uv installs from a
-#                         BuildKit cache mount (different filesystem).
-# UV_PYTHON_DOWNLOADS=0   force uv to use the apk-installed CPython instead of
-#                         silently pulling a managed interpreter.
+# UV_COMPILE_BYTECODE=1     precompiles .pyc at install time → faster cold start.
+# UV_LINK_MODE=copy         avoids hardlink warnings when uv installs from a
+#                           BuildKit cache mount (different filesystem).
+# UV_PYTHON_DOWNLOADS=0     force uv to use the apk-installed CPython instead of
+#                           silently pulling a managed interpreter.
+# PRISMA_USE_GLOBAL_NODE=true  prisma-client-py defaults to this, but stating it
+#                           explicitly documents the intent and prevents a
+#                           future env override from silently re-enabling
+#                           nodeenv's runtime Node download.
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=0 \
+    PRISMA_USE_GLOBAL_NODE=true \
     PATH="/app/.venv/bin:${PATH}"
 
 # Stage 1 — install dependencies only.
@@ -58,7 +73,9 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 USER root
 
-RUN apk add --no-cache bash openssl tzdata python3 libsndfile libatomic
+RUN for i in 1 2 3; do \
+      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break || sleep 5; \
+    done
 
 # wolfi-base ships an unprivileged `nonroot` account (UID/GID 65532) with
 # /home/nonroot. We run the backend as that user

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,27 +12,20 @@ USER root
 
 COPY --from=uvbin /uv /uvx /usr/local/bin/
 
-# Install build deps. `nodejs`/`npm` are present so that `prisma generate`
-# below uses the Wolfi-built Node (PRISMA_USE_GLOBAL_NODE picks it up) rather
-# than letting prisma-client-py's nodeenv download "latest stable" Node from
-# nodejs.org. Without this, the build is a moving target — e.g. Node 26.2.0's
-# prebuilt linux binary added a runtime dep on `libatomic.so.1` that isn't in
-# the Wolfi builder, silently breaking `prisma generate` between releases.
-# Retry the install to ride out transient apk.cgr.dev mirror flakes on the
-# arm64 leg of multi-arch builds.
+# nodejs/npm so `prisma generate` uses Wolfi's Node via PRISMA_USE_GLOBAL_NODE
+# instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
+# (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
       apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
     done
 
-# UV_COMPILE_BYTECODE=1     precompiles .pyc at install time → faster cold start.
-# UV_LINK_MODE=copy         avoids hardlink warnings when uv installs from a
-#                           BuildKit cache mount (different filesystem).
-# UV_PYTHON_DOWNLOADS=0     force uv to use the apk-installed CPython instead of
-#                           silently pulling a managed interpreter.
-# PRISMA_USE_GLOBAL_NODE=true  prisma-client-py defaults to this, but stating it
-#                           explicitly documents the intent and prevents a
-#                           future env override from silently re-enabling
-#                           nodeenv's runtime Node download.
+# UV_COMPILE_BYTECODE=1   precompiles .pyc at install time → faster cold start.
+# UV_LINK_MODE=copy       avoids hardlink warnings when uv installs from a
+#                         BuildKit cache mount (different filesystem).
+# UV_PYTHON_DOWNLOADS=0   force uv to use the apk-installed CPython instead of
+#                         silently pulling a managed interpreter.
+# PRISMA_USE_GLOBAL_NODE  explicit (matches default) so an env override can't
+#                         silently re-enable nodeenv's Node download.
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -16,7 +16,9 @@ COPY --from=uvbin /uv /uvx /usr/local/bin/
 # instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
 # (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
+      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break; \
+      [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
+      sleep 5; \
     done
 
 # UV_COMPILE_BYTECODE=1   precompiles .pyc at install time → faster cold start.
@@ -67,7 +69,9 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break || sleep 5; \
+      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break; \
+      [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
+      sleep 5; \
     done
 
 # wolfi-base ships an unprivileged `nonroot` account (UID/GID 65532) with

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,17 +12,32 @@ USER root
 
 COPY --from=uvbin /uv /uvx /usr/local/bin/
 
-RUN apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile
+# Install build deps. `nodejs`/`npm` are present so that `prisma generate`
+# below uses the Wolfi-built Node (PRISMA_USE_GLOBAL_NODE picks it up) rather
+# than letting prisma-client-py's nodeenv download "latest stable" Node from
+# nodejs.org. Without this, the build is a moving target — e.g. Node 26.2.0's
+# prebuilt linux binary added a runtime dep on `libatomic.so.1` that isn't in
+# the Wolfi builder, silently breaking `prisma generate` between releases.
+# Retry the install to ride out transient apk.cgr.dev mirror flakes on the
+# arm64 leg of multi-arch builds.
+RUN for i in 1 2 3; do \
+      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
+    done
 
-# UV_COMPILE_BYTECODE=1   precompiles .pyc at install time → faster cold start.
-# UV_LINK_MODE=copy       avoids hardlink warnings when uv installs from a
-#                         BuildKit cache mount (different filesystem).
-# UV_PYTHON_DOWNLOADS=0   force uv to use the apk-installed CPython instead of
-#                         silently pulling a managed interpreter.
+# UV_COMPILE_BYTECODE=1     precompiles .pyc at install time → faster cold start.
+# UV_LINK_MODE=copy         avoids hardlink warnings when uv installs from a
+#                           BuildKit cache mount (different filesystem).
+# UV_PYTHON_DOWNLOADS=0     force uv to use the apk-installed CPython instead of
+#                           silently pulling a managed interpreter.
+# PRISMA_USE_GLOBAL_NODE=true  prisma-client-py defaults to this, but stating it
+#                           explicitly documents the intent and prevents a
+#                           future env override from silently re-enabling
+#                           nodeenv's runtime Node download.
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=0 \
+    PRISMA_USE_GLOBAL_NODE=true \
     PATH="/app/.venv/bin:${PATH}"
 
 # Stage 1 — install dependencies only.
@@ -58,7 +73,9 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 USER root
 
-RUN apk add --no-cache bash openssl tzdata python3 libsndfile libatomic
+RUN for i in 1 2 3; do \
+      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break || sleep 5; \
+    done
 
 # wolfi-base ships an unprivileged `nonroot` account (UID/GID 65532) with
 # /home/nonroot. We run the proxy as that user.

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,27 +12,20 @@ USER root
 
 COPY --from=uvbin /uv /uvx /usr/local/bin/
 
-# Install build deps. `nodejs`/`npm` are present so that `prisma generate`
-# below uses the Wolfi-built Node (PRISMA_USE_GLOBAL_NODE picks it up) rather
-# than letting prisma-client-py's nodeenv download "latest stable" Node from
-# nodejs.org. Without this, the build is a moving target — e.g. Node 26.2.0's
-# prebuilt linux binary added a runtime dep on `libatomic.so.1` that isn't in
-# the Wolfi builder, silently breaking `prisma generate` between releases.
-# Retry the install to ride out transient apk.cgr.dev mirror flakes on the
-# arm64 leg of multi-arch builds.
+# nodejs/npm so `prisma generate` uses Wolfi's Node via PRISMA_USE_GLOBAL_NODE
+# instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
+# (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
       apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
     done
 
-# UV_COMPILE_BYTECODE=1     precompiles .pyc at install time → faster cold start.
-# UV_LINK_MODE=copy         avoids hardlink warnings when uv installs from a
-#                           BuildKit cache mount (different filesystem).
-# UV_PYTHON_DOWNLOADS=0     force uv to use the apk-installed CPython instead of
-#                           silently pulling a managed interpreter.
-# PRISMA_USE_GLOBAL_NODE=true  prisma-client-py defaults to this, but stating it
-#                           explicitly documents the intent and prevents a
-#                           future env override from silently re-enabling
-#                           nodeenv's runtime Node download.
+# UV_COMPILE_BYTECODE=1   precompiles .pyc at install time → faster cold start.
+# UV_LINK_MODE=copy       avoids hardlink warnings when uv installs from a
+#                         BuildKit cache mount (different filesystem).
+# UV_PYTHON_DOWNLOADS=0   force uv to use the apk-installed CPython instead of
+#                         silently pulling a managed interpreter.
+# PRISMA_USE_GLOBAL_NODE  explicit (matches default) so an env override can't
+#                         silently re-enable nodeenv's Node download.
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -35,7 +35,9 @@ COPY --from=uvbin /uv /uvx /usr/local/bin/
 # instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
 # (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
+      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break; \
+      [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
+      sleep 5; \
     done
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
@@ -85,7 +87,9 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break || sleep 5; \
+      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break; \
+      [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
+      sleep 5; \
     done
 
 # wolfi-base ships an unprivileged `nonroot` account (UID/GID 65532). The

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -31,20 +31,13 @@ USER root
 
 COPY --from=uvbin /uv /uvx /usr/local/bin/
 
-# `nodejs`/`npm` are present so that `prisma generate` below uses the
-# Wolfi-built Node (PRISMA_USE_GLOBAL_NODE picks it up) rather than letting
-# prisma-client-py's nodeenv download "latest stable" Node from nodejs.org.
-# Without this, the build is a moving target — e.g. Node 26.2.0's prebuilt
-# linux binary added a runtime dep on `libatomic.so.1` that isn't in the
-# Wolfi builder, silently breaking `prisma generate` between releases. Retry
-# to ride out transient apk.cgr.dev mirror flakes on multi-arch builds.
+# nodejs/npm so `prisma generate` uses Wolfi's Node via PRISMA_USE_GLOBAL_NODE
+# instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
+# (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
       apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
     done
 
-# PRISMA_USE_GLOBAL_NODE=true is the prisma-client-py default; stating it
-# explicitly documents intent and prevents a future env override from
-# silently re-enabling nodeenv's runtime Node download.
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -31,12 +31,25 @@ USER root
 
 COPY --from=uvbin /uv /uvx /usr/local/bin/
 
-RUN apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile
+# `nodejs`/`npm` are present so that `prisma generate` below uses the
+# Wolfi-built Node (PRISMA_USE_GLOBAL_NODE picks it up) rather than letting
+# prisma-client-py's nodeenv download "latest stable" Node from nodejs.org.
+# Without this, the build is a moving target — e.g. Node 26.2.0's prebuilt
+# linux binary added a runtime dep on `libatomic.so.1` that isn't in the
+# Wolfi builder, silently breaking `prisma generate` between releases. Retry
+# to ride out transient apk.cgr.dev mirror flakes on multi-arch builds.
+RUN for i in 1 2 3; do \
+      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break || sleep 5; \
+    done
 
+# PRISMA_USE_GLOBAL_NODE=true is the prisma-client-py default; stating it
+# explicitly documents intent and prevents a future env override from
+# silently re-enabling nodeenv's runtime Node download.
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=0 \
+    PRISMA_USE_GLOBAL_NODE=true \
     PATH="/app/.venv/bin:${PATH}"
 
 # Stage 1 — install third-party deps only (cached by pyproject.toml/uv.lock).
@@ -78,7 +91,9 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 USER root
 
-RUN apk add --no-cache bash openssl tzdata python3 libsndfile libatomic
+RUN for i in 1 2 3; do \
+      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break || sleep 5; \
+    done
 
 # wolfi-base ships an unprivileged `nonroot` account (UID/GID 65532). The
 # Prisma engine binaries are dynamically linked against libssl/libcrypto, so


### PR DESCRIPTION
## What

In the three componentized proxy Dockerfiles (`backend/`, `migrations/`, `gateway/`):
- Add `nodejs` and `npm` to the **builder-stage** `apk add`.
- Set `PRISMA_USE_GLOBAL_NODE=true` explicitly in the builder ENV.
- Wrap every `apk add` (builder + runtime) in the same 3-try retry loop already used by `docker/Dockerfile.non_root`.

## Why

The project-releaser componentized image build (`Build and Publish Componentized Images + Chart`) has been failing since 2026-05-24. Two distinct failure modes, same root cause class — the builders were too coupled to "whatever the network gave us at build time."

### Failure 1 — `libatomic` missing, surfaced by upstream Node bump

`prisma generate` (run in the builder stage) triggers prisma-client-py's `nodeenv`, which downloads the latest stable Node.js from nodejs.org at build time. Two snapshots from the project-releaser logs:

```
# Last passing run (2026-05-20, https://github.com/BerriAI/project-releaser/actions/runs/26134099768)
#28 0.622  * Install prebuilt node (26.1.0)

# Today's failing run
#29 0.675  * Install prebuilt node (26.2.0)
…
node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
…
subprocess.CalledProcessError: Command '['/home/nonroot/.cache/prisma-python/nodeenv/bin/npm', 'install', 'prisma@5.4.2']' returned non-zero exit status 127.
```

Node 26.2.0's prebuilt Linux binary added a runtime dependency on `libatomic.so.1`. Wolfi doesn't include `libatomic` in the base image, and the componentized builder stages don't `apk add` it — so the first build that pulled 26.2.0 broke.

**Pinning the Node version** (e.g. via `PRISMA_NODEENV_EXTRA_ARGS=--node=26.1.0`) would unblock today, but it's a treadmill: the next time prisma-client-py changes its nodeenv default, or 26.1.0 gets pulled from the mirror, the build breaks again.

**Adding `libatomic` to the builder** would unblock today, but doesn't solve "the next Node release silently adds a new dynamic dep" either.

**The real fix** is to stop letting nodeenv decide the Node version at build time. prisma-client-py respects `PRISMA_USE_GLOBAL_NODE` (default `true`) — if a `node` binary is on `PATH`, it skips nodeenv entirely. The legacy `docker/Dockerfile.non_root` already does this — its builder `apk add` includes `nodejs` and `npm`. The componentized Dockerfiles regressed it.

Using Wolfi's own `nodejs` package means:
- The Node binary is built against the same image's libc; no `libatomic.so.1` gap.
- The version moves only when we bump the Wolfi base digest — a deliberate, reviewable change instead of a daily roll.
- No network call to nodejs.org during build.

Setting `PRISMA_USE_GLOBAL_NODE=true` in ENV is redundant with the default but documents intent and prevents a future env override from silently re-enabling nodeenv's download.

### Failure 2 — transient Chainguard mirror flakes

The same run also showed mid-`apk add` failures on the arm64 leg:

```
ERROR: nss-db-2.43-r7: remote server returned error (try 'apk update')
ERROR: libzstd1-1.5.7-r7: remote server returned error (try 'apk update')
ERROR: libogg-1.3.6-r5: remote server returned error (try 'apk update')
ERROR: binutils-2.46-r1: remote server returned error (try 'apk update')
```

These are HTTP errors from `apk.cgr.dev` on individual package fetches — classic mirror flakiness during multi-arch builds. None of the componentized Dockerfiles wrap their `apk add` in a retry loop. The legacy `docker/Dockerfile.non_root` does (lines 17–29 and 91–96). This PR mirrors that pattern across builder + runtime in all three files.

## Why these three files have the same diff

`backend/`, `migrations/`, and `gateway/Dockerfile` are three near-identical componentizations of the original monolithic proxy Dockerfile. They share the same `apk add` lists and the same lifecycle. The fix is structurally identical in each.

## Testing

This change is build-system-only and can't be unit-tested. The verification is a green run of the project-releaser workflow — please trigger one against this branch before merge. The diff is conservative: it only **adds** packages and retries; nothing existing is removed. Worst case, the builder image grows slightly to include the Wolfi `nodejs` + `npm` packages (these layers are not in the final runtime image — they live in the builder stage only).

## Follow-ups (not in this PR)

- `docker/Dockerfile.database` has the same shape (builder + runtime `apk add` with no retry) — it doesn't have the Node problem because it already includes `nodejs npm` in the builder, but it could use the same retry-loop hardening.
- The project-releaser repo could pin a Wolfi base digest known to ship `libatomic` in the base image as a belt-and-suspenders guard — but the `nodejs`-from-Wolfi approach in this PR makes that unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)