### PR TITLE
fix(team): clone-on-write shared budget row in _upsert_budget_and_membership (LIT-3359)

### DIFF
--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -429,7 +429,9 @@ async def _upsert_budget_and_membership(
             team metadata.team_member_budget_id), if any. When the membership's
             existing_budget_id matches this, we clone-on-write so editing one
             member's budget does not mutate the shared default (and therefore
-            every other member who still points at it).
+            every other member who still points at it). The same clone-on-write
+            path also fires when the existing_budget_id is shared by more than
+            one membership for any other reason (LIT-3359).
 
     If max_budget, tpm_limit, rpm_limit, and allowed_models are all None, the user's budget is removed from the team membership.
     If any of these values exist, a budget is updated or created and linked to the team membership.
@@ -453,7 +455,41 @@ async def _upsert_budget_and_membership(
         and existing_budget_id == team_default_budget_id
     )
 
+    # Ref-count check: even when the membership's existing_budget_id does NOT
+    # match the team's `team_member_budget_id` default, the row can still be
+    # shared by other memberships (e.g. after a default rotation, a manual
+    # cleanup, or the `backfill_team_member_budget_entries` migration that
+    # historically pointed multiple memberships at one budget row). Updating
+    # such a row in place leaks the new limits onto every other member that
+    # still points at it (LIT-3359). Detect the shared state by counting how
+    # many memberships reference this budget_id and clone-on-write whenever
+    # the row has more than one referrer.
+    is_shared_by_refcount = False
     if existing_budget_id is not None and not is_shared_default:
