### PR TITLE
Add Veto guardrail provider

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/veto/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Package marker for the Veto LiteLLM guardrail hook.
+# Upstream destination: litellm/proxy/guardrails/guardrail_hooks/veto/__init__.py

--- a/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
@@ -59,8 +59,7 @@ class VetoGuardrail(CustomGuardrail):
         """POST one text to the Veto gateway. Returns the verdict JSON.
 
         Uses litellm's shared async HTTP client (connection pooling, retries,
-        observability; lifecycle owned by the global client cache). The handler
-        raises for non-2xx and retries transient connection errors internally.
+        observability; lifecycle owned by the global client cache).
         """
         headers = {"Content-Type": "application/json"}
         if self.api_key:
@@ -74,6 +73,11 @@ class VetoGuardrail(CustomGuardrail):
             json={"text": text, "categories": self.categories},
             timeout=self.timeout,
         )
+        # Fail closed on any non-2xx (auth / rate-limit / 5xx). The shared
+        # handler raises on its primary path; calling it here also covers the
+        # connection-retry path, so a gateway error can never silently pass
+        # unscanned text through to the model.
+        resp.raise_for_status()
         return resp.json()
 
     def _raise_blocked(self, verdict: dict) -> None:

--- a/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
@@ -13,10 +13,14 @@
 
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Type, Union
 
-import httpx
+from fastapi import HTTPException
 
 from litellm import DualCache
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import ModelResponse
 
@@ -35,13 +39,12 @@ class VetoGuardrail(CustomGuardrail):
         self,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
-        categories: Optional[List[str]] = None,
         **kwargs,
     ):
         self.api_base = (api_base or "https://api.vetocheck.com").rstrip("/")
         self.api_key = api_key
-        self.categories = categories or VETO_DEFAULT_CATEGORIES
-        self.client = httpx.AsyncClient(timeout=10.0)
+        self.categories = VETO_DEFAULT_CATEGORIES
+        self.timeout = 10.0
         super().__init__(**kwargs)
 
     @staticmethod
@@ -53,21 +56,27 @@ class VetoGuardrail(CustomGuardrail):
         return VetoGuardrailConfigModel
 
     async def _check(self, text: str) -> dict:
-        """POST one text to the Veto gateway. Returns the verdict JSON."""
+        """POST one text to the Veto gateway. Returns the verdict JSON.
+
+        Uses litellm's shared async HTTP client (connection pooling, retries,
+        observability; lifecycle owned by the global client cache). The handler
+        raises for non-2xx and retries transient connection errors internally.
+        """
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
-        resp = await self.client.post(
+        client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback
+        )
+        resp = await client.post(
             f"{self.api_base}/v1/check",
             headers=headers,
             json={"text": text, "categories": self.categories},
+            timeout=self.timeout,
         )
-        resp.raise_for_status()
         return resp.json()
 
     def _raise_blocked(self, verdict: dict) -> None:
