### PR TITLE
fix(batch-jobs): serialize datetime objects in batch job logging response

### DIFF
--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import Any, Optional, cast
 
@@ -271,12 +272,10 @@ class BedrockBatchesHandler:
             # (submitTime, endTime, …) and in ResponseMetadata. The
             # logging post_call path calls json.dumps() on dict responses,
             # which chokes on datetime — so we serialize with default=str.
-            import json as _json
-
             logging_obj.post_call(
                 input=batch_id,
                 api_key="",
-                original_response=_json.dumps(response, default=str),
+                original_response=json.dumps(response, default=str),
                 additional_args={"complete_input_dict": {"jobIdentifier": batch_id}},
             )
 

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -267,10 +267,16 @@ class BedrockBatchesHandler:
         response = client.get_model_invocation_job(jobIdentifier=batch_id)
 
         if logging_obj is not None:
+            # boto3 returns native datetime objects for time fields
+            # (submitTime, endTime, …) and in ResponseMetadata. The
+            # logging post_call path calls json.dumps() on dict responses,
+            # which chokes on datetime — so we serialize with default=str.
+            import json as _json
+
             logging_obj.post_call(
                 input=batch_id,
                 api_key="",
-                original_response=response,
+                original_response=_json.dumps(response, default=str),
                 additional_args={"complete_input_dict": {"jobIdentifier": batch_id}},
             )
 

--- a/tests/test_litellm/llms/bedrock/batches/test_handler.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_handler.py
@@ -300,7 +300,11 @@ def test_logging_obj_pre_and_post_call_invoked(patched_boto3):
 
     post_kwargs = logging_obj.post_call.call_args.kwargs
     assert post_kwargs["input"] == JOB_ARN
-    assert post_kwargs["original_response"]["jobArn"] == JOB_ARN
+    # original_response is JSON-serialized (str) because boto3 returns
+    # datetime objects that json.dumps() cannot handle natively.
+    import json
+    parsed = json.loads(post_kwargs["original_response"])
+    assert parsed["jobArn"] == JOB_ARN
 
 
 def test_missing_boto3_raises_helpful_import_error():


### PR DESCRIPTION


## Relevant issues

<!-- e.g. "Fixes #000" -->
N/A

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

* Fix TypeError in retrieve_batch logging when json.dumps() encounters native datetime objects returned by boto3's get_model_invocation_job (e.g. submitTime, endTime, ResponseMetadata)
* Serialize the response with json.dumps(response, default=str) before passing to logging_obj.post_call

### Test plan
Updated unit test to assert original_response is now a JSON string and parses correctly