### PR TITLE
fix(mcp): preserve stdio env on edit

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -65,8 +65,10 @@ def _prepare_mcp_server_data(
     if data.mcp_info is not None:
         data_dict["mcp_info"] = safe_dumps(data.mcp_info)
 
-    # Handle env serialization
-    if data.env is not None:
+    env_was_set = "env" in data.fields_set()
+    if isinstance(data, UpdateMCPServerRequest) and not env_was_set:
+        data_dict.pop("env", None)
+    elif data.env is not None:
         data_dict["env"] = safe_dumps(data.env)
 
     # Handle tool name override serialization

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -2181,6 +2181,54 @@ class TestUpdateMCPServer:
     """Test suite for update MCP server functionality"""
 
     @pytest.mark.asyncio
+    async def test_update_mcp_server_omits_env_when_not_explicitly_set(self):
+        """Omitted env must not overwrite stored stdio env with the model default."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+
+        mock_prisma_client = MagicMock()
+        mock_prisma_client.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        update_request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            description="Updated Test Server",
+        )
+
+        await update_mcp_server(mock_prisma_client, update_request, "test-user")
+
+        data_dict = mock_prisma_client.db.litellm_mcpservertable.update.call_args[1][
+            "data"
+        ]
+        assert data_dict["description"] == "Updated Test Server"
+        assert "env" not in data_dict
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_serializes_explicit_env(self):
+        """Explicit env updates should still replace stored stdio env."""
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+
+        mock_prisma_client = MagicMock()
+        mock_prisma_client.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=MagicMock()
+        )
+
+        update_request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            transport=MCPTransport.stdio,
+            command="npx",
+            args=["-y", "@circleci/mcp-server-circleci"],
+            env={"CIRCLECI_TOKEN": "replacement-token"},
+        )
+
+        await update_mcp_server(mock_prisma_client, update_request, "test-user")
+
+        data_dict = mock_prisma_client.db.litellm_mcpservertable.update.call_args[1][
+            "data"
+        ]
+        assert json.loads(data_dict["env"]) == {"CIRCLECI_TOKEN": "replacement-token"}
+
+    @pytest.mark.asyncio
     async def test_update_mcp_server_respects_extra_headers(self):
         """
         Test that updating an MCP server with extra_headers properly saves the field.

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -175,6 +175,145 @@ describe("MCPServerEdit (stdio)", () => {
     expect(payload.args).toEqual(["-y", "@circleci/mcp-server-circleci"]);
     expect(payload.env).toEqual({ CIRCLECI_TOKEN: "new-token", CIRCLECI_BASE_URL: "https://circleci.com" });
   });
+
+  it("should preserve existing stdio env when saving without env edits", async () => {
+    const existingEnv = {
+      CIRCLECI_TOKEN: "token",
+      CIRCLECI_BASE_URL: "https://circleci.com",
+    };
+
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      server_id: "server-1",
+      server_name: "TestServer",
+      alias: "test",
+      transport: "stdio",
+      url: null,
+      command: "npx",
+      args: ["-y", "@circleci/mcp-server-circleci"],
+      env: existingEnv,
+      created_at: "2024-01-01T00:00:00Z",
+      created_by: "user-1",
+      updated_at: "2024-01-01T00:00:00Z",
+      updated_by: "user-1",
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          server_id: "server-1",
+          server_name: "TestServer",
+          alias: "test",
+          description: "desc",
+          transport: "stdio",
+          url: null,
+          auth_type: "none",
+          command: "npx",
+          args: ["-y", "@circleci/mcp-server-circleci"],
+          env: existingEnv,
+          created_at: "2024-01-01T00:00:00Z",
+          created_by: "user-1",
+          updated_at: "2024-01-01T00:00:00Z",
+          updated_by: "user-1",
+          mcp_access_groups: [],
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const envTextarea = screen.getByLabelText("Environment (JSON object)");
+    expect(envTextarea).toHaveValue("");
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.transport).toBe("stdio");
+    expect(payload).not.toHaveProperty("env");
+  });
+
+  it("should preserve existing stdio env when JSON stdio config omits env", async () => {
+    const existingEnv = {
+      CIRCLECI_TOKEN: "token",
+      CIRCLECI_BASE_URL: "https://circleci.com",
+    };
+
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      server_id: "server-1",
+      server_name: "TestServer",
+      alias: "test",
+      transport: "stdio",
+      url: null,
+      command: "npx",
+      args: ["-y", "@circleci/mcp-server-circleci"],
+      env: existingEnv,
+      created_at: "2024-01-01T00:00:00Z",
+      created_by: "user-1",
+      updated_at: "2024-01-01T00:00:00Z",
+      updated_by: "user-1",
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          server_id: "server-1",
+          server_name: "TestServer",
+          alias: "test",
+          description: "desc",
+          transport: "stdio",
+          url: null,
+          auth_type: "none",
+          command: "npx",
+          args: ["-y", "@circleci/mcp-server-circleci"],
+          env: existingEnv,
+          created_at: "2024-01-01T00:00:00Z",
+          created_by: "user-1",
+          updated_at: "2024-01-01T00:00:00Z",
+          updated_by: "user-1",
+          mcp_access_groups: [],
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const stdioConfigTextarea = screen.getByLabelText("Stdio Configuration (JSON)");
+    await act(async () => {
+      fireEvent.change(stdioConfigTextarea, {
+        target: {
+          value: JSON.stringify({
+            command: "node",
+            args: ["server.js"],
+          }),
+        },
+      });
+    });
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.transport).toBe("stdio");
+    expect(payload.command).toBe("node");
+    expect(payload.args).toEqual(["server.js"]);
+    expect(payload).not.toHaveProperty("env");
+  });
 });
 
 describe("MCPServerEdit (delegate auth)", () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -164,19 +164,6 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }));
   }, [mcpServer.static_headers]);
 