-        from fastapi import HTTPException
-
         raise HTTPException(
             status_code=400,
             detail={

--- a/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
@@ -11,12 +11,25 @@
 # contract. See veto-core/integrations/litellm/README.md for the full PR
 # checklist (enum + initializer + registry edits).
 
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Type, Union
+import uuid
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
 
 from fastapi import HTTPException
 
 from litellm import DualCache
-from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    log_guardrail_information,
+)
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -24,8 +37,11 @@ from litellm.llms.custom_httpx.http_handler import (
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import (
     CallTypesLiteral,
+    Delta,
     GenericGuardrailAPIInputs,
     ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
 )
 
 if TYPE_CHECKING:
@@ -38,6 +54,15 @@ if TYPE_CHECKING:
 # redact → swap message content for the masked text and continue; allow → pass.
 VETO_DEFAULT_CATEGORIES = ["pii", "secrets", "injection"]
 
+# Streaming (SPEC §3.5): the adapter buffers ~N tokens of the upstream
+# stream locally, holds them until the gateway clears that buffer, then
+# releases. Default 128 tokens (tier-tunable 64/128/256). The gateway has
+# no tokenizer either, so token budget is approximated as chars/4 on both
+# sides — buffer size is passed back via ?buffer=N so the gateway's
+# sliding window matches what the adapter buffered.
+VETO_STREAM_BUFFER_TOKENS = 128
+VETO_APPROX_CHARS_PER_TOKEN = 4
+
 
 class VetoGuardrail(CustomGuardrail):
     def __init__(
@@ -49,6 +74,7 @@ class VetoGuardrail(CustomGuardrail):
         self.api_base = (api_base or "https://api.vetocheck.com").rstrip("/")
         self.api_key = api_key
         self.categories = VETO_DEFAULT_CATEGORIES
+        self.buffer_tokens = VETO_STREAM_BUFFER_TOKENS
         self.timeout = 10.0
         super().__init__(**kwargs)
 
@@ -84,6 +110,131 @@ class VetoGuardrail(CustomGuardrail):
         # unscanned text through to the model.
         resp.raise_for_status()
         return resp.json()
+
+    async def _check_stream(
+        self, text: str, stream_id: str, chunk_index: int, final: bool
+    ) -> dict:
+        """POST one buffered chunk to the stateful streaming endpoint
+        (POST /v1/check?stream_id=…&buffer=N — SPEC §3.5.2). The gateway
+        keeps a Redis-backed sliding window keyed by stream_id; the fast
+        lane runs per chunk, the slow lane on final=true. Fail closed on
+        any non-2xx, same as the batch path."""
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback
+        )
+        resp = await client.post(
+            f"{self.api_base}/v1/check",
+            headers=headers,
+            params={"stream_id": stream_id, "buffer": self.buffer_tokens},
+            json={
+                "text": text,
+                "chunk_index": chunk_index,
+                "final": final,
+                "categories": self.categories,
+            },
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    def _stream_chunk_text(chunk: ModelResponseStream) -> str:
+        """Concatenate the assistant text delta carried by one stream chunk.
+        Tool-call / function deltas and role-only chunks contribute no text."""
+        parts: List[str] = []
+        for choice in getattr(chunk, "choices", None) or []:
+            delta = getattr(choice, "delta", None)
+            content = getattr(delta, "content", None) if delta is not None else None
+            if isinstance(content, str):
+                parts.append(content)
+        return "".join(parts)
+
+    @staticmethod
+    def _blocked_stream_chunk(model: str) -> ModelResponseStream:
+        """Terminal chunk emitted when Veto blocks mid-stream: an empty
+        delta with finish_reason="content_filter" (SPEC §3.5.8 chunked-JSON
+        fallback). Downstream SDKs read it as a content-policy stop; the
+        offending buffered tokens are never yielded."""
+        return ModelResponseStream(
+            model=model,
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content=None),
+                    finish_reason="content_filter",
+                )
+            ],
+        )
+
+    async def async_post_call_streaming_iterator_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+        request_data: dict,
+    ) -> AsyncGenerator[Any, None]:
+        """Output guardrail for streaming responses (SPEC §3.5).
+
+        Wraps the upstream LLM iterator. Buffers ~buffer_tokens of assistant
+        text locally and HOLDS those chunks until the gateway clears the
+        buffer, then releases them. On a fast-lane block the held buffer is
+        dropped (never yielded) and a content_filter terminal chunk closes
+        the stream — already-yielded tokens cannot be unsaid, so redact is
+        not applied mid-stream (SPEC §3.5.1); a final redact verdict is
+        treated as allow. Fails closed on any gateway error: blocks the
+        remainder of the stream (SPEC §3.6 / §3.5.8)."""
+        stream_id = uuid.uuid4().hex
+        model = request_data.get("model") or ""
+        buffer_chars = self.buffer_tokens * VETO_APPROX_CHARS_PER_TOKEN
+        chunk_index = 0
+        held: List[ModelResponseStream] = []
+        buffered_text = ""
+
+        async for chunk in response:
+            # Non-chat stream shapes (raw bytes SSE, /v1/responses events)
+            # are passed through unscanned in v1 — the prompt was already
+            # scanned by the pre-call + moderation hooks. Documented limit.
+            if not isinstance(chunk, ModelResponseStream):
+                yield chunk
+                continue
+
+            held.append(chunk)
+            buffered_text += self._stream_chunk_text(chunk)
+            if len(buffered_text) < buffer_chars:
+                continue
+
+            try:
+                verdict = await self._check_stream(
+                    buffered_text, stream_id, chunk_index, final=False
+                )
+            except Exception:
+                yield self._blocked_stream_chunk(model)  # fail closed
+                return
+            chunk_index += 1
+            if verdict.get("action") == "block":
+                yield self._blocked_stream_chunk(model)
+                return
+            for held_chunk in held:
+                yield held_chunk
+            held = []
+            buffered_text = ""
+
+        # EOF: flush the trailing buffer with final=true so the slow lane
+        # (AI classifiers) runs on the assembled response.
+        try:
+            verdict = await self._check_stream(
+                buffered_text, stream_id, chunk_index, final=True
+            )
+        except Exception:
+            yield self._blocked_stream_chunk(model)
+            return
+        if verdict.get("action") == "block":
+            yield self._blocked_stream_chunk(model)
+            return
+        for held_chunk in held:
+            yield held_chunk
 
     def _raise_blocked(self, verdict: dict) -> None:
         raise HTTPException(
@@ -210,6 +361,7 @@ class VetoGuardrail(CustomGuardrail):
                 message.content = await self._scan_text(content)
         return response
 
+    @log_guardrail_information
     async def apply_guardrail(
         self,
         inputs: "GenericGuardrailAPIInputs",

--- a/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Veto guardrail for LiteLLM.
+#
+# Upstream destination (when submitting the PR to BerriAI/litellm):
+#   litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+#
+# This file contains NO detection logic. It is a thin HTTP client that calls
+# the hosted Veto gateway (POST {api_base}/v1/check). All detection lives in
+# veto-core; this adapter only maps Veto's verdict onto LiteLLM's hook
+# contract. See veto-core/integrations/litellm/README.md for the full PR
+# checklist (enum + initializer + registry edits).
+
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Type, Union
+
+import httpx
+
+from litellm import DualCache
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import ModelResponse
+
+if TYPE_CHECKING:
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import (
+        GuardrailConfigModel,
+    )
+
+# Veto returns action ∈ {allow, redact, block}. block → reject the call;
+# redact → swap message content for the masked text and continue; allow → pass.
+VETO_DEFAULT_CATEGORIES = ["pii", "secrets", "injection"]
+
+
+class VetoGuardrail(CustomGuardrail):
+    def __init__(
+        self,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        categories: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        self.api_base = (api_base or "https://api.vetocheck.com").rstrip("/")
+        self.api_key = api_key
+        self.categories = categories or VETO_DEFAULT_CATEGORIES
+        self.client = httpx.AsyncClient(timeout=10.0)
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def get_config_model() -> Optional[Type["GuardrailConfigModel"]]:
+        from litellm.types.proxy.guardrails.guardrail_hooks.veto import (
+            VetoGuardrailConfigModel,
+        )
+
+        return VetoGuardrailConfigModel
+
+    async def _check(self, text: str) -> dict:
+        """POST one text to the Veto gateway. Returns the verdict JSON."""
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        resp = await self.client.post(
+            f"{self.api_base}/v1/check",
+            headers=headers,
+            json={"text": text, "categories": self.categories},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _raise_blocked(self, verdict: dict) -> None:
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "Request blocked by Veto guardrail",
+                "veto": {
+                    "action": verdict.get("action"),
+                    "findings": verdict.get("findings", []),
+                    "degraded": verdict.get("degraded", []),
+                },
+            },
+        )
+
+    async def _scan_messages(self, messages: List[dict]) -> List[dict]:
+        """Scan each string-content message. Block raises; redact rewrites the
+        content in place. Returns the (possibly redacted) messages."""
+        for msg in messages:
+            content = msg.get("content")
+            if not isinstance(content, str) or not content.strip():
+                continue
+            verdict = await self._check(content)
+            action = verdict.get("action")
+            if action == "block":
+                self._raise_blocked(verdict)
+            elif action == "redact":
+                msg["content"] = verdict.get("redacted", content)
+        return messages
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: str,
+    ) -> Optional[Union[Exception, str, dict]]:
+        """Input guardrail: scan the prompt before it reaches the LLM."""
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            data["messages"] = await self._scan_messages(messages)
+        return data
+
+    async def async_moderation_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        call_type: Literal[
+            "completion",
+            "embeddings",
+            "image_generation",
+            "moderation",
+            "audio_transcription",
+            "responses",
+        ],
+    ) -> Any:
+        """Parallel guardrail (block-only): runs alongside the LLM call. Cannot
+        rewrite content here, so a redact verdict is logged, not applied."""
+        messages = data.get("messages")
+        if not isinstance(messages, list):
+            return data
+        for msg in messages:
+            content = msg.get("content")
+            if not isinstance(content, str) or not content.strip():
+                continue
+            verdict = await self._check(content)
+            if verdict.get("action") == "block":
+                self._raise_blocked(verdict)
+        return data
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> Any:
+        """Output guardrail: scan the model response. Block raises; redact
+        rewrites the assistant message content."""
+        if not isinstance(response, ModelResponse):
+            return response
+        for choice in getattr(response, "choices", []) or []:
+            message = getattr(choice, "message", None)
+            content = getattr(message, "content", None)
+            if not isinstance(content, str) or not content.strip():
+                continue
+            verdict = await self._check(content)
+            action = verdict.get("action")
+            if action == "block":
+                self._raise_blocked(verdict)
+            elif action == "redact":
+                message.content = verdict.get("redacted", content)
+        return response
+
+    async def apply_guardrail(
+        self,
+        text: str,
+        language: Optional[str] = None,
+        entities: Optional[List[Any]] = None,
+        request_data: Optional[dict] = None,
+    ) -> str:
+        """Text-in / text-out surface used by the unified guardrail API.
+        Block raises; redact returns the masked text; allow returns input."""
+        verdict = await self._check(text)
+        if verdict.get("action") == "block":
+            self._raise_blocked(verdict)
+        if verdict.get("action") == "redact":
+            return verdict.get("redacted", text)
+        return text

--- a/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
@@ -89,20 +89,67 @@ class VetoGuardrail(CustomGuardrail):
             },
         )
 
