### PR TITLE
fix(auth): expand LiteLLMRoutes bucket names in non_proxy_admin_allowed_routes_check (LIT-3300)

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -200,7 +200,11 @@ class RouteChecks:
           ``"management_routes"`` / ``"llm_api_routes"`` /
           ``"info_routes"``) — the values that the
           ``/key/generate`` ``key_type`` presets in
-          ``handle_key_type`` write onto the token.
+          ``handle_key_type`` write onto the token. For the
+          ``llm_api_routes`` bucket this additionally honours
+          dynamically registered pass-through endpoints, matching
+          the symmetric behaviour of
+          ``is_virtual_key_allowed_to_call_route``.
 
         Bucket-name expansion mirrors the symmetric check in
         ``is_virtual_key_allowed_to_call_route``; without it a Proxy-
@@ -221,6 +225,23 @@ class RouteChecks:
                     allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
                 ):
                     return True
+
+                # Mirror the llm_api_routes pass-through carve-out in
+                # is_virtual_key_allowed_to_call_route: keys scoped to
+                # llm_api_routes also reach dynamically registered
+                # pass-through endpoints (e.g. config-driven
+                # /fake-openai-proxy/*). Without this, a Proxy-Admin-
+                # issued llm_api key whose user_obj falls back to None
+                # would 401 on a route the first gate would have allowed.
+                if allowed_route == "llm_api_routes":
+                    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+                        InitPassThroughEndpointHelpers,
+                    )
+
+                    if InitPassThroughEndpointHelpers.is_registered_pass_through_route(
+                        route=route
+                    ):
+                        return True
                 continue
 
             if RouteChecks._route_matches_allowed_route(

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -281,9 +281,39 @@ class RouteChecks:
         ):
             pass
         elif valid_token.allowed_routes is not None:
-            # check if route is in allowed_routes (exact match or prefix match)
+            # Check if route is in allowed_routes via exact / prefix match,
+            # wildcard pattern, OR a ``LiteLLMRoutes`` enum-member bucket name
+            # (e.g. ``"management_routes"`` / ``"llm_api_routes"`` /
+            # ``"info_routes"`` — the values that the ``/key/generate``
+            # ``key_type`` presets in ``handle_key_type`` write onto the token).
+            #
+            # Without bucket-name expansion here, a Proxy-Admin-issued virtual
+            # key created with ``key_type=management`` (or ``llm_api`` /
+            # ``read_only``) hits this branch with
+            # ``allowed_routes=["management_routes"]`` and the raw string
+            # ``"management_routes"`` can never match a real route like
+            # ``/key/generate`` or ``/team/list``. The call falls through to
+            # ``_raise_admin_only_route_exception`` and the user sees an
+            # ``Unauthorized`` 401 (``"Only proxy admin can be used to..."`` /
+            # ``"Only admin users can..."``) on routes that the key's bucket
+            # already covers. Mirrors the symmetric bucket-name expansion in
+            # ``is_virtual_key_allowed_to_call_route``.
             route_allowed = False
             for allowed_route in valid_token.allowed_routes:
+                if (
+                    isinstance(allowed_route, str)
+                    and allowed_route in LiteLLMRoutes._member_names_
+                ):
+                    if RouteChecks.check_route_access(
+                        route=route,
+                        allowed_routes=LiteLLMRoutes._member_map_[
+                            allowed_route
+                        ].value,
+                    ):
+                        route_allowed = True
+                        break
+                    continue
+
                 if RouteChecks._route_matches_allowed_route(
                     route=route, allowed_route=allowed_route
                 ):

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -190,6 +190,52 @@ class RouteChecks:
         )
 
     @staticmethod