-  const initialEnvJson = React.useMemo(() => {
-    const env = mcpServer.env ?? undefined;
-    if (!env || Object.keys(env).length === 0) {
-      return "";
-    }
-    try {
-      return JSON.stringify(env, null, 2);
-    } catch {
-      return "";
-    }
-  }, [mcpServer.env]);
-
-
   // If server has spec_path, show it as "openapi" transport in the UI
   const effectiveTransport = React.useMemo(() => {
     if (mcpServer.spec_path && mcpServer.transport !== "stdio") {
@@ -191,12 +178,13 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       transport: effectiveTransport,
       static_headers: initialStaticHeaders,
       extra_headers: mcpServer.extra_headers || [],
+      env_json: undefined,
       oauth_flow_type: mcpServer.token_url ? OAUTH_FLOW.M2M : OAUTH_FLOW.INTERACTIVE,
       token_validation_json: mcpServer.token_validation
         ? JSON.stringify(mcpServer.token_validation, null, 2)
         : undefined,
     }),
-    [mcpServer, effectiveTransport, initialStaticHeaders, initialEnvJson],
+    [mcpServer, effectiveTransport, initialStaticHeaders],
   );
 
   // Initialize cost config from existing server data
@@ -444,19 +432,28 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               ? actualConfig.args.map((v: any) => String(v)).filter((v: string) => v.trim() !== "")
               : [];
 
