### PR TITLE
fix(utils): convert server_tool_use dict to ServerToolUse in Usage.__init__

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -589,6 +589,8 @@ class ChunkProcessor:
                     and usage_chunk.server_tool_use is not None
                 ):
                     server_tool_use = usage_chunk.server_tool_use
+                    if isinstance(server_tool_use, dict):
+                        server_tool_use = ServerToolUse(**server_tool_use)
                 if (
                     usage_chunk_dict["prompt_tokens_details"] is not None
                     and getattr(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1554,7 +1554,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
         completion_tokens_details: Optional[
             Union[CompletionTokensDetailsWrapper, dict]
         ] = None,
-        server_tool_use: Optional[ServerToolUse] = None,
+        server_tool_use: Optional[Union[ServerToolUse, dict]] = None,
         cost: Optional[float] = None,
         **params,
     ):
@@ -1656,7 +1656,10 @@ class Usage(SafeAttributeModel, CompletionUsage):
         )
 
         if server_tool_use is not None:
-            self.server_tool_use = server_tool_use
+            if isinstance(server_tool_use, dict):
+                self.server_tool_use = ServerToolUse(**server_tool_use)
+            else:
+                self.server_tool_use = server_tool_use
         else:  # maintain openai compatibility in usage object if possible
             del self.server_tool_use
 

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -520,7 +520,56 @@ def test_stream_chunk_builder_anthropic_web_search():
     assert usage.prompt_tokens == 50
     assert usage.completion_tokens == 27
     assert usage.total_tokens == 77
-    assert usage.server_tool_use["web_search_requests"] == 2
+    assert usage.server_tool_use.web_search_requests == 2
+
+
+def test_stream_chunk_builder_anthropic_web_search_dict():
+    """server_tool_use as a dict in usage should be converted to ServerToolUse."""
+    # Create a usage object with server_tool_use as a raw dict
+    usage = Usage(
+        completion_tokens=27,
+        prompt_tokens=50,
+        total_tokens=77,
+        completion_tokens_details=None,
+        prompt_tokens_details=None,
+    )
+    # Bypass Pydantic validation to set server_tool_use as a dict
+    # (simulates data arriving from raw JSON parsing)
+    object.__setattr__(usage, "server_tool_use", {"web_search_requests": 2})
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-mocked-usage-dict",
+        created=1745513206,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content=None,
+                    role=None,
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=usage,
+    )
+
+    processor = ChunkProcessor(chunks=[chunk])
+    result = processor.calculate_usage(
+        chunks=[chunk], model="claude-sonnet-4-5-20250929", completion_output=""
+    )
+
+    assert result.server_tool_use.web_search_requests == 2
+    assert isinstance(result.server_tool_use, ServerToolUse)
 
 
 def test_sort_chunks_handles_dict_hidden_params_created_at():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -301,6 +301,20 @@ def test_server_tool_use_usage():
     assert usage.server_tool_use.web_search_requests == 1
 
 
+def test_usage_init_with_server_tool_use_dict():
+    """Usage(**dict) should convert server_tool_use from dict to ServerToolUse."""
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        server_tool_use={"web_search_requests": 1},
+    )
+    assert usage.server_tool_use.web_search_requests == 1
+    assert usage.server_tool_use.tool_search_requests is None
+
+
 def test_web_search_tool_transformation():
     from litellm.types.llms.openai import OpenAIWebSearchOptions
 


### PR DESCRIPTION
## Problem

`Usage.__init__` stores `server_tool_use` as-is without converting Python dicts to the `ServerToolUse` Pydantic model. This causes a crash in `response_object_includes_web_search_call` at `tool_call_cost_tracking.py:342`:

```
AttributeError: 'dict' object has no attribute 'web_search_requests'
```

The crash occurs because `hasattr(usage, "server_tool_use")` passes (the dict is stored), but `usage.server_tool_use.web_search_requests` fails since dicts don't support attribute access.

## Fix

Added `isinstance(server_tool_use, dict)` checks with conversion to `ServerToolUse(**server_tool_use)` in two locations, mirroring the existing pattern used by `completion_tokens_details` and `prompt_tokens_details` in the same `__init__` method:

1. **`litellm/types/utils.py`** — `Usage.__init__` primary constructor
2. **`litellm/litellm_core_utils/streaming_chunk_builder_utils.py`** — `_calculate_usage_per_chunk` streaming assembly path

## Testing

- Added `test_usage_init_with_server_tool_use_dict` to verify `Usage(**{"server_tool_use": {"web_search_requests": 1}})` correctly converts to `ServerToolUse`
- Updated existing `test_stream_chunk_builder_anthropic_web_search` to use attribute access (`.web_search_requests`) instead of dict subscript (`["web_search_requests"]`)

## Related

- `ServerToolUse` is already defined at `litellm/types/utils.py:1523`
- An analogous conversion pattern exists for `completion_tokens_details` (line 1566) and `prompt_tokens_details` (line 1605) in the same `__init__