### PR TITLE
fix(docker): pin python to 3.13 in apk add and uv sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=uvbin /uvx /usr/local/bin/uvx
 RUN apk add --no-cache \
     bash \
     gcc \
-    python3 \
-    python3-dev \
+    python-3.13 \
+    python-3.13-dev \
     openssl \
     openssl-dev \
     nodejs \
@@ -29,6 +29,8 @@ RUN apk add --no-cache \
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0 \
+    PRISMA_USE_GLOBAL_NODE=true \
     PATH="/app/.venv/bin:${PATH}"
 
 # Copy dependency metadata first for layer caching
@@ -42,7 +44,7 @@ RUN uv sync --frozen --no-install-project --no-install-workspace --no-default-gr
     --extra proxy-runtime \
     --extra extra_proxy \
     --extra semantic-router \
-    --python python3
+    --python python3.13
 
 # Copy full source tree
 COPY . .
@@ -56,7 +58,7 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra proxy-runtime \
     --extra extra_proxy \
     --extra semantic-router \
-    --python python3
+    --python python3.13
 
 RUN prisma generate --schema=./schema.prisma
 
@@ -68,7 +70,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 USER root
 
-RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile && \
+RUN apk add --no-cache bash openssl tzdata nodejs npm python-3.13 libsndfile && \
     npm install -g npm@11.14.0 tar@7.5.11 glob@13.0.6 @isaacs/brace-expansion@5.0.1 brace-expansion@5.0.5 minimatch@10.2.4 diff@8.0.3 picomatch@4.0.4 && \
     GLOBAL="$(npm root -g)" && \
     for pkg in tar glob @isaacs/brace-expansion brace-expansion minimatch diff picomatch; do \

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -18,8 +18,8 @@ COPY --from=uvbin /uvx /usr/local/bin/uvx
 RUN apk add --no-cache \
     bash \
     gcc \
-    python3 \
-    python3-dev \
+    python-3.13 \
+    python-3.13-dev \
     openssl \
     openssl-dev \
     nodejs \
@@ -28,6 +28,8 @@ RUN apk add --no-cache \
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0 \
+    PRISMA_USE_GLOBAL_NODE=true \
     PATH="/app/.venv/bin:${PATH}"
 
 # Copy dependency metadata first for layer caching
@@ -41,7 +43,7 @@ RUN uv sync --frozen --no-install-project --no-install-workspace --no-default-gr
     --extra proxy-runtime \
     --extra extra_proxy \
     --extra semantic-router \
-    --python python3
+    --python python3.13
 
 # Copy full source tree
 COPY . .
@@ -55,7 +57,7 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra proxy-runtime \
     --extra extra_proxy \
     --extra semantic-router \
-    --python python3
+    --python python3.13
 
 RUN prisma generate --schema=./schema.prisma
 
@@ -66,7 +68,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 USER root
 
-RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile && \
+RUN apk add --no-cache bash openssl tzdata nodejs npm python-3.13 libsndfile && \
     npm install -g npm@11.12.1 tar@7.5.11 glob@11.1.0 @isaacs/brace-expansion@5.0.1 minimatch@10.2.4 diff@8.0.3 && \
     GLOBAL="$(npm root -g)" && \
     find "$GLOBAL/npm" -type d -name "tar" -path "*/node_modules/tar" | while read d; do \

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -16,8 +16,8 @@ COPY --from=uvbin /uvx /usr/local/bin/uvx
 
 RUN for i in 1 2 3; do \
       apk add --no-cache \
-        python3 \
-        python3-dev \
+        python-3.13 \
+        python-3.13-dev \
         gcc \
         bash \
         coreutils \
@@ -30,8 +30,10 @@ RUN for i in 1 2 3; do \
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0 \
     PATH="/app/.venv/bin:${PATH}" \
     LITELLM_NON_ROOT=true \
+    PRISMA_USE_GLOBAL_NODE=true \
     PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
     XDG_CACHE_HOME=/app/.cache
 
@@ -47,7 +49,7 @@ RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
     --extra proxy-runtime \
     --extra extra_proxy \
     --extra semantic-router \