+    def _check_allowed_routes_match(route: str, allowed_routes: list) -> bool:
+        """Return True if ``route`` is allowed by any entry in
+        ``allowed_routes`` via:
+
+        - exact / prefix match
+        - wildcard pattern match
+        - a ``LiteLLMRoutes`` enum-member bucket NAME (e.g.
+          ``"management_routes"`` / ``"llm_api_routes"`` /
+          ``"info_routes"``) — the values that the
+          ``/key/generate`` ``key_type`` presets in
+          ``handle_key_type`` write onto the token.
+
+        Bucket-name expansion mirrors the symmetric check in
+        ``is_virtual_key_allowed_to_call_route``; without it a Proxy-
+        Admin-issued virtual key created with ``key_type=management``
+        (or ``llm_api`` / ``read_only``) would hit the second-pass
+        route gate with ``allowed_routes=['management_routes']`` and
+        the raw string ``"management_routes"`` would never match a
+        real route like ``/key/generate`` or ``/team/list``, so the
+        caller would see a misleading 401 (LIT-3300).
+        """
+        for allowed_route in allowed_routes:
+            if (
+                isinstance(allowed_route, str)
+                and allowed_route in LiteLLMRoutes._member_names_
+            ):
+                if RouteChecks.check_route_access(
+                    route=route,
+                    allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
+                ):
+                    return True
+                continue
+
+            if RouteChecks._route_matches_allowed_route(
+                route=route, allowed_route=allowed_route
+            ):
+                return True
+
+            if RouteChecks._route_matches_wildcard_pattern(
+                route=route, pattern=allowed_route
+            ):
+                return True
+
+        return False
+
+    @staticmethod
     def non_proxy_admin_allowed_routes_check(
         user_obj: Optional[LiteLLM_UserTable],
         _user_role: Optional[LitellmUserRoles],
@@ -281,50 +327,12 @@ class RouteChecks:
         ):
             pass
         elif valid_token.allowed_routes is not None:
-            # Check if route is in allowed_routes via exact / prefix match,
-            # wildcard pattern, OR a ``LiteLLMRoutes`` enum-member bucket name
-            # (e.g. ``"management_routes"`` / ``"llm_api_routes"`` /
-            # ``"info_routes"`` — the values that the ``/key/generate``
-            # ``key_type`` presets in ``handle_key_type`` write onto the token).
-            #
-            # Without bucket-name expansion here, a Proxy-Admin-issued virtual
-            # key created with ``key_type=management`` (or ``llm_api`` /
-            # ``read_only``) hits this branch with
-            # ``allowed_routes=["management_routes"]`` and the raw string
-            # ``"management_routes"`` can never match a real route like
-            # ``/key/generate`` or ``/team/list``. The call falls through to
-            # ``_raise_admin_only_route_exception`` and the user sees an
-            # ``Unauthorized`` 401 (``"Only proxy admin can be used to..."`` /
-            # ``"Only admin users can..."``) on routes that the key's bucket
-            # already covers. Mirrors the symmetric bucket-name expansion in
-            # ``is_virtual_key_allowed_to_call_route``.
-            route_allowed = False
-            for allowed_route in valid_token.allowed_routes:
-                if (
-                    isinstance(allowed_route, str)
-                    and allowed_route in LiteLLMRoutes._member_names_
-                ):
-                    if RouteChecks.check_route_access(
-                        route=route,
-                        allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
-                    ):
-                        route_allowed = True
-                        break
-                    continue
-
-                if RouteChecks._route_matches_allowed_route(
-                    route=route, allowed_route=allowed_route
-                ):
-                    route_allowed = True
-                    break
-
-                if RouteChecks._route_matches_wildcard_pattern(
-                    route=route, pattern=allowed_route
-                ):
-                    route_allowed = True
-                    break
-
-            if not route_allowed:
+            # Delegate to _check_allowed_routes_match — it expands
+            # ``LiteLLMRoutes`` enum-member bucket names alongside
+            # exact / prefix / wildcard matching (LIT-3300).
+            if not RouteChecks._check_allowed_routes_match(
+                route=route, allowed_routes=valid_token.allowed_routes
+            ):
                 RouteChecks._raise_admin_only_route_exception(
                     user_obj=user_obj, route=route
                 )

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -306,9 +306,7 @@ class RouteChecks:
                 ):
                     if RouteChecks.check_route_access(
                         route=route,
-                        allowed_routes=LiteLLMRoutes._member_map_[
-                            allowed_route
-                        ].value,
+                        allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
                     ):
                         route_allowed = True
                         break

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -2231,7 +2231,6 @@ def _ticket_3300_token(allowed_routes):
         "/user/new",
         "/user/info",
         "/model/info",
