### PR TITLE
fix(key-mgmt): auto-extend expiration on regenerate of expired key (LIT-2569)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4311,6 +4311,23 @@ async def _execute_virtual_key_regeneration(  # noqa: PLR0915
                     _original_lifetime = timedelta(0)
                 if _original_lifetime.total_seconds() <= 0:
                     _original_lifetime = timedelta(days=30)
+                # Cap the auto-extended lifetime to the configured upper
+                # bound so a caller can't revive a 30-day key on a deployment
+                # that has since been locked down to e.g. ``duration="1d"``.
+                # The upperbound check on the regenerate request body above
+                # (``_enforce_upperbound_key_params``) only fires when the
+                # caller supplied ``duration`` explicitly; without this cap,
+                # omitting ``duration`` would silently bypass it.
+                if litellm.upperbound_key_generate_params is not None:
+                    upperbound_duration_str = getattr(
+                        litellm.upperbound_key_generate_params, "duration", None
+                    )
+                    if upperbound_duration_str:
+                        upperbound_seconds = duration_in_seconds(
+                            duration=upperbound_duration_str
+                        )
+                        if _original_lifetime.total_seconds() > upperbound_seconds:
+                            _original_lifetime = timedelta(seconds=upperbound_seconds)
                 update_data["expires"] = _now + _original_lifetime
                 # Identify the old key by hashed token (always present) plus
                 # alias (often None) so log lines are actionable on their own

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4267,6 +4267,59 @@ async def _execute_virtual_key_regeneration(
             _validate_key_alias_format(key_alias=new_key_alias)
         verbose_proxy_logger.debug("non_default_values: %s", non_default_values)
     update_data.update(non_default_values)
+
+    # LIT-2569: when the caller did not supply duration and the
+    # existing key has *already* expired, auto-extend the expiration so
+    # the regenerated key is actually usable. Without this, a key whose
+    # expires is in the past stays in the past after regeneration --
+    # users would receive a new sk-... value that immediately fails
+    # auth, which defeats the purpose of regenerating a key.
+    #
+    # Scope of the auto-extend:
+    #   - Only fires when expires is NOT in update_data (i.e. the
+    #     caller did not pass duration). An explicit duration
+    #     (including duration="-1" to mean "never expire") always wins.
+    #   - Only fires when the existing key has a concrete expires in
+    #     the past. Non-expiring keys (expires is None) and
+    #     not-yet-expired keys are left alone.
+    #   - The new expiration preserves the original lifetime
+    #     old.expires - old.created_at so a 30-day key stays a 30-day
+    #     key. If created_at is missing or the computed lifetime is
+    #     non-positive, fall back to a 30-day default.
+    if "expires" not in update_data:
+        _existing_expires = getattr(key_in_db, "expires", None)
+        if isinstance(_existing_expires, str):
+            try:
+                _existing_expires = datetime.fromisoformat(
+                    _existing_expires.replace("Z", "+00:00")
+                )
+            except ValueError:
+                _existing_expires = None
+        if isinstance(_existing_expires, datetime):
+            _now = datetime.now(timezone.utc)
+            if _existing_expires.tzinfo is None:
+                _existing_expires = _existing_expires.replace(tzinfo=timezone.utc)
+            if _existing_expires < _now:
+                _existing_created = getattr(key_in_db, "created_at", None)
+                if isinstance(_existing_created, datetime):
+                    if _existing_created.tzinfo is None:
+                        _existing_created = _existing_created.replace(
+                            tzinfo=timezone.utc
+                        )
+                    _original_lifetime = _existing_expires - _existing_created
+                else:
+                    _original_lifetime = timedelta(0)
+                if _original_lifetime.total_seconds() <= 0:
+                    _original_lifetime = timedelta(days=30)
+                update_data["expires"] = _now + _original_lifetime
+                verbose_proxy_logger.info(
+                    "Regenerated expired key %s: auto-extending expires to %s "
+                    "(original lifetime %s)",
+                    getattr(key_in_db, "key_alias", None),
+                    update_data["expires"].isoformat(),
+                    _original_lifetime,
+                )
+
     update_data = prisma_client.jsonify_object(data=update_data)
 
     # If grace period set, insert deprecated key so old key remains valid

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4312,10 +4312,16 @@ async def _execute_virtual_key_regeneration(  # noqa: PLR0915
                 if _original_lifetime.total_seconds() <= 0:
                     _original_lifetime = timedelta(days=30)
                 update_data["expires"] = _now + _original_lifetime
+                # Identify the old key by hashed token (always present) plus
+                # alias (often None) so log lines are actionable on their own
+                # without needing to cross-reference other log entries.
                 verbose_proxy_logger.info(
-                    "Regenerated expired key %s: auto-extending expires to %s "
+                    "Regenerated expired key (token_hash=%s, alias=%s, "
+                    "new_key_name=%s): auto-extending expires to %s "
                     "(original lifetime %s)",
+                    hashed_api_key,
                     getattr(key_in_db, "key_alias", None),
+                    new_token_key_name,
                     update_data["expires"].isoformat(),
                     _original_lifetime,
                 )

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4211,7 +4211,7 @@ async def _insert_deprecated_key(
         )
 
 
-async def _execute_virtual_key_regeneration(
+async def _execute_virtual_key_regeneration(  # noqa: PLR0915
     *,
     prisma_client: PrismaClient,
     key_in_db: LiteLLM_VerificationToken,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4311,13 +4311,16 @@ async def _execute_virtual_key_regeneration(  # noqa: PLR0915
                     _original_lifetime = timedelta(0)
                 if _original_lifetime.total_seconds() <= 0:
                     _original_lifetime = timedelta(days=30)
-                # Cap the auto-extended lifetime to the configured upper
-                # bound so a caller can't revive a 30-day key on a deployment
-                # that has since been locked down to e.g. ``duration="1d"``.
-                # The upperbound check on the regenerate request body above
-                # (``_enforce_upperbound_key_params``) only fires when the
-                # caller supplied ``duration`` explicitly; without this cap,
-                # omitting ``duration`` would silently bypass it.
+                # Guard against lifetime creep on successive regenerations.
+                #
+                # ``created_at`` does not change on regenerate; only the new
+                # ``expires`` is written. So if a key is regenerated several
+                # times while expired, naive ``new_expires - created_at``
+                # grows on each pass (30d -> 61d -> 123d -> ...). Cap the
+                # auto-extended lifetime to a fixed default (30d) when no
+                # operator-configured upperbound exists; if the upperbound
+                # IS set, defer to that value as the authoritative cap.
+                _AUTO_EXTEND_DEFAULT_CAP = timedelta(days=30)
                 if litellm.upperbound_key_generate_params is not None:
                     upperbound_duration_str = getattr(
                         litellm.upperbound_key_generate_params, "duration", None
@@ -4328,6 +4331,10 @@ async def _execute_virtual_key_regeneration(  # noqa: PLR0915
                         )
                         if _original_lifetime.total_seconds() > upperbound_seconds:
                             _original_lifetime = timedelta(seconds=upperbound_seconds)
+                    elif _original_lifetime > _AUTO_EXTEND_DEFAULT_CAP:
+                        _original_lifetime = _AUTO_EXTEND_DEFAULT_CAP
+                elif _original_lifetime > _AUTO_EXTEND_DEFAULT_CAP:
+                    _original_lifetime = _AUTO_EXTEND_DEFAULT_CAP
                 update_data["expires"] = _now + _original_lifetime
                 # Identify the old key by hashed token (always present) plus
                 # alias (often None) so log lines are actionable on their own

--- a/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
@@ -1,0 +1,197 @@
+"""Regression tests for LIT-2569: auto-extend expiration on key regenerate
+when the existing key is already expired and the caller did not supply a
+new duration.
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_prisma_capturing_update():
+    captured = {}
+    mock = AsyncMock()
+
+    async def _fake_update(*, where, data):
+        captured["data"] = data
+
+        class R:
+            def __init__(self, d):
+                self._d = d
+
+            def __iter__(self):
+                return iter(self._d.items())
+
+        return R(
+            {
+                "token": data["token"],
+                "key_name": data["key_name"],
+                "user_id": "user-1",
+                "expires": data.get("expires"),
+            }
+        )
+
+    mock.db.litellm_verificationtoken.update = _fake_update
+    mock.db.litellm_verificationtoken.create = AsyncMock(return_value=None)
+    mock.jsonify_object = MagicMock(side_effect=lambda data: data)
+    mock._captured = captured
+    return mock
+
+
+def _make_expired_key(*, days_ago_created=31, days_ago_expired=1):
+    from litellm.proxy._types import LiteLLM_VerificationToken
+
+    now = datetime.now(timezone.utc)
+    return LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=now - timedelta(days=days_ago_created),
+        expires=now - timedelta(days=days_ago_expired),
+    )
+
+
+async def _run_regenerate(existing_key, data):
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-admin",
+        user_id="admin-1",
+    )
+    mock_prisma = _mock_prisma_capturing_update()
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+            new_callable=AsyncMock,
+            return_value="sk-newtoken1234ab12",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma,
+            key_in_db=existing_key,
+            hashed_api_key="abc123",
+            key="abc123",
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+        )
+
+    return mock_prisma._captured["data"]
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_expired_key_without_duration_auto_extends():
+    """Headline: regenerating an already-expired key without supplying
+    duration produces a key whose expires is in the future, with
+    the original lifetime (~30 days) preserved."""
+    from litellm.proxy._types import RegenerateKeyRequest
+
+    existing_key = _make_expired_key(days_ago_created=31, days_ago_expired=1)
+    data = RegenerateKeyRequest()  # NO duration
+
+    written = await _run_regenerate(existing_key, data)
+
+    new_expires = written.get("expires")
+    assert new_expires is not None, (
+        "BUG: expires not set on regenerate of expired key -- new key "
+        "would inherit the existing (expired) date."
+    )
+    assert new_expires > datetime.now(timezone.utc), (
+        f"BUG: regenerated key still expired (new expires={new_expires!r})"
+    )
+    # Original lifetime (~30d) should be preserved (within tolerance for
+    # the test runners wall-clock drift between key creation and now).
+    delta = new_expires - datetime.now(timezone.utc)
+    assert timedelta(days=29) < delta < timedelta(days=31), (
+        f"Expected ~30d lifetime, got {delta}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_non_expired_key_unchanged():
+    """A key whose expires is still in the future must NOT be
+    auto-extended. This guards against regressions for callers who rely
+    on /key/regenerate being a no-op on the expiration field."""
+    from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+
+    now = datetime.now(timezone.utc)
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=now - timedelta(days=5),
+        expires=now + timedelta(days=25),  # still valid for 25 days
+    )
+
+    written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+
+    assert "expires" not in written, (
+        'non-expired key was auto-extended; expires=' + repr(written.get('expires'))
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_explicit_duration_still_wins():
+    """When the caller explicitly supplies duration, the auto-extend
+    branch must not fire -- the supplied value takes precedence."""
+    from litellm.proxy._types import RegenerateKeyRequest
+
+    existing_key = _make_expired_key()
+    data = RegenerateKeyRequest(duration="7d")
+
+    written = await _run_regenerate(existing_key, data)
+    new_expires = written.get("expires")
+    assert new_expires is not None
+    delta = new_expires - datetime.now(timezone.utc)
+    assert timedelta(days=6) < delta < timedelta(days=8), (
+        f"Expected ~7d from explicit duration, got {delta}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_non_expiring_key_unchanged():
+    """A key with expires=None (never expires) must remain
+    non-expiring after regenerate without duration."""
+    from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=datetime.now(timezone.utc) - timedelta(days=5),
+        expires=None,
+    )
+
+    written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+
+    assert "expires" not in written, (
+        "non-expiring key was given an expires by the LIT-2569 branch"
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
@@ -195,3 +195,91 @@ async def test_lit2569_regenerate_non_expiring_key_unchanged():
     assert "expires" not in written, (
         "non-expiring key was given an expires by the LIT-2569 branch"
     )
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_expired_key_with_string_expires_parses_iso():
+    """Covers the defensive `isinstance(_existing_expires, str)` branch:
+    if Prisma surfaces ``expires`` as an ISO-8601 string instead of a
+    datetime, the auto-extend logic must still fire."""
+    from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+
+    now = datetime.now(timezone.utc)
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=now - timedelta(days=31),
+        # ISO-8601 string with trailing Z, the shape datetime.fromisoformat()
+        # used to choke on prior to py3.11. The branch normalizes "Z" to "+00:00".
+        expires=(now - timedelta(days=1)).isoformat().replace("+00:00", "Z"),
+    )
+
+    written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+    new_expires = written.get("expires")
+    assert new_expires is not None, (
+        "expected auto-extend to fire when expires is provided as an ISO string"
+    )
+    assert new_expires > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_expired_key_tz_naive_expires_treated_as_utc():
+    """Defensive branch: if either ``expires`` or ``created_at`` is
+    timezone-naive (legacy rows / SQLite-backed installs), the helper
+    must coerce to UTC so the ``< now`` comparison is well-defined."""
+    from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+
+    now = datetime.now(timezone.utc)
+    # Construct expires/created_at without tzinfo
+    expires_naive = (now - timedelta(days=1)).replace(tzinfo=None)
+    created_naive = (now - timedelta(days=31)).replace(tzinfo=None)
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=created_naive,
+        expires=expires_naive,
+    )
+
+    written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+    new_expires = written.get("expires")
+    assert new_expires is not None
+    assert new_expires > datetime.now(timezone.utc)
+    delta = new_expires - datetime.now(timezone.utc)
+    assert timedelta(days=29) < delta < timedelta(days=31)
+
+
+@pytest.mark.asyncio
+async def test_lit2569_regenerate_expired_key_missing_created_at_falls_back_to_30d():
+    """Defensive branch: if ``created_at`` is missing on the row (very
+    old keys that pre-date that column), the helper falls back to a
+    30-day lifetime so the regenerated key is still usable."""
+    from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+
+    now = datetime.now(timezone.utc)
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=None,
+        expires=now - timedelta(days=1),
+    )
+
+    written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+    new_expires = written.get("expires")
+    assert new_expires is not None
+    delta = new_expires - datetime.now(timezone.utc)
+    # 30-day fallback (within tolerance)
+    assert timedelta(days=29) < delta < timedelta(days=31), (
+        f"Expected 30d fallback, got {delta}"
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
@@ -283,3 +283,37 @@ async def test_lit2569_regenerate_expired_key_missing_created_at_falls_back_to_3
     assert timedelta(days=29) < delta < timedelta(days=31), (
         f"Expected 30d fallback, got {delta}"
     )
+
+
+@pytest.mark.asyncio
+async def test_lit2569_auto_extend_respects_upperbound_duration():
+    """LIT-2569 + Veria review: when ``upperbound_key_generate_params.duration``
+    is configured, the auto-extend lifetime is capped to that bound. Without
+    this cap a caller could revive a 30-day key on a deployment that has
+    since been locked down to e.g. ``duration="1d"`` by omitting
+    ``duration`` from the regenerate request.
+    """
+    import litellm
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    existing_key = _make_expired_key(days_ago_created=31, days_ago_expired=1)
+    saved = litellm.upperbound_key_generate_params
+    try:
+        litellm.upperbound_key_generate_params = (
+            LiteLLM_UpperboundKeyGenerateParams(duration="1d")
+        )
+        written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+    finally:
+        litellm.upperbound_key_generate_params = saved
+
+    new_expires = written.get("expires")
+    assert new_expires is not None
+    delta = new_expires - datetime.now(timezone.utc)
+    # Cap is 1d -- new expires should be ~1d out, NOT the original ~30d.
+    assert delta < timedelta(days=2), (
+        f"BUG: auto-extend bypassed upperbound cap; new expires {delta} > 1d"
+    )
+    assert delta > timedelta(hours=23)

--- a/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py
@@ -317,3 +317,40 @@ async def test_lit2569_auto_extend_respects_upperbound_duration():
         f"BUG: auto-extend bypassed upperbound cap; new expires {delta} > 1d"
     )
     assert delta > timedelta(hours=23)
+
+
+@pytest.mark.asyncio
+async def test_lit2569_auto_extend_caps_lifetime_at_30d_no_creep():
+    """LIT-2569 + Greptile review: prevent lifetime creep on successive
+    regenerations. ``created_at`` does not change on regenerate, so a naive
+    ``expires - created_at`` lifetime calculation grows on each cycle
+    (30d -> 61d -> 123d). Cap the auto-extended lifetime at a 30-day
+    default when no upperbound is configured.
+    """
+    from litellm.proxy._types import LiteLLM_VerificationToken, RegenerateKeyRequest
+
+    now = datetime.now(timezone.utc)
+    # Simulate a key that has already been regenerated twice with lifetime
+    # creep: ``expires - created_at`` is now ~90d even though it started
+    # life as a 30-day key.
+    existing_key = LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        created_at=now - timedelta(days=120),
+        expires=now - timedelta(days=1),  # still expired
+    )
+
+    written = await _run_regenerate(existing_key, RegenerateKeyRequest())
+    new_expires = written.get("expires")
+    assert new_expires is not None
+    delta = new_expires - datetime.now(timezone.utc)
+    # Must be capped at the 30-day default, not the naive 119d
+    # (created_at -> expires) span.
+    assert delta < timedelta(days=31), (
+        f"BUG: lifetime creep -- new expires {delta} > 30d cap"
+    )
+    assert delta > timedelta(days=29)


### PR DESCRIPTION
## Summary

Auto-extend the expiration when `/key/regenerate` is called without an explicit `duration` on a key that has already expired. Without this, the regenerated key inherited the past `expires` value, so the user immediately got auth errors on a key they just rotated.

Fixes [LIT-2569](https://linear.app/litellm-ai/issue/LIT-2569/feat-make-expiration-date-mandatory-or-auto-update-on-key-regeneration).

## Why

Reported by PMI: their developers self-serve key regeneration on a 30-day expiration cycle. When a developer's key expires and they hit "Regenerate" without filling in **Expire Key**, the new key is also expired the moment it's issued — defeating the whole point. Each occurrence creates a support ticket.

## What changes

In `_execute_virtual_key_regeneration`, after the existing per-field merge runs:

* If `expires` is **not** in `update_data` (i.e. the caller did not supply `duration`)
* AND the existing key has a concrete `expires` value that is in the past

Then set `update_data["expires"] = now + new_lifetime`, where `new_lifetime` is:

1. `old.expires - old.created_at` (preserves the original lifetime — 30-day key stays 30-day on first regen), then
2. Capped at `litellm.upperbound_key_generate_params.duration` when the operator has configured one (Veria review), or
3. Capped at a fixed **30-day default** to prevent **lifetime creep on successive regenerations** (Greptile review). Without this cap, `created_at` never moves while `expires` does, so naive `expires - created_at` grows on each cycle (30d → 61d → 123d → …).

### Out of scope (intentionally unchanged)

* Non-expired keys (e.g. `expires` is 25 days in the future). No auto-extend — caller still sees the original `expires`.
* Non-expiring keys (`expires is None`). Still non-expiring.
* Explicit `duration` in the request body. Wins, including `duration="-1"` to mean "never expire" — the auto-extend branch only fires when the caller did **not** supply `duration`.

This matches **option 1** in the ticket. Options 2 (mandatory) and 3 (warning) would have required a UI/API contract change.

### Evidence

Backend-only change; no UI surface. Repro is via the same code path the proxy hits when serving `POST /key/{key}/regenerate` — `_execute_virtual_key_regeneration` is the single shared function. The new test file `tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py` drives that function directly with a mocked Prisma layer that captures the exact `data` dict written to `litellm_verificationtoken.update`, which is what would flow into the DB row.

**Before — on clean `main`, the repro asserts the bug:**

```
$ python3 -m pytest tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py::test_lit2569_regenerate_expired_key_without_duration_auto_extends -x

tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py:117: AssertionError
E       AssertionError: BUG: expires not set on regenerate of expired key -- new key
                        would inherit the existing (expired) date.
E       assert None is not None

FAILED tests/...test_lit2569_regenerate_expired_key_without_duration_auto_extends
============================== 1 failed in 8.65s ===============================
```

The `data` dict written to Prisma when regenerating an expired key has **no `expires` field**, so the existing (expired) value in the row is preserved — exactly the PMI report.

**After — with this PR, all nine scenarios pass:**

```
$ python3 -m pytest tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py -v

test_lit2569_auto_extend_caps_lifetime_at_30d_no_creep              PASSED
test_lit2569_auto_extend_respects_upperbound_duration               PASSED
test_lit2569_regenerate_expired_key_missing_created_at_falls_back_to_30d PASSED
test_lit2569_regenerate_expired_key_tz_naive_expires_treated_as_utc PASSED
test_lit2569_regenerate_expired_key_with_string_expires_parses_iso  PASSED
test_lit2569_regenerate_expired_key_without_duration_auto_extends   PASSED
test_lit2569_regenerate_explicit_duration_still_wins                PASSED
test_lit2569_regenerate_non_expired_key_unchanged                   PASSED
test_lit2569_regenerate_non_expiring_key_unchanged                  PASSED

============================== 9 passed in 8.57s ===============================
```

The nine cases cover the headline fix plus eight regression / defensive guards (lifetime-creep cap, upperbound cap, explicit `duration` wins, non-expired keys untouched, non-expiring keys untouched, ISO-string `expires`, tz-naive datetime, missing `created_at`).

**Existing regenerate / key-management tests, no regressions:**

```
$ python3 -m pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -q

...........................................                              [100%]
259 passed, 1 warning in 10.47s
```

Including the 6 existing `regenerate_*` tests.

## Test plan

* New: `tests/test_litellm/proxy/management_endpoints/test_regenerate_expired_key.py` — 9 tests.
* Re-run: full `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py` (259 tests) — pass.

## Notes for reviewers

* PR was filed via the GitHub contents API (one PUT per file) because the agent's `GITHUB_TOKEN` lacks `repo`/`workflow` scope, so `git push` is unavailable. Functionally equivalent — the resulting commits are normal commits on `lit2569-auto-extend-regenerate-expired-key` in the fork, just one-per-file instead of squashed into a single commit. Targeting `litellm_oss_agent_shin_daily_branch` per the OSS agent base-branch rule.
* Cosmetic note: due to the contents-API path, comment-block backticks (markdown `\`...\`` around field names) got normalized to plain text in the inline doc comment. Functionality unaffected.

Agent session: https://litellm-agent-platform.onrender.com/sessions/1d697238-8525-43c4-8edc-49fec0dd1650

### Verification (ship-pr)

| Check | Status |
|---|---|
| PR open, correct base (`litellm_oss_agent_shin_daily_branch`) | ✅ |
| All GitHub Actions green | ✅ 44/44 |
| Greptile confidence | ✅ 5/5 |
| Veria AI | ✅ Prior issues resolved — no new issues found |
| Evidence section present (before + after curl/pytest) | ✅ |
| Unit tests added (9 tests, all green) | ✅ |
| No regressions in existing key-management tests (259/259) | ✅ |
| Codecov patch coverage | ✅ 91.30% (target 66.79%) |
| No secrets in body | ✅ |
| Linear ticket commented with PR link | ✅ |
| Reviewer comments addressed (Greptile log + creep; Veria upperbound bypass) | ✅ |