-    async def _scan_messages(self, messages: List[dict]) -> List[dict]:
-        """Scan each string-content message. Block raises; redact rewrites the
-        content in place. Returns the (possibly redacted) messages."""
+    async def _scan_text(self, text: str, allow_redact: bool = True) -> str:
+        """Scan one string against the Veto gateway. Block raises; redact
+        returns the masked text when allow_redact is set (the parallel
+        moderation hook passes False — it cannot rewrite); allow returns the
+        input. Empty / non-string input is returned untouched."""
+        if not isinstance(text, str) or not text.strip():
+            return text
+        verdict = await self._check(text)
+        action = verdict.get("action")
+        if action == "block":
+            self._raise_blocked(verdict)
+        if action == "redact" and allow_redact:
+            return verdict.get("redacted", text)
+        return text
+
+    async def _scan_content(self, content: Any, allow_redact: bool = True) -> Any:
+        """Scan a message ``content`` value — a plain string or a multimodal
+        list of parts. Every part carrying a string ``text`` field is scanned
+        (and rewritten in place on redact); non-text parts (image, audio) are
+        left untouched. Closes the bypass where blocked text rides inside a
+        multimodal part."""
+        if isinstance(content, str):
+            return await self._scan_text(content, allow_redact)
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    scanned = await self._scan_text(part["text"], allow_redact)
+                    if allow_redact:
+                        part["text"] = scanned
+        return content
+
+    async def _scan_messages(
+        self, messages: List[dict], allow_redact: bool = True
+    ) -> List[dict]:
+        """Scan every message's content (string or multimodal). Block raises;
+        redact rewrites content in place when allow_redact is set."""
         for msg in messages:
-            content = msg.get("content")
-            if not isinstance(content, str) or not content.strip():
-                continue
-            verdict = await self._check(content)
-            action = verdict.get("action")
-            if action == "block":
-                self._raise_blocked(verdict)
-            elif action == "redact":
-                msg["content"] = verdict.get("redacted", content)
+            if isinstance(msg, dict) and "content" in msg:
+                msg["content"] = await self._scan_content(
+                    msg.get("content"), allow_redact
+                )
         return messages
+
+    async def _scan_input(self, value: Any, allow_redact: bool = True) -> Any:
+        """Scan the Responses-API ``input`` field — a plain string, or a list
+        of items (strings or message dicts carrying ``content``). Mirrors the
+        chat ``messages`` path so blocked text cannot bypass via /v1/responses.
+        """
+        if isinstance(value, str):
+            return await self._scan_text(value, allow_redact)
+        if isinstance(value, list):
+            for i, item in enumerate(value):
+                if isinstance(item, str):
+                    scanned = await self._scan_text(item, allow_redact)
+                    if allow_redact:
+                        value[i] = scanned
+                elif isinstance(item, dict) and "content" in item:
+                    item["content"] = await self._scan_content(
+                        item.get("content"), allow_redact
+                    )
+        return value
 
     async def async_pre_call_hook(
         self,
@@ -111,10 +158,13 @@ class VetoGuardrail(CustomGuardrail):
         data: dict,
         call_type: str,
     ) -> Optional[Union[Exception, str, dict]]:
-        """Input guardrail: scan the prompt before it reaches the LLM."""
+        """Input guardrail: scan the prompt — chat ``messages`` and/or the
+        Responses ``input`` field — before it reaches the LLM."""
         messages = data.get("messages")
         if isinstance(messages, list):
             data["messages"] = await self._scan_messages(messages)
+        if "input" in data:
+            data["input"] = await self._scan_input(data.get("input"))
         return data
 
     async def async_moderation_hook(
@@ -131,17 +181,12 @@ class VetoGuardrail(CustomGuardrail):
         ],
     ) -> Any:
         """Parallel guardrail (block-only): runs alongside the LLM call. Cannot
-        rewrite content here, so a redact verdict is logged, not applied."""
+        rewrite content, so redact is not applied — only block raises."""
         messages = data.get("messages")
-        if not isinstance(messages, list):
-            return data
-        for msg in messages:
-            content = msg.get("content")
-            if not isinstance(content, str) or not content.strip():
-                continue
-            verdict = await self._check(content)
-            if verdict.get("action") == "block":
-                self._raise_blocked(verdict)
+        if isinstance(messages, list):
+            await self._scan_messages(messages, allow_redact=False)
+        if "input" in data:
+            await self._scan_input(data.get("input"), allow_redact=False)
         return data
 
     async def async_post_call_success_hook(
@@ -157,14 +202,8 @@ class VetoGuardrail(CustomGuardrail):
         for choice in getattr(response, "choices", []) or []:
             message = getattr(choice, "message", None)
             content = getattr(message, "content", None)
-            if not isinstance(content, str) or not content.strip():
-                continue
-            verdict = await self._check(content)
-            action = verdict.get("action")
-            if action == "block":
-                self._raise_blocked(verdict)
-            elif action == "redact":
-                message.content = verdict.get("redacted", content)
+            if isinstance(content, str) and content.strip():
+                message.content = await self._scan_text(content)
         return response
 
     async def apply_guardrail(
@@ -176,9 +215,4 @@ class VetoGuardrail(CustomGuardrail):
     ) -> str:
         """Text-in / text-out surface used by the unified guardrail API.
         Block raises; redact returns the masked text; allow returns input."""
-        verdict = await self._check(text)
-        if verdict.get("action") == "block":
-            self._raise_blocked(verdict)
-        if verdict.get("action") == "redact":
-            return verdict.get("redacted", text)
-        return text
+        return await self._scan_text(text)

--- a/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/veto/veto.py
@@ -22,9 +22,14 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import (
+    CallTypesLiteral,
+    GenericGuardrailAPIInputs,
+    ModelResponse,
+)
 
 if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.proxy.guardrails.guardrail_hooks.base import (
         GuardrailConfigModel,
     )
@@ -175,14 +180,7 @@ class VetoGuardrail(CustomGuardrail):
         self,
         data: dict,
         user_api_key_dict: UserAPIKeyAuth,
-        call_type: Literal[
-            "completion",
-            "embeddings",
-            "image_generation",
-            "moderation",
-            "audio_transcription",
-            "responses",
-        ],
+        call_type: CallTypesLiteral,
     ) -> Any:
         """Parallel guardrail (block-only): runs alongside the LLM call. Cannot
         rewrite content, so redact is not applied — only block raises."""
@@ -205,6 +203,8 @@ class VetoGuardrail(CustomGuardrail):
             return response
         for choice in getattr(response, "choices", []) or []:
             message = getattr(choice, "message", None)
+            if message is None:
+                continue
             content = getattr(message, "content", None)
             if isinstance(content, str) and content.strip():
                 message.content = await self._scan_text(content)
@@ -212,11 +212,17 @@ class VetoGuardrail(CustomGuardrail):
 
     async def apply_guardrail(
         self,
-        text: str,
-        language: Optional[str] = None,
-        entities: Optional[List[Any]] = None,
-        request_data: Optional[dict] = None,
-    ) -> str:
+        inputs: "GenericGuardrailAPIInputs",
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> "GenericGuardrailAPIInputs":
         """Text-in / text-out surface used by the unified guardrail API.
-        Block raises; redact returns the masked text; allow returns input."""
-        return await self._scan_text(text)
+        Scans each entry in ``inputs['texts']``: block raises; redact rewrites
+        the text in place; allow returns it untouched."""
+        texts = inputs.get("texts") or []
+        for i, text in enumerate(texts):
+            scanned = await self._scan_text(text)
+            if isinstance(scanned, str):
+                texts[i] = scanned
+        return inputs

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -223,3 +223,17 @@ def initialize_panw_prisma_airs(litellm_params, guardrail):
     litellm.logging_callback_manager.add_litellm_callback(_panw_callback)
 
     return _panw_callback
