### PR TITLE
fix(proxy): populate /key/info model_spend from spend logs

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3352,13 +3352,14 @@ async def info_key_fn(
         # The verification-token's `model_spend` column is no longer written by the
         # spend-queue pipeline (it carries only a scalar `response_cost` per entity),
         # so compute the per-model breakdown at read time from LiteLLM_SpendLogs,
-        # matching the 30-day window the per-key UI chart uses.
-        if hashed_key is not None:
-            aggregated = await _aggregate_key_model_spend_from_logs(
-                prisma_client, hashed_key
-            )
-            if aggregated is not None:
-                key_info["model_spend"] = aggregated
+        # matching the 30-day window the per-key UI chart uses. By this point
+        # `hashed_key` is non-None: an absent key would have failed `find_unique`
+        # above and tripped the 404 ProxyException.
+        aggregated = await _aggregate_key_model_spend_from_logs(
+            prisma_client, hashed_key  # type: ignore[arg-type]
+        )
+        if aggregated is not None:
+            key_info["model_spend"] = aggregated
 
         # Attach object_permission if object_permission_id is set
         key_info = await attach_object_permission_to_dict(key_info, prisma_client)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3223,6 +3223,55 @@ async def info_key_fn_v2(
         raise handle_exception_on_proxy(e)
 
 
+async def _aggregate_key_model_spend_from_logs(
+    prisma_client: Any,
+    hashed_token: str,
+) -> Optional[Dict[str, float]]:
+    """Sum LiteLLM_SpendLogs.spend per model for one key over the last 30 days.
+
+    Returns a {model: total_spend} dict, {} when the key has no entries in the
+    window, or None if the query fails (caller should keep the row's stored value).
+
+    Window matches the Last30dKeysBySpend view that backs the per-key UI chart, so
+    /key/info agrees with what the dashboard shows.
+    """
+    window_start = datetime.now(timezone.utc) - timedelta(days=30)
+    try:
+        response = await prisma_client.db.litellm_spendlogs.group_by(
+            by=["model"],
+            where={
+                "api_key": hashed_token,
+                "startTime": {"gte": window_start},
+            },
+            sum={"spend": True},
+        )
+    except Exception:
+        verbose_proxy_logger.exception(
+            "info_key_fn: failed to aggregate model_spend from LiteLLM_SpendLogs for token"
+        )
+        return None
+
+    result: Dict[str, float] = {}
+    for row in response or []:
+        model = (
+            row.get("model") if isinstance(row, dict) else getattr(row, "model", None)
+        )
+        if not model:
+            continue
+        sum_row = (
+            row.get("_sum") if isinstance(row, dict) else getattr(row, "_sum", None)
+        )
+        spend = (
+            sum_row.get("spend")
+            if isinstance(sum_row, dict)
+            else getattr(sum_row, "spend", None)
+        )
+        if spend is None:
+            continue
+        result[model] = float(spend)
+    return result
+
+
 @router.get(
     "/key/info", tags=["key management"], dependencies=[Depends(user_api_key_auth)]
 )
@@ -3299,6 +3348,17 @@ async def info_key_fn(
             # if using pydantic v1
             key_info = key_info.dict()
         key_info.pop("token")
+
+        # The verification-token's `model_spend` column is no longer written by the
+        # spend-queue pipeline (it carries only a scalar `response_cost` per entity),
+        # so compute the per-model breakdown at read time from LiteLLM_SpendLogs,
+        # matching the 30-day window the per-key UI chart uses.
+        if hashed_key is not None:
+            aggregated = await _aggregate_key_model_spend_from_logs(
+                prisma_client, hashed_key
+            )
+            if aggregated is not None:
+                key_info["model_spend"] = aggregated
 
         # Attach object_permission if object_permission_id is set
         key_info = await attach_object_permission_to_dict(key_info, prisma_client)

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11250,15 +11250,17 @@ async def test_key_info_aggregates_model_spend_from_spend_logs(monkeypatch):
 
     from litellm.proxy._types import LiteLLM_VerificationToken
     from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+    from litellm.proxy.utils import _hash_token_if_needed
 
     mock_prisma_client = AsyncMock()
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 
-    hashed_token = "hashed_test_token_aggregate"
+    input_key = "sk-test-aggregate"
+    expected_hashed_token = _hash_token_if_needed(token=input_key)
     mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
-    mock_key_info.token = hashed_token
+    mock_key_info.token = expected_hashed_token
     mock_key_info.model_dump.return_value = {
-        "token": hashed_token,
+        "token": expected_hashed_token,
         "user_id": "user-aggregate",
         "team_id": None,
         "spend": 12.34,
@@ -11271,21 +11273,22 @@ async def test_key_info_aggregates_model_spend_from_spend_logs(monkeypatch):
         return_value=mock_key_info
     )
 
-    mock_prisma_client.db.litellm_spendlogs.group_by = AsyncMock(
+    group_by_mock = AsyncMock(
         return_value=[
             {"model": "claude-3-5-sonnet", "_sum": {"spend": 7.25}},
             {"model": "gpt-4o", "_sum": {"spend": 5.09}},
             {"model": "", "_sum": {"spend": 0.10}},
         ]
     )
+    mock_prisma_client.db.litellm_spendlogs.group_by = group_by_mock
 
     user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN,
-        api_key="sk-test-aggregate",
+        api_key=input_key,
     )
 
     result = await info_key_fn(
-        key="sk-test-aggregate",
+        key=input_key,
         user_api_key_dict=user_api_key_dict,
     )
 
@@ -11293,6 +11296,7 @@ async def test_key_info_aggregates_model_spend_from_spend_logs(monkeypatch):
         "claude-3-5-sonnet": 7.25,
         "gpt-4o": 5.09,
     }
+    assert group_by_mock.call_args.kwargs["where"]["api_key"] == expected_hashed_token
 
 
 @pytest.mark.asyncio
@@ -11304,15 +11308,17 @@ async def test_key_info_model_spend_empty_when_no_logs(monkeypatch):
 
     from litellm.proxy._types import LiteLLM_VerificationToken
     from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+    from litellm.proxy.utils import _hash_token_if_needed
 
     mock_prisma_client = AsyncMock()
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 
-    hashed_token = "hashed_test_token_empty"
+    input_key = "sk-test-empty"
+    expected_hashed_token = _hash_token_if_needed(token=input_key)
     mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
-    mock_key_info.token = hashed_token
+    mock_key_info.token = expected_hashed_token
     mock_key_info.model_dump.return_value = {
-        "token": hashed_token,
+        "token": expected_hashed_token,
         "user_id": "user-empty",
         "team_id": None,
         "spend": 0.0,
@@ -11324,19 +11330,21 @@ async def test_key_info_model_spend_empty_when_no_logs(monkeypatch):
     mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
         return_value=mock_key_info
     )
-    mock_prisma_client.db.litellm_spendlogs.group_by = AsyncMock(return_value=[])
+    group_by_mock = AsyncMock(return_value=[])
+    mock_prisma_client.db.litellm_spendlogs.group_by = group_by_mock
 
     user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN,
-        api_key="sk-test-empty",
+        api_key=input_key,
     )
 
     result = await info_key_fn(
-        key="sk-test-empty",
+        key=input_key,
         user_api_key_dict=user_api_key_dict,
     )
 
     assert result["info"]["model_spend"] == {}
+    assert group_by_mock.call_args.kwargs["where"]["api_key"] == expected_hashed_token
 
 
 @pytest.mark.asyncio
@@ -11348,16 +11356,18 @@ async def test_key_info_falls_back_when_spend_logs_query_fails(monkeypatch):
 
     from litellm.proxy._types import LiteLLM_VerificationToken
     from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+    from litellm.proxy.utils import _hash_token_if_needed
 
     mock_prisma_client = AsyncMock()
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 
-    hashed_token = "hashed_test_token_fail"
+    input_key = "sk-test-fail"
+    expected_hashed_token = _hash_token_if_needed(token=input_key)
     stored_model_spend = {"stale-model": 99.99}
     mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
-    mock_key_info.token = hashed_token
+    mock_key_info.token = expected_hashed_token
     mock_key_info.model_dump.return_value = {
-        "token": hashed_token,
+        "token": expected_hashed_token,
         "user_id": "user-fail",
         "team_id": None,
         "spend": 1.0,
@@ -11369,22 +11379,24 @@ async def test_key_info_falls_back_when_spend_logs_query_fails(monkeypatch):
     mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
         return_value=mock_key_info
     )
-    mock_prisma_client.db.litellm_spendlogs.group_by = AsyncMock(
+    group_by_mock = AsyncMock(
         side_effect=Exception("simulated DB outage on LiteLLM_SpendLogs")
     )
+    mock_prisma_client.db.litellm_spendlogs.group_by = group_by_mock
 
     user_api_key_dict = UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN,
-        api_key="sk-test-fail",
+        api_key=input_key,
     )
 
     result = await info_key_fn(
-        key="sk-test-fail",
+        key=input_key,
         user_api_key_dict=user_api_key_dict,
     )
 
     assert result["info"]["spend"] == 1.0
     assert result["info"]["model_spend"] == stored_model_spend
+    assert group_by_mock.call_args.kwargs["where"]["api_key"] == expected_hashed_token
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11234,3 +11234,206 @@ async def test_ghsa_q775_admin_bypasses_budget_ceiling():
             litellm_changed_by=None,
         )
         assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_key_info_aggregates_model_spend_from_spend_logs(monkeypatch):
