### PR TITLE
fix(otel): propagate team attrs onto child service spans (LIT-3192)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1256,8 +1256,13 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                         value=value,
                     )
         except Exception:
-            # Never let observability plumbing crash a real request path.
-            pass
+            # Never let observability plumbing crash a real request path,
+            # but surface internal regressions via verbose_logger so they
+            # do not hide forever.
+            verbose_logger.exception(
+                "OpenTelemetry: _propagate_team_attributes_from_parent_span failed; "
+                "child span will be missing team attrs"
+            )
 
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
         duration_s = (end_time - start_time).total_seconds()

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -577,6 +577,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 key="service",
                 value=payload.service.value,
             )
+            # Propagate team attrs from the proxy SERVER root span onto this
+            # child service span so dashboards filtered by team do not lose
+            # DB/Redis/cache spans (LIT-3192).
+            self._propagate_team_attributes_from_parent_span(
+                child_span=service_logging_span, parent_otel_span=parent_otel_span
+            )
 
             if event_metadata:
                 for key, value in event_metadata.items():
@@ -636,6 +642,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 span=service_logging_span,
                 key="service",
                 value=payload.service.value,
+            )
+            # Propagate team attrs from the proxy SERVER root span onto this
+            # child service span (LIT-3192).
+            self._propagate_team_attributes_from_parent_span(
+                child_span=service_logging_span, parent_otel_span=parent_otel_span
             )
             if error:
                 self.safe_set_attribute(
@@ -1212,6 +1223,41 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             and proxy_span.is_recording()
         ):
             self._set_team_attributes_from_kwargs(proxy_span, kwargs)
+
+    def _propagate_team_attributes_from_parent_span(
+        self, child_span: Span, parent_otel_span: Span
+    ) -> None:
+        """Copy team attrs from a (real-SDK) parent span onto a child span.
+
+        Service-logger spans (DB/Redis/cache child spans created in
+        ``async_service_success_hook`` / ``async_service_failure_hook``)
+        otherwise inherit nothing from the proxy SERVER root span - the
+        team attrs only live as set_attribute() calls on the root span, not
+        on the OTel context - so without this, dashboards filtered by
+        ``metadata.user_api_key_team_id`` lose every service span in the
+        trace.
+
+        Defensive about non-SDK / NoOp spans that do not expose ``.attributes``
+        (e.g. propagated remote spans, no-op tracer); falls through silently.
+        """
+        try:
+            parent_attrs = getattr(parent_otel_span, "attributes", None)
+            if not parent_attrs:
+                return
+            for key in (
+                "metadata.user_api_key_team_id",
+                "metadata.user_api_key_team_alias",
+            ):
+                value = parent_attrs.get(key)
+                if value:
+                    self.safe_set_attribute(
+                        span=child_span,
+                        key=key,
+                        value=value,
+                    )
+        except Exception:
+            # Never let observability plumbing crash a real request path.
+            pass
 
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
         duration_s = (end_time - start_time).total_seconds()

--- a/tests/test_litellm/integrations/test_otel_team_attributes_matrix.py
+++ b/tests/test_litellm/integrations/test_otel_team_attributes_matrix.py
@@ -281,5 +281,168 @@ class TestAdminTeamInfoCells(unittest.TestCase):
         self.skipTest("/team/info has no 3xx redirect path (N/A)")
 
 
