### PR TITLE
fix(streaming): tolerate empty `choices` in raise_on_model_repetition…

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -269,6 +269,13 @@ class CustomStreamWrapper:
         if len(self.chunks) < 2:
             return
 
+        # Some providers (e.g. Vertex Gemini grounding/search/thought-only chunks)
+        # emit metadata-only stream chunks where `choices` is empty. Those chunks
+        # cannot contribute to a repetition signal, so skip them instead of
+        # IndexError-ing. https://github.com/BerriAI/litellm/issues/28884
+        if not self.chunks[-1].choices or not self.chunks[-2].choices:
+            return
+
         last_content = self.chunks[-1].choices[0].delta.content
 
         if (

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1511,6 +1511,36 @@ def test_raise_on_model_repetition(
             wrapper.raise_on_model_repetition()
 
 
+def test_raise_on_model_repetition_tolerates_empty_choices(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/28884
+
+    Vertex Gemini grounding/search/thought-only stream chunks can arrive with
+    `choices=[]`. raise_on_model_repetition should treat them as non-signal
+    instead of raising IndexError on chunks[-1].choices[0].
+    """
+    wrapper = initialized_custom_stream_wrapper
+
+    content_chunk = _make_chunk("hello world")
+    metadata_only_chunk = ModelResponseStream(
+        id="test",
+        created=1741037890,
+        model="test-model",
+        choices=[],
+    )
+
+    # Empty-choices chunk after a content chunk must not raise.
+    wrapper.chunks.append(content_chunk)
+    wrapper.chunks.append(metadata_only_chunk)
+    wrapper.raise_on_model_repetition()
+
+    # Empty-choices chunk as the prior chunk must also not raise.
+    wrapper.chunks.append(content_chunk)
+    wrapper.raise_on_model_repetition()
+
+
 def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
     """
     Test that provider-reported usage from a post-finish_reason chunk


### PR DESCRIPTION
… (#28884)

`raise_on_model_repetition` did `self.chunks[-1].choices[0].delta.content` without checking whether `choices` is non-empty. Vertex Gemini's grounding / web-search / thought-only stream chunks legitimately arrive with `choices=[]` when `web_search_options` + `reasoning_effort` + `stream=True` are combined (see #28884, also related to #27928). The unguarded indexing surfaces to callers as `litellm.APIConnectionError: list index out of range`, killing the whole stream after the first metadata-only chunk.

Treat any chunk with empty `choices` as non-signal for repetition detection (both the latest and the prior chunk are checked, since the prior chunk can also be metadata-only). Adds a regression test exercising both positions.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
