### PR TITLE
fix(docker): cherry-pick #28519 (restore npm to non_root builder) onto patch/v1.84.1

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -24,7 +24,8 @@ RUN for i in 1 2 3; do \
         curl \
         openssl \
         libsndfile \
-        nodejs && break || sleep 5; \
+        nodejs \
+        npm && break || sleep 5; \
     done
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.84.2"
+version = "1.84.3"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -242,7 +242,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.84.2"
+version = "1.84.3"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-24T07:22:56.779644Z"
+exclude-newer = "2026-05-24T07:50:00.208911Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3083,7 +3083,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.84.2"
+version = "1.84.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cherry-picks `9e7192e099` (`fix(docker): restore npm to non_root builder image (#28519)`) onto `patch/v1.84.1`. Already present on `patch/v1.86.1`; missing from `patch/v1.84.1` and `patch/v1.85.1`. Sibling PR for v1.85.1 will follow.

## Why this matters on the 1.84 line

The non_root builder stage installs `nodejs` but not `npm`. Without `npm` on PATH, `prisma-python` falls back to downloading a Node runtime via `nodeenv` from nodejs.org, and the downloaded binary fails to load `libatomic.so.1` — breaking `prisma generate` and the non_root image build.

## Diff

- `docker/Dockerfile.non_root` — 2+/1- (single apk add line)
- `pyproject.toml` — version bump 1.84.2 → 1.84.3
- `uv.lock` — workspace pin sync

## Conflict resolution

Cherry-pick applied cleanly with no conflicts.

## Test plan

- [ ] CI builds the non_root image without falling back to nodeenv