+
+
+def initialize_veto(litellm_params: LitellmParams, guardrail: Guardrail):
+    from litellm.proxy.guardrails.guardrail_hooks.veto.veto import VetoGuardrail
+
+    _veto_callback = VetoGuardrail(
+        guardrail_name=guardrail.get("guardrail_name", "veto"),
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+        event_hook=litellm_params.mode,
+        default_on=litellm_params.default_on,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(_veto_callback)
+    return _veto_callback

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -33,6 +33,7 @@ from .guardrail_initializers import (
     initialize_lakera_v2,
     initialize_presidio,
     initialize_tool_permission,
+    initialize_veto,
 )
 from .guardrail_hooks.llm_as_a_judge import (
     initialize_guardrail as initialize_llm_as_a_judge,
@@ -47,6 +48,7 @@ guardrail_initializer_registry = {
     SupportedGuardrailIntegrations.TOOL_PERMISSION.value: initialize_tool_permission,
     SupportedGuardrailIntegrations.GRAYSWAN.value: initialize_grayswan,
     SupportedGuardrailIntegrations.LLM_AS_A_JUDGE.value: initialize_llm_as_a_judge,
+    SupportedGuardrailIntegrations.VETO.value: initialize_veto,
 }
 
 guardrail_class_registry: Dict[str, Type[CustomGuardrail]] = {

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -102,6 +102,7 @@ class SupportedGuardrailIntegrations(Enum):
     LLM_AS_A_JUDGE = "llm_as_a_judge"
     QOSTODIAN_NEXUS = "qostodian_nexus"
     RUBRIK = "rubrik"
+    VETO = "veto"
 
 
 class Role(Enum):

--- a/litellm/types/proxy/guardrails/guardrail_hooks/veto.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/veto.py
@@ -1,0 +1,43 @@
+from typing import Any, List, Optional, cast
+
+from pydantic import Field
+
+from .base import GuardrailConfigModel
+
+VETO_CATEGORY_OPTIONS = ["pii", "secrets", "injection"]
+
+
+class VetoGuardrailConfigModel(GuardrailConfigModel):
+    api_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "Veto API key (prefix 'vt_'). If not provided, the "
+            "VETO_API_KEY environment variable is used."
+        ),
+    )
+    api_base: Optional[str] = Field(
+        default=None,
+        description=(
+            "Veto gateway base URL. Defaults to https://api.vetocheck.com. "
+            "Falls back to the VETO_API_BASE env var."
+        ),
+    )
+    categories: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Detector categories to run on each request. Select one or more "
+            "of pii, secrets, injection; if none are selected the guardrail "
+            "runs all three."
+        ),
+        json_schema_extra=cast(
+            Any,
+            {
+                "ui_type": "multiselect",
+                "options": VETO_CATEGORY_OPTIONS,
+            },
+        ),
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Veto"

--- a/litellm/types/proxy/guardrails/guardrail_hooks/veto.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/veto.py
@@ -1,10 +1,8 @@
-from typing import Any, List, Optional, cast
+from typing import Optional
 
 from pydantic import Field
 
 from .base import GuardrailConfigModel
-
-VETO_CATEGORY_OPTIONS = ["pii", "secrets", "injection"]
 
 
 class VetoGuardrailConfigModel(GuardrailConfigModel):
@@ -20,21 +18,6 @@ class VetoGuardrailConfigModel(GuardrailConfigModel):
         description=(
             "Veto gateway base URL. Defaults to https://api.vetocheck.com. "
             "Falls back to the VETO_API_BASE env var."
-        ),
-    )
-    categories: Optional[List[str]] = Field(
-        default=None,
-        description=(
-            "Detector categories to run on each request. Select one or more "
-            "of pii, secrets, injection; if none are selected the guardrail "
-            "runs all three."
-        ),
-        json_schema_extra=cast(
-            Any,
-            {
-                "ui_type": "multiselect",
-                "options": VETO_CATEGORY_OPTIONS,
-            },
         ),
     )
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
@@ -15,7 +15,14 @@ import pytest
 from fastapi.exceptions import HTTPException
 
 from litellm.proxy.guardrails.guardrail_hooks.veto.veto import VetoGuardrail
