### PR TITLE
fix(s3): await batch uploads before clearing queue

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -3,7 +3,9 @@ s3 Bucket Logging Integration
 
 async_log_success_event: Processes the event, stores it in memory for DEFAULT_S3_FLUSH_INTERVAL_SECONDS seconds or until DEFAULT_S3_BATCH_SIZE and then flushes to s3
 async_log_failure_event: Processes the event, stores it in memory for DEFAULT_S3_FLUSH_INTERVAL_SECONDS seconds or until DEFAULT_S3_BATCH_SIZE and then flushes to s3
-NOTE 1: S3 does not provide a BATCH PUT API endpoint, so we create tasks to upload each element individually
+NOTE 1: S3 does not provide a BATCH PUT API endpoint, so each queued
+element is uploaded individually and the batch flush awaits all uploads
+before clearing the queue
 """
 
 import asyncio
@@ -30,6 +32,8 @@ from .custom_batch_logger import CustomBatchLogger
 
 
 class S3Logger(CustomBatchLogger, BaseAWSLLM):
+    preserve_events_added_during_flush = True
+
     def __init__(
         self,
         s3_bucket_name: Optional[str] = None,
@@ -318,7 +322,9 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             self.handle_callback_failure(callback_name="S3Logger")
 
     async def async_upload_data_to_s3(
-        self, batch_logging_element: s3BatchLoggingElement
+        self,
+        batch_logging_element: s3BatchLoggingElement,
+        raise_on_error: bool = False,
     ):
         try:
             import hashlib
@@ -427,6 +433,8 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 response.raise_for_status()
                 break
         except Exception as e:
+            if raise_on_error:
+                raise
             verbose_logger.exception(f"Error uploading to s3: {str(e)}")
             self.handle_callback_failure(callback_name="S3Logger")
 
@@ -437,19 +445,44 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
         Returns: None
 
-        Raises: Does not raise an exception, will only verbose_logger.exception()
+        Raises: RuntimeError when one or more uploads fail. The parent
+        CustomBatchLogger preserves the failed events for retry.
         """
         verbose_logger.debug(f"s3_v2 logger - sending batch of {len(self.log_queue)}")
         if not self.log_queue:
             return
+
+        log_queue_snapshot = list(self.log_queue)
 
         #########################################################
         #  Flush the log queue to s3
         #  the log queue can be bounded by DEFAULT_S3_BATCH_SIZE
         #  see custom_batch_logger.py which triggers the flush
         #########################################################
