### PR TITLE
fix(spend-tracking): preserve x-litellm-spend-logs-metadata header on /v1/messages (LIT-3302)

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -141,14 +141,26 @@ def remove_items_at_indices(items: Optional[List[Any]], indices: Iterable[int]) 
             items.pop(index)
 
 
-# Proxy-set metadata fields (populated by the proxy, not the client request body) that
-# must survive the merge from `metadata` -> `litellm_metadata` when both containers exist.
-# - `spend_logs_metadata`, `agent_id`, `trace_id`, `session_id` are set by
-#   `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers` based on the
-#   `LitellmMetadataFromRequestHeaders` TypedDict.
-# - `requester_ip_address` is set separately by the proxy from `x-forwarded-for` /
-#   `request.client.host` in `litellm_pre_call_utils.py`.
-# In all cases the value lives on `metadata` and is needed by `_get_spend_logs_metadata`.
+# Proxy-set metadata fields that live on `metadata` rather than `litellm_metadata`
+# on the endpoints where `_metadata_variable_name == "metadata"` (most LiteLLM
+# routes; see `_get_metadata_variable_name`). When the caller also populates
+# `litellm_metadata` from the request body, these must survive the merge so
+# spend tracking and observability callbacks see them downstream.
+#
+# - `spend_logs_metadata`, `agent_id`, `trace_id`, `session_id` are written by
+#   `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers`
+#   (`LitellmMetadataFromRequestHeaders` TypedDict).
+# - `requester_ip_address` is written separately in `litellm_pre_call_utils.py`
+#   from `x-forwarded-for` / `request.client.host`.
+#
+# These keys are propagated with `setdefault` semantics (only when the
+# destination does NOT already have the key) so that on the inverse case —
+# routes where `_metadata_variable_name == "litellm_metadata"` (e.g.
+# `/v1/messages`, `batches`, `responses`, `files`) and the proxy-trusted
+# value lives on `litellm_metadata` instead — a forged value passed by the
+# client on the body `metadata` cannot overwrite the real proxy-set value.
+# This matches the upstream pre_call_utils convention
+# (`if key not in data[_metadata_variable_name]: ...`).
 _PROXY_SET_METADATA_KEYS_TO_PRESERVE: frozenset = frozenset(
     {
         "spend_logs_metadata",
@@ -166,27 +178,35 @@ def add_missing_spend_metadata_to_litellm_metadata(
     """
     Helper to get litellm metadata for spend tracking.
 
-    PATCH for the case where both `litellm_metadata` and `metadata` are present in the
-    request kwargs. The proxy populates spend-tracking and header-derived fields onto
-    `metadata`; if `litellm_metadata` also exists (e.g. when a request body carries
-    Anthropic-style provider `metadata`), those fields would otherwise be dropped when
-    downstream code reads `litellm_metadata` only.
+    PATCH for the case where both `litellm_metadata` and `metadata` are present
+    in the request kwargs. The proxy populates spend-tracking and header-derived
+    fields onto whichever container is selected by `_get_metadata_variable_name`
+    for that route; the other container may carry client-body metadata. This
+    helper bridges proxy-set fields from `metadata` -> `litellm_metadata` so a
+    downstream reader of `litellm_metadata` still sees them.
 
-    Preserves:
-    - any key on `metadata` that contains the substring `user_api_key` (proxy auth fields)
-    - well-known proxy-set keys from request headers / proxy auth
-      (`spend_logs_metadata`, `agent_id`, `trace_id`, `session_id`, `requester_ip_address`)
-
-    Existing `litellm_metadata` values are overwritten so the proxy-set view wins, matching
-    the prior `user_api_key*` behavior. Client-supplied keys on `litellm_metadata` that
-    are not in either preserve set are left untouched.
+    - `user_api_key*`: copied with overwrite. This is the existing behavior and
+      is safe because pre_call_utils strips any forged `user_api_key_*` from
+      both containers before this stage (see `_UNTRUSTED_METADATA_CONTROL_FIELDS`).
+    - `_PROXY_SET_METADATA_KEYS_TO_PRESERVE` (header-derived spend keys):
+      copied only when `litellm_metadata` does NOT already have the key, so
+      that on routes where `litellm_metadata` is the proxy-trusted container
+      (e.g. `/v1/messages`), a client-supplied `metadata.<key>` from the
+      request body cannot overwrite the real proxy-set value.
     """
     potential_spend_tracking_metadata_substring = "user_api_key"
     for key, value in metadata.items():
-        if (
-            potential_spend_tracking_metadata_substring in key
-            or key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE
+        if potential_spend_tracking_metadata_substring in key:
+            # Existing behavior: copy with overwrite. Forged values were
+            # already stripped from `metadata` upstream.
+            litellm_metadata[key] = value
+        elif (
+            key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE
+            and key not in litellm_metadata
         ):
+            # Header-derived spend keys: only copy when the destination does
+            # not already have the key, to avoid letting a client-body
+            # `metadata.<key>` overwrite a proxy-set `litellm_metadata.<key>`.
             litellm_metadata[key] = value
     return litellm_metadata
 

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -143,13 +143,20 @@ def remove_items_at_indices(items: Optional[List[Any]], indices: Iterable[int]) 
 
 # Proxy-set metadata fields (populated by the proxy, not the client request body) that
 # must survive the merge from `metadata` -> `litellm_metadata` when both containers exist.
-# Keep in sync with `LitellmMetadataFromRequestHeaders` and `add_litellm_metadata_from_request_headers`.
-_PROXY_SET_METADATA_KEYS_TO_PRESERVE: tuple = (
-    "spend_logs_metadata",
-    "agent_id",
-    "trace_id",
-    "session_id",
-    "requester_ip_address",
+# - `spend_logs_metadata`, `agent_id`, `trace_id`, `session_id` are set by
+#   `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers` based on the
+#   `LitellmMetadataFromRequestHeaders` TypedDict.
+# - `requester_ip_address` is set separately by the proxy from `x-forwarded-for` /
+#   `request.client.host` in `litellm_pre_call_utils.py`.
+# In all cases the value lives on `metadata` and is needed by `_get_spend_logs_metadata`.
+_PROXY_SET_METADATA_KEYS_TO_PRESERVE: frozenset = frozenset(
+    {
+        "spend_logs_metadata",
+        "agent_id",
+        "trace_id",
+        "session_id",
+        "requester_ip_address",
+    }
 )
 
 

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -201,8 +201,7 @@ def add_missing_spend_metadata_to_litellm_metadata(
             # already stripped from `metadata` upstream.
             litellm_metadata[key] = value
         elif (
-            key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE
-            and key not in litellm_metadata
+            key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE and key not in litellm_metadata
         ):
             # Header-derived spend keys: only copy when the destination does
             # not already have the key, to avoid letting a client-body

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -141,18 +141,45 @@ def remove_items_at_indices(items: Optional[List[Any]], indices: Iterable[int]) 
             items.pop(index)
 
 
+# Proxy-set metadata fields (populated by the proxy, not the client request body) that
+# must survive the merge from `metadata` -> `litellm_metadata` when both containers exist.
+# Keep in sync with `LitellmMetadataFromRequestHeaders` and `add_litellm_metadata_from_request_headers`.
+_PROXY_SET_METADATA_KEYS_TO_PRESERVE: tuple = (
+    "spend_logs_metadata",
+    "agent_id",
+    "trace_id",
+    "session_id",
+    "requester_ip_address",
+)
+
+
 def add_missing_spend_metadata_to_litellm_metadata(
     litellm_metadata: dict, metadata: dict
 ) -> dict:
     """
-    Helper to get litellm metadata for spend tracking
+    Helper to get litellm metadata for spend tracking.
 
-    PATCH for issue where both `litellm_metadata` and `metadata` are present in the kwargs
-    and user_api_key values are in 'metadata'.
+    PATCH for the case where both `litellm_metadata` and `metadata` are present in the
+    request kwargs. The proxy populates spend-tracking and header-derived fields onto
+    `metadata`; if `litellm_metadata` also exists (e.g. when a request body carries
+    Anthropic-style provider `metadata`), those fields would otherwise be dropped when
+    downstream code reads `litellm_metadata` only.
+
+    Preserves:
+    - any key on `metadata` that contains the substring `user_api_key` (proxy auth fields)
+    - well-known proxy-set keys from request headers / proxy auth
+      (`spend_logs_metadata`, `agent_id`, `trace_id`, `session_id`, `requester_ip_address`)
+
+    Existing `litellm_metadata` values are overwritten so the proxy-set view wins, matching
+    the prior `user_api_key*` behavior. Client-supplied keys on `litellm_metadata` that
+    are not in either preserve set are left untouched.
     """
     potential_spend_tracking_metadata_substring = "user_api_key"
     for key, value in metadata.items():
-        if potential_spend_tracking_metadata_substring in key:
+        if (
+            potential_spend_tracking_metadata_substring in key
+            or key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE
+        ):
             litellm_metadata[key] = value
     return litellm_metadata
 

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -201,3 +201,133 @@ class TestRedactNestedMatchAndRegexKeys:
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
         assert redact_nested_match_and_regex_keys("plain") == "plain"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for LIT-3302
+# (`x-litellm-spend-logs-metadata` header dropped on /v1/messages requests)
+# ---------------------------------------------------------------------------
+
+
+class TestAddMissingSpendMetadataToLitellmMetadata:
+    """Regression coverage for `add_missing_spend_metadata_to_litellm_metadata`.
+
+    The proxy puts spend-tracking + header-derived fields on `metadata`, while
+    some endpoints (e.g. Anthropic `/v1/messages`) also populate
+    `litellm_metadata`. The helper must preserve the proxy-set fields when
+    merging so they reach the spend logs.
+    """
+
+    def test_preserves_spend_logs_metadata_from_request_header(self):
+        """`spend_logs_metadata` (set from `x-litellm-spend-logs-metadata`) must
+        survive a merge when `litellm_metadata` is also present."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        header_attrs = {
+            "billing_uuid": "9af2b4e0-1c11-4d8b-bcb3-1234567890ab",
+            "agent_id": "agent-cogni-7",
+            "agent_owner_id": "owner-disney-42",
+            "request_type": "chat_completion",
+        }
+        metadata = {
+            "user_api_key": "sk-hashed-abc",
+            "user_api_key_alias": "test-key",
+            "spend_logs_metadata": header_attrs,
+        }
+        litellm_metadata = {"user_id": "anthropic-end-user"}
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        assert merged["spend_logs_metadata"] == header_attrs
+        assert merged["user_api_key"] == "sk-hashed-abc"
+        assert merged["user_api_key_alias"] == "test-key"
+        # Original litellm_metadata content stays untouched.
+        assert merged["user_id"] == "anthropic-end-user"
+
+    def test_preserves_other_proxy_header_metadata(self):
+        """`agent_id`, `trace_id`, `session_id`, `requester_ip_address` are all
+        proxy-populated and must also survive the merge."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        metadata = {
+            "user_api_key_team_id": "team-1",
+            "agent_id": "agent-7",
+            "trace_id": "trace-abc",
+            "session_id": "sess-xyz",
+            "requester_ip_address": "10.0.0.1",
+            "spend_logs_metadata": {"foo": "bar"},
+        }
+        litellm_metadata = {"user_id": "u"}
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        for key in (
+            "agent_id",
+            "trace_id",
+            "session_id",
+            "requester_ip_address",
+            "spend_logs_metadata",
+            "user_api_key_team_id",
+        ):
+            assert merged[key] == metadata[key]
+
+    def test_does_not_leak_unrelated_metadata_keys(self):
+        """Client-supplied (request body) keys on `metadata` that are not
+        spend-tracking or proxy-set must NOT clobber `litellm_metadata`."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        metadata = {
+            "user_api_key": "sk-hashed",
+            "user_id": "client-1",  # client-supplied body field
+            "custom_unrelated": "noise",
+        }
+        litellm_metadata = {"user_id": "proxy-set-user"}
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        # user_api_key still copied
+        assert merged["user_api_key"] == "sk-hashed"
+        # client-supplied body fields NOT propagated
+        assert merged["user_id"] == "proxy-set-user"
+        assert "custom_unrelated" not in merged
+
+    def test_get_litellm_metadata_from_kwargs_round_trip(self):
+        """End-to-end: `get_litellm_metadata_from_kwargs` returns the merged dict
+        with `spend_logs_metadata` intact for the LIT-3302 customer scenario."""
+        from litellm.litellm_core_utils.core_helpers import (
+            get_litellm_metadata_from_kwargs,
+        )
+
+        kwargs = {
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key": "sk-hashed",
+                    "spend_logs_metadata": {
+                        "billing_uuid": "uuid-1",
+                        "agent_id": "agent-1",
+                        "agent_owner_id": "owner-1",
+                        "request_type": "chat_completion",
+                    },
+                },
+                "litellm_metadata": {
+                    "user_id": "client",  # forces the merge path
+                },
+            }
+        }
+
+        result = get_litellm_metadata_from_kwargs(kwargs)
+        assert "spend_logs_metadata" in result
+        assert result["spend_logs_metadata"]["billing_uuid"] == "uuid-1"
+        assert result["user_api_key"] == "sk-hashed"

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -331,3 +331,67 @@ class TestAddMissingSpendMetadataToLitellmMetadata:
         assert "spend_logs_metadata" in result
         assert result["spend_logs_metadata"]["billing_uuid"] == "uuid-1"
         assert result["user_api_key"] == "sk-hashed"
+
+
+    def test_does_not_overwrite_proxy_set_value_when_litellm_metadata_already_has_it(
+        self,
+    ):
+        """Veria scenario: on `/v1/messages` (and other LITELLM_METADATA_ROUTES)
+        the proxy-trusted values live on `litellm_metadata`. A client can forge
+        body `metadata.<key>` for one of the header-derived keys; the merge must
+        NOT overwrite the real proxy-set value with the forged one."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        # Proxy-set values on litellm_metadata (e.g. /v1/messages)
+        litellm_metadata = {
+            "user_api_key": "sk-hashed",
+            "agent_id": "agent-real-from-proxy",
+            "trace_id": "trace-real",
+            "session_id": "session-real",
+            "requester_ip_address": "10.0.0.1",
+            "spend_logs_metadata": {"billing_uuid": "real-bu"},
+        }
+        # Client-forged values on the body metadata
+        metadata = {
+            "agent_id": "agent-forged",
+            "trace_id": "trace-forged",
+            "session_id": "session-forged",
+            "requester_ip_address": "1.2.3.4",
+            "spend_logs_metadata": {"billing_uuid": "forged-bu"},
+        }
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        # Every proxy-set value is preserved unchanged.
+        assert merged["agent_id"] == "agent-real-from-proxy"
+        assert merged["trace_id"] == "trace-real"
+        assert merged["session_id"] == "session-real"
+        assert merged["requester_ip_address"] == "10.0.0.1"
+        assert merged["spend_logs_metadata"] == {"billing_uuid": "real-bu"}
+
+    def test_preserve_keys_use_setdefault_semantics(self):
+        """Even with only one proxy key already present on litellm_metadata,
+        only that one is left untouched; the others (absent on litellm_metadata)
+        are propagated from metadata."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        litellm_metadata = {"agent_id": "agent-real"}  # only agent_id pre-set
+        metadata = {
+            "agent_id": "forged-agent",
+            "trace_id": "trace-from-metadata",  # not on litellm_metadata
+            "spend_logs_metadata": {"k": "v"},  # not on litellm_metadata
+        }
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        assert merged["agent_id"] == "agent-real"  # not overwritten
+        assert merged["trace_id"] == "trace-from-metadata"  # newly copied
+        assert merged["spend_logs_metadata"] == {"k": "v"}  # newly copied


### PR DESCRIPTION
## Summary

## Root cause

`litellm/litellm_core_utils/core_helpers.py::get_litellm_metadata_from_kwargs()` — when both `litellm_params.metadata` and `litellm_params.litellm_metadata` are present on a request, it calls `add_missing_spend_metadata_to_litellm_metadata()` to merge them. The helper only preserved keys from `metadata` whose name contains the substring `user_api_key`:

```python
potential_spend_tracking_metadata_substring = "user_api_key"
for key, value in metadata.items():
    if potential_spend_tracking_metadata_substring in key:
        litellm_metadata[key] = value
```

`spend_logs_metadata` (set from `x-litellm-spend-logs-metadata` in `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers`) and the other proxy-set header-derived keys (`agent_id`, `trace_id`, `session_id`, `requester_ip_address`) were silently dropped before reaching the `SpendLogsPayload` written to the DB. The bug fires whenever the request also populates `litellm_metadata` (e.g. a `/chat/completions` call where the client adds `litellm_metadata` in the body), because then `litellm_metadata` becomes the returned dict and any spend-tracking key on `metadata` not in the substring allowlist is dropped.

## Fix

`add_missing_spend_metadata_to_litellm_metadata` now also preserves the explicit set of proxy-populated keys (`_PROXY_SET_METADATA_KEYS_TO_PRESERVE`):
- `spend_logs_metadata`, `agent_id`, `trace_id`, `session_id` — written by `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers` (`LitellmMetadataFromRequestHeaders` TypedDict)
- `requester_ip_address` — written separately in `litellm_pre_call_utils.py` from `x-forwarded-for` / `request.client.host`

**Critical safety detail (addressing Veria's review):** these keys are propagated with **setdefault semantics** (only when `litellm_metadata` does not already have the key). This protects the inverse case — routes where `_metadata_variable_name == "litellm_metadata"` (e.g. `/v1/messages`, `batches`, `responses`, `files`) — where the proxy-trusted value lives on `litellm_metadata`. Without the setdefault guard, a client could forge a value on the body `metadata.<key>` that would overwrite the real proxy-set `litellm_metadata.<key>`. The existing `user_api_key*` overwrite path is left unchanged because `_UNTRUSTED_METADATA_CONTROL_FIELDS` already strips any forged `user_api_key_*` from both containers in `litellm_pre_call_utils.py` before this helper runs.

Two files changed:
- `litellm/litellm_core_utils/core_helpers.py` — minimal ~25 line change: add `_PROXY_SET_METADATA_KEYS_TO_PRESERVE` frozenset and the conditional `elif key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE and key not in litellm_metadata` branch.
- `tests/test_litellm/litellm_core_utils/test_core_helpers.py` — 6 new regression tests in `TestAddMissingSpendMetadataToLitellmMetadata`:
  - `test_preserves_spend_logs_metadata_from_request_header` — Disney scenario
  - `test_preserves_other_proxy_header_metadata` — all 5 header-derived keys
  - `test_does_not_leak_unrelated_metadata_keys` — client body keys NOT propagated
  - `test_get_litellm_metadata_from_kwargs_round_trip` — end-to-end via the wrapper
  - `test_does_not_overwrite_proxy_set_value_when_litellm_metadata_already_has_it` — Veria scenario (forgery prevented)
  - `test_preserve_keys_use_setdefault_semantics` — partial preset behaves correctly

## Evidence

### BEFORE FIX (clean main, demonstrating bug)

`/chat/completions` with `x-litellm-spend-logs-metadata` header + client-side `litellm_metadata` in body — `metadata` is the proxy-populated dict (since `_metadata_variable_name == "metadata"`), `litellm_metadata` is the client-body container:

```
=== Scenario B (clean main): SLM in metadata (proxy), litellm_metadata={user_id: body} ===
result keys: ['user_api_key', 'user_id']
spend_logs_metadata: None    ← BUG: dropped before reaching spend logs DB
```

End-to-end (BEFORE) — final SpendLogsPayload `metadata` JSON the proxy writes to DB:

```
spend_logs_metadata in DB metadata blob? None
```

### AFTER FIX (this PR)

Same scenario, with the fix:

```
=== Scenario B: SLM in metadata (proxy), litellm_metadata from body ===
  spend_logs_metadata: {'billing_uuid': '9af2b4e0-1c11-4d8b-bcb3-1234567890ab', 'agent_id': 'agent-cogni-7', 'agent_owner_id': 'owner-disney-42', 'request_type': 'chat_completion'}
  agent_id: proxy-agent
  trace_id: proxy-trace
  user_api_key: sk-hashed
```

End-to-end (AFTER) — final SpendLogsPayload `metadata` JSON the proxy writes to DB:

```json
{
  "user_api_key": "sk-hashed-test",
  "user_api_key_alias": "disney-test",
  "user_api_key_team_id": "disney-team",
  "user_api_key_user_id": "disney-user",
  "spend_logs_metadata": {
    "billing_uuid": "9af2b4e0-1c11-4d8b-bcb3-1234567890ab",
    "agent_id": "agent-cogni-7",
    "agent_owner_id": "owner-disney-42",
    "request_type": "chat_completion"
  },
  ...
}
```

Confirmation: `spend_logs_metadata present in DB-bound row? True` and `matches the customer attributes? True`.

### Forgery-prevention (Veria scenario)

`/v1/messages`-style request where `litellm_metadata` is the proxy-trusted container and the client forges every preserve key on body `metadata`:

```
=== V: Veria scenario — forged client metadata vs proxy litellm_metadata ===
  spend_logs_metadata: {'billing_uuid': 'real', ...}    ← proxy value retained
  agent_id: real-from-proxy                              ← proxy value retained
  trace_id: real-from-proxy                              ← proxy value retained
  user_api_key: sk-hashed
>>> Both scenarios pass — bug fixed AND forgery prevented
```

### Unit tests

```
$ python3 -m pytest tests/test_litellm/litellm_core_utils/test_core_helpers.py -x -q
.................................................                        [100%]
49 passed, 2 warnings in 0.84s
```

## Risk

Low. The helper's contract is unchanged: it merges proxy-populated keys from `metadata` into `litellm_metadata`. The change adds 5 well-known proxy keys to the allowlist and uses setdefault semantics to prevent client forgery on routes where `litellm_metadata` is the proxy-trusted container. Client-supplied request-body keys that aren't in the allowlist are still not propagated.

## Push method

This PR was pushed using the GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`) because the agent token lacks `repo` scope for `git push`. Reviewers may see a slightly noisier merge-base diff than from a single squashed local commit (multiple file-level commits).

### Verification (ship-pr)

- [x] Reproduced bug on clean main with concrete kwargs shape that triggers `get_litellm_metadata_from_kwargs`'s merge path — `spend_logs_metadata` was `None` in the final `SpendLogsPayload.metadata` JSON blob.
- [x] After the fix on the same kwargs, `spend_logs_metadata` round-trips end-to-end and matches the customer's 4 attributes verbatim in the DB-bound `SpendLogsPayload.metadata`.
- [x] Veria's medium-severity finding (forged client `metadata.<key>` overwriting proxy-set `litellm_metadata.<key>` on `/v1/messages`-style routes) addressed by switching to setdefault semantics for the new preserve set; explicit regression test added.
- [x] All 49 tests in `tests/test_litellm/litellm_core_utils/test_core_helpers.py` pass (47 prior + 2 new for the security path = 49 total; the other 4 new are part of the 49 — total breakdown: 43 pre-existing + 6 new).
- [x] `black --check` clean on `litellm/litellm_core_utils/core_helpers.py` (CI ran `black==24.10.0`).
- [x] `ruff check` clean.
- [x] No secrets in diff or PR body.

Linear: [LIT-3302](https://linear.app/litellm-prod/issue/LIT-3302)
Agent session: https://litellm-agent-platform.onrender.com/sessions/138bb7bf-2439-49c7-b6ef-3ae3af29a7b6
