### PR TITLE
fix(s3-vectors): use selected embedding model during ingest

### DIFF
--- a/litellm/rag/ingestion/s3_vectors_ingestion.py
+++ b/litellm/rag/ingestion/s3_vectors_ingestion.py
@@ -67,6 +67,9 @@ class S3VectorsRAGIngestion(BaseRAGIngestion, BaseAWSLLM):
 
         # Extract config
         self.vector_bucket_name = self.vector_store_config["vector_bucket_name"]
+        embedding_model = self.vector_store_config.get("embedding_model")
+        if not self.embedding_config and embedding_model:
+            self.embedding_config = {"model": embedding_model}
         self.index_name = self.vector_store_config.get("index_name")
         self.distance_metric = self.vector_store_config.get(
             "distance_metric", S3_VECTORS_DEFAULT_DISTANCE_METRIC

--- a/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -36,15 +36,22 @@ async def test_s3_vectors_ingestion_uses_vector_store_embedding_model():
         )
 
         embeddings = await ingestion.embed(["hello"])
+
+        mock_aembedding.assert_awaited_once_with(
+            model="text-embedding-3-large", input=["hello"]
+        )
+        assert embeddings == [[0.1, 0.2, 0.3]]
+
+        mock_aembedding.reset_mock()
+        mock_aembedding.return_value = SimpleNamespace(
+            data=[{"embedding": [0.1, 0.2, 0.3]}]
+        )
+
         dimension = await ingestion._get_dimension_from_embedding_request()
 
-    mock_aembedding.assert_has_awaits(
-        [
-            call(model="text-embedding-3-large", input=["hello"]),
-            call(model="text-embedding-3-large", input=["test"]),
-        ]
+    mock_aembedding.assert_awaited_once_with(
+        model="text-embedding-3-large", input=["test"]
     )
-    assert embeddings == [[0.1, 0.2, 0.3]]
     assert dimension == 3
 
 

--- a/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
@@ -42,6 +42,9 @@ async def test_s3_vectors_ingestion_uses_vector_store_embedding_model():
         )
         assert embeddings == [[0.1, 0.2, 0.3]]
 
+        # Scope the next assertion to dimension auto-detection. It must call
+        # aembedding with the selected model instead of returning the default
+        # S3 vector dimension without probing the embedding model.
         mock_aembedding.reset_mock()
         mock_aembedding.return_value = SimpleNamespace(
             data=[{"embedding": [0.1, 0.2, 0.3]}]

--- a/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -36,11 +36,16 @@ async def test_s3_vectors_ingestion_uses_vector_store_embedding_model():
         )
 
         embeddings = await ingestion.embed(["hello"])
+        dimension = await ingestion._get_dimension_from_embedding_request()
 
-    mock_aembedding.assert_awaited_once_with(
-        model="text-embedding-3-large", input=["hello"]
+    mock_aembedding.assert_has_awaits(
+        [
+            call(model="text-embedding-3-large", input=["hello"]),
+            call(model="text-embedding-3-large", input=["test"]),
+        ]
     )
     assert embeddings == [[0.1, 0.2, 0.3]]
+    assert dimension == 3
 
 
 def test_s3_vectors_ingestion_prefers_top_level_embedding_config():

--- a/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.rag.ingestion.s3_vectors_ingestion import S3VectorsRAGIngestion
+
+
+def _s3_vectors_ingest_options(**overrides):
+    vector_store = {
+        "custom_llm_provider": "s3_vectors",
+        "vector_bucket_name": "test-vector-bucket",
+        "aws_region_name": "us-east-1",
+    }
+    vector_store.update(overrides.pop("vector_store", {}))
+    return {
+        "vector_store": vector_store,
+        **overrides,
+    }
+
+
+@pytest.mark.asyncio
+async def test_s3_vectors_ingestion_uses_vector_store_embedding_model():
+    ingestion = S3VectorsRAGIngestion(
+        ingest_options=_s3_vectors_ingest_options(
+            vector_store={"embedding_model": "text-embedding-3-large"}
+        )
+    )
+
+    with patch(
+        "litellm.rag.ingestion.s3_vectors_ingestion.litellm.aembedding",
+        new_callable=AsyncMock,
+    ) as mock_aembedding:
+        mock_aembedding.return_value = SimpleNamespace(
+            data=[{"embedding": [0.1, 0.2, 0.3]}]
+        )
+
+        embeddings = await ingestion.embed(["hello"])
+
+    mock_aembedding.assert_awaited_once_with(
+        model="text-embedding-3-large", input=["hello"]
+    )
+    assert embeddings == [[0.1, 0.2, 0.3]]
+
+
+def test_s3_vectors_ingestion_prefers_top_level_embedding_config():
+    ingestion = S3VectorsRAGIngestion(
+        ingest_options=_s3_vectors_ingest_options(
+            embedding={"model": "text-embedding-3-small"},
+            vector_store={"embedding_model": "text-embedding-3-large"},
+        )
+    )
+
+    assert ingestion.embedding_config == {"model": "text-embedding-3-small"}


### PR DESCRIPTION
## Relevant issues

Fixes #28905

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated RAG/S3 vectors change: `uv run --extra proxy pytest tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py -q` (16 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, the dashboard's S3 vector-store create flow sent the selected model as `ingest_options.vector_store.embedding_model`, but `S3VectorsRAGIngestion` only read `ingest_options.embedding`. Ingest therefore fell back to `text-embedding-3-small` while the saved vector-store config used the selected model for search.

After this change, S3 vectors ingestion uses `vector_store.embedding_model` when top-level `ingest_options.embedding` is absent. If callers provide top-level embedding config, it still takes precedence. Dimension auto-detection also uses the selected embedding model instead of falling back to the default model.

Reviewer-note coverage: the S3 vectors regression test intentionally resets the `litellm.aembedding` mock before calling `_get_dimension_from_embedding_request()`, then asserts the auto-detect request is made with `model="text-embedding-3-large"` and `input=["test"]`. That makes the dimension-path check independent from the earlier `embed()` assertion, and it fails if the code returns the default S3 vector dimension without probing or if it probes with the hardcoded `text-embedding-3-small` default.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py -q
# 2 passed

uv run --extra proxy pytest tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py -q
# 16 passed

uv run ruff check litellm/rag/ingestion/s3_vectors_ingestion.py tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
# All checks passed

uv run black --check litellm/rag/ingestion/s3_vectors_ingestion.py tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
# 2 files would be left unchanged

uv run --extra proxy mypy litellm/rag/ingestion/s3_vectors_ingestion.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# [from litellm import *] OK! no issues!
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Teach `S3VectorsRAGIngestion` to use `vector_store.embedding_model` as the ingest embedding model when no top-level `embedding` config is provided.
- Preserve top-level `ingest_options.embedding` precedence for callers that explicitly set it.
- Add regression coverage proving the selected S3 embedding model is passed to `litellm.aembedding` for both embedding and dimension auto-detection.

## Thermo-nuclear code quality review

Passed before opening. The final diff keeps the behavior in the S3 vectors ingestion layer where the provider-specific option is already owned, avoids dashboard-specific branching, keeps `s3_vectors_ingestion.py` well under 1k lines, and adds focused RAG coverage under the proxy RAG endpoint test shard used by upstream CI coverage.