### PR TITLE
fix(proxy): list_files honors AsyncCursorPage from post-call hook (LIT-3386)

### DIFF
--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -47,7 +47,7 @@ from litellm.types.llms.openai import (
 )
 from openai.pagination import (
     AsyncCursorPage,
-)  # noqa: E402  # used in list_files post-call type check
+)  # used in list_files post-call type check
 
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -45,7 +45,9 @@ from litellm.types.llms.openai import (
     OpenAIFileObject,
     OpenAIFilesPurpose,
 )
-from openai.pagination import AsyncCursorPage  # noqa: E402  # used in list_files post-call type check
+from openai.pagination import (
+    AsyncCursorPage,
+)  # noqa: E402  # used in list_files post-call type check
 
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
@@ -1378,7 +1380,9 @@ async def list_files(
         _response = await proxy_logging_obj.post_call_success_hook(
             data=data, user_api_key_dict=user_api_key_dict, response=response
         )
-        if _response is not None and isinstance(_response, (OpenAIFileObject, AsyncCursorPage)):
+        if _response is not None and isinstance(
+            _response, (OpenAIFileObject, AsyncCursorPage)
+        ):
             response = _response
 
         ### ALERTING ###

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -45,6 +45,7 @@ from litellm.types.llms.openai import (
     OpenAIFileObject,
     OpenAIFilesPurpose,
 )
+from openai.pagination import AsyncCursorPage  # noqa: E402  # used in list_files post-call type check
 
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
@@ -1377,7 +1378,7 @@ async def list_files(
         _response = await proxy_logging_obj.post_call_success_hook(
             data=data, user_api_key_dict=user_api_key_dict, response=response
         )
-        if _response is not None and isinstance(_response, OpenAIFileObject):
+        if _response is not None and isinstance(_response, (OpenAIFileObject, AsyncCursorPage)):
             response = _response
 
         ### ALERTING ###

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py
@@ -15,6 +15,7 @@ that returns a fresh AsyncCursorPage instance.
 This regression test pins the broadened type check
 (OpenAIFileObject, AsyncCursorPage).
 """
+
 import pytest
 from unittest.mock import patch
 from fastapi.testclient import TestClient

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py
@@ -1,0 +1,129 @@
+"""Regression tests for LIT-3386 / GH #28294 (Point 72).
+
+The list_files endpoint runs proxy_logging_obj.post_call_success_hook after the
+upstream provider call. UnifiedFileIdHook (managed files) returns an
+openai.pagination.AsyncCursorPage for the list-files response shape (filtered
+to the caller's owned files).
+
+Previously the endpoint guarded reassignment with
+isinstance(_response, OpenAIFileObject), which is always False for an
+AsyncCursorPage, so the hook return was silently discarded. The in-place
+mutation of response.data inside the hook masked the bug in production paths
+but the type check itself was incorrect and would fail for any future hook
+that returns a fresh AsyncCursorPage instance.
+
+This regression test pins the broadened type check
+(OpenAIFileObject, AsyncCursorPage).
+"""
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from openai.pagination import AsyncCursorPage
+from openai.types.file_object import FileObject
+
+
+def _file(file_id):
+    return FileObject(
+        id=file_id,
+        object="file",
+        bytes=10,
+        created_at=0,
+        filename="x.jsonl",
+        purpose="batch",
+        status="processed",
+    )
+
+
+@pytest.fixture
+def client():
+    # Import inside the fixture so we resolve the live proxy_server module after
+    # tests/test_litellm/conftest.py::setup_and_teardown has reloaded it.
+    from litellm.proxy import proxy_server
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import (
+        user_api_key_auth as user_api_key_auth_dep,
+    )
+
+    def _override_auth():
+        return UserAPIKeyAuth(user_id="user-42", api_key="sk-test", token="sk-test")
+
+    proxy_server.app.dependency_overrides[user_api_key_auth_dep] = _override_auth
+    yield TestClient(proxy_server.app)
+    proxy_server.app.dependency_overrides.pop(user_api_key_auth_dep, None)
+
+
+@pytest.fixture
+def unfiltered_page():
+    return AsyncCursorPage(
+        data=[
+            _file("file-raw-input-aaa"),
+            _file("file-raw-output-bbb"),
+            _file("file-raw-other-ccc"),
+        ]
+    )
+
+
+def _patch_provider(unfiltered_page):
+    import litellm
+
+    async def _fake(*args, **kwargs):
+        return unfiltered_page
+
+    return patch.object(litellm, "afile_list", side_effect=_fake)
+
+
+def _patch_hook(side_effect):
+    # Patch the live module attribute, not a stale imported reference -
+    # conftest.py reloads litellm.proxy.proxy_server at module scope, which
+    # replaces proxy_logging_obj.
+    from litellm.proxy import proxy_server
+
+    return patch.object(
+        proxy_server.proxy_logging_obj,
+        "post_call_success_hook",
+        side_effect=side_effect,
+    )
+
+
+def test_list_files_honors_async_cursor_page_returned_by_hook(client, unfiltered_page):
+    """LIT-3386: list_files must honor AsyncCursorPage returned by the post-call hook.
+
+    The UnifiedFileIdHook (managed files) returns a filtered AsyncCursorPage for
+    file-list responses. Previously the endpoint's isinstance check only allowed
+    OpenAIFileObject, silently discarding the hook return. With Point 72's
+    secondary bug fixed, the endpoint reassigns response to the hook return.
+    """
+    filtered_page = AsyncCursorPage(data=[_file("litellm_proxy:managed-aaa")])
+
+    async def _hook(*, data, user_api_key_dict, response):
+        return filtered_page
+
+    with _patch_provider(unfiltered_page), _patch_hook(_hook):
+        r = client.get("/v1/files?purpose=batch")
+
+    assert r.status_code == 200, r.text
+    ids = [f["id"] for f in r.json()["data"]]
+    assert ids == ["litellm_proxy:managed-aaa"], (
+        f"list_files dropped the hook return value; got {ids}. The endpoint "
+        "type check must include AsyncCursorPage."
+    )
+
+
+def test_list_files_passes_through_unchanged_when_hook_returns_none(
+    client, unfiltered_page
+):
+    """Hook returns None - endpoint must keep the upstream response unchanged."""
+
+    async def _hook(*, data, user_api_key_dict, response):
+        return None
+
+    with _patch_provider(unfiltered_page), _patch_hook(_hook):
+        r = client.get("/v1/files?purpose=batch")
+
+    assert r.status_code == 200, r.text
+    ids = [f["id"] for f in r.json()["data"]]
+    assert ids == [
+        "file-raw-input-aaa",
+        "file-raw-output-bbb",
+        "file-raw-other-ccc",
+    ]

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py
@@ -128,3 +128,39 @@ def test_list_files_passes_through_unchanged_when_hook_returns_none(
         "file-raw-output-bbb",
         "file-raw-other-ccc",
     ]
+
+
+def test_list_files_still_honors_openai_file_object_returned_by_hook(
+    client, unfiltered_page
+):
+    """Regression guard for the pre-existing OpenAIFileObject branch of the
+    broadened isinstance tuple.
+
+    Future refactors that accidentally drop OpenAIFileObject from the tuple
+    must fail this test.
+    """
+    from litellm.types.llms.openai import OpenAIFileObject
+
+    synthetic = OpenAIFileObject(
+        id="file-from-hook",
+        object="file",
+        bytes=1,
+        created_at=0,
+        filename="y.jsonl",
+        purpose="batch",
+        status="processed",
+    )
+
+    async def _hook(*, data, user_api_key_dict, response):
+        return synthetic
+
+    with _patch_provider(unfiltered_page), _patch_hook(_hook):
+        r = client.get("/v1/files?purpose=batch")
+
+    assert r.status_code == 200, r.text
+    # When the hook returns a single OpenAIFileObject (legacy / synthetic path),
+    # the endpoint serializes that single object - not a list page - so the
+    # caller sees the object's fields at the top level.
+    assert (
+        r.json()["id"] == "file-from-hook"
+    ), "Pre-existing isinstance branch for OpenAIFileObject regressed."


### PR DESCRIPTION
## Summary

Closes the remaining secondary bug called out in [GH #28294](https://github.com/BerriAI/litellm/issues/28294) 

The customer's analysis of [#28339](https://github.com/BerriAI/litellm/pull/28339) and [#27984](https://github.com/BerriAI/litellm/pull/27984) confirmed:

> "The type check `isinstance(_response, OpenAIFileObject)` in `files_endpoints.py:list_files` (around line 1378) also remains. The managed files hook returns `AsyncCursorPage` for the file list, which is correctly handled in the hook (`managed_files.py:1166`) but the endpoint's post-call check discards it. This is masked by the in-place mutation of `response.data`, but the type check is still incorrect."

After `proxy_logging_obj.post_call_success_hook` runs, `list_files` reassigns the response only when the hook returns an `OpenAIFileObject`. `UnifiedFileIdHook.async_post_call_success_hook` actually returns an `openai.pagination.AsyncCursorPage` for the list-files response shape (see `enterprise/litellm_enterprise/proxy/hooks/managed_files.py:1209-1232`), so `isinstance(_response, OpenAIFileObject)` is always `False` and the hook's return value is silently dropped. In practice the bug is partially masked by the hook also mutating `response.data` in place, but the type check itself is wrong and any future hook that returns a fresh `AsyncCursorPage` (built from a different upstream payload, or rebuilt to drop a forbidden item, etc.) is silently discarded.

The other site that uses the same pattern — `acreate_file` (`POST /v1/files`) at line ~524 — does not need this change because `acreate_file` only returns `OpenAIFileObject`.

**Fix 1 from the GH issue** (`CheckBatchCost` poller writing output files with `created_by = default_user_id` instead of `job.created_by`) is **already in place** — see the `_minimal_auth` block at `enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py:307-326`, which was added in [#27984](https://github.com/BerriAI/litellm/pull/27984) (5/15). That code path passes `user_id=job.created_by` into `store_unified_file_id`, which is what writes `LiteLLM_ManagedFileTable.created_by`. No change needed there in this PR.

## Change

```diff
--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -45,6 +45,7 @@ from litellm.types.llms.openai import (
     OpenAIFileObject,
     OpenAIFilesPurpose,
 )
+from openai.pagination import AsyncCursorPage  # noqa: E402  # used in list_files post-call type check
@@ -1377,7 +1378,7 @@ async def list_files(
         _response = await proxy_logging_obj.post_call_success_hook(
             data=data, user_api_key_dict=user_api_key_dict, response=response
         )
-        if _response is not None and isinstance(_response, OpenAIFileObject):
+        if _response is not None and isinstance(_response, (OpenAIFileObject, AsyncCursorPage)):
             response = _response
```

Two new pytest cases pin the behavior at the FastAPI endpoint layer (`TestClient` against the live `/v1/files` route, real `app.dependency_overrides`, real `proxy_logging_obj`).

### Evidence

**BEFORE the fix** — the regression test fails because the hook's filtered `AsyncCursorPage` is dropped and the endpoint returns the raw upstream `AsyncCursorPage` to the caller:

```
$ pytest tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py -v
tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py::test_list_files_honors_async_cursor_page_returned_by_hook FAILED
tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py::test_list_files_passes_through_unchanged_when_hook_returns_none PASSED

E   AssertionError: list_files dropped the hook return value;
E   got ['file-raw-input-aaa', 'file-raw-output-bbb', 'file-raw-other-ccc'].
E   The endpoint type check must include AsyncCursorPage.

1 failed, 1 passed in 8.95s
```

**AFTER the fix** — both tests pass; the endpoint reassigns `response` to the hook's filtered `AsyncCursorPage`, so the caller sees only their own (managed-id) files:

```
$ pytest tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py -v
tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py::test_list_files_honors_async_cursor_page_returned_by_hook PASSED
tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py::test_list_files_passes_through_unchanged_when_hook_returns_none PASSED

2 passed in 9.00s
```

The test drives the endpoint through `fastapi.testclient.TestClient` (full FastAPI request/response stack), patches `litellm.afile_list` to act as the upstream provider, and patches `proxy_server.proxy_logging_obj.post_call_success_hook` to return a fresh `AsyncCursorPage` instance with different `data`. The before/after difference is observable at the HTTP layer in `r.json()["data"]`.

## Risk

- **Scope**: type check broadened in exactly one place (`list_files`). `acreate_file` (`POST /v1/files`) unchanged.
- **Backward compat**: hooks that return `None` still pass through (covered by `test_list_files_passes_through_unchanged_when_hook_returns_none`). Hooks that return `OpenAIFileObject` (legacy / synthetic single-file responses) still honored.
- **Today's `UnifiedFileIdHook` behavior**: mutates `response.data` in place AND returns the same `response`, so the user-visible behavior is unchanged for the production hook. The fix corrects the type check so that *any* future hook (including a refactor of `UnifiedFileIdHook` that constructs a fresh page) is honored.

## Note on diff shape

Pushed via the GitHub Contents API (current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes). The net working-tree change is exactly the two files shown above.

Closes LIT-3386.


---

### Verification (ship-pr)

- ✅ **Base branch**: `litellm_oss_agent_shin_daily_branch` (per Shin policy)
- ✅ **Greptile**: 5/5 ("Safe to merge")
- ✅ **Veria AI - PR Review**: success
- ✅ **GitHub Actions**: 20/20 workflow runs green (UI Build, Semgrep, Code Quality, Linting, all Unit Test suites, Documentation, Helm, MCP, Proxy SERVER_ROOT_PATH, etc.)
- ✅ **Check runs**: 43/44 success. The 1 non-green check is `codecov/patch` — Codecov bot informational only, not part of GitHub Actions, not blocking the merge gate.
- ✅ **Tests**: 3 new pytest cases in `tests/test_litellm/proxy/openai_files_endpoint/test_list_files_post_call_hook.py`, all passing locally. The first test fails on a reverted main, confirming it is a real regression guard.
- ✅ **Runtime evidence**: BEFORE-fix and AFTER-fix pytest output captured inline above (full request/response through FastAPI TestClient against `/v1/files`).
- ✅ **Diff scope**: exactly 2 files. No accidental changes elsewhere.
- ✅ **No secrets** in PR or test fixtures.