-        "/v1/mcp/server",
     ],
 )
 def test_lit_3300_management_bucket_allows_management_routes(route):
@@ -2362,3 +2361,59 @@ def test_lit_3300_bucket_and_explicit_routes_coexist():
             valid_token=token,
             request_data={},
         )
+
+
+def test_lit_3300_llm_api_bucket_allows_registered_pass_through_in_fallback():
+    """LIT-3300 + Greptile follow-up: at the second-pass fallback gate
+    (``non_proxy_admin_allowed_routes_check``), a virtual key with
+    ``allowed_routes=['llm_api_routes']`` must also reach dynamically
+    registered pass-through endpoints, mirroring the carve-out already
+    present in the first-pass ``is_virtual_key_allowed_to_call_route``.
+    Without this, a Proxy-Admin-issued llm_api key whose user_obj falls
+    back to None would 401 on a route the first gate would have allowed.
+    """
+    mock_registered_routes = {
+        "lit3300-uuid:exact:/fake-openai-proxy-6": {
+            "endpoint_id": "lit3300-uuid",
+            "path": "/fake-openai-proxy-6",
+            "type": "exact",
+        },
+    }
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints._registered_pass_through_routes",
+            mock_registered_routes,
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_server_root_path",
+            return_value="/",
+        ),
+    ):
+        request = MagicMock(spec=Request)
+        request.query_params = {}
+
+        # Must NOT raise — the helper's llm_api_routes pass-through carve-out
+        # honors the registered pass-through endpoint.
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=None,
+            _user_role=None,
+            route="/fake-openai-proxy-6",
+            request=request,
+            valid_token=_ticket_3300_token(["llm_api_routes"]),
+            request_data={},
+        )
+
+        # A route NOT in the registered pass-through map and NOT in
+        # llm_api_routes.value must still raise. /key/generate is a
+        # management write that reaches the fallback (no earlier guard
+        # covers it for an llm_api bucket key).
+        with pytest.raises(Exception):
+            RouteChecks.non_proxy_admin_allowed_routes_check(
+                user_obj=None,
+                _user_role=None,
+                route="/key/generate",
+                request=request,
+                valid_token=_ticket_3300_token(["llm_api_routes"]),
+                request_data={},
+            )

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -2193,7 +2193,6 @@ def test_legitimate_passthrough_routes_still_classified_as_llm_route(route):
     ), f"{route!r} should be classified as an LLM API route"
 
 
-
 # ---------------------------------------------------------------------------
 # LIT-3300: ``/key/generate`` ``key_type`` presets (``llm_api`` /
 # ``management`` / ``read_only``) store a ``LiteLLMRoutes`` bucket NAME on the

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -2191,3 +2191,175 @@ def test_legitimate_passthrough_routes_still_classified_as_llm_route(route):
     assert (
         RouteChecks.is_llm_api_route(route=route) is True
     ), f"{route!r} should be classified as an LLM API route"
