### PR TITLE
fix(usage): dedupe Daily Spend chart by date so `Today` shows one bar (LIT-3383)

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -45,6 +45,7 @@ import ViewUserSpend from "../../view_user_spend";
 import { usePaginatedDailyActivity } from "../hooks/usePaginatedDailyActivity";
 import { DailyData, KeyMetricWithMetadata, MetricWithMetadata } from "../types";
 import { valueFormatterSpend } from "../utils/value_formatters";
+import { mergeResultsByDate } from "../utils/mergeDailyResults";
 import EndpointUsage from "./EndpointUsage/EndpointUsage";
 import EntityUsage, { EntityList } from "./EntityUsage/EntityUsage";
 import SpendByProvider from "./EntityUsage/SpendByProvider";
@@ -428,8 +429,16 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       .slice(0, topKeysLimit);
   }, [userSpendData.results, topKeysLimit]);
 
+  // Dedupe by date BEFORE sorting so the Daily Spend BarChart can never
+  // receive multiple rows whose `date` collides (one X-axis label, two+
+  // bars). Belt + suspenders alongside the dedupe inside
+  // `usePaginatedDailyActivity`: also guards the aggregated endpoint and
+  // the backend timezone-window ghost-row case. See LIT-3383.
   const sortedDailyResults = useMemo(
-    () => [...userSpendData.results].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()),
+    () =>
+      mergeResultsByDate(userSpendData.results).sort(
+        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+      ),
     [userSpendData.results],
   );
   const modelMetrics = useMemo(() => processActivityData(userSpendData, "models", teams), [userSpendData, teams]);

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -45,7 +45,7 @@ import ViewUserSpend from "../../view_user_spend";
 import { usePaginatedDailyActivity } from "../hooks/usePaginatedDailyActivity";
 import { DailyData, KeyMetricWithMetadata, MetricWithMetadata } from "../types";
 import { valueFormatterSpend } from "../utils/value_formatters";
-import { mergeResultsByDate } from "../utils/mergeDailyResults";
+import { hasDuplicateDates, mergeResultsByDate } from "../utils/mergeDailyResults";
 import EndpointUsage from "./EndpointUsage/EndpointUsage";
 import EntityUsage, { EntityList } from "./EntityUsage/EntityUsage";
 import SpendByProvider from "./EntityUsage/SpendByProvider";
@@ -431,16 +431,19 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
 
   // Dedupe by date BEFORE sorting so the Daily Spend BarChart can never
   // receive multiple rows whose `date` collides (one X-axis label, two+
