### PR TITLE
perf(vertex-ai/files): stream JSONL transform to fix OOM on large Gemini batch uploads (LIT-3382)

### DIFF
--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import httpx
 from httpx import Headers, Response
@@ -273,17 +273,20 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             raise ValueError("file content is required")
 
         if purpose == "batch":
-            ## 1. If jsonl, check if there's a model name
-            file_content = self._get_content_from_openai_file(
-                extracted_file_data_content
+            ## 1. If jsonl, sniff only the first row for its model (we don't
+            #     need to parse the full payload here). This keeps peak
+            #     memory ~O(line) instead of ~O(file_size) for very large
+            #     batches -- see LIT-3382.
+            first_entry: Optional[Dict[str, Any]] = next(
+                iter(
+                    self.jsonl_transformation._iter_openai_jsonl_entries(
+                        extracted_file_data_content
+                    )
+                ),
+                None,
             )
-
-            # Split into lines and parse each line as JSON
-            openai_jsonl_content = [
-                json.loads(line) for line in file_content.splitlines() if line.strip()
-            ]
-            if len(openai_jsonl_content) > 0:
-                return self._get_gcs_object_name_from_batch_jsonl(openai_jsonl_content)
+            if first_entry is not None:
+                return self._get_gcs_object_name_from_batch_jsonl([first_entry])
 
         ## 2. If not jsonl, store under a server-generated managed object name
         filename = extracted_file_data.get("filename")
@@ -399,21 +402,18 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             create_file_data=create_file_data,
             extracted_file_data=extracted_file_data,
         ):
-            ## 1. If jsonl, check if there's a model name
-            file_content = self._get_content_from_openai_file(
+            ## 1. If jsonl, stream the transform line-by-line to keep peak
+            #     memory bounded -- see LIT-3382 for the original OOM
+            #     regression on ~1 GB Gemini batch uploads.
+            out_parts: List[str] = []
+            for entry in self.jsonl_transformation._iter_openai_jsonl_entries(
                 extracted_file_data_content
-            )
-
-            # Split into lines and parse each line as JSON
-            openai_jsonl_content = [
-                json.loads(line) for line in file_content.splitlines() if line.strip()
-            ]
-            vertex_jsonl_content = (
-                self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
-                    openai_jsonl_content
+            ):
+                vertex_request_body = (
+                    self.jsonl_transformation._build_vertex_request_body(entry)
                 )
-            )
-            return "\n".join(json.dumps(item) for item in vertex_jsonl_content)
+                out_parts.append(json.dumps({"request": vertex_request_body}))
+            return "\n".join(out_parts)
         elif isinstance(extracted_file_data_content, bytes):
             return extracted_file_data_content
         else:
@@ -802,32 +802,148 @@ class VertexAIJsonlFilesTransformation(VertexGeminiConfig):
     Transforms OpenAI /v1/files/* requests to VertexAI /v1/files/* requests
     """
 
+    def _iter_openai_jsonl_entries(
+        self, openai_file_content: FileTypes
+    ) -> Iterator[Dict[str, Any]]:
+        """
+        Yields parsed OpenAI batch JSONL entries one at a time without
+        materializing the full list in memory.
+
+        Streams from file-like / PathLike inputs directly so we never have to
+        hold the entire decoded payload AND a ``splitlines`` list AND a
+        parsed-dicts list simultaneously. For ``str`` / ``bytes`` inputs we
+        still fall back to iterating ``splitlines()`` -- those callers already
+        chose to hold the whole payload in memory before calling us.
+
+        Introduced for LIT-3382 (large Gemini batch uploads OOM-killed
+        uvicorn workers because each transform held ~5 simultaneous copies
+        of the JSONL payload).
+        """
+        import io as _io
+
+        if isinstance(openai_file_content, tuple):
+            file_content = openai_file_content[1]
+        else:
+            file_content = openai_file_content
+
+        if hasattr(file_content, "read") and hasattr(file_content, "readline"):
+            try:
+                if hasattr(file_content, "seek"):
+                    file_content.seek(0)
+            except Exception:
+                pass
+            wrapper: Any = file_content
+            detach_after = False
+            if hasattr(file_content, "readinto"):
+                try:
+                    wrapper = _io.TextIOWrapper(
+                        file_content, encoding="utf-8", newline=""
+                    )
+                    detach_after = True
+                except Exception:
+                    wrapper = file_content
+            try:
+                for raw_line in wrapper:
+                    if isinstance(raw_line, bytes):
+                        raw_line = raw_line.decode("utf-8")
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    yield json.loads(line)
+            finally:
+                if detach_after:
+                    try:
+                        wrapper.detach()
+                    except Exception:
+                        pass
+            return
+
+        if isinstance(file_content, PathLike):
+            with open(str(file_content), "r", encoding="utf-8") as fh:
+                for raw_line in fh:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    yield json.loads(line)
+            return
+
+        if isinstance(file_content, bytes):
+            text = file_content.decode("utf-8")
+        elif isinstance(file_content, str):
+            text = file_content
+        else:
+            text = self._get_content_from_openai_file(openai_file_content)
+
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+    def _build_vertex_request_body(
+        self, openai_entry: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Transform a single OpenAI batch JSONL entry to a Vertex AI request
+        body dict (without the outer ``{"request": ...}`` wrapper). Mirrors
+        the per-entry logic of
+        ``_openai_batch_jsonl_entries_to_vertex_wrapped_requests`` but
+        operates on one row at a time so callers can stream the transform.
+        """
+        openai_request_body = openai_entry.get("body") or {}
+        vertex_request_body = _transform_request_body(
+            messages=openai_request_body.get("messages", []),
+            model=openai_request_body.get("model", ""),
+            optional_params=self._map_openai_to_vertex_params(openai_request_body),
+            custom_llm_provider="vertex_ai",
+            litellm_params={},
+            cached_content=None,
+        )
+        custom_id = openai_entry.get("custom_id")
+        if custom_id is not None:
+            if "labels" not in vertex_request_body:
+                vertex_request_body["labels"] = {}
+            _set_litellm_batch_custom_id_labels(
+                vertex_request_body["labels"], custom_id
+            )
+        return vertex_request_body
+
     def transform_openai_file_content_to_vertex_ai_file_content(
         self, openai_file_content: Optional[FileTypes] = None
     ) -> Tuple[str, str]:
         """
-        Transforms OpenAI FileContentRequest to VertexAI FileContentRequest
+        Transforms OpenAI FileContentRequest to VertexAI FileContentRequest.
+
+        Streams the transform line-by-line so peak memory stays close to
+        ``input_size + output_size`` instead of ``~5x input_size``. The
+        previous implementation kept three full intermediate copies of the
+        payload (the openai parsed-dicts list, the vertex parsed-dicts list,
+        and the joined output string), which caused LiteLLM workers to OOM
+        and uvicorn to restart when customers (e.g. Tempus) uploaded ~1 GB
+        Gemini batch JSONL files (LIT-3382).
         """
 
         if openai_file_content is None:
             raise ValueError("contents of file are None")
-        # Read the content of the file
-        file_content = self._get_content_from_openai_file(openai_file_content)
 
-        # Split into lines and parse each line as JSON
-        openai_jsonl_content = [
-            json.loads(line) for line in file_content.splitlines() if line.strip()
-        ]
-        vertex_jsonl_content = (
-            self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
-                openai_jsonl_content
-            )
-        )
-        vertex_jsonl_string = "\n".join(
-            json.dumps(item) for item in vertex_jsonl_content
-        )
+        first_entry: Optional[Dict[str, Any]] = None
+        out_parts: List[str] = []
+        for entry in self._iter_openai_jsonl_entries(openai_file_content):
+            if first_entry is None:
+                # Capture only the first entry for object_name (needs the model).
+                first_entry = entry
+            vertex_request_body = self._build_vertex_request_body(entry)
+            out_parts.append(json.dumps({"request": vertex_request_body}))
+
+        if first_entry is None:
+            raise ValueError("contents of file are empty")
+
+        vertex_jsonl_string = "\n".join(out_parts)
+        # Free the intermediate list before returning the (already-large)
+        # joined string so peak memory stays bounded.
+        del out_parts
         object_name = self._get_gcs_object_name(
-            openai_jsonl_content=openai_jsonl_content
+            openai_jsonl_content=[first_entry]
         )
         return vertex_jsonl_string, object_name
 

--- a/tests/test_litellm/llms/vertex_ai/files/test_lit_3382_streaming_transform.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_lit_3382_streaming_transform.py
@@ -1,0 +1,300 @@
+"""
+Regression tests for LIT-3382: large Gemini batch JSONL uploads must not
+materialize ~5 simultaneous copies of the payload (raw bytes, decoded
+string, splitlines list, parsed-openai-dicts list, parsed-vertex-dicts list,
+joined string). That caused uvicorn workers on 12 GB pods to OOM on ~1 GB
+inputs and crash with "Child process died" (Tempus customer report).
+
+After the streaming refactor, peak memory should stay roughly within
+``input_size + output_size`` (~2-3x input), not ~5-8x input.
+
+These tests guard all three call sites that handle the JSONL transform:
+
+1. ``VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content``
+   — used by ``VertexAIFilesHandler.async_create_file`` (legacy GCS-direct path).
+2. ``VertexAIFilesConfig.transform_create_file_request``
+   — used by ``litellm.files.main.create_file`` (modern ``/v1/files`` route).
+3. ``VertexAIFilesConfig.get_object_name``
+   — called inside ``get_complete_file_url``.
+"""
+
+import gc
+import io
+import json
+import tracemalloc
+from typing import List, Tuple
+
+import pytest
+
+from litellm.llms.vertex_ai.files.transformation import (
+    VertexAIFilesConfig,
+    VertexAIJsonlFilesTransformation,
+)
+
+
+def _build_batch_jsonl(num_rows: int, prompt_chars: int = 2000) -> bytes:
+    prompt = "x" * prompt_chars
+    lines: List[str] = []
+    for i in range(num_rows):
+        lines.append(
+            json.dumps(
+                {
+                    "custom_id": f"req-{i}",
+                    "method": "POST",
+                    "url": "/v1/chat/completions",
+                    "body": {
+                        "model": "gemini-1.5-pro",
+                        "messages": [{"role": "user", "content": prompt}],
+                        "max_tokens": 8,
+                    },
+                }
+            )
+        )
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _measure_handler(num_rows: int) -> Tuple[int, int, int]:
+    payload = _build_batch_jsonl(num_rows)
+    cfg = VertexAIJsonlFilesTransformation()
+    gc.collect()
+    tracemalloc.start()
+    try:
+        out, _ = cfg.transform_openai_file_content_to_vertex_ai_file_content(
+            io.BytesIO(payload)
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return len(payload), len(out.encode("utf-8")), peak
+
+
+def _measure_create_file_request(num_rows: int) -> Tuple[int, int, int]:
+    payload = _build_batch_jsonl(num_rows)
+    cfg = VertexAIFilesConfig()
+    d = {"file": ("b.jsonl", payload, "application/jsonl"), "purpose": "batch"}
+    gc.collect()
+    tracemalloc.start()
+    try:
+        out = cfg.transform_create_file_request(
+            model="gemini-1.5-pro",
+            create_file_data=d,
+            optional_params={},
+            litellm_params={},
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return len(payload), len(out.encode("utf-8")), peak
+
+
+def _measure_object_name(num_rows: int) -> Tuple[int, int, int]:
+    payload = _build_batch_jsonl(num_rows)
+    cfg = VertexAIFilesConfig()
+    extracted = {"content": payload, "filename": "b.jsonl"}
+    gc.collect()
+    tracemalloc.start()
+    try:
+        name = cfg.get_object_name(extracted_file_data=extracted, purpose="batch")
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return len(payload), len(name), peak
+
+
+class TestLit3382StreamingHandlerPath:
+    """Memory + correctness guards for the
+    ``VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content``
+    code path (legacy ``VertexAIFilesHandler.async_create_file`` route)."""
+
+    def test_peak_under_4x_input_size(self):
+        """Peak memory must stay <4x input size for a representative batch.
+        Pre-fix this was ~5.24x; post-fix it is ~2.05x. The 4x ceiling
+        leaves room for tracemalloc accounting wobble across Python
+        versions."""
+        in_b, out_b, peak = _measure_handler(num_rows=5000)
+        amplification = peak / in_b
+        assert 0.5 * in_b <= out_b <= 2 * in_b
+        assert amplification < 4.0, (
+            f"Peak memory {peak/1e6:.1f} MB is {amplification:.2f}x the "
+            f"input {in_b/1e6:.1f} MB — should be <4x."
+        )
+
+    def test_scales_linearly(self):
+        """Doubling input must not super-linearly increase peak."""
+        _, _, peak_small = _measure_handler(num_rows=2000)
+        _, _, peak_big = _measure_handler(num_rows=8000)
+        ratio = peak_big / peak_small
+        assert ratio < 5.5, (
+            f"Peak grew {ratio:.2f}x for a 4x input increase "
+            f"({peak_small/1e6:.1f}MB -> {peak_big/1e6:.1f}MB)."
+        )
+
+    def test_output_is_valid_jsonl_with_request_wrapper(self):
+        """Streaming must not change the wire format."""
+        payload = _build_batch_jsonl(num_rows=5, prompt_chars=50)
+        cfg = VertexAIJsonlFilesTransformation()
+        out, object_name = cfg.transform_openai_file_content_to_vertex_ai_file_content(
+            io.BytesIO(payload)
+        )
+        lines = out.splitlines()
+        assert len(lines) == 5
+        for idx, line in enumerate(lines):
+            obj = json.loads(line)
+            assert set(obj.keys()) == {"request"}, f"row {idx}"
+            assert "contents" in obj["request"]
+            assert "labels" in obj["request"]
+        assert "publishers/google/models/gemini-1.5-pro" in object_name
+
+    def test_empty_payload_raises_value_error(self):
+        cfg = VertexAIJsonlFilesTransformation()
+        with pytest.raises(ValueError):
+            cfg.transform_openai_file_content_to_vertex_ai_file_content(
+                io.BytesIO(b"")
+            )
+
+    def test_object_name_uses_first_row_model_only(self):
+        """object_name must be derived from the FIRST row's model so we
+        never need to keep the full parsed list around just for naming."""
+        cfg = VertexAIJsonlFilesTransformation()
+        payload = (
+            json.dumps(
+                {
+                    "custom_id": "first",
+                    "body": {"model": "gemini-2.0-flash", "messages": []},
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "custom_id": "second",
+                    "body": {"model": "gemini-1.5-pro", "messages": []},
+                }
+            )
+            + "\n"
+        ).encode("utf-8")
+        _, name = cfg.transform_openai_file_content_to_vertex_ai_file_content(
+            io.BytesIO(payload)
+        )
+        assert "publishers/google/models/gemini-2.0-flash" in name
+        assert "gemini-1.5-pro" not in name
+
+
+class TestLit3382StreamingFilesApiPath:
+    """Memory + correctness guards for
+    ``VertexAIFilesConfig.transform_create_file_request`` — the modern
+    registered ``/v1/files`` create_file path."""
+
+    def test_peak_under_5x_input_size(self):
+        """Pre-fix ~5.24x; post-fix ~3.06x. The 5x ceiling guards against
+        re-introducing an intermediate full-payload copy while leaving room
+        for the bytes -> str decode step that ``extract_file_data`` performs
+        before our transform sees the payload."""
+        in_b, out_b, peak = _measure_create_file_request(num_rows=5000)
+        amplification = peak / in_b
+        assert 0.5 * in_b <= out_b <= 2 * in_b
+        assert amplification < 5.0, (
+            f"Peak memory {peak/1e6:.1f} MB is {amplification:.2f}x the "
+            f"input {in_b/1e6:.1f} MB — should be <5x."
+        )
+
+    def test_scales_linearly(self):
+        _, _, peak_small = _measure_create_file_request(num_rows=2000)
+        _, _, peak_big = _measure_create_file_request(num_rows=8000)
+        ratio = peak_big / peak_small
+        assert ratio < 5.5, (
+            f"Peak grew {ratio:.2f}x for a 4x input increase "
+            f"({peak_small/1e6:.1f}MB -> {peak_big/1e6:.1f}MB)."
+        )
+
+    def test_output_preserves_request_wrapper_and_labels(self):
+        payload = _build_batch_jsonl(num_rows=4, prompt_chars=20)
+        cfg = VertexAIFilesConfig()
+        d = {"file": ("b.jsonl", payload, "application/jsonl"), "purpose": "batch"}
+        out = cfg.transform_create_file_request(
+            model="gemini-1.5-pro",
+            create_file_data=d,
+            optional_params={},
+            litellm_params={},
+        )
+        lines = out.splitlines()
+        assert len(lines) == 4
+        for line in lines:
+            obj = json.loads(line)
+            assert set(obj.keys()) == {"request"}
+            assert "labels" in obj["request"]
+
+    def test_get_object_name_does_not_load_full_payload(self):
+        """``get_object_name`` should only sniff the first row to derive the
+        object key — peak memory must stay <3x input."""
+        in_b, _, peak = _measure_object_name(num_rows=5000)
+        amplification = peak / in_b
+        assert amplification < 3.0, (
+            f"get_object_name peak {peak/1e6:.1f} MB is {amplification:.2f}x "
+            f"the {in_b/1e6:.1f} MB input — must not load full payload."
+        )
+
+
+class TestLit3382IterHelper:
+    """Direct tests of the new streaming helper.
+
+    ``_iter_openai_jsonl_entries`` MUST be a generator. If it ever becomes
+    a list (e.g. someone writes ``return [...]``), the memory win is lost
+    and the OOM regression returns silently."""
+
+    def test_yields_one_entry_at_a_time(self):
+        cfg = VertexAIJsonlFilesTransformation()
+        payload = _build_batch_jsonl(num_rows=3, prompt_chars=50)
+        gen = cfg._iter_openai_jsonl_entries(io.BytesIO(payload))
+        assert hasattr(gen, "__next__")
+        assert not isinstance(gen, list)
+        items = list(gen)
+        assert len(items) == 3
+        assert items[0]["custom_id"] == "req-0"
+        assert items[0]["body"]["model"] == "gemini-1.5-pro"
+
+    def test_accepts_bytes_str_and_tuple_inputs(self):
+        """Parity with the legacy ``_get_content_from_openai_file`` helper:
+        bytes / str / (filename, content) tuples must all work."""
+        cfg = VertexAIJsonlFilesTransformation()
+        payload = _build_batch_jsonl(num_rows=2, prompt_chars=20)
+
+        assert len(list(cfg._iter_openai_jsonl_entries(payload))) == 2
+        assert (
+            len(list(cfg._iter_openai_jsonl_entries(payload.decode("utf-8")))) == 2
+        )
+        assert (
+            len(list(cfg._iter_openai_jsonl_entries(("batch.jsonl", payload))))
+            == 2
+        )
+        assert (
+            len(
+                list(
+                    cfg._iter_openai_jsonl_entries(
+                        ("batch.jsonl", io.BytesIO(payload))
+                    )
+                )
+            )
+            == 2
+        )
+
+    def test_skips_blank_lines(self):
+        """Legacy semantics: blank lines must be silently skipped."""
+        cfg = VertexAIJsonlFilesTransformation()
+        body = (
+            json.dumps(
+                {
+                    "custom_id": "a",
+                    "body": {"model": "gemini-1.5-pro", "messages": []},
+                }
+            )
+            + "\n\n   \n"
+            + json.dumps(
+                {
+                    "custom_id": "b",
+                    "body": {"model": "gemini-1.5-pro", "messages": []},
+                }
+            )
+            + "\n"
+        )
+        out = list(cfg._iter_openai_jsonl_entries(body))
+        assert [e["custom_id"] for e in out] == ["a", "b"]


### PR DESCRIPTION
## What

Refactor the Vertex AI batch JSONL transform to stream line-by-line, eliminating the ~5x peak memory amplification that caused **Tempus**'s uvicorn workers to OOM and restart on ~1 GB Gemini batch uploads.

Closes LIT-3382.

## Root cause

For `purpose="batch"` JSONL uploads, three call sites in `litellm/llms/vertex_ai/files/transformation.py` materialized five+ simultaneous copies of the payload:

1. raw bytes (input)
2. full decoded `str` (`_get_content_from_openai_file`)
3. full `splitlines()` list
4. full list of `json.loads(line)` dicts (openai shape)
5. full list of transformed dicts (vertex shape)
6. final joined string

For a 1 GB JSONL input that's ~5–8 GB resident before the GCS upload starts. On Tempus's 12 GB/worker pod the uvicorn child gets killed and you see:

```
Waiting for child process
Child process died
```

## Fix

Add two helpers on `VertexAIJsonlFilesTransformation`:

- `_iter_openai_jsonl_entries(openai_file_content)` — a generator that yields parsed entries one row at a time. For file-like inputs it iterates `readline()` directly, so we never decode the whole payload at once.
- `_build_vertex_request_body(entry)` — per-entry counterpart to `_openai_batch_jsonl_entries_to_vertex_wrapped_requests`.

Then rewrite the three offending call sites to stream:

- `VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content` (legacy `VertexAIFilesHandler.async_create_file` path)
- `VertexAIFilesConfig.transform_create_file_request` (the modern `/v1/files` route used by `litellm.files.main.create_file`)
- `VertexAIFilesConfig.get_object_name` — only needs the **first** row's model

Wire format is unchanged: same `{"request": {...}}` envelope, same `labels` for `custom_id` correlation, same object name shape.

## Evidence

Measured peak heap with `tracemalloc.get_traced_memory()` on synthetic Gemini batch JSONL inputs at 11 / 22 / 44 MB.

### BEFORE (clean `main`, commit `73e9071`)

```
## handler path: VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content
rows=  5000  input= 10.88MB  output= 11.04MB  peak=  57.43MB  amp=5.28x
rows= 10000  input= 21.76MB  output= 22.08MB  peak= 114.05MB  amp=5.24x
rows= 20000  input= 43.53MB  output= 44.19MB  peak= 228.22MB  amp=5.24x

## /v1/files path: VertexAIFilesConfig.transform_create_file_request
rows=  5000  input= 10.88MB  output= 11.04MB  peak=  57.03MB  amp=5.24x
rows= 10000  input= 21.76MB  output= 22.08MB  peak= 114.05MB  amp=5.24x
rows= 20000  input= 43.53MB  output= 44.19MB  peak= 228.22MB  amp=5.24x

## /v1/files path: VertexAIFilesConfig.get_object_name
rows=  5000  input= 10.88MB  peak=  38.85MB  amp=3.57x
rows= 10000  input= 21.76MB  peak=  77.70MB  amp=3.57x
rows= 20000  input= 43.53MB  peak= 155.43MB  amp=3.57x
```

### AFTER (this branch)

```
## handler path: VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content
rows=  5000  input= 10.88MB  output= 11.04MB  peak=  22.73MB  amp=2.09x
rows= 10000  input= 21.76MB  output= 22.08MB  peak=  44.66MB  amp=2.05x
rows= 20000  input= 43.53MB  output= 44.19MB  peak=  89.37MB  amp=2.05x

## /v1/files path: VertexAIFilesConfig.transform_create_file_request
rows=  5000  input= 10.88MB  output= 11.04MB  peak=  33.31MB  amp=3.06x
rows= 10000  input= 21.76MB  output= 22.08MB  peak=  66.59MB  amp=3.06x
rows= 20000  input= 43.53MB  output= 44.19MB  peak= 133.22MB  amp=3.06x

## /v1/files path: VertexAIFilesConfig.get_object_name
rows=  5000  input= 10.88MB  peak=  22.00MB  amp=2.02x
rows= 10000  input= 21.76MB  peak=  44.01MB  amp=2.02x
rows= 20000  input= 43.53MB  peak=  88.04MB  amp=2.02x
```

### Summary

| Path | Before peak amp | After peak amp |
| --- | --- | --- |
| handler `transform_openai_file_content_to_vertex_ai_file_content` | **5.24×** | **2.05×** |
| `/v1/files` `transform_create_file_request` | **5.24×** | **3.06×** |
| `/v1/files` `get_object_name` | **3.57×** | **2.02×** |

Extrapolated to Tempus's 1 GB batch upload, the modern `/v1/files` path drops from ~5.2 GB peak to ~3.1 GB peak — comfortably under a 12 GB worker. The legacy handler path drops to ~2.05 GB peak.

## Tests

```
$ python3 -m pytest tests/test_litellm/llms/vertex_ai/files/ -q
86 passed, 3 warnings in 37.75s
```

New file `tests/test_litellm/llms/vertex_ai/files/test_lit_3382_streaming_transform.py` adds 12 regression tests:

- 3 groups (`TestLit3382StreamingHandlerPath`, `TestLit3382StreamingFilesApiPath`, `TestLit3382IterHelper`)
- Each path has both **a tracemalloc-based peak-memory ceiling** and a **linear-scaling guard** that detect re-introduction of an intermediate full-payload copy
- Plus wire-format / blank-line / first-row-model / empty-payload correctness checks

## Notes for reviewers

- Pushed via the GitHub Contents API because this token lacks `repo` + `workflow` scopes. The PR diff will look noisier than a `git push` would; the actual two-file diff is `litellm/llms/vertex_ai/files/transformation.py` + `tests/test_litellm/llms/vertex_ai/files/test_lit_3382_streaming_transform.py`.
- The amplification ceiling on `transform_create_file_request` (5×) is intentionally looser than the other two (4× / 3×). `extract_file_data` decodes the bytes->str ahead of our streaming helper for the `/v1/files` route, which adds one extra full-payload copy we don't control from this transform.
- No protocol / wire-format changes. Same input shapes still accepted (`bytes`, `str`, `BytesIO`, `PathLike`, `(filename, content)` tuples).

Agent session: https://litellm-agent-platform.onrender.com/sessions/4940a0d9-194b-464d-be1d-6fa2ddf037e6
