### PR TITLE
fix(search-tools): preserve masked api keys on update

### DIFF
--- a/litellm/proxy/search_endpoints/search_tool_management.py
+++ b/litellm/proxy/search_endpoints/search_tool_management.py
@@ -3,12 +3,13 @@ CRUD ENDPOINTS FOR SEARCH TOOLS
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.litellm_logging import _get_masked_values
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.search_endpoints.search_tool_registry import SearchToolRegistry
 from litellm.types.search import (
@@ -22,6 +23,9 @@ from litellm.types.utils import SearchProviders
 
 router = APIRouter()
 SEARCH_TOOL_REGISTRY = SearchToolRegistry()
+_MASK_UNMASKED_LENGTH: int = 4
+_MASK_NUMBER_OF_ASTERISKS: int = 4
+_SECRET_DESTINATION_FIELDS = ("search_provider", "api_base")
 
 
 def _convert_datetime_to_str(value: Union[datetime, str, None]) -> Union[str, None]:
@@ -39,6 +43,94 @@ def _convert_datetime_to_str(value: Union[datetime, str, None]) -> Union[str, No
     if isinstance(value, datetime):
         return value.isoformat()
     return value
+
+
+def _is_masked_search_tool_value(
+    *,
+    key: str,
+    submitted_value: Any,
+    stored_value: Any,
+    unmasked_length: int = _MASK_UNMASKED_LENGTH,
+    number_of_asterisks: int = _MASK_NUMBER_OF_ASTERISKS,
+) -> bool:
+    if not isinstance(submitted_value, str) or not isinstance(stored_value, str):
+        return False
+
+    masked_value = _get_masked_values(
+        {key: stored_value},
+        unmasked_length=unmasked_length,
+        number_of_asterisks=number_of_asterisks,
+    )[key]
+    if masked_value == stored_value:
+        return False
+
+    return submitted_value == masked_value
+
+
+def _secret_destination_changed(
+    existing_litellm_params: Dict[str, Any],
+    updated_litellm_params: Dict[str, Any],
+) -> bool:
+    return any(
+        existing_litellm_params.get(field) != updated_litellm_params.get(field)
+        for field in _SECRET_DESTINATION_FIELDS
+    )
+
+
+def _preserve_masked_search_tool_params(
+    existing_tool: SearchTool,
+    updated_tool: SearchTool,
+) -> SearchTool:
+    updated_litellm_params = dict(updated_tool.get("litellm_params", {}))
+    if not updated_litellm_params:
+        return updated_tool
+
+    existing_litellm_params = dict(existing_tool.get("litellm_params", {}))
+    destination_changed = _secret_destination_changed(
+        existing_litellm_params=existing_litellm_params,
+        updated_litellm_params=updated_litellm_params,
+    )
+    for key, value in list(updated_litellm_params.items()):
+        existing_value = existing_litellm_params.get(key)
+        if _is_masked_search_tool_value(
+            key=key,
+            submitted_value=value,
+            stored_value=existing_value,
+        ):
+            if destination_changed:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Masked search tool credentials cannot be reused when "
+                        "search_provider or api_base changes. Submit the cleartext "
+                        "credential again."
+                    ),
+                )
+            updated_litellm_params[key] = existing_value
+
+    return cast(
+        SearchTool,
+        {
+            **updated_tool,
+            "litellm_params": updated_litellm_params,
+        },
+    )
+
+
+def _mask_search_tool_litellm_params(search_tool: SearchTool) -> SearchTool:
+    litellm_params = dict(search_tool.get("litellm_params", {}))
+    masked_litellm_params = _get_masked_values(
+        litellm_params,
+        unmasked_length=_MASK_UNMASKED_LENGTH,
+        number_of_asterisks=_MASK_NUMBER_OF_ASTERISKS,
+    )
+    return cast(
+        SearchTool,
+        {
+            **search_tool,
+            "litellm_params": masked_litellm_params,
+        },
+    )
 
 
 @router.get(
@@ -304,9 +396,14 @@ async def update_search_tool(search_tool_id: str, request: UpdateSearchToolReque
                 detail=f"Search tool with ID {search_tool_id} not found",
             )
 
+        search_tool = _preserve_masked_search_tool_params(
+            existing_tool=existing_tool,
+            updated_tool=request.search_tool,
+        )
+
         result = await SEARCH_TOOL_REGISTRY.update_search_tool_in_db(
             search_tool_id=search_tool_id,
-            search_tool=request.search_tool,
+            search_tool=search_tool,
             prisma_client=prisma_client,
         )
 
@@ -315,7 +412,7 @@ async def update_search_tool(search_tool_id: str, request: UpdateSearchToolReque
             f"Router will be updated by the cron job."
         )
 
-        return result
+        return _mask_search_tool_litellm_params(result)
     except HTTPException as e:
         raise e
     except Exception as e:

--- a/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 sys.path.insert(
@@ -603,3 +604,205 @@ async def test_list_search_tools_db_masking_sensitive_values(monkeypatch):
                     assert tool4["litellm_params"]["search_provider"] == "custom"
                 finally:
                     app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_update_search_tool_preserves_masked_api_key(monkeypatch):
+    from litellm.proxy.search_endpoints import search_tool_management
+
+    existing_tool = {
+        "search_tool_id": "test-id-1",
+        "search_tool_name": "perplexity-tool",
+        "litellm_params": {
+            "search_provider": "perplexity",
+            "api_key": "pplx-secret-1234",
+            "api_base": "https://api.perplexity.ai",
+        },
+        "search_tool_info": {"description": "old description"},
+    }
+    request = search_tool_management.UpdateSearchToolRequest(
+        search_tool={
+            "search_tool_name": "perplexity-tool",
+            "litellm_params": {
+                "search_provider": "perplexity",
+                "api_key": "pp****34",
+                "api_base": "https://api.perplexity.ai",
+            },
+            "search_tool_info": {"description": "new description"},
+        }
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.get_search_tool_by_id_from_db = AsyncMock(return_value=existing_tool)
+    mock_registry.update_search_tool_in_db = AsyncMock(
+        return_value={
+            **existing_tool,
+            "search_tool_info": {"description": "new description"},
+        }
+    )
+
+    monkeypatch.setattr(
+        search_tool_management,
+        "SEARCH_TOOL_REGISTRY",
+        mock_registry,
+    )
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+
+    result = await search_tool_management.update_search_tool("test-id-1", request)
+
+    called_search_tool = mock_registry.update_search_tool_in_db.call_args.kwargs[
+        "search_tool"
+    ]
+    assert called_search_tool["litellm_params"]["api_key"] == "pplx-secret-1234"
+    assert called_search_tool["litellm_params"]["api_base"] == (
+        "https://api.perplexity.ai"
+    )
+    assert result["litellm_params"]["api_key"] == "pp****34"
+    assert result["litellm_params"]["api_base"] == "https://api.perplexity.ai"
+
+
+def test_masked_search_tool_value_ignores_non_string_values():
+    from litellm.proxy.search_endpoints import search_tool_management
+
+    assert (
+        search_tool_management._is_masked_search_tool_value(
+            key="api_key",
+            submitted_value=None,
+            stored_value="pplx-secret-1234",
+        )
+        is False
+    )
+    assert (
+        search_tool_management._is_masked_search_tool_value(
+            key="api_key",
+            submitted_value="pp****34",
+            stored_value=None,
+        )
+        is False
+    )
+
+
+def test_preserve_masked_search_tool_params_returns_update_without_litellm_params():
+    from litellm.proxy.search_endpoints import search_tool_management
+
+    updated_tool = {"search_tool_name": "perplexity-tool"}
+
+    assert (
+        search_tool_management._preserve_masked_search_tool_params(
+            existing_tool={
+                "search_tool_name": "perplexity-tool",
+                "litellm_params": {"api_key": "pplx-secret-1234"},
+            },
+            updated_tool=updated_tool,
+        )
+        is updated_tool
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("updated_search_provider", "updated_api_base"),
+    [
+        ("perplexity", "https://attacker.example"),
+        ("tavily", "https://api.perplexity.ai"),
+    ],
+)
+async def test_update_search_tool_rejects_masked_api_key_when_destination_changes(
+    monkeypatch,
+    updated_search_provider,
+    updated_api_base,
+):
+    from litellm.proxy.search_endpoints import search_tool_management
+
+    existing_tool = {
+        "search_tool_id": "test-id-1",
+        "search_tool_name": "perplexity-tool",
+        "litellm_params": {
+            "search_provider": "perplexity",
+            "api_key": "pplx-secret-1234",
+            "api_base": "https://api.perplexity.ai",
+        },
+        "search_tool_info": {"description": "old description"},
+    }
+    request = search_tool_management.UpdateSearchToolRequest(
+        search_tool={
+            "search_tool_name": "perplexity-tool",
+            "litellm_params": {
+                "search_provider": updated_search_provider,
+                "api_key": "pp****34",
+                "api_base": updated_api_base,
+            },
+            "search_tool_info": {"description": "new description"},
+        }
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.get_search_tool_by_id_from_db = AsyncMock(return_value=existing_tool)
+    mock_registry.update_search_tool_in_db = AsyncMock()
+
+    monkeypatch.setattr(
+        search_tool_management,
+        "SEARCH_TOOL_REGISTRY",
+        mock_registry,
+    )
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await search_tool_management.update_search_tool("test-id-1", request)
+
+    assert exc_info.value.status_code == 400
+    assert "Submit the cleartext credential again" in exc_info.value.detail
+    mock_registry.update_search_tool_in_db.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_search_tool_allows_api_key_rotation(monkeypatch):
+    from litellm.proxy.search_endpoints import search_tool_management
+
+    existing_tool = {
+        "search_tool_id": "test-id-1",
+        "search_tool_name": "perplexity-tool",
+        "litellm_params": {
+            "search_provider": "perplexity",
+            "api_key": "pplx-secret-1234",
+        },
+        "search_tool_info": {"description": "old description"},
+    }
+    request = search_tool_management.UpdateSearchToolRequest(
+        search_tool={
+            "search_tool_name": "perplexity-tool",
+            "litellm_params": {
+                "search_provider": "perplexity",
+                "api_key": "pplx-new-secret-5678",
+            },
+            "search_tool_info": {"description": "new description"},
+        }
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.get_search_tool_by_id_from_db = AsyncMock(return_value=existing_tool)
+    mock_registry.update_search_tool_in_db = AsyncMock(
+        return_value={
+            **existing_tool,
+            "litellm_params": {
+                "search_provider": "perplexity",
+                "api_key": "pplx-new-secret-5678",
+            },
+            "search_tool_info": {"description": "new description"},
+        }
+    )
+
+    monkeypatch.setattr(
+        search_tool_management,
+        "SEARCH_TOOL_REGISTRY",
+        mock_registry,
+    )
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+
+    result = await search_tool_management.update_search_tool("test-id-1", request)
+
+    called_search_tool = mock_registry.update_search_tool_in_db.call_args.kwargs[
+        "search_tool"
+    ]
+    assert called_search_tool["litellm_params"]["api_key"] == "pplx-new-secret-5678"
+    assert result["litellm_params"]["api_key"] == "pp****78"


### PR DESCRIPTION
## Relevant issues

Fixes #28902

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated search-tool update change: `uv run --extra proxy pytest tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py -q` (13 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, search-tool list/detail endpoints returned masked `litellm_params.api_key` values such as `pp****34`. Updating the tool with that displayed value could replace the real API key in `LiteLLM_SearchToolsTable` because the update path wrote the submitted `litellm_params` directly.

After this change, the update path compares submitted sensitive params to the stored value's masked representation. Exact masked-display matches are replaced with the stored value before writing; real new API keys still rotate normally.

Review follow-up: masked stored credentials are now preserved only when `search_provider` and `api_base` are unchanged. If either destination field changes while the submitted credential is still masked, the update is rejected with a 400 and requires the caller to submit the cleartext credential again, preventing stored API keys from being redirected to a new provider/base URL. The update response masks `litellm_params` before returning, so preserved or rotated cleartext secrets are not echoed back to the caller. Defensive tests also cover non-string values and updates without `litellm_params` so all modified coverable lines are exercised locally.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py -q --cov=litellm.proxy.search_endpoints.search_tool_management --cov-report=term-missing
# 13 passed; all modified helper and response-masking lines covered locally

uv run ruff check litellm/proxy/search_endpoints/search_tool_management.py tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
# All checks passed

uv run black --check litellm/proxy/search_endpoints/search_tool_management.py tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
# 2 files would be left unchanged

uv run --extra proxy mypy litellm/proxy/search_endpoints/search_tool_management.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# [from litellm import *] OK! no issues!
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Preserve stored search-tool `litellm_params` values when an update payload submits the same masked value returned by read/list endpoints.
- Reject masked credential reuse when `search_provider` or `api_base` changes, requiring a fresh cleartext credential for destination changes.
- Mask `litellm_params` in the update response so preserved or rotated secrets are not returned in cleartext.
- Keep explicit API key rotations working when a real new value is submitted.
- Add regression coverage for masked API key preservation, destination-change rejection, response masking, real key rotation, and defensive helper branches.

## Thermo-nuclear code quality review

Passed after review feedback. The endpoint-local helper keeps the policy at the update boundary where the stored and submitted `litellm_params` are both available, uses shared mask constants so read/write semantics stay aligned, and avoids expanding this narrow fix into a broad secret-management abstraction.
