### PR TITLE
feat(complexity_router): add custom_technical_keywords config (LIT-3237)

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -92,9 +92,25 @@ class ComplexityRouter(CustomLogger):
         self.reasoning_keywords = (
             self.config.reasoning_keywords or DEFAULT_REASONING_KEYWORDS
         )
-        self.technical_keywords = (
+        _base_technical_keywords = (
             self.config.technical_keywords or DEFAULT_TECHNICAL_KEYWORDS
         )
+        if self.config.custom_technical_keywords:
+            # Append-not-replace: extend the effective technical keyword list
+            # with caller-provided domain-specific terms. De-duplicate while
+            # preserving order so repeated user entries (or overlap with the
+            # base list) do not double-count during keyword matching.
+            seen = set()
+            merged: List[str] = []
+            for kw in list(_base_technical_keywords) + list(
+                self.config.custom_technical_keywords
+            ):
+                if kw not in seen:
+                    seen.add(kw)
+                    merged.append(kw)
+            self.technical_keywords = merged
+        else:
+            self.technical_keywords = list(_base_technical_keywords)
         self.simple_keywords = self.config.simple_keywords or DEFAULT_SIMPLE_KEYWORDS
 
         # Pre-compile regex patterns for efficiency

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -240,10 +240,11 @@ class ComplexityRouterConfig(BaseModel):
     custom_technical_keywords: Optional[List[str]] = Field(
         default=None,
         description=(
-            "Additional technical keywords to append to the technical "
-            "keywords list. Unlike `technical_keywords` (which replaces "
-            "the defaults), this field extends them. Useful for "
-            "domain-specific terms such as udp, dns, ssl, kafka, redis."
+            "Additional technical keywords to append to the effective "
+            "technical keywords list. When `technical_keywords` is also "
+            "set, this field appends to that override list; otherwise it "
+            "appends to the built-in defaults. Useful for domain-specific "
+            "terms such as udp, dns, ssl, kafka, redis."
         ),
     )
     simple_keywords: Optional[List[str]] = Field(

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -237,6 +237,15 @@ class ComplexityRouterConfig(BaseModel):
         default=None,
         description="Keywords indicating technical content",
     )
+    custom_technical_keywords: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Additional technical keywords to append to the technical "
+            "keywords list. Unlike `technical_keywords` (which replaces "
+            "the defaults), this field extends them. Useful for "
+            "domain-specific terms such as udp, dns, ssl, kafka, redis."
+        ),
+    )
     simple_keywords: Optional[List[str]] = Field(
         default=None,
         description="Keywords indicating simple/basic queries",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1095,16 +1095,27 @@ class TestCustomTechnicalKeywords:
         ) + len(unique_new)
 
     def test_overlap_dedupes(self, mock_router_instance):
+        """Repeated entries or overlap with defaults are de-duplicated."""
         from litellm.router_strategy.complexity_router.config import (
             DEFAULT_TECHNICAL_KEYWORDS,
         )
+        custom = ["http", "kafka", "kafka", "redis"]
         router = self._make_router(
             mock_router_instance,
-            custom_technical_keywords=["http", "kafka", "kafka", "redis"],
+            custom_technical_keywords=custom,
         )
+        # Compute expected unique additions explicitly so the assertion stays
+        # correct even if DEFAULT_TECHNICAL_KEYWORDS later gains one of these
+        # terms. Mirrors the dedup logic in ComplexityRouter.__init__.
+        seen = set(DEFAULT_TECHNICAL_KEYWORDS)
+        unique_new = []
+        for kw in custom:
+            if kw not in seen:
+                seen.add(kw)
+                unique_new.append(kw)
         assert (
             len(router.technical_keywords)
-            == len(DEFAULT_TECHNICAL_KEYWORDS) + 2
+            == len(DEFAULT_TECHNICAL_KEYWORDS) + len(unique_new)
         )
         assert router.technical_keywords.count("kafka") == 1
         assert router.technical_keywords.count("redis") == 1

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1087,9 +1087,12 @@ class TestCustomTechnicalKeywords:
             assert kw in router.technical_keywords, f"default {kw!r} dropped"
         for kw in custom:
             assert kw in router.technical_keywords, f"custom {kw!r} missing"
+        # Compute expected unique additions so the assertion stays correct
+        # even if DEFAULT_TECHNICAL_KEYWORDS later gains one of `custom`.
+        unique_new = [kw for kw in custom if kw not in DEFAULT_TECHNICAL_KEYWORDS]
         assert len(router.technical_keywords) == len(
             DEFAULT_TECHNICAL_KEYWORDS
-        ) + len(custom)
+        ) + len(unique_new)
 
     def test_overlap_dedupes(self, mock_router_instance):
         from litellm.router_strategy.complexity_router.config import (

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1047,3 +1047,114 @@ class TestExtractUserMessageAndSystemPrompt:
         )
         assert user_msg is None
         assert sys_prompt is None
