### PR TITLE
fix: prevent [System: ...] messages leaking into client-visible output and preserve tool_calls during sanitization

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2151,8 +2151,29 @@ def _sanitize_empty_text_content(
     Returns:
         The message with sanitized content if needed, otherwise the original message
     """
-    if message.get("role") not in ["user", "assistant"]:
-        return message
+    if message.get("role") != "user":
+        # For assistant messages: only skip sanitization when the message has
+        # content beyond empty text blocks -- either tool_calls (OpenAI format)
+        # or non-text content blocks (tool_use, image, etc.) that remain after
+        # the Anthropic conversion drops empty text blocks (the conversion logic
+        # only keeps text blocks whose content is truthy and non-empty, so
+        # remaining non-text blocks are substantive). If the message has ONLY
+        # empty/whitespace text blocks, still sanitize to prevent sending
+        # content: [] which the Anthropic API rejects.
+        if message.get("role") == "assistant":
+            content = message.get("content")
+            if message.get("tool_calls"):
+                return message
+            if isinstance(content, list) and any(
+                isinstance(b, dict)
+                and isinstance(b.get("type"), str)
+                and b.get("type") != "text"
+                for b in content
+            ):
+                return message
+            # Assistant messages with ONLY empty text blocks fall through
+        else:
+            return message
 
     content = message.get("content")
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2181,7 +2181,7 @@ def _sanitize_empty_text_content(
         if not content or not content.strip():
             message = cast(AllMessageValues, dict(message))  # Make a copy
             if message.get("role") == "assistant":
-                message["content"] = None
+                message["content"] = None  # type: ignore[arg-type]
             else:
                 message["content"] = _DEFAULT_EMPTY_CONTENT_MESSAGE
             verbose_logger.debug(
@@ -2211,7 +2211,7 @@ def _sanitize_empty_text_content(
                 # All blocks were empty text blocks -- fall back to string treatment
                 message = cast(AllMessageValues, dict(message))
                 if message.get("role") == "assistant":
-                    message["content"] = None
+                    message["content"] = None  # type: ignore[arg-type]
                 else:
                     message["content"] = _DEFAULT_EMPTY_CONTENT_MESSAGE
             else:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2124,9 +2124,7 @@ def anthropic_process_openai_file_message(
     )
 
 
-_EMPTY_TEXT_PLACEHOLDER = (
-    "[System: Empty message content sanitised to satisfy protocol]"
-)
+_DEFAULT_EMPTY_CONTENT_MESSAGE = "Please continue."
 
 
 def _sanitize_empty_text_content(
@@ -2134,10 +2132,15 @@ def _sanitize_empty_text_content(
 ) -> AllMessageValues:
     """
     Case C: Sanitize empty text content
-    - Replace empty or whitespace-only text content with a placeholder message.
-    - Handles both string content and list-of-blocks content (rewriting only
-      the empty text blocks in place; non-text blocks like images are left
-      untouched).
+    - For assistant messages: replace empty/whitespace-only string content with
+      ``None``. The downstream Anthropic converter skips ``None`` content, and
+      any tool_calls are converted to tool_use blocks separately.
+    - For user messages: replace empty/whitespace-only string content with a
+      minimal natural continuation message (``"Please continue."``) instead of
+      a protocol diagnostic.
+    - For list-of-blocks content: drop empty text blocks rather than replacing
+      them with a placeholder. If dropping leaves no blocks at all, fall back
+      to the role-appropriate string treatment above.
 
     Returns:
         The message with sanitized content if needed, otherwise the original message
@@ -2150,34 +2153,45 @@ def _sanitize_empty_text_content(
     if isinstance(content, str):
         if not content or not content.strip():
             message = cast(AllMessageValues, dict(message))  # Make a copy
-            message["content"] = _EMPTY_TEXT_PLACEHOLDER
+            if message.get("role") == "assistant":
+                message["content"] = None
+            else:
+                message["content"] = _DEFAULT_EMPTY_CONTENT_MESSAGE
             verbose_logger.debug(
                 f"_sanitize_empty_text_content: Replaced empty text content in {message.get('role')} message"
             )
         return message
 
     if isinstance(content, list):
-        # Walk the blocks and rewrite any empty text blocks. We rewrite (rather
-        # than drop) so callers don't end up with an entirely empty content
-        # list, which Anthropic also rejects.
-        new_blocks: List[Any] = []
-        rewrote_any = False
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if not isinstance(text, str) or not text or not text.strip():
-                    new_block = dict(block)
-                    new_block["text"] = _EMPTY_TEXT_PLACEHOLDER
-                    new_blocks.append(new_block)
-                    rewrote_any = True
-                    continue
-            new_blocks.append(block)
+        # Drop empty text blocks. If an empty text block is surrounded by
+        # non-text blocks (images, documents, etc.), the remaining list is
+        # still valid for Anthropic. If dropping would leave an entirely
+        # empty list, fall back to the role-appropriate string treatment.
+        new_blocks: List[Any] = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and (
+                    not isinstance(block.get("text"), str) or not block["text"].strip()
+                )
+            )
+        ]
 
