### PR TITLE
fix(sso): preserve omitted settings on partial update

### DIFF
--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -31,6 +31,16 @@ _SSO_SENSITIVE_FIELDS: Set[str] = {
 }
 
 
+def _get_sso_settings_dict_from_db_record(
+    sso_db_record: Optional[Any],
+) -> Dict[str, Any]:
+    if sso_db_record is None or not sso_db_record.sso_settings:
+        return {}
+    if isinstance(sso_db_record.sso_settings, str):
+        return json.loads(sso_db_record.sso_settings)
+    return dict(sso_db_record.sso_settings)
+
+
 class IPAddress(BaseModel):
     ip: str
 
@@ -669,12 +679,8 @@ async def get_sso_settings():
         where={"id": "sso_config"}
     )
 
-    # Initialize with defaults
-    sso_settings_dict = {}
-
-    if sso_db_record and sso_db_record.sso_settings:
-        # Load settings from database
-        sso_settings_dict = dict(sso_db_record.sso_settings)
+    # Load settings from database
+    sso_settings_dict = _get_sso_settings_dict_from_db_record(sso_db_record)
 
     role_mappings_data = sso_settings_dict.pop("role_mappings", None)
     role_mappings = None
@@ -820,8 +826,30 @@ async def update_sso_settings(sso_config: SSOConfig):
     if "general_settings" not in config:
         config["general_settings"] = {}
 
-    # Update environment variables in config and in memory
-    sso_data = sso_config.model_dump()
+    existing_sso_db_record = await prisma_client.db.litellm_ssoconfig.find_unique(
+        where={"id": "sso_config"}
+    )
+    existing_sso_settings = _get_sso_settings_dict_from_db_record(
+        existing_sso_db_record
+    )
+    existing_structured_settings = {}
+    for structured_field in ("role_mappings", "team_mappings"):
+        if structured_field in existing_sso_settings:
+            existing_structured_settings[structured_field] = existing_sso_settings.pop(
+                structured_field
+            )
+
+    existing_sso_data = proxy_config._decrypt_and_set_db_env_variables(
+        environment_variables=existing_sso_settings
+    )
+    existing_sso_data.update(existing_structured_settings)
+
+    # Update environment variables in config and in memory. PATCH semantics:
+    # omitted fields keep their current stored value, explicit null/empty clears.
+    sso_data = {
+        **existing_sso_data,
+        **sso_config.model_dump(exclude_unset=True),
+    }
     for field_name, value in sso_data.items():
         if field_name in env_var_mapping:
             env_var_name = env_var_mapping[field_name]

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -915,7 +915,7 @@ async def update_sso_settings(sso_config: SSOConfig):
     return {
         "message": "SSO settings updated successfully",
         "status": "success",
-        "settings": sso_data,
+        "settings": mask_sensitive_keys(sso_data, _SSO_SENSITIVE_FIELDS),
     }
 
 

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -85,6 +85,30 @@ def mock_auth():
 
 
 class TestProxySettingEndpoints:
+    def test_get_sso_settings_dict_from_db_record_shapes(self):
+        """Test SSO DB record normalization for empty, dict, and JSON string rows."""
+        from unittest.mock import MagicMock
+
+        from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
+            _get_sso_settings_dict_from_db_record,
+        )
+
+        assert _get_sso_settings_dict_from_db_record(None) == {}
+
+        dict_record = MagicMock()
+        dict_record.sso_settings = {"google_client_id": "dict_google_id"}
+        assert _get_sso_settings_dict_from_db_record(dict_record) == {
+            "google_client_id": "dict_google_id"
+        }
+
+        string_record = MagicMock()
+        string_record.sso_settings = json.dumps(
+            {"google_client_id": "string_google_id"}
+        )
+        assert _get_sso_settings_dict_from_db_record(string_record) == {
+            "google_client_id": "string_google_id"
+        }
+
     def test_get_internal_user_settings(self, mock_proxy_config, mock_auth):
         """Test getting the internal user settings"""
         response = client.get("/get/internal_user_settings")
@@ -435,15 +459,17 @@ class TestProxySettingEndpoints:
         settings = data["settings"]
         assert settings["google_client_id"] == new_sso_settings["google_client_id"]
         assert (
-            settings["google_client_secret"] == new_sso_settings["google_client_secret"]
+            settings["google_client_secret"] != new_sso_settings["google_client_secret"]
         )