-  // bars). Belt + suspenders alongside the dedupe inside
-  // `usePaginatedDailyActivity`: also guards the aggregated endpoint and
-  // the backend timezone-window ghost-row case. See LIT-3383.
-  const sortedDailyResults = useMemo(
-    () =>
-      mergeResultsByDate(userSpendData.results).sort(
-        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-      ),
-    [userSpendData.results],
-  );
+  // bars). Primary dedupe lives in `usePaginatedDailyActivity`; this call
+  // is a defense-in-depth guard for the aggregated endpoint path and the
+  // backend timezone-window ghost-row case, with an O(n) Set-based
+  // short-circuit so we don't allocate a fresh array on already-clean
+  // inputs (the common case once the hook has run). See LIT-3383.
+  const sortedDailyResults = useMemo(() => {
+    const rows = hasDuplicateDates(userSpendData.results)
+      ? mergeResultsByDate(userSpendData.results)
+      : userSpendData.results;
+    return [...rows].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+  }, [userSpendData.results]);
   const modelMetrics = useMemo(() => processActivityData(userSpendData, "models", teams), [userSpendData, teams]);
   const keyMetrics = useMemo(() => processActivityData(userSpendData, "api_keys", teams), [userSpendData, teams]);
   const mcpServerMetrics = useMemo(

--- a/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DailyData } from "../types";
+import { mergeResultsByDate } from "../utils/mergeDailyResults";
 
 export interface PaginationProgress {
   currentPage: number;
@@ -164,7 +165,10 @@ export function usePaginatedDailyActivity({
 
         if (isStale()) return;
 
-        setData(firstPage);
+        setData({
+          results: mergeResultsByDate(firstPage.results),
+          metadata: firstPage.metadata,
+        });
 
         const totalPages = firstPage.metadata?.total_pages || 1;
 
@@ -212,7 +216,7 @@ export function usePaginatedDailyActivity({
           const isBatchBoundary = (page - 1) % RENDER_BATCH_SIZE === 0;
           if (isLastPage || isBatchBoundary) {
             setData({
-              results: accumulatedResults,
+              results: mergeResultsByDate(accumulatedResults),
               metadata: accumulatedMetadata,
             });
             setProgress({ currentPage: page, totalPages });

--- a/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.test.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { mergeResultsByDate } from "./mergeDailyResults";
+import { DailyData } from "../types";
+
+const emptyMetrics = () => ({
+  spend: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+  api_requests: 0,
+  successful_requests: 0,
+  failed_requests: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+});
+
+const emptyBreakdown = () => ({
+  models: {},
+  model_groups: {},
+  mcp_servers: {},
+  providers: {},
+  api_keys: {},
+  entities: {},
+});
+
+function row(date: string, overrides: Partial<DailyData> = {}): DailyData {
+  return {
+    date,
+    metrics: { ...emptyMetrics(), ...(overrides.metrics || {}) },
+    breakdown: { ...emptyBreakdown(), ...(overrides.breakdown || {}) },
+  };
+}
+
+describe("mergeResultsByDate", () => {
+  it("is a no-op for an empty input", () => {
+    expect(mergeResultsByDate([])).toEqual([]);
+  });
+
+  it("is a no-op for a single row", () => {
+    const input = [row("2026-05-27", { metrics: { ...emptyMetrics(), spend: 1.5 } })];
+    const out = mergeResultsByDate(input);
+    expect(out).toHaveLength(1);
+    expect(out[0].date).toBe("2026-05-27");
+    expect(out[0].metrics.spend).toBe(1.5);
+  });
+
+  it("collapses two rows that share the same date and sums metrics", () => {
+    // Mirrors the LIT-3383 repro: paginated `Today` returns two pages, both
+    // tagged with the same `date`. Without dedupe the BarChart renders two
+    // bars sharing one X-axis label.
+    const a = row("2026-05-27", {
+      metrics: {
+        ...emptyMetrics(),
+        spend: 1,
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+        api_requests: 2,
+        successful_requests: 2,
+      },
+    });
+    const b = row("2026-05-27", {
+      metrics: {
+        ...emptyMetrics(),
+        spend: 2.5,
+        prompt_tokens: 100,
+        completion_tokens: 200,
+        total_tokens: 300,
+        api_requests: 4,
+        successful_requests: 3,
+        failed_requests: 1,
+        cache_read_input_tokens: 7,
+        cache_creation_input_tokens: 9,
+      },
+    });
+    const out = mergeResultsByDate([a, b]);
+    expect(out).toHaveLength(1);
+    expect(out[0].date).toBe("2026-05-27");
+    expect(out[0].metrics).toEqual({
+      spend: 3.5,
+      prompt_tokens: 110,
+      completion_tokens: 220,
+      total_tokens: 330,
+      api_requests: 6,
+      successful_requests: 5,
+      failed_requests: 1,
+      cache_read_input_tokens: 7,
+      cache_creation_input_tokens: 9,
+    });
+  });
+
+  it("preserves distinct dates in first-seen order", () => {
+    const out = mergeResultsByDate([
+      row("2026-05-26"),
+      row("2026-05-27"),
+      row("2026-05-26"),
+      row("2026-05-25"),
+    ]);
+    expect(out.map((r) => r.date)).toEqual([
+      "2026-05-26",
+      "2026-05-27",
+      "2026-05-25",
+    ]);
+  });
+
+  it("merges nested breakdown maps additively", () => {
+    const a = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        models: {
+          "gpt-4": {
+            metrics: { ...emptyMetrics(), spend: 1, api_requests: 1 },
+            metadata: {},
+            api_key_breakdown: {},
+          },
+        },
+        api_keys: {
+          "sk-1": {
+            metrics: { ...emptyMetrics(), spend: 1, api_requests: 1 },
+            metadata: { key_alias: "alpha", team_id: null },
+          },
+        },
+      },
+    });
+    const b = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        models: {
+          "gpt-4": {
+            metrics: { ...emptyMetrics(), spend: 2, api_requests: 3 },
+            metadata: {},
+            api_key_breakdown: {},
+          },
+          "gpt-5": {
+            metrics: { ...emptyMetrics(), spend: 9, api_requests: 4 },
+            metadata: {},
+            api_key_breakdown: {},
+          },
+        },
+        api_keys: {
+          "sk-1": {
+            metrics: { ...emptyMetrics(), spend: 4, api_requests: 2 },
+            metadata: { key_alias: "alpha", team_id: "team-x" },
+          },
+        },
+      },
+    });
+    const out = mergeResultsByDate([a, b]);
+    expect(out).toHaveLength(1);
+    const merged = out[0];
+    expect(merged.breakdown.models["gpt-4"].metrics.spend).toBe(3);
+    expect(merged.breakdown.models["gpt-4"].metrics.api_requests).toBe(4);
+    expect(merged.breakdown.models["gpt-5"].metrics.spend).toBe(9);
+    expect(merged.breakdown.api_keys["sk-1"].metrics.spend).toBe(5);
+    expect(merged.breakdown.api_keys["sk-1"].metadata.key_alias).toBe("alpha");
+    // Prefer first non-null team_id; here second row supplied team-x because first was null.
+    expect(merged.breakdown.api_keys["sk-1"].metadata.team_id).toBe("team-x");
+  });
+
+  it("handles a row with no breakdown maps gracefully", () => {
+    const a = row("2026-05-27", {
+      metrics: { ...emptyMetrics(), spend: 1 },
+      breakdown: {} as any,
+    });
+    const b = row("2026-05-27", {
+      metrics: { ...emptyMetrics(), spend: 2 },
+      breakdown: {} as any,
+    });
+    const out = mergeResultsByDate([a, b]);
+    expect(out).toHaveLength(1);
+    expect(out[0].metrics.spend).toBe(3);
+    expect(out[0].breakdown.models).toEqual({});
+  });
+
+  it("does not mutate input rows", () => {
+    const original = row("2026-05-27", {
+      metrics: { ...emptyMetrics(), spend: 5 },
+      breakdown: {
+        ...emptyBreakdown(),
+        models: {
+          "gpt-4": {
+            metrics: { ...emptyMetrics(), spend: 5 },
+            metadata: {},
+            api_key_breakdown: {},
+          },
+        },
+      },
+    });
+    const dup = row("2026-05-27", {
+      metrics: { ...emptyMetrics(), spend: 7 },
+      breakdown: {
+        ...emptyBreakdown(),
+        models: {
+          "gpt-4": {
+            metrics: { ...emptyMetrics(), spend: 7 },
+            metadata: {},
+            api_key_breakdown: {},
+          },
+        },
+      },
+    });
+    const beforeOrig = JSON.parse(JSON.stringify(original));
+    const beforeDup = JSON.parse(JSON.stringify(dup));
+    mergeResultsByDate([original, dup]);
+    expect(original).toEqual(beforeOrig);
+    expect(dup).toEqual(beforeDup);
+  });
+
+  it("dedupes a realistic paginated `Today` accumulator (LIT-3383 repro)", () => {
+    // Three paginated pages, all on the same date — exactly what the user sees
+    // when picking the `Today` range with a tag-heavy instance.
+    const today = "2026-05-27";
+    const pages = [1, 2, 3].map((p) =>
+      row(today, {
+        metrics: {
+          ...emptyMetrics(),
+          spend: p * 1.0,
+          api_requests: p,
+          successful_requests: p,
+        },
+      }),
+    );
+    expect(pages).toHaveLength(3);
+    const merged = mergeResultsByDate(pages);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].metrics.spend).toBeCloseTo(6.0);
+    expect(merged[0].metrics.api_requests).toBe(6);
+    expect(merged[0].metrics.successful_requests).toBe(6);
+  });
+});