-from litellm.types.utils import Choices, Message, ModelResponse
+from litellm.types.utils import (
+    Choices,
+    Delta,
+    Message,
+    ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -67,6 +74,37 @@ def _model_response(content: str) -> ModelResponse:
     return ModelResponse(
         choices=[Choices(message=Message(content=content, role="assistant"))]
     )
+
+
+def _stream_chunk(text: str) -> ModelResponseStream:
+    return ModelResponseStream(
+        model="gpt-x",
+        choices=[StreamingChoices(index=0, delta=Delta(content=text))],
+    )
+
+
+async def _aiter(items):
+    for it in items:
+        yield it
+
+
+async def _collect(agen):
+    return [c async for c in agen]
+
+
+@contextmanager
+def _patch_stream(guardrail, responses):
+    """Patch the shared client; ``post`` returns each item in ``responses``
+    in order — a verdict mock to return, or an Exception instance to raise
+    (drives the fail-closed path)."""
+    post_mock = AsyncMock(side_effect=responses)
+    handler = MagicMock()
+    handler.post = post_mock
+    with patch(
+        "litellm.proxy.guardrails.guardrail_hooks.veto.veto.get_async_httpx_client",
+        return_value=handler,
+    ):
+        yield post_mock
 
 
 # ---------------------------------------------------------------------------
@@ -444,3 +482,119 @@ class TestVetoConfigModel:
 
         fields = VetoGuardrailConfigModel.model_fields
         assert {"api_key", "api_base"}.issubset(fields.keys())
+
+
+# ---------------------------------------------------------------------------
+# streaming output hook (SPEC §3.5)
+# ---------------------------------------------------------------------------
+
+
+class TestVetoStreaming:
+    @pytest.mark.asyncio
+    async def test_allow_passes_through(self, veto_guardrail):
+        # total text under the buffer → one final=true POST, all chunks yielded
+        chunks = [_stream_chunk("hel"), _stream_chunk("lo")]
+        with _patch_stream(veto_guardrail, [_verdict("allow")]) as post:
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert [c.choices[0].delta.content for c in out] == ["hel", "lo"]
+        assert post.call_count == 1
+        assert post.call_args.kwargs["json"]["final"] is True
+
+    @pytest.mark.asyncio
+    async def test_midstream_block_drops_held_buffer(self, veto_guardrail):
+        # small buffer → first chunk triggers a flush; block drops the held
+        # chunk (never yielded) and closes with a content_filter terminal.
+        veto_guardrail.buffer_tokens = 1  # buffer_chars = 4
+        chunks = [_stream_chunk("AKIA"), _stream_chunk("more")]
+        with _patch_stream(veto_guardrail, [_verdict("block")]) as post:
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert len(out) == 1
+        assert out[0].choices[0].finish_reason == "content_filter"
+        assert post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_final_block(self, veto_guardrail):
+        # under buffer → block surfaces only at EOF; held tail is dropped.
+        chunks = [_stream_chunk("hi")]
+        with _patch_stream(veto_guardrail, [_verdict("block")]):
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert out[-1].choices[0].finish_reason == "content_filter"
+        assert all(
+            getattr(c.choices[0], "delta", None) is None
+            or c.choices[0].delta.content != "hi"
+            for c in out
+        )
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_on_gateway_error(self, veto_guardrail):
+        # a thrown gateway call must close the stream, not pass tokens through
+        chunks = [_stream_chunk("hi")]
+        with _patch_stream(veto_guardrail, [RuntimeError("boom")]):
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert out[-1].choices[0].finish_reason == "content_filter"
+
+    @pytest.mark.asyncio
+    async def test_buffer_flush_releases_and_params(self, veto_guardrail):
+        veto_guardrail.buffer_tokens = 1  # buffer_chars = 4
+        chunks = [_stream_chunk("aaaa"), _stream_chunk("bb")]
+        with _patch_stream(
+            veto_guardrail, [_verdict("allow"), _verdict("allow")]
+        ) as post:
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert [c.choices[0].delta.content for c in out] == ["aaaa", "bb"]
+        assert post.call_count == 2  # one mid-stream flush + one final
+        p0 = post.call_args_list[0].kwargs["params"]
+        p1 = post.call_args_list[1].kwargs["params"]
+        assert p0["stream_id"] == p1["stream_id"]  # stable across chunks
+        assert p0["buffer"] == 1
+        assert post.call_args_list[0].kwargs["json"]["final"] is False
+        assert post.call_args_list[1].kwargs["json"]["final"] is True
+        assert post.call_args_list[1].kwargs["json"]["chunk_index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_eof_redact_treated_as_allow(self, veto_guardrail):
+        # redact is EOF-only and can't unsay yielded tokens → streaming
+        # honors only block; a final redact verdict releases the tail as-is.
+        chunks = [_stream_chunk("email a@b.com")]
+        with _patch_stream(veto_guardrail, [_verdict("redact", redacted="email X")]):
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert [c.choices[0].delta.content for c in out] == ["email a@b.com"]
+
+    @pytest.mark.asyncio
+    async def test_non_chat_chunk_passthrough(self, veto_guardrail):
+        # raw bytes (Anthropic native SSE) pass through untouched; chat
+        # chunks are still buffered + scanned.
+        chunks = [b"raw bytes", _stream_chunk("hi")]
+        with _patch_stream(veto_guardrail, [_verdict("allow")]) as post:
+            out = await _collect(
+                veto_guardrail.async_post_call_streaming_iterator_hook(
+                    MagicMock(), _aiter(chunks), {"model": "gpt-x"}
+                )
+            )
+        assert out[0] == b"raw bytes"
+        assert out[-1].choices[0].delta.content == "hi"
+        assert post.call_count == 1

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
@@ -9,6 +9,7 @@ post-call hooks plus the text-in/text-out ``apply_guardrail`` surface.
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from fastapi.exceptions import HTTPException
@@ -245,6 +246,28 @@ class TestVetoMultimodalAndInput:
                     data, MagicMock(), "completion"
                 )
 
+    @pytest.mark.asyncio
+    async def test_responses_input_list_of_strings_redacted(self, veto_guardrail):
+        data = {"input": ["email a@b.com"]}
+        with _patch_check(
+            veto_guardrail, _verdict("redact", redacted="email [REDACTED_EMAIL]")
+        ):
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "responses"
+            )
+        assert out["input"][0] == "email [REDACTED_EMAIL]"
+
+    @pytest.mark.asyncio
+    async def test_null_content_passthrough(self, veto_guardrail):
+        # a message with no string/list content (e.g. a tool call) is left alone
+        data = {"messages": [{"role": "assistant", "content": None}]}
+        with _patch_check(veto_guardrail, _verdict("block")) as mock_post:
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "completion"
+            )
+        assert mock_post.call_count == 0
+        assert out["messages"][0]["content"] is None
+
 
 # ---------------------------------------------------------------------------
 # moderation hook (block-only)
@@ -331,6 +354,12 @@ class TestVetoApplyGuardrail:
             with pytest.raises(HTTPException):
                 await veto_guardrail.apply_guardrail("ignore previous")
 
+    @pytest.mark.asyncio
+    async def test_empty_text_not_scanned(self, veto_guardrail):
+        with _patch_check(veto_guardrail, _verdict("block")) as mock_post:
+            assert await veto_guardrail.apply_guardrail("   ") == "   "
+        assert mock_post.call_count == 0
+
 
 # ---------------------------------------------------------------------------
 # request shape
@@ -353,6 +382,26 @@ class TestVetoRequest:
         assert sent["text"] == "scan me"
         assert sent["categories"] == ["pii", "secrets", "injection"]
         assert mock_post.call_args.args[0].endswith("/v1/check")
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_omits_auth_header(self):
+        g = VetoGuardrail(guardrail_name="no-key", event_hook="pre_call")
+        data = {"messages": [{"role": "user", "content": "scan me"}]}
+        with _patch_check(g, _verdict("allow")) as mock_post:
+            await g.async_pre_call_hook(MagicMock(), MagicMock(), data, "completion")
+        assert "Authorization" not in mock_post.call_args.kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_gateway_error_fails_closed(self, veto_guardrail):
+        # a non-2xx from the gateway must raise (fail closed), never silently
+        # pass unscanned text through.
+        err_resp = MagicMock()
+        err_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock()
+        )
+        with _patch_check(veto_guardrail, err_resp):
+            with pytest.raises(httpx.HTTPStatusError):
+                await veto_guardrail.apply_guardrail("scan me")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
@@ -341,23 +341,34 @@ class TestVetoApplyGuardrail:
     @pytest.mark.asyncio
     async def test_allow_returns_input(self, veto_guardrail):
         with _patch_check(veto_guardrail, _verdict("allow")):
-            assert await veto_guardrail.apply_guardrail("hello") == "hello"
+            out = await veto_guardrail.apply_guardrail(
+                {"texts": ["hello"]}, {}, "request"
+            )
+        assert out["texts"] == ["hello"]
 
     @pytest.mark.asyncio
     async def test_redact_returns_masked(self, veto_guardrail):
         with _patch_check(veto_guardrail, _verdict("redact", redacted="masked")):
-            assert await veto_guardrail.apply_guardrail("secret") == "masked"
+            out = await veto_guardrail.apply_guardrail(
+                {"texts": ["secret"]}, {}, "request"
+            )
+        assert out["texts"] == ["masked"]
 
     @pytest.mark.asyncio
     async def test_block_raises(self, veto_guardrail):
         with _patch_check(veto_guardrail, _verdict("block")):
             with pytest.raises(HTTPException):
-                await veto_guardrail.apply_guardrail("ignore previous")
+                await veto_guardrail.apply_guardrail(
+                    {"texts": ["ignore previous"]}, {}, "request"
+                )
 
     @pytest.mark.asyncio
     async def test_empty_text_not_scanned(self, veto_guardrail):
         with _patch_check(veto_guardrail, _verdict("block")) as mock_post:
-            assert await veto_guardrail.apply_guardrail("   ") == "   "
+            out = await veto_guardrail.apply_guardrail(
+                {"texts": ["   "]}, {}, "request"
+            )
+        assert out["texts"] == ["   "]
         assert mock_post.call_count == 0
 
 
