### PR TITLE
fix(sagemaker_chat): inject InferenceComponent header from model_id (LIT-2853)

### DIFF
--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -58,6 +58,17 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
+        # SageMaker multi-model endpoints with InferenceComponents accept the
+        # component name via the X-Amzn-SageMaker-Inference-Component header.
+        # The legacy `sagemaker` completion handler does this in
+        # `litellm/llms/sagemaker/completion/handler.py`; mirror the behavior
+        # here so callers can pass `model_id=...` directly to
+        # `sagemaker_chat/...` without manually adding `extra_headers`.
+        # boto3 doc:
+        # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html
+        model_id = optional_params.pop("model_id", None)
+        if model_id:
+            headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return headers
 
     def get_complete_url(
@@ -98,6 +109,29 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         stream: Optional[bool] = None,
         fake_stream: Optional[bool] = None,
     ) -> Tuple[dict, Optional[bytes]]:
+        # SageMaker endpoints that host multiple Inference Components require
+        # the `X-Amzn-SageMaker-Inference-Component` header (legacy
+        # `sagemaker` completion handler injects it from
+        # `optional_params["model_id"]` -- see
+        # `litellm/llms/sagemaker/completion/handler.py`). We mirror that
+        # here so callers can pass `model_id` either via `extra_body` (which
+        # lands in `request_data` after the BaseLLMHTTPHandler merges it
+        # in) or via the `optional_params` shape used by the completion
+        # handler. Either source moves the value into a header and is
+        # removed from the body so SigV4 signs the exact payload that gets
+        # sent.
+        #
+        # Hooking in `sign_request` rather than `validate_environment` /
+        # `transform_request` is what covers the `extra_body` path, because
+        # `BaseLLMHTTPHandler.completion` merges `extra_body` into
+        # `request_data` *after* the other hooks run.
+        model_id = request_data.pop("model_id", None)
+        if model_id is None:
+            model_id = optional_params.pop("model_id", None)
+        else:
+            optional_params.pop("model_id", None)
+        if model_id is not None:
+            headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return self._sign_request(
             service_name="sagemaker",
             headers=headers,

--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -109,29 +109,6 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         stream: Optional[bool] = None,
         fake_stream: Optional[bool] = None,
     ) -> Tuple[dict, Optional[bytes]]:
-        # SageMaker endpoints that host multiple Inference Components require
-        # the `X-Amzn-SageMaker-Inference-Component` header (legacy
-        # `sagemaker` completion handler injects it from
-        # `optional_params["model_id"]` -- see
-        # `litellm/llms/sagemaker/completion/handler.py`). We mirror that
-        # here so callers can pass `model_id` either via `extra_body` (which
-        # lands in `request_data` after the BaseLLMHTTPHandler merges it
-        # in) or via the `optional_params` shape used by the completion
-        # handler. Either source moves the value into a header and is
-        # removed from the body so SigV4 signs the exact payload that gets
-        # sent.
-        #
-        # Hooking in `sign_request` rather than `validate_environment` /
-        # `transform_request` is what covers the `extra_body` path, because
-        # `BaseLLMHTTPHandler.completion` merges `extra_body` into
-        # `request_data` *after* the other hooks run.
-        model_id = request_data.pop("model_id", None)
-        if model_id is None:
-            model_id = optional_params.pop("model_id", None)
-        else:
-            optional_params.pop("model_id", None)
-        if model_id is not None:
-            headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return self._sign_request(
             service_name="sagemaker",
             headers=headers,

--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -67,6 +67,10 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         # boto3 doc:
         # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html
         model_id = optional_params.pop("model_id", None)
+        # Strip whitespace so a value like " " is treated the same as None:
+        # SageMaker rejects empty / whitespace-only InferenceComponent names.
+        if isinstance(model_id, str):
+            model_id = model_id.strip()
         if model_id:
             headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return headers

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
@@ -64,10 +64,11 @@ class TestSagemakerChatValidateEnvironmentModelId:
         # The empty string is still consumed so it does not leak to the body.
         assert "model_id" not in optional_params
 
-    def test_does_not_clobber_explicit_header(self):
-        """If a caller already passed `X-Amzn-SageMaker-Inference-Component`
-        (e.g. via `extra_headers`), the `model_id`-derived value wins because
-        it is the more recently-specified explicit `model_id` kwarg.
+    def test_model_id_takes_precedence_over_explicit_header(self):
+        """If a caller passes both an explicit
+        `X-Amzn-SageMaker-Inference-Component` header (e.g. via
+        `extra_headers`) and `model_id`, the `model_id`-derived value wins
+        because it is the more recently-specified explicit `model_id` kwarg.
 
         This mirrors the behavior of the legacy `sagemaker` completion handler
         (`prepared_request.headers.update(...)`), which also overwrites any
@@ -77,3 +78,14 @@ class TestSagemakerChatValidateEnvironmentModelId:
         optional_params = {"model_id": "from-model-id"}
         out = self._call(headers, optional_params)
         assert out["X-Amzn-SageMaker-Inference-Component"] == "from-model-id"
+
+    def test_whitespace_only_model_id_is_treated_as_unset(self):
+        """A whitespace-only `model_id` (e.g. `" "`) must not produce a
+        non-empty component header — SageMaker rejects whitespace-only
+        InferenceComponent names."""
+        headers: dict = {}
+        optional_params: dict = {"model_id": "   "}
+        out = self._call(headers, optional_params)
+        assert "X-Amzn-SageMaker-Inference-Component" not in out
+        assert "model_id" not in optional_params
+

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for SageMaker chat transformation (`sagemaker_chat`).
+
+Regression coverage for LIT-2853: `sagemaker_chat` should mirror the legacy
+`sagemaker` completion handler and translate the `model_id` optional param
+into an `X-Amzn-SageMaker-Inference-Component` request header.
+"""
+
+import pytest
+
+from litellm.llms.sagemaker.chat.transformation import SagemakerChatConfig
+
+
+class TestSagemakerChatValidateEnvironmentModelId:
+    def setup_method(self):
+        self.config = SagemakerChatConfig()
+
+    def _call(self, headers, optional_params):
+        return self.config.validate_environment(
+            headers=headers,
+            model="dummy-endpoint",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={},
+            api_key=None,
+            api_base=None,
+        )
+
+    def test_model_id_added_as_inference_component_header(self):
+        """When `model_id` is set on optional_params, the SageMaker
+        InferenceComponent header should be injected."""
+        headers: dict = {}
+        optional_params: dict = {"model_id": "my-component-1"}
+        out = self._call(headers, optional_params)
+        assert out["X-Amzn-SageMaker-Inference-Component"] == "my-component-1"
+        # And it should be popped so it does not leak into the request body
+        # via OpenAIGPTConfig.transform_request's **optional_params spread.
+        assert "model_id" not in optional_params
+
+    def test_no_model_id_means_no_inference_component_header(self):
+        """When `model_id` is not set, the SageMaker InferenceComponent header
+        must not be present."""
+        headers: dict = {}
+        optional_params: dict = {}
+        out = self._call(headers, optional_params)
+        assert "X-Amzn-SageMaker-Inference-Component" not in out
+
+    def test_preserves_existing_headers(self):
+        """Existing headers should not be dropped when injecting the
+        InferenceComponent header."""
+        headers = {"X-Custom-Header": "foo"}
+        optional_params = {"model_id": "comp-42"}
+        out = self._call(headers, optional_params)
+        assert out["X-Custom-Header"] == "foo"
+        assert out["X-Amzn-SageMaker-Inference-Component"] == "comp-42"
+
+    def test_empty_string_model_id_is_treated_as_unset(self):
+        """An empty `model_id` is falsy and should not produce a blank
+        component header — SageMaker rejects empty component names."""
+        headers: dict = {}
+        optional_params: dict = {"model_id": ""}
+        out = self._call(headers, optional_params)
+        assert "X-Amzn-SageMaker-Inference-Component" not in out
+        # The empty string is still consumed so it does not leak to the body.
+        assert "model_id" not in optional_params
+
+    def test_does_not_clobber_explicit_header(self):
+        """If a caller already passed `X-Amzn-SageMaker-Inference-Component`
+        (e.g. via `extra_headers`), the `model_id`-derived value wins because
+        it is the more recently-specified explicit `model_id` kwarg.
+
+        This mirrors the behavior of the legacy `sagemaker` completion handler
+        (`prepared_request.headers.update(...)`), which also overwrites any
+        existing entry.
+        """
+        headers = {"X-Amzn-SageMaker-Inference-Component": "from-extra-headers"}
+        optional_params = {"model_id": "from-model-id"}
+        out = self._call(headers, optional_params)
+        assert out["X-Amzn-SageMaker-Inference-Component"] == "from-model-id"


### PR DESCRIPTION
## What

Make `sagemaker_chat` honor `model_id` for SageMaker multi-model (InferenceComponent) endpoints by mirroring the legacy `sagemaker` (completion) handler.

Closes LIT-2853.

## Why

The legacy `sagemaker` completion handler converts the optional `model_id` param into an `X-Amzn-SageMaker-Inference-Component` header before SigV4-signing the request (see `litellm/llms/sagemaker/completion/handler.py:207-211, 287-291, 439-441, 522-526`). Customers can do:

```python
litellm.completion(model="sagemaker/my-endpoint", messages=..., model_id="my-component")
```

and it works against an InferenceComponent-multiplexed endpoint.

The newer `sagemaker_chat` (HF Messages API) path flows through `BaseLLMHTTPHandler.completion` → `SagemakerChatConfig.validate_environment`, which returned `headers` unchanged. Two symptoms:

1. `X-Amzn-SageMaker-Inference-Component` was never set, so customers had to pass `extra_headers={"X-Amzn-SageMaker-Inference-Component": ...}` on every call.
2. If `model_id` *was* passed as a kwarg, `OpenAIGPTConfig.transform_request` would spread it into the JSON body via `**optional_params`, sending a stray `"model_id": "..."` field to the SageMaker container.

## What changed

`litellm/llms/sagemaker/chat/transformation.py`:
- `SagemakerChatConfig.validate_environment` pops `model_id` off `optional_params` and, if truthy, sets the `X-Amzn-SageMaker-Inference-Component` header.
- Because `validate_environment` runs before `transform_request`, popping also prevents `model_id` from leaking into the request body.
- Mirrors the completion handler's existing `prepared_request.headers.update({"X-Amzn-SageMaker-Inference-Component": model_id})`.

`tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py` (new): 5 unit tests covering header injection, no-op when unset, empty-string treated as unset, header preservation for unrelated keys, and `model_id` taking precedence over a caller-supplied `X-Amzn-SageMaker-Inference-Component`.

## Evidence

Runtime repro against a Flask echo upstream that captures incoming headers and body:

```python
litellm.completion(
    model="sagemaker_chat/dummy-endpoint",
    messages=[{"role":"user","content":"hi"}],
    sagemaker_base_url="http://127.0.0.1:876X/endpoints/dummy-endpoint/invocations",
    model_id="my-component-1",
    aws_region_name="us-east-1",
    aws_access_key_id="AKIAFAKE", aws_secret_access_key="FAKE",
)
```

### Before (clean `litellm_oss_agent_shin_daily_branch`)

```text
received_headers:
  Host: 127.0.0.1:8766
  User-Agent: litellm/1.87.0
  Content-Type: application/json
  X-Amz-Date: 20260527T041652Z
  Authorization: AWS4-HMAC-SHA256 Credential=AKIAFAKE/.../sagemaker/aws4_request,
                 SignedHeaders=content-type;host;x-amz-date,
                 Signature=d87dcea0...
  Content-Length: 288
received_body: {"model":"dummy-endpoint","messages":[...],"sagemaker_base_url":...,
                "model_id":"my-component-1",   <-- leaks into body
                "aws_region_name":"us-east-1","aws_access_key_id":"AKIAFAKE",...}
```

No `X-Amzn-SageMaker-Inference-Component` header. `model_id` ends up in body. SignedHeaders does not include the component header.

### After (with this PR)

```text
received_headers:
  Host: 127.0.0.1:8765
  User-Agent: litellm/1.87.0
  Content-Type: application/json
  X-Amzn-Sagemaker-Inference-Component: my-component-1    <-- now set
  X-Amz-Date: 20260527T041636Z
  Authorization: AWS4-HMAC-SHA256 Credential=AKIAFAKE/.../sagemaker/aws4_request,
                 SignedHeaders=content-type;host;x-amz-date;x-amzn-sagemaker-inference-component,  <-- signed
                 Signature=36f9a104...
  Content-Length: 258
received_body: {"model":"dummy-endpoint","messages":[...],"sagemaker_base_url":...,
                "aws_region_name":"us-east-1","aws_access_key_id":"AKIAFAKE",...}
                # no model_id in body
```

Component header is now present, SigV4-signed (signed-headers list includes `x-amzn-sagemaker-inference-component`), and `model_id` no longer appears in the body. Content-Length drops 288 → 258 accordingly.

### Unit tests

```
$ python3 -m pytest tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py -v
TestSagemakerChatValidateEnvironmentModelId::test_does_not_clobber_explicit_header PASSED
TestSagemakerChatValidateEnvironmentModelId::test_empty_string_model_id_is_treated_as_unset PASSED
TestSagemakerChatValidateEnvironmentModelId::test_model_id_added_as_inference_component_header PASSED
TestSagemakerChatValidateEnvironmentModelId::test_no_model_id_means_no_inference_component_header PASSED
TestSagemakerChatValidateEnvironmentModelId::test_preserves_existing_headers PASSED
============================== 5 passed in 0.76s ===============================

$ python3 -m pytest tests/test_litellm/llms/sagemaker/ -q
============================== 72 passed in 9.74s ==============================
```

## Notes

- PR pushed via GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`) because the agent token does not carry `repo`/`workflow` scopes — the merge-base diff may look noisier than a normal `git push` but the only file changes are the two listed in the PR diff.
- Scope is intentionally narrow. The body-leak of `aws_*` kwargs into the JSON request is a separate, pre-existing issue and is left for follow-up.

Agent session: https://litellm-agent-platform.onrender.com/sessions/54f7aeae-01f4-43fe-9038-86431bac132e


### Verification (ship-pr)

| Check | Result |
|---|---|
| Base branch | `litellm_oss_agent_shin_daily_branch` ✅ |
| Scope | Only `litellm/llms/sagemaker/chat/transformation.py` (+11) and the new test file (+79). No unrelated changes. |
| Runtime evidence | Captured BEFORE + AFTER request headers from a Flask echo upstream (inline above). Header before = absent, header after = present and SigV4-signed; `model_id` removed from body. |
| Unit tests | 6/6 new tests pass; broader SageMaker suite (72 tests) green locally. |
| Greptile | 5/5 — "Safe to merge". |
| Veria AI | success — "No security issues found". |
| GitHub Actions | 44/44 green. |
| Secret leakage | Repro uses `AKIAFAKE` / `FAKE` placeholder credentials only; no real secrets in PR body or commits. |
