### PR TITLE
chore: uv lock for 1.86.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-23T02:21:09.310366Z"
+exclude-newer = "2026-05-24T07:24:03.668568Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3189,7 +3189,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.86.1"
+version = "1.86.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Follow-up to merged PR #28969 — that PR bumped `pyproject.toml` to `1.86.2` but I forgot to regenerate `uv.lock`, so the lockfile still pinned `litellm==1.86.1`.

This PR runs `uv lock` to sync the lockfile.

## Diff

```
 uv.lock | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

Two-line change: the `litellm` workspace pin (`1.86.1` → `1.86.2`) plus `exclude-newer` timestamp advancement. No dependency-graph changes.

## Test plan

- [ ] `uv lock --check` passes