### PR TITLE
fix(focus): include organization_id/organization_alias in Vantage Tags (LIT-2895)

### DIFF
--- a/litellm/integrations/focus/database.py
+++ b/litellm/integrations/focus/database.py
@@ -80,10 +80,13 @@ class FocusLiteLLMDatabase:
             vt.team_id,
             vt.key_alias as api_key_alias,
             tt.team_alias,
+            tt.organization_id as organization_id,
+            ot.organization_alias as organization_alias,
             ut.user_email as user_email
         FROM "LiteLLM_DailyUserSpend" dus
         LEFT JOIN "LiteLLM_VerificationToken" vt ON dus.api_key = vt.token
         LEFT JOIN "LiteLLM_TeamTable" tt ON vt.team_id = tt.team_id
+        LEFT JOIN "LiteLLM_OrganizationTable" ot ON tt.organization_id = ot.organization_id
         LEFT JOIN "LiteLLM_UserTable" ut ON dus.user_id = ut.user_id
         {where_clause}
         ORDER BY dus.date DESC, dus.created_at DESC

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -12,6 +12,8 @@ from .schema import FOCUS_NORMALIZED_SCHEMA
 _TAG_KEYS = (
     "team_id",
     "team_alias",
+    "organization_id",
+    "organization_alias",
     "user_id",
     "user_email",
     "api_key_alias",

--- a/tests/test_litellm/integrations/focus/test_focus_database.py
+++ b/tests/test_litellm/integrations/focus/test_focus_database.py
@@ -72,3 +72,23 @@ async def test_should_reject_invalid_limit(monkeypatch: pytest.MonkeyPatch):
         await db.get_usage_data(limit="invalid")
 
     assert query_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_should_select_organization_columns_via_left_join(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """LIT-2895: SELECT clause must include organization_id (from TeamTable) and
+    organization_alias (from OrganizationTable via LEFT JOIN), so Vantage Token
+    Allocation can route on org-level data."""
+    db, query_mock = _setup_db(monkeypatch, [])
+
+    await db.get_usage_data()
+
+    query_text, *_ = query_mock.await_args.args
+    assert "tt.organization_id as organization_id" in query_text
+    assert "ot.organization_alias as organization_alias" in query_text
+    assert (
+        'LEFT JOIN "LiteLLM_OrganizationTable" ot ON tt.organization_id = ot.organization_id'
+        in query_text
+    )

--- a/tests/test_litellm/integrations/focus/test_focus_transformer.py
+++ b/tests/test_litellm/integrations/focus/test_focus_transformer.py
@@ -1,0 +1,80 @@
+"""Tests for FocusTransformer — focus on Tags JSON construction for Vantage Token Allocation."""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import polars as pl
+import pytest
+
+from litellm.integrations.focus.transformer import _TAG_KEYS, FocusTransformer
+
+
+def _base_row(**overrides):
+    row = {
+        "date": "2026-05-20",
+        "user_id": "user-1",
+        "api_key": "sk-abc",
+        "model": "gpt-5o",
+        "model_group": "gpt-5o",
+        "custom_llm_provider": "openai",
+        "spend": 1.50,
+        "team_id": "team-1",
+        "team_alias": "team-one",
+        "user_email": "alice@example.com",
+        "api_key_alias": "dev-key",
+    }
+    row.update(overrides)
+    return row
+
+
+def _tags(df: pl.DataFrame, idx: int = 0) -> dict:
+    return json.loads(FocusTransformer().transform(df)["Tags"][idx])
+
+
+def test_tag_keys_include_organization_fields():
+    """Both organization_id and organization_alias must be in _TAG_KEYS so Vantage
+    Token Allocation can route on org-level data (LIT-2895)."""
+    assert "organization_id" in _TAG_KEYS
+    assert "organization_alias" in _TAG_KEYS
+
+
+def test_organization_id_flows_into_tags_when_present():
+    row = _base_row(organization_id="org-tempus", organization_alias="Tempus")
+    tags = _tags(pl.DataFrame([row]))
+    assert tags["organization_id"] == "org-tempus"
+    assert tags["organization_alias"] == "Tempus"
+    # Existing tag keys still present (no regression)
+    assert tags["team_id"] == "team-1"
+    assert tags["user_id"] == "user-1"
+
+
+def test_organization_fields_absent_when_team_has_no_org():
+    """When organization_id/alias are NULL (team not in an org), they should
+    NOT appear in the Tags JSON (matches existing behavior for nullable keys)."""
+    row = _base_row(organization_id=None, organization_alias=None)
+    tags = _tags(pl.DataFrame([row]))
+    assert "organization_id" not in tags
+    assert "organization_alias" not in tags
+    # Other keys still flow through
+    assert tags["team_id"] == "team-1"
+
+
+def test_organization_fields_optional_when_columns_missing():
+    """If the DB query did not supply organization columns at all (e.g. older
+    custom call site), the transformer must not raise; tags simply omit them."""
+    row = _base_row()  # no organization_* keys
+    tags = _tags(pl.DataFrame([row]))
+    assert "organization_id" not in tags
+    assert "organization_alias" not in tags
+    assert tags["team_id"] == "team-1"
+
+
+def test_organization_id_only_partial_metadata():
+    """A team with organization_id but no resolvable organization_alias still
+    flows the id through."""
+    row = _base_row(organization_id="org-tempus", organization_alias=None)
+    tags = _tags(pl.DataFrame([row]))
+    assert tags["organization_id"] == "org-tempus"
+    assert "organization_alias" not in tags


### PR DESCRIPTION
## Summary

Plumbs `organization_id` and `organization_alias` through the FOCUS export pipeline so the per-row Tags JSON that Vantage Token Allocation reads includes organization-level data, matching the existing pattern for team/user fields. Fixes **LIT-2895** (customer: Tempus).

## Root cause

The Focus export builds a `Tags` column on every cost row (defined in `litellm/integrations/focus/transformer.py`). Vantage's [custom-provider integration](https://docs.vantage.sh/connecting_custom_providers) routes Token Allocation on those tags, so each key Vantage should see has to be in `_TAG_KEYS` AND fetched by the database query.

On main:
- `_TAG_KEYS` covers `team_id`, `team_alias`, `user_id`, `user_email`, `api_key_alias`, `model`, `model_group`, `custom_llm_provider` — **but not the org fields**.
- `FocusLiteLLMDatabase.get_usage_data` joins TeamTable / UserTable but never touches `LiteLLM_OrganizationTable`, so the columns aren't even loaded.

Net effect: even when a team is in an org, the Tags JSON drops `organization_id` and `organization_alias` and Vantage can't surface org-level rollups.

## Fix (4 files, +105 / -0 net)

1. `litellm/integrations/focus/transformer.py` — add `organization_id` and `organization_alias` to `_TAG_KEYS` (between team and user keys; matches the conceptual hierarchy).
2. `litellm/integrations/focus/database.py` — add `tt.organization_id` and `ot.organization_alias` to the SELECT, with a new `LEFT JOIN "LiteLLM_OrganizationTable" ot ON tt.organization_id = ot.organization_id`. Rows whose team has no org get NULL — the transformer's existing null-stripping in `_struct_to_json` then omits them from the JSON, mirroring how `user_email` already behaves for users without an email.
3. `tests/test_litellm/integrations/focus/test_focus_transformer.py` (new, 5 cases) — pins:
   - `_TAG_KEYS` contains both org keys
   - both flow into Tags when present
   - both omitted when null (team has no org)
   - no crash when columns are missing entirely (call sites that bypass the DB)
   - partial-metadata case (org_id present, org_alias null)
4. `tests/test_litellm/integrations/focus/test_focus_database.py` — 1 new case pinning the SELECT clauses and the new LEFT JOIN.

All 31 focus tests pass locally.

## Evidence

Driven `FocusTransformer().transform()` against a synthetic Polars frame containing `organization_id="org-tempus"` and `organization_alias="Tempus"`, captured the resulting `Tags` cell.

### Before (main @ 73e9071)

```text
# _TAG_KEYS:
('team_id', 'team_alias', 'user_id', 'user_email',
 'api_key_alias', 'model', 'model_group', 'custom_llm_provider')

# Tags JSON (organization_id/alias DROPPED even though present in row):
{
  "team_id": "team-1",
  "team_alias": "team-one",
  "user_id": "user-1",
  "user_email": "alice@example.com",
  "api_key_alias": "dev-key",
  "model": "gpt-5o",
  "model_group": "gpt-5o",
  "custom_llm_provider": "openai"
}
```

### After (this PR)

```text
# _TAG_KEYS:
('team_id', 'team_alias', 'organization_id', 'organization_alias',
 'user_id', 'user_email', 'api_key_alias', 'model', 'model_group',
 'custom_llm_provider')

# Tags JSON (Vantage Token Allocation now sees the org dims):
{
  "team_id": "team-1",
  "team_alias": "team-one",
  "organization_id": "org-tempus",
  "organization_alias": "Tempus",
  "user_id": "user-1",
  "user_email": "alice@example.com",
  "api_key_alias": "dev-key",
  "model": "gpt-5o",
  "model_group": "gpt-5o",
  "custom_llm_provider": "openai"
}
```

### Unit test output

```text
$ python -m pytest tests/test_litellm/integrations/focus/ -v
...
31 passed in 14.68s
```

## Notes for reviewers

- This PR was uploaded via the `PUT /repos/{owner}/{repo}/contents/{path}` API (the current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes for `git push`). Each file is its own commit on the branch, so the merge-base diff is slightly noisier than a single squashed commit, but the net diff against the daily branch is exactly the 4 files / +105 lines listed above.
- The new SELECT/JOIN runs at FOCUS export time only — it does not affect the hot per-request path. The added LEFT JOIN is on an indexed PK (`organization_id`) and produces at most one row per team, so cost is negligible on the existing aggregation query.

Linear: https://linear.app/litellm-ai/issue/LIT-2895/add-organization-to-vantage-focus-field-mapping
Session: https://litellm-agent-platform.onrender.com/sessions/9362f971-2444-4849-ad33-150252db153c


---

### Verification (ship-pr)

| Check | Result |
|---|---|
| Real runtime evidence captured (before + after) | ✅ Fenced code blocks above show `FocusTransformer().transform()` output with `organization_id="org-tempus"` / `organization_alias="Tempus"` in the row — BEFORE drops them, AFTER includes them. Data-layer change, no UI/HTTP surface so no PNG; per skill rules, that's the right artifact. |
| Unit tests added (in addition to, not instead of, runtime evidence) | ✅ 6 new tests (5 transformer cases + 1 db SELECT/JOIN case); 31/31 focus tests green locally |
| PR base branch | ✅ `litellm_oss_agent_shin_daily_branch` |
| No secrets in PR body / commits / comments | ✅ Reviewed |
| All required CI checks green | ✅ 44/44 green, 0 failing |
| Greptile score | ✅ 5/5 ("Safe to merge — changes are additive, confined to the FOCUS export path") |
| Veria | ✅ "No security issues found" |
| Codecov | ✅ "All modified and coverable lines are covered by tests" |
| Mergeable | ✅ clean |
| Linear ticket linked with PR | ✅ Comment on LIT-2895 |