-            const parsedEnv =
-              actualConfig?.env && typeof actualConfig.env === "object" && !Array.isArray(actualConfig.env)
-                ? Object.entries(actualConfig.env).reduce((acc: Record<string, string>, [k, v]) => {
-                    if (k == null || String(k).trim() === "") return acc;
-                    acc[String(k)] = v == null ? "" : String(v);
-                    return acc;
-                  }, {})
-                : {};
+            const hasEnvConfig =
+              actualConfig && Object.prototype.hasOwnProperty.call(actualConfig, "env");
+            let parsedEnv: Record<string, string> | undefined;
+            if (hasEnvConfig) {
+              if (actualConfig.env && typeof actualConfig.env === "object" && !Array.isArray(actualConfig.env)) {
+                parsedEnv = Object.entries(actualConfig.env).reduce((acc: Record<string, string>, [k, v]) => {
+                  if (k == null || String(k).trim() === "") return acc;
+                  acc[String(k)] = v == null ? "" : String(v);
+                  return acc;
+                }, {});
+              } else if (actualConfig.env == null) {
+                parsedEnv = {};
+              } else {
+                NotificationsManager.fromBackend("Stdio configuration env must be a JSON object");
+                return;
+              }
+            }
 
             stdioFields = {
               command: actualConfig?.command ? String(actualConfig.command) : undefined,
               args: parsedArgs,
-              env: parsedEnv,
+              ...(parsedEnv !== undefined ? { env: parsedEnv } : {}),
             };
 
             if (!stdioFields.command) {
@@ -469,8 +466,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           }
         } else {
           // Dedicated fields path (command/args + env JSON)
-          let parsedEnv: Record<string, string> = {};
-          if (rawEnvJson) {
+          const hasEnvReplacement = typeof rawEnvJson === "string" && rawEnvJson.trim() !== "";
+          let parsedEnv: Record<string, string> | undefined;
+          if (hasEnvReplacement) {
             try {
               const env = JSON.parse(rawEnvJson);
               if (env && typeof env === "object" && !Array.isArray(env)) {
@@ -498,7 +496,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           stdioFields = {
             command: parsedCommand,
             args: parsedArgs,
-            env: parsedEnv,
+            ...(parsedEnv !== undefined ? { env: parsedEnv } : {}),
           };
         }
       }


### PR DESCRIPTION
## Relevant issues

Fixes #28903

Related: #28917 touches broader MCP env-var support, but this PR keeps the current edit-form fix isolated to preserving existing stdio `env` values on no-op edits without rendering stored env secrets back into the UI.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant UI test for this isolated MCP edit change: `npm run test -- --run src/components/mcp_tools/mcp_server_edit.test.tsx` (12 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, saving an existing stdio MCP server from the edit form without changing the Environment field submitted `env: {}`, which erased the stored environment variables.

The first version of this PR preserved `env` by rendering the stored env JSON back into the form. Veria correctly flagged that as a disclosure risk for Admin Viewer users, because stored stdio env values can contain tokens.

After this update:

- The edit form no longer pre-populates `env_json` from stored `mcpServer.env`, so existing stdio env secrets are not rendered in the textarea.
- A no-op stdio save omits `env` from the update payload.
- The raw JSON stdio config path also omits `env` when the pasted JSON has no `env` key, preserving the existing stored env server-side.
- Pasted JSON with an explicit `env` object still updates env intentionally, and explicit `{}` can clear it intentionally.
- The backend update path preserves stored `env` when the client omits the field, instead of serializing the model default `{}` and wiping it.

Validated locally:

```bash
npm run test -- --run src/components/mcp_tools/mcp_server_edit.test.tsx
# 12 passed

npm run build
# compiled successfully; TypeScript and static generation passed

uv run --extra proxy pytest tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py::TestUpdateMCPServer::test_update_mcp_server_omits_env_when_not_explicitly_set tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py::TestUpdateMCPServer::test_update_mcp_server_serializes_explicit_env -q
# 2 passed

uv run ruff check litellm/proxy/_experimental/mcp_server/db.py tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
# All checks passed

uv run black --check litellm/proxy/_experimental/mcp_server/db.py tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
# 2 files would be left unchanged

uv run --extra proxy mypy litellm/proxy/_experimental/mcp_server/db.py --ignore-missing-imports
# Success: no issues found in 1 source file

make lint-ruff
# All checks passed

make check-import-safety
# OK
```

Note: plain `npm ci` against the configured Chainguard registry failed locally with an integrity mismatch for `whatwg-url`; the earlier retry used the public npm registry with host replacement and did not modify the lockfile.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Do not render stored stdio `env` values in the MCP edit form.
- Omit `env` from no-op stdio edit payloads, including the raw JSON config path when `env` is absent.
- Preserve stored `env` server-side when update payloads omit the field.
- Add UI and backend regression tests for no-op preservation without secret rendering.

## Thermo-nuclear code quality review

Passed after the Veria and Greptile feedback patches. The implementation keeps the UI behavior direct and moves omitted-field preservation to the backend update boundary that owns partial-update semantics. It uses the existing `fields_set()` compatibility helper rather than raw Pydantic internals, and does not add broad transport-mode branching or couple this narrow fix to the larger MCP env-var work in #28917.
