### PR TITLE
feat(datadog_llm_obs): support Unix socket transport via DD_TRACE_AGENT_URL

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -57,10 +57,16 @@ class DataDogLLMObsLogger(CustomBatchLogger):
                     "[DATADOG MOCK] DataDogLLMObs logger initialized in mock mode"
                 )
 
-            # Configure DataDog endpoint (Agent or Direct API)
-            # Use LITELLM_DD_AGENT_HOST to avoid conflicts with ddtrace's DD_AGENT_HOST
-            # Check for agent mode FIRST - agent mode doesn't require DD_API_KEY or DD_SITE
+            # Configure DataDog endpoint. Precedence:
+            #   1. LITELLM_DD_AGENT_HOST (TCP agent)
+            #   2. DD_TRACE_AGENT_URL starting with "unix://" (Unix socket agent)
+            #   3. DD_API_KEY + DD_SITE (direct API)
+            # Use LITELLM_DD_AGENT_HOST to avoid conflicts with ddtrace's DD_AGENT_HOST.
+            # The DD_TRACE_AGENT_URL fallback matches ddtrace's own env var so a single
+            # operator-injected setting (e.g. unix:///var/run/datadog/apm.socket) wires
+            # both ddtrace and LiteLLM's LLM Observability shipping at once.
             dd_agent_host = os.getenv("LITELLM_DD_AGENT_HOST")
+            dd_trace_agent_url = os.getenv("DD_TRACE_AGENT_URL", "")
 
             self.async_client = get_async_httpx_client(
                 llm_provider=httpxSpecialProvider.LoggingCallback
@@ -69,6 +75,10 @@ class DataDogLLMObsLogger(CustomBatchLogger):
 
             if dd_agent_host:
                 self._configure_dd_agent(dd_agent_host=dd_agent_host)
+            elif dd_trace_agent_url.startswith("unix://"):
+                self._configure_dd_agent_uds(
+                    socket_path=dd_trace_agent_url[len("unix://") :]
+                )
             else:
                 # Only require DD_API_KEY and DD_SITE for direct API mode
                 if os.getenv("DD_API_KEY", None) is None:
@@ -112,6 +122,35 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             f"http://{dd_agent_host}:{agent_port}/api/intake/llm-obs/v1/trace/spans"
         )
         verbose_logger.debug(f"DataDogLLMObs: Using DD Agent at {self.intake_url}")
+
+    def _configure_dd_agent_uds(self, socket_path: str):
+        """
+        Configure the Datadog logger to send LLM Observability traces to the
+        Datadog Agent over a Unix domain socket (UDS).
+
+        Required by deployments where the agent is reachable only via UDS, e.g.
+        the Datadog Operator's APM auto-instrumentation which mounts
+        /var/run/datadog/apm.socket and sets DD_TRACE_AGENT_URL to
+        unix:///var/run/datadog/apm.socket. The TCP agent ports (8126) are not
+        bound on the host in this configuration, so the existing TCP agent mode
+        cannot reach the agent.
+
+        As with TCP agent mode, the agent handles auth — no API Key required.
+        """
+        # Replace the shared HTTPX client (TCP-only) with one that routes through
+        # the UDS transport. Goes through the same get_async_httpx_client factory
+        # so we get default timeouts, headers, and a managed lifecycle; the
+        # factory bypasses its cache when a custom transport is supplied.
+        # Same URL path as TCP mode; host portion is unused because the request
+        # is delivered straight over the socket.
+        self.uds_transport = httpx.AsyncHTTPTransport(uds=socket_path)
+        self.async_client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.LoggingCallback,
+            transport=self.uds_transport,
+        )
+        self.DD_SITE = "localhost"  # Not used for URL construction in agent mode
+        self.intake_url = "http://localhost/api/intake/llm-obs/v1/trace/spans"
+        verbose_logger.debug(f"DataDogLLMObs: Using DD Agent over UDS at {socket_path}")
 
     def _configure_dd_direct_api(self):
         """

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -524,6 +524,7 @@ class AsyncHTTPHandler:
         client_alias: Optional[str] = None,  # name for client in logs
         ssl_verify: Optional[VerifyTypes] = None,
         shared_session: Optional["ClientSession"] = None,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
     ):
         self.timeout = timeout
         self.event_hooks = event_hooks
@@ -532,6 +533,7 @@ class AsyncHTTPHandler:
             event_hooks=event_hooks,
             ssl_verify=ssl_verify,
             shared_session=shared_session,
+            transport=transport,
         )
         self.client_alias = client_alias
 
@@ -541,6 +543,7 @@ class AsyncHTTPHandler:
         event_hooks: Optional[Mapping[str, List[Callable[..., Any]]]],
         ssl_verify: Optional[VerifyTypes] = None,
         shared_session: Optional["ClientSession"] = None,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
     ) -> httpx.AsyncClient:
         # Get unified SSL configuration
         ssl_config = get_ssl_configuration(ssl_verify)
@@ -553,11 +556,17 @@ class AsyncHTTPHandler:
             timeout = _DEFAULT_TIMEOUT
         # Create a client with a connection pool
 
-        transport = AsyncHTTPHandler._create_async_transport(
-            ssl_context=ssl_config if isinstance(ssl_config, ssl.SSLContext) else None,
-            ssl_verify=ssl_config if isinstance(ssl_config, bool) else None,
-            shared_session=shared_session,
-        )
+        # Use the caller-supplied transport when present (e.g. AsyncHTTPTransport(uds=...)
+        # for talking to a local Datadog agent over a Unix domain socket); otherwise
+        # fall back to the auto-selected aiohttp/httpx transport.
+        if transport is None:
+            transport = AsyncHTTPHandler._create_async_transport(
+                ssl_context=(
+                    ssl_config if isinstance(ssl_config, ssl.SSLContext) else None
+                ),
+                ssl_verify=ssl_config if isinstance(ssl_config, bool) else None,
+                shared_session=shared_session,
+            )
 
         # Get default headers (User-Agent, overridable via LITELLM_USER_AGENT)
         default_headers = get_default_headers()
@@ -1333,13 +1342,36 @@ def get_async_httpx_client(
     llm_provider: Union[LlmProviders, httpxSpecialProvider],
     params: Optional[dict] = None,
     shared_session: Optional["ClientSession"] = None,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
 ) -> AsyncHTTPHandler:
     """
     Retrieves the async HTTP client from the cache
     If not present, creates a new client
 
     Caches the new client and returns it.