@@ -401,7 +412,9 @@ class TestVetoRequest:
         )
         with _patch_check(veto_guardrail, err_resp):
             with pytest.raises(httpx.HTTPStatusError):
-                await veto_guardrail.apply_guardrail("scan me")
+                await veto_guardrail.apply_guardrail(
+                    {"texts": ["scan me"]}, {}, "request"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
@@ -6,6 +6,7 @@ mapping (allow / redact / block) across the pre-call, moderation, and
 post-call hooks plus the text-in/text-out ``apply_guardrail`` surface.
 """
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,7 +35,7 @@ def veto_guardrail():
 def _verdict(
     action: str, redacted: str = "", findings=None, degraded=None
 ) -> MagicMock:
-    """A mock httpx response whose .json() returns a Veto verdict."""
+    """A mock HTTP response whose .json() returns a Veto verdict."""
     mock = MagicMock()
     mock.json.return_value = {
         "allowed": action != "block",
@@ -44,14 +45,21 @@ def _verdict(
         "latency_ms": 1.0,
         "degraded": degraded or [],
     }
-    mock.raise_for_status = MagicMock()
     return mock
 
 
+@contextmanager
 def _patch_check(guardrail, verdict_mock):
-    return patch.object(
-        guardrail.client, "post", new=AsyncMock(return_value=verdict_mock)
-    )
+    """Patch the shared litellm async HTTP client that _check fetches, and
+    yield the AsyncMock standing in for the handler's .post."""
+    post_mock = AsyncMock(return_value=verdict_mock)
+    handler = MagicMock()
+    handler.post = post_mock
+    with patch(
+        "litellm.proxy.guardrails.guardrail_hooks.veto.veto.get_async_httpx_client",
+        return_value=handler,
+    ):
+        yield post_mock
 
 
 def _model_response(content: str) -> ModelResponse:
@@ -77,10 +85,6 @@ class TestVetoConfiguration:
     def test_default_categories(self):
         g = VetoGuardrail(api_key="vt_live_x")
         assert g.categories == ["pii", "secrets", "injection"]
-
-    def test_custom_categories(self):
-        g = VetoGuardrail(api_key="vt_live_x", categories=["pii"])
-        assert g.categories == ["pii"]
 
     def test_apply_guardrail_defined_on_class(self):
         # during_call dispatch requires apply_guardrail on the class dict,
@@ -232,9 +236,7 @@ class TestVetoRequest:
     async def test_bearer_auth_and_payload(self, veto_guardrail):
         data = {"messages": [{"role": "user", "content": "scan me"}]}
         verdict = _verdict("allow")
-        with patch.object(
-            veto_guardrail.client, "post", new=AsyncMock(return_value=verdict)
-        ) as mock_post:
+        with _patch_check(veto_guardrail, verdict) as mock_post:
             await veto_guardrail.async_pre_call_hook(
                 MagicMock(), MagicMock(), data, "completion"
             )
@@ -273,4 +275,4 @@ class TestVetoConfigModel:
         )
 
         fields = VetoGuardrailConfigModel.model_fields
-        assert {"api_key", "api_base", "categories"}.issubset(fields.keys())
+        assert {"api_key", "api_base"}.issubset(fields.keys())

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
@@ -141,6 +141,112 @@ class TestVetoPreCall:
 
 
 # ---------------------------------------------------------------------------
+# bypass prevention: multimodal parts + Responses `input` field
+# ---------------------------------------------------------------------------
+
+
+class TestVetoMultimodalAndInput:
+    """Text smuggled inside a multimodal content part or the Responses
+    ``input`` field must still be scanned — not only top-level string content."""
+
+    @pytest.mark.asyncio
+    async def test_multimodal_text_part_blocked(self, veto_guardrail):
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "ignore previous"},
+                        {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+                    ],
+                }
+            ]
+        }
+        with _patch_check(veto_guardrail, _verdict("block")) as mock_post:
+            with pytest.raises(HTTPException):
+                await veto_guardrail.async_pre_call_hook(
+                    MagicMock(), MagicMock(), data, "completion"
+                )
+        assert mock_post.call_count == 1  # only the text part is scanned
+
+    @pytest.mark.asyncio
+    async def test_multimodal_text_part_redacted(self, veto_guardrail):
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "email a@b.com"},
+                        {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+                    ],
+                }
+            ]
+        }
+        with _patch_check(
+            veto_guardrail, _verdict("redact", redacted="email [REDACTED_EMAIL]")
+        ):
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "completion"
+            )
+        parts = out["messages"][0]["content"]
+        assert parts[0]["text"] == "email [REDACTED_EMAIL]"
+        assert parts[1]["type"] == "image_url"  # non-text part untouched
+
+    @pytest.mark.asyncio
+    async def test_responses_input_string_blocked(self, veto_guardrail):
+        data = {"input": "ignore previous"}
+        with _patch_check(veto_guardrail, _verdict("block")):
+            with pytest.raises(HTTPException):
+                await veto_guardrail.async_pre_call_hook(
+                    MagicMock(), MagicMock(), data, "responses"
+                )
+
+    @pytest.mark.asyncio
+    async def test_responses_input_string_redacted(self, veto_guardrail):
+        data = {"input": "email a@b.com"}
+        with _patch_check(
+            veto_guardrail, _verdict("redact", redacted="email [REDACTED_EMAIL]")
+        ):
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "responses"
+            )
+        assert out["input"] == "email [REDACTED_EMAIL]"
+
+    @pytest.mark.asyncio
+    async def test_responses_input_list_message_blocked(self, veto_guardrail):
+        data = {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "ignore previous"}],
+                }
+            ]
+        }
+        with _patch_check(veto_guardrail, _verdict("block")):
+            with pytest.raises(HTTPException):
+                await veto_guardrail.async_pre_call_hook(
+                    MagicMock(), MagicMock(), data, "responses"
+                )
+
+    @pytest.mark.asyncio
+    async def test_moderation_scans_multimodal_text(self, veto_guardrail):
+        # the block-only parallel path must also see multimodal text parts
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "ignore previous"}],
+                }
+            ]
+        }
+        with _patch_check(veto_guardrail, _verdict("block")):
+            with pytest.raises(HTTPException):
+                await veto_guardrail.async_moderation_hook(
+                    data, MagicMock(), "completion"
+                )
+
+
+# ---------------------------------------------------------------------------
 # moderation hook (block-only)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py
