### PR TITLE
fix(sagemaker_chat): inject InferenceComponent header from model_id

### DIFF
--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -58,6 +58,21 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
+        # SageMaker multi-model endpoints with InferenceComponents accept the
+        # component name via the X-Amzn-SageMaker-Inference-Component header.
+        # The legacy `sagemaker` completion handler does this in
+        # `litellm/llms/sagemaker/completion/handler.py`; mirror the behavior
+        # here so callers can pass `model_id=...` directly to
+        # `sagemaker_chat/...` without manually adding `extra_headers`.
+        # boto3 doc:
+        # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html
+        model_id = optional_params.pop("model_id", None)
+        # Strip whitespace so a value like " " is treated the same as None:
+        # SageMaker rejects empty / whitespace-only InferenceComponent names.
+        if isinstance(model_id, str):
+            model_id = model_id.strip()
+        if model_id:
+            headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return headers
 
     def get_complete_url(
@@ -98,6 +113,29 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         stream: Optional[bool] = None,
         fake_stream: Optional[bool] = None,
     ) -> Tuple[dict, Optional[bytes]]:
+        # SageMaker endpoints that host multiple Inference Components require
+        # the `X-Amzn-SageMaker-Inference-Component` header (legacy
+        # `sagemaker` completion handler injects it from
+        # `optional_params["model_id"]` -- see
+        # `litellm/llms/sagemaker/completion/handler.py`). We mirror that
+        # here so callers can pass `model_id` either via `extra_body` (which
+        # lands in `request_data` after the BaseLLMHTTPHandler merges it
+        # in) or via the `optional_params` shape used by the completion
+        # handler. Either source moves the value into a header and is
+        # removed from the body so SigV4 signs the exact payload that gets
+        # sent.
+        #
+        # Hooking in `sign_request` rather than `validate_environment` /
+        # `transform_request` is what covers the `extra_body` path, because
+        # `BaseLLMHTTPHandler.completion` merges `extra_body` into
+        # `request_data` *after* the other hooks run.
+        model_id = request_data.pop("model_id", None)
+        if model_id is None:
+            model_id = optional_params.pop("model_id", None)
+        else:
+            optional_params.pop("model_id", None)
+        if model_id is not None:
+            headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return self._sign_request(
             service_name="sagemaker",
             headers=headers,

--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -134,7 +134,14 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
             model_id = optional_params.pop("model_id", None)
         else:
             optional_params.pop("model_id", None)
-        if model_id is not None:
+        # Mirror the same strip-and-truthiness guard `validate_environment`
+        # applies: SageMaker rejects empty / whitespace-only
+        # InferenceComponent names, so a value like " " should be treated
+        # the same as None regardless of which call shape supplied it
+        # (`extra_body` vs `optional_params`).
+        if isinstance(model_id, str):
+            model_id = model_id.strip()
+        if model_id:
             headers["X-Amzn-SageMaker-Inference-Component"] = model_id
         return self._sign_request(
             service_name="sagemaker",

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
@@ -189,3 +189,83 @@ def test_sign_request_request_data_wins_over_optional_params():
     assert out_headers["X-Amzn-SageMaker-Inference-Component"] == "component-from-extra-body"
     assert "model_id" not in request_data
     assert "model_id" not in optional_params
+
+
+
+# ----------------------------------------------------------------------
+# Whitespace / empty-string handling (parity between both hooks)
+# ----------------------------------------------------------------------
+
+
+def test_validate_env_whitespace_model_id_is_ignored():
+    """Whitespace-only ``model_id`` is treated the same as absent: no header
+    is added, and the key is popped so it cannot leak into the body."""
+    config = SagemakerChatConfig()
+    optional_params = {"model_id": "   "}
+    out = config.validate_environment(
+        headers={},
+        model="my-endpoint",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+    )
+    assert "X-Amzn-SageMaker-Inference-Component" not in out
+    assert "model_id" not in optional_params
+
+
+def test_validate_env_model_id_is_trimmed():
+    """Surrounding whitespace is trimmed before the header is written."""
+    config = SagemakerChatConfig()
+    optional_params = {"model_id": "  component-trim  "}
+    out = config.validate_environment(
+        headers={},
+        model="my-endpoint",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+    )
+    assert out["X-Amzn-SageMaker-Inference-Component"] == "component-trim"
+
+
+def test_sign_request_whitespace_model_id_in_request_data_is_ignored():
+    """Whitespace-only ``model_id`` arriving via ``extra_body`` -> ``request_data``
+    is treated the same as absent: no header is added and ``request_data``
+    keeps its other fields intact (with ``model_id`` removed)."""
+    config = SagemakerChatConfig()
+    request_data = {
+        "model": "my-endpoint",
+        "messages": [],
+        "model_id": "   ",
+    }
+    optional_params = {}
+    with patch.object(SagemakerChatConfig, "_sign_request", _stub_sign_passthrough):
+        out_headers, _ = config.sign_request(
+            headers={},
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base="https://example/endpoints/my-endpoint/invocations",
+        )
+    assert "X-Amzn-SageMaker-Inference-Component" not in out_headers
+    assert "model_id" not in request_data
+    assert request_data == {"model": "my-endpoint", "messages": []}
+
+
+def test_sign_request_model_id_in_request_data_is_trimmed():
+    """Surrounding whitespace on the ``extra_body`` ``model_id`` is trimmed
+    before being written to the header."""
+    config = SagemakerChatConfig()
+    request_data = {
+        "model": "my-endpoint",
+        "messages": [],
+        "model_id": "  component-trim  ",
+    }
+    optional_params = {}
+    with patch.object(SagemakerChatConfig, "_sign_request", _stub_sign_passthrough):
+        out_headers, _ = config.sign_request(
+            headers={},
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base="https://example/endpoints/my-endpoint/invocations",
+        )
+    assert out_headers["X-Amzn-SageMaker-Inference-Component"] == "component-trim"
+    assert "model_id" not in request_data

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
@@ -1,0 +1,191 @@
+"""Tests for ``SagemakerChatConfig`` Inference Component header injection
+(Linear LIT-2853).
+
+Bug: ``sagemaker_chat`` did not honor ``model_id`` the way the legacy
+``sagemaker`` (completion) handler does, so callers targeting a SageMaker
+endpoint that hosts multiple Inference Components had to pass
+``extra_headers={"X-Amzn-SageMaker-Inference-Component": ...}`` by hand. The
+fix moves ``model_id`` from either ``optional_params`` (in
+``validate_environment``) or the merged ``request_data`` (in
+``sign_request``) into the ``X-Amzn-SageMaker-Inference-Component`` header so
+the behavior matches the completion path.
+
+We exercise both hooks so a regression in either call shape (``model_id``
+arriving via ``optional_params`` vs. via ``extra_body``) is caught.
+"""
+from unittest.mock import patch
+
+from litellm.llms.sagemaker.chat.transformation import SagemakerChatConfig
+
+
+# ----------------------------------------------------------------------
+# validate_environment path (model_id arrives via optional_params)
+# ----------------------------------------------------------------------
+
+
+def test_validate_env_model_id_added_as_inference_component_header():
+    """When ``model_id`` is in ``optional_params``, ``validate_environment``
+    moves it into the SageMaker Inference Component header and removes it
+    from ``optional_params`` so it does not also leak into the request body
+    via ``transform_request`` (which spreads ``**optional_params``)."""
+    config = SagemakerChatConfig()
+    optional_params = {"model_id": "claude-multi-tenant-1", "temperature": 0.5}
+    headers = {"Content-Type": "application/json"}
+    out = config.validate_environment(
+        headers=headers,
+        model="my-endpoint",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+    )
+    assert out["X-Amzn-SageMaker-Inference-Component"] == "claude-multi-tenant-1"
+    assert out["Content-Type"] == "application/json"
+    assert "model_id" not in optional_params
+    assert optional_params == {"temperature": 0.5}
+
+
+def test_validate_env_no_model_id_no_header_added():
+    config = SagemakerChatConfig()
+    optional_params = {"temperature": 0.5}
+    headers = {"Content-Type": "application/json"}
+    out = config.validate_environment(
+        headers=headers,
+        model="my-endpoint",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+    )
+    assert "X-Amzn-SageMaker-Inference-Component" not in out
+    assert out == headers
+    assert optional_params == {"temperature": 0.5}
+
+
+def test_validate_env_model_id_none_no_header_added():
+    """An explicit ``model_id=None`` is treated the same as absent (no
+    header is injected) but is still popped so the key cannot leak."""
+    config = SagemakerChatConfig()
+    optional_params = {"model_id": None, "temperature": 0.5}
+    out = config.validate_environment(
+        headers={},
+        model="my-endpoint",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+    )
+    assert "X-Amzn-SageMaker-Inference-Component" not in out
+    assert "model_id" not in optional_params
+
+
+# ----------------------------------------------------------------------
+# sign_request path (model_id arrives via extra_body -> request_data)
+# ----------------------------------------------------------------------
+
+
+def _stub_sign_passthrough(self, **kwargs):
+    """Replace `_sign_request` with a no-op SigV4 stub so the
+    `sign_request` tests don't need real AWS credentials."""
+    return kwargs["headers"], None
+
+
+def test_sign_request_model_id_in_request_data_moves_to_header():
+    """When ``model_id`` lives in ``request_data`` (which happens when the
+    caller passes ``extra_body={"model_id": ...}`` -- ``BaseLLMHTTPHandler``
+    merges ``extra_body`` into the request body *after* ``transform_request``
+    runs), ``sign_request`` moves it into the header and pops it from the
+    body so SigV4 signs the right payload."""
+    config = SagemakerChatConfig()
+    headers = {"Content-Type": "application/json"}
+    request_data = {
+        "model": "my-endpoint",
+        "messages": [{"role": "user", "content": "hi"}],
+        "model_id": "component-from-extra-body",
+    }
+    optional_params = {}
+
+    with patch.object(
+        SagemakerChatConfig, "_sign_request", _stub_sign_passthrough
+    ):
+        out_headers, signed = config.sign_request(
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base="https://example/endpoints/my-endpoint/invocations",
+        )
+
+    assert out_headers["X-Amzn-SageMaker-Inference-Component"] == "component-from-extra-body"
+    assert "model_id" not in request_data
+    assert request_data["model"] == "my-endpoint"
+    assert request_data["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_sign_request_model_id_in_optional_params_moves_to_header():
+    """``sign_request`` also handles the ``optional_params`` shape (defense
+    in depth)."""
+    config = SagemakerChatConfig()
+    headers = {}
+    request_data = {"model": "my-endpoint", "messages": []}
+    optional_params = {"model_id": "component-from-optional-params"}
+
+    with patch.object(
+        SagemakerChatConfig, "_sign_request", _stub_sign_passthrough
+    ):
+        out_headers, _ = config.sign_request(
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base="https://example/endpoints/my-endpoint/invocations",
+        )
+
+    assert out_headers["X-Amzn-SageMaker-Inference-Component"] == "component-from-optional-params"
+    assert "model_id" not in optional_params
+
+
+def test_sign_request_no_model_id_no_header():
+    """When no ``model_id`` is present in either shape, no header is added
+    and the body is forwarded unchanged."""
+    config = SagemakerChatConfig()
+    headers = {}
+    request_data = {"model": "my-endpoint", "messages": []}
+    optional_params = {}
+
+    with patch.object(
+        SagemakerChatConfig, "_sign_request", _stub_sign_passthrough
+    ):
+        out_headers, _ = config.sign_request(
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base="https://example/endpoints/my-endpoint/invocations",
+        )
+
+    assert "X-Amzn-SageMaker-Inference-Component" not in out_headers
+    assert request_data == {"model": "my-endpoint", "messages": []}
+
+
+def test_sign_request_request_data_wins_over_optional_params():
+    """If ``model_id`` is present in BOTH ``request_data`` (from
+    ``extra_body``) AND ``optional_params``, ``request_data`` wins -- it is
+    the more specific, last-set source ahead of signing -- and the key is
+    cleaned out of both."""
+    config = SagemakerChatConfig()
+    headers = {}
+    request_data = {
+        "model": "my-endpoint",
+        "messages": [],
+        "model_id": "component-from-extra-body",
+    }
+    optional_params = {"model_id": "component-from-optional-params"}
+
+    with patch.object(
+        SagemakerChatConfig, "_sign_request", _stub_sign_passthrough
+    ):
+        out_headers, _ = config.sign_request(
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base="https://example/endpoints/my-endpoint/invocations",
+        )
+
+    assert out_headers["X-Amzn-SageMaker-Inference-Component"] == "component-from-extra-body"
+    assert "model_id" not in request_data
+    assert "model_id" not in optional_params


### PR DESCRIPTION
## Summary

Fixes Linear LIT-2853: `sagemaker_chat` (the HF Messages API path on SageMaker) silently ignored `model_id` for SageMaker endpoints that host multiple Inference Components, forcing callers to manually set
`extra_headers={"X-Amzn-SageMaker-Inference-Component": "..."}` on every call. The legacy `sagemaker` (completion) handler converts `model_id` to that header automatically — see [`litellm/llms/sagemaker/completion/handler.py:207-211`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/sagemaker/completion/handler.py#L207-L211) — and `sagemaker_chat` did not.

This PR makes `sagemaker_chat` honor the same `model_id` → `X-Amzn-SageMaker-Inference-Component` convention for both call shapes (`extra_body={"model_id": ...}` and the legacy `optional_params` shape).

## Root cause

`sagemaker_chat` flows through `BaseLLMHTTPHandler.completion` → `SagemakerChatConfig.{validate_environment, get_complete_url, transform_request, sign_request}`. On `main`, `SagemakerChatConfig.validate_environment` was a no-op (`return headers`) and the model-id-to-header conversion never happened.

The flow also has a subtlety: `BaseLLMHTTPHandler.completion` pops `extra_body` from optional_params and then **merges it into `request_data` after `transform_request` runs** ([`litellm/llms/custom_httpx/llm_http_handler.py`](https://github.com/BerriAI/litellm/blob/main/litellm/llms/custom_httpx/llm_http_handler.py)):

```python
data = provider_config.transform_request(...)
if extra_body is not None:
    data = {**data, **extra_body}
headers, signed_json_body = provider_config.sign_request(headers, optional_params, data, ...)
```

So when the customer passes `extra_body={"model_id": "..."}`, `model_id` arrives in `request_data` — not `optional_params` — by the time `sign_request` runs. To cover both call shapes, the model-id-to-header move has to happen in `sign_request` (which sees both dicts), with `validate_environment` providing a defense-in-depth for the `optional_params` shape.

## Fix

1. **`SagemakerChatConfig.validate_environment`** pops `model_id` from `optional_params` and injects `X-Amzn-SageMaker-Inference-Component` if present. This mirrors what the legacy `sagemaker` completion handler does.
2. **`SagemakerChatConfig.sign_request`** does the same for `request_data` (the merged-with-`extra_body` body), with `optional_params` as a fallback. The header is set **before** SigV4 signing, and `model_id` is popped from `request_data` so SigV4 signs the body that actually gets sent.

When `model_id` is in both `request_data` and `optional_params`, the `request_data` (extra_body) source wins — it is the more specific, last-set source ahead of signing, and matches the precedence other providers use for extra_body overrides.

## Evidence

### Unit tests (7/7 pass — see `tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py`)

```
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_sign_request_model_id_in_optional_params_moves_to_header PASSED [ 14%]
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_sign_request_model_id_in_request_data_moves_to_header PASSED [ 28%]
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_sign_request_no_model_id_no_header PASSED [ 42%]
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_sign_request_request_data_wins_over_optional_params PASSED [ 57%]
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_validate_env_model_id_added_as_inference_component_header PASSED [ 71%]
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_validate_env_model_id_none_no_header_added PASSED [ 85%]
tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py::test_validate_env_no_model_id_no_header_added PASSED [100%]

======================== 7 passed, 2 warnings in 0.76s =========================
```

### Runtime evidence (before/after)

Drove `litellm.completion(model="sagemaker_chat/my-multi-component-endpoint", extra_body={"model_id": "claude-multi-tenant-1"})` against a mocked `HTTPHandler.post` so the full LiteLLM stack (`get_optional_params` → `BaseLLMHTTPHandler.completion` → `validate_environment` → `transform_request` → `sign_request`) ran end-to-end. The intercept captures exactly the URL/headers/body that LiteLLM was about to put on the wire after SigV4 signing.

**BEFORE FIX** (`validate_environment` and `sign_request` reverted to the pre-PR no-ops):

```
URL: https://runtime.sagemaker.us-east-1.amazonaws.com/endpoints/my-multi-component-endpoint/invocations
X-Amzn-SageMaker-Inference-Component header sent? -> None
body['model'] -> 'my-multi-component-endpoint'
body has 'model_id'? -> True  value: 'claude-multi-tenant-1'
body keys: ['messages', 'model', 'model_id']
```

→ no Inference Component header at all, and `model_id` leaks into the JSON body — matches the customer's reported failure shape exactly.

**AFTER FIX** (PR applied):

```
URL: https://runtime.sagemaker.us-east-1.amazonaws.com/endpoints/my-multi-component-endpoint/invocations
X-Amzn-SageMaker-Inference-Component header sent? -> 'claude-multi-tenant-1'
body['model'] -> 'my-multi-component-endpoint'
body has 'model_id'? -> False  value: None
body keys: ['messages', 'model']
```

→ `X-Amzn-SageMaker-Inference-Component` is set, body is clean.

## Note on PR mechanics (Contents API path)

This branch was pushed via the GitHub Contents API (`PUT /repos/.../contents/...`) rather than `git push` because the current agent `GITHUB_TOKEN` is missing `workflow` scope and direct push was rejected. There is one commit per file as a result; reviewers may see a slightly noisier merge-base diff than a single squashed commit. The diff itself is two methods (`validate_environment`, `sign_request`) in a single file plus one new test file.

## Verification (ship-pr)

- [x] Unit tests added & passing (7/7)
- [x] Runtime evidence (before/after) captured at the HTTP boundary, not the unit boundary — confirms the customer's symptom (no Inference Component header on the wire, `model_id` leaked into body) is reproduced on `main` and gone on the fix branch
- [x] Backward compatible — when `model_id` is absent, the new code is a no-op and `validate_environment` / `sign_request` behave exactly as before
- [x] Matches existing behavior of the legacy `sagemaker` (completion) handler

Closes LIT-2853.

Session: https://litellm-agent-platform.onrender.com/sessions/031d66ef-57ea-4952-91cf-053ade994557
