### PR TITLE
feat(proxy/auth): configurable EXPERIMENTAL_UI_LOGIN session duration (LIT-2394)

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1458,7 +1458,9 @@ LITELLM_UI_SESSION_DURATION = os.getenv("LITELLM_UI_SESSION_DURATION", "24h")
 # Duration for the EXPERIMENTAL_UI_LOGIN flow. Same format as LITELLM_UI_SESSION_DURATION ("10m", "1h", "2h", etc.).
 # Defaults to 10 minutes to preserve the historical short-lived security default; operators can extend session
 # length without touching the standard UI login flow. Malformed or non-positive values fall back to 10 minutes.
-EXPERIMENTAL_UI_LOGIN_SESSION_DURATION = os.getenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", "10m")
+EXPERIMENTAL_UI_LOGIN_SESSION_DURATION = os.getenv(
+    "EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", "10m"
+)
 EXPERIMENTAL_UI_LOGIN_SESSION_DURATION_FALLBACK_SECONDS = 600  # 10 minutes
 
 ########################### DB CRON JOB NAMES ###########################

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1452,8 +1452,14 @@ CLI_SSO_CLAIM_MAX_SCALAR_LENGTH = 1024
 
 ########################### UI SESSION DURATION ###########################
 # Duration for UI login session (username/password, SSO, invitation links). Format: "30s", "30m", "24h", "7d"
-# Does NOT apply to EXPERIMENTAL_UI_LOGIN flow, which intentionally uses a fixed 10-minute expiry for security.
+# Does NOT apply to EXPERIMENTAL_UI_LOGIN flow, which has its own configurable duration below.
 LITELLM_UI_SESSION_DURATION = os.getenv("LITELLM_UI_SESSION_DURATION", "24h")
+
+# Duration for the EXPERIMENTAL_UI_LOGIN flow. Same format as LITELLM_UI_SESSION_DURATION ("10m", "1h", "2h", etc.).
+# Defaults to 10 minutes to preserve the historical short-lived security default; operators can extend session
+# length without touching the standard UI login flow. Malformed or non-positive values fall back to 10 minutes.
+EXPERIMENTAL_UI_LOGIN_SESSION_DURATION = os.getenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", "10m")
+EXPERIMENTAL_UI_LOGIN_SESSION_DURATION_FALLBACK_SECONDS = 600  # 10 minutes
 
 ########################### DB CRON JOB NAMES ###########################
 DB_SPEND_UPDATE_JOB_NAME = "db_spend_update_job"

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1765,18 +1765,38 @@ async def _cache_team_object(
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: Optional[ProxyLogging],
 ):
-    key = "team_id:{}".format(team_id)
-
     ## CACHE REFRESH TIME!
     team_table.last_refreshed_at = time.time()
 
+    # team_id is the table primary key — guaranteed unique, safe to write.
     await _cache_management_object(
-        key=key,
+        key="team_id:{}".format(team_id),
         value=team_table,
         user_api_key_cache=user_api_key_cache,
         proxy_logging_obj=proxy_logging_obj,
         model_type=LiteLLM_TeamTableCachedObj,
     )
