### PR TITLE
feat(batch): add opt-out flag for input-file retrieval + batch rate-limit accounting (LIT-3266)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -343,6 +343,7 @@ enable_gemini_default_thinking_level_low: bool = (
 ####################
 logging: bool = True
 enable_loadbalancing_on_batch_endpoints: Optional[bool] = None
+skip_batch_input_file_retrieval: Optional[bool] = False  # LIT-3266: opt-out flag - when True, _PROXY_BatchRateLimiter skips the input-file fetch + batch RPM/TPM accounting for /v1/batches submissions. Per-deployment override via model_info.skip_batch_input_file_retrieval.
 enable_caching_on_provider_specific_optional_params: bool = (
     False  # feature-flag for caching on optional params - e.g. 'top_k'
 )

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -343,7 +343,9 @@ enable_gemini_default_thinking_level_low: bool = (
 ####################
 logging: bool = True
 enable_loadbalancing_on_batch_endpoints: Optional[bool] = None
-skip_batch_input_file_retrieval: Optional[bool] = False  # LIT-3266: opt-out flag - when True, _PROXY_BatchRateLimiter skips the input-file fetch + batch RPM/TPM accounting for /v1/batches submissions. Per-deployment override via model_info.skip_batch_input_file_retrieval.
+skip_batch_input_file_retrieval: Optional[bool] = (
+    False  # LIT-3266: opt-out flag - when True, _PROXY_BatchRateLimiter skips the input-file fetch + batch RPM/TPM accounting for /v1/batches submissions. Per-deployment override via model_info.skip_batch_input_file_retrieval.
+)
 enable_caching_on_provider_specific_optional_params: bool = (
     False  # feature-flag for caching on optional params - e.g. 'top_k'
 )

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -402,6 +402,20 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         Safe by default: returns False on any lookup error, so misconfiguration
         never silently disables rate limiting.
+
+        Security contract (operators read this):
+
+            Skipping the input-file retrieval also skips
+            ``_enforce_batch_file_model_access`` - the per-line model
+            allowlist check that prevents a caller from smuggling restricted
+            models inside the JSONL ``body.model`` field. Only set the flag
+            on deployments where you control the upstream (e.g. a custom vLLM
+            deployment that ignores ``body.model`` and serves a single fixed
+            model). For shared/loadbalanced deployments, leave the flag unset
+            so the per-line authorization check runs.
+
+            ``async_pre_call_hook`` emits a WARNING log on every skip so
+            operators can audit the trust decision in production.
         """
         try:
             from litellm.proxy.proxy_server import llm_router
@@ -490,9 +504,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         # audit-log gaps (the internal retrieve does not propagate
         # ``UserApiKeyAuth``), and 404 on base64-encoded file IDs.
         if self._should_skip_input_file_retrieval(data=data):
-            verbose_proxy_logger.debug(
-                "Batch rate limiter: skip_batch_input_file_retrieval is set; "
-                "skipping input-file retrieval and batch rate-limit accounting"
+            verbose_proxy_logger.warning(
+                "Batch rate limiter: skip_batch_input_file_retrieval is set for "
+                "model=%s; skipping input-file retrieval, batch rate-limit "
+                "accounting, AND per-line model allowlist enforcement. Operator "
+                "must trust this deployment.",
+                data.get("model") if isinstance(data, dict) else None,
             )
             return data
 

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -392,10 +392,13 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         """Return True iff the input-file retrieval + batch rate-limit step
         should be skipped for this batch request (LIT-3266).
 
-        Resolution order:
-        1. Per-deployment ``model_info.skip_batch_input_file_retrieval`` on the
-           deployment matching ``data["model"]`` in the router model list.
-        2. Global ``litellm.skip_batch_input_file_retrieval``.
+        Resolution order (per-deployment is *authoritative* when set):
+        1. If ``model_info.skip_batch_input_file_retrieval`` is **present** on
+           the deployment matching ``data["model"]`` in the router model list,
+           its boolean value is final - including an explicit ``False`` that
+           re-enables accounting on a specific deployment when the global
+           flag is on.
+        2. Otherwise, fall back to the global ``litellm.skip_batch_input_file_retrieval``.
 
         Safe by default: returns False on any lookup error, so misconfiguration
         never silently disables rate limiting.
@@ -432,10 +435,14 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                                 model_info = model_info.dict()
                             except Exception:
                                 model_info = None
-                if isinstance(model_info, dict) and model_info.get(
-                    "skip_batch_input_file_retrieval"
+                # Per-deployment override is authoritative when *present*.
+                # Explicit False on a deployment must beat a True global flag.
+                if (
+                    isinstance(model_info, dict)
+                    and "skip_batch_input_file_retrieval" in model_info
                 ):
-                    return True
+                    return bool(model_info["skip_batch_input_file_retrieval"])
+        # Fall back to the global flag.
         if getattr(litellm, "skip_batch_input_file_retrieval", False):
             return True
         return False

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -388,6 +388,58 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         return file_content
 
+    def _should_skip_input_file_retrieval(self, data: Dict) -> bool:
+        """Return True iff the input-file retrieval + batch rate-limit step
+        should be skipped for this batch request (LIT-3266).
+
+        Resolution order:
+        1. Per-deployment ``model_info.skip_batch_input_file_retrieval`` on the
+           deployment matching ``data["model"]`` in the router model list.
+        2. Global ``litellm.skip_batch_input_file_retrieval``.
+
+        Safe by default: returns False on any lookup error, so misconfiguration
+        never silently disables rate limiting.
+        """
+        try:
+            from litellm.proxy.proxy_server import llm_router
+        except Exception:
+            llm_router = None  # type: ignore[assignment]
+        model = data.get("model") if isinstance(data, dict) else None
+        if llm_router is not None and isinstance(model, str) and model:
+            try:
+                deployment = llm_router.get_deployment_by_model_group_name(
+                    model_group_name=model
+                )
+            except Exception as exc:
+                verbose_proxy_logger.debug(
+                    "skip_batch_input_file_retrieval: deployment lookup failed "
+                    "for model=%s: %s",
+                    model,
+                    str(exc),
+                )
+                deployment = None
+            if deployment is not None:
+                model_info = None
+                if isinstance(deployment, dict):
+                    model_info = deployment.get("model_info")
+                else:
+                    model_info = getattr(deployment, "model_info", None)
+                    if model_info is not None and not isinstance(model_info, dict):
+                        try:
+                            model_info = model_info.model_dump()
+                        except Exception:
+                            try:
+                                model_info = model_info.dict()
+                            except Exception:
+                                model_info = None
+                if isinstance(model_info, dict) and model_info.get(
+                    "skip_batch_input_file_retrieval"
+                ):
+                    return True
+        if getattr(litellm, "skip_batch_input_file_retrieval", False):
+            return True
+        return False
+
     async def async_pre_call_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -419,6 +471,21 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         if call_type != "acreate_batch":
             verbose_proxy_logger.debug(
                 f"Batch rate limiter: Not handling batch creation rate limiting for call type: {call_type}"
+            )
+            return data
+
+        # LIT-3266: Allow operators to opt out of input-file retrieval +
+        # batch rate-limiting per-deployment (via
+        # ``model_info.skip_batch_input_file_retrieval``) or globally (via
+        # ``litellm.skip_batch_input_file_retrieval``). Custom vLLM batch jobs
+        # do not need per-batch TPM/RPM accounting, and the internal
+        # file-content fetch can download 30-60 MB files unnecessarily, cause
+        # audit-log gaps (the internal retrieve does not propagate
+        # ``UserApiKeyAuth``), and 404 on base64-encoded file IDs.
+        if self._should_skip_input_file_retrieval(data=data):
+            verbose_proxy_logger.debug(
+                "Batch rate limiter: skip_batch_input_file_retrieval is set; "
+                "skipping input-file retrieval and batch rate-limit accounting"
             )
             return data
 

--- a/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
@@ -1,0 +1,291 @@
+"""Tests for LIT-3266: skip_batch_input_file_retrieval opt-out flag.
+
+Covers:
+- Default behaviour: input-file retrieval still runs (no regression).
+- Global flag (`litellm.skip_batch_input_file_retrieval=True`): retrieval is
+  skipped, rate-limit counters are NOT touched, no exception is raised.
+- Per-deployment flag (`model_info.skip_batch_input_file_retrieval=True`):
+  same skip behaviour, on both raw-dict and pydantic-shaped deployments.
+- Per-deployment flag set to False does NOT skip.
+- Router lookup error: falls back to global flag, never crashes.
+- Wrong call_type still short-circuits before the skip check.
+- Defensive helper handles missing/None model in data.
+"""
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://nope")
+
+import litellm
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.hooks.batch_rate_limiter import (
+    _PROXY_BatchRateLimiter,
+    BatchFileUsage,
+)
+
+
+class _StubRateLimiter:
+    """Minimal stand-in for the parallel-rate-limiter v3."""
+
+    window_size = 60
+
+    def _create_rate_limit_descriptors(self, **kwargs):
+        return []
+
+    async def atomic_check_and_increment_by_n(self, **kwargs):
+        return {"overall_code": "OK", "statuses": []}
+
+
+def _make_limiter():
+    return _PROXY_BatchRateLimiter(
+        internal_usage_cache=SimpleNamespace(),
+        parallel_request_limiter=_StubRateLimiter(),
+    )
+
+
+def _make_data(model="custom-vllm-model"):
+    return {
+        "input_file_id": "file-abc123",
+        "custom_llm_provider": "openai",
+        "model": model,
+    }
+
+
+def _user():
+    return UserAPIKeyAuth(api_key="sk-test", user_id="u")
+
+
+def _install_router(deployment):
+    """Install a fake llm_router on proxy_server; return cleanup callable."""
+    fake_router = SimpleNamespace(
+        model_list=[deployment] if deployment else [],
+        get_deployment_by_model_group_name=(
+            lambda model_group_name=None, **kw: deployment
+        ),
+    )
+    import litellm.proxy.proxy_server as ps
+    prev = getattr(ps, "llm_router", None)
+    ps.llm_router = fake_router
+
+    def restore():
+        ps.llm_router = prev
+
+    return restore
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_flag():
+    prev = getattr(litellm, "skip_batch_input_file_retrieval", False)
+    litellm.skip_batch_input_file_retrieval = False
+    yield
+    litellm.skip_batch_input_file_retrieval = prev
+
+
+@pytest.mark.asyncio
+async def test_default_runs_input_file_retrieval():
+    """With neither flag set, the existing fetch happens (no regression)."""
+    limiter = _make_limiter()
+    restore = _install_router(None)
+    try:
+        called = {"n": 0}
+
+        async def fake_count(
+            file_id, custom_llm_provider="openai", user_api_key_dict=None
+        ):
+            called["n"] += 1
+            return BatchFileUsage(total_tokens=0, request_count=0)
+
+        with patch.object(
+            limiter, "count_input_file_usage", side_effect=fake_count
+        ):
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acreate_batch",
+            )
+        assert called["n"] == 1
+    finally:
+        restore()
+
+
+@pytest.mark.asyncio
+async def test_global_flag_skips_retrieval():
+    """Setting litellm.skip_batch_input_file_retrieval=True skips the fetch."""
+    litellm.skip_batch_input_file_retrieval = True
+    limiter = _make_limiter()
+    restore = _install_router(None)
+    try:
+        with patch.object(limiter, "count_input_file_usage") as m:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acreate_batch",
+            )
+        assert m.call_count == 0
+    finally:
+        restore()
+
+
+@pytest.mark.asyncio
+async def test_per_deployment_flag_dict_skips_retrieval():
+    """Per-deployment flag on a raw-dict deployment skips the fetch."""
+    limiter = _make_limiter()
+    deployment = {
+        "model_name": "custom-vllm-model",
+        "litellm_params": {"model": "openai/custom-vllm-model"},
+        "model_info": {
+            "id": "dep-1",
+            "skip_batch_input_file_retrieval": True,
+        },
+    }
+    restore = _install_router(deployment)
+    try:
+        with patch.object(limiter, "count_input_file_usage") as m:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acreate_batch",
+            )
+        assert m.call_count == 0
+    finally:
+        restore()
+
+
+@pytest.mark.asyncio
+async def test_per_deployment_flag_pydantic_deployment_skips_retrieval():
+    """Per-deployment flag on a pydantic-shaped Deployment also works."""
+    limiter = _make_limiter()
+
+    class _ModelInfo:
+        def __init__(self, **kw):
+            self._kw = kw
+
+        def model_dump(self):
+            return dict(self._kw)
+
+    class _Deployment:
+        model_name = "custom-vllm-model"
+        model_info = _ModelInfo(
+            id="dep-1",
+            skip_batch_input_file_retrieval=True,
+        )
+
+    restore = _install_router(_Deployment())
+    try:
+        with patch.object(limiter, "count_input_file_usage") as m:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acreate_batch",
+            )
+        assert m.call_count == 0
+    finally:
+        restore()
+
+
+@pytest.mark.asyncio
+async def test_per_deployment_flag_false_still_runs_retrieval():
+    """Per-deployment flag set to False does NOT skip the fetch."""
+    limiter = _make_limiter()
+    deployment = {
+        "model_name": "custom-vllm-model",
+        "model_info": {
+            "id": "dep-1",
+            "skip_batch_input_file_retrieval": False,
+        },
+    }
+    restore = _install_router(deployment)
+    try:
+        called = {"n": 0}
+
+        async def fake_count(
+            file_id, custom_llm_provider="openai", user_api_key_dict=None
+        ):
+            called["n"] += 1
+            return BatchFileUsage(total_tokens=0, request_count=0)
+
+        with patch.object(
+            limiter, "count_input_file_usage", side_effect=fake_count
+        ):
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acreate_batch",
+            )
+        assert called["n"] == 1
+    finally:
+        restore()
+
+
+@pytest.mark.asyncio
+async def test_router_lookup_error_falls_back_to_global_flag():
+    """Deployment lookup raises: global flag still wins, no crash."""
+    limiter = _make_limiter()
+    litellm.skip_batch_input_file_retrieval = True
+
+    class _RaisingRouter:
+        model_list = []
+
+        def get_deployment_by_model_group_name(self, model_group_name=None, **kw):
+            raise RuntimeError("boom")
+
+    import litellm.proxy.proxy_server as ps
+    prev = getattr(ps, "llm_router", None)
+    ps.llm_router = _RaisingRouter()
+    try:
+        with patch.object(limiter, "count_input_file_usage") as m:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acreate_batch",
+            )
+        # Lookup error is swallowed, then global flag takes effect -> skip.
+        assert m.call_count == 0
+    finally:
+        ps.llm_router = prev
+
+
+@pytest.mark.asyncio
+async def test_non_acreate_batch_call_type_short_circuits():
+    """Existing behaviour: any non-acreate_batch call_type returns immediately."""
+    limiter = _make_limiter()
+    # Set the flag too - proves we never even reach the skip check on
+    # non-batch call_types (the call_type guard runs first).
+    litellm.skip_batch_input_file_retrieval = True
+    restore = _install_router(None)
+    try:
+        with patch.object(limiter, "count_input_file_usage") as m:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(),
+                call_type="acompletion",
+            )
+        assert m.call_count == 0
+    finally:
+        restore()
+
+
+def test_helper_returns_false_when_data_has_no_model():
+    """Defensive: empty/missing model in data falls through to global flag."""
+    limiter = _make_limiter()
+    restore = _install_router(None)
+    try:
+        assert limiter._should_skip_input_file_retrieval(data={}) is False
+        assert (
+            limiter._should_skip_input_file_retrieval(data={"model": None})
+            is False
+        )
+        litellm.skip_batch_input_file_retrieval = True
+        assert limiter._should_skip_input_file_retrieval(data={}) is True
+    finally:
+        restore()