+        try:
+            membership_refcount = await tx.litellm_teammembership.count(
+                where={"budget_id": existing_budget_id}
+            )
+        except Exception as count_err:
+            # If the count probe fails (e.g. on a tx implementation that does
+            # not support count on this model), fall back to the previous
+            # in-place behavior rather than blocking the update — but emit a
+            # log so the silent fallback does not mask a regression of the
+            # LIT-3359 guard in production.
+            verbose_proxy_logger.exception(
+                "LIT-3359 ref-count probe failed for budget_id=%s on team_id=%s, "
+                "falling back to in-place update: %s",
+                existing_budget_id,
+                team_id,
+                count_err,
+            )
+            membership_refcount = 1
+        if membership_refcount > 1:
+            is_shared_by_refcount = True
+
+    is_shared = is_shared_default or is_shared_by_refcount
+
+    if existing_budget_id is not None and not is_shared:
         # Update the existing budget in-place to preserve fields not being changed.
         # Only write fields that the caller explicitly provided (non-None).
         update_data: Dict[str, Any] = {
@@ -481,9 +517,10 @@ async def _upsert_budget_and_membership(
         "updated_by": user_api_key_dict.user_id or "",
     }
 
-    # If we're forking off the shared default, seed the new row with the
-    # default's values so fields the caller did not change carry over.
-    if is_shared_default:
+    # If we're forking off a shared row (the team default OR any other
+    # budget_id shared by multiple memberships), seed the new row with the
+    # shared row's values so fields the caller did not change carry over.
+    if is_shared:
         default_budget_row = await tx.litellm_budgettable.find_unique(
             where={"budget_id": existing_budget_id}
         )

--- a/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
+++ b/tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py
@@ -23,6 +23,11 @@ def mock_tx():
     membership = MagicMock()
     membership.update = AsyncMock()
     membership.upsert = AsyncMock()
+    # Stub the ref-count probe used by _upsert_budget_and_membership so the
+    # primary in-place / clone code paths are exercised (rather than the
+    # legacy fallback that fires when .count() is unawaitable). Tests that
+    # need a >1 count override this on the fixture before calling.
+    membership.count = AsyncMock(return_value=1)
 
     # budget “table”
     budget = MagicMock()
@@ -369,3 +374,151 @@ async def test_upsert_updates_in_place_when_member_has_private_budget(
     )
     mock_tx.litellm_budgettable.create.assert_not_called()
     mock_tx.litellm_teammembership.upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# LIT-3359: ref-count clone-on-write when a budget row is shared by more than
+# one membership for ANY reason (not just being the team's declared default).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_clones_when_budget_shared_by_other_memberships(
+    mock_tx, fake_user
+):
+    """
+    Regression for LIT-3359: when ``existing_budget_id`` is the SAME row that
+    multiple ``LiteLLM_TeamMembership`` entries already point at (because a
+    prior backfill / default-rotation / manual cleanup left them sharing one
+    budget row), updating a single member's cap must NOT mutate the shared
+    row in place. We must clone-on-write a private budget for the member
+    being updated and re-link their membership, leaving the other members'
+    caps untouched.
+    """
+    shared_budget_id = "shared-by-3-members-budget-1"
+
+    shared_row = MagicMock()
+    shared_row.model_dump.return_value = {
+        "budget_id": shared_budget_id,
+        "max_budget": 100.0,
+        "soft_budget": None,
+        "max_parallel_requests": None,
+        "tpm_limit": 250,
+        "rpm_limit": None,
+        "model_max_budget": None,
+        "budget_duration": None,
+        "allowed_models": [],
+    }
+    mock_tx.litellm_budgettable.find_unique = AsyncMock(return_value=shared_row)
+    mock_tx.litellm_teammembership.count = AsyncMock(return_value=3)
+
+    await _upsert_budget_and_membership(
+        mock_tx,
+        team_id="team-lit3359",
+        user_id="alice",
+        max_budget=999.0,
+        existing_budget_id=shared_budget_id,
+        user_api_key_dict=fake_user,
+        team_default_budget_id=None,
+    )
+
+    mock_tx.litellm_budgettable.update.assert_not_called()
+    mock_tx.litellm_budgettable.find_unique.assert_awaited_once_with(
+        where={"budget_id": shared_budget_id},
+    )
+    mock_tx.litellm_budgettable.create.assert_awaited_once_with(
+        data={
+            "created_by": fake_user.user_id,
+            "updated_by": fake_user.user_id,
+            "max_budget": 999.0,
+            "tpm_limit": 250,
+        },
+        include={"team_membership": True},
+    )
+    new_budget_id = mock_tx.litellm_budgettable.create.return_value.budget_id
+    mock_tx.litellm_teammembership.upsert.assert_awaited_once_with(
+        where={"user_id_team_id": {"user_id": "alice", "team_id": "team-lit3359"}},
+        data={
+            "create": {
+                "user_id": "alice",
+                "team_id": "team-lit3359",
+                "litellm_budget_table": {"connect": {"budget_id": new_budget_id}},
+            },
+            "update": {
+                "litellm_budget_table": {"connect": {"budget_id": new_budget_id}},
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_inplace_when_sole_owner_of_existing_budget(mock_tx, fake_user):
+    """
+    Perf-preservation companion to the LIT-3359 fix: when the member is the
+    SOLE owner of the existing budget (ref-count == 1) and the row is not
+    the team default, we keep the original cheap in-place ``update`` and
+    skip the clone path entirely.
+    """
+    private_budget_id = "alice-only-budget"
+    mock_tx.litellm_teammembership.count = AsyncMock(return_value=1)
+
+    await _upsert_budget_and_membership(
+        mock_tx,
+        team_id="team-1",
+        user_id="alice",
+        max_budget=75.0,
+        existing_budget_id=private_budget_id,
+        user_api_key_dict=fake_user,
+        team_default_budget_id="something-else",
+    )
+
+    mock_tx.litellm_teammembership.count.assert_awaited_once_with(
+        where={"budget_id": private_budget_id},
+    )
+    mock_tx.litellm_budgettable.update.assert_awaited_once_with(
+        where={"budget_id": private_budget_id},
+        data={"max_budget": 75.0, "updated_by": fake_user.user_id},
+    )
+    mock_tx.litellm_budgettable.create.assert_not_called()
+    mock_tx.litellm_teammembership.upsert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upsert_falls_back_to_inplace_when_count_probe_raises(
+    mock_tx, fake_user, caplog
+):
+    """
+    Safety net: if the ref-count probe raises (e.g. on a tx implementation
+    that does not support count on this model), the function must NOT raise
+    and must fall back to the original in-place update behavior. The
+    fallback must log the failure so a regression of the LIT-3359 guard
+    cannot silently persist in production.
+    """
+    import logging
+
+    private_budget_id = "probe-may-fail-budget"
+    mock_tx.litellm_teammembership.count = AsyncMock(
+        side_effect=RuntimeError("tx does not support count() on this model")
+    )
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM Proxy"):
+        await _upsert_budget_and_membership(
+            mock_tx,
+            team_id="team-fallback",
+            user_id="alice",
+            max_budget=42.0,
+            existing_budget_id=private_budget_id,
+            user_api_key_dict=fake_user,
+            team_default_budget_id=None,
+        )
+
+    mock_tx.litellm_budgettable.update.assert_awaited_once_with(
+        where={"budget_id": private_budget_id},
+        data={"max_budget": 42.0, "updated_by": fake_user.user_id},
+    )
+    mock_tx.litellm_budgettable.create.assert_not_called()
+    mock_tx.litellm_teammembership.upsert.assert_not_called()
+
+    assert any(
+        "LIT-3359 ref-count probe failed" in rec.message for rec in caplog.records
+    ), f"expected LIT-3359 log; got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## Summary

Fix LIT-3359: changing a single team member's budget no longer mutates the whole shared `LiteLLM_BudgetTable` row when multiple memberships happen to point at the same `budget_id`.

## Root cause

`_upsert_budget_and_membership` (`litellm/proxy/management_endpoints/common_utils.py`) only avoided in-place mutation of the existing `LiteLLM_BudgetTable` row when the membership's `existing_budget_id == team_default_budget_id` (the team's declared `team_member_budget_id` metadata default).

In production it is very easy to end up with multiple memberships sharing a single `budget_id` outside that narrow guard: post-rotation of the team default, manual cleanup, or the `backfill_team_member_budget_entries` migration that historically pointed multiple memberships at one budget row. In all those cases the old guard returned `is_shared_default=False`, the function fell into the bare `litellm_budgettable.update(where={budget_id: existing_budget_id}, …)` path, and that single shared row was rewritten — moving every other member's cap with it.

## Fix

Extend the existing `is_shared_default` guard with a *reference-count* probe (`tx.litellm_teammembership.count(where={"budget_id": existing_budget_id})`). If more than one membership points at this `budget_id` we take the same clone-on-write branch as the shared-default case:
- look up the shared row,
- seed a new private budget row from its fields,
- apply the caller's overrides (`max_budget` / `tpm_limit` / `rpm_limit` / `allowed_models`),
- re-link the membership to the new row.

Sole-owner updates keep the original cheap in-place `update`. The ref-count probe is wrapped in a `try/except` so any tx backend that does not support `count()` on this model still falls back to the previous in-place behaviour (we'd rather preserve current semantics than block a legitimate update).

## Test

- New unit tests in `tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py`:
  - `test_upsert_clones_when_budget_shared_by_other_memberships` — shared by N>1 → clone-on-write, no in-place mutation, membership re-linked, caller wins over cloned defaults
  - `test_upsert_inplace_when_sole_owner_of_existing_budget` — perf preservation, in-place fast path still fires
  - `test_upsert_falls_back_to_inplace_when_count_probe_raises` — safety net: if the count probe raises, fall back to in-place update
- Existing 8 tests in that file continue to pass (the shared-default clone path, the disconnect path, the all-fields-none path, etc.).

```
$ pytest tests/test_litellm/proxy/common_utils/test_upsert_budget_membership.py -q
...........                                                                  [100%]
11 passed in 7.97s
```

### Evidence

Same Python script driving the patched and unpatched `_upsert_budget_and_membership` directly against a live Postgres `LiteLLM_*` schema, seeded with one budget row at `$100` shared by three memberships (alice / bob / carol), then updating only alice to `$999`.

**BEFORE (unpatched main, bug present):**

```
========================= [BEFORE] BEFORE upsert(alice -> $999) =========================
  lit3359mega-alice: budget_id=lit3359mega-bud-4bef9902  cap=$100.0
  lit3359mega-bob:   budget_id=lit3359mega-bud-4bef9902  cap=$100.0
  lit3359mega-carol: budget_id=lit3359mega-bud-4bef9902  cap=$100.0
  [budget rows touched]
    lit3359mega-bud-4bef9902: max_budget=$100.0

========================= [BEFORE] AFTER upsert(alice -> $999) =========================
  lit3359mega-alice: budget_id=lit3359mega-bud-4bef9902  cap=$999.0
  lit3359mega-bob:   budget_id=lit3359mega-bud-4bef9902  cap=$999.0    <-- BUG: bob leaked
  lit3359mega-carol: budget_id=lit3359mega-bud-4bef9902  cap=$999.0    <-- BUG: carol leaked
  [budget rows touched]
    lit3359mega-bud-4bef9902: max_budget=$999.0
VERDICT[BEFORE]: BUG PRESENT — bob/carol moved to $999 because the shared row was mutated in place.
```

**AFTER (this PR):**

```
========================= [AFTER] BEFORE upsert(alice -> $999) =========================
  lit3359mega-alice: budget_id=lit3359mega-bud-139d5ec0  cap=$100.0
  lit3359mega-bob:   budget_id=lit3359mega-bud-139d5ec0  cap=$100.0
  lit3359mega-carol: budget_id=lit3359mega-bud-139d5ec0  cap=$100.0
  [budget rows touched]
    lit3359mega-bud-139d5ec0: max_budget=$100.0

========================= [AFTER] AFTER upsert(alice -> $999) =========================
  lit3359mega-alice: budget_id=136612a3-525c-47f7-82cf-f9528370f022  cap=$999.0    <-- new private row
  lit3359mega-bob:   budget_id=lit3359mega-bud-139d5ec0  cap=$100.0    <-- preserved
  lit3359mega-carol: budget_id=lit3359mega-bud-139d5ec0  cap=$100.0    <-- preserved
  [budget rows touched]
    136612a3-525c-47f7-82cf-f9528370f022: max_budget=$999.0
    lit3359mega-bud-139d5ec0: max_budget=$100.0
VERDICT[AFTER]: FIX WORKS — alice forked to a private $999 budget, bob & carol stayed at the shared $100.
```

Linear: https://linear.app/litellm-ai/issue/LIT-3359/changing-team-member-budget-updates-whole-team-budget


### Verification (ship-pr)

- [x] **Base branch:** `litellm_oss_agent_shin_daily_branch` (verified via GitHub API)
- [x] **Source branch check:** PR head = `oss-agent-shin:shin/lit-3359-budget-refcount-fork`
- [x] **GitHub Actions:** 44/44 checks green at commit `e92307e1` (lint, semgrep, secret-scan, unit-test, proxy-* suites, integrations, Vertex AI, enterprise-routing, test-server-root-path, build-ui, etc.)
- [x] **Greptile:** Confidence Score **5/5** — "Safe to merge — the fix is narrowly scoped to the budget-sharing guard, the fallback preserves existing behaviour, and the change is covered by 11 passing unit tests."
- [x] **Veria AI - PR Review:** `success` — "No security issues found"
- [x] **Codecov:** "All modified and coverable lines are covered by tests."
- [x] **mergeable_state:** `clean`
- [x] **Runtime evidence:** before/after terminal capture inlined under `### Evidence` above; bug reproduces on unpatched code (bob & carol's caps both move to \$999 when only alice was updated), bug disappears with this patch (alice forked to a new private \$999 row, bob & carol stay at the shared \$100).