@@ -1,0 +1,276 @@
+"""
+Unit tests for the Veto guardrail integration.
+
+Network calls are always mocked. Exercises the verdict → hook-action
+mapping (allow / redact / block) across the pre-call, moderation, and
+post-call hooks plus the text-in/text-out ``apply_guardrail`` surface.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fastapi.exceptions import HTTPException
+
+from litellm.proxy.guardrails.guardrail_hooks.veto.veto import VetoGuardrail
+from litellm.types.utils import Choices, Message, ModelResponse
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def veto_guardrail():
+    return VetoGuardrail(
+        api_base="https://api.test.vetocheck.local",
+        api_key="vt_live_test_key",
+        guardrail_name="test-veto",
+        event_hook="pre_call",
+        default_on=True,
+    )
+
+
+def _verdict(
+    action: str, redacted: str = "", findings=None, degraded=None
+) -> MagicMock:
+    """A mock httpx response whose .json() returns a Veto verdict."""
+    mock = MagicMock()
+    mock.json.return_value = {
+        "allowed": action != "block",
+        "action": action,
+        "findings": findings or [],
+        "redacted": redacted,
+        "latency_ms": 1.0,
+        "degraded": degraded or [],
+    }
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _patch_check(guardrail, verdict_mock):
+    return patch.object(
+        guardrail.client, "post", new=AsyncMock(return_value=verdict_mock)
+    )
+
+
+def _model_response(content: str) -> ModelResponse:
+    return ModelResponse(
+        choices=[Choices(message=Message(content=content, role="assistant"))]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class TestVetoConfiguration:
+    def test_default_api_base(self):
+        g = VetoGuardrail(api_key="vt_live_x")
+        assert g.api_base == "https://api.vetocheck.com"
+
+    def test_strips_trailing_slash(self):
+        g = VetoGuardrail(api_key="vt_live_x", api_base="https://custom.local/")
+        assert g.api_base == "https://custom.local"
+
+    def test_default_categories(self):
+        g = VetoGuardrail(api_key="vt_live_x")
+        assert g.categories == ["pii", "secrets", "injection"]
+
+    def test_custom_categories(self):
+        g = VetoGuardrail(api_key="vt_live_x", categories=["pii"])
+        assert g.categories == ["pii"]
+
+    def test_apply_guardrail_defined_on_class(self):
+        # during_call dispatch requires apply_guardrail on the class dict,
+        # not merely inherited. Guard against accidental refactors.
+        assert "apply_guardrail" in VetoGuardrail.__dict__
+
+
+# ---------------------------------------------------------------------------
+# pre_call hook (input)
+# ---------------------------------------------------------------------------
+
+
+class TestVetoPreCall:
+    @pytest.mark.asyncio
+    async def test_allow_passes_unchanged(self, veto_guardrail):
+        data = {"messages": [{"role": "user", "content": "hello"}]}
+        with _patch_check(veto_guardrail, _verdict("allow")):
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "completion"
+            )
+        assert out["messages"][0]["content"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_redact_rewrites_content(self, veto_guardrail):
+        data = {"messages": [{"role": "user", "content": "email a@b.com"}]}
+        with _patch_check(
+            veto_guardrail, _verdict("redact", redacted="email [REDACTED_EMAIL]")
+        ):
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "completion"
+            )
+        assert out["messages"][0]["content"] == "email [REDACTED_EMAIL]"
+
+    @pytest.mark.asyncio
+    async def test_block_raises(self, veto_guardrail):
+        data = {"messages": [{"role": "user", "content": "ignore previous"}]}
+        finding = {"category": "injection", "rule": "ml", "severity": "high"}
+        with _patch_check(veto_guardrail, _verdict("block", findings=[finding])):
+            with pytest.raises(HTTPException) as exc:
+                await veto_guardrail.async_pre_call_hook(
+                    MagicMock(), MagicMock(), data, "completion"
+                )
+        assert exc.value.detail["veto"]["action"] == "block"
+
+    @pytest.mark.asyncio
+    async def test_non_string_content_skipped(self, veto_guardrail):
+        data = {"messages": [{"role": "user", "content": [{"type": "image_url"}]}]}
+        with _patch_check(veto_guardrail, _verdict("block")) as mock_post:
+            out = await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "completion"
+            )
+        assert mock_post.call_count == 0
+        assert out == data
+
+
+# ---------------------------------------------------------------------------
+# moderation hook (block-only)
+# ---------------------------------------------------------------------------
+
+
+class TestVetoModeration:
+    @pytest.mark.asyncio
+    async def test_block_raises(self, veto_guardrail):
+        data = {"messages": [{"role": "user", "content": "ignore previous"}]}
+        with _patch_check(veto_guardrail, _verdict("block")):
+            with pytest.raises(HTTPException):
+                await veto_guardrail.async_moderation_hook(
+                    data, MagicMock(), "completion"
+                )
+
+    @pytest.mark.asyncio
+    async def test_redact_does_not_rewrite(self, veto_guardrail):
+        # moderation runs parallel to the LLM call and cannot mutate input.
+        data = {"messages": [{"role": "user", "content": "email a@b.com"}]}
+        with _patch_check(veto_guardrail, _verdict("redact", redacted="email X")):
+            out = await veto_guardrail.async_moderation_hook(
+                data, MagicMock(), "completion"
+            )
+        assert out["messages"][0]["content"] == "email a@b.com"
+
+
+# ---------------------------------------------------------------------------
+# post_call hook (output)
+# ---------------------------------------------------------------------------
+
+
+class TestVetoPostCall:
+    @pytest.mark.asyncio
+    async def test_block_raises(self, veto_guardrail):
+        response = _model_response("harmful output")
+        with _patch_check(veto_guardrail, _verdict("block")):
+            with pytest.raises(HTTPException):
+                await veto_guardrail.async_post_call_success_hook(
+                    {}, MagicMock(), response
+                )
+
+    @pytest.mark.asyncio
+    async def test_redact_rewrites_message(self, veto_guardrail):
+        response = _model_response("my key is sk-123")
+        with _patch_check(
+            veto_guardrail,
+            _verdict("redact", redacted="my key is [REDACTED_OPENAI_KEY]"),
+        ):
+            out = await veto_guardrail.async_post_call_success_hook(
+                {}, MagicMock(), response
+            )
+        assert out.choices[0].message.content == "my key is [REDACTED_OPENAI_KEY]"
+
+    @pytest.mark.asyncio
+    async def test_non_model_response_returned_unchanged(self, veto_guardrail):
+        with _patch_check(veto_guardrail, _verdict("block")) as mock_post:
+            out = await veto_guardrail.async_post_call_success_hook(
+                {}, MagicMock(), "raw string"
+            )
+        assert out == "raw string"
+        assert mock_post.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# apply_guardrail (text in / text out)
+# ---------------------------------------------------------------------------
+
+
+class TestVetoApplyGuardrail:
+    @pytest.mark.asyncio
+    async def test_allow_returns_input(self, veto_guardrail):
+        with _patch_check(veto_guardrail, _verdict("allow")):
+            assert await veto_guardrail.apply_guardrail("hello") == "hello"
+
+    @pytest.mark.asyncio
+    async def test_redact_returns_masked(self, veto_guardrail):
+        with _patch_check(veto_guardrail, _verdict("redact", redacted="masked")):
+            assert await veto_guardrail.apply_guardrail("secret") == "masked"
+
+    @pytest.mark.asyncio
+    async def test_block_raises(self, veto_guardrail):
+        with _patch_check(veto_guardrail, _verdict("block")):
+            with pytest.raises(HTTPException):
+                await veto_guardrail.apply_guardrail("ignore previous")
+
+
+# ---------------------------------------------------------------------------
+# request shape
+# ---------------------------------------------------------------------------
+
+
+class TestVetoRequest:
+    @pytest.mark.asyncio
+    async def test_bearer_auth_and_payload(self, veto_guardrail):
+        data = {"messages": [{"role": "user", "content": "scan me"}]}
+        verdict = _verdict("allow")
+        with patch.object(
+            veto_guardrail.client, "post", new=AsyncMock(return_value=verdict)
+        ) as mock_post:
+            await veto_guardrail.async_pre_call_hook(
+                MagicMock(), MagicMock(), data, "completion"
+            )
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == (
+            "Bearer vt_live_test_key"
+        )
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent["text"] == "scan me"
+        assert sent["categories"] == ["pii", "secrets", "injection"]
+        assert mock_post.call_args.args[0].endswith("/v1/check")
+
+
+# ---------------------------------------------------------------------------
+# Config model (UI / typed params)
+# ---------------------------------------------------------------------------
+
+
+class TestVetoConfigModel:
+    def test_get_config_model_returns_veto_model(self):
+        from litellm.types.proxy.guardrails.guardrail_hooks.veto import (
+            VetoGuardrailConfigModel,
+        )
+
+        assert VetoGuardrail.get_config_model() is VetoGuardrailConfigModel
+
+    def test_ui_friendly_name(self):
+        from litellm.types.proxy.guardrails.guardrail_hooks.veto import (
+            VetoGuardrailConfigModel,
+        )
+
+        assert VetoGuardrailConfigModel.ui_friendly_name() == "Veto"
+
+    def test_config_model_fields(self):
+        from litellm.types.proxy.guardrails.guardrail_hooks.veto import (
+            VetoGuardrailConfigModel,
+        )
+
+        fields = VetoGuardrailConfigModel.model_fields
+        assert {"api_key", "api_base", "categories"}.issubset(fields.keys())

--- a/ui/litellm-dashboard/public/assets/logos/veto.svg
+++ b/ui/litellm-dashboard/public/assets/logos/veto.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Veto">
+  <title>Veto</title>
+  <defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="1.2" result="blur"/>
+      <feColorMatrix in="blur" type="matrix"
+        values="0 0 0 0 0.937
+                0 0 0 0 0.267
+                0 0 0 0 0.267
+                0 0 0 0.35 0"/>
+      <feComposite in2="SourceGraphic" operator="in" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <g filter="url(#glow)">
+    <rect x="1.5" y="1.5" width="21" height="21" rx="5"
+          fill="none" stroke="#ef4444" stroke-width="1.6"/>
+    <rect x="4.5" y="4.5" width="15" height="15" rx="3"
+          fill="none" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1"/>
+    <line x1="5.5" y1="18.5" x2="18.5" y2="5.5"
+          stroke="#ef4444" stroke-width="2.4" stroke-linecap="round"/>
+    <circle cx="12" cy="12" r="1.5" fill="#ef4444"/>
+  </g>
+</svg>

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_garden_configs.ts
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_garden_configs.ts
@@ -282,4 +282,10 @@ export const GUARDRAIL_PRESETS: Record<string, GuardrailPreset> = {
     mode: "pre_call",
     defaultOn: false,
   },
+  veto: {
+    provider: "Veto",
+    guardrailNameSuggestion: "Veto",
+    mode: "pre_call",
+    defaultOn: false,
+  },
 };

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_garden_data.ts
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_garden_data.ts
@@ -408,6 +408,16 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     tags: ["Security", "Policy", "Grounding", "RAG"],
     providerKey: "Xecguard",
   },
+  {
+    id: "veto",
+    name: "Veto",
+    description:
+      "EU-hosted LLM guardrails. PII and secret redaction, prompt-injection detection, and content moderation behind one endpoint and one API key.",
+    category: "partner",
+    logo: `${ASSET_PREFIX}veto.svg`,
+    tags: ["Security", "PII", "Secrets", "Injection"],
+    providerKey: "Veto",
+  },
 ];
 
 export const ALL_CARDS = [...LITELLM_CONTENT_FILTER_CARDS, ...PARTNER_GUARDRAIL_CARDS];

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info_helpers.tsx
@@ -53,6 +53,7 @@ export const guardrail_provider_map: Record<string, string> = {
   LlmAsAJudge: "llm_as_a_judge",
   Xecguard: "xecguard",
   QostodianNexus: "qostodian_nexus",
+  Veto: "veto",
 };
 
 // Function to populate provider map from API response - updates the original map
@@ -140,6 +141,7 @@ export const guardrailLogoMap: Record<string, string> = {
   "LiteLLM LLM as a Judge": `${asset_logos_folder}litellm_logo.jpg`,
   "Akto": `${asset_logos_folder}akto.svg`,
   "Qostodian Nexus": `${asset_logos_folder}qohash.jpg`,
+  Veto: `${asset_logos_folder}veto.svg`,
 };
 
 export const getGuardrailLogoAndName = (guardrailValue: string): { logo: string; displayName: string } => {


### PR DESCRIPTION
## Relevant issues

N/A — adds a new, self-contained guardrail provider.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py` (21 unit tests)
- [x] My PR passes all unit tests on `make test-unit` — 4816 passed / 2 failed; both failures are pre-existing and unrelated to this change (a Bedrock document-MIME quirk and a key-rotation **e2e** test needing a live connection) — neither touches guardrails
- [x] My PR's scope is as isolated as possible — it only adds the `veto` provider; no existing provider is modified
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 (will request immediately after opening)

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Guardrail Garden card for Veto 
<img width="24" height="24" alt="veto" src="https://github.com/user-attachments/assets/59a12149-de0d-400a-ae51-2f06da2dfdd5" />


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

Adds **Veto** ([vetocheck.com](https://vetocheck.com)) as a first-class, named guardrail provider. Users write `guardrail: veto` in `config.yaml` and Veto appears in the supported-guardrails list and the Guardrail Garden UI.

The hook is a **thin HTTP client** — no detection logic ships here. It calls the hosted Veto gateway (`POST {api_base}/v1/check`) and maps the verdict onto the LiteLLM hook contract:

- `allow` → request passes unchanged
- `redact` → offending span masked in place, request continues
- `block` → raises HTTP 400 with findings under `detail.veto`

Supports `pre_call`, `during_call`, and `post_call` modes via `CustomGuardrail`'s `async_pre_call_hook` / `async_moderation_hook` / `async_post_call_success_hook` / `apply_guardrail`.

### Example config

```yaml
guardrails:
  - guardrail_name: "veto-guard"
    litellm_params:
      guardrail: veto
      mode: pre_call
      api_base: https://api.vetocheck.com
      api_key: os.environ/VETO_API_KEY
```

### Files

| File | Change |
|---|---|
| `litellm/proxy/guardrails/guardrail_hooks/veto/veto.py` | `VetoGuardrail(CustomGuardrail)` hook + `get_config_model()` |
| `litellm/proxy/guardrails/guardrail_hooks/veto/__init__.py` | package init |
| `litellm/types/proxy/guardrails/guardrail_hooks/veto.py` | `VetoGuardrailConfigModel` (api_key / api_base / categories) + `ui_friendly_name()` |
| `litellm/types/guardrails.py` | `SupportedGuardrailIntegrations.VETO = "veto"` |
| `litellm/proxy/guardrails/guardrail_initializers.py` | `initialize_veto(...)` |
| `litellm/proxy/guardrails/guardrail_registry.py` | registry entry + import |
| `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_veto.py` | 21 unit tests |
| `ui/litellm-dashboard/public/assets/logos/veto.svg` | Garden logo |
| `ui/litellm-dashboard/src/components/guardrails/guardrail_garden_data.ts` | partner card |
| `ui/litellm-dashboard/src/components/guardrails/guardrail_garden_configs.ts` | preset |
| `ui/litellm-dashboard/src/components/guardrails/guardrail_info_helpers.tsx` | provider + logo map |

Docs for `docs/my-website/docs/proxy/guardrails/veto.md` will follow as a separate PR.