-        for payload in self.log_queue:
-            asyncio.create_task(self.async_upload_data_to_s3(payload))
+        results = await asyncio.gather(
+            *(
+                self.async_upload_data_to_s3(payload, raise_on_error=True)
+                for payload in log_queue_snapshot
+            ),
+            return_exceptions=True,
+        )
+        failed_payloads = [
+            payload
+            for payload, result in zip(log_queue_snapshot, results)
+            if isinstance(result, BaseException)
+        ]
+        if failed_payloads:
+            # The base flush handler preserves the current queue when
+            # async_send_batch raises. Replace the flushed snapshot with only
+            # the failed payloads so successful uploads are not duplicated on
+            # the next retry, while events appended during this flush remain.
+            self.log_queue[:] = (
+                failed_payloads + self.log_queue[len(log_queue_snapshot) :]
+            )
+            raise RuntimeError(
+                f"S3 batch upload failed for {len(failed_payloads)} of "
+                f"{len(log_queue_snapshot)} queued events"
+            )
 
     def create_s3_batch_logging_element(
         self,

--- a/tests/test_litellm/integrations/test_s3_v2_batch_flush.py
+++ b/tests/test_litellm/integrations/test_s3_v2_batch_flush.py
@@ -1,0 +1,117 @@
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+
+from litellm.integrations.s3_v2 import S3Logger
+from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+
+def _s3_batch_element(key: str) -> s3BatchLoggingElement:
+    return s3BatchLoggingElement(
+        s3_object_key=f"2025-09-14/{key}.json",
+        payload={"test": key},
+        s3_object_download_filename=f"{key}.json",
+    )
+
+
+def _s3_logger() -> S3Logger:
+    with (
+        patch("asyncio.create_task"),
+        patch(
+            "litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush",
+            new=lambda self: None,
+        ),
+    ):
+        return S3Logger(
+            s3_bucket_name="test-bucket",
+            s3_aws_access_key_id="test-key",
+            s3_aws_secret_access_key="test-secret",
+            s3_region_name="us-east-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_awaits_all_s3_uploads():
+    logger = _s3_logger()
+    first = _s3_batch_element("first")
+    second = _s3_batch_element("second")
+    logger.log_queue = [first, second]
+    completed_uploads = []
+
+    async def upload(payload, raise_on_error=False):
+        assert raise_on_error is True
+        await asyncio.sleep(0)
+        completed_uploads.append(payload.s3_object_key)
+
+    logger.async_upload_data_to_s3 = upload
+
+    await logger.async_send_batch()
+
+    assert set(completed_uploads) == {first.s3_object_key, second.s3_object_key}
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_noops_when_queue_is_empty():
+    logger = _s3_logger()
+    logger.async_upload_data_to_s3 = Mock()
+
+    await logger.async_send_batch()
+
+    logger.async_upload_data_to_s3.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flush_queue_preserves_failed_s3_uploads_for_retry():
+    logger = _s3_logger()
+    first = _s3_batch_element("first")
+    failed = _s3_batch_element("failed")
+    added_during_flush = _s3_batch_element("added-during-flush")
+    logger.log_queue = [first, failed]
+
+    async def upload(payload, raise_on_error=False):
+        assert raise_on_error is True
+        if payload is failed:
+            logger.log_queue.append(added_during_flush)
+            raise RuntimeError("s3 upload failed")
+
+    logger.async_upload_data_to_s3 = upload
+
+    await logger.flush_queue()
+
+    assert logger.log_queue == [failed, added_during_flush]
+
+
+@pytest.mark.asyncio
+async def test_flush_queue_preserves_s3_events_added_during_successful_flush():
+    logger = _s3_logger()
+    first = _s3_batch_element("first")
+    second = _s3_batch_element("second")
+    added_during_flush = _s3_batch_element("added-during-flush")
+    logger.log_queue = [first, second]
+
+    async def upload(payload, raise_on_error=False):
+        assert raise_on_error is True
+        if payload is first:
+            logger.log_queue.append(added_during_flush)
+
+    logger.async_upload_data_to_s3 = upload
+
+    await logger.flush_queue()
+
+    assert logger.log_queue == [added_during_flush]
+
+
+@pytest.mark.asyncio
+async def test_async_upload_data_to_s3_reraises_without_callback_failure():
+    logger = _s3_logger()
+    logger.get_credentials = Mock(side_effect=RuntimeError("credential failure"))
+    logger.handle_callback_failure = Mock()
+
+    with pytest.raises(RuntimeError, match="credential failure"):
+        await logger.async_upload_data_to_s3(
+            _s3_batch_element("failed"),
+            raise_on_error=True,
+        )
+
+    logger.handle_callback_failure.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Fixes #28907

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated integration change: `uv run --extra proxy pytest tests/test_litellm/integrations/test_s3_v2.py tests/test_litellm/integrations/test_s3_v2_batch_flush.py -q` (36 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review by commenting ``; waiting for the confidence score before requesting maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, `S3Logger.async_send_batch()` scheduled one upload task per queued event with `asyncio.create_task(...)` and returned immediately. `CustomBatchLogger.flush_queue()` then cleared the queue before any S3 PUT had completed, so failed or cancelled uploads could permanently drop queued log/audit events.

After this change, S3 batch flushing awaits all queued uploads before returning. If any upload fails, only the failed payloads remain queued for retry, successful uploads are not duplicated, and events appended while the flush is in progress are preserved.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/integrations/test_s3_v2.py tests/test_litellm/integrations/test_s3_v2_batch_flush.py -q
# 36 passed

uv run black --check litellm/integrations/s3_v2.py tests/test_litellm/integrations/test_s3_v2.py tests/test_litellm/integrations/test_s3_v2_batch_flush.py
# 3 files would be left unchanged

uv run ruff check litellm/integrations/s3_v2.py tests/test_litellm/integrations/test_s3_v2_batch_flush.py
# All checks passed

uv run --extra proxy mypy litellm/integrations/s3_v2.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# [from litellm import *] OK! no issues!
```

Local full-shard notes:

- `make test-unit-integrations` did not reach pytest in this local environment because `uv sync --frozen --all-groups --all-extras` failed resolving `forbiddenfruit==0.1.4` via the configured package indexes (`setuptools>=40.8.0` filtered by the Chainguard/remediated index cutoff).
- `make lint` stopped at `format-check` on 13 pre-existing enterprise formatting differences outside this PR. The changed files pass Black/Ruff checks directly.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Replace fire-and-forget S3 batch uploads with `asyncio.gather(...)` so `flush_queue()` only drains after queued uploads finish.
- Preserve events appended during a long S3 flush.
- On partial upload failure, keep only failed snapshot payloads queued for retry so successful uploads are not sent again.
- Add focused regression tests for awaiting all uploads, retry preservation on failure, and preserving events appended during successful flush.

## Thermo-nuclear code quality review

Passed before opening. The final diff keeps the behavior in the S3 integration layer, does not change the shared `CustomBatchLogger` contract for other integrations, keeps `s3_v2.py` under 1k lines, and puts new regression coverage in a focused test module instead of growing the existing 1.2k-line S3 test file.