+
+    # Invalidate the alias-keyed cache so the JWT auth path with
+    # `team_alias_jwt_field` (which reads via `get_team_object_by_alias`)
+    # doesn't keep serving the pre-mutation team after every team-write
+    # endpoint (team_model_add, team_model_delete, update_team, etc.).
+    #
+    # Why DELETE and not WRITE: `team_alias` has no UNIQUE constraint in
+    # schema.prisma. Writing this cache from the generic refresh path
+    # would let a team admin who renamed their team to collide with
+    # another team's alias silently overwrite the cached team for
+    # JWT-by-alias auth (veria-ai review on #28739). Deleting forces the
+    # next reader through `get_team_object_by_alias`, which DOES enforce
+    # uniqueness (len(teams) > 1 raises HTTPException) before populating
+    # the cache from a verified single row.
+    if team_table.team_alias:
+        alias_key = "team_alias:{}".format(team_table.team_alias)
+        user_api_key_cache.delete_cache(key=alias_key)
+        if proxy_logging_obj is not None:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(
+                key=alias_key
+            )
 
 
 async def _cache_key_object(
@@ -2319,6 +2339,39 @@ async def get_org_object_by_alias(
 
 class ExperimentalUIJWTToken:
     @staticmethod
+    def _get_experimental_ui_session_seconds() -> int:
+        """Resolve the EXPERIMENTAL_UI_LOGIN session duration in seconds.
+
+        Reads ``litellm.constants.EXPERIMENTAL_UI_LOGIN_SESSION_DURATION`` (sourced from the
+        ``EXPERIMENTAL_UI_LOGIN_SESSION_DURATION`` env var) and parses it with
+        :func:`duration_in_seconds`. On any parsing error (empty, missing/unknown unit, etc.)
+        or non-positive result, falls back to the historical 10-minute default so a typo in
+        operator config never produces an unbounded session.
+        """
+        from litellm import constants as _constants
+        from litellm.litellm_core_utils.duration_parser import duration_in_seconds
+
+        raw = getattr(
+            _constants,
+            "EXPERIMENTAL_UI_LOGIN_SESSION_DURATION",
+            None,
+        )
+        fallback = getattr(
+            _constants,
+            "EXPERIMENTAL_UI_LOGIN_SESSION_DURATION_FALLBACK_SECONDS",
+            600,
+        )
+        if not raw or not isinstance(raw, str):
+            return fallback
+        try:
+            seconds = duration_in_seconds(raw)
+        except (ValueError, AttributeError):
+            return fallback
+        if seconds <= 0:
+            return fallback
+        return seconds
+
+    @staticmethod
     def get_experimental_ui_login_jwt_auth_token(user_info: LiteLLM_UserTable) -> str:
         from datetime import timedelta
 
@@ -2329,8 +2382,10 @@ class ExperimentalUIJWTToken:
         if user_info.user_role is None:
             raise Exception("User role is required for experimental UI login")
 
-        # Experimental UI flow uses fixed 10-min expiry for security (does not use LITELLM_UI_SESSION_DURATION)
-        expiration_time = get_utc_datetime() + timedelta(minutes=10)
+        # Experimental UI flow uses its own session-duration env var (does not use LITELLM_UI_SESSION_DURATION).
+        # Defaults to 10 minutes for backwards compatibility / security. Malformed values fall back to 10 min.
+        expiration_seconds = ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        expiration_time = get_utc_datetime() + timedelta(seconds=expiration_seconds)
 
         # Format the expiration time as ISO 8601 string
         expires = expiration_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+00:00"
@@ -3143,44 +3198,40 @@ async def can_team_access_model(
         raise
 
 
-async def _key_access_group_grants_model(
-    model: Union[str, List[str]],
+async def get_authorized_resources_from_key_access_groups(
     valid_token: Optional[UserAPIKeyAuth],
     team_object: Optional[LiteLLM_TeamTable],
-    llm_router: Optional[Router],
-) -> bool:
+    resource_field: Literal[
+        "access_model_names", "access_mcp_server_ids", "access_agent_ids"
+    ],
+) -> List[str]:
     """
-    Returns True if the key's `access_group_ids` expand to models that grant
-    access to `model`. Used to let a key's access group override a team's
-    model restriction in `common_checks`.
-
-    A key's access group only counts if the access group itself authorizes the
-    caller as an owner — that is, the group's `assigned_team_ids` includes the
-    key's `team_id`, or the group's `assigned_key_ids` includes the key's
-    token. This preserves the team-as-owner boundary (a team member cannot
-    escalate by naming a group assigned to a different team) while still
-    letting a group reach the key without first being added to the team's
-    `access_group_ids` list.
+    For each access_group_id on the key, fetch the LiteLLM_AccessGroupTable row
+    and contribute its `resource_field` only if the group authorizes the caller
+    as an owner — that is, the group's `assigned_team_ids` includes the key's
+    `team_id`, or the group's `assigned_key_ids` includes the key's token. This
+    preserves the team-as-owner boundary while still letting a group reach the
+    key without first being added to the team's `access_group_ids` list.
     """
     if valid_token is None:
-        return False
+        return []
     key_access_group_ids = list(valid_token.access_group_ids or [])
     if not key_access_group_ids:
-        return False
+        return []
 
     from litellm.proxy.proxy_server import prisma_client as _prisma_client
     from litellm.proxy.proxy_server import proxy_logging_obj as _proxy_logging_obj
     from litellm.proxy.proxy_server import user_api_key_cache as _user_api_key_cache
 
     if _prisma_client is None or _user_api_key_cache is None:
-        return False
+        return []
 
     key_team_id = valid_token.team_id or (
         team_object.team_id if team_object is not None else None
     )
     key_token = valid_token.token
 
-    authorized_models: List[str] = []
+    authorized_resources: List[str] = []
     for ag_id in key_access_group_ids:
         try:
             ag = await get_access_object(
@@ -3196,17 +3247,36 @@ async def _key_access_group_grants_model(
         )
         key_authorized = bool(key_token and key_token in (ag.assigned_key_ids or []))
         if team_authorized or key_authorized:
-            authorized_models.extend(ag.access_model_names or [])
+            authorized_resources.extend(getattr(ag, resource_field, []) or [])
 
+    return list(set(authorized_resources))
+
+
+async def _key_access_group_grants_model(
+    model: Union[str, List[str]],
+    valid_token: Optional[UserAPIKeyAuth],
+    team_object: Optional[LiteLLM_TeamTable],
+    llm_router: Optional[Router],
+) -> bool:
+    """
+    Returns True if the key's `access_group_ids` expand to models that grant
+    access to `model`. Used to let a key's access group override a team's
+    model restriction in `common_checks`.
+    """
+    authorized_models = await get_authorized_resources_from_key_access_groups(
+        valid_token=valid_token,
+        team_object=team_object,
+        resource_field="access_model_names",
+    )
     if not authorized_models:
         return False
     try:
         _can_object_call_model(
             model=model,
             llm_router=llm_router,
-            models=list(set(authorized_models)),
-            team_model_aliases=valid_token.team_model_aliases,
-            team_id=valid_token.team_id,
+            models=authorized_models,
+            team_model_aliases=valid_token.team_model_aliases if valid_token else None,
+            team_id=valid_token.team_id if valid_token else None,
             object_type="key",
         )
         return True

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2384,7 +2384,9 @@ class ExperimentalUIJWTToken:
 
         # Experimental UI flow uses its own session-duration env var (does not use LITELLM_UI_SESSION_DURATION).
         # Defaults to 10 minutes for backwards compatibility / security. Malformed values fall back to 10 min.
-        expiration_seconds = ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        expiration_seconds = (
+            ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        )
         expiration_time = get_utc_datetime() + timedelta(seconds=expiration_seconds)
 
         # Format the expiration time as ISO 8601 string

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3370,3 +3370,220 @@ async def test_resolve_end_user_reraises_budget_exceeded(
             prisma_client=MagicMock(),
             user_api_key_cache=cache,
         )
+
+
+@pytest.mark.asyncio
+async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
+    """
+    Regression pin for LIT-3244 patch/1.86.0 follow-up.
+
+    `_cache_team_object` is the canonical "refresh this team" primitive.
+    Two cache keys are in play:
+      - "team_id:<id>"    — used by `get_team_object(team_id=...)`,
+                            i.e. API-key auth and JWT-with-team_id_jwt_field
+      - "team_alias:<alias>" — used by `get_team_object_by_alias(team_alias=...)`,
+                               i.e. JWT-with-team_alias_jwt_field
+
+    Invariants this test pins:
+      1. Writes the team_id-keyed entry with the refreshed object (team_id
+         is the table PK — guaranteed unique, safe to write).
+      2. DELETES (does NOT write) the team_alias-keyed entry. `team_alias`
+         has no UNIQUE constraint in schema.prisma, so writing it from
+         this generic refresh path would let a team admin who renames
+         their team to collide with another team's alias silently
+         overwrite the cached team for JWT-by-alias auth (veria-ai
+         review on #28739). Deleting forces the next JWT-by-alias
+         reader through `get_team_object_by_alias`, which enforces
+         len(teams)==1 before populating the cache.
+      3. When team_alias is None, NO alias-key operation happens (no
+         delete of an empty-keyed entry, no spurious write).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+    from litellm.proxy.auth.auth_checks import _cache_team_object
+
+    base_team_row = {
+        "team_id": "team-1234",
+        "team_alias": "H-Capacity",
+        "models": ["openai/*", "bedrock-claude-sonnet-4"],
+    }
+
+    # ===== team_alias is set =====
+    team_table = LiteLLM_TeamTableCachedObj(**base_team_row)
+    cache = MagicMock()
+    cache.async_set_cache = AsyncMock()
+    cache.delete_cache = MagicMock()
+    logging_obj = MagicMock()
+    logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+
+    await _cache_team_object(
+        team_id="team-1234",
+        team_table=team_table,
+        user_api_key_cache=cache,
+        proxy_logging_obj=logging_obj,
+    )
+
+    # (1) team_id-keyed write fires with the refreshed object
+    written_keys = [
+        (c.kwargs.get("key") or c.args[0])
+        for c in cache.async_set_cache.await_args_list
+    ]
+    assert written_keys == ["team_id:team-1234"], (
+        "Only the team_id-keyed write should fire; the alias key must be "
+        "deleted, NOT written. "
+        f"Got writes: {written_keys}"
+    )
+    written_value = (
+        cache.async_set_cache.await_args.kwargs.get("value")
+        or cache.async_set_cache.await_args.args[1]
+    )
+    assert written_value is team_table
+
+    # (2) team_alias-keyed entry is deleted in BOTH the in-memory cache
+    # and the Redis dual cache (mirrors _delete_cache_key_object pattern).
+    cache.delete_cache.assert_called_once_with(key="team_alias:H-Capacity")
+    logging_obj.internal_usage_cache.dual_cache.async_delete_cache.assert_awaited_once_with(
+        key="team_alias:H-Capacity"
+    )
+
+    # ===== team_alias is None: no alias-key operation =====
+    aliasless = LiteLLM_TeamTableCachedObj(**{**base_team_row, "team_alias": None})
+    cache2 = MagicMock()
+    cache2.async_set_cache = AsyncMock()
+    cache2.delete_cache = MagicMock()
+    logging_obj2 = MagicMock()
+    logging_obj2.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+
+    await _cache_team_object(
+        team_id="team-no-alias",
+        team_table=aliasless,
+        user_api_key_cache=cache2,
+        proxy_logging_obj=logging_obj2,
+    )
+
+    cache2.delete_cache.assert_not_called()
+    logging_obj2.internal_usage_cache.dual_cache.async_delete_cache.assert_not_awaited()
+    written_keys_aliasless = [
+        (c.kwargs.get("key") or c.args[0])
+        for c in cache2.async_set_cache.await_args_list
+    ]
+    assert written_keys_aliasless == ["team_id:team-no-alias"]
+
+
+
+def _reload_constants_and_auth_checks():
+    import importlib
+    import litellm.constants as _constants
+    import litellm.proxy.auth.auth_checks as _auth_checks
+    importlib.reload(_constants)
+    importlib.reload(_auth_checks)
+    return _constants, _auth_checks
+
+
+def test_experimental_ui_session_duration_default_is_10_min(
+    valid_sso_user_defined_values, monkeypatch
+):
+    """Default (no env override): expiry remains ~10 minutes."""
+    monkeypatch.delenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", raising=False)
+    _, _auth_checks = _reload_constants_and_auth_checks()
+
+    token = _auth_checks.ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+    expires = datetime.fromisoformat(token_data["expires"].replace("Z", "+00:00"))
+    now = get_utc_datetime()
+    assert expires > now + timedelta(minutes=9)
+    assert expires <= now + timedelta(minutes=10, seconds=2)
+
+
+@pytest.mark.parametrize(
+    "value,expected_minutes",
+    [
+        ("30m", 30),
+        ("1h", 60),
+        ("2h", 120),
+        ("12h", 12 * 60),
+    ],
+)
+def test_experimental_ui_session_duration_env_override_honoured(
+    valid_sso_user_defined_values, monkeypatch, value, expected_minutes
+):
+    """Setting EXPERIMENTAL_UI_LOGIN_SESSION_DURATION extends or shortens session."""
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", value)
+    _, _auth_checks = _reload_constants_and_auth_checks()
+
+    token = _auth_checks.ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+    expires = datetime.fromisoformat(token_data["expires"].replace("Z", "+00:00"))
+    now = get_utc_datetime()
+    assert expires > now + timedelta(minutes=expected_minutes) - timedelta(seconds=5)
+    assert expires <= now + timedelta(minutes=expected_minutes) + timedelta(seconds=5)
+
+
+@pytest.mark.parametrize("bad_value", ["", "abc", "10x", "5", "0m", "0h"])
+def test_experimental_ui_session_duration_invalid_falls_back_to_10_min(
+    valid_sso_user_defined_values, monkeypatch, bad_value
+):
+    """Malformed or non-positive durations fall back to the 10-minute default."""
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", bad_value)
+    _, _auth_checks = _reload_constants_and_auth_checks()
+
+    token = _auth_checks.ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+    expires = datetime.fromisoformat(token_data["expires"].replace("Z", "+00:00"))
+    now = get_utc_datetime()
+    assert expires > now + timedelta(minutes=9), (
+        f"Bad value {bad_value!r} should fall back to 10 min"
+    )
+    assert expires <= now + timedelta(minutes=10, seconds=2), (
+        f"Bad value {bad_value!r} should not extend session"
+    )
+
+
+def test_experimental_ui_session_helper_pure_function(monkeypatch):
+    """Direct unit test of the helper (no token round-trip)."""
+    monkeypatch.delenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", raising=False)
+    _, _auth_checks = _reload_constants_and_auth_checks()
+    assert (
+        _auth_checks.ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        == 600
+    )
+
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", "2h")
+    _, _auth_checks = _reload_constants_and_auth_checks()
+    assert (
+        _auth_checks.ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        == 7200
+    )
+
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", "abc")
+    _, _auth_checks = _reload_constants_and_auth_checks()
+    assert (
+        _auth_checks.ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        == 600
+    )
+
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN_SESSION_DURATION", "0s")
+    _, _auth_checks = _reload_constants_and_auth_checks()
+    assert (
+        _auth_checks.ExperimentalUIJWTToken._get_experimental_ui_session_seconds()
+        == 600
+    )


### PR DESCRIPTION
## Summary

LiteLLM customers (Moon Active, LIT-2394) report that the **experimental UI login** flow times out after ~10 minutes and there is no knob to extend it. The standard UI login flow already has `LITELLM_UI_SESSION_DURATION`, but it intentionally does not affect the experimental flow.

This PR adds a parallel knob:

```
EXPERIMENTAL_UI_LOGIN_SESSION_DURATION=10m   # default (unchanged behaviour)
EXPERIMENTAL_UI_LOGIN_SESSION_DURATION=2h    # extend session length
EXPERIMENTAL_UI_LOGIN_SESSION_DURATION=12h
```

* **Default stays at 10 minutes** — backwards compatible / preserves the existing security default. The regression test `test_experimental_ui_token_ignores_litellm_ui_session_duration` still passes.
* Same `<num><unit>` format (`30m`, `1h`, `2h`, `12h`, etc.) as `LITELLM_UI_SESSION_DURATION`, parsed by the existing `duration_in_seconds()` helper.
* **Malformed or non-positive values fall back to 10 minutes** so a typo in operator config never produces an unbounded session.

## Files

| File | Change |
|------|--------|
| `litellm/constants.py` | Add `EXPERIMENTAL_UI_LOGIN_SESSION_DURATION` (default `"10m"`) and a fallback-seconds constant. |
| `litellm/proxy/auth/auth_checks.py` | New `ExperimentalUIJWTToken._get_experimental_ui_session_seconds()` helper; the existing `get_experimental_ui_login_jwt_auth_token()` now uses it instead of a hard-coded `timedelta(minutes=10)`. |
| `tests/test_litellm/proxy/auth/test_auth_checks.py` | +12 new tests (default, 4 parametrized overrides, 6 parametrized invalid values, plus a pure-function helper test). |

## Evidence

Runtime evidence captured by driving `ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token()` and decrypting the JWT `expires` claim under various `EXPERIMENTAL_UI_LOGIN_SESSION_DURATION` values, on **clean main** (before) and **this branch** (after).

**Before — main, no fix:**
```
LIT-2394 runtime evidence — JWT 'expires' claim from ExperimentalUIJWTToken
  default (no env)                 env=None       expires_in=   592s (   9.9 min)
  30 minutes                       env='30m'      expires_in=   598s (  10.0 min)
  1 hour                           env='1h'       expires_in=   598s (  10.0 min)
  2 hours                          env='2h'       expires_in=   597s (   9.9 min)
  12 hours                         env='12h'      expires_in=   596s (   9.9 min)
  malformed 'abc'                  env='abc'      expires_in=   597s (   9.9 min)
  zero '0s'                        env='0s'       expires_in=   598s (  10.0 min)
```
→ env var has zero effect; the call uses hard-coded `timedelta(minutes=10)`.

**After — this branch:**
```
LIT-2394 runtime evidence — JWT 'expires' claim from ExperimentalUIJWTToken
  default (no env)                 env=None       expires_in=   592s (   9.9 min)
  30 minutes                       env='30m'      expires_in=  1798s (  30.0 min)
  1 hour                           env='1h'       expires_in=  3598s (  60.0 min)
  2 hours                          env='2h'       expires_in=  7196s ( 119.9 min)
  12 hours                         env='12h'      expires_in= 43196s ( 719.9 min)
  malformed 'abc'                  env='abc'      expires_in=   597s (   9.9 min)
  zero '0s'                        env='0s'       expires_in=   598s (  10.0 min)
```
→ env var honoured; default and malformed/zero stay at 10 min.

**Unit tests:** `144 passed in 13.87s` on `tests/test_litellm/proxy/auth/test_auth_checks.py`. The 12 new tests live alongside the existing experimental-UI tests; all 16 experimental-UI tests pass:
```
$ pytest tests/test_litellm/proxy/auth/test_auth_checks.py -k experimental_ui -q
................                                                         [100%]
16 passed, 128 deselected in 10.38s
```

## Note on the upload mechanism

The agent's `GITHUB_TOKEN` lacks the `repo` scope needed for `git push`, so this branch was created via the GitHub Contents API (`PUT /repos/{owner}/{repo}/contents/{path}`). Each file is therefore one commit; reviewers should expect a slightly noisier merge-base diff but the file deltas are identical to what `git diff origin/litellm_oss_agent_shin_daily_branch` would show.

Closes LIT-2394 (Moon Active — Add configurable UI session timeout for experimental login flow).

Agent session: https://litellm-agent-platform.onrender.com/sessions/3838a0ed-6786-40b9-982e-605ddbeda123


---

### Verification (ship-pr)

| Check | Status | Notes |
|---|---|---|
| Runtime evidence captured (before + after) | ✅ | Decrypted JWT `expires` claim observed under 7 env-var configurations. Hard-coded `10m` BEFORE → tracking env value AFTER. |
| Unit tests added | ✅ | +12 new tests in `tests/test_litellm/proxy/auth/test_auth_checks.py`; `144 passed` in the file. |
| Existing tests unchanged | ✅ | Regression `test_experimental_ui_token_ignores_litellm_ui_session_duration` still passes — the two env vars remain independent. |
| Default behaviour unchanged | ✅ | Default `EXPERIMENTAL_UI_LOGIN_SESSION_DURATION="10m"` → identical expiry to old hard-coded path. |
| Malformed input safe | ✅ | `"abc"`, `"10x"`, `"5"` (no unit), `"0m"`, `"0h"`, `""` all fall back to 10 min — no unbounded sessions. |
| Greptile score | ✅ | **4/5 — "Safe to merge"** |
| Veria | ⏳ | Still in progress at time of writing |
| GitHub Actions | ⚠️ | All green except `documentation` + `code-quality`, both red because `EXPERIMENTAL_UI_LOGIN_SESSION_DURATION` is not in `docs/proxy/config_settings.md`. Companion docs PR is up: https://github.com/BerriAI/litellm-docs/pull/233 — once that lands these two checks pass on the next rerun. |
| Lint (black --check) | ✅ | Passed after `style: run black` follow-up commits. |
| Push mechanism | ℹ️ | Token lacks `repo` scope, so branch was created via the GitHub Contents API (one commit per file). Merge-base diff is slightly noisier than a normal squash; the per-file deltas are unchanged. |
