### PR TITLE
docs(agents): require consent before writing new third-party names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 This document provides comprehensive instructions for AI agents working in the LiteLLM repository.
 
+## Confidentiality: Customer and Company Names in Code
+
+The codebase is public. Before writing **any** third-party organization name into this repository — in source code, file or directory names, docstrings, comments, tests, fixtures, mock payloads, error messages, log lines, commit messages, or PR descriptions — pause and check:
+
+**Already in the codebase** (OpenAI, Anthropic, Google, Azure, Bedrock, Fireworks, and other established LLM providers / integrations) — fine to use. Quick check: `git grep -i "<name>"` — if it returns hits in real code (not just your current diff), the name is established.
+
+**Anything else** — customers, prospects, partners, new vendor integrations, observability tools, infra vendors, or any organization name that does not already appear in the repo. STOP and surface it to the user. Ask for explicit consent before writing the name into any file, commit message, or PR description. Do not write it speculatively and clean up later. Do not substitute a placeholder and proceed. Do not assume it is safe because it "looks like" a public company. The user must approve first.
+
+**What to do instead of a customer-specific reference:**
+- If you find yourself reaching for a customer name — real or fake — step back. The code shouldn't be customer-specific in the first place. Generalize the feature, or capture the customer motivation in internal docs (Notion / Linear / the internal staging PR description), never in the repo.
+- Frame changes by the capability they add, not the customer who asked for it ("add per-team Bedrock guardrail routing", not "add routing for $CUSTOMER").
+- Standard "fake value" markers (`example.com`, `localhost`, `127.0.0.1`, `test@example.com`) and abstract identifiers (`team_a`, `user_1`, `tenant_x`) are fine — those are not customer stand-ins.
+
 ## OVERVIEW
 
 LiteLLM is a unified interface for 100+ LLMs that:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Confidentiality: Customer and Company Names in Code
+
+The codebase is public. Before writing **any** third-party organization name into this repository — in source code, file or directory names, docstrings, comments, tests, fixtures, mock payloads, error messages, log lines, commit messages, or PR descriptions — pause and check:
+
+**Already in the codebase** (OpenAI, Anthropic, Google, Azure, Bedrock, Fireworks, and other established LLM providers / integrations) — fine to use. Quick check: `git grep -i "<name>"` — if it returns hits in real code (not just your current diff), the name is established.
+
+**Anything else** — customers, prospects, partners, new vendor integrations, observability tools, infra vendors, or any organization name that does not already appear in the repo. STOP and surface it to the user. Ask for explicit consent before writing the name into any file, commit message, or PR description. Do not write it speculatively and clean up later. Do not substitute a placeholder and proceed. Do not assume it is safe because it "looks like" a public company. The user must approve first.
+
+**What to do instead of a customer-specific reference:**
+- If you find yourself reaching for a customer name — real or fake — step back. The code shouldn't be customer-specific in the first place. Generalize the feature, or capture the customer motivation in internal docs (Notion / Linear / the internal staging PR description), never in the repo.
+- Frame changes by the capability they add, not the customer who asked for it ("add per-team Bedrock guardrail routing", not "add routing for $CUSTOMER").
+- Standard "fake value" markers (`example.com`, `localhost`, `127.0.0.1`, `test@example.com`) and abstract identifiers (`team_a`, `user_1`, `tenant_x`) are fine — those are not customer stand-ins.
+
 ## Documentation
 
 Documentation lives in a separate repository: [BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs). It is served at [docs.litellm.ai](https://docs.litellm.ai). Do not create or edit documentation files in this repository — open doc PRs against `BerriAI/litellm-docs` instead.


### PR DESCRIPTION
## Summary

Adds a new section to `CLAUDE.md` and `AGENTS.md` ("Confidentiality: Customer and Company Names in Code") that instructs AI coding agents to pause and ask the user before writing any third-party organization name that does not already appear in the repository.

- Names already established in the codebase (existing LLM providers — OpenAI, Anthropic, Google, Azure, Bedrock, Fireworks, etc.) remain fine to use without prompting. Quick check: `git grep -i "<name>"`.
- Any other organization name — customers, prospects, partners, new vendor integrations, observability tools, infra vendors — must be surfaced to the user for explicit consent before it lands in any file, commit message, or PR description.
- Also adds guidance to generalize features rather than reference a specific organization, and clarifies that standard "fake value" markers (`example.com`, `localhost`, `127.0.0.1`) and abstract identifiers (`team_a`, `user_1`) are not affected.

Docs-only change — no code or config touched.

## Test plan

- [ ] Confirm both files render cleanly on GitHub