### PR TITLE
fix: strip internal _litellm fields from openai chat payloads

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -341,7 +341,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         super().__init__()
 
     @staticmethod
-    def _strip_internal_request_fields(data: dict) -> dict:
+    def _strip_internal_request_fields(data: Any) -> Any:
         """
         Keep LiteLLM bookkeeping fields off the upstream OpenAI payload.
 
@@ -349,14 +349,29 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         post-call reconciliation. They are not part of the OpenAI API schema
         and should never be forwarded upstream.
         """
-        if not isinstance(data, dict):
-            return data
+        if isinstance(data, dict):
+            sanitized = {}
+            for key, value in data.items():
+                if isinstance(key, str) and key.startswith("_litellm_"):
+                    continue
+                sanitized[key] = OpenAIChatCompletion._strip_internal_request_fields(
+                    value
+                )
+            return sanitized
 
-        sanitized = dict(data)
-        for key in list(sanitized):
-            if isinstance(key, str) and key.startswith("_litellm_"):
-                sanitized.pop(key, None)
-        return sanitized
+        if isinstance(data, list):
+            return [
+                OpenAIChatCompletion._strip_internal_request_fields(item)
+                for item in data
+            ]
+
+        if isinstance(data, tuple):
+            return tuple(
+                OpenAIChatCompletion._strip_internal_request_fields(item)
+                for item in data
+            )
+
+        return data
 
     def _set_dynamic_params_on_client(
         self,

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -340,6 +340,24 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     def __init__(self) -> None:
         super().__init__()
 
+    @staticmethod
+    def _strip_internal_request_fields(data: dict) -> dict:
+        """
+        Keep LiteLLM bookkeeping fields off the upstream OpenAI payload.
+
+        Proxy hooks may stash `_litellm_*` values on the request dict for
+        post-call reconciliation. They are not part of the OpenAI API schema
+        and should never be forwarded upstream.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        sanitized = dict(data)
+        for key in list(sanitized):
+            if isinstance(key, str) and key.startswith("_litellm_"):
+                sanitized.pop(key, None)
+        return sanitized
+
     def _set_dynamic_params_on_client(
         self,
         client: Union[OpenAI, AsyncOpenAI],
@@ -432,11 +450,12 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call chat.completions.create.with_raw_response when litellm.return_response_headers is True
         - call chat.completions.create by default
         """
+        sanitized_data = self._strip_internal_request_fields(data)
         start_time = time.time()
         try:
             raw_response = (
                 await openai_aclient.chat.completions.with_raw_response.create(
-                    **data, timeout=timeout
+                    **sanitized_data, timeout=timeout
                 )
             )
             end_time = time.time()
@@ -473,10 +492,11 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call chat.completions.create.with_raw_response when litellm.return_response_headers is True
         - call chat.completions.create by default
         """
+        sanitized_data = self._strip_internal_request_fields(data)
         raw_response = None
         try:
             raw_response = openai_client.chat.completions.with_raw_response.create(
-                **data, timeout=timeout
+                **sanitized_data, timeout=timeout
             )
 
             if hasattr(raw_response, "headers"):

--- a/tests/test_litellm/llms/openai/test_openai_empty_response.py
+++ b/tests/test_litellm/llms/openai/test_openai_empty_response.py
@@ -146,6 +146,19 @@ class TestEmptyResponseHandling:
             "messages": [{"role": "user", "content": "test"}],
             "_litellm_rate_limit_descriptors": ["should-not-leave-litellm"],
             "_litellm_tpm_reserved_tokens": 42,
+            "extra_body": {
+                "_litellm_tpm_reserved_model": "gpt-4.1",
+                "metadata": {
+                    "_litellm_tpm_reserved_scopes": [["api_key", "hash"]],
+                    "trace_id": "trace-123",
+                },
+                "items": [
+                    {
+                        "_litellm_tpm_reservation_released": True,
+                        "keep": "value",
+                    }
+                ],
+            },
         }
 
         openai_chat.make_sync_openai_chat_completion_request(
@@ -158,8 +171,21 @@ class TestEmptyResponseHandling:
         _, kwargs = create_mock.call_args
         assert "_litellm_rate_limit_descriptors" not in kwargs
         assert "_litellm_tpm_reserved_tokens" not in kwargs
+        assert "_litellm_tpm_reserved_model" not in kwargs["extra_body"]
+        assert (
+            "_litellm_tpm_reserved_scopes"
+            not in kwargs["extra_body"]["metadata"]
+        )
+        assert (
+            "_litellm_tpm_reservation_released"
+            not in kwargs["extra_body"]["items"][0]
+        )
+        assert kwargs["extra_body"]["metadata"]["trace_id"] == "trace-123"
+        assert kwargs["extra_body"]["items"] == [{"keep": "value"}]
         assert kwargs["model"] == "gpt-4.1"
         assert kwargs["messages"] == [{"role": "user", "content": "test"}]
+        assert "_litellm_rate_limit_descriptors" in data
+        assert "_litellm_tpm_reserved_model" in data["extra_body"]
 
     @pytest.mark.asyncio
     async def test_async_request_drops_internal_litellm_fields(self):
@@ -181,6 +207,19 @@ class TestEmptyResponseHandling:
             "messages": [{"role": "user", "content": "test"}],
             "_litellm_rate_limit_descriptors": ["should-not-leave-litellm"],
             "_litellm_tpm_reserved_tokens": 42,
+            "extra_body": {
+                "_litellm_tpm_reserved_model": "gpt-4.1",
+                "metadata": {
+                    "_litellm_tpm_reserved_scopes": [["api_key", "hash"]],
+                    "trace_id": "trace-123",
+                },
+                "items": [
+                    {
+                        "_litellm_tpm_reservation_released": True,
+                        "keep": "value",
+                    }
+                ],
+            },
         }
 
         await openai_chat.make_openai_chat_completion_request(
@@ -193,5 +232,18 @@ class TestEmptyResponseHandling:
         _, kwargs = create_mock.call_args
         assert "_litellm_rate_limit_descriptors" not in kwargs
         assert "_litellm_tpm_reserved_tokens" not in kwargs
+        assert "_litellm_tpm_reserved_model" not in kwargs["extra_body"]
+        assert (
+            "_litellm_tpm_reserved_scopes"
+            not in kwargs["extra_body"]["metadata"]
+        )
+        assert (
+            "_litellm_tpm_reservation_released"
+            not in kwargs["extra_body"]["items"][0]
+        )
+        assert kwargs["extra_body"]["metadata"]["trace_id"] == "trace-123"
+        assert kwargs["extra_body"]["items"] == [{"keep": "value"}]
         assert kwargs["model"] == "gpt-4.1"
         assert kwargs["messages"] == [{"role": "user", "content": "test"}]
+        assert "_litellm_rate_limit_descriptors" in data
+        assert "_litellm_tpm_reserved_model" in data["extra_body"]

--- a/tests/test_litellm/llms/openai/test_openai_empty_response.py
+++ b/tests/test_litellm/llms/openai/test_openai_empty_response.py
@@ -126,3 +126,37 @@ class TestEmptyResponseHandling:
 
         assert response == mock_stream
         assert headers == {"x-request-id": "123"}
+
+    def test_sync_request_drops_internal_litellm_fields(self):
+        openai_chat = OpenAIChatCompletion()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"choices": []}
+
+        mock_raw_response = MagicMock()
+        mock_raw_response.headers = {}
+        mock_raw_response.parse.return_value = mock_response
+
+        mock_client = MagicMock()
+        create_mock = mock_client.chat.completions.with_raw_response.create
+        create_mock.return_value = mock_raw_response
+
+        data = {
+            "model": "gpt-4.1",
+            "messages": [{"role": "user", "content": "test"}],
+            "_litellm_rate_limit_descriptors": ["should-not-leave-litellm"],
+            "_litellm_tpm_reserved_tokens": 42,
+        }
+
+        openai_chat.make_sync_openai_chat_completion_request(
+            openai_client=mock_client,
+            data=data,
+            timeout=30,
+            logging_obj=MagicMock(),
+        )
+
+        _, kwargs = create_mock.call_args
+        assert "_litellm_rate_limit_descriptors" not in kwargs
+        assert "_litellm_tpm_reserved_tokens" not in kwargs
+        assert kwargs["model"] == "gpt-4.1"
+        assert kwargs["messages"] == [{"role": "user", "content": "test"}]

--- a/tests/test_litellm/llms/openai/test_openai_empty_response.py
+++ b/tests/test_litellm/llms/openai/test_openai_empty_response.py
@@ -4,7 +4,7 @@ Test for issue #17209: Clearer error when LLM endpoint returns empty response
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -150,6 +150,41 @@ class TestEmptyResponseHandling:
 
         openai_chat.make_sync_openai_chat_completion_request(
             openai_client=mock_client,
+            data=data,
+            timeout=30,
+            logging_obj=MagicMock(),
+        )
+
+        _, kwargs = create_mock.call_args
+        assert "_litellm_rate_limit_descriptors" not in kwargs
+        assert "_litellm_tpm_reserved_tokens" not in kwargs
+        assert kwargs["model"] == "gpt-4.1"
+        assert kwargs["messages"] == [{"role": "user", "content": "test"}]
+
+    @pytest.mark.asyncio
+    async def test_async_request_drops_internal_litellm_fields(self):
+        openai_chat = OpenAIChatCompletion()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"choices": []}
+
+        mock_raw_response = MagicMock()
+        mock_raw_response.headers = {}
+        mock_raw_response.parse.return_value = mock_response
+
+        mock_client = MagicMock()
+        create_mock = AsyncMock(return_value=mock_raw_response)
+        mock_client.chat.completions.with_raw_response.create = create_mock
+
+        data = {
+            "model": "gpt-4.1",
+            "messages": [{"role": "user", "content": "test"}],
+            "_litellm_rate_limit_descriptors": ["should-not-leave-litellm"],
+            "_litellm_tpm_reserved_tokens": 42,
+        }
+
+        await openai_chat.make_openai_chat_completion_request(
+            openai_aclient=mock_client,
             data=data,
             timeout=30,
             logging_obj=MagicMock(),


### PR DESCRIPTION
## Summary

Strip LiteLLM internal `_litellm_*` bookkeeping fields from OpenAI chat completion payloads before forwarding requests upstream, including fields nested under `extra_body`.

## Problem

Proxy hooks can stash internal reservation / rate-limiter fields on the request `data` dict, for example:

- `_litellm_rate_limit_descriptors`
- `_litellm_tpm_reserved_tokens`
- `_litellm_tpm_reserved_model`
- `_litellm_tpm_reserved_scopes`

`OpenAIChatCompletion` forwards the request through the OpenAI SDK. If any of those internal fields are present at the top level, or inside `extra_body`, they can be merged into the upstream request body and OpenAI rejects the request with `400 invalid_request_error`, for example:

- `Unknown parameter: '_litellm_rate_limit_descriptors'.`
- `Unrecognized request arguments supplied: _litellm_rate_limit_descriptors, ...`

In proxy deployments this can be surfaced back as `RateLimitError` / `429`, which makes the failure look like quota pressure even though the upstream response is a bad request.

## Fix

- Add `OpenAIChatCompletion._strip_internal_request_fields()`.
- Use a sanitized copy in both:
  - `make_openai_chat_completion_request()`
  - `make_sync_openai_chat_completion_request()`
- Strip `_litellm_*` keys recursively so `extra_body` and other nested passthrough structures cannot leak internal reservation fields.
- Keep the original LiteLLM-side request dict untouched so callbacks / reservation reconciliation can still read their internal metadata.

## Test

Added sync and async coverage in `tests/test_litellm/llms/openai/test_openai_empty_response.py` verifying that:

- top-level `_litellm_*` keys are not passed to the OpenAI SDK
- nested `_litellm_*` keys inside `extra_body`, nested metadata, and list items are not passed upstream
- non-internal nested values are preserved
- the original request dict still contains the internal fields after sanitization

## Validation

Ran:

```bash
python3 -m pytest tests/test_litellm/llms/openai/test_openai_empty_response.py -q
```

Result:

```text
6 passed
```

Also ran:

```bash
git diff --check
```

Result: no whitespace errors.

Closes #28991
