### PR TITLE
fix(responses): default completion_tokens_details when provider omits output_tokens_details (#15377)

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -959,6 +959,16 @@ class ResponseAPILoggingUtils:
                 image_tokens=getattr(output_tokens_details, "image_tokens", None),
                 text_tokens=getattr(output_tokens_details, "text_tokens", None),
             )
+        else:
+            # Some providers (notably Azure OpenAI) omit ``output_tokens_details``
+            # from the Responses API payload even when ``input_tokens_details``
+            # is populated. Mirror what OpenAI sends by default
+            # (``reasoning_tokens=0``) so downstream loggers always see a
+            # ``CompletionTokensDetailsWrapper`` on ``response_obj.usage``.
+            # See: https://github.com/BerriAI/litellm/issues/15377
+            completion_tokens_details = CompletionTokensDetailsWrapper(
+                reasoning_tokens=0,
+            )
 
         chat_usage = Usage(
             prompt_tokens=prompt_tokens,

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -348,6 +348,71 @@ class TestResponseAPILoggingUtils:
         assert result.completion_tokens_details.image_tokens == 100
         assert result.completion_tokens_details.text_tokens == 70
 
+    def test_transform_response_api_usage_defaults_completion_tokens_details_when_provider_omits_it(
+        self,
+    ):
+        """
+        Regression for https://github.com/BerriAI/litellm/issues/15377 (LIT-1771).
+
+        Azure OpenAI's Responses API can omit ``output_tokens_details`` from the
+        usage payload even when ``input_tokens_details`` is present. In that
+        case, downstream loggers used to see
+        ``response_obj.usage.completion_tokens_details`` as ``None`` while
+        ``prompt_tokens_details`` was populated — asymmetric and confusing for
+        cost/observability callbacks. After the fix we always emit a default
+        ``CompletionTokensDetailsWrapper(reasoning_tokens=0)`` in this case.
+        """
+        # Setup — Azure-style payload (no output_tokens_details)
+        usage = {
+            "input_tokens": 12,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 204,
+            "total_tokens": 216,
+        }
+
+        # Execute
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        # Assert — the key regression: completion_tokens_details is populated,
+        # not None.
+        assert result.completion_tokens == 204
+        assert result.prompt_tokens == 12
+        assert result.total_tokens == 216
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 0
+        # Other fields stay None — no info from the provider.
+        assert result.completion_tokens_details.text_tokens is None
+        assert result.completion_tokens_details.image_tokens is None
+        # And we did NOT regress the populated input side.
+        assert result.prompt_tokens_details is not None
+        assert result.prompt_tokens_details.cached_tokens == 0
+
+    def test_transform_response_api_usage_preserves_output_tokens_details_when_provided(
+        self,
+    ):
+        """
+        Ensure the default-fallback path does not stomp on a provider-supplied
+        ``output_tokens_details`` block.
+        """
+        usage = {
+            "input_tokens": 15,
+            "input_tokens_details": {"cached_tokens": 5},
+            "output_tokens": 25,
+            "output_tokens_details": {"reasoning_tokens": 7},
+            "total_tokens": 40,
+        }
+
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 7
+        assert result.prompt_tokens_details is not None
+        assert result.prompt_tokens_details.cached_tokens == 5
+
 
 class TestResponsesAPIProviderSpecificParams:
     """
@@ -463,73 +528,3 @@ def test_responses_maps_reasoning_effort_from_litellm_params_to_reasoning():
             "effort": "high",
             "summary": "detailed",
         }
-
-    def test_transform_response_api_usage_defaults_completion_tokens_details_when_provider_omits_it(
-        self,
-    ):
-        """
-        Regression for https://github.com/BerriAI/litellm/issues/15377 (LIT-1771).
-
-        Azure OpenAI's Responses API can omit ``output_tokens_details`` from the
-        usage payload even when ``input_tokens_details`` is present. In that
-        case, downstream loggers used to see ``response_obj.usage.completion_tokens_details``
-        as ``None`` while ``prompt_tokens_details`` was populated — asymmetric
-        and confusing for cost/observability callbacks. After the fix we always
-        emit a default ``CompletionTokensDetailsWrapper(reasoning_tokens=0)``
-        in this case.
-        """
-        # Setup — Azure-style payload (no output_tokens_details)
-        usage = {
-            "input_tokens": 12,
-            "input_tokens_details": {"cached_tokens": 0},
-            "output_tokens": 204,
-            "total_tokens": 216,
-        }
-
-        # Execute
-        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-            usage
-        )
-
-        # Assert
-        assert result.completion_tokens == 204
-        assert result.prompt_tokens == 12
-        assert result.total_tokens == 216
-        # The key regression assertion: completion_tokens_details is populated,
-        # not None.
-        assert result.completion_tokens_details is not None
-        assert result.completion_tokens_details.reasoning_tokens == 0
-        # Other fields stay None — we have no info on them from the provider.
-        assert result.completion_tokens_details.text_tokens is None
-        assert result.completion_tokens_details.image_tokens is None
-        # And we did NOT regress the populated input side.
-        assert result.prompt_tokens_details is not None
-        assert result.prompt_tokens_details.cached_tokens == 0
-
-    def test_transform_response_api_usage_preserves_output_tokens_details_when_provided(
-        self,
-    ):
-        """
-        Ensure the default-fallback path does not stomp on a provider-supplied
-        ``output_tokens_details`` block.
-        """
-        # Setup — full payload (output_tokens_details present)
-        usage = {
-            "input_tokens": 15,
-            "input_tokens_details": {"cached_tokens": 5},
-            "output_tokens": 25,
-            "output_tokens_details": {"reasoning_tokens": 7},
-            "total_tokens": 40,
-        }
-
-        # Execute
-        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-            usage
-        )
-
-        # Assert
-        assert result.completion_tokens_details is not None
-        assert result.completion_tokens_details.reasoning_tokens == 7
-        assert result.prompt_tokens_details is not None
-        assert result.prompt_tokens_details.cached_tokens == 5
-

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -463,3 +463,73 @@ def test_responses_maps_reasoning_effort_from_litellm_params_to_reasoning():
             "effort": "high",
             "summary": "detailed",
         }
+
+    def test_transform_response_api_usage_defaults_completion_tokens_details_when_provider_omits_it(
+        self,
+    ):
+        """
+        Regression for https://github.com/BerriAI/litellm/issues/15377 (LIT-1771).
+
+        Azure OpenAI's Responses API can omit ``output_tokens_details`` from the
+        usage payload even when ``input_tokens_details`` is present. In that
+        case, downstream loggers used to see ``response_obj.usage.completion_tokens_details``
+        as ``None`` while ``prompt_tokens_details`` was populated — asymmetric
+        and confusing for cost/observability callbacks. After the fix we always
+        emit a default ``CompletionTokensDetailsWrapper(reasoning_tokens=0)``
+        in this case.
+        """
+        # Setup — Azure-style payload (no output_tokens_details)
+        usage = {
+            "input_tokens": 12,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 204,
+            "total_tokens": 216,
+        }
+
+        # Execute
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        # Assert
+        assert result.completion_tokens == 204
+        assert result.prompt_tokens == 12
+        assert result.total_tokens == 216
+        # The key regression assertion: completion_tokens_details is populated,
+        # not None.
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 0
+        # Other fields stay None — we have no info on them from the provider.
+        assert result.completion_tokens_details.text_tokens is None
+        assert result.completion_tokens_details.image_tokens is None
+        # And we did NOT regress the populated input side.
+        assert result.prompt_tokens_details is not None
+        assert result.prompt_tokens_details.cached_tokens == 0
+
+    def test_transform_response_api_usage_preserves_output_tokens_details_when_provided(
+        self,
+    ):
+        """
+        Ensure the default-fallback path does not stomp on a provider-supplied
+        ``output_tokens_details`` block.
+        """
+        # Setup — full payload (output_tokens_details present)
+        usage = {
+            "input_tokens": 15,
+            "input_tokens_details": {"cached_tokens": 5},
+            "output_tokens": 25,
+            "output_tokens_details": {"reasoning_tokens": 7},
+            "total_tokens": 40,
+        }
+
+        # Execute
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        # Assert
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 7
+        assert result.prompt_tokens_details is not None
+        assert result.prompt_tokens_details.cached_tokens == 5
+


### PR DESCRIPTION
## Summary

Fixes [#15377](https://github.com/BerriAI/litellm/issues/15377) / LIT-1771.

Azure OpenAI's Responses API sometimes omits `output_tokens_details` from the usage payload — even when `input_tokens_details` is populated. The transform in `ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage` (`litellm/responses/utils.py:950-961`) only created a `CompletionTokensDetailsWrapper` when `output_tokens_details` was truthy, so downstream logging callbacks saw an asymmetric `Usage` where `prompt_tokens_details` was populated but `completion_tokens_details=None`.

That's confusing for cost calculators and structured logging consumers (Langfuse, DataDog, etc.) which key off `usage.completion_tokens_details.reasoning_tokens` and now incorrectly treat the missing object as "unknown" instead of "zero reasoning tokens".

## Fix

When the provider omits `output_tokens_details`, fall back to the same default OpenAI sends for non-reasoning models — `CompletionTokensDetailsWrapper(reasoning_tokens=0)` — so callbacks always see a populated wrapper symmetrically with the input side.

Only the missing-field path changes; provider-supplied `output_tokens_details` (e.g. with `reasoning_tokens=5`) continues to flow through unchanged.

## Evidence

Repro & verification driven through the exact transform that produces `response_obj.usage` inside `async_log_success_event` for the Azure Responses API (`litellm_logging._transform_usage_objects → ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage`).

**Before (clean upstream main):**

```
  resp.usage.input_tokens_details  = audio_tokens=None cached_tokens=0 text_tokens=None
  resp.usage.output_tokens_details = None

Usage object that reaches async_log_success_event:
  Usage(completion_tokens=204, prompt_tokens=12, total_tokens=216, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, video_tokens=None))
```

`completion_tokens_details=None` — matches the user's bug report verbatim (issue #15377).

**After (this PR):**

```
  resp.usage.input_tokens_details  = audio_tokens=None cached_tokens=0 text_tokens=None
  resp.usage.output_tokens_details = None

Usage object that reaches async_log_success_event:
  Usage(completion_tokens=204, prompt_tokens=12, total_tokens=216, completion_tokens_details=CompletionTokensDetailsWrapper(accepted_prediction_tokens=None, audio_tokens=None, reasoning_tokens=0, rejected_prediction_tokens=None, text_tokens=None, image_tokens=None, video_tokens=None), prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, video_tokens=None))
```

`completion_tokens_details` is now populated, symmetric with `prompt_tokens_details`.

**Negative test (proves the new test exercises the fix):**

Running the new regression test against unpatched `main` fails with the exact assertion the user reported:

```
>       assert result.completion_tokens_details is not None
E       assert None is not None
E        +  where None = Usage(completion_tokens=204, prompt_tokens=12, total_tokens=216, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, video_tokens=None)).completion_tokens_details

tests/test_litellm/responses/test_responses_utils.py:383: AssertionError
```

**Unit tests (with fix applied):**

```
tests/test_litellm/responses/test_responses_utils.py::TestResponseAPILoggingUtils ... 21 passed in 0.86s
tests/test_litellm/llms/azure/ -k respons ........................ 36 passed
```

## Notes

- Files pushed via the GitHub Contents API (not `git push`) because the current `oss-agent-shin` token lacks `repo`/`workflow` scope. Reviewers may see a slightly noisier merge-base diff than from a direct push; the only files actually changed are `litellm/responses/utils.py` (+10 lines) and `tests/test_litellm/responses/test_responses_utils.py` (+58 lines).

### Pre-Submission Checklist

- [x] Added testing in `tests/test_litellm/responses/test_responses_utils.py` — two new tests inside `TestResponseAPILoggingUtils`.
- [x] PR passes unit tests on `make test-unit` (21/21 in the touched file).
- [x] PR scope is as isolated as possible — only one transform branch changes.
- [x] Will request a Greptile review by commenting `@greptileai` and aim for a Confidence Score of at least 4/5 before requesting a maintainer review.

Closes LIT-1771.


### Verification (ship-pr)

- [x] Branch targets `litellm_oss_agent_shin_daily_branch` (required by "Verify PR source branch" check).
- [x] All 44 CI check-runs completed = success (Veria AI - PR Review, lint, unit-test, every proxy/responses/integrations job).
- [x] Greptile review: **5/5** confidence — "Safe to merge".
- [x] PR body contains `### Evidence` with paired before/after fenced blocks captured from the real transform.
- [x] Negative test demonstrated: new regression test fails on unpatched `main` with the exact assertion the user reported, passes with the fix.
- [x] Unit tests added inside `TestResponseAPILoggingUtils` class (21/21 pass in touched file; 36/36 pre-existing Azure responses tests still pass).
- [x] No secrets / no committed binaries.
- [x] `mergeable_state: clean`.