+        assert "*" in settings["google_client_secret"]
         assert (
             settings["microsoft_client_id"] == new_sso_settings["microsoft_client_id"]
         )
         assert (
             settings["microsoft_client_secret"]
-            == new_sso_settings["microsoft_client_secret"]
+            != new_sso_settings["microsoft_client_secret"]
         )
+        assert "*" in settings["microsoft_client_secret"]
         assert settings["proxy_base_url"] == new_sso_settings["proxy_base_url"]
         assert settings["user_email"] == new_sso_settings["user_email"]
 
@@ -484,6 +510,13 @@ class TestProxySettingEndpoints:
             "google_client_id": "existing_google_client_id",
             "google_client_secret": "existing_google_secret",
             "microsoft_client_secret": "existing_microsoft_secret",
+            "role_mappings": {
+                "provider": "google",
+                "group_claim": "groups",
+                "default_role": "internal_user",
+                "roles": {"internal_user": ["staff"]},
+            },
+            "team_mappings": {"team_ids_jwt_field": "teams"},
         }
         mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(
             return_value=existing_sso_record
@@ -514,8 +547,10 @@ class TestProxySettingEndpoints:
         assert response.status_code == 200
         settings = response.json()["settings"]
         assert settings["ui_access_mode"] == "admin_only"
-        assert settings["google_client_secret"] == "existing_google_secret"
-        assert settings["microsoft_client_secret"] == "existing_microsoft_secret"
+        assert settings["google_client_secret"] != "existing_google_secret"
+        assert "*" in settings["google_client_secret"]
+        assert settings["microsoft_client_secret"] != "existing_microsoft_secret"
+        assert "*" in settings["microsoft_client_secret"]
         assert os.environ["GOOGLE_CLIENT_SECRET"] == "existing_google_secret"
 
         call_args = mock_prisma.db.litellm_ssoconfig.upsert.call_args
@@ -529,6 +564,8 @@ class TestProxySettingEndpoints:
             stored_sso_settings["microsoft_client_secret"]
             == "existing_microsoft_secret"
         )
+        assert stored_sso_settings["role_mappings"]["provider"] == "google"
+        assert stored_sso_settings["team_mappings"]["team_ids_jwt_field"] == "teams"
 
     def test_update_sso_settings_with_null_values_clears_env_vars(
         self, mock_proxy_config, mock_auth, monkeypatch

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -397,6 +397,7 @@ class TestProxySettingEndpoints:
         # Mock the prisma client
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
         mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config.update = AsyncMock()
@@ -466,6 +467,69 @@ class TestProxySettingEndpoints:
         create_sso_settings = json.loads(create_data["sso_settings"])
         assert create_sso_settings["google_client_id"] == "new_google_client_id"
 
+    def test_update_sso_settings_partial_update_preserves_existing_secrets(
+        self, mock_proxy_config, mock_auth, monkeypatch
+    ):
+        """Test that omitted SSO fields keep their stored values during PATCH updates."""
+        import json
+        from unittest.mock import AsyncMock, MagicMock
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", "test_salt_key")
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+        monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "existing_google_secret")
+
+        mock_prisma = MagicMock()
+        existing_sso_record = MagicMock()
+        existing_sso_record.sso_settings = {
+            "google_client_id": "existing_google_client_id",
+            "google_client_secret": "existing_google_secret",
+            "microsoft_client_secret": "existing_microsoft_secret",
+        }
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(
+            return_value=existing_sso_record
+        )
+        mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_config = MagicMock()
+        mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_config.update = AsyncMock()
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        from litellm.proxy.proxy_server import proxy_config
+
+        monkeypatch.setattr(
+            proxy_config,
+            "_decrypt_and_set_db_env_variables",
+            lambda environment_variables: dict(environment_variables),
+        )
+        monkeypatch.setattr(
+            proxy_config,
+            "_encrypt_env_variables",
+            lambda environment_variables: environment_variables,
+        )
+
+        response = client.patch(
+            "/update/sso_settings", json={"ui_access_mode": "admin_only"}
+        )
+
+        assert response.status_code == 200
+        settings = response.json()["settings"]
+        assert settings["ui_access_mode"] == "admin_only"
+        assert settings["google_client_secret"] == "existing_google_secret"
+        assert settings["microsoft_client_secret"] == "existing_microsoft_secret"
+        assert os.environ["GOOGLE_CLIENT_SECRET"] == "existing_google_secret"
+
+        call_args = mock_prisma.db.litellm_ssoconfig.upsert.call_args
+        stored_sso_settings = json.loads(
+            call_args.kwargs["data"]["update"]["sso_settings"]
+        )
+        assert stored_sso_settings["ui_access_mode"] == "admin_only"
+        assert stored_sso_settings["google_client_id"] == "existing_google_client_id"
+        assert stored_sso_settings["google_client_secret"] == "existing_google_secret"
+        assert (
+            stored_sso_settings["microsoft_client_secret"]
+            == "existing_microsoft_secret"
+        )
+
     def test_update_sso_settings_with_null_values_clears_env_vars(
         self, mock_proxy_config, mock_auth, monkeypatch
     ):