--- a/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.test.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mergeResultsByDate } from "./mergeDailyResults";
+import { hasDuplicateDates, mergeResultsByDate } from "./mergeDailyResults";
 import { DailyData } from "../types";
 
 const emptyMetrics = () => ({
@@ -226,5 +226,123 @@ describe("mergeResultsByDate", () => {
     expect(merged[0].metrics.spend).toBeCloseTo(6.0);
     expect(merged[0].metrics.api_requests).toBe(6);
     expect(merged[0].metrics.successful_requests).toBe(6);
+  });
+
+  it("merges `tags` additively by tag name when both pages carry tags for the same key", () => {
+    const a = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        api_keys: {
+          "sk-1": {
+            metrics: { ...emptyMetrics(), spend: 1, api_requests: 1 },
+            metadata: {
+              key_alias: "alpha",
+              team_id: null,
+              tags: [
+                { tag: "prod", usage: 3 },
+                { tag: "exp",  usage: 1 },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const b = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        api_keys: {
+          "sk-1": {
+            metrics: { ...emptyMetrics(), spend: 2, api_requests: 2 },
+            metadata: {
+              key_alias: "alpha",
+              team_id: null,
+              tags: [
+                { tag: "prod",  usage: 4 },
+                { tag: "canary", usage: 5 },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const out = mergeResultsByDate([a, b]);
+    expect(out).toHaveLength(1);
+    const tags = out[0].breakdown.api_keys["sk-1"].metadata.tags!;
+    const tagMap = Object.fromEntries(tags.map((t) => [t.tag, t.usage]));
+    expect(tagMap).toEqual({ prod: 7, exp: 1, canary: 5 });
+    // Sanity: spend is also summed.
+    expect(out[0].breakdown.api_keys["sk-1"].metrics.spend).toBe(3);
+  });
+
+  it("preserves tags when only one side carries them", () => {
+    const a = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        api_keys: {
+          "sk-1": {
+            metrics: { ...emptyMetrics(), spend: 1 },
+            metadata: { key_alias: "alpha", team_id: null, tags: [{ tag: "prod", usage: 2 }] },
+          },
+        },
+      },
+    });
+    const b = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        api_keys: {
+          "sk-1": {
+            metrics: { ...emptyMetrics(), spend: 1 },
+            metadata: { key_alias: "alpha", team_id: null },
+          },
+        },
+      },
+    });
+    const out = mergeResultsByDate([a, b]);
+    expect(out[0].breakdown.api_keys["sk-1"].metadata.tags).toEqual([{ tag: "prod", usage: 2 }]);
+  });
+
+  it("does not mutate input tag arrays", () => {
+    const tagsA = [{ tag: "prod", usage: 2 }];
+    const tagsB = [{ tag: "prod", usage: 3 }];
+    const a = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        api_keys: {
+          "sk-1": {
+            metrics: emptyMetrics(),
+            metadata: { key_alias: "alpha", team_id: null, tags: tagsA },
+          },
+        },
+      },
+    });
+    const b = row("2026-05-27", {
+      breakdown: {
+        ...emptyBreakdown(),
+        api_keys: {
+          "sk-1": {
+            metrics: emptyMetrics(),
+            metadata: { key_alias: "alpha", team_id: null, tags: tagsB },
+          },
+        },
+      },
+    });
+    mergeResultsByDate([a, b]);
+    expect(tagsA).toEqual([{ tag: "prod", usage: 2 }]);
+    expect(tagsB).toEqual([{ tag: "prod", usage: 3 }]);
+  });
+});
+
+describe("hasDuplicateDates", () => {
+  it("returns false for empty or single-row input", () => {
+    expect(hasDuplicateDates([])).toBe(false);
+    expect(hasDuplicateDates([row("2026-05-27")])).toBe(false);
+  });
+
+  it("returns false when every row has a distinct date", () => {
+    expect(hasDuplicateDates([row("2026-05-26"), row("2026-05-27"), row("2026-05-28")])).toBe(false);
+  });
+
+  it("returns true on the first repeat", () => {
+    expect(hasDuplicateDates([row("2026-05-26"), row("2026-05-27"), row("2026-05-26")])).toBe(true);
   });
 });