-        if rewrote_any:
-            message = cast(AllMessageValues, dict(message))  # Make a copy
-            message["content"] = new_blocks  # type: ignore
+        if len(new_blocks) != len(content):
+            if not new_blocks:
+                # All blocks were empty text blocks -- fall back to string treatment
+                message = cast(AllMessageValues, dict(message))
+                if message.get("role") == "assistant":
+                    message["content"] = None
+                else:
+                    message["content"] = _DEFAULT_EMPTY_CONTENT_MESSAGE
+            else:
+                message = cast(AllMessageValues, dict(message))
+                message["content"] = new_blocks  # type: ignore
             verbose_logger.debug(
-                f"_sanitize_empty_text_content: Replaced empty text block(s) in {message.get('role')} message"
+                f"_sanitize_empty_text_content: Removed empty text block(s) in {message.get('role')} message"
             )
 
     return message

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -86,6 +86,9 @@ DEFAULT_ASSISTANT_CONTINUE_MESSAGE = ChatCompletionAssistantMessage(
     ],
 )  # similar to autogen. Only used if `litellm.modify_params=True`.
 
+# used as a filler for empty/whitespace-only user messages
+_DEFAULT_EMPTY_CONTENT_MESSAGE = "."
+
 
 def map_system_message_pt(messages: list) -> list:
     """
@@ -1148,7 +1151,13 @@ def anthropic_messages_pt_xml(messages: list):
     if not new_messages or new_messages[0]["role"] != "user":
         if litellm.modify_params:
             new_messages.insert(
-                0, {"role": "user", "content": [{"type": "text", "text": "."}]}
+                0,
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _DEFAULT_EMPTY_CONTENT_MESSAGE}
+                    ],
+                },
             )
         else:
             raise Exception(
@@ -2122,9 +2131,6 @@ def anthropic_process_openai_file_message(
     raise Exception(
         f"Either file_data or file_id must be present in the file message: {message}"
     )
-
-
-_DEFAULT_EMPTY_CONTENT_MESSAGE = "Please continue."
 
 
 def _sanitize_empty_text_content(

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -1033,7 +1033,7 @@ class ModelResponseIterator:
                     StreamingChoices(
                         index=index,
                         delta=Delta(
-                            content=text,
+                            content=text or None,
                             tool_calls=[tool_use] if tool_use is not None else None,
                             provider_specific_fields=(
                                 provider_specific_fields

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -9,6 +9,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     BAD_MESSAGE_ERROR_STR,
     BedrockConverseMessagesProcessor,
     BedrockImageProcessor,
+    _sanitize_empty_text_content,
     _bedrock_converse_messages_pt,
     _convert_to_bedrock_tool_call_invoke,
     _convert_to_bedrock_tool_call_result,
@@ -2680,3 +2681,125 @@ def test_bedrock_converse_messages_pt_document_rejects_url_source():
         _bedrock_converse_messages_pt(
             messages, "anthropic.claude-sonnet-4-6", "bedrock"
         )
+
+
+def test_sanitize_empty_text_assistant_with_tool_calls():
+    """Assistant messages with tool_calls should not be sanitized
+    (they should be returned as-is with tool_calls preserved)."""
+    message = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"loc": "NY"}'},
+            }
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    # Message should be returned unchanged (with tool_calls intact)
+    assert result.get("tool_calls") is not None
+    assert len(result["tool_calls"]) == 1
+    assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_sanitize_empty_text_assistant_with_non_text_content():
+    """Assistant messages with non-text content blocks (e.g., tool_use)
+    should not be sanitized - they contain substantive content beyond text."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {}}
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    # Message should be returned unchanged (content preserved)
+    assert result.get("content") == message["content"]
+
+
+def test_sanitize_empty_text_assistant_with_only_text_blocks():
+    """Assistant messages with ONLY empty/whitespace text blocks
+    should still be sanitized."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "   "},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    # Content should have been sanitized - empty text blocks replaced
+    assert result.get("content") is not None
+    result_content = result["content"]
+    assert isinstance(result_content, list)
+    for block in result_content:
+        assert block["type"] == "text"
+        # Should not be empty/whitespace anymore
+        assert block["text"].strip()
+
+
+def test_sanitize_empty_text_assistant_with_mixed_content():
+    """Assistant messages with mixed content (text + non-text blocks)
+    should be preserved when they have non-text blocks."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": ""},
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {}},
+            {"type": "text", "text": "   "},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    # Message should be returned unchanged because it has non-text content blocks
+    assert result.get("content") == message["content"]
+
+
+def test_sanitize_empty_text_non_assistant_non_user_roles():
+    """Non-user/assistant roles (tool, function) should pass through unchanged."""
+    tool_message = {"role": "tool", "content": "Result data", "tool_call_id": "call_1"}
+    result = _sanitize_empty_text_content(tool_message)
+    assert result["role"] == "tool"
+    assert result["content"] == "Result data"
+
+    function_message = {"role": "function", "content": "Result data", "name": "my_func"}
+    result = _sanitize_empty_text_content(function_message)
+    assert result["role"] == "function"
+    assert result["content"] == "Result data"
+
+
+def test_sanitize_empty_text_assistant_with_string_content():
+    """Assistant messages with plain string content (not a list) and
+    no tool_calls should pass through unchanged when content is non-empty.
+
+    This exercises the isinstance(content, list) -> False branch."""
+    message = {"role": "assistant", "content": "Hello, how can I help?"}
+    result = _sanitize_empty_text_content(message)
+    assert result["role"] == "assistant"
+    assert result["content"] == "Hello, how can I help?"
+
+
+def test_sanitize_empty_text_assistant_with_empty_string_content():
+    """Assistant messages with an empty string content and no tool_calls
+    should be sanitized (replaced with placeholder)."""
+    message = {"role": "assistant", "content": ""}
+    result = _sanitize_empty_text_content(message)
+    assert result["role"] == "assistant"
+    # Empty string should be replaced with placeholder
+    assert result["content"] != ""
+
+
+def test_sanitize_empty_text_assistant_with_missing_type_block():
+    """Assistant messages with content blocks missing a 'type' key should NOT
+    be treated as non-text — they should fall through to sanitization.
+    A dict block without a 'type' key is malformed and should not suppress
+    the empty-text guard."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"no_type": "value"},  # malformed: dict without 'type' key
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    # The malformed block should not prevent sanitization from running
+    assert result.get("content") is not None

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2845,3 +2845,30 @@ def test_sanitize_empty_text_assistant_none_content():
     message = {"role": "assistant", "content": None}
     result = _sanitize_empty_text_content(message)
     assert result["content"] is None
+
+
+def test_sanitize_empty_text_assistant_all_empty_list():
+    """Assistant messages with a list where ALL text blocks are empty/whitespace
+    should fall back to content=None (no text content, no non-text blocks)."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": ""},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    assert result["content"] is None
+
+
+def test_sanitize_empty_text_assistant_mixed_text_list():
+    """Assistant messages with a mix of non-empty and empty text blocks
+    and no non-text blocks should drop the empty blocks."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": ""},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    assert result["content"] == [{"type": "text", "text": "hello"}]

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2729,14 +2729,8 @@ def test_sanitize_empty_text_assistant_with_only_text_blocks():
         ],
     }
     result = _sanitize_empty_text_content(message)
-    # Content should have been sanitized - empty text blocks replaced
-    assert result.get("content") is not None
-    result_content = result["content"]
-    assert isinstance(result_content, list)
-    for block in result_content:
-        assert block["type"] == "text"
-        # Should not be empty/whitespace anymore
-        assert block["text"].strip()
+    # Only-empty-text assistant messages get content=None
+    assert result.get("content") is None
 
 
 def test_sanitize_empty_text_assistant_with_mixed_content():
@@ -2785,7 +2779,7 @@ def test_sanitize_empty_text_assistant_with_empty_string_content():
     message = {"role": "assistant", "content": ""}
     result = _sanitize_empty_text_content(message)
     assert result["role"] == "assistant"
-    # Empty string should be replaced with placeholder
+    # Empty string should be replaced with None
     assert result["content"] != ""
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2872,3 +2872,55 @@ def test_sanitize_empty_text_assistant_mixed_text_list():
     }
     result = _sanitize_empty_text_content(message)
     assert result["content"] == [{"type": "text", "text": "hello"}]
+
+
+def test_anthropic_messages_pt_xml_inserts_placeholder_first_message():
+    """When anthropic_messages_pt_xml receives messages starting with assistant
+    (no user message first), it should insert a placeholder user message with
+    _DEFAULT_EMPTY_CONTENT_MESSAGE (".") to satisfy Anthropic's role alternation."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt_xml,
+        _DEFAULT_EMPTY_CONTENT_MESSAGE,
+    )
+    import litellm
+
+    original_modify = litellm.modify_params
+    litellm.modify_params = True
+    try:
+        messages = [
+            {"role": "assistant", "content": "Hello"},
+        ]
+        result = anthropic_messages_pt_xml(messages)
+        assert len(result) >= 2
+        assert result[0]["role"] == "user"
+        # The placeholder should use _DEFAULT_EMPTY_CONTENT_MESSAGE
+        text_blocks = [
+            b
+            for b in result[0]["content"]
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        assert any(b["text"] == _DEFAULT_EMPTY_CONTENT_MESSAGE for b in text_blocks)
+    finally:
+        litellm.modify_params = original_modify
+
+
+def test_anthropic_messages_pt_xml_raises_without_modify_params():
+    """When modify_params=False and the first message is not a user message,
+    anthropic_messages_pt_xml should raise an Exception."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt_xml,
+    )
+    import litellm
+
+    original_modify = litellm.modify_params
+    litellm.modify_params = False
+    try:
+        messages = [
+            {"role": "assistant", "content": "Hello"},
+        ]
+        import pytest
+
+        with pytest.raises(Exception, match="Invalid first message"):
+            anthropic_messages_pt_xml(messages)
+    finally:
+        litellm.modify_params = original_modify

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2797,3 +2797,51 @@ def test_sanitize_empty_text_assistant_with_missing_type_block():
     result = _sanitize_empty_text_content(message)
     # The malformed block should not prevent sanitization from running
     assert result.get("content") is not None
+
+
+def test_sanitize_empty_text_user_all_empty_list():
+    """User messages with a list where ALL text blocks are empty/whitespace
+    should fall back to '.' (the default empty content message)."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "   "},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    assert result["content"] == "."
+
+
+def test_sanitize_empty_text_user_mixed_list():
+    """User messages with a mix of non-empty and empty text blocks
+    should drop the empty blocks and keep the non-empty ones."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": ""},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    assert result["content"] == [{"type": "text", "text": "hello"}]
+
+
+def test_sanitize_empty_text_user_non_empty_list():
+    """User messages with all non-empty text blocks should pass through unchanged."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ],
+    }
+    result = _sanitize_empty_text_content(message)
+    assert result["content"] == message["content"]
+
+
+def test_sanitize_empty_text_assistant_none_content():
+    """Assistant messages with content=None should pass through unchanged."""
+    message = {"role": "assistant", "content": None}
+    result = _sanitize_empty_text_content(message)
+    assert result["content"] is None

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -4494,6 +4494,31 @@ def test_streaming_iterator_passthrough_when_name_not_in_map():
     assert tool_calls[0]["function"]["name"] == "plain_tool"
 
 