+
+
+class TestCustomTechnicalKeywords:
+    """Tests for the `custom_technical_keywords` config field (LIT-3237)."""
+
+    def _make_router(self, mock_router_instance, **config_extras):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TIER_BOUNDARIES,
+            DEFAULT_TIER_MODELS,
+        )
+        config = {
+            "tiers": dict(DEFAULT_TIER_MODELS),
+            "tier_boundaries": dict(DEFAULT_TIER_BOUNDARIES),
+        }
+        config.update(config_extras)
+        return ComplexityRouter(
+            model_name="test",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=config,
+        )
+
+    def test_default_when_field_absent(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        router = self._make_router(mock_router_instance)
+        assert router.technical_keywords == list(DEFAULT_TECHNICAL_KEYWORDS)
+
+    def test_extends_defaults_not_replaces(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        custom = ["kafka", "redis", "postgresql"]
+        router = self._make_router(
+            mock_router_instance, custom_technical_keywords=custom
+        )
+        for kw in DEFAULT_TECHNICAL_KEYWORDS:
+            assert kw in router.technical_keywords, f"default {kw!r} dropped"
+        for kw in custom:
+            assert kw in router.technical_keywords, f"custom {kw!r} missing"
+        assert len(router.technical_keywords) == len(
+            DEFAULT_TECHNICAL_KEYWORDS
+        ) + len(custom)
+
+    def test_overlap_dedupes(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        router = self._make_router(
+            mock_router_instance,
+            custom_technical_keywords=["http", "kafka", "kafka", "redis"],
+        )
+        assert (
+            len(router.technical_keywords)
+            == len(DEFAULT_TECHNICAL_KEYWORDS) + 2
+        )
+        assert router.technical_keywords.count("kafka") == 1
+        assert router.technical_keywords.count("redis") == 1
+        assert router.technical_keywords.count("http") == 1
+
+    def test_combined_with_technical_keywords_override(self, mock_router_instance):
+        router = self._make_router(
+            mock_router_instance,
+            technical_keywords=["alpha", "beta"],
+            custom_technical_keywords=["gamma", "delta"],
+        )
+        assert router.technical_keywords == ["alpha", "beta", "gamma", "delta"]
+
+    def test_empty_list_is_treated_as_unset(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        router = self._make_router(
+            mock_router_instance, custom_technical_keywords=[]
+        )
+        assert router.technical_keywords == list(DEFAULT_TECHNICAL_KEYWORDS)
+
+    def test_verizon_keyword_list_round_trip(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        verizon = [
+            "udp", "dns", "ssl", "tls", "ssh", "rest",
+            "graphql", "kafka", "redis", "postgresql", "mongodb",
+        ]
+        router = self._make_router(
+            mock_router_instance, custom_technical_keywords=verizon
+        )
+        for kw in verizon:
+            assert kw in router.technical_keywords
+        for kw in DEFAULT_TECHNICAL_KEYWORDS:
+            assert kw in router.technical_keywords
+
+    def test_custom_keywords_increase_complexity_signal(self, mock_router_instance):
+        prompt = (
+            "How do I configure a Kafka consumer with Redis as a state store "
+            "to read from a Postgresql change-data-capture topic?"
+        )
+        without = self._make_router(mock_router_instance)
+        with_custom = self._make_router(
+            mock_router_instance,
+            custom_technical_keywords=["kafka", "redis", "postgresql"],
+        )
+        _, score_off, _ = without.classify(prompt)
+        _, score_on, _ = with_custom.classify(prompt)
+        assert score_on > score_off
+
+    def test_config_field_round_trip_in_pydantic(self):
+        cfg = ComplexityRouterConfig(custom_technical_keywords=["kafka"])
+        assert cfg.custom_technical_keywords == ["kafka"]
+        assert ComplexityRouterConfig().custom_technical_keywords is None


### PR DESCRIPTION
## Summary

Adds `custom_technical_keywords: Optional[List[str]]` to `ComplexityRouterConfig`. Unlike the existing `technical_keywords` (which **replaces** the default technical keyword list when set), `custom_technical_keywords` **appends** caller-supplied domain-specific terms on top of the defaults — preserving order and de-duplicating overlap.

 ask in [LIT-3237](https://linear.app/litellm-ai/issue/LIT-3237/add-custom-technical-keywords-configuration): teams need to add terms like `udp`, `dns`, `ssl`, `tls`, `ssh`, `rest`, `graphql`, `kafka`, `redis`, `postgresql`, `mongodb` to the complexity router's technical signal without re-declaring the existing defaults.

```yaml
router_settings:
  routing_strategy: complexity-based-routing
  complexity_router_config:
    custom_technical_keywords:
      - udp
      - dns
      - ssl
      - tls
      - ssh
      - rest
      - graphql
      - kafka
      - redis
      - postgresql
      - mongodb
```

## Changes

- `litellm/router_strategy/complexity_router/config.py` — new optional pydantic field with docstring describing the append-not-replace contract.
- `litellm/router_strategy/complexity_router/complexity_router.py` — merge logic: take the effective base list (`technical_keywords` override OR `DEFAULT_TECHNICAL_KEYWORDS`), then append `custom_technical_keywords` while de-duplicating in order. Empty list is treated as unset.
- `tests/test_litellm/router_strategy/test_complexity_router.py` — 8 new tests in `TestCustomTechnicalKeywords` covering: defaults preserved, append-not-replace, dedupe overlap+repeats, interaction with `technical_keywords` override, empty list = unset, exact Verizon list round-trip, scoring delta on a kafka/redis/postgresql prompt, pydantic round-trip.

## Evidence

This is a router-internal behavior change with no HTTP surface; evidence is the same `ComplexityRouter` instantiated against `main` vs this branch with the customer config, plus a `classify()` score delta on a prompt that uses the requested keywords.

```
================================================================
BEFORE this PR -- only `technical_keywords` exists (REPLACES defaults)
================================================================
DEFAULT_TECHNICAL_KEYWORDS count: 28
Effective technical_keywords count: 11
  default "architecture" present? False   <- defaults LOST
  default "http" present?         False   <- defaults LOST
  verizon "kafka" present?        True
  Effective list: ['udp','dns','ssl','tls','ssh','rest','graphql','kafka','redis','postgresql','mongodb']

================================================================
AFTER this PR -- new `custom_technical_keywords` APPENDS to defaults
================================================================
DEFAULT_TECHNICAL_KEYWORDS count: 28
Effective technical_keywords count: 39   (28 defaults + 11 verizon)
  default "architecture" present? True   <- preserved
  default "http" present?         True   <- preserved
  verizon "kafka" present?        True

================================================================
Routing signal -- same prompt, custom kws off vs on
================================================================
Prompt: "How do I configure a Kafka consumer with Redis as a state store
         to read from a Postgresql change-data-capture topic?"
Baseline (no custom kws):       tier=SIMPLE score=0.0000 signals=[]
With custom_technical_keywords: tier=SIMPLE score=0.1250 signals=['technical (kafka, redis, postgresql)']
Score delta: +0.1250            (technical dimension lit up as expected)

================================================================
De-dup -- overlap with defaults & repeats
================================================================
custom_technical_keywords = ["http","kafka","kafka","redis"]   # http overlaps defaults; kafka repeated
After merge: 30 keywords        (= 28 defaults + 2 unique new)
  kafka count in list: 1        (expected 1)
  http  count in list: 1        (expected 1)
```

## Test results

```
$ pytest tests/test_litellm/router_strategy/test_complexity_router.py
============================== 75 passed in 2.69s ==============================
```

(67 existing + 8 new in `TestCustomTechnicalKeywords`.)

## Push note

Pushed via GitHub contents API (one PUT per file) because this agent's token lacks the `repo` scope needed for `git push`. Reviewers may see a slightly noisier merge-base diff because of how the contents API stages files.

---
Linear: LIT-3237 (Verizon)
Session: https://litellm-agent-platform.onrender.com/sessions/e79c9387-b8c5-45e4-9321-40eb1ecc4253


### Verification (ship-pr)

- **Linear ticket**: LIT-3237 (Verizon — Add custom technical keywords configuration)
- **Bug reproduces on baseline**: yes — running `ComplexityRouter` with the Verizon keyword list via the existing `technical_keywords` knob wipes the 28 built-in defaults (count goes from 28 → 11), so callers cannot extend without redeclaring every default. Captured under `### Evidence > BEFORE`.
- **Fix shown in runtime artifact, not just unit tests**: yes — `### Evidence > AFTER` instantiates `ComplexityRouter` with `custom_technical_keywords=verizon` and shows the effective list grow to 39 (28 defaults preserved + 11 new). `### Evidence > Routing signal` then runs `classify()` on a kafka/redis/postgresql prompt and shows the technical-dimension score jump from 0.0000 → 0.1250 (signals: `technical (kafka, redis, postgresql)`).
- **Unit tests are additive, not the only evidence**: yes — 8 new tests in `TestCustomTechnicalKeywords` + 67 existing pass (`75 passed in 2.69s`). They cover the same contracts as the runtime artifact (append-not-replace, dedup, override interaction, empty-list-as-unset, Verizon round-trip, scoring delta, pydantic round-trip).
- **No HTTP/UI/metrics surface**: correct — this is a router-internal initialisation change in `ComplexityRouter.__init__`. No request/response shape, no headers, no metrics, no callbacks. The closest user-visible surface is the proxy `config.yaml` schema; that's covered by `test_config_field_round_trip_in_pydantic`.
- **CI**: 44/44 checks green, `mergeable_state=clean`. Codecov: all modified lines covered.
- **Greptile**: 5/5 (P2 comments addressed in commit `56ec1af`, follow-up nit on `test_overlap_dedupes` hardened in `7ad8f3c`).
- **Veria AI**: pass (`No security issues found`).
- **No secrets**: verified — push path used contents API + a redacted-by-default token, no logs leaked.
- **Push path**: contents API (one PUT per file) because the agent's `GITHUB_TOKEN` lacks `repo` scope for `git push`. Each commit was made through `PUT /repos/{owner}/{repo}/contents/{path}` against the `shin/lit-3237-custom-technical-keywords` branch on the fork.