### PR TITLE
fix(ui): allow renaming a credential after creation (LIT-2074)

### DIFF
--- a/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Providers } from "../provider_info_helpers";
 import { CredentialItem } from "../networking";
@@ -117,7 +118,47 @@ describe("EditCredentialModal", () => {
     await waitFor(() => {
       const credentialNameInput = screen.getByLabelText("Credential Name:") as HTMLInputElement;
       expect(credentialNameInput.value).toBe("test-credential");
-      expect(credentialNameInput.disabled).toBe(true);
+      // LIT-2074: the Credential Name field is now editable after creation so
+      // admins can rename a credential without deleting and recreating it.
+      expect(credentialNameInput.disabled).toBe(false);
     });
+  });
+
+  it("should propagate a renamed credential_name to onUpdateCredential", async () => {
+    const queryClient = createQueryClient();
+    const onCancel = vi.fn();
+    const onUpdateCredential = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditCredentialModal
+          open={true}
+          onCancel={onCancel}
+          onUpdateCredential={onUpdateCredential}
+          uploadProps={mockUploadProps}
+          existingCredential={mockCredential}
+        />
+      </QueryClientProvider>,
+    );
+
+    const credentialNameInput = (await screen.findByLabelText(
+      "Credential Name:",
+    )) as HTMLInputElement;
+    expect(credentialNameInput.disabled).toBe(false);
+
+    await user.clear(credentialNameInput);
+    await user.type(credentialNameInput, "renamed-credential");
+    expect(credentialNameInput.value).toBe("renamed-credential");
+
+    await user.click(
+      screen.getByRole("button", { name: /update credential/i }),
+    );
+
+    await waitFor(() => {
+      expect(onUpdateCredential).toHaveBeenCalled();
+    });
+    const submittedValues = onUpdateCredential.mock.calls[0][0];
+    expect(submittedValues.credential_name).toBe("renamed-credential");
   });
 });

--- a/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx
@@ -76,10 +76,7 @@ export default function EditCredentialsModal({
           rules={[{ required: true, message: "Credential name is required" }]}
           initialValue={existingCredential?.credential_name}
         >
-          <TextInput
-            placeholder="Enter a friendly name for these credentials"
-            disabled={existingCredential?.credential_name ? true : false}
-          />
+          <TextInput placeholder="Enter a friendly name for these credentials" />
         </Form.Item>
 
         {/* Provider Selection */}

--- a/ui/litellm-dashboard/src/components/model_add/credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.tsx
@@ -64,7 +64,11 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ uploadProps }) => {
       },
     };
 
-    await credentialUpdateCall(accessToken, values.credential_name, newCredential);
+    // Use the *original* credential name in the URL path so the backend lookup hits
+    // the existing row even when the user renames it. The new name travels in the
+    // request body and the existing backend rename path picks it up from there.
+    const originalName = selectedCredential?.credential_name ?? values.credential_name;
+    await credentialUpdateCall(accessToken, originalName, newCredential);
     NotificationsManager.success("Credential updated successfully");
     setIsUpdateModalOpen(false);
     await refetchCredentials();

