### PR TITLE
fix(policy): reject empty specific attachments

### DIFF
--- a/litellm/types/proxy/policy_engine/resolver_types.py
+++ b/litellm/types/proxy/policy_engine/resolver_types.py
@@ -8,7 +8,7 @@ the final guardrails list.
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class PolicyMatchContext(BaseModel):
@@ -325,6 +325,19 @@ class PolicyAttachmentCreateRequest(BaseModel):
         default=None,
         description="Tag patterns this attachment applies to. Supports wildcards (e.g., health-*).",
     )
+
+    @model_validator(mode="after")
+    def validate_scope_has_selector(self) -> "PolicyAttachmentCreateRequest":
+        if self.scope == "*":
+            return self
+
+        if any((self.teams, self.keys, self.models, self.tags)):
+            return self
+
+        raise ValueError(
+            "Specific policy attachments must include at least one non-empty selector "
+            "(teams, keys, models, or tags). Use scope='*' for global attachments."
+        )
 
 
 class PolicyAttachmentDBResponse(BaseModel):

--- a/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
+++ b/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
@@ -3,8 +3,10 @@ Tests for pipeline field on policy CRUD types (resolver_types.py).
 """
 
 import pytest
+from pydantic import ValidationError
 
 from litellm.types.proxy.policy_engine.resolver_types import (
+    PolicyAttachmentCreateRequest,
     PolicyCreateRequest,
     PolicyDBResponse,
     PolicyUpdateRequest,
@@ -100,3 +102,33 @@ def test_policy_create_request_roundtrip():
     dumped = req.model_dump()
     restored = PolicyCreateRequest(**dumped)
     assert restored.pipeline == pipeline_data
+
+
+def test_policy_attachment_create_request_rejects_empty_specific_scope():
+    with pytest.raises(ValidationError, match="at least one non-empty selector"):
+        PolicyAttachmentCreateRequest(policy_name="pii-policy")
+
+
+def test_policy_attachment_create_request_rejects_empty_selector_list():
+    with pytest.raises(ValidationError, match="at least one non-empty selector"):
+        PolicyAttachmentCreateRequest(policy_name="pii-policy", teams=[])
+
+
+def test_policy_attachment_create_request_allows_explicit_global_scope():
+    request = PolicyAttachmentCreateRequest(
+        policy_name="pii-policy",
+        scope="*",
+    )
+
+    assert request.scope == "*"
+
+
+@pytest.mark.parametrize("selector_field", ["teams", "keys", "models", "tags"])
+def test_policy_attachment_create_request_allows_selector_scope(selector_field):
+    selector_value = f"{selector_field}-a"
+    request = PolicyAttachmentCreateRequest(
+        policy_name="pii-policy",
+        **{selector_field: [selector_value]},
+    )
+
+    assert getattr(request, selector_field) == [selector_value]


### PR DESCRIPTION
## Relevant issues

Fixes #28904

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated policy attachment validation change: `uv run --extra proxy pytest tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py tests/test_litellm/proxy/policy_engine/test_attachment_registry.py tests/test_litellm/proxy/policy_engine/test_policy_matcher.py -q` (40 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, `POST /policies/attachments` accepted a request with no `scope`, `teams`, `keys`, `models`, or `tags`. That persisted an attachment that `PolicyScope` normalized to wildcard teams/keys/models, so an operator-created "Specific" attachment with no selectors behaved like a global attachment.

After this change, the policy attachment create request rejects non-global attachments unless at least one non-empty selector is supplied. Explicit global attachments still use `scope: "*"`, and existing YAML/runtime matching behavior is unchanged.

Review follow-up: the validator now uses tuple-based `any`, the error message clarifies that empty lists do not count, and tests cover `teams=[]` rejection plus non-empty `teams`, `keys`, `models`, and `tags` selectors. The request-model tests live in the existing resolver-types test module so coverage is attributed to `litellm/types/proxy/policy_engine/resolver_types.py`.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py tests/test_litellm/proxy/policy_engine/test_attachment_registry.py tests/test_litellm/proxy/policy_engine/test_policy_matcher.py -q --cov=litellm.types.proxy.policy_engine.resolver_types --cov-report=term-missing
# 40 passed; resolver_types.py 100% covered locally

uv run ruff check litellm/types/proxy/policy_engine/resolver_types.py tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
# All checks passed

uv run black --check litellm/types/proxy/policy_engine/resolver_types.py tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
# 2 files would be left unchanged

uv run --extra proxy mypy litellm/types/proxy/policy_engine/resolver_types.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# [from litellm import *] OK! no issues!
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Add request-model validation that rejects non-global policy attachments without any non-empty teams, keys, models, or tags selector.
- Keep `scope: "*"` as the explicit global attachment path.
- Add regression tests for rejecting empty specific attachments, rejecting explicitly empty selector lists, allowing explicit global attachments, and allowing each selector-scoped attachment field.

## Thermo-nuclear code quality review

Passed after review feedback. The final diff enforces the invariant at the API request boundary, avoids changing the lower-level matcher semantics used by YAML/config attachments, keeps the shared type file under 1k lines, and adds narrow validation coverage in the resolver-types test module that already owns this request model.
