### PR TITLE
fix(ui): dedupe paginated daily activity results by date (LIT-3383)

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.test.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { mergeBreakdowns, mergeResultsByDate } from "./usePaginatedDailyActivity";
+import type { DailyData } from "../types";
+
+const baseMetrics = {
+  spend: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+  api_requests: 0,
+  successful_requests: 0,
+  failed_requests: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+
+const baseBreakdown = {
+  models: {},
+  model_groups: {},
+  mcp_servers: {},
+  providers: {},
+  api_keys: {},
+  entities: {},
+};
+
+const row = (
+  date: string,
+  metrics: Partial<typeof baseMetrics>,
+  breakdown: Partial<typeof baseBreakdown> = {},
+): DailyData => ({
+  date,
+  metrics: { ...baseMetrics, ...metrics },
+  breakdown: { ...baseBreakdown, ...breakdown } as DailyData["breakdown"],
+});
+
+const modelEntry = (spend: number, api_requests: number) => ({
+  metrics: { ...baseMetrics, spend, api_requests },
+  metadata: {},
+  api_key_breakdown: {},
+});
+
+describe("mergeResultsByDate", () => {
+  it("collapses duplicate-date rows into a single row with summed metrics", () => {
+    const rows = [
+      row("2025-05-26", { spend: 1.1, api_requests: 5 }),
+      row("2025-05-26", { spend: 2.2, api_requests: 8 }),
+      row("2025-05-26", { spend: 0.55, api_requests: 3 }),
+    ];
+    const out = mergeResultsByDate(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0].date).toBe("2025-05-26");
+    expect(out[0].metrics.spend).toBeCloseTo(3.85, 5);
+    expect(out[0].metrics.api_requests).toBe(16);
+  });
+
+  it("preserves distinct dates and merges only matching ones", () => {
+    const rows = [
+      row("2025-05-25", { spend: 1, api_requests: 1 }),
+      row("2025-05-26", { spend: 2, api_requests: 2 }),
+      row("2025-05-26", { spend: 3, api_requests: 3 }),
+      row("2025-05-27", { spend: 4, api_requests: 4 }),
+    ];
+    const out = mergeResultsByDate(rows);
+    expect(out.map((r) => r.date)).toEqual([
+      "2025-05-25",
+      "2025-05-26",
+      "2025-05-27",
+    ]);
+    const may26 = out.find((r) => r.date === "2025-05-26")!;
+    expect(may26.metrics.spend).toBe(5);
+    expect(may26.metrics.api_requests).toBe(5);
+  });
+
+  it("merges breakdown.models sub-map across same-date rows", () => {
+    const rows = [
+      row(
+        "2025-05-26",
+        { spend: 1, api_requests: 1 },
+        { models: { "gpt-4o": modelEntry(1, 1) } },
+      ),
+      row(
+        "2025-05-26",
+        { spend: 2, api_requests: 2 },
+        { models: { "gpt-4o": modelEntry(2, 2) } },
+      ),
+      row(
+        "2025-05-26",
+        { spend: 5, api_requests: 5 },
+        { models: { "claude-3-5-sonnet": modelEntry(5, 5) } },
+      ),
+    ];
+    const out = mergeResultsByDate(rows);
+    expect(out).toHaveLength(1);
+    const models = out[0].breakdown.models as Record<string, any>;
+    expect(Object.keys(models).sort()).toEqual([
+      "claude-3-5-sonnet",
+      "gpt-4o",
+    ]);
+    expect(models["gpt-4o"].metrics.spend).toBe(3);
+    expect(models["gpt-4o"].metrics.api_requests).toBe(3);
+    expect(models["claude-3-5-sonnet"].metrics.spend).toBe(5);
+  });
+
+  it("preserves first-seen order of dates", () => {
+    const rows = [
+      row("2025-05-27", { spend: 1, api_requests: 1 }),
+      row("2025-05-25", { spend: 1, api_requests: 1 }),
+      row("2025-05-27", { spend: 1, api_requests: 1 }),
+      row("2025-05-26", { spend: 1, api_requests: 1 }),
+    ];
+    const out = mergeResultsByDate(rows);
+    expect(out.map((r) => r.date)).toEqual([
+      "2025-05-27",
+      "2025-05-25",
+      "2025-05-26",
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(mergeResultsByDate([])).toEqual([]);
+  });
+
+  it("returns single row unchanged when no duplicates", () => {
+    const rows = [row("2025-05-26", { spend: 1, api_requests: 1 })];
+    const out = mergeResultsByDate(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0].date).toBe("2025-05-26");
+    expect(out[0].metrics.spend).toBe(1);
+  });
+});
+
+describe("mergeBreakdowns", () => {
+  it("merges identical model keys by summing metrics", () => {
+    const a = { models: { "gpt-4o": modelEntry(1, 1) } };
+    const b = { models: { "gpt-4o": modelEntry(2, 2) } };
+    const out = mergeBreakdowns(a, b);
+    expect(out.models["gpt-4o"].metrics.spend).toBe(3);
+    expect(out.models["gpt-4o"].metrics.api_requests).toBe(3);
+  });
+
+  it("unions disjoint keys from both sides", () => {
+    const a = { models: { "gpt-4o": modelEntry(1, 1) } };
+    const b = { models: { "claude-3-5-sonnet": modelEntry(2, 2) } };
+    const out = mergeBreakdowns(a, b);
+    expect(out.models["gpt-4o"].metrics.spend).toBe(1);
+    expect(out.models["claude-3-5-sonnet"].metrics.spend).toBe(2);
+  });
+
+  it("handles missing sub-maps gracefully", () => {
+    const a = { models: { "gpt-4o": modelEntry(1, 1) } };
+    const b = {};
+    const out = mergeBreakdowns(a, b);
+    expect(out.models["gpt-4o"].metrics.spend).toBe(1);
+    expect(out.providers).toEqual({});
+  });
+
+  it("recursively merges api_key_breakdown when same key on both sides", () => {
+    const keyEntry = (spend: number) => ({
+      metrics: { ...baseMetrics, spend, api_requests: 1 },
+      metadata: { key_alias: "alias", team_id: null },
+    });
+    const a = {
+      models: {
+        "gpt-4o": {
+          metrics: { ...baseMetrics, spend: 1, api_requests: 1 },
+          metadata: {},
+          api_key_breakdown: { "sk-xxx": keyEntry(1) },
+        },
+      },
+    };
+    const b = {
+      models: {
+        "gpt-4o": {
+          metrics: { ...baseMetrics, spend: 2, api_requests: 2 },
+          metadata: {},
+          api_key_breakdown: { "sk-xxx": keyEntry(2) },
+        },
+      },
+    };
+    const out = mergeBreakdowns(a, b);
+    expect(out.models["gpt-4o"].metrics.spend).toBe(3);
+    expect(out.models["gpt-4o"].api_key_breakdown["sk-xxx"].metrics.spend).toBe(3);
+  });
+});

--- a/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.test.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.test.ts
@@ -39,6 +39,11 @@ const modelEntry = (spend: number, api_requests: number) => ({
   api_key_breakdown: {},
 });
 
+const keyEntry = (spend: number, alias: string) => ({
+  metrics: { ...baseMetrics, spend, api_requests: 1 },
+  metadata: { key_alias: alias, team_id: null },
+});
+
 describe("mergeResultsByDate", () => {
   it("collapses duplicate-date rows into a single row with summed metrics", () => {
     const rows = [
@@ -155,7 +160,7 @@ describe("mergeBreakdowns", () => {
   });
 
   it("recursively merges api_key_breakdown when same key on both sides", () => {
-    const keyEntry = (spend: number) => ({
+    const keyEntryFor = (spend: number) => ({
       metrics: { ...baseMetrics, spend, api_requests: 1 },
       metadata: { key_alias: "alias", team_id: null },
     });
@@ -164,7 +169,7 @@ describe("mergeBreakdowns", () => {
         "gpt-4o": {
           metrics: { ...baseMetrics, spend: 1, api_requests: 1 },
           metadata: {},
-          api_key_breakdown: { "sk-xxx": keyEntry(1) },
+          api_key_breakdown: { "sk-xxx": keyEntryFor(1) },
         },
       },
     };
@@ -173,12 +178,74 @@ describe("mergeBreakdowns", () => {
         "gpt-4o": {
           metrics: { ...baseMetrics, spend: 2, api_requests: 2 },
           metadata: {},
-          api_key_breakdown: { "sk-xxx": keyEntry(2) },
+          api_key_breakdown: { "sk-xxx": keyEntryFor(2) },
         },
       },
     };
     const out = mergeBreakdowns(a, b);
     expect(out.models["gpt-4o"].metrics.spend).toBe(3);
     expect(out.models["gpt-4o"].api_key_breakdown["sk-xxx"].metrics.spend).toBe(3);
+  });
+
+  it("does NOT inject api_key_breakdown into entries that never had it (api_keys sub-map)", () => {
+    // Entries inside breakdown.api_keys are KeyMetricWithMetadata, which has
+    // no `api_key_breakdown` field. Merging two such entries must preserve
+    // that shape (no spurious empty object).
+    const a = { api_keys: { "sk-aaa": keyEntry(1, "alias-1") } };
+    const b = { api_keys: { "sk-aaa": keyEntry(2, "alias-1") } };
+    const out = mergeBreakdowns(a, b);
+    const merged = out.api_keys["sk-aaa"];
+    expect(merged.metrics.spend).toBe(3);
+    expect("api_key_breakdown" in merged).toBe(false);
+  });
+
+  it("does NOT inject api_key_breakdown into nested key-breakdown entries", () => {
+    const a = {
+      models: {
+        "gpt-4o": {
+          metrics: { ...baseMetrics, spend: 1, api_requests: 1 },
+          metadata: {},
+          api_key_breakdown: { "sk-xxx": keyEntry(1, "alias-1") },
+        },
+      },
+    };
+    const b = {
+      models: {
+        "gpt-4o": {
+          metrics: { ...baseMetrics, spend: 2, api_requests: 2 },
+          metadata: {},
+          api_key_breakdown: { "sk-xxx": keyEntry(2, "alias-1") },
+        },
+      },
+    };
+    const out = mergeBreakdowns(a, b);
+    const inner = out.models["gpt-4o"].api_key_breakdown["sk-xxx"];
+    expect(inner.metrics.spend).toBe(3);
+    expect("api_key_breakdown" in inner).toBe(false);
+  });
+
+  it("merges unknown shared sub-maps instead of overwriting them", () => {
+    // If the backend adds a new breakdown sub-map (e.g. "regions") that this
+    // helper does not list in BREAKDOWN_SUBMAPS, shared entries must still be
+    // merged correctly, not silently dropped by last-write-wins object spread.
+    const a = {
+      regions: {
+        "us-east-1": {
+          metrics: { ...baseMetrics, spend: 1, api_requests: 1 },
+          metadata: {},
+        },
+      },
+    } as any;
+    const b = {
+      regions: {
+        "us-east-1": {
+          metrics: { ...baseMetrics, spend: 2, api_requests: 2 },
+          metadata: {},
+        },
+      },
+    } as any;
+    const out = mergeBreakdowns(a, b);
+    expect(out.regions["us-east-1"].metrics.spend).toBe(3);
+    expect(out.regions["us-east-1"].metrics.api_requests).toBe(3);
   });
 });

--- a/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts
@@ -107,6 +107,11 @@ function sumRowMetrics(
  * Merge two breakdown sub-maps (e.g. models, api_keys) keyed by entity id.
  * When the same entity appears in both, metrics are summed and the nested
  * api_key_breakdown is recursively merged. metadata from the first row wins.
+ *
+ * `api_key_breakdown` is only set on the merged entry if at least one of the
+ * inputs had it -- this preserves the shape of `KeyMetricWithMetadata` entries
+ * (which have no `api_key_breakdown` field) instead of injecting an empty
+ * object on every merge.
  */
 function mergeBreakdownSubMap(
   a: Record<string, any> | undefined,
@@ -121,15 +126,21 @@ function mergeBreakdownSubMap(
       result[key] = bEntry;
       continue;
     }
-    result[key] = {
+    const merged: Record<string, any> = {
       ...aEntry,
       metrics: sumRowMetrics(aEntry.metrics || {}, bEntry.metrics || {}),
       metadata: aEntry.metadata ?? bEntry.metadata,
-      api_key_breakdown: mergeBreakdownSubMap(
+    };
+    // Only carry api_key_breakdown forward if at least one side had it, so we
+    // don't add a `{}` field to entries (e.g. KeyMetricWithMetadata) whose
+    // interface does not include it.
+    if (aEntry.api_key_breakdown !== undefined || bEntry.api_key_breakdown !== undefined) {
+      merged.api_key_breakdown = mergeBreakdownSubMap(
         aEntry.api_key_breakdown,
         bEntry.api_key_breakdown,
-      ),
-    };
+      );
+    }
+    result[key] = merged;
   }
   return result;
 }
@@ -146,22 +157,32 @@ const BREAKDOWN_SUBMAPS = [
 
 /**
  * Merge the full breakdown object of two DailyData rows that share a date.
- * Each known sub-map is merged independently; unknown sub-maps from either
- * side are passed through so we never drop fields the backend adds later.
+ * Every sub-map (known *and* unknown) is merged with mergeBreakdownSubMap, so
+ * a future backend addition (e.g. a "regions" sub-map) is never silently
+ * dropped by last-write-wins object spreads. Known sub-maps are always at
+ * least `{}` in the output so downstream consumers do not need to guard for
+ * undefined.
  */
 export function mergeBreakdowns(
   a: Record<string, any> | undefined,
   b: Record<string, any> | undefined,
 ): Record<string, any> {
-  const merged: Record<string, any> = { ...(a || {}), ...(b || {}) };
-  for (const key of BREAKDOWN_SUBMAPS) {
+  const allKeys = new Set<string>([
+    ...Object.keys(a || {}),
+    ...Object.keys(b || {}),
+  ]);
+  const merged: Record<string, any> = {};
+  for (const key of allKeys) {
     merged[key] = mergeBreakdownSubMap(a?.[key], b?.[key]);
+  }
+  for (const key of BREAKDOWN_SUBMAPS) {
+    if (merged[key] === undefined) merged[key] = {};
   }
   return merged;
 }
 
 /**
- * Collapse paginated DailyData results so rows with the same date are
+ * Collapse paginated DailyData results so rows with the same `date` are
  * merged into one entry (metrics summed, breakdowns merged). Without this,
  * a paginated backend response for a single-day window emits one chart bar
  * per page instead of one bar per actual day. Order is preserved by

--- a/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts
@@ -25,6 +25,19 @@ const SUMMABLE_METADATA_KEYS = [
   "total_cache_creation_input_tokens",
 ] as const;
 
+/** The per-row metric fields that should be summed when two rows share a date. */
+const SUMMABLE_ROW_METRIC_KEYS = [
+  "spend",
+  "prompt_tokens",
+  "completion_tokens",
+  "total_tokens",
+  "api_requests",
+  "successful_requests",
+  "failed_requests",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+] as const;
+
 interface DailyActivityResponse {
   results: DailyData[];
   metadata: Record<string, any>;
@@ -77,6 +90,98 @@ function sumMetadata(
     result[key] = (a[key] || 0) + (b[key] || 0);
   }
   return result;
+}
+
+function sumRowMetrics(
+  a: Record<string, any>,
+  b: Record<string, any>,
+): Record<string, any> {
+  const result = { ...a };
+  for (const key of SUMMABLE_ROW_METRIC_KEYS) {
+    result[key] = (a[key] || 0) + (b[key] || 0);
+  }
+  return result;
+}
+
+/**
+ * Merge two breakdown sub-maps (e.g. models, api_keys) keyed by entity id.
+ * When the same entity appears in both, metrics are summed and the nested
+ * api_key_breakdown is recursively merged. metadata from the first row wins.
+ */
+function mergeBreakdownSubMap(
+  a: Record<string, any> | undefined,
+  b: Record<string, any> | undefined,
+): Record<string, any> {
+  if (!a) return { ...(b || {}) };
+  if (!b) return { ...a };
+  const result: Record<string, any> = { ...a };
+  for (const [key, bEntry] of Object.entries(b)) {
+    const aEntry = result[key];
+    if (!aEntry) {
+      result[key] = bEntry;
+      continue;
+    }
+    result[key] = {
+      ...aEntry,
+      metrics: sumRowMetrics(aEntry.metrics || {}, bEntry.metrics || {}),
+      metadata: aEntry.metadata ?? bEntry.metadata,
+      api_key_breakdown: mergeBreakdownSubMap(
+        aEntry.api_key_breakdown,
+        bEntry.api_key_breakdown,
+      ),
+    };
+  }
+  return result;
+}
+
+const BREAKDOWN_SUBMAPS = [
+  "models",
+  "model_groups",
+  "mcp_servers",
+  "providers",
+  "api_keys",
+  "entities",
+  "endpoints",
+] as const;
+
+/**
+ * Merge the full breakdown object of two DailyData rows that share a date.
+ * Each known sub-map is merged independently; unknown sub-maps from either
+ * side are passed through so we never drop fields the backend adds later.
+ */
+export function mergeBreakdowns(
+  a: Record<string, any> | undefined,
+  b: Record<string, any> | undefined,
+): Record<string, any> {
+  const merged: Record<string, any> = { ...(a || {}), ...(b || {}) };
+  for (const key of BREAKDOWN_SUBMAPS) {
+    merged[key] = mergeBreakdownSubMap(a?.[key], b?.[key]);
+  }
+  return merged;
+}
+
+/**
+ * Collapse paginated DailyData results so rows with the same date are
+ * merged into one entry (metrics summed, breakdowns merged). Without this,
+ * a paginated backend response for a single-day window emits one chart bar
+ * per page instead of one bar per actual day. Order is preserved by
+ * first-seen date.
+ */
+export function mergeResultsByDate(rows: DailyData[]): DailyData[] {
+  const byDate = new Map<string, DailyData>();
+  for (const row of rows) {
+    const existing = byDate.get(row.date);
+    if (!existing) {
+      byDate.set(row.date, row);
+      continue;
+    }
+    byDate.set(row.date, {
+      date: row.date,
+      metrics: sumRowMetrics(existing.metrics, row.metrics) as DailyData["metrics"],
+      breakdown: mergeBreakdowns(existing.breakdown, row.breakdown) as DailyData["breakdown"],
+    });
+  }
+  return Array.from(byDate.values());
 }
 
 /**
@@ -164,7 +269,14 @@ export function usePaginatedDailyActivity({
 
         if (isStale()) return;
 
-        setData(firstPage);
+        // Dedupe rows that share a date within the first page too -- e.g. the
+        // backend _adjust_dates_for_timezone may emit a UTC ghost-bar for the
+        // same local-day window.
+        const firstPageDeduped: DailyActivityResponse = {
+          ...firstPage,
+          results: mergeResultsByDate(firstPage.results),
+        };
+        setData(firstPageDeduped);
 
         const totalPages = firstPage.metadata?.total_pages || 1;
 
@@ -175,11 +287,11 @@ export function usePaginatedDailyActivity({
           return;
         }
 
-        // More pages — start fetching sequentially.
+        // More pages -- start fetching sequentially.
         setLoading(false);
         setIsFetchingMore(true);
 
-        let accumulatedResults = [...firstPage.results];
+        let accumulatedResults = [...firstPageDeduped.results];
         let accumulatedMetadata = { ...firstPage.metadata };
 
         for (let page = 2; page <= totalPages; page++) {
@@ -195,7 +307,12 @@ export function usePaginatedDailyActivity({
 
           if (isStale()) return;
 
-          accumulatedResults = [...accumulatedResults, ...pageData.results];
+          // Merge rows that share the same date (one bar per actual day,
+          // not one bar per paginated page).
+          accumulatedResults = mergeResultsByDate([
+            ...accumulatedResults,
+            ...pageData.results,
+          ]);
           accumulatedMetadata = sumMetadata(
             accumulatedMetadata,
             pageData.metadata,


### PR DESCRIPTION
## Summary

Fixes **LIT-3383** (Barracuda): when the Usage page time range is `Today`, the Daily Spend bar chart renders multiple bars all labelled with today's date instead of a single bar.

## Root cause

`usePaginatedDailyActivity` paginates `/user/daily/activity` and concatenates `pageData.results` into `accumulatedResults` without merging rows by `date`. When the time window covers a single day (e.g. `Today`), the backend can return multiple paginated pages whose rows all carry the same `date` string. The Daily Spend chart in `UsagePageView.tsx` then renders one bar per row (`<BarChart index="date" data={sortedDailyResults} />`), so the user sees N identical-date bars instead of one bar with the day's total.

The backend also occasionally emits a UTC ghost-bar (`_adjust_dates_for_timezone` expanding +/-1 day around the local-day window), which compounds the same visual symptom.

## Fix

Add two pure helpers in `usePaginatedDailyActivity.ts` and use them in the page-loop accumulator:

- `mergeResultsByDate(rows: DailyData[])` collapses rows that share a `date` into one row, summing `metrics` and merging `breakdown.*` sub-maps.
- `mergeBreakdowns(a, b)` merges two breakdown objects key-by-key (over the union of keys from both sides, so unknown sub-maps the backend might add later are not silently dropped). `mergeBreakdownSubMap` only sets `api_key_breakdown` on a merged entry when at least one input had it, preserving the shape of `KeyMetricWithMetadata` entries.

The hook now:

1. Dedupes the first page on arrival (handles single-page UTC ghost-bar).
2. Dedupes `[...accumulatedResults, ...pageData.results]` on every additional page (handles the multi-page paginated-Today case).

This is a frontend-only fix, orthogonal to any backend changes around `_adjust_dates_for_timezone` — it stays correct even if the backend stops emitting duplicate-date rows.

### Evidence

The fix is a deterministic transformation of the array passed straight to `<BarChart index="date">`. The Daily Spend bars are a pure function of `sortedDailyResults`, so showing the array before/after the dedup proves the visual fix.

**Repro setup** — three paginated pages, all rows with `date = "2025-05-26"` (simulating the backend response for `Today`):

```
page 1: [{date:"2025-05-26", spend:1.10, requests:5, model:gpt-4o}]
page 2: [{date:"2025-05-26", spend:2.20, requests:8, model:claude-3-5-sonnet}]
page 3: [{date:"2025-05-26", spend:0.55, requests:3, model:gpt-4o}]
```

**BEFORE FIX** — what the BarChart receives today (3 bars all labelled 2025-05-26, exactly matches the Barracuda screenshots in the Linear ticket):

```json
=== Daily Spend BarChart bars (index=date) ===
[
  { "date": "2025-05-26", "spend": 1.1,  "requests": 5 },
  { "date": "2025-05-26", "spend": 2.2,  "requests": 8 },
  { "date": "2025-05-26", "spend": 0.55, "requests": 3 }
]
Total bars: 3  Distinct date labels: 1
```

**AFTER FIX** — same paginated input, deduped accumulator:

```json
=== Daily Spend BarChart bars (index=date) ===
[
  { "date": "2025-05-26", "spend": 3.85, "requests": 16 }
]
Total bars: 1  Distinct date labels: 1

Merged row models breakdown (preserved):
{
  "gpt-4o":            { "spend": 1.65, "requests": 8 },
  "claude-3-5-sonnet": { "spend": 2.20, "requests": 8 }
}
```

One bar, all metrics summed, model breakdown preserved so the "Top Models" panel still shows accurate per-model spend.

**Unit tests** (`usePaginatedDailyActivity.test.ts`, 13 cases, all passing locally with vitest 3.2.4):

```
 RUN  v3.2.4 /tmp/lt5/ui/litellm-dashboard

 ✓ mergeResultsByDate > collapses duplicate-date rows into a single row with summed metrics 2ms
 ✓ mergeResultsByDate > preserves distinct dates and merges only matching ones 1ms
 ✓ mergeResultsByDate > merges breakdown.models sub-map across same-date rows 1ms
 ✓ mergeResultsByDate > preserves first-seen order of dates 0ms
 ✓ mergeResultsByDate > returns empty array for empty input 0ms
 ✓ mergeResultsByDate > returns single row unchanged when no duplicates 0ms
 ✓ mergeBreakdowns > merges identical model keys by summing metrics 0ms
 ✓ mergeBreakdowns > unions disjoint keys from both sides 0ms
 ✓ mergeBreakdowns > handles missing sub-maps gracefully 0ms
 ✓ mergeBreakdowns > recursively merges api_key_breakdown when same key on both sides 0ms
 ✓ mergeBreakdowns > does NOT inject api_key_breakdown into entries that never had it (api_keys sub-map) 0ms
 ✓ mergeBreakdowns > does NOT inject api_key_breakdown into nested key-breakdown entries 0ms
 ✓ mergeBreakdowns > merges unknown shared sub-maps instead of overwriting them 0ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  1.03s
```

## Files changed

- `ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.ts` — add `sumRowMetrics`, `mergeBreakdownSubMap`, `mergeBreakdowns`, `mergeResultsByDate`; use `mergeResultsByDate` in the page-loop accumulator and on the first-page response.
- `ui/litellm-dashboard/src/components/UsagePage/hooks/usePaginatedDailyActivity.test.ts` — new unit tests covering the dedup + breakdown merge (13 cases).

## Notes

- Files were pushed via the GitHub Contents API (one commit per file) because the agent token lacks the `workflow` scope needed for `git push`. The base-branch diff may look noisier than a normal squashed PR.
- Linear: https://linear.app/litellm-ai/issue/LIT-3383
- Agent session: https://litellm-agent-platform.onrender.com/sessions/65c167d6-fb40-4ddd-8279-26da7cc60378

### Verification (ship-pr)

- [x] **Bug reproduced on main**: ran the production accumulator pattern on three paginated pages all dated `2025-05-26` and observed 3 BarChart entries with identical date labels (matches the screenshot attached to LIT-3383).
- [x] **Fix reproduced after change**: same input now produces 1 entry with `spend: 3.85`, `requests: 16`, breakdown preserved per-model — JSON above.
- [x] **Unit tests added and passing**: 13/13 in vitest 3.2.4. Tests cover happy path, multiple distinct dates, breakdown merging, ordering, edge cases, and the two Greptile-flagged shape-preservation cases.
- [x] **Greptile review**: initial score 4/5 (https://github.com/BerriAI/litellm/pull/28950#issuecomment-4551174928). Both P2 issues addressed and explained in-thread; awaiting re-review confirmation.
- [x] **Veria review**: passed — "No security issues found".
- [x] **CircleCI / GitHub Actions**: 44/44 green at `49a3fbcf1ab4` (head), 0 failures.
- [x] **PR base branch**: targets `litellm_oss_agent_shin_daily_branch` (passes the "Verify PR source branch" check).
- [x] **No secrets in diff / PR body**: confirmed by inspection; no env vars or tokens echoed.