+
+
+
+# ---------------------------------------------------------------------------
+# LIT-3300: ``/key/generate`` ``key_type`` presets (``llm_api`` /
+# ``management`` / ``read_only``) store a ``LiteLLMRoutes`` bucket NAME on the
+# token (e.g. ``allowed_routes=["management_routes"]``). The second-pass route
+# gate in ``non_proxy_admin_allowed_routes_check`` previously compared the
+# raw bucket name against the request path, so virtual keys created with these
+# presets returned 401 Unauthorized on routes the bucket actually covers.
+# ---------------------------------------------------------------------------
+
+
+def _ticket_3300_token(allowed_routes):
+    """Token shape produced by ``handle_key_type``: no ``user_id`` (Proxy
+    Admin issued the key without an explicit owner), no ``user_role`` — so
+    ``_is_user_proxy_admin`` is False and the call falls all the way through
+    to the ``valid_token.allowed_routes`` fallback under test.
+    """
+    return UserAPIKeyAuth(
+        api_key="hashed-token",
+        allowed_routes=allowed_routes,
+        user_role=None,
+        user_id=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/key/generate",
+        "/key/update",
+        "/key/delete",
+        "/key/info",
+        "/team/list",
+        "/v2/team/list",
+        "/team/new",
+        "/team/update",
+        "/user/new",
+        "/user/info",
+        "/model/info",
+        "/v1/mcp/server",
+    ],
+)
+def test_lit_3300_management_bucket_allows_management_routes(route):
+    """Regression for LIT-3300: a key with allowed_routes=['management_routes']
+    must reach routes in ``LiteLLMRoutes.management_routes.value`` via the
+    bucket-name expansion at the ``non_proxy_admin_allowed_routes_check``
+    fallback."""
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=None,
+        _user_role=None,
+        route=route,
+        request=request,
+        valid_token=_ticket_3300_token(["management_routes"]),
+        request_data={},
+    )
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/key/info",
+        "/team/info",
+        "/team/list",
+        "/v2/team/list",
+        "/user/info",
+        "/model/info",
+        "/health",
+        "/key/list",
+    ],
+)
+def test_lit_3300_read_only_bucket_allows_info_routes(route):
+    """Regression for LIT-3300: a key with allowed_routes=['info_routes']
+    must reach routes in ``LiteLLMRoutes.info_routes.value`` via bucket-name
+    expansion."""
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=None,
+        _user_role=None,
+        route=route,
+        request=request,
+        valid_token=_ticket_3300_token(["info_routes"]),
+        request_data={},
+    )
+
+
+@pytest.mark.parametrize(
+    "allowed_bucket,disallowed_route",
+    [
+        # Disallowed routes that only reach this fallback (not covered by
+        # llm_api_routes / info_routes / internal_user_routes /
+        # self_managed_routes earlier in the function). All picked from
+        # management_routes write entries.
+        ("info_routes", "/key/generate"),
+        ("info_routes", "/team/new"),
+        ("info_routes", "/team/delete"),
+        ("info_routes", "/user/new"),
+        ("info_routes", "/key/delete"),
+        ("info_routes", "/user/delete"),
+        ("llm_api_routes", "/key/generate"),
+        ("llm_api_routes", "/team/new"),
+        ("llm_api_routes", "/team/delete"),
+        ("llm_api_routes", "/user/new"),
+        ("llm_api_routes", "/key/delete"),
+        ("llm_api_routes", "/user/delete"),
+    ],
+)
+def test_lit_3300_bucket_does_not_overreach(allowed_bucket, disallowed_route):
+    """Negative regression for LIT-3300: bucket-name expansion at the
+    fallback must NOT silently grant a key access to routes outside its
+    bucket."""
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    with pytest.raises(Exception) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=None,
+            _user_role=None,
+            route=disallowed_route,
+            request=request,
+            valid_token=_ticket_3300_token([allowed_bucket]),
+            request_data={},
+        )
+    assert (
+        "Only proxy admin can be used to generate, delete, update info for new keys/users/teams"
+        in str(exc_info.value)
+    )
+
+
+def test_lit_3300_bucket_and_explicit_routes_coexist():
+    """A virtual key may carry a mix of bucket names AND explicit paths in
+    ``allowed_routes``. Both forms must be honored together; routes outside
+    both must still raise."""
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    token = _ticket_3300_token(["info_routes", "/custom/route"])
+
+    # info_routes bucket-covered route — allowed via expansion
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=None,
+        _user_role=None,
+        route="/key/info",
+        request=request,
+        valid_token=token,
+        request_data={},
+    )
+    # explicit path — still allowed via the existing prefix-match branch
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=None,
+        _user_role=None,
+        route="/custom/route",
+        request=request,
+        valid_token=token,
+        request_data={},
+    )
+    # write route outside both bucket and explicit set — must still raise
+    with pytest.raises(Exception):
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=None,
+            _user_role=None,
+            route="/key/generate",
+            request=request,
+            valid_token=token,
+            request_data={},
+        )


### PR DESCRIPTION
## Summary

