### PR TITLE
fix(docker): cherry-pick #28519 (restore npm to non_root builder) onto patch/v1.85.1

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -24,7 +24,8 @@ RUN for i in 1 2 3; do \
         curl \
         openssl \
         libsndfile \
-        nodejs && break || sleep 5; \
+        nodejs \
+        npm && break || sleep 5; \
     done
 
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \


### PR DESCRIPTION
Cherry-picks `9e7192e099` (`fix(docker): restore npm to non_root builder image (#28519)`) onto `patch/v1.85.1`. Already present on `patch/v1.86.1`; missing from `patch/v1.84.1` and `patch/v1.85.1`. Sibling PR for v1.84.1: #28973.

## Why this matters on the 1.85 line

The non_root builder stage installs `nodejs` but not `npm`. Without `npm` on PATH, `prisma-python` falls back to downloading a Node runtime via `nodeenv` from nodejs.org, and the downloaded binary fails to load `libatomic.so.1` — breaking `prisma generate` and the non_root image build.

## Diff

- `docker/Dockerfile.non_root` — 2+/1- (single apk add line). No version bump, no lockfile change.

## Conflict resolution

Cherry-pick applied cleanly with no conflicts.

## Test plan

- [ ] CI builds the non_root image without falling back to nodeenv