--- a/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
@@ -285,3 +285,84 @@ def test_helper_returns_false_when_data_has_no_model():
         assert limiter._should_skip_input_file_retrieval(data={}) is True
     finally:
         restore()
+
+
+@pytest.mark.asyncio
+async def test_per_deployment_false_beats_global_true():
+    """LIT-3266 Greptile feedback: an explicit per-deployment False must
+    re-enable input-file retrieval / batch accounting for a specific model
+    even when the global skip flag is on.
+    """
+    limiter = _make_limiter()
+    litellm.skip_batch_input_file_retrieval = True  # global says "skip everything"
+
+    deployment = {
+        "model_name": "billed-batch-model",
+        "model_info": {
+            "id": "dep-1",
+            "skip_batch_input_file_retrieval": False,  # but THIS deployment is billed
+        },
+    }
+    restore = _install_router(deployment)
+    try:
+        called = {"n": 0}
+
+        async def fake_count(
+            file_id, custom_llm_provider="openai", user_api_key_dict=None
+        ):
+            called["n"] += 1
+            return BatchFileUsage(total_tokens=0, request_count=0)
+
+        with patch.object(limiter, "count_input_file_usage", side_effect=fake_count):
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(model="billed-batch-model"),
+                call_type="acreate_batch",
+            )
+        assert (
+            called["n"] == 1
+        ), "explicit per-deployment False must override a True global flag"
+    finally:
+        restore()
+
+
+def test_helper_presence_aware_resolution_order():
+    """Direct helper test: per-deployment value (even False) is authoritative.
+
+    - global=True,  deployment unset             -> skip
+    - global=True,  deployment present and True  -> skip
+    - global=True,  deployment present and False -> do NOT skip
+    - global=False, deployment unset             -> do NOT skip
+    - global=False, deployment present and True  -> skip
+    - global=False, deployment present and False -> do NOT skip
+    """
+    limiter = _make_limiter()
+
+    def _check(global_flag, per_dep_present, per_dep_value, expected):
+        litellm.skip_batch_input_file_retrieval = global_flag
+        deployment = None
+        if per_dep_present:
+            deployment = {
+                "model_name": "x",
+                "model_info": {
+                    "id": "d",
+                    "skip_batch_input_file_retrieval": per_dep_value,
+                },
+            }
+        restore = _install_router(deployment)
+        try:
+            got = limiter._should_skip_input_file_retrieval(data={"model": "x"})
+            assert got is expected, (
+                f"global={global_flag} per_dep_present={per_dep_present} "
+                f"per_dep_value={per_dep_value!r} -> got {got!r}, want {expected!r}"
+            )
+        finally:
+            restore()
+
+    _check(True, False, None, True)  # case 1
+    _check(True, True, True, True)  # case 2
+    _check(True, True, False, False)  # case 3 (the bug fixed by Greptile feedback)
+    _check(False, False, None, False)  # case 4
+    _check(False, True, True, True)  # case 5
+    _check(False, True, False, False)  # case 6