--- a/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.ts
@@ -43,6 +43,24 @@ function addMetrics(a: SpendMetrics, b: SpendMetrics): SpendMetrics {
   return out;
 }
 
+/**
+ * Merge two `tag: { tag, usage }[]` arrays by `tag` name, summing `usage`.
+ * If only one side has tags, that side wins; if both are absent, returns
+ * undefined to preserve the original shape.
+ */
+function mergeTags(
+  a: { tag: string; usage: number }[] | undefined,
+  b: { tag: string; usage: number }[] | undefined,
+): { tag: string; usage: number }[] | undefined {
+  if (!a && !b) return undefined;
+  if (!a) return b!.map((t) => ({ ...t }));
+  if (!b) return a.map((t) => ({ ...t }));
+  const totals = new Map<string, number>();
+  for (const t of a) totals.set(t.tag, (totals.get(t.tag) ?? 0) + (t.usage ?? 0));
+  for (const t of b) totals.set(t.tag, (totals.get(t.tag) ?? 0) + (t.usage ?? 0));
+  return Array.from(totals, ([tag, usage]) => ({ tag, usage }));
+}
+
 function mergeKeyMetricWithMetadata(
   a: KeyMetricWithMetadata | undefined,
   b: KeyMetricWithMetadata,
@@ -53,7 +71,7 @@ function mergeKeyMetricWithMetadata(
       metadata: {
         key_alias: b.metadata?.key_alias ?? null,
         team_id: b.metadata?.team_id ?? null,
-        tags: b.metadata?.tags ? [...b.metadata.tags] : undefined,
+        tags: b.metadata?.tags ? b.metadata.tags.map((t) => ({ ...t })) : undefined,
       },
     };
   }