-    --python python3
+    --python python3.13
 
 # Copy full source tree
 COPY . .
@@ -67,7 +69,7 @@ RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
         --extra proxy-runtime \
         --extra extra_proxy \
         --extra semantic-router \
-        --python python3 \
+        --python python3.13 \
         --no-sources-package litellm-proxy-extras; \
     else \
       uv sync --frozen --no-default-groups --no-editable \
@@ -75,7 +77,7 @@ RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
         --extra proxy-runtime \
         --extra extra_proxy \
         --extra semantic-router \
-        --python python3; \
+        --python python3.13; \
     fi
 
 RUN prisma generate --schema=./schema.prisma
@@ -92,7 +94,7 @@ RUN for i in 1 2 3; do \
       apk upgrade --no-cache && break || sleep 5; \
     done && \
     for i in 1 2 3; do \
-      apk add --no-cache python3 bash openssl tzdata libsndfile nodejs && break || sleep 5; \
+      apk add --no-cache python-3.13 bash openssl tzdata libsndfile nodejs && break || sleep 5; \
     done
 
 COPY --from=builder /app /app
@@ -103,6 +105,7 @@ ENV PATH="/app/.venv/bin:${PATH}" \
     PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
     HOME=/app \
     LITELLM_NON_ROOT=true \
+    PRISMA_USE_GLOBAL_NODE=true \
     XDG_CACHE_HOME=/app/.cache \
     PRISMA_SKIP_POSTINSTALL_GENERATE=1 \
     PRISMA_HIDE_UPDATE_MESSAGE=1 \


### PR DESCRIPTION
## Summary

The three legacy Dockerfiles (root `Dockerfile`, `docker/Dockerfile.database`, `docker/Dockerfile.non_root`) implicitly tracked two upstream "use latest" channels that both drifted past what the project supports, and `docker build` started failing:

**Drift 1 — Python.** `apk add python3` is a wolfi *meta*-package that resolves to whichever versioned `python-3.X` is newest. It used to land on 3.13, which `pyproject.toml`'s `requires-python = ">=3.10, <3.14"` accepts. Wolfi recently shipped `python-3.14` and the meta now resolves there. `uv sync ... --python python3` fails with `interpreter resolved to Python 3.14.x, which is incompatible with the project's Python requirement`.

**Drift 2 — Node.** prisma-python uses nodeenv to bootstrap Node, and nodeenv's "latest" picked up Node 26.2.0. Node 26 on arm64 is dynamically linked against `libatomic.so.1`, which wolfi-base doesn't ship. `prisma generate` fails with `node: error while loading shared libraries: libatomic.so.1`.

## Fix — four explicit pins that close both drifts

Each of the three Dockerfiles gets:

| Pin | Replaces | Closes |
|---|---|---|
| `apk add python-3.13 python-3.13-dev` | `python3` / `python3-dev` meta | Drift 1 |
| `uv sync ... --python python3.13` | `--python python3` | Drift 1 |
| `ENV UV_PYTHON_DOWNLOADS=0` | (new) — defense-in-depth | Drift 1 (refuses silent fallback to a uv-managed CPython if the system one disappears) |
| `ENV PRISMA_USE_GLOBAL_NODE=true` | (new) | Drift 2 (uses the apk-installed `nodejs` instead of nodeenv's "latest") |

This is the pattern the newer componentized Dockerfiles (`backend/`, `gateway/`, `migrations/`) already use. 3.13 is also the version `docker/tests/nonroot.yaml` already asserts at `/usr/local/lib/python3.13/site-packages/prisma/`.

Scope is intentionally limited to the three legacy Dockerfiles; `backend/`, `gateway/`, `migrations/` are not modified.

## Test plan
- [ ] CI `build_docker_image` / `build_docker_database_image` jobs pass.
- [ ] `docker build -f docker/Dockerfile.non_root .` succeeds locally (the original repro).
- [ ] `docker build -f Dockerfile .` and `-f docker/Dockerfile.database .` succeed.
- [ ] `docker/tests/nonroot.yaml` structure tests still pass (Prisma at `/usr/local/lib/python3.13/site-packages/prisma/`).