--- a/ui/litellm-dashboard/src/components/model_add/credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.tsx
@@ -51,6 +51,16 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ uploadProps }) => {
     if (!accessToken) {
       return;
     }
+    // The Edit modal is only mounted after selectedCredential is set via the
+    // pencil-icon onClick handler, so this null case should be unreachable in
+    // practice. Bail out explicitly rather than fall back to values.credential_name
+    // — that fallback would silently reintroduce the LIT-2074 routing bug (URL
+    // path = NEW name -> backend lookup misses the existing row) on any future
+    // refactor that drops the prerequisite. (Greptile review feedback.)
+    if (!selectedCredential) {
+      NotificationsManager.fromBackend("Cannot update credential: no credential selected");
+      return;
+    }
 
     const filter_credential_values = Object.entries(values)
       .filter(([key]) => !restrictedFields.includes(key))
@@ -67,8 +77,7 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ uploadProps }) => {
     // Use the *original* credential name in the URL path so the backend lookup hits
     // the existing row even when the user renames it. The new name travels in the
     // request body and the existing backend rename path picks it up from there.
-    const originalName = selectedCredential?.credential_name ?? values.credential_name;
-    await credentialUpdateCall(accessToken, originalName, newCredential);
+    await credentialUpdateCall(accessToken, selectedCredential.credential_name, newCredential);
     NotificationsManager.success("Credential updated successfully");
     setIsUpdateModalOpen(false);
     await refetchCredentials();


### PR DESCRIPTION
## What

Lets admins rename a credential after it has been created. Today the **Edit Credential** modal hard-disables the credential name input, so the only way to "rename" is to delete the credential and create a new one — which loses any model deployments that reference it. The backend `PATCH /credentials/{credential_name}` endpoint already supports rename (`update_db_credential` updates the name, and the in-memory `litellm.credential_list` rebuild handles the old→new key swap in `litellm/proxy/credential_endpoints/endpoints.py`), so this is a small UI-only unlock plus a related routing fix.

Re-files prior PR [#28817](https://github.com/BerriAI/litellm/pull/28817) (closed without review) — the bug is still present on `main`.

Linear: [LIT-2074](https://linear.app/litellm-ai/issue/LIT-2074/feat-be-able-to-edit-name-of-a-credential-after-creation) (Swietelsky Issue Tracker)

## Change

- **`ui/litellm-dashboard/src/components/model_add/EditCredentialModal.tsx`** — drop the `disabled={existingCredential?.credential_name ? true : false}` on the credential-name `<TextInput>` so the field is editable when an existing credential is loaded.
- **`ui/litellm-dashboard/src/components/model_add/credentials.tsx`** — in `handleUpdateCredential`, route the PATCH to the credential's **original** name (`selectedCredential.credential_name`) so the backend lookup still finds the row when the user renames it. The new name travels in the request body and the existing backend rename path (`update_db_credential` → `prisma_client.db.litellm_credentialstable.update(where={credential_name: <old>}, data={credential_name: <new>, …})` at `litellm/proxy/credential_endpoints/endpoints.py:330-343`) takes it from there.
- **`ui/litellm-dashboard/src/components/model_add/EditCredentialModal.test.tsx`** — flip the assertion that pinned `disabled=true` to `disabled=false`, and add a new test that types a new name and clicks **Update Credential**, asserting the renamed `credential_name` value is forwarded to `onUpdateCredential`.

Push was done via `PUT /repos/{owner}/{repo}/contents/{path}` (Contents API) because the agent's `GITHUB_TOKEN` lacks `repo` scope and `git push` returns "Password authentication is not supported" — so reviewers may see this branch as three small commits instead of one squashed change.

### Evidence

#### Backend rename round-trip (curl against a running LiteLLM proxy)

Both halves of the fix come through here:

1. **Why the routing change matters** — if the UI just put the new name in the URL (which is what `values.credential_name` was doing before this PR), the backend's `find_unique(where={credential_name: <url>})` lookup fails because the row is still keyed on the *original* name. The proxy's exception handler wraps the inner `404 Credential not found in DB` into a `200`-with-error-body, but the operation has failed and no rename occurs.
2. **The fix** — addressing PATCH to the original name (`selectedCredential.credential_name`) with the new name in the body succeeds, and `GET /credentials` confirms the rename persisted in the DB.

Captured against the proxy started in-sandbox on port `4530` with the bundled Postgres DB (`DATABASE_URL=postgresql://litellm:litellm@localhost:5432/litellm`, master key `sk-1234`):

```text
=== Backend evidence: routing fix against a running LiteLLM proxy on :4530 ===

==[1] POST /credentials (create 'demo-openai-creds') ==
{"success":true,"message":"Credential created successfully"}

==[2] BEFORE FIX: old UI code put values.credential_name in the URL path.
    On rename, that's the NEW name, but the backend looks up the row by
    the URL name, so the PATCH never finds it:
    PATCH /credentials/renamed-openai-creds
{"message":"Credential not found in DB.","type":"internal_server_error","param":"None","openai_code":404,"code":"404","headers":{},"provider_specific_fields":null}
HTTP_STATUS=200

==[3] AFTER FIX: PATCH /credentials/<ORIGINAL name>, new name in body.
    This is what the PR's handleUpdateCredential now does:
    PATCH /credentials/demo-openai-creds
{"success":true,"message":"Credential updated successfully"}
HTTP_STATUS=200

==[4] GET /credentials -> rename persisted in DB ==
{
    "success": true,
    "credentials": [
        {
            "credential_name": "renamed-openai-creds",
            "credential_values": {
                "api_key": "sk****ew"
            },
            "credential_info": {
                "custom_llm_provider": "openai"
            }
        }
    ]
}
```

The `HTTP_STATUS=200` on both sides comes from `handle_exception_on_proxy()` (`litellm/proxy/credential_endpoints/endpoints.py:373-374`) wrapping HTTPException into a 200-with-error-body — the meaningful signal is the response body (`"Credential not found in DB"` before vs `"Credential updated successfully"` after) and the persisted state of the row after each call.

#### UI rendering — vitest in JSDOM

`npx vitest run src/components/model_add/EditCredentialModal.test.tsx` against this branch:

```text
 ✓ src/components/model_add/EditCredentialModal.test.tsx (3 tests) 4359ms
   ✓ EditCredentialModal > should render
   ✓ EditCredentialModal > should render initial values
     (asserts credentialNameInput.disabled === false after the fix)
   ✓ EditCredentialModal > should propagate a renamed credential_name to onUpdateCredential
     (types a new value into the now-enabled field and asserts it reaches onUpdateCredential)

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

#### UI screenshots — sandbox blocker (transparency note)

I could not attach before/after browser screenshots of the running modal in this PR. The sandbox repeatedly OOM-killed the proxy and/or rolled `/home/user/*.png` and `/tmp/*` back to an earlier snapshot between `sandbox_execute` calls (4 GB cap; Postgres + Prisma engine + LiteLLM uvicorn + Chromium together blow past it). I also burned time on a `prisma "vault upstream 502"` error caused by `HTTP_PROXY`/`HTTPS_PROXY` env vars being inherited by the Prisma engine's localhost calls — workaround is to start the proxy with `NO_PROXY=localhost,127.0.0.1` exported.

The change is narrow enough to verify from the diff:

- removing `disabled={existingCredential?.credential_name ? true : false}` from `<TextInput>` is a one-line attribute drop; the input falls back to its default (enabled) state, identical to the **Add Credential** flow's input that already works correctly. There is no other code path that disables this input.
- The new unit test exercises the *DOM* state (`credentialNameInput.disabled === false`) plus the value-propagation path through React Hook Form into `onUpdateCredential` — the same surface a UI screenshot would have shown.

If a maintainer wants visual confirmation before merging, the easiest local reproduction is:

```bash
cd ui/litellm-dashboard && npm install && npm run build
# from the litellm repo root:
litellm --config .../config.yaml
# then open http://localhost:4000/ui/?page=credentials and click the pencil icon
```

Session: https://litellm-agent-platform.onrender.com/sessions/77f09a66-9c72-436a-a0a6-d13a8fc183a3

### Verification (ship-pr)

- change-type: 3 UI files touched -> ship-pr requires before/after screenshots of the running UI for `ui/`/`*.tsx` changes
- evidence present: PARTIAL — backend curl evidence ✓, vitest output ✓, UI screenshots ✗
- image sanity: N/A (no embedded screenshots; sandbox blocker documented above)
- image content matches caption: N/A
- backend evidence from running system: PASS (proxy started in-sandbox on :4530 with the bundled Postgres DB; the curl block above shows the real before/after request + body + persisted state)
- hygiene: PASS (no external image hosts; only the 3 intended UI files are staged)
- re-verify after fix: PASS (Greptile 4/5 + Veria "No security issues found" + 44/44 CI checks green on `6b24b94` after addressing the null-fallback concern)

Honest classification: the UI-screenshot check is **NOT PASS** because of the sandbox blocker (OOM-kill of Chromium when run alongside Postgres + Prisma engine + LiteLLM uvicorn at the 4 GB cap, plus file-system state being rolled back between `sandbox_execute` calls — see the "UI screenshots — sandbox blocker" section above and the retro in #test-shin). I'm explicitly flagging this rather than silently shipping. The unit test exercises the same DOM state (`credentialNameInput.disabled === false`) plus the value-propagation path that a UI screenshot would have verified visually.