+
+    When `transport` is provided (e.g. an `httpx.AsyncHTTPTransport(uds=...)`
+    for talking to a local Datadog agent over a Unix domain socket), the
+    cache is bypassed — each transport is typically a one-off and we don't
+    have a stable cache key for it.
     """
+    if transport is not None:
+        # Cache bypass: each caller-supplied transport is treated as unique.
+        # The caller is responsible for retaining the returned handler so it
+        # isn't garbage-collected mid-flight.
+        if params is not None:
+            handler_params = {
+                k: v for k, v in params.items() if k != "disable_aiohttp_transport"
+            }
+            handler_params["shared_session"] = shared_session
+            handler_params["transport"] = transport
+            return AsyncHTTPHandler(**handler_params)
+        return AsyncHTTPHandler(
+            timeout=_DEFAULT_TIMEOUT,
+            shared_session=shared_session,
+            transport=transport,
+        )
+
     _params_key_name = ""
     if params is not None:
         for key, value in params.items():

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py
@@ -1,5 +1,8 @@
 import os
 from unittest.mock import patch
+
+import httpx
+
 from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
 
 
@@ -60,3 +63,78 @@ def test_datadog_llm_obs_direct_api_configuration():
         expected_url = "https://api.us5.datadoghq.com/api/intake/llm-obs/v1/trace/spans"
         assert dd_logger.intake_url == expected_url
         assert dd_logger.DD_API_KEY == "direct-api-key"
+
+
+def test_datadog_llm_obs_agent_uds_configuration():
+    """
+    Test that DD_TRACE_AGENT_URL with a unix:// scheme configures the logger
+    to ship LLM Obs spans over a Unix domain socket. Matches the env var
+    that ddtrace and the Datadog Operator's APM auto-inject already use.
+    """
+    test_env = {
+        "DD_TRACE_AGENT_URL": "unix:///var/run/datadog/apm.socket",
+    }
+
+    # Spy on AsyncHTTPTransport so we can assert the socket path without
+    # poking at httpx private attributes (which move between versions).
+    original_transport_init = httpx.AsyncHTTPTransport.__init__
+    captured_uds = []
+
+    def spy_init(self, *args, **kwargs):
+        captured_uds.append(kwargs.get("uds"))
+        return original_transport_init(self, *args, **kwargs)
+
+    with patch.dict(os.environ, test_env, clear=True):
+        with patch("asyncio.create_task"):
+            with patch.object(httpx.AsyncHTTPTransport, "__init__", spy_init):
+                dd_logger = DataDogLLMObsLogger()
+
+        # URL uses localhost since the request is delivered straight over the socket.
+        expected_url = "http://localhost/api/intake/llm-obs/v1/trace/spans"
+        assert dd_logger.intake_url == expected_url
+
+        # Agent mode does not require an API key — agent handles auth.
+        assert dd_logger.DD_API_KEY is None
+
+        # Logger holds the UDS transport built from DD_TRACE_AGENT_URL.
+        assert isinstance(dd_logger.uds_transport, httpx.AsyncHTTPTransport)
+        assert "/var/run/datadog/apm.socket" in captured_uds
+
+
+def test_datadog_llm_obs_agent_host_takes_precedence_over_uds():
+    """
+    If both LITELLM_DD_AGENT_HOST (TCP) and DD_TRACE_AGENT_URL (UDS) are set,
+    the explicit LITELLM_DD_AGENT_HOST wins for backward compatibility.
+    """
+    test_env = {
+        "LITELLM_DD_AGENT_HOST": "127.0.0.1",
+        "DD_TRACE_AGENT_URL": "unix:///var/run/datadog/apm.socket",
+    }
+
+    with patch.dict(os.environ, test_env, clear=True):
+        with patch("asyncio.create_task"):
+            dd_logger = DataDogLLMObsLogger()
+
+        expected_url = "http://127.0.0.1:8126/api/intake/llm-obs/v1/trace/spans"
+        assert dd_logger.intake_url == expected_url
+
+
+def test_datadog_llm_obs_tcp_dd_trace_agent_url_falls_back_to_direct():
+    """
+    A non-unix DD_TRACE_AGENT_URL (e.g. http://...) is ignored by this
+    integration; the logger falls back to direct intake. Avoids accidentally
+    sending LLM Obs traffic to the ddtrace HTTP endpoint when the operator
+    has only injected the TCP form.
+    """
+    test_env = {
+        "DD_TRACE_AGENT_URL": "http://datadog-agent.datadog.svc:8126",
+        "DD_API_KEY": "direct-api-key",
+        "DD_SITE": "us5.datadoghq.com",
+    }
+
+    with patch.dict(os.environ, test_env, clear=True):
+        with patch("asyncio.create_task"):
+            dd_logger = DataDogLLMObsLogger()
+
+        expected_url = "https://api.us5.datadoghq.com/api/intake/llm-obs/v1/trace/spans"
+        assert dd_logger.intake_url == expected_url


### PR DESCRIPTION
## Title

`feat(datadog_llm_obs): support Unix socket transport via DD_TRACE_AGENT_URL`

## Relevant issues

Closes #28892

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/test_litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Adds a third configuration mode to the DataDogLLMObs logger for shipping LLM Observability spans over a **Unix domain socket**. Activates automatically when `DD_TRACE_AGENT_URL` starts with `unix://` — the same env var ddtrace consumes, which is what the Datadog Operator's APM auto-instrumentation injects (`unix:///var/run/datadog/apm.socket`).

### Why

In modern Datadog Operator deployments using APM auto-instrumentation, the agent is reachable only via a Unix socket — the TCP receiver on port 8126 is **not** bound on the host network. Today the LLM Obs logger has no working path to the agent in that environment:

- TCP agent mode (`LITELLM_DD_AGENT_HOST`) → `ConnectionRefusedError` on every flush
- Users have to fall back to direct intake (`DD_API_KEY` + `DD_SITE`), losing agent-side batching, tagging, and egress consolidation

Observed in production on a Datadog Operator v1.7+ deployment: ~24k connection-refused errors/day from a single proxy until we forced direct intake by removing `LITELLM_DD_AGENT_HOST`.

### Implementation

- New `_configure_dd_agent_uds(socket_path)` method on `DataDogLLMObsLogger`
- Swaps `self.async_client` for an `httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=...))`
- `intake_url` becomes `http://localhost/api/intake/llm-obs/v1/trace/spans` (httpx requires a URL even with UDS — the host portion is unused because the request is delivered straight over the socket)
- No new env var; reuses `DD_TRACE_AGENT_URL` for consistency with ddtrace

Precedence (backward-compatible):
1. `LITELLM_DD_AGENT_HOST` → existing TCP agent mode
2. `DD_TRACE_AGENT_URL` (`unix://...`) → **new** UDS agent mode
3. `DD_API_KEY` + `DD_SITE` → existing direct intake

A non-unix scheme on `DD_TRACE_AGENT_URL` is intentionally ignored (falls through to direct intake) — avoids accidentally sending LLM Obs spans to the ddtrace HTTP endpoint when only the TCP form was injected.

### Tests

Added 3 new cases to `tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py`:

- `test_datadog_llm_obs_agent_uds_configuration` — `DD_TRACE_AGENT_URL=unix://...` produces the localhost URL and a UDS-backed httpx transport pointing at the socket path
- `test_datadog_llm_obs_agent_host_takes_precedence_over_uds` — `LITELLM_DD_AGENT_HOST` wins when both are set (backward compat)
- `test_datadog_llm_obs_tcp_dd_trace_agent_url_falls_back_to_direct` — non-unix `DD_TRACE_AGENT_URL` (e.g. `http://...`) falls through to direct intake

All 6 tests in the file pass:

```
$ python3 -m pytest tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py -v
...
tests/.../test_datadog_llm_obs_agent_configuration                       PASSED
tests/.../test_datadog_llm_obs_agent_host_takes_precedence_over_uds      PASSED
tests/.../test_datadog_llm_obs_agent_no_api_key_ok                       PASSED
tests/.../test_datadog_llm_obs_agent_uds_configuration                   PASSED
tests/.../test_datadog_llm_obs_direct_api_configuration                  PASSED
tests/.../test_datadog_llm_obs_tcp_dd_trace_agent_url_falls_back_to_direct PASSED
============================== 6 passed in 0.18s ===============================
```

Format/lint clean: `black` reformatted whitespace only; `ruff check` passes.