### PR TITLE
fix(auth): recover from stale Redis team spend counter on auth check (LIT-3132)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1765,38 +1765,18 @@ async def _cache_team_object(
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: Optional[ProxyLogging],
 ):
+    key = "team_id:{}".format(team_id)
+
     ## CACHE REFRESH TIME!
     team_table.last_refreshed_at = time.time()
 
-    # team_id is the table primary key — guaranteed unique, safe to write.
     await _cache_management_object(
-        key="team_id:{}".format(team_id),
+        key=key,
         value=team_table,
         user_api_key_cache=user_api_key_cache,
         proxy_logging_obj=proxy_logging_obj,
         model_type=LiteLLM_TeamTableCachedObj,
     )
-
-    # Invalidate the alias-keyed cache so the JWT auth path with
-    # `team_alias_jwt_field` (which reads via `get_team_object_by_alias`)
-    # doesn't keep serving the pre-mutation team after every team-write
-    # endpoint (team_model_add, team_model_delete, update_team, etc.).
-    #
-    # Why DELETE and not WRITE: `team_alias` has no UNIQUE constraint in
-    # schema.prisma. Writing this cache from the generic refresh path
-    # would let a team admin who renamed their team to collide with
-    # another team's alias silently overwrite the cached team for
-    # JWT-by-alias auth (veria-ai review on #28739). Deleting forces the
-    # next reader through `get_team_object_by_alias`, which DOES enforce
-    # uniqueness (len(teams) > 1 raises HTTPException) before populating
-    # the cache from a verified single row.
-    if team_table.team_alias:
-        alias_key = "team_alias:{}".format(team_table.team_alias)
-        user_api_key_cache.delete_cache(key=alias_key)
-        if proxy_logging_obj is not None:
-            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(
-                key=alias_key
-            )
 
 
 async def _cache_key_object(
@@ -3163,40 +3143,44 @@ async def can_team_access_model(
         raise
 
 
-async def get_authorized_resources_from_key_access_groups(
+async def _key_access_group_grants_model(
+    model: Union[str, List[str]],
     valid_token: Optional[UserAPIKeyAuth],
     team_object: Optional[LiteLLM_TeamTable],
-    resource_field: Literal[
-        "access_model_names", "access_mcp_server_ids", "access_agent_ids"
-    ],
-) -> List[str]:
+    llm_router: Optional[Router],
+) -> bool:
     """
-    For each access_group_id on the key, fetch the LiteLLM_AccessGroupTable row
-    and contribute its `resource_field` only if the group authorizes the caller
-    as an owner — that is, the group's `assigned_team_ids` includes the key's
-    `team_id`, or the group's `assigned_key_ids` includes the key's token. This
-    preserves the team-as-owner boundary while still letting a group reach the
-    key without first being added to the team's `access_group_ids` list.
+    Returns True if the key's `access_group_ids` expand to models that grant
+    access to `model`. Used to let a key's access group override a team's
+    model restriction in `common_checks`.
+
+    A key's access group only counts if the access group itself authorizes the
+    caller as an owner — that is, the group's `assigned_team_ids` includes the
+    key's `team_id`, or the group's `assigned_key_ids` includes the key's
+    token. This preserves the team-as-owner boundary (a team member cannot
+    escalate by naming a group assigned to a different team) while still
+    letting a group reach the key without first being added to the team's
+    `access_group_ids` list.
     """
     if valid_token is None:
-        return []
+        return False
     key_access_group_ids = list(valid_token.access_group_ids or [])
     if not key_access_group_ids:
-        return []
+        return False
 
     from litellm.proxy.proxy_server import prisma_client as _prisma_client
     from litellm.proxy.proxy_server import proxy_logging_obj as _proxy_logging_obj
     from litellm.proxy.proxy_server import user_api_key_cache as _user_api_key_cache
 
     if _prisma_client is None or _user_api_key_cache is None:
-        return []
+        return False
 
     key_team_id = valid_token.team_id or (
         team_object.team_id if team_object is not None else None
     )
     key_token = valid_token.token
 
-    authorized_resources: List[str] = []
+    authorized_models: List[str] = []
     for ag_id in key_access_group_ids:
         try:
             ag = await get_access_object(
@@ -3212,36 +3196,17 @@ async def get_authorized_resources_from_key_access_groups(
         )
         key_authorized = bool(key_token and key_token in (ag.assigned_key_ids or []))
         if team_authorized or key_authorized:
-            authorized_resources.extend(getattr(ag, resource_field, []) or [])
+            authorized_models.extend(ag.access_model_names or [])
 
-    return list(set(authorized_resources))
-
-
-async def _key_access_group_grants_model(
-    model: Union[str, List[str]],
-    valid_token: Optional[UserAPIKeyAuth],
-    team_object: Optional[LiteLLM_TeamTable],
-    llm_router: Optional[Router],
-) -> bool:
-    """
-    Returns True if the key's `access_group_ids` expand to models that grant
-    access to `model`. Used to let a key's access group override a team's
-    model restriction in `common_checks`.
-    """
-    authorized_models = await get_authorized_resources_from_key_access_groups(
-        valid_token=valid_token,
-        team_object=team_object,
-        resource_field="access_model_names",
-    )
     if not authorized_models:
         return False
     try:
         _can_object_call_model(
             model=model,
             llm_router=llm_router,
-            models=authorized_models,
-            team_model_aliases=valid_token.team_model_aliases if valid_token else None,
-            team_id=valid_token.team_id if valid_token else None,
+            models=list(set(authorized_models)),
+            team_model_aliases=valid_token.team_model_aliases,
+            team_id=valid_token.team_id,
             object_type="key",
         )
         return True
@@ -3950,10 +3915,7 @@ async def _team_max_budget_check(
         # authoritative — if the DB row says spend is well under the cap
         # while Redis says it is over, the Redis counter is stale and we
         # reseed from DB. Customer-reported in LIT-3132.
-        if (
-            math.isfinite(team_object.max_budget)
-            and spend > team_object.max_budget
-        ):
+        if math.isfinite(team_object.max_budget) and spend > team_object.max_budget:
             spend = await _maybe_reseed_stale_team_spend_counter(
                 counter_key=counter_key,
                 team_object=team_object,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1765,18 +1765,38 @@ async def _cache_team_object(
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: Optional[ProxyLogging],
 ):
-    key = "team_id:{}".format(team_id)
-
     ## CACHE REFRESH TIME!
     team_table.last_refreshed_at = time.time()
 
+    # team_id is the table primary key — guaranteed unique, safe to write.
     await _cache_management_object(
-        key=key,
+        key="team_id:{}".format(team_id),
         value=team_table,
         user_api_key_cache=user_api_key_cache,
         proxy_logging_obj=proxy_logging_obj,
         model_type=LiteLLM_TeamTableCachedObj,
     )
+
+    # Invalidate the alias-keyed cache so the JWT auth path with
+    # `team_alias_jwt_field` (which reads via `get_team_object_by_alias`)
+    # doesn't keep serving the pre-mutation team after every team-write
+    # endpoint (team_model_add, team_model_delete, update_team, etc.).
+    #
+    # Why DELETE and not WRITE: `team_alias` has no UNIQUE constraint in
+    # schema.prisma. Writing this cache from the generic refresh path
+    # would let a team admin who renamed their team to collide with
+    # another team's alias silently overwrite the cached team for
+    # JWT-by-alias auth (veria-ai review on #28739). Deleting forces the
+    # next reader through `get_team_object_by_alias`, which DOES enforce
+    # uniqueness (len(teams) > 1 raises HTTPException) before populating
+    # the cache from a verified single row.
+    if team_table.team_alias:
+        alias_key = "team_alias:{}".format(team_table.team_alias)
+        user_api_key_cache.delete_cache(key=alias_key)
+        if proxy_logging_obj is not None:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(
+                key=alias_key
+            )
 
 
 async def _cache_key_object(
@@ -3143,44 +3163,40 @@ async def can_team_access_model(
         raise
 
 
-async def _key_access_group_grants_model(
-    model: Union[str, List[str]],
+async def get_authorized_resources_from_key_access_groups(
     valid_token: Optional[UserAPIKeyAuth],
     team_object: Optional[LiteLLM_TeamTable],
-    llm_router: Optional[Router],
-) -> bool:
+    resource_field: Literal[
+        "access_model_names", "access_mcp_server_ids", "access_agent_ids"
+    ],
+) -> List[str]:
     """
-    Returns True if the key's `access_group_ids` expand to models that grant
-    access to `model`. Used to let a key's access group override a team's
-    model restriction in `common_checks`.
-
-    A key's access group only counts if the access group itself authorizes the
-    caller as an owner — that is, the group's `assigned_team_ids` includes the
-    key's `team_id`, or the group's `assigned_key_ids` includes the key's
-    token. This preserves the team-as-owner boundary (a team member cannot
-    escalate by naming a group assigned to a different team) while still
-    letting a group reach the key without first being added to the team's
-    `access_group_ids` list.
+    For each access_group_id on the key, fetch the LiteLLM_AccessGroupTable row
+    and contribute its `resource_field` only if the group authorizes the caller
+    as an owner — that is, the group's `assigned_team_ids` includes the key's
+    `team_id`, or the group's `assigned_key_ids` includes the key's token. This
+    preserves the team-as-owner boundary while still letting a group reach the
+    key without first being added to the team's `access_group_ids` list.
     """
     if valid_token is None:
-        return False
+        return []
     key_access_group_ids = list(valid_token.access_group_ids or [])
     if not key_access_group_ids:
-        return False
+        return []
 
     from litellm.proxy.proxy_server import prisma_client as _prisma_client
     from litellm.proxy.proxy_server import proxy_logging_obj as _proxy_logging_obj
     from litellm.proxy.proxy_server import user_api_key_cache as _user_api_key_cache
 
     if _prisma_client is None or _user_api_key_cache is None:
-        return False
+        return []
 
     key_team_id = valid_token.team_id or (
         team_object.team_id if team_object is not None else None
     )
     key_token = valid_token.token
 
-    authorized_models: List[str] = []
+    authorized_resources: List[str] = []
     for ag_id in key_access_group_ids:
         try:
             ag = await get_access_object(
@@ -3196,17 +3212,36 @@ async def _key_access_group_grants_model(
         )
         key_authorized = bool(key_token and key_token in (ag.assigned_key_ids or []))
         if team_authorized or key_authorized:
-            authorized_models.extend(ag.access_model_names or [])
+            authorized_resources.extend(getattr(ag, resource_field, []) or [])
 
+    return list(set(authorized_resources))
+
+
+async def _key_access_group_grants_model(
+    model: Union[str, List[str]],
+    valid_token: Optional[UserAPIKeyAuth],
+    team_object: Optional[LiteLLM_TeamTable],
+    llm_router: Optional[Router],
+) -> bool:
+    """
+    Returns True if the key's `access_group_ids` expand to models that grant
+    access to `model`. Used to let a key's access group override a team's
+    model restriction in `common_checks`.
+    """
+    authorized_models = await get_authorized_resources_from_key_access_groups(
+        valid_token=valid_token,
+        team_object=team_object,
+        resource_field="access_model_names",
+    )
     if not authorized_models:
         return False
     try:
         _can_object_call_model(
             model=model,
             llm_router=llm_router,
-            models=list(set(authorized_models)),
-            team_model_aliases=valid_token.team_model_aliases,
-            team_id=valid_token.team_id,
+            models=authorized_models,
+            team_model_aliases=valid_token.team_model_aliases if valid_token else None,
+            team_id=valid_token.team_id if valid_token else None,
             object_type="key",
         )
         return True
@@ -3798,6 +3833,94 @@ async def _check_team_member_model_access(
         )
 
 
+async def _maybe_reseed_stale_team_spend_counter(
+    counter_key: str,
+    team_object: LiteLLM_TeamTable,
+    redis_spend: float,
+) -> float:
+    """Detect-and-recover from a stale Redis team spend counter.
+
+    Called from ``_team_max_budget_check`` when the cross-pod Redis counter
+    says the team is over budget. Reads the authoritative
+    ``LiteLLM_TeamTable.spend`` from the DB directly (not from the cached
+    team_object, which can lag), and if the DB spend is well under the cap
+    while Redis says over, treats Redis as stale: deletes the counter key
+    so subsequent reads reseed from the DB, and returns the DB value.
+
+    The most common cause of this drift is the periodic reset job
+    committing ``team.spend = 0`` to Postgres but the corresponding Redis
+    write silently no-opping — Redis unreachable from the reset-job pod,
+    ``spend_counter_cache.redis_cache is None`` on that pod, etc.
+    Customer-reported in LIT-3132 (8451): ``Current cost: 2000.0000014,
+    Max budget: 2000.0`` from the auth check while the team's DB row
+    showed ``spend = 0.144``.
+
+    On any failure (DB unreachable, Prisma error, etc.) the caller's
+    existing ``redis_spend`` is returned unchanged, so this can only
+    relax enforcement on a clear staleness signal, never harden it.
+    """
+    from litellm.proxy.db.spend_counter_reseed import SpendCounterReseed
+    from litellm.proxy.proxy_server import prisma_client, spend_counter_cache
+
+    if team_object.max_budget is None or prisma_client is None:
+        return redis_spend
+
+    try:
+        db_spend = await SpendCounterReseed.from_db(
+            prisma_client=prisma_client, counter_key=counter_key
+        )
+    except Exception as e:
+        verbose_proxy_logger.debug(
+            "_maybe_reseed_stale_team_spend_counter: SpendCounterReseed.from_db "
+            "failed for %s, leaving Redis value in place: %s",
+            counter_key,
+            e,
+        )
+        return redis_spend
+
+    if db_spend is None:
+        # DB unreachable or row missing — keep enforcing whatever Redis said.
+        return redis_spend
+
+    # Only treat Redis as stale when the DB row clearly contradicts it.
+    # "Clearly": DB spend is below 50% of the cap. A real over-budget
+    # condition is one where the DB will also reflect spend at or near
+    # the cap once the spend flusher commits.
+    if db_spend >= team_object.max_budget * 0.5:
+        return redis_spend
+
+    if spend_counter_cache is not None:
+        # Drop the stale counter so future reads on this pod take the
+        # clean-miss path through SpendCounterReseed.coalesced and
+        # converge on the DB value. SET NX inside that reseed keeps
+        # concurrent pods from multiplying the counter.
+        if spend_counter_cache.redis_cache is not None:
+            try:
+                await spend_counter_cache.redis_cache.async_delete_cache(counter_key)
+            except Exception as redis_err:
+                verbose_proxy_logger.debug(
+                    "_maybe_reseed_stale_team_spend_counter: Redis delete failed "
+                    "for %s: %s",
+                    counter_key,
+                    redis_err,
+                )
+        spend_counter_cache.in_memory_cache.set_cache(key=counter_key, value=db_spend)
+
+    verbose_proxy_logger.warning(
+        "Reseeded stale team spend counter %s from DB: Redis reported %.6f "
+        "(over max_budget=%.6f) but the authoritative DB row had spend=%.6f. "
+        "This typically means the cross-pod Redis counter did not get "
+        "invalidated by the most recent budget reset (e.g. Redis unreachable "
+        "on the reset-job pod, or spend_counter_cache.redis_cache was None "
+        "during reset).",
+        counter_key,
+        redis_spend,
+        team_object.max_budget,
+        db_spend,
+    )
+    return float(db_spend)
+
+
 async def _team_max_budget_check(
     team_object: Optional[LiteLLM_TeamTable],
     valid_token: Optional[UserAPIKeyAuth],
@@ -3814,10 +3937,28 @@ async def _team_max_budget_check(
         from litellm.proxy.proxy_server import get_current_spend
 
         # Read spend from cross-pod counter (Redis-first) or cached object (fallback)
+        counter_key = f"spend:team:{team_object.team_id}"
         spend = await get_current_spend(
-            counter_key=f"spend:team:{team_object.team_id}",
+            counter_key=counter_key,
             fallback_spend=team_object.spend or 0.0,
         )
+
+        # Defensive: when Redis says we are over budget, double-check
+        # against the authoritative DB spend before raising. The cached
+        # team_object.spend can lag a multi-pod Redis counter (so trusting
+        # it would let real over-spend through), but a direct DB read is
+        # authoritative — if the DB row says spend is well under the cap
+        # while Redis says it is over, the Redis counter is stale and we
+        # reseed from DB. Customer-reported in LIT-3132.
+        if (
+            math.isfinite(team_object.max_budget)
+            and spend > team_object.max_budget
+        ):
+            spend = await _maybe_reseed_stale_team_spend_counter(
+                counter_key=counter_key,
+                team_object=team_object,
+                redis_spend=spend,
+            )
 
         if math.isfinite(team_object.max_budget) and spend > team_object.max_budget:
             if valid_token:

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3372,105 +3372,6 @@ async def test_resolve_end_user_reraises_budget_exceeded(
         )
 
 
-@pytest.mark.asyncio
-async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
-    """
-    Regression pin for LIT-3244 patch/1.86.0 follow-up.
-
-    `_cache_team_object` is the canonical "refresh this team" primitive.
-    Two cache keys are in play:
-      - "team_id:<id>"    — used by `get_team_object(team_id=...)`,
-                            i.e. API-key auth and JWT-with-team_id_jwt_field
-      - "team_alias:<alias>" — used by `get_team_object_by_alias(team_alias=...)`,
-                               i.e. JWT-with-team_alias_jwt_field
-
-    Invariants this test pins:
-      1. Writes the team_id-keyed entry with the refreshed object (team_id
-         is the table PK — guaranteed unique, safe to write).
-      2. DELETES (does NOT write) the team_alias-keyed entry. `team_alias`
-         has no UNIQUE constraint in schema.prisma, so writing it from
-         this generic refresh path would let a team admin who renames
-         their team to collide with another team's alias silently
-         overwrite the cached team for JWT-by-alias auth (veria-ai
-         review on #28739). Deleting forces the next JWT-by-alias
-         reader through `get_team_object_by_alias`, which enforces
-         len(teams)==1 before populating the cache.
-      3. When team_alias is None, NO alias-key operation happens (no
-         delete of an empty-keyed entry, no spurious write).
-    """
-    from unittest.mock import AsyncMock, MagicMock
-
-    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
-    from litellm.proxy.auth.auth_checks import _cache_team_object
-
-    base_team_row = {
-        "team_id": "team-1234",
-        "team_alias": "H-Capacity",
-        "models": ["openai/*", "bedrock-claude-sonnet-4"],
-    }
-
-    # ===== team_alias is set =====
-    team_table = LiteLLM_TeamTableCachedObj(**base_team_row)
-    cache = MagicMock()
-    cache.async_set_cache = AsyncMock()
-    cache.delete_cache = MagicMock()
-    logging_obj = MagicMock()
-    logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
-
-    await _cache_team_object(
-        team_id="team-1234",
-        team_table=team_table,
-        user_api_key_cache=cache,
-        proxy_logging_obj=logging_obj,
-    )
-
-    # (1) team_id-keyed write fires with the refreshed object
-    written_keys = [
-        (c.kwargs.get("key") or c.args[0])
-        for c in cache.async_set_cache.await_args_list
-    ]
-    assert written_keys == ["team_id:team-1234"], (
-        "Only the team_id-keyed write should fire; the alias key must be "
-        "deleted, NOT written. "
-        f"Got writes: {written_keys}"
-    )
-    written_value = (
-        cache.async_set_cache.await_args.kwargs.get("value")
-        or cache.async_set_cache.await_args.args[1]
-    )
-    assert written_value is team_table
-
-    # (2) team_alias-keyed entry is deleted in BOTH the in-memory cache
-    # and the Redis dual cache (mirrors _delete_cache_key_object pattern).
-    cache.delete_cache.assert_called_once_with(key="team_alias:H-Capacity")
-    logging_obj.internal_usage_cache.dual_cache.async_delete_cache.assert_awaited_once_with(
-        key="team_alias:H-Capacity"
-    )
-
-    # ===== team_alias is None: no alias-key operation =====
-    aliasless = LiteLLM_TeamTableCachedObj(**{**base_team_row, "team_alias": None})
-    cache2 = MagicMock()
-    cache2.async_set_cache = AsyncMock()
-    cache2.delete_cache = MagicMock()
-    logging_obj2 = MagicMock()
-    logging_obj2.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
-
-    await _cache_team_object(
-        team_id="team-no-alias",
-        team_table=aliasless,
-        user_api_key_cache=cache2,
-        proxy_logging_obj=logging_obj2,
-    )
-
-    cache2.delete_cache.assert_not_called()
-    logging_obj2.internal_usage_cache.dual_cache.async_delete_cache.assert_not_awaited()
-    written_keys_aliasless = [
-        (c.kwargs.get("key") or c.args[0])
-        for c in cache2.async_set_cache.await_args_list
-    ]
-    assert written_keys_aliasless == ["team_id:team-no-alias"]
-
-
 # Regression tests for LIT-3132 — stale Redis team spend counter
 # https://github.com/BerriAI/litellm/issues/<this PR>
 #
@@ -3489,7 +3390,7 @@ async def test_team_budget_check_recovers_when_redis_counter_is_stale():
     team_object = LiteLLM_TeamTable(
         team_id="test-team-stale-redis",
         spend=0.144,  # the cached team_object can lag in multi-pod setups;
-                     # we cannot rely on it. The fix re-reads the DB.
+        # we cannot rely on it. The fix re-reads the DB.
         max_budget=2.0,
     )
     valid_token = UserAPIKeyAuth(token="t", team_id="test-team-stale-redis")
@@ -3516,9 +3417,7 @@ async def test_team_budget_check_recovers_when_redis_counter_is_stale():
     with (
         patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
         patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
-        patch(
-            "litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache
-        ),
+        patch("litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache),
         patch(
             "litellm.proxy.db.spend_counter_reseed.SpendCounterReseed.from_db",
             mock_from_db,
@@ -3568,9 +3467,7 @@ async def test_team_budget_check_still_blocks_when_db_confirms_overspend():
     with (
         patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
         patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
-        patch(
-            "litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache
-        ),
+        patch("litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache),
         patch(
             "litellm.proxy.db.spend_counter_reseed.SpendCounterReseed.from_db",
             mock_from_db,
@@ -3617,9 +3514,7 @@ async def test_team_budget_check_keeps_blocking_when_db_unavailable():
     with (
         patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
         patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
-        patch(
-            "litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache
-        ),
+        patch("litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache),
         patch(
             "litellm.proxy.db.spend_counter_reseed.SpendCounterReseed.from_db",
             mock_from_db,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -3370,3 +3370,266 @@ async def test_resolve_end_user_reraises_budget_exceeded(
             prisma_client=MagicMock(),
             user_api_key_cache=cache,
         )
+
+
+@pytest.mark.asyncio
+async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
+    """
+    Regression pin for LIT-3244 patch/1.86.0 follow-up.
+
+    `_cache_team_object` is the canonical "refresh this team" primitive.
+    Two cache keys are in play:
+      - "team_id:<id>"    — used by `get_team_object(team_id=...)`,
+                            i.e. API-key auth and JWT-with-team_id_jwt_field
+      - "team_alias:<alias>" — used by `get_team_object_by_alias(team_alias=...)`,
+                               i.e. JWT-with-team_alias_jwt_field
+
+    Invariants this test pins:
+      1. Writes the team_id-keyed entry with the refreshed object (team_id
+         is the table PK — guaranteed unique, safe to write).
+      2. DELETES (does NOT write) the team_alias-keyed entry. `team_alias`
+         has no UNIQUE constraint in schema.prisma, so writing it from
+         this generic refresh path would let a team admin who renames
+         their team to collide with another team's alias silently
+         overwrite the cached team for JWT-by-alias auth (veria-ai
+         review on #28739). Deleting forces the next JWT-by-alias
+         reader through `get_team_object_by_alias`, which enforces
+         len(teams)==1 before populating the cache.
+      3. When team_alias is None, NO alias-key operation happens (no
+         delete of an empty-keyed entry, no spurious write).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+    from litellm.proxy.auth.auth_checks import _cache_team_object
+
+    base_team_row = {
+        "team_id": "team-1234",
+        "team_alias": "H-Capacity",
+        "models": ["openai/*", "bedrock-claude-sonnet-4"],
+    }
+
+    # ===== team_alias is set =====
+    team_table = LiteLLM_TeamTableCachedObj(**base_team_row)
+    cache = MagicMock()
+    cache.async_set_cache = AsyncMock()
+    cache.delete_cache = MagicMock()
+    logging_obj = MagicMock()
+    logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+
+    await _cache_team_object(
+        team_id="team-1234",
+        team_table=team_table,
+        user_api_key_cache=cache,
+        proxy_logging_obj=logging_obj,
+    )
+
+    # (1) team_id-keyed write fires with the refreshed object
+    written_keys = [
+        (c.kwargs.get("key") or c.args[0])
+        for c in cache.async_set_cache.await_args_list
+    ]
+    assert written_keys == ["team_id:team-1234"], (
+        "Only the team_id-keyed write should fire; the alias key must be "
+        "deleted, NOT written. "
+        f"Got writes: {written_keys}"
+    )
+    written_value = (
+        cache.async_set_cache.await_args.kwargs.get("value")
+        or cache.async_set_cache.await_args.args[1]
+    )
+    assert written_value is team_table
+
+    # (2) team_alias-keyed entry is deleted in BOTH the in-memory cache
+    # and the Redis dual cache (mirrors _delete_cache_key_object pattern).
+    cache.delete_cache.assert_called_once_with(key="team_alias:H-Capacity")
+    logging_obj.internal_usage_cache.dual_cache.async_delete_cache.assert_awaited_once_with(
+        key="team_alias:H-Capacity"
+    )
+
+    # ===== team_alias is None: no alias-key operation =====
+    aliasless = LiteLLM_TeamTableCachedObj(**{**base_team_row, "team_alias": None})
+    cache2 = MagicMock()
+    cache2.async_set_cache = AsyncMock()
+    cache2.delete_cache = MagicMock()
+    logging_obj2 = MagicMock()
+    logging_obj2.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+
+    await _cache_team_object(
+        team_id="team-no-alias",
+        team_table=aliasless,
+        user_api_key_cache=cache2,
+        proxy_logging_obj=logging_obj2,
+    )
+
+    cache2.delete_cache.assert_not_called()
+    logging_obj2.internal_usage_cache.dual_cache.async_delete_cache.assert_not_awaited()
+    written_keys_aliasless = [
+        (c.kwargs.get("key") or c.args[0])
+        for c in cache2.async_set_cache.await_args_list
+    ]
+    assert written_keys_aliasless == ["team_id:team-no-alias"]
+
+
+# Regression tests for LIT-3132 — stale Redis team spend counter
+# https://github.com/BerriAI/litellm/issues/<this PR>
+#
+# When the cross-pod Redis counter `spend:team:{team_id}` reports the team is
+# over its budget but the authoritative `LiteLLM_TeamTable.spend` row is well
+# under the cap, the Redis counter is stale (typically because the reset job
+# committed `team.spend = 0` to Postgres but the Redis write silently failed —
+# Redis unreachable from the reset-job pod, `spend_counter_cache.redis_cache`
+# was None on that pod, etc.). `_team_max_budget_check` must recover by
+# trusting the DB value rather than blocking the team out of its budget.
+@pytest.mark.asyncio
+async def test_team_budget_check_recovers_when_redis_counter_is_stale():
+    """Redis says over-budget but DB says well under → reseed and let through."""
+    from litellm.proxy.utils import ProxyLogging
+
+    team_object = LiteLLM_TeamTable(
+        team_id="test-team-stale-redis",
+        spend=0.144,  # the cached team_object can lag in multi-pod setups;
+                     # we cannot rely on it. The fix re-reads the DB.
+        max_budget=2.0,
+    )
+    valid_token = UserAPIKeyAuth(token="t", team_id="test-team-stale-redis")
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
+    proxy_logging_obj.budget_alerts = AsyncMock()
+
+    # Redis reports an over-budget value (stale lifetime accumulation)
+    async def mock_get_current_spend(counter_key, fallback_spend):
+        if counter_key == "spend:team:test-team-stale-redis":
+            return 2.5
+        return fallback_spend
+
+    # DB says spend=0.144 (well under max_budget=2.0)
+    async def mock_from_db(prisma_client, counter_key):
+        if counter_key == "spend:team:test-team-stale-redis":
+            return 0.144
+        return None
+
+    mock_prisma = MagicMock()
+    mock_spend_cache = MagicMock()
+    mock_spend_cache.redis_cache = AsyncMock()
+    mock_spend_cache.in_memory_cache = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache
+        ),
+        patch(
+            "litellm.proxy.db.spend_counter_reseed.SpendCounterReseed.from_db",
+            mock_from_db,
+        ),
+    ):
+        # Should NOT raise — DB is authoritative and says we are under
+        await _team_max_budget_check(
+            team_object=team_object,
+            valid_token=valid_token,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+    # Confirms the stale Redis key was deleted so subsequent reads reseed
+    mock_spend_cache.redis_cache.async_delete_cache.assert_awaited_once_with(
+        "spend:team:test-team-stale-redis"
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_budget_check_still_blocks_when_db_confirms_overspend():
+    """Both Redis and DB say over the cap → still raise BudgetExceededError."""
+    from litellm.proxy.utils import ProxyLogging
+
+    team_object = LiteLLM_TeamTable(
+        team_id="test-team-real-overspend",
+        spend=1.5,
+        max_budget=1.0,
+    )
+    valid_token = UserAPIKeyAuth(token="t", team_id="test-team-real-overspend")
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
+    proxy_logging_obj.budget_alerts = AsyncMock()
+
+    async def mock_get_current_spend(counter_key, fallback_spend):
+        if counter_key == "spend:team:test-team-real-overspend":
+            return 1.5
+        return fallback_spend
+
+    async def mock_from_db(prisma_client, counter_key):
+        # DB also confirms overspend
+        return 1.5
+
+    mock_prisma = MagicMock()
+    mock_spend_cache = MagicMock()
+    mock_spend_cache.redis_cache = AsyncMock()
+    mock_spend_cache.in_memory_cache = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache
+        ),
+        patch(
+            "litellm.proxy.db.spend_counter_reseed.SpendCounterReseed.from_db",
+            mock_from_db,
+        ),
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await _team_max_budget_check(
+                team_object=team_object,
+                valid_token=valid_token,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        assert exc_info.value.current_cost == 1.5
+        assert exc_info.value.max_budget == 1.0
+
+    # No counter delete on a legitimate over-budget path
+    mock_spend_cache.redis_cache.async_delete_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_team_budget_check_keeps_blocking_when_db_unavailable():
+    """DB read returns None (e.g. Prisma error) → fall back to Redis enforcement."""
+    from litellm.proxy.utils import ProxyLogging
+
+    team_object = LiteLLM_TeamTable(
+        team_id="test-team-db-unavailable",
+        spend=0.0,
+        max_budget=1.0,
+    )
+    valid_token = UserAPIKeyAuth(token="t", team_id="test-team-db-unavailable")
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
+    proxy_logging_obj.budget_alerts = AsyncMock()
+
+    async def mock_get_current_spend(counter_key, fallback_spend):
+        return 1.5  # over
+
+    async def mock_from_db(prisma_client, counter_key):
+        return None  # simulate DB unavailable
+
+    mock_prisma = MagicMock()
+    mock_spend_cache = MagicMock()
+    mock_spend_cache.redis_cache = AsyncMock()
+    mock_spend_cache.in_memory_cache = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.get_current_spend", mock_get_current_spend),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.spend_counter_cache", mock_spend_cache
+        ),
+        patch(
+            "litellm.proxy.db.spend_counter_reseed.SpendCounterReseed.from_db",
+            mock_from_db,
+        ),
+    ):
+        # DB unavailable → cannot verify staleness → enforce on Redis value
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await _team_max_budget_check(
+                team_object=team_object,
+                valid_token=valid_token,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        assert exc_info.value.current_cost == 1.5


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3132 (8451 Issue Tracker).

## Linear ticket

Resolves LIT-3132

## What this fixes

When the cross-pod Redis counter `spend:team:{team_id}` reports a team is over its budget but the authoritative `LiteLLM_TeamTable.spend` row is well under, the Redis counter is stale. `_team_max_budget_check` was reading Redis-first and raising `BudgetExceededError` without ever cross-checking the DB, so the team stayed locked out of its own budget until the counter was manually cleared.

Customer-reported (8451 / LIT-3132): the auth check raised  
```
Current cost: 2000.0000014, Max budget: 2000.0
```  
while the team's DB row showed `spend = 0.144` (well after a 30-day budget reset). The most common cause is the periodic reset job committing `team.spend = 0` to Postgres but its Redis write silently no-opping — Redis unreachable from the reset-job pod, `spend_counter_cache.redis_cache is None` on that pod, etc.

## What changed

Adds `_maybe_reseed_stale_team_spend_counter` in `litellm/proxy/auth/auth_checks.py`. When Redis says over-budget, it reads `LiteLLM_TeamTable.spend` directly via `SpendCounterReseed.from_db` (authoritative — does **not** trust the cached `team_object`, which can lag in multi-pod deployments). Only treats Redis as stale when the DB row is **below 50% of `max_budget`** while Redis is over.

Why the 50% gate: a legitimate over-budget condition has both sides at or near the cap once the spend flusher commits, so we never relax enforcement on a real over-spend.

On any DB failure (Prisma error, row missing, etc.) the caller's existing Redis-based enforcement runs unchanged. This change can only *relax* enforcement on a clear staleness signal, never *harden* it.

When the staleness signal fires, the stale Redis key is **deleted** (not zeroed) so subsequent reads on this pod take the clean-miss path through `SpendCounterReseed.coalesced`, which `SET NX` seeds the counter from the DB and keeps concurrent pods converging on the same value.

## Evidence

Repro: Postgres 17 + Redis 8 + LiteLLM proxy off `main`. One team `max_budget=2.0, budget_duration=30d`, one key bound to the team.

Bug state setup mirrors the customer screenshot:
- Redis `spend:team:{id} = 2.5` (over the cap)
- DB `LiteLLM_TeamTable.spend = 0.144`, `max_budget = 2.0`

### Before (current `main`)

```
$ redis-cli GET spend:team:1144cc08-c2f3-4326-bbca-bb1eb9bc3c59
2.5
$ psql -c "SELECT spend, max_budget FROM LiteLLM_TeamTable WHERE team_id=..."
 spend | max_budget 
-------+------------
 0.144 |          2

$ curl -s -X POST http://127.0.0.1:4000/chat/completions \
    -H "Authorization: Bearer sk-..." -H "Content-Type: application/json" \
    -d '{"model":"fake","messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"Budget has been exceeded! Team=1144cc08-c2f3-4326-bbca-bb1eb9bc3c59 Current cost: 2.5, Max budget: 2.0","type":"budget_exceeded","param":null,"code":"429"}}
HTTP_CODE=429

$ # Redis state after — still stale
$ redis-cli GET spend:team:1144cc08-c2f3-4326-bbca-bb1eb9bc3c59
2.5
```

### After (this PR)

```
$ # identical state setup
$ curl -s -X POST http://127.0.0.1:4000/chat/completions \
    -H "Authorization: Bearer sk-..." -H "Content-Type: application/json" \
    -d '{"model":"fake","messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"litellm.InternalServerError: ... Connection error.. Received Model Group=fake ...","code":"500"}}
HTTP_CODE=500   # got past auth; upstream "fake" model unreachable (expected — model isn't real)

$ # Redis state after the request — counter deleted, next read reseeds from DB
$ redis-cli GET spend:team:1144cc08-c2f3-4326-bbca-bb1eb9bc3c59
(nil)

$ # Proxy logged the staleness recovery
[WARNING] auth_checks.py:3909 - Reseeded stale team spend counter spend:team:1144cc08-c2f3-4326-bbca-bb1eb9bc3c59 from DB:
  Redis reported 2.500000 (over max_budget=2.000000) but the authoritative DB row had spend=0.144000.
  This typically means the cross-pod Redis counter did not get invalidated by the most recent budget reset
  (e.g. Redis unreachable on the reset-job pod, or spend_counter_cache.redis_cache was None during reset).
```

### Enforcement preserved (legitimate over-budget — `team.spend=1.5, max_budget=1.0, Redis=1.5`)

```
$ curl -s -X POST http://127.0.0.1:4000/chat/completions ...
{"error":{"message":"Budget has been exceeded! Team=... Current cost: 1.5, Max budget: 1.0","type":"budget_exceeded","code":"429"}}
HTTP_CODE=429
```

When DB also confirms spend is at/near the cap, the request is still blocked.

## Tests

```
$ python3 -m pytest tests/test_litellm/proxy/auth/test_auth_checks.py \
    ::test_team_budget_check_recovers_when_redis_counter_is_stale \
    ::test_team_budget_check_still_blocks_when_db_confirms_overspend \
    ::test_team_budget_check_keeps_blocking_when_db_unavailable \
    ::test_team_budget_check_reads_from_spend_counter \
    -xvs
============================== 4 passed in 8.17s ===============================
```

New tests:
- `test_team_budget_check_recovers_when_redis_counter_is_stale` — bug repro: Redis says 2.5 (over), DB says 0.144 (under) → no exception, stale Redis key is deleted.
- `test_team_budget_check_still_blocks_when_db_confirms_overspend` — Redis 1.5 + DB 1.5, cap 1.0 → still raises `BudgetExceededError`.
- `test_team_budget_check_keeps_blocking_when_db_unavailable` — `SpendCounterReseed.from_db` returns `None` → fall back to Redis-only enforcement (safe default).

Existing `test_team_budget_check_reads_from_spend_counter` (`team_object.spend=0.0, Redis=1.5, cap=1.0`) still passes — the helper short-circuits when `prisma_client is None` and the existing assertion (`current_cost == 1.5`) holds.

## Note on PR mechanics

This branch was uploaded via the GitHub Contents API (one PUT per file) because the current agent token lacks `repo`/`workflow` scopes for `git push`. The merge-base diff may look noisier than a plain `git push` would produce. The only logical diff is the one shown in the diff view here: `litellm/proxy/auth/auth_checks.py` (+86) and `tests/test_litellm/proxy/auth/test_auth_checks.py` (+164).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR's scope is as isolated as possible
- [ ] Greptile + Veria review pending (will tag once CI runs)

## CI (LiteLLM team)

- [ ] **Branch creation CI run** — will fill in after CI publishes the link
- [ ] **CI run for the last commit** — will fill in after CI publishes the link
- [ ] **Merge / cherry-pick CI run** — will fill in after merge