+
+# ---------------------------------------------------------------------------
+# Service-logger cells: DB / Redis / cache child spans created by
+# ``async_service_success_hook`` / ``async_service_failure_hook``.
+#
+# These spans are siblings of the LLM request inside the proxy SERVER span
+# (parent_otel_span = user_api_key_dict.parent_otel_span). They previously
+# inherited *nothing* from the team-stamped root span, so dashboards
+# filtered by ``metadata.user_api_key_team_id`` lost every DB/Redis span
+# in the trace (LIT-3192).
+# ---------------------------------------------------------------------------
+class TestServiceSpanCells(unittest.TestCase):
+    """Every service-hook span emitted under a team-stamped parent span
+    carries team_id / team_alias."""
+
+    def _team_stamped_parent(self, otel):
+        parent = _server_span(otel)
+        otel._set_team_attributes_on_span(
+            span=parent, team_id=TEAM_ID, team_alias=TEAM_ALIAS
+        )
+        return parent
+
+    def _run_service_success(self, service, call_type):
+        from litellm.types.services import ServiceLoggerPayload
+        otel, exporter = _make_otel()
+        parent = self._team_stamped_parent(otel)
+        now = datetime.now()
+        asyncio.run(
+            otel.async_service_success_hook(
+                payload=ServiceLoggerPayload(
+                    is_error=False, error=None, service=service,
+                    duration=0.05, call_type=call_type, event_metadata=None,
+                ),
+                parent_otel_span=parent, start_time=now, end_time=now,
+                event_metadata=None,
+            )
+        )
+        parent.end()
+        return exporter.get_finished_spans()
+
+    def _run_service_failure(self, service, call_type):
+        from litellm.types.services import ServiceLoggerPayload
+        otel, exporter = _make_otel()
+        parent = self._team_stamped_parent(otel)
+        now = datetime.now()
+        asyncio.run(
+            otel.async_service_failure_hook(
+                payload=ServiceLoggerPayload(
+                    is_error=True, error="timeout", service=service,
+                    duration=0.30, call_type=call_type, event_metadata=None,
+                ),
+                error="timeout", parent_otel_span=parent,
+                start_time=now, end_time=now, event_metadata=None,
+            )
+        )
+        parent.end()
+        return exporter.get_finished_spans()
+
+    @staticmethod
+    def _span_with_service(spans, service_value):
+        """Find a service-hook span by its ``service`` attribute
+        (= ``ServiceTypes.<NAME>.value``).
+
+        The span name itself is the ``ServiceTypes`` enum object, which the
+        OTel SDK stringifies as ``ServiceTypes.DB`` - match by the explicit
+        ``service`` attribute instead, which is always the enum ``.value``.
+        """
+        for s in spans:
+            if s.attributes and s.attributes.get("service") == service_value:
+                return s
+        raise AssertionError(
+            f"No span with service={service_value!r}; saw "
+            f"{[s.attributes.get('service') if s.attributes else None for s in spans]}"
+        )
+
+    def test_db_success_carries_team_attrs(self):
+        from litellm.types.services import ServiceTypes
+        spans = self._run_service_success(ServiceTypes.DB, "spend_logs_insert")
+        _assert_team_attrs(
+            self._span_with_service(spans, "postgres"),
+            where="ServiceTypes.DB success span",
+        )
+
+    def test_db_failure_carries_team_attrs(self):
+        from litellm.types.services import ServiceTypes
+        spans = self._run_service_failure(ServiceTypes.DB, "spend_logs_insert")
+        _assert_team_attrs(
+            self._span_with_service(spans, "postgres"),
+            where="ServiceTypes.DB failure span",
+        )
+
+    def test_redis_success_carries_team_attrs(self):
+        from litellm.types.services import ServiceTypes
+        spans = self._run_service_success(ServiceTypes.REDIS, "redis_get")
+        _assert_team_attrs(
+            self._span_with_service(spans, "redis"),
+            where="ServiceTypes.REDIS success span",
+        )
+
+    def test_redis_failure_carries_team_attrs(self):
+        from litellm.types.services import ServiceTypes
+        spans = self._run_service_failure(ServiceTypes.REDIS, "EVALSHA")
+        _assert_team_attrs(
+            self._span_with_service(spans, "redis"),
+            where="ServiceTypes.REDIS failure span",
+        )
+
+    def test_batch_write_to_db_success_carries_team_attrs(self):
+        from litellm.types.services import ServiceTypes
+        spans = self._run_service_success(
+            ServiceTypes.BATCH_WRITE_TO_DB, "batch_db_write"
+        )
+        _assert_team_attrs(
+            self._span_with_service(spans, "batch_write_to_db"),
+            where="ServiceTypes.BATCH_WRITE_TO_DB success span",
+        )
+
+    def test_parent_without_team_attrs_leaves_child_clean(self):
+        """Un-team-stamped parent (master-key request or externally
+        provided parent span) MUST NOT cause invented values on the child."""
+        from litellm.types.services import ServiceLoggerPayload, ServiceTypes
+        otel, exporter = _make_otel()
+        parent = _server_span(otel)  # no team attrs stamped
+        now = datetime.now()
+        asyncio.run(
+            otel.async_service_success_hook(
+                payload=ServiceLoggerPayload(
+                    is_error=False, error=None, service=ServiceTypes.DB,
+                    duration=0.01, call_type="x", event_metadata=None,
+                ),
+                parent_otel_span=parent, start_time=now, end_time=now,
+                event_metadata=None,
+            )
+        )
+        parent.end()
+        db_span = self._span_with_service(exporter.get_finished_spans(), "postgres")
+        assert db_span.attributes.get(TEAM_ID_ATTR) is None
+        assert db_span.attributes.get(TEAM_ALIAS_ATTR) is None
+
+    def test_propagation_helper_swallows_non_sdk_parent(self):
+        """A NoOpSpan / propagated remote span exposes no ``.attributes``;
+        helper must fall through silently, not raise."""
+        from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+        from litellm.types.services import ServiceLoggerPayload, ServiceTypes
+        otel, _exporter = _make_otel()
+        ctx = SpanContext(
+            trace_id=0x1, span_id=0x2, is_remote=True,
+            trace_flags=TraceFlags(0x1),
+        )
+        nonrec_parent = NonRecordingSpan(ctx)
+        now = datetime.now()
+        asyncio.run(
+            otel.async_service_success_hook(
+                payload=ServiceLoggerPayload(
+                    is_error=False, error=None, service=ServiceTypes.DB,
+                    duration=0.01, call_type="x", event_metadata=None,
+                ),
+                parent_otel_span=nonrec_parent, start_time=now, end_time=now,
+                event_metadata=None,
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Service-logger spans (DB / Redis / cache child spans created in
`async_service_success_hook` / `async_service_failure_hook` in
`litellm/integrations/opentelemetry.py`) previously inherited **nothing**
from the team-stamped proxy SERVER root span. The team attrs only live as
`set_attribute()` calls on the root span, not on the OTel context — so
dashboards filtered by `metadata.user_api_key_team_id` lost every DB /
Redis / cache span in the trace.

Fix: a small `_propagate_team_attributes_from_parent_span` helper reads
`metadata.user_api_key_team_id` / `metadata.user_api_key_team_alias` from
`parent_otel_span.attributes` and stamps them onto the new child service
span, called once in each service hook right after the span is created.

The helper is defensive:
- non-SDK / NoOp / propagated remote spans don't expose `.attributes` →
  helper falls through silently (no crash).
- parent never team-stamped (master-key request, externally-provided
  parent) → child stays attribute-less; no invented values.

Closes LIT-3192.

## Files

- `litellm/integrations/opentelemetry.py` — add helper + call from both
  service hooks. ~46 lines, no behavior change outside the two hooks.
- `tests/test_litellm/integrations/test_otel_team_attributes_matrix.py` —
  new `TestServiceSpanCells` matrix (7 tests): DB success/failure, Redis
  success/failure, BATCH_WRITE_TO_DB success, un-stamped parent guard,
  NoOp parent guard.

## Test matrix

| Service              | Success | Failure |
|----------------------|:-------:|:-------:|
| `ServiceTypes.DB`               | ✅      | ✅      |
| `ServiceTypes.REDIS`            | ✅      | ✅      |
| `ServiceTypes.BATCH_WRITE_TO_DB`| ✅      |  —      |
| Un-stamped parent → child clean | ✅      |  —      |
| NoOp / non-SDK parent           | ✅      |  —      |

## Evidence

Runtime evidence captured by driving the real `async_service_success_hook`
+ `async_service_failure_hook` code path against an in-memory OTel
exporter (the same SDK plumbing the proxy uses). The parent SERVER span
is team-stamped via the same `_set_team_attributes_on_span` call site
production uses (`_set_team_attributes_on_proxy_span_from_kwargs`).

**Before (clean default branch):** DB + Redis child spans missing team attrs.

```
Captured 3 span(s):
==============================================================================
  span=ServiceTypes.DB           service=postgres             call_type=spend_logs_insert
      team_id    = '<<MISSING>>'
      team_alias = '<<MISSING>>'
  span=ServiceTypes.REDIS        service=redis                call_type=EVALSHA
      team_id    = '<<MISSING>>'
      team_alias = '<<MISSING>>'
  span=litellm_request           service=-                    call_type=-
      team_id    = 'team_engineering'
      team_alias = 'engineering'
```

**After (this branch):** both child spans now carry the parent's team attrs.

```
Captured 3 span(s):
==============================================================================
  span=ServiceTypes.DB           service=postgres             call_type=spend_logs_insert
      team_id    = 'team_engineering'
      team_alias = 'engineering'
  span=ServiceTypes.REDIS        service=redis                call_type=EVALSHA
      team_id    = 'team_engineering'
      team_alias = 'engineering'
  span=litellm_request           service=-                    call_type=-
      team_id    = 'team_engineering'
      team_alias = 'engineering'
```

**Test run** (`pytest tests/test_litellm/integrations/test_otel_team_attributes_matrix.py::TestServiceSpanCells -v`):

```
collected 7 items
tests/.../TestServiceSpanCells::test_batch_write_to_db_success_carries_team_attrs PASSED
tests/.../TestServiceSpanCells::test_db_failure_carries_team_attrs                 PASSED
tests/.../TestServiceSpanCells::test_db_success_carries_team_attrs                 PASSED
tests/.../TestServiceSpanCells::test_parent_without_team_attrs_leaves_child_clean  PASSED
tests/.../TestServiceSpanCells::test_propagation_helper_swallows_non_sdk_parent    PASSED
tests/.../TestServiceSpanCells::test_redis_failure_carries_team_attrs              PASSED
tests/.../TestServiceSpanCells::test_redis_success_carries_team_attrs              PASSED
======================== 7 passed in 8.28s ========================
```

Full suite for the file: 16 passed, 1 skipped (the pre-existing
`test_team_info_3xx_not_applicable` skip).

> **Push path note:** the sandbox `GITHUB_TOKEN` lacks `git push` over
> HTTPS, so this PR was created via `PUT /repos/{owner}/{repo}/contents/{path}`
> (one commit per file). Diff is correct; merge-base is the daily branch
> HEAD at push time.

### Verification (ship-pr)
- change-type: `litellm/integrations/opentelemetry.py` (observability) + `tests/.../test_otel_team_attributes_matrix.py` (tests) → require telemetry capture + tests
- evidence present: PASS (2 fenced terminal captures, before + after, from real `async_service_success_hook` / `async_service_failure_hook` code path)
- image sanity: N/A (backend/observability change; no UI)
- image content matches caption: N/A
- backend evidence from running system: PASS — captures are from a live `OpenTelemetry` instance with an `InMemorySpanExporter` exercising both service hooks, NOT from the unit-test runner
- hygiene: no external image hosts; 2 files committed exactly as intended; no customer name in title or body
- greptile: 4/5 (initial review). P2 inline comment "silent exception swallows helper bugs" addressed by follow-up commit that swaps the bare `except Exception: pass` for `verbose_logger.exception(...)`
- veria: completed success — "No security issues found"
- CI: 44/44 check-runs done, 0 failed