--- a/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
@@ -11,6 +11,7 @@ Covers:
 - Wrong call_type still short-circuits before the skip check.
 - Defensive helper handles missing/None model in data.
 """
+
 import os
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -67,6 +68,7 @@ def _install_router(deployment):
         ),
     )
     import litellm.proxy.proxy_server as ps
+
     prev = getattr(ps, "llm_router", None)
     ps.llm_router = fake_router
 
@@ -98,9 +100,7 @@ async def test_default_runs_input_file_retrieval():
             called["n"] += 1
             return BatchFileUsage(total_tokens=0, request_count=0)
 
-        with patch.object(
-            limiter, "count_input_file_usage", side_effect=fake_count
-        ):
+        with patch.object(limiter, "count_input_file_usage", side_effect=fake_count):
             await limiter.async_pre_call_hook(
                 user_api_key_dict=_user(),
                 cache=None,
@@ -211,9 +211,7 @@ async def test_per_deployment_flag_false_still_runs_retrieval():
             called["n"] += 1
             return BatchFileUsage(total_tokens=0, request_count=0)
 
-        with patch.object(
-            limiter, "count_input_file_usage", side_effect=fake_count
-        ):
+        with patch.object(limiter, "count_input_file_usage", side_effect=fake_count):
             await limiter.async_pre_call_hook(
                 user_api_key_dict=_user(),
                 cache=None,
@@ -238,6 +236,7 @@ async def test_router_lookup_error_falls_back_to_global_flag():
             raise RuntimeError("boom")
 
     import litellm.proxy.proxy_server as ps
+
     prev = getattr(ps, "llm_router", None)
     ps.llm_router = _RaisingRouter()
     try:
@@ -281,10 +280,7 @@ def test_helper_returns_false_when_data_has_no_model():
     restore = _install_router(None)
     try:
         assert limiter._should_skip_input_file_retrieval(data={}) is False
-        assert (
-            limiter._should_skip_input_file_retrieval(data={"model": None})
-            is False
-        )
+        assert limiter._should_skip_input_file_retrieval(data={"model": None}) is False
         litellm.skip_batch_input_file_retrieval = True
         assert limiter._should_skip_input_file_retrieval(data={}) is True
     finally:

--- a/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py
@@ -366,3 +366,47 @@ def test_helper_presence_aware_resolution_order():
     _check(False, False, None, False)  # case 4
     _check(False, True, True, True)  # case 5
     _check(False, True, False, False)  # case 6
+
+
+@pytest.mark.asyncio
+async def test_skip_path_emits_warning_log(caplog):
+    """LIT-3266 / Veria feedback: when the skip path is taken, the hook MUST
+    log a WARNING that names the model and the security implication, so
+    operators can audit the trust decision in production.
+    """
+    import logging
+
+    limiter = _make_limiter()
+    deployment = {
+        "model_name": "trusted-vllm",
+        "model_info": {
+            "id": "dep-1",
+            "skip_batch_input_file_retrieval": True,
+        },
+    }
+    restore = _install_router(deployment)
+    try:
+        with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"), patch.object(
+            limiter, "count_input_file_usage"
+        ) as m:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=_user(),
+                cache=None,
+                data=_make_data(model="trusted-vllm"),
+                call_type="acreate_batch",
+            )
+        assert m.call_count == 0
+        # The warning must include the model name and call out the security
+        # implication, not just say "skipping".
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "skip_batch_input_file_retrieval" in r.getMessage()
+        ]
+        assert warning_records, "expected a WARNING log when the skip path is taken"
+        message = warning_records[-1].getMessage()
+        assert "trusted-vllm" in message
+        assert "model allowlist" in message or "trust" in message
+    finally:
+        restore()


### PR DESCRIPTION
## Summary

Adds a per-deployment + global opt-out flag for the `_PROXY_BatchRateLimiter` input-file retrieval step on `POST /v1/batches`. Customer (vLLM batch deployments) does not need per-batch TPM/RPM accounting and the current unconditional fetch causes three operational issues:

1. **Unnecessary 30–60 MB file downloads** on every batch submission, even when the deployment opts out of batch rate limiting.
2. **Audit-log gaps** — the internal file retrieve does not propagate `UserApiKeyAuth`, so the file-retrieve event is logged without the caller's key context.
3. **404s on base64-encoded unified file IDs** before the batch request even runs.

Closes LIT-3266.

## Config surface

```yaml
# Global (litellm_settings.skip_batch_input_file_retrieval is read via the
# generic setattr fallback in proxy_server.py, so no new wire-up needed):
litellm_settings:
  skip_batch_input_file_retrieval: true

# Or, per deployment:
model_list:
  - model_name: custom-vllm-batch
    litellm_params:
      model: openai/llama-3-70b
      api_base: http://my-vllm-batch:8000/v1
    model_info:
      skip_batch_input_file_retrieval: true   # <-- new
```

When set, `_PROXY_BatchRateLimiter.async_pre_call_hook` returns `data` unchanged before the `count_input_file_usage` call. No file fetch, no TPM/RPM increment.

## Resolution order

`_should_skip_input_file_retrieval(data)`:

1. Look up the deployment matching `data["model"]` via `llm_router.get_deployment_by_model_group_name(...)`.
2. If `model_info.skip_batch_input_file_retrieval` is truthy → **skip**.
3. Otherwise, if `litellm.skip_batch_input_file_retrieval` is truthy → **skip**.
4. Otherwise → run the existing fetch + accounting path.

Failure-safe: any router lookup error is caught, logged at DEBUG, and treated as "no per-deployment override" so we fall back to the global flag. Misconfiguration cannot silently disable rate limiting beyond what the operator opted into.

## Code paths covered

- Raw-dict deployments (the in-memory router after a config-file reload).
- Pydantic `Deployment` objects (model_info exposed as a `ModelInfo` with `model_dump()`).
- Pre-1.0 pydantic `.dict()` shape (fallback).
- `data["model"]` missing / `None`.
- `llm_router` not yet initialized.
- `get_deployment_by_model_group_name` raises.
- Call types other than `acreate_batch` still short-circuit first (existing guard preserved).

## Why this is the minimum scope

I considered also unconditionally skipping the file fetch for managed (`litellm_proxy:`) file IDs, but that would change behavior for callers who do want TPM/RPM accounting for those. An opt-out flag preserves existing behaviour for every user who doesn't set it. Audit-log propagation (#2) is a follow-up — when the flag is set the call site doesn't exist, so the gap goes away by construction. When the flag is unset, propagating `UserApiKeyAuth` into `_fetch_managed_file_content` is a separate change worth doing independently.

## Evidence

Ran a real-process repro that calls `_PROXY_BatchRateLimiter.async_pre_call_hook` directly (the file-fetch is mocked so we can _observe_ whether the hook attempts it). Three scenarios:

- **A**: defaults (no flag) — fetch expected.
- **B**: `litellm.skip_batch_input_file_retrieval=True` — fetch expected to be skipped.
- **C**: `model_info.skip_batch_input_file_retrieval=True` on the deployment matching `data["model"]` — fetch expected to be skipped.

### Before (clean main, daily branch)
```
============================================================
Runtime evidence: LIT-3266 - skip batch input-file retrieval
============================================================

>>> Scenario A: default (no skip flag) - fetch SHOULD happen
[A] global=False per_deployment=False
  count_input_file_usage called?  True
  call_count                      1

>>> Scenario B: global skip flag set - fetch SHOULD be skipped
[B] global=True per_deployment=False
  count_input_file_usage called?  True
  call_count                      1

>>> Scenario C: per-deployment skip flag set - fetch SHOULD be skipped
[C] global=False per_deployment=True
  count_input_file_usage called?  True
  call_count                      1
```

Bug confirmed: today the hook unconditionally awaits `count_input_file_usage` (which is what triggers the 30–60 MB managed-file fetch and the audit-log-gap path) regardless of any flag.

### After (this branch)
```
============================================================
Runtime evidence: LIT-3266 - skip batch input-file retrieval
============================================================

>>> Scenario A: default (no skip flag) - fetch SHOULD happen
[A] global=False per_deployment=False
  count_input_file_usage called?  True
  call_count                      1

>>> Scenario B: global skip flag set - fetch SHOULD be skipped
[B] global=True per_deployment=False
  count_input_file_usage called?  False
  call_count                      0

>>> Scenario C: per-deployment skip flag set - fetch SHOULD be skipped
[C] global=False per_deployment=True
  count_input_file_usage called?  False
  call_count                      0
```

Scenario A is unchanged (no regression for existing users). B and C both correctly skip the fetch.

### Unit tests
`tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py` — 8 tests, all pass locally:

```
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_default_runs_input_file_retrieval PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_global_flag_skips_retrieval PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_helper_returns_false_when_data_has_no_model PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_non_acreate_batch_call_type_short_circuits PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_per_deployment_flag_dict_skips_retrieval PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_per_deployment_flag_false_still_runs_retrieval PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_per_deployment_flag_pydantic_deployment_skips_retrieval PASSED
tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py::test_router_lookup_error_falls_back_to_global_flag PASSED

============================== 8 passed in 7.91s ===============================
```

## Notes on the diff

This branch was pushed via the GitHub Contents API (one PUT per file) because the agent's token lacks `repo` + `workflow` scopes. The merge-base diff is otherwise standard — 3 changed/added files.

— Shin (agent session: https://litellm-agent-platform.onrender.com/sessions/b331da0e-a15e-46b6-ae53-8c63bd4f2e8c)


### Verification (ship-pr)

- [x] **Greptile**: 5/5 ("Safe to merge — the flag defaults to False so no existing behaviour changes, and the per-deployment presence-check correctly resolves all six override combinations.") — https://github.com/BerriAI/litellm/pull/28946#issuecomment-4551109987
- [x] **Veria**: High-severity "Batch model authorization bypass" finding addressed by (a) emitting a WARNING log on every skip that names the model and the security implication, (b) documenting the trust contract on the helper docstring, (c) adding `test_skip_path_emits_warning_log` so the audit signal can't regress. Veria re-review still queued at time of writing — fix replied at https://github.com/BerriAI/litellm/pull/28946#issuecomment-4551138172
- [x] **GitHub Actions**: 0 failures at HEAD `ce6861d`. 32+/40 checks green, remainder still running, no failures.
- [x] **Runtime evidence**: before/after capture from real-process repro driving `_PROXY_BatchRateLimiter.async_pre_call_hook` (file fetch mocked so we can observe whether the hook attempts it). Inline above under `## Evidence`.
- [x] **Tests**: 11/11 pass locally — `tests/test_litellm/proxy/hooks/test_batch_rate_limiter_skip.py` (default-no-regression, global flag, per-deployment dict, per-deployment pydantic-ModelInfo, per-deployment-False-no-skip, per-deployment-False-beats-global-True, router-lookup-error fallback, non-batch-call-type, defensive-no-model-helper, full-truth-table helper test, WARNING-on-skip).
- [x] **Linear ticket**: LIT-3266 linked, PR posted on the ticket: https://linear.app/litellm-ai/issue/LIT-3266
- [x] **No secrets leaked**: diff scanned. The 3 changed files contain no API keys, tokens, or credentials. The new flag is a boolean, not a secret.
- [x] **Branch base**: targets `litellm_oss_agent_shin_daily_branch` (the "Verify PR source branch" check requires this for fork PRs).
- [x] **Push method**: GitHub Contents API (one PUT per file) — the current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes, so `git push` and `PUT /pulls/N/update-branch` were not available. Noted in the PR body above so reviewers know to expect a noisier merge-base diff.

Session: https://litellm-agent-platform.onrender.com/sessions/b331da0e-a15e-46b6-ae53-8c63bd4f2e8c
