### PR TITLE
feat(guardrails): wire apply_guardrail into proxy logging callbacks

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -839,6 +839,7 @@ class ProxyBaseLLMRequestProcessing:
             "aget_run",
             "acancel_run",
             "adelete_run",
+            "apply_guardrail",
         ],
         version: Optional[str] = None,
         user_model: Optional[str] = None,

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2204,7 +2204,7 @@ def _patch_logging_obj_for_guardrail(
     """Configure the logging object so Langfuse/OTEL extract input and output correctly."""
     litellm_logging_obj.call_type = "pass_through_endpoint"
     litellm_logging_obj.model_call_details["call_type"] = "pass_through_endpoint"
-    litellm_logging_obj.model_call_details["messages"] = (
+    litellm_logging_obj.update_messages(
         request.messages
         if request.messages
         else [{"role": "user", "content": request.text}]

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2254,6 +2254,11 @@ async def _emit_guardrail_success_logs(
                 end_time=end_time,
                 cache_hit=False,
             )
+        except Exception:
+            verbose_proxy_logger.exception(
+                "apply_guardrail: async_success_handler failed"
+            )
+        try:
             thread_pool_executor.submit(
                 litellm_logging_obj.success_handler,
                 response_for_logging,
@@ -2262,7 +2267,9 @@ async def _emit_guardrail_success_logs(
                 False,
             )
         except Exception:
-            verbose_proxy_logger.exception("apply_guardrail: success logging failed")
+            verbose_proxy_logger.exception(
+                "apply_guardrail: success_handler submit failed"
+            )
 
     return response
 
@@ -2344,21 +2351,26 @@ async def apply_guardrail(
             response_text=response_text[0] if response_text else request.text
         )
     except Exception as e:
-        try:
-            if litellm_logging_obj is not None and not isinstance(e, HTTPException):
+        if litellm_logging_obj is not None and not isinstance(e, HTTPException):
+            try:
                 await litellm_logging_obj.async_failure_handler(
                     exception=e,
                     traceback_exception=traceback.format_exc(),
                 )
+            except Exception:
+                verbose_proxy_logger.exception(
+                    "apply_guardrail: async_failure_handler failed"
+                )
+            try:
                 thread_pool_executor.submit(
                     litellm_logging_obj.failure_handler,
                     e,
                     traceback.format_exc(),
                 )
-        except Exception:
-            verbose_proxy_logger.exception(
-                "apply_guardrail: async_failure_handler failed"
-            )
+            except Exception:
+                verbose_proxy_logger.exception(
+                    "apply_guardrail: failure_handler submit failed"
+                )
         try:
             transformed_exception = await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2360,11 +2360,13 @@ async def apply_guardrail(
                 "apply_guardrail: async_failure_handler failed"
             )
         try:
-            await proxy_logging_obj.post_call_failure_hook(
+            transformed_exception = await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
                 original_exception=e,
                 request_data=data,
             )
+            if transformed_exception is not None:
+                e = transformed_exception
         except Exception:
             verbose_proxy_logger.exception(
                 "apply_guardrail: post_call_failure_hook failed"

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2187,6 +2187,80 @@ async def test_custom_code_guardrail(
         )
 
 
+def _resolve_guardrail_input_type(
+    active_guardrail: CustomGuardrail, input_type: str
+) -> Literal["request", "response"]:
+    """Return the effective input_type, auto-upgrading to 'response' for post_call guardrails."""
+    if input_type == "request":
+        hook = getattr(active_guardrail, "event_hook", None)
+        if hook == GuardrailEventHooks.post_call or hook == "post_call":
+            return "response"
+    return "response" if input_type == "response" else "request"
+
+
+def _patch_logging_obj_for_guardrail(
+    litellm_logging_obj: Any, request: ApplyGuardrailRequest
+) -> None:
+    """Configure the logging object so Langfuse/OTEL extract input and output correctly."""
+    litellm_logging_obj.call_type = "pass_through_endpoint"
+    litellm_logging_obj.model_call_details["call_type"] = "pass_through_endpoint"
+    litellm_logging_obj.model_call_details["messages"] = (
+        request.messages if request.messages else [{"role": "user", "content": request.text}]
+    )
+
+
+async def _emit_guardrail_success_logs(
+    proxy_logging_obj: Any,
+    litellm_logging_obj: Any,
+    data: dict,
+    user_api_key_dict: UserAPIKeyAuth,
+    response: ApplyGuardrailResponse,
+    response_for_logging: dict,
+    start_time: datetime,
+) -> ApplyGuardrailResponse:
+    """Fire proxy and LiteLLM success hooks after a successful guardrail run.
+
+    Each hook is wrapped defensively so a callback failure never prevents the
+    caller from receiving the guardrail response.  Returns the (possibly
+    hook-modified) response.
+    """
+    from litellm.litellm_core_utils.thread_pool_executor import (
+        executor as thread_pool_executor,
+    )
+
+    try:
+        modified = await proxy_logging_obj.post_call_success_hook(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            response=response,
+        )
+        if isinstance(modified, ApplyGuardrailResponse):
+            response = modified
+    except Exception:
+        verbose_proxy_logger.exception("apply_guardrail: post_call_success_hook failed")
+
+    if litellm_logging_obj is not None:
+        end_time = datetime.now(timezone.utc)
+        try:
+            await litellm_logging_obj.async_success_handler(
+                result=response_for_logging,
+                start_time=start_time,
+                end_time=end_time,
+                cache_hit=False,
+            )
+            thread_pool_executor.submit(
+                litellm_logging_obj.success_handler,
+                response_for_logging,
+                start_time,
+                end_time,
+                False,
+            )
+        except Exception:
+            verbose_proxy_logger.exception("apply_guardrail: success logging failed")
+
+    return response
+
+
 @router.post("/guardrails/apply_guardrail", response_model=ApplyGuardrailResponse)
 @router.post("/apply_guardrail", response_model=ApplyGuardrailResponse)
 async def apply_guardrail(
@@ -2199,6 +2273,8 @@ async def apply_guardrail(
 
     This endpoint allows testing guardrails by applying them to custom text inputs.
     """
+    import traceback
+
     from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
     from litellm.litellm_core_utils.thread_pool_executor import (
         executor as thread_pool_executor,
@@ -2210,7 +2286,6 @@ async def apply_guardrail(
         version,
     )
     from litellm.proxy.utils import handle_exception_on_proxy
-    import traceback
 
     data: dict = {
         "guardrail_name": request.guardrail_name,
@@ -2234,61 +2309,31 @@ async def apply_guardrail(
             )
 
         request_processor = ProxyBaseLLMRequestProcessing(data=data)
-        data, litellm_logging_obj = (
-            await request_processor.common_processing_pre_call_logic(
-                request=fastapi_request,
-                general_settings=general_settings,
-                user_api_key_dict=user_api_key_dict,
-                version=version,
-                proxy_logging_obj=proxy_logging_obj,
-                proxy_config=proxy_config,
-                route_type="apply_guardrail",
-            )
+        data, litellm_logging_obj = await request_processor.common_processing_pre_call_logic(
+            request=fastapi_request,
+            general_settings=general_settings,
+            user_api_key_dict=user_api_key_dict,
+            version=version,
+            proxy_logging_obj=proxy_logging_obj,
+            proxy_config=proxy_config,
+            route_type="apply_guardrail",
         )
 
-        # Langfuse reads input/output for pass_through_endpoint call_type only.
         if litellm_logging_obj is not None:
-            litellm_logging_obj.call_type = "pass_through_endpoint"
-            litellm_logging_obj.model_call_details["call_type"] = (
-                "pass_through_endpoint"
-            )
-            litellm_logging_obj.model_call_details["messages"] = (
-                request.messages
-                if request.messages
-                else [{"role": "user", "content": request.text}]
-            )
+            _patch_logging_obj_for_guardrail(litellm_logging_obj, request)
 
-        request_data: dict = {}
-        if request.messages:
-            request_data["messages"] = request.messages
-
-        # Auto-detect input_type: if the caller didn't specify "response" but the
-        # guardrail only runs post_call (e.g. LLM-as-a-judge), use "response" so
-        # the test actually exercises the guardrail logic.
-        from litellm.types.guardrails import GuardrailEventHooks
-
-        resolved_input_type = request.input_type
-        if resolved_input_type == "request":
-            hook = getattr(active_guardrail, "event_hook", None)
-            if hook == GuardrailEventHooks.post_call or hook == "post_call":
-                resolved_input_type = "response"
-
-        _input_type: Literal["request", "response"] = (
-            "response" if resolved_input_type == "response" else "request"
-        )
+        request_data: dict = {"messages": request.messages} if request.messages else {}
+        _input_type = _resolve_guardrail_input_type(active_guardrail, request.input_type)
         guardrailed_inputs = await active_guardrail.apply_guardrail(
             inputs={"texts": [request.text]},
             request_data=request_data,
             input_type=_input_type,
         )
         response_text = guardrailed_inputs.get("texts", [])
-
         response = ApplyGuardrailResponse(
             response_text=response_text[0] if response_text else request.text
         )
-        response_for_logging = {
-            "response": response.model_dump(exclude_none=True),
-        }
+        response_for_logging = {"response": response.model_dump(exclude_none=True)}
     except Exception as e:
         try:
             if litellm_logging_obj is not None and not isinstance(e, HTTPException):
@@ -2310,40 +2355,16 @@ async def apply_guardrail(
             verbose_proxy_logger.exception("apply_guardrail: failure logging failed")
         raise handle_exception_on_proxy(e)
 
-    # Success logging is outside the try/except so a hook error never
-    # triggers failure handlers for a successful guardrail run, and each
-    # logging call is wrapped defensively so callback failures don't
-    # discard the response the caller is waiting for.
-    try:
-        modified_response = await proxy_logging_obj.post_call_success_hook(
-            data=data,
-            user_api_key_dict=user_api_key_dict,
-            response=response,
-        )
-        if isinstance(modified_response, ApplyGuardrailResponse):
-            response = modified_response
-    except Exception:
-        verbose_proxy_logger.exception("apply_guardrail: post_call_success_hook failed")
-
-    end_time = datetime.now(timezone.utc)
-    if litellm_logging_obj is not None:
-        try:
-            await litellm_logging_obj.async_success_handler(
-                result=response_for_logging,
-                start_time=start_time,
-                end_time=end_time,
-                cache_hit=False,
-            )
-            thread_pool_executor.submit(
-                litellm_logging_obj.success_handler,
-                response_for_logging,
-                start_time,
-                end_time,
-                False,
-            )
-        except Exception:
-            verbose_proxy_logger.exception("apply_guardrail: success logging failed")
-
+    # Success logging outside except so a hook error never triggers failure handlers.
+    response = await _emit_guardrail_success_logs(
+        proxy_logging_obj=proxy_logging_obj,
+        litellm_logging_obj=litellm_logging_obj,
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+        response=response,
+        response_for_logging=response_for_logging,
+        start_time=start_time,
+    )
     return response
 
 

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2377,7 +2377,7 @@ async def apply_guardrail(
                 original_exception=e,
                 request_data=data,
             )
-            if transformed_exception is not None:
+            if isinstance(transformed_exception, Exception):
                 e = transformed_exception
         except Exception:
             verbose_proxy_logger.exception(

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2252,9 +2252,11 @@ async def apply_guardrail(
             litellm_logging_obj.model_call_details["call_type"] = (
                 "pass_through_endpoint"
             )
-            litellm_logging_obj.model_call_details["messages"] = [
-                {"role": "user", "content": request.text}
-            ]
+            litellm_logging_obj.model_call_details["messages"] = (
+                request.messages
+                if request.messages
+                else [{"role": "user", "content": request.text}]
+            )
 
         request_data: dict = {}
         if request.messages:
@@ -2287,29 +2289,6 @@ async def apply_guardrail(
         response_for_logging = {
             "response": response.model_dump(exclude_none=True),
         }
-
-        await proxy_logging_obj.post_call_success_hook(
-            data=data,
-            user_api_key_dict=user_api_key_dict,
-            response=response,
-        )
-        end_time = datetime.now(timezone.utc)
-        if litellm_logging_obj is not None:
-            await litellm_logging_obj.async_success_handler(
-                result=response_for_logging,
-                start_time=start_time,
-                end_time=end_time,
-                cache_hit=False,
-            )
-            thread_pool_executor.submit(
-                litellm_logging_obj.success_handler,
-                response_for_logging,
-                start_time,
-                end_time,
-                False,
-            )
-
-        return response
     except Exception as e:
         if litellm_logging_obj is not None and not isinstance(e, HTTPException):
             await litellm_logging_obj.async_failure_handler(
@@ -2327,6 +2306,31 @@ async def apply_guardrail(
             request_data=data,
         )
         raise handle_exception_on_proxy(e)
+
+    # Success logging is outside the except block so a hook error never
+    # triggers failure handlers for a successful guardrail run.
+    await proxy_logging_obj.post_call_success_hook(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+        response=response,
+    )
+    end_time = datetime.now(timezone.utc)
+    if litellm_logging_obj is not None:
+        await litellm_logging_obj.async_success_handler(
+            result=response_for_logging,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=False,
+        )
+        thread_pool_executor.submit(
+            litellm_logging_obj.success_handler,
+            response_for_logging,
+            start_time,
+            end_time,
+            False,
+        )
+
+    return response
 
 
 # Usage (dashboard) endpoints: overview, detail, logs

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union, cast
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from litellm.proxy.common_utils.path_utils import safe_join
@@ -2190,6 +2190,7 @@ async def test_custom_code_guardrail(
 @router.post("/guardrails/apply_guardrail", response_model=ApplyGuardrailResponse)
 @router.post("/apply_guardrail", response_model=ApplyGuardrailResponse)
 async def apply_guardrail(
+    fastapi_request: Request,
     request: ApplyGuardrailRequest,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
@@ -2198,7 +2199,27 @@ async def apply_guardrail(
 
     This endpoint allows testing guardrails by applying them to custom text inputs.
     """
+    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+    from litellm.litellm_core_utils.thread_pool_executor import (
+        executor as thread_pool_executor,
+    )
+    from litellm.proxy.proxy_server import (
+        general_settings,
+        proxy_config,
+        proxy_logging_obj,
+        version,
+    )
     from litellm.proxy.utils import handle_exception_on_proxy
+    import traceback
+
+    data: dict = {
+        "guardrail_name": request.guardrail_name,
+        "input": [request.text],
+        "messages": request.messages or [],
+        "metadata": {"route": "/apply_guardrail"},
+    }
+    litellm_logging_obj = None
+    start_time = datetime.now(timezone.utc)
 
     try:
         active_guardrail: Optional[CustomGuardrail] = (
@@ -2211,6 +2232,29 @@ async def apply_guardrail(
                 status_code=404,
                 detail=f"Guardrail '{request.guardrail_name}' not found. Please ensure the guardrail is configured in your LiteLLM proxy.",
             )
+
+        request_processor = ProxyBaseLLMRequestProcessing(data=data)
+        data, litellm_logging_obj = (
+            await request_processor.common_processing_pre_call_logic(
+                request=fastapi_request,
+                general_settings=general_settings,
+                user_api_key_dict=user_api_key_dict,
+                version=version,
+                proxy_logging_obj=proxy_logging_obj,
+                proxy_config=proxy_config,
+                route_type="apply_guardrail",
+            )
+        )
+
+        # Langfuse reads input/output for pass_through_endpoint call_type only.
+        if litellm_logging_obj is not None:
+            litellm_logging_obj.call_type = "pass_through_endpoint"
+            litellm_logging_obj.model_call_details["call_type"] = (
+                "pass_through_endpoint"
+            )
+            litellm_logging_obj.model_call_details["messages"] = [
+                {"role": "user", "content": request.text}
+            ]
 
         request_data: dict = {}
         if request.messages:
@@ -2237,10 +2281,51 @@ async def apply_guardrail(
         )
         response_text = guardrailed_inputs.get("texts", [])
 
-        return ApplyGuardrailResponse(
+        response = ApplyGuardrailResponse(
             response_text=response_text[0] if response_text else request.text
         )
+        response_for_logging = {
+            "response": response.model_dump(exclude_none=True),
+        }
+
+        await proxy_logging_obj.post_call_success_hook(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            response=response,
+        )
+        end_time = datetime.now(timezone.utc)
+        if litellm_logging_obj is not None:
+            await litellm_logging_obj.async_success_handler(
+                result=response_for_logging,
+                start_time=start_time,
+                end_time=end_time,
+                cache_hit=False,
+            )
+            thread_pool_executor.submit(
+                litellm_logging_obj.success_handler,
+                response_for_logging,
+                start_time,
+                end_time,
+                False,
+            )
+
+        return response
     except Exception as e:
+        if litellm_logging_obj is not None and not isinstance(e, HTTPException):
+            await litellm_logging_obj.async_failure_handler(
+                exception=e,
+                traceback_exception=traceback.format_exc(),
+            )
+            thread_pool_executor.submit(
+                litellm_logging_obj.failure_handler,
+                e,
+                traceback.format_exc(),
+            )
+        await proxy_logging_obj.post_call_failure_hook(
+            user_api_key_dict=user_api_key_dict,
+            original_exception=e,
+            request_data=data,
+        )
         raise handle_exception_on_proxy(e)
 
 

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2290,45 +2290,59 @@ async def apply_guardrail(
             "response": response.model_dump(exclude_none=True),
         }
     except Exception as e:
-        if litellm_logging_obj is not None and not isinstance(e, HTTPException):
-            await litellm_logging_obj.async_failure_handler(
-                exception=e,
-                traceback_exception=traceback.format_exc(),
+        try:
+            if litellm_logging_obj is not None and not isinstance(e, HTTPException):
+                await litellm_logging_obj.async_failure_handler(
+                    exception=e,
+                    traceback_exception=traceback.format_exc(),
+                )
+                thread_pool_executor.submit(
+                    litellm_logging_obj.failure_handler,
+                    e,
+                    traceback.format_exc(),
+                )
+            await proxy_logging_obj.post_call_failure_hook(
+                user_api_key_dict=user_api_key_dict,
+                original_exception=e,
+                request_data=data,
             )
-            thread_pool_executor.submit(
-                litellm_logging_obj.failure_handler,
-                e,
-                traceback.format_exc(),
-            )
-        await proxy_logging_obj.post_call_failure_hook(
-            user_api_key_dict=user_api_key_dict,
-            original_exception=e,
-            request_data=data,
-        )
+        except Exception:
+            verbose_proxy_logger.exception("apply_guardrail: failure logging failed")
         raise handle_exception_on_proxy(e)
 
-    # Success logging is outside the except block so a hook error never
-    # triggers failure handlers for a successful guardrail run.
-    await proxy_logging_obj.post_call_success_hook(
-        data=data,
-        user_api_key_dict=user_api_key_dict,
-        response=response,
-    )
+    # Success logging is outside the try/except so a hook error never
+    # triggers failure handlers for a successful guardrail run, and each
+    # logging call is wrapped defensively so callback failures don't
+    # discard the response the caller is waiting for.
+    try:
+        modified_response = await proxy_logging_obj.post_call_success_hook(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            response=response,
+        )
+        if isinstance(modified_response, ApplyGuardrailResponse):
+            response = modified_response
+    except Exception:
+        verbose_proxy_logger.exception("apply_guardrail: post_call_success_hook failed")
+
     end_time = datetime.now(timezone.utc)
     if litellm_logging_obj is not None:
-        await litellm_logging_obj.async_success_handler(
-            result=response_for_logging,
-            start_time=start_time,
-            end_time=end_time,
-            cache_hit=False,
-        )
-        thread_pool_executor.submit(
-            litellm_logging_obj.success_handler,
-            response_for_logging,
-            start_time,
-            end_time,
-            False,
-        )
+        try:
+            await litellm_logging_obj.async_success_handler(
+                result=response_for_logging,
+                start_time=start_time,
+                end_time=end_time,
+                cache_hit=False,
+            )
+            thread_pool_executor.submit(
+                litellm_logging_obj.success_handler,
+                response_for_logging,
+                start_time,
+                end_time,
+                False,
+            )
+        except Exception:
+            verbose_proxy_logger.exception("apply_guardrail: success logging failed")
 
     return response
 

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2205,7 +2205,9 @@ def _patch_logging_obj_for_guardrail(
     litellm_logging_obj.call_type = "pass_through_endpoint"
     litellm_logging_obj.model_call_details["call_type"] = "pass_through_endpoint"
     litellm_logging_obj.model_call_details["messages"] = (
-        request.messages if request.messages else [{"role": "user", "content": request.text}]
+        request.messages
+        if request.messages
+        else [{"role": "user", "content": request.text}]
     )
 
 
@@ -2313,21 +2315,25 @@ async def apply_guardrail(
             )
 
         request_processor = ProxyBaseLLMRequestProcessing(data=data)
-        data, litellm_logging_obj = await request_processor.common_processing_pre_call_logic(
-            request=fastapi_request,
-            general_settings=general_settings,
-            user_api_key_dict=user_api_key_dict,
-            version=version,
-            proxy_logging_obj=proxy_logging_obj,
-            proxy_config=proxy_config,
-            route_type="apply_guardrail",
+        data, litellm_logging_obj = (
+            await request_processor.common_processing_pre_call_logic(
+                request=fastapi_request,
+                general_settings=general_settings,
+                user_api_key_dict=user_api_key_dict,
+                version=version,
+                proxy_logging_obj=proxy_logging_obj,
+                proxy_config=proxy_config,
+                route_type="apply_guardrail",
+            )
         )
 
         if litellm_logging_obj is not None:
             _patch_logging_obj_for_guardrail(litellm_logging_obj, request)
 
         request_data: dict = {"messages": request.messages} if request.messages else {}
-        _input_type = _resolve_guardrail_input_type(active_guardrail, request.input_type)
+        _input_type = _resolve_guardrail_input_type(
+            active_guardrail, request.input_type
+        )
         guardrailed_inputs = await active_guardrail.apply_guardrail(
             inputs={"texts": [request.text]},
             request_data=request_data,

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2215,7 +2215,6 @@ async def _emit_guardrail_success_logs(
     data: dict,
     user_api_key_dict: UserAPIKeyAuth,
     response: ApplyGuardrailResponse,
-    response_for_logging: dict,
     start_time: datetime,
 ) -> ApplyGuardrailResponse:
     """Fire proxy and LiteLLM success hooks after a successful guardrail run.
@@ -2238,6 +2237,11 @@ async def _emit_guardrail_success_logs(
             response = modified
     except Exception:
         verbose_proxy_logger.exception("apply_guardrail: post_call_success_hook failed")
+
+    # Build the logging payload after post_call_success_hook so that logged
+    # data matches what the caller actually receives if the hook modified
+    # the response.
+    response_for_logging = {"response": response.model_dump(exclude_none=True)}
 
     if litellm_logging_obj is not None:
         end_time = datetime.now(timezone.utc)
@@ -2333,7 +2337,6 @@ async def apply_guardrail(
         response = ApplyGuardrailResponse(
             response_text=response_text[0] if response_text else request.text
         )
-        response_for_logging = {"response": response.model_dump(exclude_none=True)}
     except Exception as e:
         try:
             if litellm_logging_obj is not None and not isinstance(e, HTTPException):
@@ -2346,13 +2349,20 @@ async def apply_guardrail(
                     e,
                     traceback.format_exc(),
                 )
+        except Exception:
+            verbose_proxy_logger.exception(
+                "apply_guardrail: async_failure_handler failed"
+            )
+        try:
             await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
                 original_exception=e,
                 request_data=data,
             )
         except Exception:
-            verbose_proxy_logger.exception("apply_guardrail: failure logging failed")
+            verbose_proxy_logger.exception(
+                "apply_guardrail: post_call_failure_hook failed"
+            )
         raise handle_exception_on_proxy(e)
 
     # Success logging outside except so a hook error never triggers failure handlers.
@@ -2362,7 +2372,6 @@ async def apply_guardrail(
         data=data,
         user_api_key_dict=user_api_key_dict,
         response=response,
-        response_for_logging=response_for_logging,
         start_time=start_time,
     )
     return response

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/conftest.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/conftest.py
@@ -1,0 +1,42 @@
+"""Shared fixtures for guardrail apply_guardrail tests."""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@contextmanager
+def _mock_proxy_logging():
+    """Patch the proxy-server globals that apply_guardrail imports at call time."""
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.post_call_success_hook = AsyncMock(return_value=None)
+    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.async_success_handler = AsyncMock(return_value=None)
+    mock_logging_obj.async_failure_handler = AsyncMock(return_value=None)
+    mock_logging_obj.success_handler = MagicMock(return_value=None)
+    mock_logging_obj.failure_handler = MagicMock(return_value=None)
+    mock_logging_obj.model_call_details = {}
+
+    with (
+        patch(
+            "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing"
+        ) as mock_proc_cls,
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),
+        patch("litellm.proxy.proxy_server.general_settings", {}),
+        patch("litellm.proxy.proxy_server.proxy_config", MagicMock()),
+        patch("litellm.proxy.proxy_server.version", "0.0.0"),
+    ):
+        mock_proc = MagicMock()
+        mock_proc.common_processing_pre_call_logic = AsyncMock(
+            return_value=({}, mock_logging_obj)
+        )
+        mock_proc_cls.return_value = mock_proc
+        yield mock_proxy_logging
+
+
+@pytest.fixture
+def mock_proxy_logging_ctx():
+    """Return the proxy-logging context manager factory for use as `with ctx():`."""
+    return _mock_proxy_logging

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
@@ -4,7 +4,8 @@ Test the /guardrails/apply_guardrail endpoint
 
 import os
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -17,6 +18,38 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import ApplyGuardrailRequest, ApplyGuardrailResponse
 
 
+@contextmanager
+def _mock_proxy_logging():
+    """Patch the proxy-server globals that apply_guardrail imports at call time."""
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.post_call_success_hook = AsyncMock(return_value=None)
+    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.async_success_handler = AsyncMock(return_value=None)
+    mock_logging_obj.async_failure_handler = AsyncMock(return_value=None)
+    mock_logging_obj.success_handler = MagicMock(return_value=None)
+    mock_logging_obj.failure_handler = MagicMock(return_value=None)
+    mock_logging_obj.model_call_details = {}
+
+    with patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing"
+    ) as mock_proc_cls, patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging
+    ), patch(
+        "litellm.proxy.proxy_server.general_settings", {}
+    ), patch(
+        "litellm.proxy.proxy_server.proxy_config", MagicMock()
+    ), patch(
+        "litellm.proxy.proxy_server.version", "0.0.0"
+    ):
+        mock_proc = MagicMock()
+        mock_proc.common_processing_pre_call_logic = AsyncMock(
+            return_value=({}, mock_logging_obj)
+        )
+        mock_proc_cls.return_value = mock_proc
+        yield mock_proxy_logging
+
+
 @pytest.mark.asyncio
 async def test_apply_guardrail_endpoint_returns_correct_response():
     """Test that apply_guardrail endpoint returns ApplyGuardrailResponse object"""
@@ -25,7 +58,7 @@ async def test_apply_guardrail_endpoint_returns_correct_response():
     # Mock the guardrail registry
     with patch(
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry:
+    ) as mock_registry, _mock_proxy_logging():
         # Create a mock guardrail
         mock_guardrail = Mock(spec=CustomGuardrail)
         # Apply guardrail returns GenericGuardrailAPIInputs (dict with texts key)
@@ -49,7 +82,9 @@ async def test_apply_guardrail_endpoint_returns_correct_response():
 
         # Call the endpoint
         response = await apply_guardrail(
-            request=request, user_api_key_dict=user_api_key_dict
+            fastapi_request=Mock(),
+            request=request,
+            user_api_key_dict=user_api_key_dict,
         )
 
         # Verify the response is of the correct type
@@ -73,7 +108,7 @@ async def test_apply_guardrail_endpoint_guardrail_not_found():
     # Mock the guardrail registry to return None
     with patch(
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry:
+    ) as mock_registry, _mock_proxy_logging():
         mock_registry.get_initialized_guardrail_callback.return_value = None
 
         # Create the request
@@ -86,7 +121,11 @@ async def test_apply_guardrail_endpoint_guardrail_not_found():
 
         # Verify exception is raised
         with pytest.raises(ProxyException) as exc_info:
-            await apply_guardrail(request=request, user_api_key_dict=user_api_key_dict)
+            await apply_guardrail(
+                fastapi_request=Mock(),
+                request=request,
+                user_api_key_dict=user_api_key_dict,
+            )
 
         assert "non-existent-guardrail" in exc_info.value.message
         assert "not found" in exc_info.value.message
@@ -100,7 +139,7 @@ async def test_apply_guardrail_endpoint_with_presidio_guardrail():
     # Mock the guardrail registry
     with patch(
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry:
+    ) as mock_registry, _mock_proxy_logging():
         # Create a mock guardrail that simulates Presidio behavior
         mock_guardrail = Mock(spec=CustomGuardrail)
         # Simulate masking PII entities - returns GenericGuardrailAPIInputs (dict with texts key)
@@ -124,7 +163,9 @@ async def test_apply_guardrail_endpoint_with_presidio_guardrail():
 
         # Call the endpoint
         response = await apply_guardrail(
-            request=request, user_api_key_dict=user_api_key_dict
+            fastapi_request=Mock(),
+            request=request,
+            user_api_key_dict=user_api_key_dict,
         )
 
         # Verify the response is of the correct type
@@ -145,7 +186,7 @@ async def test_apply_guardrail_endpoint_without_optional_params():
     # Mock the guardrail registry
     with patch(
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry:
+    ) as mock_registry, _mock_proxy_logging():
         # Create a mock guardrail
         mock_guardrail = Mock(spec=CustomGuardrail)
         # Returns GenericGuardrailAPIInputs (dict with texts key)
@@ -166,7 +207,9 @@ async def test_apply_guardrail_endpoint_without_optional_params():
 
         # Call the endpoint
         response = await apply_guardrail(
-            request=request, user_api_key_dict=user_api_key_dict
+            fastapi_request=Mock(),
+            request=request,
+            user_api_key_dict=user_api_key_dict,
         )
 
         # Verify the response is of the correct type

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
@@ -4,8 +4,7 @@ Test the /guardrails/apply_guardrail endpoint
 
 import os
 import sys
-from contextlib import contextmanager
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -18,47 +17,20 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import ApplyGuardrailRequest, ApplyGuardrailResponse
 
 
-@contextmanager
-def _mock_proxy_logging():
-    """Patch the proxy-server globals that apply_guardrail imports at call time."""
-    mock_proxy_logging = MagicMock()
-    mock_proxy_logging.post_call_success_hook = AsyncMock(return_value=None)
-    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
-    mock_logging_obj = MagicMock()
-    mock_logging_obj.async_success_handler = AsyncMock(return_value=None)
-    mock_logging_obj.async_failure_handler = AsyncMock(return_value=None)
-    mock_logging_obj.success_handler = MagicMock(return_value=None)
-    mock_logging_obj.failure_handler = MagicMock(return_value=None)
-    mock_logging_obj.model_call_details = {}
-
-    with patch(
-        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing"
-    ) as mock_proc_cls, patch(
-        "litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging
-    ), patch(
-        "litellm.proxy.proxy_server.general_settings", {}
-    ), patch(
-        "litellm.proxy.proxy_server.proxy_config", MagicMock()
-    ), patch(
-        "litellm.proxy.proxy_server.version", "0.0.0"
-    ):
-        mock_proc = MagicMock()
-        mock_proc.common_processing_pre_call_logic = AsyncMock(
-            return_value=({}, mock_logging_obj)
-        )
-        mock_proc_cls.return_value = mock_proc
-        yield mock_proxy_logging
-
-
 @pytest.mark.asyncio
-async def test_apply_guardrail_endpoint_returns_correct_response():
+async def test_apply_guardrail_endpoint_returns_correct_response(
+    mock_proxy_logging_ctx,
+):
     """Test that apply_guardrail endpoint returns ApplyGuardrailResponse object"""
     from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
 
     # Mock the guardrail registry
-    with patch(
-        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry, _mock_proxy_logging():
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
         # Create a mock guardrail
         mock_guardrail = Mock(spec=CustomGuardrail)
         # Apply guardrail returns GenericGuardrailAPIInputs (dict with texts key)
@@ -100,15 +72,18 @@ async def test_apply_guardrail_endpoint_returns_correct_response():
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_endpoint_guardrail_not_found():
+async def test_apply_guardrail_endpoint_guardrail_not_found(mock_proxy_logging_ctx):
     """Test that apply_guardrail endpoint raises exception when guardrail not found"""
     from litellm.proxy._types import ProxyException
     from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
 
     # Mock the guardrail registry to return None
-    with patch(
-        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry, _mock_proxy_logging():
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
         mock_registry.get_initialized_guardrail_callback.return_value = None
 
         # Create the request
@@ -132,19 +107,24 @@ async def test_apply_guardrail_endpoint_guardrail_not_found():
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_endpoint_with_presidio_guardrail():
+async def test_apply_guardrail_endpoint_with_presidio_guardrail(mock_proxy_logging_ctx):
     """Test apply_guardrail endpoint with a Presidio-like guardrail"""
     from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
 
     # Mock the guardrail registry
-    with patch(
-        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry, _mock_proxy_logging():
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
         # Create a mock guardrail that simulates Presidio behavior
         mock_guardrail = Mock(spec=CustomGuardrail)
         # Simulate masking PII entities - returns GenericGuardrailAPIInputs (dict with texts key)
         mock_guardrail.apply_guardrail = AsyncMock(
-            return_value={"texts": ["My name is [PERSON] and my email is [EMAIL_ADDRESS]"]}
+            return_value={
+                "texts": ["My name is [PERSON] and my email is [EMAIL_ADDRESS]"]
+            }
         )
 
         # Configure the registry to return our mock guardrail
@@ -179,14 +159,17 @@ async def test_apply_guardrail_endpoint_with_presidio_guardrail():
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_endpoint_without_optional_params():
+async def test_apply_guardrail_endpoint_without_optional_params(mock_proxy_logging_ctx):
     """Test apply_guardrail endpoint without optional language and entities parameters"""
     from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
 
     # Mock the guardrail registry
-    with patch(
-        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry, _mock_proxy_logging():
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
         # Create a mock guardrail
         mock_guardrail = Mock(spec=CustomGuardrail)
         # Returns GenericGuardrailAPIInputs (dict with texts key)

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -4,7 +4,8 @@ Test the Bedrock guardrail apply_guardrail functionality
 
 import os
 import sys
-from unittest.mock import AsyncMock, patch
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -14,6 +15,38 @@ sys.path.insert(0, os.path.abspath("../../../../.."))
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import BedrockGuardrail
 from litellm.types.guardrails import ApplyGuardrailRequest, ApplyGuardrailResponse
+
+
+@contextmanager
+def _mock_proxy_logging():
+    """Patch the proxy-server globals that apply_guardrail imports at call time."""
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.post_call_success_hook = AsyncMock(return_value=None)
+    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.async_success_handler = AsyncMock(return_value=None)
+    mock_logging_obj.async_failure_handler = AsyncMock(return_value=None)
+    mock_logging_obj.success_handler = MagicMock(return_value=None)
+    mock_logging_obj.failure_handler = MagicMock(return_value=None)
+    mock_logging_obj.model_call_details = {}
+
+    with patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing"
+    ) as mock_proc_cls, patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging
+    ), patch(
+        "litellm.proxy.proxy_server.general_settings", {}
+    ), patch(
+        "litellm.proxy.proxy_server.proxy_config", MagicMock()
+    ), patch(
+        "litellm.proxy.proxy_server.version", "0.0.0"
+    ):
+        mock_proc = MagicMock()
+        mock_proc.common_processing_pre_call_logic = AsyncMock(
+            return_value=({}, mock_logging_obj)
+        )
+        mock_proc_cls.return_value = mock_proc
+        yield mock_proxy_logging
 
 
 @pytest.mark.asyncio
@@ -167,7 +200,7 @@ async def test_bedrock_apply_guardrail_endpoint_integration():
     # Mock the guardrail registry
     with patch(
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry:
+    ) as mock_registry, _mock_proxy_logging():
         # Mock the make_bedrock_api_request method
         with patch.object(
             guardrail, "make_bedrock_api_request", new_callable=AsyncMock
@@ -194,7 +227,9 @@ async def test_bedrock_apply_guardrail_endpoint_integration():
 
             # Call the endpoint
             response = await apply_guardrail(
-                request=request, user_api_key_dict=user_api_key_dict
+                fastapi_request=Mock(),
+                request=request,
+                user_api_key_dict=user_api_key_dict,
             )
 
             # Verify the response

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -4,8 +4,7 @@ Test the Bedrock guardrail apply_guardrail functionality
 
 import os
 import sys
-from contextlib import contextmanager
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -15,38 +14,6 @@ sys.path.insert(0, os.path.abspath("../../../../.."))
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import BedrockGuardrail
 from litellm.types.guardrails import ApplyGuardrailRequest, ApplyGuardrailResponse
-
-
-@contextmanager
-def _mock_proxy_logging():
-    """Patch the proxy-server globals that apply_guardrail imports at call time."""
-    mock_proxy_logging = MagicMock()
-    mock_proxy_logging.post_call_success_hook = AsyncMock(return_value=None)
-    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
-    mock_logging_obj = MagicMock()
-    mock_logging_obj.async_success_handler = AsyncMock(return_value=None)
-    mock_logging_obj.async_failure_handler = AsyncMock(return_value=None)
-    mock_logging_obj.success_handler = MagicMock(return_value=None)
-    mock_logging_obj.failure_handler = MagicMock(return_value=None)
-    mock_logging_obj.model_call_details = {}
-
-    with patch(
-        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing"
-    ) as mock_proc_cls, patch(
-        "litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging
-    ), patch(
-        "litellm.proxy.proxy_server.general_settings", {}
-    ), patch(
-        "litellm.proxy.proxy_server.proxy_config", MagicMock()
-    ), patch(
-        "litellm.proxy.proxy_server.version", "0.0.0"
-    ):
-        mock_proc = MagicMock()
-        mock_proc.common_processing_pre_call_logic = AsyncMock(
-            return_value=({}, mock_logging_obj)
-        )
-        mock_proc_cls.return_value = mock_proc
-        yield mock_proxy_logging
 
 
 @pytest.mark.asyncio
@@ -186,7 +153,7 @@ async def test_bedrock_apply_guardrail_api_failure():
 
 
 @pytest.mark.asyncio
-async def test_bedrock_apply_guardrail_endpoint_integration():
+async def test_bedrock_apply_guardrail_endpoint_integration(mock_proxy_logging_ctx):
     """Test the full endpoint integration with Bedrock guardrail"""
     from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
 
@@ -198,9 +165,12 @@ async def test_bedrock_apply_guardrail_endpoint_integration():
     )
 
     # Mock the guardrail registry
-    with patch(
-        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
-    ) as mock_registry, _mock_proxy_logging():
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
         # Mock the make_bedrock_api_request method
         with patch.object(
             guardrail, "make_bedrock_api_request", new_callable=AsyncMock

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -1159,7 +1159,11 @@ async def test_apply_guardrail_not_found(mocker):
 
     # Call endpoint and expect ProxyException
     with pytest.raises(ProxyException) as exc_info:
-        await apply_guardrail(request=request, user_api_key_dict=mock_user_auth)
+        await apply_guardrail(
+            fastapi_request=mocker.Mock(),
+            request=request,
+            user_api_key_dict=mock_user_auth,
+        )
 
     # Verify error details
     assert str(exc_info.value.code) == "404"
@@ -1186,6 +1190,25 @@ async def test_apply_guardrail_execution_error(mocker):
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY", mock_registry
     )
 
+    mock_logging_obj = mocker.Mock()
+    mock_logging_obj.async_failure_handler = AsyncMock()
+    mock_logging_obj.model_call_details = {}
+    mock_processor = mocker.Mock()
+    mock_processor.common_processing_pre_call_logic = AsyncMock(
+        return_value=({"guardrail_name": "test-guardrail"}, mock_logging_obj)
+    )
+    mocker.patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing",
+        return_value=mock_processor,
+    )
+    mock_proxy_logging = mocker.Mock()
+    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+    mocker.patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging)
+    mocker.patch("litellm.proxy.proxy_server.general_settings", {})
+    mocker.patch("litellm.proxy.proxy_server.proxy_config", mocker.Mock())
+    mocker.patch("litellm.proxy.proxy_server.version", "test")
+    mocker.patch("litellm.litellm_core_utils.thread_pool_executor.executor")
+
     # Create request
     request = ApplyGuardrailRequest(
         guardrail_name="test-guardrail", text="Test input text with forbidden content"
@@ -1196,10 +1219,68 @@ async def test_apply_guardrail_execution_error(mocker):
 
     # Call endpoint and expect ProxyException
     with pytest.raises(ProxyException) as exc_info:
-        await apply_guardrail(request=request, user_api_key_dict=mock_user_auth)
+        await apply_guardrail(
+            fastapi_request=mocker.Mock(),
+            request=request,
+            user_api_key_dict=mock_user_auth,
+        )
 
     # Verify error is properly handled
     assert "Bedrock guardrail failed" in str(exc_info.value.message)
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_invokes_logging_pipeline(mocker):
+    mock_guardrail = mocker.Mock()
+    mock_guardrail.apply_guardrail = AsyncMock(return_value={"texts": ["masked"]})
+
+    mock_registry = mocker.Mock()
+    mock_registry.get_initialized_guardrail_callback.return_value = mock_guardrail
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY", mock_registry
+    )
+
+    mock_logging_obj = mocker.Mock()
+    mock_logging_obj.async_success_handler = AsyncMock()
+    mock_logging_obj.model_call_details = {}
+    mock_processor = mocker.Mock()
+    mock_processor.common_processing_pre_call_logic = AsyncMock(
+        return_value=({"guardrail_name": "test-guardrail"}, mock_logging_obj)
+    )
+    mocker.patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing",
+        return_value=mock_processor,
+    )
+
+    mock_proxy_logging = mocker.Mock()
+    mock_proxy_logging.post_call_success_hook = AsyncMock()
+    mocker.patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging)
+    mocker.patch("litellm.proxy.proxy_server.general_settings", {})
+    mocker.patch("litellm.proxy.proxy_server.proxy_config", mocker.Mock())
+    mocker.patch("litellm.proxy.proxy_server.version", "test")
+    mock_executor = mocker.Mock()
+    mocker.patch(
+        "litellm.litellm_core_utils.thread_pool_executor.executor", mock_executor
+    )
+
+    request = ApplyGuardrailRequest(
+        guardrail_name="test-guardrail", text="hello@example.com"
+    )
+    response = await apply_guardrail(
+        fastapi_request=mocker.Mock(),
+        request=request,
+        user_api_key_dict=UserAPIKeyAuth(),
+    )
+
+    assert response.response_text == "masked"
+    mock_processor.common_processing_pre_call_logic.assert_awaited_once()
+    mock_proxy_logging.post_call_success_hook.assert_awaited_once()
+    mock_logging_obj.async_success_handler.assert_awaited_once()
+    assert mock_logging_obj.call_type == "pass_through_endpoint"
+    mock_executor.submit.assert_called_once()
+    assert mock_logging_obj.async_success_handler.await_args.kwargs["result"] == {
+        "response": {"response_text": "masked"}
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -1149,6 +1149,13 @@ async def test_apply_guardrail_not_found(mocker):
         "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY", mock_registry
     )
 
+    mock_proxy_logging = mocker.Mock()
+    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+    mocker.patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging)
+    mocker.patch("litellm.proxy.proxy_server.general_settings", {})
+    mocker.patch("litellm.proxy.proxy_server.proxy_config", mocker.Mock())
+    mocker.patch("litellm.proxy.proxy_server.version", "test")
+
     # Create request
     request = ApplyGuardrailRequest(
         guardrail_name="non-existent-guardrail", text="Test input text"


### PR DESCRIPTION
## Summary
- Route `/apply_guardrail` through proxy pre/post hooks and LiteLLM success/failure logging handlers so configured callbacks (Langfuse, OTEL, etc.) run on guardrail-only requests.
- Set logging call type to `pass_through_endpoint` with messages/response payload so Langfuse records input and output on this endpoint.
- Add regression test covering logging pipeline invocation.

Fixes LIT-3139

## Test plan
- [x] `poetry run pytest tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py::test_apply_guardrail_not_found -v`
- [x] `poetry run pytest tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py::test_apply_guardrail_execution_error -v`
- [x] `poetry run pytest tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py::test_apply_guardrail_invokes_logging_pipeline -v`
<img width="1267" height="850" alt="image" src="https://github.com/user-attachments/assets/621b882c-d0d1-458e-898f-92eb9daf8dd1" />


<img width="1267" height="850" alt="image" src="https://github.com/user-attachments/assets/59afc5cd-66fa-411f-a1fb-2b2318166638" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and hook wiring around an existing guardrail test endpoint; hook failures are isolated so API responses still return.
> 
> **Overview**
> The **`/apply_guardrail`** endpoint now follows the same proxy request and logging path as LLM routes instead of running guardrails in isolation.
> 
> It uses **`ProxyBaseLLMRequestProcessing.common_processing_pre_call_logic`** with a new **`apply_guardrail`** route type (registered in **`common_request_processing`**), accepts the FastAPI **`Request`**, and on success runs **`post_call_success_hook`**, LiteLLM **`async_success_handler`**, and sync **`success_handler`**. Failures go through the matching failure hooks. The logging object is patched so **`call_type`** is **`pass_through_endpoint`** and messages/response are shaped for integrations like Langfuse and OTEL. Post-call guardrails still get the correct **`input_type`** via **`_resolve_guardrail_input_type`**.
> 
> Tests add a shared **`mock_proxy_logging_ctx`** fixture and assert the logging pipeline is invoked on success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156e0d2c1ab65cee6e391e12c926a385175eef36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->