+def test_streaming_iterator_emits_content_none_for_non_text_chunks():
+    """Non-text streaming chunks (tool_use content_block_start, etc.) should
+    emit delta.content=None rather than empty string, so the client SDK
+    reconstructs assistant messages with content=None instead of content=''."""
+    from litellm.llms.anthropic.chat.handler import ModelResponseIterator
+
+    iterator = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+    )
+    chunk = {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "get_weather",
+            "input": {},
+        },
+    }
+    parsed = iterator.chunk_parser(chunk=chunk)
+    # delta.content should be None, not ''
+    assert parsed.choices[0].delta.content is None
+
+
 # ---------------------------------------------------------------------------
 # transform_request: end-to-end sanitization regression coverage
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/llms/anthropic/test_message_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/test_message_sanitization.py
@@ -188,7 +188,7 @@ class TestMessageSanitization:
 
         assert len(sanitized) == 2
         assert sanitized[0]["role"] == "user"
-        assert sanitized[0]["content"] == "Please continue."
+        assert sanitized[0]["content"] == "."
 
     def test_case_c_whitespace_only_content(self):
         """
@@ -203,7 +203,7 @@ class TestMessageSanitization:
         sanitized = sanitize_messages_for_tool_calling(messages)
 
         assert len(sanitized) == 2
-        assert sanitized[0]["content"] == "Please continue."
+        assert sanitized[0]["content"] == "."
         assert sanitized[1]["content"] is None
 
     def test_case_c_valid_content_preserved(self):
@@ -261,7 +261,7 @@ class TestMessageSanitization:
         assert sanitized[2]["role"] == "tool"
         assert sanitized[2]["tool_call_id"] == "call_1"  # Dummy added
         assert sanitized[3]["role"] == "user"
-        assert sanitized[3]["content"] == "Please continue."
+        assert sanitized[3]["content"] == "."
         assert sanitized[4]["role"] == "assistant"
 
     def test_modify_params_false_no_sanitization(self):
@@ -359,7 +359,7 @@ class TestMessageSanitization:
         # No text block may be empty — that's the contract Anthropic enforces.
         for block in text_blocks:
             assert block["text"].strip() != ""
-        assert text_blocks[2]["text"] == "Please continue."
+        assert text_blocks[2]["text"] == "."
 
     def test_empty_text_block_in_list_content_sanitized(self):
         """

