### PR TITLE
fix(azure): route image edit to /openai/v1 when api_version is v1/latest/preview

### DIFF
--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -83,12 +83,19 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
             "https://litellm8397336933.openai.azure.com"
             OR
             "https://litellm8397336933.openai.azure.com/openai/deployments/<deployment_name>/images/edits?api-version=2024-05-01-preview"
-        - model: Model name (deployment name).
+            OR (Azure OpenAI v1 API)
+            "https://litellm8397336933.openai.azure.com/openai/v1/images/edits?api-version=preview"
+        - model: Model name (deployment name for deployment-style URLs;
+            value of the ``model`` form field for the v1 API).
         - litellm_params: Additional query parameters, including "api_version".
 
         Returns:
-        - A complete URL string, e.g.,
-        "https://litellm8397336933.openai.azure.com/openai/deployments/<deployment_name>/images/edits?api-version=2024-05-01-preview"
+        - A complete URL string. When ``api_version`` is one of ``v1`` /
+        ``latest`` / ``preview`` the request is routed through
+        ``/openai/v1/images/edits`` (model selected via form field), matching
+        the convention introduced in #19313 for chat completions. Otherwise
+        the legacy ``/openai/deployments/{deployment}/images/edits`` path is
+        used.
         """
         api_base = api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
         if api_base is None:
@@ -107,14 +114,26 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
         if "api-version" not in query_params and api_version:
             query_params["api-version"] = api_version
 
-        # Add the path to the base URL using the model as deployment name
-        if "/openai/deployments/" not in api_base:
+        # Pick the route. The v1 API exposes models like ``gpt-image-2`` that
+        # have no Azure deployment, so the deployment-scoped path returns 404
+        # for them. The model is carried in the multipart ``model`` form field
+        # instead (see ``azure_deployment_image_edit_form_data``, which only
+        # strips ``model`` on deployment URLs).
+        if BaseAzureLLM._is_azure_v1_api_version(api_version):
+            if "/openai/v1/images/edits" in api_base:
+                new_url = api_base
+            else:
+                new_url = _add_path_to_api_base(
+                    api_base=api_base,
+                    ending_path="/openai/v1/images/edits",
+                )
+        elif "/openai/deployments/" in api_base:
+            new_url = api_base
+        else:
             new_url = _add_path_to_api_base(
                 api_base=api_base,
                 ending_path=f"/openai/deployments/{model}/images/edits",
             )
-        else:
-            new_url = api_base
 
         # Use the new query_params dictionary
         final_url = httpx.URL(new_url).copy_with(params=query_params)

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -109,6 +109,89 @@ def test_azure_deployment_image_edit_form_data_keeps_model_non_deployment_url():
     assert out == data
 
 
+def test_get_complete_url_legacy_api_version_uses_deployment_path():
+    """
+    Regression guard: a traditional Azure ``api-version`` (e.g. the GA preview
+    versions) must keep routing to ``/openai/deployments/{model}/images/edits``.
+    """
+    config = AzureImageEditConfig()
+    url = config.get_complete_url(
+        model="my-deployment",
+        api_base="https://example.openai.azure.com",
+        litellm_params={"api_version": "2025-02-01-preview"},
+    )
+    assert "/openai/deployments/my-deployment/images/edits" in url
+    assert "/openai/v1/" not in url
+    assert "api-version=2025-02-01-preview" in url
+
+
+def test_get_complete_url_v1_api_version_uses_v1_path():
+    """
+    Azure OpenAI exposes models like ``gpt-image-2`` only through the v1 API
+    (``/openai/v1/...``), selecting the model via the ``model`` form field
+    instead of the URL deployment segment. ``api_version`` of ``v1`` /
+    ``latest`` / ``preview`` opts into that surface, matching the convention
+    introduced for chat completions in PR #19313.
+
+    Routing the deployment-style URL for these models returns
+    ``404 Resource not found`` (see LiteLLM #27978).
+    """
+    config = AzureImageEditConfig()
+    for api_version in ("v1", "latest", "preview"):
+        url = config.get_complete_url(
+            model="gpt-image-2",
+            api_base="https://example.openai.azure.com",
+            litellm_params={"api_version": api_version},
+        )
+        assert "/openai/v1/images/edits" in url, api_version
+        assert "/openai/deployments/" not in url, api_version
+        assert f"api-version={api_version}" in url, api_version
+
+
+def test_get_complete_url_v1_api_version_does_not_double_append():
+    """An ``api_base`` already pointing at ``/openai/v1/images/edits`` is kept as-is."""
+    config = AzureImageEditConfig()
+    api_base = "https://example.openai.azure.com/openai/v1/images/edits"
+    url = config.get_complete_url(
+        model="gpt-image-2",
+        api_base=api_base,
+        litellm_params={"api_version": "preview"},
+    )
+    assert url.count("/openai/v1/images/edits") == 1
+    assert "/openai/deployments/" not in url
+
+
+def test_v1_api_version_keeps_model_in_form_data():
+    """
+    The v1 endpoint requires the ``model`` form field to select the target
+    model. ``finalize_image_edit_request_data`` must leave it alone for v1
+    URLs (it only strips ``model`` for deployment-scoped URLs).
+    """
+    config = AzureImageEditConfig()
+    model = "gpt-image-2"
+    litellm_params = GenericLiteLLMParams(
+        api_base="https://example.openai.azure.com",
+        api_version="preview",
+    )
+    data, _files = config.transform_image_edit_request(
+        model=model,
+        prompt="add a hat",
+        image=b"fake_png_bytes",
+        image_edit_optional_request_params={"n": 1},
+        litellm_params=litellm_params,
+        headers={},
+    )
+    resolved = config.get_complete_url(
+        model=model,
+        api_base=litellm_params.api_base,
+        litellm_params=litellm_params.model_dump(exclude_none=True),
+    )
+    data_out = config.finalize_image_edit_request_data(data, resolved)
+    assert "/openai/v1/images/edits" in resolved
+    assert data_out.get("model") == model
+    assert data_out.get("n") == 1
+
+
 def test_azure_finalize_image_edit_strips_model_after_openai_transform():
     """OpenAI transform still includes model; finalize uses the real request URL."""
     config = AzureImageEditConfig()


### PR DESCRIPTION
## Relevant issues

Refs #27978 — Azure `gpt-image-2` image edit returns `404 Resource not found` through the LiteLLM proxy.

This complements #28326, which fixes the separate `n` `str`→`int` coercion bug on the same proxy path. With both PRs applied, the `gpt-image-2` edit route works end to end.

## Pre-Submission checklist

- [x] I have Added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) (4 new tests, plus a regression guard for the legacy deployment route)
- [x] My PR passes `make test-unit` for the touched test file and the broader `tests/test_litellm/llms/azure/` suite (270 passed, 26 skipped locally)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Root cause

`AzureImageEditConfig.get_complete_url` (`litellm/llms/azure/image_edit/transformation.py`) always builds the deployment-style URL:

```
/openai/deployments/{model}/images/edits
```

Azure exposes newer image models (e.g. `gpt-image-2` / `gpt-image-2-1`) only through the v1 API surface (`/openai/v1/...`), where the model is selected via the multipart `model` form field rather than via the URL path. The deployment-scoped URL for these models does not exist, so Azure responds with:

```
{"error":{"code":"404","message":"Resource not found"}}
```

A direct request to `POST /openai/v1/images/edits` with `model=gpt-image-2-1` in the form data returns `200 OK` against the same Azure resource. The discrepancy is entirely in LiteLLM's URL construction.

### Fix

When `litellm_params["api_version"]` is one of `v1` / `latest` / `preview` (the existing Azure v1 API opt-in introduced for chat completions in #19313), route to `/openai/v1/images/edits` instead of the deployment path. The model field stays in the multipart body because `azure_deployment_image_edit_form_data` already only strips `model` for URLs containing `/openai/deployments/`.

```python
if BaseAzureLLM._is_azure_v1_api_version(api_version):
    if "/openai/v1/images/edits" in api_base:
        new_url = api_base
    else:
        new_url = _add_path_to_api_base(
            api_base=api_base,
            ending_path="/openai/v1/images/edits",
        )
elif "/openai/deployments/" in api_base:
    new_url = api_base
else:
    new_url = _add_path_to_api_base(
        api_base=api_base,
        ending_path=f"/openai/deployments/{model}/images/edits",
    )
```

Existing callers using a traditional `api-version` (e.g. `2025-02-01-preview`) keep the legacy deployment URL — a dedicated regression test pins this.

### Routing output

The table below shows the URL `AzureImageEditConfig.get_complete_url` actually produces for each `api_version` value. Captured against this PR's branch with `api_base="https://x.openai.azure.com"` and `model="gpt-image-2"`:

| `api_version`            | Constructed URL                                                                                                 | Branch exercised in `### Fix` above                            |
| ------------------------ | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| `"v1"`                   | `https://x.openai.azure.com/openai/v1/images/edits?api-version=v1`                                              | new `_is_azure_v1_api_version(...)` true → build v1 path       |
| `"latest"`               | `https://x.openai.azure.com/openai/v1/images/edits?api-version=latest`                                          | new `_is_azure_v1_api_version(...)` true → build v1 path       |
| `"preview"`              | `https://x.openai.azure.com/openai/v1/images/edits?api-version=preview`                                         | new `_is_azure_v1_api_version(...)` true → build v1 path       |
| `"2025-04-01-preview"`   | `https://x.openai.azure.com/openai/deployments/gpt-image-2/images/edits?api-version=2025-04-01-preview`         | legacy `else` → build `/openai/deployments/{model}/...` path   |
| `None`                   | `https://x.openai.azure.com/openai/deployments/gpt-image-2/images/edits`                                        | legacy `else` → build `/openai/deployments/{model}/...` path   |

So the v1 vs. legacy split is driven entirely by `BaseAzureLLM._is_azure_v1_api_version(api_version)`. The two "`api_base` already contains the target path" short-circuits in the same conditional (`if "/openai/v1/images/edits" in api_base` and `elif "/openai/deployments/" in api_base`) are exercised by the dedicated pytest case `test_get_complete_url_v1_api_version_does_not_double_append` rather than by the script above, to keep the script to a single shape of `api_base`.

Reproduction (6 lines of `print`, no Azure credentials needed — exercises the exact conditional shown in `### Fix` above):

```python
from litellm.llms.azure.image_edit.transformation import AzureImageEditConfig

cfg = AzureImageEditConfig()
for v in ["v1", "latest", "preview", "2025-04-01-preview", None]:
    url = cfg.get_complete_url(
        model="gpt-image-2",
        api_base="https://x.openai.azure.com",
        litellm_params={"api_version": v} if v else {},
    )
    print(f"api_version={v!r:<23} -> {url}")
```

A combined screenshot of the script output plus `pytest -v` (all 11 tests in the touched file green) is attached below; happy to also supply a real Azure production screenshot (`curl` against an Azure resource with a `gpt-image-2` deployment, returning `200 OK`) on request.

## Tests

`tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py` — 4 new tests:

- `test_get_complete_url_legacy_api_version_uses_deployment_path` — regression guard for the deployment-style route.
- `test_get_complete_url_v1_api_version_uses_v1_path` — `v1` / `latest` / `preview` all route through `/openai/v1/images/edits`.
- `test_get_complete_url_v1_api_version_does_not_double_append` — `api_base` already ending in `/openai/v1/images/edits` is kept as-is.
- `test_v1_api_version_keeps_model_in_form_data` — the v1 path keeps the `model` form field intact (deployment URLs still strip it, covered by an existing test).

```
$ pytest tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py -v
============================== 11 passed in 0.68s ==============================
$ pytest tests/test_litellm/llms/azure/ -x
================ 270 passed, 26 skipped, 13 warnings in 38.28s =================
```

## Risk

Low. The change is gated behind a known opt-in (`api_version in {v1, latest, preview}`) that already changes Azure routing in other code paths (#19313). The legacy deployment route is preserved bit-for-bit when that gate is not active, with a dedicated regression test.