@@ -62,7 +80,9 @@ function mergeKeyMetricWithMetadata(
     metadata: {
       key_alias: a.metadata.key_alias ?? b.metadata?.key_alias ?? null,
       team_id: a.metadata.team_id ?? b.metadata?.team_id ?? null,
-      tags: b.metadata?.tags ?? a.metadata.tags,
+      // Tags carry a per-(date, key) usage counter, so additive-by-tag-name
+      // preserves earlier pages instead of silently dropping them.
+      tags: mergeTags(a.metadata.tags, b.metadata?.tags),
     },
   };
 }
@@ -158,6 +178,22 @@ const EMPTY_BREAKDOWN = (): BreakdownMetrics => ({
  *
  * Pure & deterministic; no-op on already-deduped input.
  */
+/**
+ * Fast O(n) check: returns true if any two rows share a `date`. Useful as a
+ * pre-flight guard for callers that want to avoid materialising a fresh
+ * deduped array on already-clean inputs (e.g. the view-layer
+ * `sortedDailyResults` `useMemo`, where the hook already deduped).
+ */
+export function hasDuplicateDates(results: DailyData[]): boolean {
+  if (results.length < 2) return false;
+  const seen = new Set<string>();
+  for (const row of results) {
+    if (seen.has(row.date)) return true;
+    seen.add(row.date);
+  }
+  return false;
+}
+
 export function mergeResultsByDate(results: DailyData[]): DailyData[] {
   if (results.length < 2) return results.slice();
   const byDate = new Map<string, DailyData>();

--- a/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.ts
@@ -1,0 +1,181 @@
+import {
+  BreakdownMetrics,
+  DailyData,
+  KeyMetricWithMetadata,
+  MetricWithMetadata,
+  SpendMetrics,
+} from "../types";
+
+/**
+ * Keys of `SpendMetrics` that are numeric and additive across rows sharing the
+ * same `date`. Tuple is constrained to `keyof SpendMetrics` so TypeScript
+ * catches drift if `SpendMetrics` ever changes shape.
+ */
+const SUMMABLE_METRIC_KEYS = [
+  "spend",
+  "prompt_tokens",
+  "completion_tokens",
+  "total_tokens",
+  "api_requests",
+  "successful_requests",
+  "failed_requests",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+] as const satisfies readonly (keyof SpendMetrics)[];
+
+const EMPTY_METRICS = (): SpendMetrics => ({
+  spend: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+  api_requests: 0,
+  successful_requests: 0,
+  failed_requests: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+});
+
+function addMetrics(a: SpendMetrics, b: SpendMetrics): SpendMetrics {
+  const out = EMPTY_METRICS();
+  for (const k of SUMMABLE_METRIC_KEYS) {
+    out[k] = (a[k] ?? 0) + (b[k] ?? 0);
+  }
+  return out;
+}
+
+function mergeKeyMetricWithMetadata(
+  a: KeyMetricWithMetadata | undefined,
+  b: KeyMetricWithMetadata,
+): KeyMetricWithMetadata {
+  if (!a) {
+    return {
+      metrics: { ...b.metrics },
+      metadata: {
+        key_alias: b.metadata?.key_alias ?? null,
+        team_id: b.metadata?.team_id ?? null,
+        tags: b.metadata?.tags ? [...b.metadata.tags] : undefined,
+      },
+    };
+  }
+  return {
+    metrics: addMetrics(a.metrics, b.metrics),
+    metadata: {
+      key_alias: a.metadata.key_alias ?? b.metadata?.key_alias ?? null,
+      team_id: a.metadata.team_id ?? b.metadata?.team_id ?? null,
+      tags: b.metadata?.tags ?? a.metadata.tags,
+    },
+  };
+}
+
+function mergeApiKeyBreakdown(
+  a: { [key: string]: KeyMetricWithMetadata },
+  b: { [key: string]: KeyMetricWithMetadata },
+): { [key: string]: KeyMetricWithMetadata } {
+  const out: { [key: string]: KeyMetricWithMetadata } = {};
+  for (const [k, v] of Object.entries(a)) out[k] = mergeKeyMetricWithMetadata(undefined, v);
+  for (const [k, v] of Object.entries(b)) out[k] = mergeKeyMetricWithMetadata(out[k], v);
+  return out;
+}
+
+function mergeMetricWithMetadata(
+  a: MetricWithMetadata | undefined,
+  b: MetricWithMetadata,
+): MetricWithMetadata {
+  if (!a) {
+    return {
+      metrics: { ...b.metrics },
+      metadata: { ...((b.metadata as object) ?? {}) },
+      api_key_breakdown: mergeApiKeyBreakdown({}, b.api_key_breakdown || {}),
+    };
+  }
+  return {
+    metrics: addMetrics(a.metrics, b.metrics),
+    // Later row wins on metadata keys it explicitly provides — matches the
+    // existing per-page `sumMetadata` behaviour in `usePaginatedDailyActivity`.
+    metadata: { ...((a.metadata as object) ?? {}), ...((b.metadata as object) ?? {}) },
+    api_key_breakdown: mergeApiKeyBreakdown(a.api_key_breakdown || {}, b.api_key_breakdown || {}),
+  };
+}
+
+function mergeMetricMap(
+  a: { [key: string]: MetricWithMetadata } | undefined,
+  b: { [key: string]: MetricWithMetadata } | undefined,
+): { [key: string]: MetricWithMetadata } {
+  const out: { [key: string]: MetricWithMetadata } = {};
+  for (const [k, v] of Object.entries(a || {})) out[k] = mergeMetricWithMetadata(undefined, v);
+  for (const [k, v] of Object.entries(b || {})) out[k] = mergeMetricWithMetadata(out[k], v);
+  return out;
+}
+
+function mergeKeyMetricMap(
+  a: { [key: string]: KeyMetricWithMetadata } | undefined,
+  b: { [key: string]: KeyMetricWithMetadata } | undefined,
+): { [key: string]: KeyMetricWithMetadata } {
+  const out: { [key: string]: KeyMetricWithMetadata } = {};
+  for (const [k, v] of Object.entries(a || {})) out[k] = mergeKeyMetricWithMetadata(undefined, v);
+  for (const [k, v] of Object.entries(b || {})) out[k] = mergeKeyMetricWithMetadata(out[k], v);
+  return out;
+}
+
+function mergeBreakdown(a: BreakdownMetrics, b: BreakdownMetrics): BreakdownMetrics {
+  const merged: BreakdownMetrics = {
+    models: mergeMetricMap(a.models, b.models),
+    model_groups: mergeMetricMap(a.model_groups, b.model_groups),
+    mcp_servers: mergeMetricMap(a.mcp_servers, b.mcp_servers),
+    providers: mergeMetricMap(a.providers, b.providers),
+    api_keys: mergeKeyMetricMap(a.api_keys, b.api_keys),
+    entities: mergeMetricMap(a.entities, b.entities),
+  };
+  if (a.endpoints || b.endpoints) {
+    merged.endpoints = mergeMetricMap(a.endpoints, b.endpoints);
+  }
+  return merged;
+}
+
+const EMPTY_BREAKDOWN = (): BreakdownMetrics => ({
+  models: {},
+  model_groups: {},
+  mcp_servers: {},
+  providers: {},
+  api_keys: {},
+  entities: {},
+});
+
+/**
+ * Collapse multiple `DailyData` rows that share the same `date` into a single
+ * row.
+ *
+ * Why: the Daily Spend bar chart uses `date` as the BarChart `index`. When the
+ * paginated `/user/daily/activity` accumulator concatenates rows across pages
+ * (`usePaginatedDailyActivity.ts`), pages that all fall on the same date —
+ * which is exactly what happens for the `Today` range — produce one bar per
+ * page, all wearing the same X-axis label. The backend timezone window can
+ * also emit a ±1 day ghost-row for the same reason.
+ *
+ * This function sums `metrics` and recursively merges every `breakdown.*` map
+ * so downstream aggregations (top models, top keys, provider spend, etc.) see
+ * exactly one row per date. First-seen date order is preserved.
+ *
+ * Pure & deterministic; no-op on already-deduped input.
+ */
+export function mergeResultsByDate(results: DailyData[]): DailyData[] {
+  if (results.length < 2) return results.slice();
+  const byDate = new Map<string, DailyData>();
+  for (const row of results) {
+    const existing = byDate.get(row.date);
+    if (!existing) {
+      byDate.set(row.date, {
+        date: row.date,
+        metrics: { ...row.metrics },
+        breakdown: mergeBreakdown(EMPTY_BREAKDOWN(), row.breakdown),
+      });
+      continue;
+    }
+    byDate.set(row.date, {
+      date: existing.date,
+      metrics: addMetrics(existing.metrics, row.metrics),
+      breakdown: mergeBreakdown(existing.breakdown, row.breakdown),
+    });
+  }
+  return Array.from(byDate.values());
+}


### PR DESCRIPTION
## Relevant issue

LIT-3383 — Daily Spend chart shows multiple bars all labelled with today's date when the `Today` time range is selected (Barracuda, reported on v1.83.7).

## Root cause

`usePaginatedDailyActivity.ts` accumulates per-page `results` by **concatenating** the arrays straight into `setData({ results: accumulatedResults, ... })`. The `Today` range maps to a single calendar date but is split across many backend pages (one page per slice of tag/key data), and each page comes back with one or more rows tagged with that same `date` string.

`UsagePageView.tsx` then sorts those rows by `date` and passes them straight to `<BarChart data={...} index="date" />`. Tremor's BarChart treats every row as its own bar — so the chart renders N bars, all wearing the same X-axis label. The "ghost +1 day" row that `_adjust_dates_for_timezone` can emit on the backend produces the same shape.

## Fix

New pure helper `mergeResultsByDate` (`ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.ts`) collapses any `DailyData[]` so each `date` appears at most once. It sums `metrics` and recursively merges every `breakdown.*` map so downstream aggregations (top models, top keys, provider spend, etc.) still see the same totals.

Applied in two places:

- `usePaginatedDailyActivity.ts` — calls `mergeResultsByDate(accumulatedResults)` on every `setData` flush. Fixes the paginated path at the source so the BarChart, the export modal, and every downstream `useMemo` that consumes `userSpendData.results` all see deduped rows.
- `UsagePageView.tsx` — also passes `userSpendData.results` through `mergeResultsByDate` before sorting into `sortedDailyResults`. Belt-and-suspenders: also catches the **aggregated** `/user/daily/activity/aggregated` endpoint path and the backend timezone-window ghost-row case (orthogonal to PR #26810, which fixes the backend by removing `_adjust_dates_for_timezone`; this stays correct whether or not that lands).

Helper is `O(n)`, deterministic, preserves first-seen date order, and is a no-op for input that is already deduped (`results.length < 2` short-circuit).

## Tests

`ui/litellm-dashboard/src/components/UsagePage/utils/mergeDailyResults.test.ts` (8 cases):

- empty input
- single-row input (no-op)
- two rows on the same date → metrics summed
- distinct dates preserved in first-seen order
- nested breakdown maps merged additively (models, api_keys, including `team_id` precedence)
- row with empty `breakdown` (defensive)
- input rows are not mutated
- LIT-3383 repro: 3 paginated pages all on the same date → 1 row, spend summed

```
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > is a no-op for an empty input 1ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > is a no-op for a single row 1ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > collapses two rows that share the same date and sums metrics 1ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > preserves distinct dates in first-seen order 0ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > merges nested breakdown maps additively 1ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > handles a row with no breakdown maps gracefully 0ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > does not mutate input rows 1ms
 ✓ src/components/UsagePage/utils/mergeDailyResults.test.ts > mergeResultsByDate > dedupes a realistic paginated `Today` accumulator (LIT-3383 repro) 1ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

### Evidence

Runtime reproduction (`/tmp/evidence/runtime_repro.mjs`) — feeds the exact array shape that `usePaginatedDailyActivity` builds into the `sort`+`<BarChart>` pipeline used by `UsagePageView`, before and after `mergeResultsByDate`:

```
=== LIT-3383 runtime reproduction ===
Paginated `Today` returns 5 pages, each with date='2026-05-27'.

BEFORE FIX - <BarChart data={...}/> receives 5 rows:
  { date: "2026-05-27", metrics.spend: 4.20, metrics.api_requests: 7 }
  { date: "2026-05-27", metrics.spend: 6.30, metrics.api_requests: 14 }
  { date: "2026-05-27", metrics.spend: 5.10, metrics.api_requests: 21 }
  { date: "2026-05-27", metrics.spend: 8.15, metrics.api_requests: 28 }
  { date: "2026-05-27", metrics.spend: 3.05, metrics.api_requests: 35 }
-> BarChart renders 5 bars, ALL labeled "2026-05-27".  (this is the bug)

AFTER FIX  - <BarChart data={...}/> receives 1 row(s):
  { date: "2026-05-27", metrics.spend: 26.80, metrics.api_requests: 105 }
-> BarChart renders 1 bar labeled "2026-05-27", with totals summed across pages.

Assertions:
  sortedBefore.length === 5      : true
  sortedAfter.length  === 1                     : true
  sum(spend) preserved (26.80) : true

=== Bonus: backend timezone-window ghost-bar scenario ===
BEFORE (with ghost):  3 rows  -> 2026-05-27, 2026-05-27, 2026-05-28
AFTER  (deduped):     2 rows  -> 2026-05-27, 2026-05-28
```

Because Tremor's `<BarChart data={...} index="date">` renders exactly one bar per element of `data`, the row count is the bar count — the screenshot in the Linear ticket showing N bars all labeled "today" is exactly the BEFORE row array, and the AFTER row array collapses to one bar with the same total.

> _Note: this PR was pushed via `PUT /repos/{owner}/{repo}/contents/{path}` (one commit per file) because the available `GITHUB_TOKEN` lacks `repo`+`workflow` scopes for `git push`. The merge-base diff will look slightly noisier than a single squashed commit; the final diff vs `litellm_oss_agent_shin_daily_branch` is still just the 4 files listed above._


---

### Verification (ship-pr)

- [x] **Reproduces the reported bug.** Runtime reproduction (above) drives the same `accumulatedResults → sort → <BarChart index="date">` pipeline `UsagePageView.tsx` uses; without the fix, 5 paginated pages all dated `2026-05-27` produce 5 chart rows (== 5 bars with the same label), matching the Linear screenshot.
- [x] **Fix has runtime evidence.** Same script with `mergeResultsByDate` applied collapses to 1 row with `spend=26.80` (sum preserved). Posted in PR body and verified against the actual exported helper in the branch.
- [x] **Unit tests cover the fix.** `mergeDailyResults.test.ts` — 8 original + 3 new (additive tag merge, one-sided tags, tag-array immutability) + 3 new for `hasDuplicateDates` (empty/distinct/repeat). All 8 originals run green locally (vitest output captured); the new tests follow identical patterns. CI re-runs all of them on every push to this PR.
- [x] **CI: all GitHub Actions green.** 44/44 checks completed success on head `03599b110a`, including `build-ui`, `code-quality`, `lint`, `secret-scan`, `Vertex AI / Run tests`, and every proxy/integrations runner.
- [x] **Codecov.** "All modified and coverable lines are covered by tests."
- [x] **Veria AI.** Completed success, "No security issues found".
- [x] **Greptile.** Confidence 4/5 on initial review (commit `c7368cea0f`). Both P2 comments addressed:
  - `mergeKeyMetricWithMetadata` tag merge → now additive by tag name via new `mergeTags` helper; covered by 3 new tests including the both-sides-tagged case Greptile flagged as untested.
  - Redundant view-layer merge → guarded behind a new `hasDuplicateDates` O(n) Set short-circuit so already-deduped inputs allocate nothing; kept the view-layer call for the aggregated endpoint path (`userDailyActivityAggregatedCall`) which does NOT go through `usePaginatedDailyActivity`.
  - Both threads replied to with the fix commits inline.
- [x] **PR base.** `litellm_oss_agent_shin_daily_branch`, not `main` (Verify PR source branch check is green).
- [x] **No secrets** in code, commit messages, PR body, or comments.
- [x] **Linear ticket updated** with PR link.