--- a/tests/test_litellm/llms/anthropic/test_message_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/test_message_sanitization.py
@@ -177,7 +177,7 @@ class TestMessageSanitization:
     def test_case_c_empty_text_content_user(self):
         """
         Test Case C: Empty text content in user message
-        Should replace with placeholder
+        Should handle empty content appropriately
         """
         messages = [
             {"role": "user", "content": ""},
@@ -188,15 +188,12 @@ class TestMessageSanitization:
 
         assert len(sanitized) == 2
         assert sanitized[0]["role"] == "user"
-        assert (
-            sanitized[0]["content"]
-            == "[System: Empty message content sanitised to satisfy protocol]"
-        )
+        assert sanitized[0]["content"] == "Please continue."
 
     def test_case_c_whitespace_only_content(self):
         """
         Test Case C: Whitespace-only content
-        Should replace with placeholder
+        Should handle empty content appropriately
         """
         messages = [
             {"role": "user", "content": "   \n  \t  "},
@@ -206,14 +203,8 @@ class TestMessageSanitization:
         sanitized = sanitize_messages_for_tool_calling(messages)
 
         assert len(sanitized) == 2
-        assert (
-            sanitized[0]["content"]
-            == "[System: Empty message content sanitised to satisfy protocol]"
-        )
-        assert (
-            sanitized[1]["content"]
-            == "[System: Empty message content sanitised to satisfy protocol]"
-        )
+        assert sanitized[0]["content"] == "Please continue."
+        assert sanitized[1]["content"] is None
 
     def test_case_c_valid_content_preserved(self):
         """
@@ -270,10 +261,7 @@ class TestMessageSanitization:
         assert sanitized[2]["role"] == "tool"
         assert sanitized[2]["tool_call_id"] == "call_1"  # Dummy added
         assert sanitized[3]["role"] == "user"
-        assert (
-            sanitized[3]["content"]
-            == "[System: Empty message content sanitised to satisfy protocol]"
-        )
+        assert sanitized[3]["content"] == "Please continue."
         assert sanitized[4]["role"] == "assistant"
 
     def test_modify_params_false_no_sanitization(self):
@@ -363,15 +351,15 @@ class TestMessageSanitization:
         assert len(result) == 1
         assert result[0]["role"] == "user"
         text_blocks = [
-            b for b in result[0]["content"] if isinstance(b, dict) and b.get("type") == "text"
+            b
+            for b in result[0]["content"]
+            if isinstance(b, dict) and b.get("type") == "text"
         ]
         assert len(text_blocks) == 3
         # No text block may be empty — that's the contract Anthropic enforces.
         for block in text_blocks:
             assert block["text"].strip() != ""
-        assert text_blocks[2]["text"] == (
-            "[System: Empty message content sanitised to satisfy protocol]"
-        )
+        assert text_blocks[2]["text"] == "Please continue."
 
     def test_empty_text_block_in_list_content_sanitized(self):
         """
@@ -398,12 +386,13 @@ class TestMessageSanitization:
 
         assert len(result) == 1
         text_blocks = [
-            b for b in result[0]["content"] if isinstance(b, dict) and b.get("type") == "text"
+            b
+            for b in result[0]["content"]
+            if isinstance(b, dict) and b.get("type") == "text"
         ]
-        assert len(text_blocks) == 3
+        # Empty text blocks are dropped; only the non-empty one remains
+        assert len(text_blocks) == 1
         assert text_blocks[0]["text"] == "real content"
-        for block in text_blocks[1:]:
-            assert block["text"].strip() != ""
 
     def test_non_empty_content_unchanged_without_modify_params(self):
         """


### PR DESCRIPTION
## Problem

When an OpenAI-format client (e.g. Codex, Cursor, any OpenAI SDK agent) connects through LiteLLM to an Anthropic endpoint with tool calling, messages like `[System: Empty message content sanitised to satisfy protocol]` appear in the response stream. The model then starts echoing this text, compounding on every turn.

## Investigation

### Root cause chain

**1. Anthropic API enforces non-empty text blocks**

The Anthropic Messages API requires every `text` content block to be non-empty. If you send:
```json
{"role": "assistant", "content": ""}
```
Anthropic returns `400: "text content blocks must be non-empty"`.

**2. LiteLLM replaced empty content with a visible placeholder**

To work around Anthropic's validation, `_sanitize_empty_text_content()` in `factory.py` replaced empty/whitespace-only content with the string `"[System: Empty message content sanitised to satisfy protocol]"`. This text was put into the `content` field of the message — the same field the OpenAI protocol defines as the user/assistant's actual utterance. There is no mechanism in the OpenAI protocol for protocol-level diagnostics in `content`.

**3. LiteLLM's streaming delta also sent content: "" for non-text chunks**

In `handler.py:chunk_parser()`, the `text` variable starts as `""` and stays `""` for events that aren't text deltas (tool_use `content_block_start`, `input_json_delta`, `content_block_stop`, `message_start`). The `Delta(content=text)` emitted `content: ""` instead of `content: null`.

The OpenAI streaming protocol specifies `delta.content` should be `string | null` — `null` when there is no text. The SDK accumulated `""` (falsy, so nothing accumulated) but when building the final message from accumulated chunks + tool_calls, the reconstructed assistant message had `content: ""` instead of `content: null`.

**4. The cycle**

```
Turn N:   LiteLLM streams content="" for tool_use
          Client builds assistant message with content="" + tool_calls
          Client sends content="" back in next request
          LiteLLM sanitizer catches "" → replaces with "[System: ...]"
          Placeholder goes to Anthropic as conversation content
          Model echoes placeholder in response

Turn N+1: Same cycle, placeholder compounds
```

### Why the model echoes it

The placeholder is part of the message history sent to Anthropic. The model "sees" it as a user/assistant utterance. Users reported the model changed "protocol" to "protection" (a typo), proving the model was repeating text it saw in history, not generating it fresh.

## Fix

### 1. Streaming handler (handler.py)
`Delta(content=text)` → `Delta(content=text or None)` — converts "" to None for non-text chunks.

### 2. Request sanitizer (factory.py)
Replaced `[System: ...]` placeholder with role-appropriate handling:

| Role | Previous behavior | New behavior |
|---|---|---|
| Assistant, content: "" | Replaced with `[System: ...]` | Set to `None` |
| User, content: "" | Replaced with `[System: ...]` | Set to `"."` |
| List with empty text blocks | Each replaced with `[System: ...]` | Empty blocks dropped |

### 3. Preserve tool_calls on assistant messages
Assistant messages with `tool_calls` or non-text content blocks are returned unchanged.

### 4. Constant consolidation
Moved `_DEFAULT_EMPTY_CONTENT_MESSAGE = "."` to the top of `factory.py`.

## Related issues
- **#24498** — Direct report of `[System: Empty message content sanitised to satisfy protocol]`
- **#26554** — Empty text blocks in /v1/messages → Bedrock (same root cause)
- **#25669, #23841** — Original PR scope

## Testing
- `test_message_sanitization.py`: 13 tests
- `test_litellm_core_utils_prompt_templates_factory.py`: 90 tests (12 `_sanitize_empty_text_content` unit tests)
- `test_anthropic_chat_transformation.py`: 220 tests (streaming delta assertion)

### New tests
- `test_sanitize_empty_text_user_all_empty_list`
- `test_sanitize_empty_text_user_mixed_list`
- `test_sanitize_empty_text_user_non_empty_list`
- `test_sanitize_empty_text_assistant_none_content`
- `test_streaming_iterator_emits_content_none_for_non_text_chunks`

### CI
- ✅ lint (Black, Ruff, MyPy)
- ✅ core-utils tests
- ✅ all unit test suites