+    """/key/info overwrites the empty model_spend column with the per-model sum
+    from LiteLLM_SpendLogs over the last 30 days.
+
+    Regression test for the case where the verification-token row's model_spend
+    JSON column is no longer written by the runtime spend pipeline (orphaned
+    after the spend-queue refactor), so the endpoint computes it from spend logs
+    at read time.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._types import LiteLLM_VerificationToken
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    hashed_token = "hashed_test_token_aggregate"
+    mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
+    mock_key_info.token = hashed_token
+    mock_key_info.model_dump.return_value = {
+        "token": hashed_token,
+        "user_id": "user-aggregate",
+        "team_id": None,
+        "spend": 12.34,
+        "model_spend": {},
+        "object_permission_id": None,
+        "litellm_budget_table": None,
+    }
+    mock_key_info.dict.return_value = mock_key_info.model_dump.return_value
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_info
+    )
+
+    mock_prisma_client.db.litellm_spendlogs.group_by = AsyncMock(
+        return_value=[
+            {"model": "claude-3-5-sonnet", "_sum": {"spend": 7.25}},
+            {"model": "gpt-4o", "_sum": {"spend": 5.09}},
+            {"model": "", "_sum": {"spend": 0.10}},
+        ]
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-test-aggregate",
+    )
+
+    result = await info_key_fn(
+        key="sk-test-aggregate",
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert result["info"]["model_spend"] == {
+        "claude-3-5-sonnet": 7.25,
+        "gpt-4o": 5.09,
+    }
+
+
+@pytest.mark.asyncio
+async def test_key_info_model_spend_empty_when_no_logs(monkeypatch):
+    """/key/info returns model_spend: {} when the key has no spend-log entries
+    in the 30-day window — the row's stored value is also {}, so the response
+    surface is unchanged for new keys."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._types import LiteLLM_VerificationToken
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    hashed_token = "hashed_test_token_empty"
+    mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
+    mock_key_info.token = hashed_token
+    mock_key_info.model_dump.return_value = {
+        "token": hashed_token,
+        "user_id": "user-empty",
+        "team_id": None,
+        "spend": 0.0,
+        "model_spend": {},
+        "object_permission_id": None,
+        "litellm_budget_table": None,
+    }
+    mock_key_info.dict.return_value = mock_key_info.model_dump.return_value
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_info
+    )
+    mock_prisma_client.db.litellm_spendlogs.group_by = AsyncMock(return_value=[])
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-test-empty",
+    )
+
+    result = await info_key_fn(
+        key="sk-test-empty",
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert result["info"]["model_spend"] == {}
+
+
+@pytest.mark.asyncio
+async def test_key_info_falls_back_when_spend_logs_query_fails(monkeypatch):
+    """/key/info must not 500 when the spend-logs aggregation fails. The DB
+    row's stored model_spend value is preserved as a graceful fallback, and the
+    rest of the key info still surfaces (auth/budget callers must keep working)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._types import LiteLLM_VerificationToken
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    hashed_token = "hashed_test_token_fail"
+    stored_model_spend = {"stale-model": 99.99}
+    mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
+    mock_key_info.token = hashed_token
+    mock_key_info.model_dump.return_value = {
+        "token": hashed_token,
+        "user_id": "user-fail",
+        "team_id": None,
+        "spend": 1.0,
+        "model_spend": stored_model_spend,
+        "object_permission_id": None,
+        "litellm_budget_table": None,
+    }
+    mock_key_info.dict.return_value = mock_key_info.model_dump.return_value
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_info
+    )
+    mock_prisma_client.db.litellm_spendlogs.group_by = AsyncMock(
+        side_effect=Exception("simulated DB outage on LiteLLM_SpendLogs")
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-test-fail",
+    )
+
+    result = await info_key_fn(
+        key="sk-test-fail",
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert result["info"]["spend"] == 1.0
+    assert result["info"]["model_spend"] == stored_model_spend
+
+
+@pytest.mark.asyncio
+async def test_key_info_aggregation_uses_30_day_window(monkeypatch):
+    """The spend-logs aggregation must scope to the last 30 days, matching the
+    Last30dKeysBySpend view that backs the per-key UI chart."""
+    from datetime import datetime, timedelta, timezone
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._types import LiteLLM_VerificationToken
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+    from litellm.proxy.utils import _hash_token_if_needed
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    input_key = "sk-test-window"
+    expected_hashed_token = _hash_token_if_needed(token=input_key)
+    mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
+    mock_key_info.token = expected_hashed_token
+    mock_key_info.model_dump.return_value = {
+        "token": expected_hashed_token,
+        "user_id": "user-window",
+        "team_id": None,
+        "spend": 0.0,
+        "model_spend": {},
+        "object_permission_id": None,
+        "litellm_budget_table": None,
+    }
+    mock_key_info.dict.return_value = mock_key_info.model_dump.return_value
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_info
+    )
+    group_by_mock = AsyncMock(return_value=[])
+    mock_prisma_client.db.litellm_spendlogs.group_by = group_by_mock
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key=input_key,
+    )
+
+    before = datetime.now(timezone.utc)
+    await info_key_fn(key=input_key, user_api_key_dict=user_api_key_dict)
+    after = datetime.now(timezone.utc)
+
+    group_by_mock.assert_called_once()
+    where_arg = group_by_mock.call_args.kwargs["where"]
+    assert where_arg["api_key"] == expected_hashed_token
+    window_start = where_arg["startTime"]["gte"]
+    assert before - timedelta(days=30) <= window_start <= after - timedelta(days=30)
+    assert group_by_mock.call_args.kwargs["by"] == ["model"]
+    assert group_by_mock.call_args.kwargs["sum"] == {"spend": True}


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

**Before** — `GET /key/info` for a key with traffic on two models (the verification-token row's `spend` is being incremented, the per-model column is the Postgres default):

```json
{
  "key": "sk-...",
  "info": {
    "spend": 0.001929,
    "model_spend": {},
    ...
  }
}
```

Same point in time, direct read on `LiteLLM_SpendLogs` for the same hashed token:

```
        model        | total_spend
---------------------+-------------
 openai/mock-model-a |  0.00015000
 openai/mock-model-b |  0.00033000
```

**After** — same key, same DB state, `/key/info` now overwrites the orphaned column with the 30-day per-model aggregate from `LiteLLM_SpendLogs`:

```json
{
  "key": "sk-...",
  "info": {
    "spend": 0.001929,
    "model_spend": {
      "openai/mock-model-a": 0.00015,
      "openai/mock-model-b": 0.00033
    },
    ...
  }
}
```

The values match the SpendLogs aggregation exactly, and they agree with what the dashboard's per-key chart shows (which reads from the same source via the `Last30dKeysBySpend` view).

Reverting the patched file on the same fixture deterministically reproduces the `"model_spend": {}` response — i.e. the fix is doing the work, not a coincidence of the test setup.

## Type

🐛 Bug Fix

## Changes

### The bug

`GET /key/info` always returns `"model_spend": {}` for every key regardless of traffic, while the scalar `"spend"` field is incremented normally. The dashboard's per-key chart shows the correct per-model breakdown, so callers comparing the two surfaces see an inconsistency they can't resolve from config.

### Root cause

The `LiteLLM_VerificationToken.model_spend` JSON column has no producer in the current runtime spend pipeline. `SpendUpdateQueueItem` carries only `entity_type`, `entity_id`, `response_cost: float`; `DBSpendUpdateTransactions` aggregates per-entity into `Dict[str, float]`; the terminal Prisma `update_many` sets only `{"spend": {"increment": response_cost}, "last_active": ...}`. The per-model dimension has migrated to the Redis counter path that powers `model_max_budget` enforcement (`spend:team_member:{uid}:{tid}:model:{model}` etc.) — but the DB column was never re-wired and is now dead storage that still surfaces through `/key/info`.

The same orphaned-column shape exists on `LiteLLM_UserTable.model_spend` and `LiteLLM_TeamTable.model_spend`. This PR only changes the key path.

### The fix (read-side)

In `info_key_fn`, after `find_unique` returns the verification token row and after `model_dump`, compute `model_spend` from `LiteLLM_SpendLogs` over the last 30 days for that key's hashed token and overwrite the response field. The 30-day window matches the `Last30dKeysBySpend` view that backs the per-key UI chart, so `/key/info` and the dashboard read from the same source.

Helper: `_aggregate_key_model_spend_from_logs(prisma_client, hashed_token)` — single Prisma `group_by(by=["model"], where={"api_key": ..., "startTime": {"gte": now - 30d}}, sum={"spend": True})`. Mirrors the `group_by` pattern already used in `litellm/proxy/db/spend_counter_reseed.py` for budget-counter reseeding from spend logs.

Failure mode: the helper is wrapped in `try/except` and returns `None` on query failure; in that case the caller keeps the row's stored column value (`{}` in practice) and the endpoint still returns 200 with all other fields intact. `/key/info` does not 500 on this path.

### What this PR does *not* change

- **The runtime spend pipeline** (`SpendUpdateQueueItem` / `DBSpendUpdateTransactions` / `_commit_spend_updates_to_db`). Re-populating the DB column would expand contracts the team is actively narrowing (cf. #26523 moves per-model team-member spend to a dedicated table). The read-side fix is a smaller blast radius and trivially reversible if the column is ever re-populated.
- **`info_key_fn_v2`** (bulk endpoint). A naive port would be O(N) extra round-trips per call; the efficient shape is one `group_by(["api_key", "model"])` and an in-memory distribute. Deserves a separate PR once the v1 shape is settled.
- **`/user/info` and `/team/info`**. Same orphaned column, same one-helper fix — follow-up PRs.
- **The `model_spend Json @default("{}")` schema column and the matching Pydantic field.** Left in place to avoid a breaking change for any external consumer; the read-side overwrite makes the column's contents irrelevant for the customer-facing path.
- **`LiteLLM_SpendLogs` indexes.** No new index added. The query's cost profile is identical to the existing `Last30dKeysBySpend` view the UI already runs on every dashboard load, so the perf characteristic is unchanged. `/key/info` is a low-frequency admin endpoint, not a per-request hot path. If we add an index later, `@@index([api_key, startTime])` would benefit both this query and the existing view.

### Tests

`tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py` — 4 new tests:

- `test_key_info_aggregates_model_spend_from_spend_logs` — populated `model_spend` from `LiteLLM_SpendLogs` rows; empty-model rows are skipped.
- `test_key_info_model_spend_empty_when_no_logs` — `{}` when the key has no entries in the window.
- `test_key_info_falls_back_when_spend_logs_query_fails` — aggregation raises → row's stored `model_spend` value is preserved, endpoint returns 200.
- `test_key_info_aggregation_uses_30_day_window` — verifies `where`/`by`/`sum` shape on the Prisma `group_by` and that `startTime` is bounded to ~30 days before `now`.