### PR TITLE
fix(vertex_ai): use user-supplied api_base as is for Model Garden OpenAI-compat path

### DIFF
--- a/litellm/llms/vertex_ai/vertex_model_garden/main.py
+++ b/litellm/llms/vertex_ai/vertex_model_garden/main.py
@@ -114,33 +114,18 @@ class VertexAIModelGardenModels(VertexBase):
             openai_like_chat_completions = OpenAILikeChatHandler()
 
             ## CONSTRUCT API BASE
+            # Skip _check_custom_proxy: its ":verb" URL construction corrupts a
+            # user-supplied api_base (e.g. Vertex MG dedicated endpoint), and
+            # OpenAILikeChatHandler already appends "/chat/completions".
             stream: bool = optional_params.get("stream", False) or False
             optional_params["stream"] = stream
-            default_api_base = create_vertex_url(
-                vertex_location=vertex_location or "us-central1",
-                vertex_project=vertex_project or project_id,
-                stream=stream,
-                model=model,
-            )
-
-            if len(default_api_base.split(":")) > 1:
-                endpoint = default_api_base.split(":")[-1]
-            else:
-                endpoint = ""
-
-            _, api_base = self._check_custom_proxy(
-                api_base=api_base,
-                custom_llm_provider="vertex_ai",
-                gemini_api_key=None,
-                endpoint=endpoint,
-                stream=stream,
-                auth_header=None,
-                url=default_api_base,
-                model=model,
-                vertex_project=vertex_project or project_id,
-                vertex_location=vertex_location or "us-central1",
-                vertex_api_version="v1beta1",
-            )
+            if api_base is None:
+                api_base = create_vertex_url(
+                    vertex_location=vertex_location or "us-central1",
+                    vertex_project=vertex_project or project_id,
+                    stream=stream,
+                    model=model,
+                )
             # Publisher/catalog models: model id must be sent in the JSON body (OpenAPI route).
             # Single-segment endpoint ids: model is encoded in the URL path; body model stays empty.
             if not _vertex_model_garden_model_id_in_json_body(model):

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_model_garden_openapi.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_model_garden_openapi.py
@@ -1,7 +1,13 @@
 """Vertex Model Garden: OpenAPI base URL for publisher/model ids vs per-endpoint path."""
 
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
+import litellm
 from litellm.llms.vertex_ai.vertex_model_garden.main import (
     _vertex_model_garden_model_id_in_json_body,
     create_vertex_url,
@@ -39,3 +45,195 @@ def test_create_vertex_url_openapi_vs_deployed_endpoint(
 def test_model_id_in_json_body_heuristic() -> None:
     assert _vertex_model_garden_model_id_in_json_body("xai/grok-4.1-fast-reasoning") is True
     assert _vertex_model_garden_model_id_in_json_body("5464397967697903616") is False
+
+
+@pytest.fixture
+def _reset_litellm_http_client_cache():
+    from litellm import in_memory_llm_clients_cache
+
+    in_memory_llm_clients_cache.flush_cache()
+    yield
+    in_memory_llm_clients_cache.flush_cache()
+
+
+@pytest.fixture
+def clean_vertex_env():
+    saved_env = {}
+    env_vars_to_clear = [
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "VERTEXAI_PROJECT",
+        "VERTEXAI_LOCATION",
+        "VERTEXAI_CREDENTIALS",
+        "VERTEX_PROJECT",
+        "VERTEX_LOCATION",
+        "VERTEX_AI_PROJECT",
+    ]
+    for var in env_vars_to_clear:
+        if var in os.environ:
+            saved_env[var] = os.environ[var]
+            del os.environ[var]
+
+    yield
+
+    for var, value in saved_env.items():
+        os.environ[var] = value
+
+
+def _mock_chat_completion_response(model_in_response: str) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.json.return_value = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": model_in_response,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    return response
+
+
+async def _invoke_model_garden_completion(
+    *,
+    model: str,
+    api_base,
+    mock_response: MagicMock,
+):
+    """Drive litellm.acompletion through the Vertex Model Garden route and return
+    the patched AsyncHTTPHandler so callers can inspect the outbound HTTP call."""
+    mock_vertexai = MagicMock()
+    mock_vertexai.preview = MagicMock()
+    mock_vertexai.preview.language_models = MagicMock()
+
+    with (
+        patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler"
+        ) as mock_http_handler,
+        patch(
+            "litellm.llms.vertex_ai.vertex_model_garden.main.VertexAIModelGardenModels._ensure_access_token",
+            return_value=("fake-token", "test-project"),
+        ),
+        patch.dict(
+            sys.modules,
+            {"vertexai": mock_vertexai, "vertexai.preview": mock_vertexai.preview},
+        ),
+    ):
+        mock_http_handler.return_value.post = AsyncMock(return_value=mock_response)
+
+        kwargs = dict(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            vertex_ai_location="us-central1",
+            vertex_ai_project="test-project",
+        )
+        if api_base is not None:
+            kwargs["api_base"] = api_base
+
+        await litellm.acompletion(**kwargs)
+
+        return mock_http_handler
+
+
+@pytest.mark.asyncio
+async def test_user_supplied_api_base_passes_through_unchanged(
+    clean_vertex_env, _reset_litellm_http_client_cache
+):
+    """Regression test for b439b66f49: a user-supplied api_base must reach the
+    OpenAI-like handler unchanged, with only its own '/chat/completions' suffix
+    appended. The pre-fix code routed through _check_custom_proxy and mutated
+    the URL with a ':verb' segment, corrupting custom Vertex MG endpoints."""
+    user_api_base = "https://my-endpoint.example.com/v1"
+    mock_http_handler = await _invoke_model_garden_completion(
+        model="vertex_ai/openai/5464397967697903616",
+        api_base=user_api_base,
+        mock_response=_mock_chat_completion_response("5464397967697903616"),
+    )
+
+    mock_http_handler.return_value.post.assert_called_once()
+    call_args = mock_http_handler.return_value.post.call_args
+    called_url = call_args.kwargs.get("url") or call_args.args[0]
+    request_body = json.loads(call_args.kwargs["data"])
+
+    assert called_url == f"{user_api_base}/chat/completions"
+    assert ":" not in called_url.replace("https://", "")
+    assert "aiplatform.googleapis.com" not in called_url
+    assert request_body["model"] == ""
+
+
+@pytest.mark.asyncio
+async def test_user_supplied_api_base_passthrough_for_publisher_model(
+    clean_vertex_env, _reset_litellm_http_client_cache
+):
+    """User-supplied api_base is forwarded unchanged for publisher/catalog
+    models too; the publisher model id stays in the JSON body."""
+    user_api_base = "https://my-endpoint.example.com/v1"
+    mock_http_handler = await _invoke_model_garden_completion(
+        model="vertex_ai/openai/xai/grok-4.1-fast-reasoning",
+        api_base=user_api_base,
+        mock_response=_mock_chat_completion_response("xai/grok-4.1-fast-reasoning"),
+    )
+
+    mock_http_handler.return_value.post.assert_called_once()
+    call_args = mock_http_handler.return_value.post.call_args
+    called_url = call_args.kwargs.get("url") or call_args.args[0]
+    request_body = json.loads(call_args.kwargs["data"])
+
+    assert called_url == f"{user_api_base}/chat/completions"
+    assert "aiplatform.googleapis.com" not in called_url
+    assert request_body["model"] == "xai/grok-4.1-fast-reasoning"
+
+
+@pytest.mark.asyncio
+async def test_default_api_base_when_none_provided_single_segment(
+    clean_vertex_env, _reset_litellm_http_client_cache
+):
+    """With no api_base, single-segment endpoint ids must hit the per-endpoint
+    Vertex URL and send an empty model field in the body."""
+    mock_http_handler = await _invoke_model_garden_completion(
+        model="vertex_ai/openai/5464397967697903616",
+        api_base=None,
+        mock_response=_mock_chat_completion_response("5464397967697903616"),
+    )
+
+    mock_http_handler.return_value.post.assert_called_once()
+    call_args = mock_http_handler.return_value.post.call_args
+    called_url = call_args.kwargs.get("url") or call_args.args[0]
+    request_body = json.loads(call_args.kwargs["data"])
+
+    assert called_url == (
+        "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/"
+        "test-project/locations/us-central1/endpoints/5464397967697903616/chat/completions"
+    )
+    assert request_body["model"] == ""
+
+
+@pytest.mark.asyncio
+async def test_default_api_base_when_none_provided_publisher_model(
+    clean_vertex_env, _reset_litellm_http_client_cache
+):
+    """With no api_base, publisher/catalog models must hit the shared OpenAPI
+    URL and send the publisher model id in the body."""
+    mock_http_handler = await _invoke_model_garden_completion(
+        model="vertex_ai/openai/xai/grok-4.1-fast-reasoning",
+        api_base=None,
+        mock_response=_mock_chat_completion_response("xai/grok-4.1-fast-reasoning"),
+    )
+
+    mock_http_handler.return_value.post.assert_called_once()
+    call_args = mock_http_handler.return_value.post.call_args
+    called_url = call_args.kwargs.get("url") or call_args.args[0]
+    request_body = json.loads(call_args.kwargs["data"])
+
+    assert called_url == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/"
+        "test-project/locations/us-central1/endpoints/openapi/chat/completions"
+    )
+    assert request_body["model"] == "xai/grok-4.1-fast-reasoning"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_model_garden_openapi.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_model_garden_openapi.py
@@ -43,7 +43,10 @@ def test_create_vertex_url_openapi_vs_deployed_endpoint(
 
 
 def test_model_id_in_json_body_heuristic() -> None:
-    assert _vertex_model_garden_model_id_in_json_body("xai/grok-4.1-fast-reasoning") is True
+    assert (
+        _vertex_model_garden_model_id_in_json_body("xai/grok-4.1-fast-reasoning")
+        is True
+    )
     assert _vertex_model_garden_model_id_in_json_body("5464397967697903616") is False
 
 
@@ -146,10 +149,8 @@ async def _invoke_model_garden_completion(
 async def test_user_supplied_api_base_passes_through_unchanged(
     clean_vertex_env, _reset_litellm_http_client_cache
 ):
-    """Regression test for b439b66f49: a user-supplied api_base must reach the
-    OpenAI-like handler unchanged, with only its own '/chat/completions' suffix
-    appended. The pre-fix code routed through _check_custom_proxy and mutated
-    the URL with a ':verb' segment, corrupting custom Vertex MG endpoints."""
+    """A user-supplied api_base must reach the OpenAI-like handler unchanged,
+    with only its own '/chat/completions' suffix appended."""
     user_api_base = "https://my-endpoint.example.com/v1"
     mock_http_handler = await _invoke_model_garden_completion(
         model="vertex_ai/openai/5464397967697903616",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

```yaml
litellm_settings:
  drop_params: True

model_list:
  # OpenAI-compatible /chat/completions route 
  - model_name: gemma4
    litellm_params:
      model: vertex_ai/openai/gemma4
      api_base: "https://mg-endpoint-<someguid>.prediction.vertexai.goog/v1/projects/<someproject/locations/us-west1/endpoints/mg-endpoint-<someguid>"
      vertex_project: some-project
      vertex_location: us-west1
```


before
```
Error fetching response: 404 litellm.NotFoundError: Vertex_aiException - b'{"error":{"code":404,"message":"The server could not process your request because the specified resource was not found. Please verify that you are using the correct URL, protocol (e.g., HTTPS), HTTP method (e.g., GET, POST),  and port number. If the issue persists, contact support https://cloud.google.com/contact for assistance.","status":"UNIMPLEMENTED"}}\n'. Received Model Group=gemma4
Available Model Group Fallbacks=None
```

```sh
☸ <orbstack> litellm on  fix/vertex-mg-openai-api-base [!] is 📦 v1.87.0 via  v22.20.0 via 🐍 v3.12.9 took 22s
❯ mise run claude:test-openai
[claude:test-openai] $ pass=0
[claude:run] $ if [ -z "$MODEL" ]; then
[FAIL] gemma4 :: exit=1 stdout=There's an issue with the selected model (gemma4). It may not exist or you may not have access to it. Run --model to pick a different model. stderr_last=You can manually restore it by running: cp "/root/.claude/backups/.claude.json.backup.1779904669653" "/root/.claude.json"
[claude:run] ERROR task failed
[claude:run] $ if [ -z "$MODEL" ]; then
[FAIL] qwen3 :: exit=1 stdout=There's an issue with the selected model (qwen3). It may not exist or you may not have access to it. Run --model to pick a different model. stderr_last=You can manually restore it by running: cp "/root/.claude/backups/.claude.json.backup.1779904669653" "/root/.claude.json"
[claude:run] ERROR task failed
[claude:run] $ if [ -z "$MODEL" ]; then
[FAIL] glm5p1 :: exit=1 stdout=There's an issue with the selected model (glm5p1). It may not exist or you may not have access to it. Run --model to pick a different model. stderr_last=You can manually restore it by running: cp "/root/.claude/backups/.claude.json.backup.1779904669653" "/root/.claude.json"
[claude:run] ERROR task failed
Summary: 0 passed, 3 failed
[claude:test-openai] ERROR task failed
```

After
```sh
☸ <orbstack> litellm on  fix/vertex-mg-openai-api-base [!] is 📦 v1.87.0 via  v22.20.0 via 🐍 v3.12.9
❯ mise run claude:test-openai
[claude:test-openai] $ pass=0
[claude:run] $ if [ -z "$MODEL" ]; then
[PASS] gemma4 :: Today is Wednesday, May 27, 2026.
[claude:run] $ if [ -z "$MODEL" ]; then
[PASS] qwen3 :: It's Thursday, May 27, 2026.
[claude:run] $ if [ -z "$MODEL" ]; then
[PASS] glm5p1 :: Thursday, May 27, 2026.
Summary: 3 passed, 0 failed
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

 ## Problem

  When a user supplied a custom api_base for a Vertex AI Model Garden OpenAI-compatible model (e.g. a gemma model deployed
  on a Vertex MG dedicated endpoint, addressed as vertex_ai/openai/<ENDPOINT_ID>), the URL was getting mangled before being
  sent to the upstream endpoint.

  The old code path in VertexAIModelGardenModels.completion() ran the user's api_base through _check_custom_proxy, which is
  built for Vertex AI's gRPC-style URLs that use a :verb suffix (e.g. .../endpoints/123:streamGenerateContent). For the
  OpenAI-compat route, that helper:

  1. Computed a default Vertex URL (https://us-central1-aiplatform.googleapis.com/v1beta1/...).
  2. Took everything after the first : of that URL as endpoint (so endpoint =
  "//us-central1-aiplatform.googleapis.com/v1beta1/projects/.../endpoints/<ENDPOINT_ID>" — the : was just from https:, not a
   real verb).
  3. Concatenated f"{user_api_base}:{endpoint}".

  OpenAILikeChatHandler then appended its own /chat/completions, producing a URL that interleaves the user's host with
  aiplatform.googleapis.com. Requests went to the wrong host (or failed DNS) and Vertex MG dedicated endpoints hosting gemma
   were unusable through a custom api_base.

 ## Fix 

  vertex_model_garden/main.py: when api_base is supplied, pass it through unchanged. Only call create_vertex_url(...) when
  no api_base was given. _check_custom_proxy is skipped entirely on this path.

  Example — what happens to the URL
```
  litellm.acompletion(
      model="vertex_ai/openai/5464397967697903616",  # gemma endpoint id
      api_base="https://my-endpoint.example.com/v1",
      messages=[...],
  )
```

  Before this PR — outbound HTTP request URL:

  https://my-endpoint.example.com/v1://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-cent
  ral1/endpoints/5464397967697903616/chat/completions

  Note the v1: followed by //us-central1-aiplatform... — that's _check_custom_proxy splicing the default Vertex URL onto the
   user-supplied base.

  After this PR — outbound HTTP request URL:

  https://my-endpoint.example.com/v1/chat/completions

  The user-supplied base is used verbatim; only OpenAILikeChatHandler's standard /chat/completions suffix is appended. The
  request body's model field is empty, because for single-segment endpoint ids the model is encoded in the URL path that the
   gateway forwards to.

  The no-api_base path is unchanged: create_vertex_url(...) still produces the default Vertex MG URL for both single-segment
   endpoint ids hosting gemma (.../endpoints/<id>/chat/completions) and publisher/catalog models
  (.../endpoints/openapi/chat/completions).

  ## Tests  

  tests/test_litellm/llms/vertex_ai/test_vertex_model_garden_openapi.py:
  - 4 end-to-end async tests covering both api_base supplied / not supplied × single-segment / publisher model, asserting
  the final HTTP URL and request body model field.
  - 1 parametrized inverse-proof test (test_pre_fix_check_custom_proxy_would_corrupt_user_api_base) that replays the pre-fix
   logic by calling _check_custom_proxy directly with the same inputs the old code passed, and asserts the resulting URL is
  corrupted with the spurious : join. The buggy helper still exists in VertexBase (it's correct for other vertex routes);
  the fix just stopped calling it on the Model Garden path.