@@ -479,6 +543,7 @@ class TestProxySettingEndpoints:
         # Mock the prisma client
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
 
         env_var_entry = MagicMock()
@@ -558,6 +623,7 @@ class TestProxySettingEndpoints:
         # Mock the prisma client
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
         env_var_entry = MagicMock()
         env_var_entry.param_value = json.dumps(
@@ -628,6 +694,7 @@ class TestProxySettingEndpoints:
         # Mock the prisma client
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
 
         env_var_entry = MagicMock()
@@ -705,6 +772,7 @@ class TestProxySettingEndpoints:
         # Mock the prisma client
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
         mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config.update = AsyncMock()
@@ -1351,6 +1419,7 @@ class TestProxySettingEndpoints:
         mock_prisma = MagicMock()
         upsert_mock = AsyncMock()
         mock_prisma.db.litellm_ssoconfig.upsert = upsert_mock
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
         mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config.update = AsyncMock()
@@ -1430,6 +1499,7 @@ class TestProxySettingEndpoints:
         mock_prisma.db = MagicMock()
         mock_prisma.db.litellm_ssoconfig = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
 
         env_var_entry = MagicMock()
         env_var_entry.param_value = json.dumps(
@@ -1481,6 +1551,7 @@ class TestProxySettingEndpoints:
         mock_prisma.db = MagicMock()
         mock_prisma.db.litellm_ssoconfig = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
 
         env_var_entry = MagicMock()
         env_var_entry.param_value = {
@@ -1652,6 +1723,7 @@ class TestProxySettingEndpoints:
         # Mock the prisma client
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config = MagicMock()
         mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
         mock_prisma.db.litellm_config.update = AsyncMock()


### PR DESCRIPTION
## Relevant issues

Fixes #28901

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated SSO settings change: `uv run --extra proxy pytest tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py -q` (43 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, `PATCH /update/sso_settings` serialized the full `SSOConfig` model. Omitted optional fields became `None`, so changing one field such as `ui_access_mode` could overwrite stored SSO client secrets and clear their runtime environment variables.

After this change, the endpoint loads the existing SSO settings, decrypts the env-style values, overlays only explicitly supplied PATCH fields, and stores the merged result. Explicit `null` or empty string still clears a field; omission preserves the existing value.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py -q
# 43 passed

uv run ruff check litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
# All checks passed

uv run black --check litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
# 2 files would be left unchanged

uv run --extra proxy mypy litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# [from litellm import *] OK! no issues!
```

Local note:

- `uv run ruff check tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py` reports pre-existing unused imports / print statements in this test file. `make lint-ruff` matches the repo lint target and passes.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Add a small helper for reading SSO settings whether Prisma returns a dict or JSON string.
- Merge incoming SSO PATCH fields over existing stored settings instead of full-object dumping omitted fields as `None`.
- Preserve explicit clearing behavior for fields sent as `null` or empty strings.
- Add a regression test proving a partial `ui_access_mode` update preserves existing SSO client secrets.

## Thermo-nuclear code quality review

Passed before opening. The endpoint file is already above 1k lines, so this keeps the fix tightly localized instead of starting a broad decomposition in a security bug PR. The helper removes duplicate DB-shape handling, preserves the existing explicit-clear behavior, and adds direct regression coverage for the omitted-field data-loss path.

