### PR TITLE
fix(credentials): preserve masked values on update

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -2,7 +2,7 @@
 CRUD endpoints for storing reusable credentials.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, Path
 
@@ -12,7 +12,10 @@ from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import _get_masked_values
 from litellm.proxy._types import CommonProxyErrors, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_value_helper,
+    encrypt_value_helper,
+)
 from litellm.proxy.utils import handle_exception_on_proxy, jsonify_object
 from litellm.types.utils import CreateCredentialItem, CredentialItem
 
@@ -38,6 +41,88 @@ class CredentialHelperUtils:
             credential_values=encrypted_credential_values,
             credential_info=credential.credential_info or {},
         )
+
+
+def _is_masked_credential_value(
+    *,
+    key: str,
+    submitted_value: Any,
+    stored_value: Any,
+    unmasked_length: int = 4,
+    number_of_asterisks: int = 4,
+) -> bool:
+    if not isinstance(submitted_value, str) or not isinstance(stored_value, str):
+        return False
+
+    masked_value = _get_masked_values(
+        {key: stored_value},
+        unmasked_length=unmasked_length,
+        number_of_asterisks=number_of_asterisks,
+    )[key]
+    return submitted_value == masked_value
+
+
+def _looks_like_masked_credential_value(
+    *,
+    key: str,
+    submitted_value: Any,
+    unmasked_length: int = 4,
+    number_of_asterisks: int = 4,
+) -> bool:
+    if not isinstance(submitted_value, str) or "*" not in submitted_value:
+        return False
+
+    return _is_masked_credential_value(
+        key=key,
+        submitted_value=submitted_value,
+        stored_value=submitted_value,
+        unmasked_length=unmasked_length,
+        number_of_asterisks=number_of_asterisks,
+    )
+
+
+def _preserve_masked_credential_values(
+    db_credential: CredentialItem,
+    updated_patch: CredentialItem,
+) -> CredentialItem:
+    if not updated_patch.credential_values:
+        return updated_patch
+
+    existing_credential_values = db_credential.credential_values or {}
+    filtered_credential_values = {}
+
+    for key, value in updated_patch.credential_values.items():
+        existing_value = existing_credential_values.get(key)
+        decrypted_existing_value = existing_value
+        if isinstance(existing_value, str):
+            decrypted_existing_value = decrypt_value_helper(
+                value=existing_value,
+                key=key,
+                exception_type="debug",
+                return_original_value=False,
+            )
+            if decrypted_existing_value is None:
+                if _looks_like_masked_credential_value(
+                    key=key,
+                    submitted_value=value,
+                ):
+                    continue
+                decrypted_existing_value = existing_value
+
+        if _is_masked_credential_value(
+            key=key,
+            submitted_value=value,
+            stored_value=decrypted_existing_value,
+        ):
+            continue
+
+        filtered_credential_values[key] = value
+
+    return CredentialItem(
+        credential_name=updated_patch.credential_name,
+        credential_values=filtered_credential_values,
+        credential_info=updated_patch.credential_info,
+    )
 
 
 @router.post(
@@ -331,6 +416,7 @@ async def update_credential(
         )
         if db_credential is None:
             raise HTTPException(status_code=404, detail="Credential not found in DB.")
+        credential = _preserve_masked_credential_values(db_credential, credential)
         merged_credential = update_db_credential(db_credential, credential)
         credential_object_jsonified = jsonify_object(merged_credential.model_dump())
         await prisma_client.db.litellm_credentialstable.update(

--- a/tests/test_litellm/proxy/management_endpoints/credential_endpoints/test_credential_update.py
+++ b/tests/test_litellm/proxy/management_endpoints/credential_endpoints/test_credential_update.py
@@ -1,0 +1,114 @@
+from unittest.mock import patch
+
+from litellm.proxy.credential_endpoints.endpoints import (
+    _preserve_masked_credential_values,
+    update_db_credential,
+)
+from litellm.types.utils import CredentialItem
+
+
+def test_preserve_masked_credential_value_keeps_existing_secret():
+    db_credential = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={
+            "api_key": "encrypted-stored-api-key",
+            "api_base": "https://old.example",
+        },
+        credential_info={},
+    )
+    updated_patch = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={
+            "api_key": "sk****34",
+            "api_base": "https://new.example",
+        },
+        credential_info={},
+    )
+
+    with (
+        patch(
+            "litellm.proxy.credential_endpoints.endpoints.decrypt_value_helper",
+            return_value="sk-live-secret-1234",
+        ),
+        patch(
+            "litellm.proxy.credential_endpoints.endpoints.encrypt_value_helper",
+            side_effect=lambda value, new_encryption_key=None: f"encrypted:{value}",
+        ),
+    ):
+        sanitized_patch = _preserve_masked_credential_values(
+            db_credential, updated_patch
+        )
+        merged_credential = update_db_credential(db_credential, sanitized_patch)
+
+    assert sanitized_patch.credential_values == {"api_base": "https://new.example"}
+    assert merged_credential.credential_values["api_key"] == "encrypted-stored-api-key"
+    assert merged_credential.credential_values["api_base"] == (
+        "encrypted:https://new.example"
+    )
+
+
+def test_preserve_masked_credential_value_allows_real_secret_rotation():
+    db_credential = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={"api_key": "encrypted-stored-api-key"},
+        credential_info={},
+    )
+    updated_patch = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={"api_key": "sk-new-secret-5678"},
+        credential_info={},
+    )
+
+    with (
+        patch(
+            "litellm.proxy.credential_endpoints.endpoints.decrypt_value_helper",
+            return_value="sk-live-secret-1234",
+        ),
+        patch(
+            "litellm.proxy.credential_endpoints.endpoints.encrypt_value_helper",
+            side_effect=lambda value, new_encryption_key=None: f"encrypted:{value}",
+        ),
+    ):
+        sanitized_patch = _preserve_masked_credential_values(
+            db_credential, updated_patch
+        )
+        merged_credential = update_db_credential(db_credential, sanitized_patch)
+
+    assert sanitized_patch.credential_values == {"api_key": "sk-new-secret-5678"}
+    assert merged_credential.credential_values["api_key"] == (
+        "encrypted:sk-new-secret-5678"
+    )
+
+
+def test_preserve_masked_credential_value_on_decryption_failure():
+    db_credential = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={"api_key": "encrypted-with-old-master-key"},
+        credential_info={},
+    )
+    updated_patch = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={"api_key": "sk****34"},
+        credential_info={},
+    )
+
+    with (
+        patch(
+            "litellm.proxy.credential_endpoints.endpoints.decrypt_value_helper",
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.credential_endpoints.endpoints.encrypt_value_helper",
+            side_effect=lambda value, new_encryption_key=None: f"encrypted:{value}",
+        ),
+    ):
+        sanitized_patch = _preserve_masked_credential_values(
+            db_credential, updated_patch
+        )
+        merged_credential = update_db_credential(db_credential, sanitized_patch)
+
+    assert sanitized_patch.credential_values == {}
+    assert (
+        merged_credential.credential_values["api_key"]
+        == "encrypted-with-old-master-key"
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #28906

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated credential update change: `uv run --extra proxy pytest tests/test_litellm/proxy/management_endpoints/credential_endpoints/test_credential_update.py -q` (3 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, `GET /credentials/by_name/{credential_name}` returned masked credential values such as `sk****34`, and a subsequent `PATCH /credentials/{credential_name}` could treat that masked display value as a real secret rotation. The encrypted stored secret and in-memory credential could therefore be overwritten with the placeholder.

After this change, the credential update path decrypts the stored value for comparison and drops submitted values that exactly match the stored secret's masked representation. If the stored value cannot be decrypted, the patch still preserves likely masked display placeholders rather than overwriting an unreadable existing secret. Explicit new values are still encrypted and saved normally.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/proxy/management_endpoints/credential_endpoints/test_credential_update.py -q
# 3 passed

uv run ruff check litellm/proxy/credential_endpoints/endpoints.py tests/test_litellm/proxy/management_endpoints/credential_endpoints/test_credential_update.py
# All checks passed

uv run black --check litellm/proxy/credential_endpoints/endpoints.py tests/test_litellm/proxy/management_endpoints/credential_endpoints/test_credential_update.py
# 2 files would be left unchanged

uv run --extra proxy mypy litellm/proxy/credential_endpoints/endpoints.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# [from litellm import *] OK! no issues!
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Preserve existing reusable credential values when an update payload submits the same masked value returned by the read endpoint.
- Preserve likely masked placeholders even if the stored DB value cannot be decrypted under the current master key.
- Keep explicit real secret rotations working by only treating masked-display matches as unchanged.
- Add regression tests for placeholder preservation, decryption-failure preservation, and real key rotation.

## Thermo-nuclear code quality review

Passed before opening. The diff keeps the policy in the credential endpoint where encrypted DB values are already merged, avoids UI-only protection, does not add a broad abstraction for a single endpoint surface, and keeps the tests under the proxy management endpoint test path that upstream CI collects for patch coverage.