Virtual keys created via `/key/generate` with `key_type=management` (UI label "Management") or `key_type=llm_api` (UI "AI APIs") returned **401 Unauthorized** on routes that the key's bucket already covered (e.g. `mgmt` key → `POST /key/generate` → 401 "Only proxy admin can be used to..."; `mgmt` key → `POST /team/new` → 401 "Only proxy admin can be used to..."). Keys created with `key_type=default` ("All APIs") worked because they leave `allowed_routes` empty.

Fixes [LIT-3300](https://linear.app/litellm/issue/LIT-3300/virtual-keys-return-unauthorized-for-limited-key-types).

## Root cause

`handle_key_type` in `litellm/proxy/management_endpoints/key_management_endpoints.py:454-466` writes a **`LiteLLMRoutes` enum-member NAME** onto the token, not a list of concrete paths:

```python
if key_type == LiteLLMKeyType.LLM_API:
    data_json["allowed_routes"] = ["llm_api_routes"]
elif key_type == LiteLLMKeyType.MANAGEMENT:
    data_json["allowed_routes"] = ["management_routes"]
elif key_type == LiteLLMKeyType.READ_ONLY:
    data_json["allowed_routes"] = ["info_routes"]
```

`is_virtual_key_allowed_to_call_route` (`route_checks.py:111-132`) correctly expands those bucket names via `LiteLLMRoutes._member_names_` and `_member_map_[name].value`. But the **second-pass** fallback in `non_proxy_admin_allowed_routes_check` (`route_checks.py:304-321` on `main`) did **not** — it ran `_route_matches_allowed_route(route, "management_routes")` which compares the bucket-name string directly against the request path. That comparison can never succeed, so the call fell through to `_raise_admin_only_route_exception` and the user saw the 401.

The reason the fallback is even hit for these keys: the key is created by a Proxy Admin caller, but the resulting virtual key has `user_id=None` (no owner is set). On a subsequent request the key's `user_obj` resolves to `None` ⇒ `_is_user_proxy_admin = False` ⇒ the call drops into `non_proxy_admin_allowed_routes_check`.

## Fix

In `non_proxy_admin_allowed_routes_check` (`litellm/proxy/auth/route_checks.py`), when an entry in `valid_token.allowed_routes` is a `LiteLLMRoutes` enum-member name, expand it to that bucket's `.value` list and check via `RouteChecks.check_route_access`. Mirrors the symmetric expansion already done by `is_virtual_key_allowed_to_call_route`.

```python
elif valid_token.allowed_routes is not None:
    route_allowed = False
    for allowed_route in valid_token.allowed_routes:
        if (
            isinstance(allowed_route, str)
            and allowed_route in LiteLLMRoutes._member_names_
        ):
            if RouteChecks.check_route_access(
                route=route,
                allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
            ):
                route_allowed = True
                break
            continue
        # ... existing exact / prefix / wildcard matching unchanged
```

## Evidence

Reproduced and captured both before and after on a running proxy in the sandbox at port 45943 (BEFORE) and 37175 (AFTER). Same Proxy-Admin-issued virtual keys (`key_type=management` → `allowed_routes=['management_routes']`, etc.), same routes.

**BEFORE (on the daily branch, no patch):**

```
mgmt key (allowed_routes=['management_routes']):
### POST /key/generate -> code=401
  body= {"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/key/generate. Your role=unknown. Your user_id=unknown","type":"auth_error","param":"None","code":"401"}}
### POST /team/new -> code=401
  body= {"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/team/new. Your role=unknown. Your user_id=unknown","type":"auth_error","param":"None","code":"401"}}
### GET /key/info -> code=200  (this one already worked because /key/info is in info_routes which passes the earlier is_info_route() branch)

read_only key (allowed_routes=['info_routes']):
### POST /key/generate -> code=403
  body= {"detail":"Virtual key is not allowed to call this route. Only allowed to call routes: ['info_routes']. Tried to call route: /key/generate"}
  (this 403 is from is_virtual_key_allowed_to_call_route — bucket overreach is already blocked at the FIRST gate)

llm_api key (allowed_routes=['llm_api_routes']):
### POST /key/generate -> code=403
  (same — already blocked at the first gate)
```

**AFTER (with this patch):**

```
mgmt key (allowed_routes=['management_routes']):
### POST /key/generate -> code=200 ✅  (was 401)
  body= {"key_alias":"from-mgmt-A","duration":null,"models":[],"spend":0.0,"max_budget":null,"user_id":null,"team_id":null,...}
### POST /team/new -> code=200 ✅  (was 401)
  body= {"team_alias":"from-mgmt-A","team_id":"7acd4ba1-5a00-4128-a8e8-8dd7c9626c03","organization_id":null,"admins":[],"members":[],...}
### GET /key/info -> code=200 (unchanged)

read_only key (allowed_routes=['info_routes']):
### POST /key/generate -> code=403 ✅  (still blocked — no over-reach across buckets)
### GET /key/info       -> code=200 (unchanged)

llm_api key (allowed_routes=['llm_api_routes']):
### POST /key/generate -> code=403 ✅  (still blocked)
### POST /team/new      -> code=403 ✅  (still blocked)
### GET  /v1/models     -> code=200 (unchanged)

default key (allowed_routes=[]):
### GET /v1/models      -> code=200 (control — unchanged)
```

## Note on `/v2/team/list`

`mgmt key → GET /v2/team/list` still returns 401 after this patch — but that 401 is **not** the LIT-3300 bug. It comes from a separate role-based check **inside** the `/v2/team/list` handler (`team_endpoints.py:4057`: `"Only admin users can query all teams/other teams. Your user role=internal_user"`), which gates listing all teams by user_role, not by `allowed_routes`. That handler-level RBAC is independent of the route gate and out of scope for this fix.

## Tests

Added 33 parametrized regression tests in `tests/test_litellm/proxy/auth/test_route_checks.py` covering:
- All three `handle_key_type` presets (`management_routes` / `info_routes` / `llm_api_routes`) reaching their bucket routes via the fallback expansion (positive)
- Bucket-name expansion does **NOT** over-reach across buckets — `info_routes` and `llm_api_routes` keys still raise on management-write routes (negative)
- Mixed bucket-name + explicit-path `allowed_routes` continues to honor both

`python3 -m pytest tests/test_litellm/proxy/auth/test_route_checks.py -k lit_3300` → **33 passed**.
Full `test_route_checks.py` (existing 286 tests + 33 new) → **319 passed, 1 unrelated existing failure** (`test_initialize_pass_through_registers_wildcard_for_auth_subpath` fails identically on the unmodified daily branch).

## Push method

Files were pushed via the GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`) because the current `GITHUB_TOKEN` lacks `repo` scope for `git push`. Reviewers should expect a slightly noisier merge-base diff than a normal `git push`.

---

Agent session: https://litellm-agent-platform.onrender.com/sessions/fda74157-ef7d-425c-a66e-72345abff36a


---

### Verification (ship-pr)

- **change-type:** `litellm/proxy/auth/route_checks.py` (HTTP auth gate) → required: before/after curl request+response. `tests/test_litellm/proxy/auth/test_route_checks.py` → unit tests only, no separate evidence required.
- **evidence present:** PASS — PR body contains BEFORE and AFTER fenced blocks for the same Proxy-Admin-issued virtual keys against the same routes.
- **backend evidence from a RUNNING system:** PASS — captured against a real running proxy in the sandbox (ports 45943 / 37175). 401 → 200 transition on `mgmt POST /key/generate` and `mgmt POST /team/new`; negative cases (`read_only` and `llm_api` buckets still 403 on management writes) confirmed against the same running proxy.
- **image sanity:** N/A — no image embeds; backend change uses inline fenced curl output.
- **content matches captions:** PASS — each fenced block's caption matches the captured status code / body (BEFORE 401 "Only proxy admin can be used to..."; AFTER 200 with the actual response payload).
- **hygiene:** PASS — no external image hosts; only the two intentionally changed files in the diff (and the small black-formatting + helper-extraction follow-up commits).
- **re-verify after fix:** PASS — Greptile feedback addressed (pass-through carve-out + misleading test param dropped + new test added); Greptile re-reviewed at **5/5** on the latest commit; all 43 CI checks GREEN (Veria check is `in_progress`/likely-to-be-skipped, the same infra-timeout pattern Veria has shown on every prior commit in this PR — known issue, not a regression caused by this change).
