### PR TITLE
fix(otel): normalize error/exception span attributes across failure paths (LIT-3199)

### DIFF
--- a/litellm/integrations/_types/open_inference.py
+++ b/litellm/integrations/_types/open_inference.py
@@ -439,6 +439,7 @@ class ErrorAttributes:
     Corresponds to StandardLoggingPayloadErrorInformation.llm_provider
     """
 
+
 class ExceptionAttributes:
     """
     OTEL semantic-convention attribute names for exception/error info.
@@ -463,4 +464,3 @@ class ExceptionAttributes:
 
     EXCEPTION_STACKTRACE = "exception.stacktrace"
     """The exception stack trace. Mirrors ErrorAttributes.ERROR_STACK_TRACE."""
-

--- a/litellm/integrations/_types/open_inference.py
+++ b/litellm/integrations/_types/open_inference.py
@@ -438,3 +438,29 @@ class ErrorAttributes:
     The LLM provider where the error occurred (e.g., 'openai', 'anthropic', 'azure').
     Corresponds to StandardLoggingPayloadErrorInformation.llm_provider
     """
+
+class ExceptionAttributes:
+    """
+    OTEL semantic-convention attribute names for exception/error info.
+
+    These follow the OpenTelemetry exception semantic conventions
+    (https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/).
+    They mirror :class:`ErrorAttributes` but use the standard ``exception.*``
+    keys that OTEL-aware backends (Datadog, Tempo, Jaeger, etc.) recognise
+    natively.
+
+    Stamped on the span as plain attributes in addition to the ``exception``
+    event written by ``span.record_exception``, so the information is
+    queryable even when no exception object is available (e.g. guardrail
+    rejections, HTTP-status-only errors).
+    """
+
+    EXCEPTION_TYPE = "exception.type"
+    """The type/class of the exception. Mirrors ErrorAttributes.ERROR_TYPE."""
+
+    EXCEPTION_MESSAGE = "exception.message"
+    """The exception message. Mirrors ErrorAttributes.ERROR_MESSAGE."""
+
+    EXCEPTION_STACKTRACE = "exception.stacktrace"
+    """The exception stack trace. Mirrors ErrorAttributes.ERROR_STACK_TRACE."""
+

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1843,7 +1843,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             # Step 2: collect every source of error info into a normalized
             # tuple. Each source feeds into one set of attributes so the span
             # surface is identical regardless of which input was populated.
-            error_information: Optional[dict] = None
+            error_information: Any = None
             error_str: Optional[str] = None
             if standard_logging_payload is not None:
                 error_information = standard_logging_payload.get("error_information")
@@ -1937,7 +1937,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     @staticmethod
     def _normalize_error_attributes(
         exception: Any,
-        error_information: Optional[dict],
+        error_information: Any,
         error_str: Optional[str],
     ) -> dict:
         """

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1843,10 +1843,14 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             # Step 2: collect every source of error info into a normalized
             # tuple. Each source feeds into one set of attributes so the span
             # surface is identical regardless of which input was populated.
-            error_information: Any = None
+            error_information: Optional[dict] = None
             error_str: Optional[str] = None
             if standard_logging_payload is not None:
-                error_information = standard_logging_payload.get("error_information")
+                # StandardLoggingPayloadErrorInformation is a TypedDict; cast to
+                # plain dict for the normalizer (it only reads .get()).
+                _ei = standard_logging_payload.get("error_information")
+                if _ei is not None:
+                    error_information = dict(_ei)
                 error_str = standard_logging_payload.get("error_str")
 
             normalized = self._normalize_error_attributes(
@@ -1937,7 +1941,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     @staticmethod
     def _normalize_error_attributes(
         exception: Any,
-        error_information: Any,
+        error_information: Optional[dict],
         error_str: Optional[str],
     ) -> dict:
         """

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1796,99 +1796,231 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
     def _record_exception_on_span(self, span: Span, kwargs: dict):
         """
-        Record exception information on the span using OTEL standard methods.
+        Record error information on the span using OTEL standard methods.
 
-        This extracts error information from StandardLoggingPayload and:
-        1. Uses span.record_exception() for the actual exception object (OTEL standard)
-        2. Sets structured error attributes from StandardLoggingPayloadErrorInformation
+        Normalizes the error attribute surface across every failure path so
+        downstream collectors (Datadog, Tempo, Jaeger, etc.) see a consistent
+        set of attributes whether the failure originated from:
+
+          * an exception object (e.g. ``litellm.AuthenticationError``)
+          * a ``StandardLoggingPayloadErrorInformation`` block (proxy path)
+          * a fallback ``error_str`` only (older logging payloads)
+          * an HTTP-status-only error with no Python exception (guardrail
+            rejection, upstream 4xx returned as a response body)
+
+        Always stamps, when at least one input source is non-empty:
+
+          * ``error.type`` / ``exception.type``
+          * ``error.message`` / ``exception.message``
+          * ``error.stack_trace`` / ``exception.stacktrace`` (when a stack
+            trace is available from any source)
+          * ``error.code`` (legacy) and ``http.response.status_code`` (when
+            the error code is a parseable HTTP status)
+          * ``error.llm_provider`` (when available)
+
+        ``span.record_exception()`` is still invoked when an exception object
+        is supplied so the OTEL ``exception`` event is emitted as before; the
+        attribute stamping is additive and ensures the attributes are
+        queryable even on spans that never saw a Python exception.
         """
         try:
             from litellm.integrations._types.open_inference import (
                 ErrorAttributes,
+                ExceptionAttributes,
             )
 
-            # Get the exception object if available
             exception = kwargs.get("exception")
+            standard_logging_payload: Optional[StandardLoggingPayload] = (
+                kwargs.get("standard_logging_object")
+            )
 
-            # Record the exception using OTEL's standard method
+            # Step 1: emit the OTEL ``exception`` span event when we have a
+            # real exception object. Unconditional regardless of whether the
+            # downstream attribute stamping runs.
             if exception is not None:
                 span.record_exception(exception)
 
-            # Get StandardLoggingPayload for structured error information
-            standard_logging_payload: Optional[StandardLoggingPayload] = kwargs.get(
-                "standard_logging_object"
+            # Step 2: collect every source of error info into a normalized
+            # tuple. Each source feeds into one set of attributes so the span
+            # surface is identical regardless of which input was populated.
+            error_information: Optional[dict] = None
+            error_str: Optional[str] = None
+            if standard_logging_payload is not None:
+                error_information = standard_logging_payload.get(
+                    "error_information"
+                )
+                error_str = standard_logging_payload.get("error_str")
+
+            normalized = self._normalize_error_attributes(
+                exception=exception,
+                error_information=error_information,
+                error_str=error_str,
             )
 
-            if standard_logging_payload is None:
+            # Step 3: if no input source produced any error info at all, leave
+            # the span untouched (preserves the prior no-op behaviour when
+            # both exception and standard_logging_payload are missing).
+            if not normalized["has_any_error_info"]:
                 return
 
-            # Extract error_information from StandardLoggingPayload
-            error_information = standard_logging_payload.get("error_information")
-
-            if error_information is None:
-                # Fallback to error_str if error_information is not available
-                error_str = standard_logging_payload.get("error_str")
-                if error_str:
-                    self.safe_set_attribute(
-                        span=span,
-                        key=ErrorAttributes.ERROR_MESSAGE,
-                        value=error_str,
-                    )
-                return
-
-            # Set structured error attributes from StandardLoggingPayloadErrorInformation
-            if error_information.get("error_code"):
-                self.safe_set_attribute(
-                    span=span,
-                    key=ErrorAttributes.ERROR_CODE,
-                    value=error_information["error_code"],
-                )
-
-                # Also expose under the OTel-standard name as an int
-                # (error_code is a str, may be non-numeric).
-                _error_code_val = error_information["error_code"]
-                if _error_code_val is not None:
-                    try:
-                        self.safe_set_attribute(
-                            span=span,
-                            key=HTTP_RESPONSE_STATUS_CODE_ATTRIBUTE,
-                            value=int(_error_code_val),
-                        )
-                    except (ValueError, TypeError):
-                        pass
-
-            if error_information.get("error_class"):
+            # Step 4: stamp normalized attributes. Empty strings are skipped
+            # via the ``if value:`` guard so a blank field from one source
+            # never overwrites a real value from another.
+            error_type = normalized["error_type"]
+            if error_type:
                 self.safe_set_attribute(
                     span=span,
                     key=ErrorAttributes.ERROR_TYPE,
-                    value=error_information["error_class"],
+                    value=error_type,
+                )
+                self.safe_set_attribute(
+                    span=span,
+                    key=ExceptionAttributes.EXCEPTION_TYPE,
+                    value=error_type,
                 )
 
-            if error_information.get("error_message"):
+            error_message = normalized["error_message"]
+            if error_message:
                 self.safe_set_attribute(
                     span=span,
                     key=ErrorAttributes.ERROR_MESSAGE,
-                    value=error_information["error_message"],
+                    value=error_message,
                 )
-
-            if error_information.get("llm_provider"):
                 self.safe_set_attribute(
                     span=span,
-                    key=ErrorAttributes.ERROR_LLM_PROVIDER,
-                    value=error_information["llm_provider"],
+                    key=ExceptionAttributes.EXCEPTION_MESSAGE,
+                    value=error_message,
                 )
 
-            if error_information.get("traceback"):
+            error_stack_trace = normalized["error_stack_trace"]
+            if error_stack_trace:
                 self.safe_set_attribute(
                     span=span,
                     key=ErrorAttributes.ERROR_STACK_TRACE,
-                    value=error_information["traceback"],
+                    value=error_stack_trace,
+                )
+                self.safe_set_attribute(
+                    span=span,
+                    key=ExceptionAttributes.EXCEPTION_STACKTRACE,
+                    value=error_stack_trace,
+                )
+
+            error_code = normalized["error_code"]
+            if error_code:
+                self.safe_set_attribute(
+                    span=span,
+                    key=ErrorAttributes.ERROR_CODE,
+                    value=error_code,
+                )
+                # OTel-standard HTTP status code as int, only when parseable.
+                # error_code may be non-numeric (e.g. "ContextWindowExceeded").
+                try:
+                    self.safe_set_attribute(
+                        span=span,
+                        key=HTTP_RESPONSE_STATUS_CODE_ATTRIBUTE,
+                        value=int(error_code),
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+            llm_provider = normalized["llm_provider"]
+            if llm_provider:
+                self.safe_set_attribute(
+                    span=span,
+                    key=ErrorAttributes.ERROR_LLM_PROVIDER,
+                    value=llm_provider,
                 )
 
         except Exception as e:
             verbose_logger.exception(
                 "OpenTelemetry: Error recording exception on span: %s", str(e)
             )
+
+    @staticmethod
+    def _normalize_error_attributes(
+        exception: Any,
+        error_information: Optional[dict],
+        error_str: Optional[str],
+    ) -> dict:
+        """
+        Build a single source-of-truth attribute set from every available
+        error-info input. Precedence per attribute:
+
+          ``error.type``     : error_information.error_class
+                               -> type(exception).__name__
+          ``error.message``  : error_information.error_message
+                               -> error_str
+                               -> str(exception)
+          ``error.stack_trace`` : error_information.traceback
+                                  -> traceback.format_exception(exception)
+                                     when a traceback is attached
+          ``error.code``     : error_information.error_code (str)
+          ``error.llm_provider`` : error_information.llm_provider
+
+        Returns a dict with the resolved fields plus ``has_any_error_info``
+        which is False only when every source was empty / None.
+        """
+        ei = error_information or {}
+
+        # error.type
+        error_type = ei.get("error_class") or ""
+        if not error_type and exception is not None:
+            error_type = type(exception).__name__
+
+        # error.message
+        error_message = ei.get("error_message") or ""
+        if not error_message and error_str:
+            error_message = error_str
+        if not error_message and exception is not None:
+            try:
+                error_message = str(exception)
+            except Exception:
+                error_message = ""
+
+        # error.stack_trace
+        error_stack_trace = ei.get("traceback") or ""
+        if not error_stack_trace and exception is not None:
+            tb = getattr(exception, "__traceback__", None)
+            if tb is not None:
+                try:
+                    import traceback as _tb_mod
+
+                    error_stack_trace = "".join(
+                        _tb_mod.format_exception(
+                            type(exception), exception, tb
+                        )
+                    )
+                except Exception:
+                    error_stack_trace = ""
+
+        # error.code (str form, preserved for back-compat)
+        error_code = ""
+        if ei.get("error_code") is not None:
+            try:
+                error_code = str(ei["error_code"])
+            except Exception:
+                error_code = ""
+
+        # error.llm_provider
+        llm_provider = ei.get("llm_provider") or ""
+
+        has_any_error_info = bool(
+            error_type
+            or error_message
+            or error_stack_trace
+            or error_code
+            or llm_provider
+        )
+
+        return {
+            "error_type": error_type,
+            "error_message": error_message,
+            "error_stack_trace": error_stack_trace,
+            "error_code": error_code,
+            "llm_provider": llm_provider,
+            "has_any_error_info": has_any_error_info,
+        }
+
 
     def set_tools_attributes(self, span: Span, tools):
         import json

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1830,8 +1830,8 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             )
 
             exception = kwargs.get("exception")
-            standard_logging_payload: Optional[StandardLoggingPayload] = (
-                kwargs.get("standard_logging_object")
+            standard_logging_payload: Optional[StandardLoggingPayload] = kwargs.get(
+                "standard_logging_object"
             )
 
             # Step 1: emit the OTEL ``exception`` span event when we have a
@@ -1846,9 +1846,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             error_information: Optional[dict] = None
             error_str: Optional[str] = None
             if standard_logging_payload is not None:
-                error_information = standard_logging_payload.get(
-                    "error_information"
-                )
+                error_information = standard_logging_payload.get("error_information")
                 error_str = standard_logging_payload.get("error_str")
 
             normalized = self._normalize_error_attributes(
@@ -1986,9 +1984,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     import traceback as _tb_mod
 
                     error_stack_trace = "".join(
-                        _tb_mod.format_exception(
-                            type(exception), exception, tb
-                        )
+                        _tb_mod.format_exception(type(exception), exception, tb)
                     )
                 except Exception:
                     error_stack_trace = ""
@@ -2020,7 +2016,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             "llm_provider": llm_provider,
             "has_any_error_info": has_any_error_info,
         }
-
 
     def set_tools_attributes(self, span: Span, tools):
         import json

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5211,10 +5211,16 @@ class TestRecordExceptionOnSpanNormalizationMatrix(unittest.TestCase):
         assert span.attributes["error.message"] == "bad key"
         assert span.attributes["error.code"] == "401"
         assert span.attributes["error.llm_provider"] == "openai"
-        assert span.attributes["error.stack_trace"] == "Traceback (most recent call last)..."
+        assert (
+            span.attributes["error.stack_trace"]
+            == "Traceback (most recent call last)..."
+        )
         assert span.attributes["exception.type"] == "AuthenticationError"
         assert span.attributes["exception.message"] == "bad key"
-        assert span.attributes["exception.stacktrace"] == "Traceback (most recent call last)..."
+        assert (
+            span.attributes["exception.stacktrace"]
+            == "Traceback (most recent call last)..."
+        )
         assert span.attributes["http.response.status_code"] == 401
 
     def test_error_str_fallback_with_exception_object(self):
@@ -5296,8 +5302,13 @@ class TestRecordExceptionOnSpanNormalizationMatrix(unittest.TestCase):
     def test_no_inputs_is_noop(self):
         span = self._record_and_get_span({})
         for attr in (
-            "error.type", "error.message", "error.code", "error.stack_trace",
-            "exception.type", "exception.message", "exception.stacktrace",
+            "error.type",
+            "error.message",
+            "error.code",
+            "error.stack_trace",
+            "exception.type",
+            "exception.message",
+            "exception.stacktrace",
             "http.response.status_code",
         ):
             assert attr not in span.attributes
@@ -5321,4 +5332,3 @@ class TestRecordExceptionOnSpanNormalizationMatrix(unittest.TestCase):
         span = self._record_and_get_span(kwargs)
         assert span.attributes["error.code"] == "401"
         assert isinstance(span.attributes["error.code"], str)
-

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5224,25 +5224,54 @@ class TestRecordExceptionOnSpanNormalizationMatrix(unittest.TestCase):
         assert span.attributes["http.response.status_code"] == 401
 
     def test_error_str_fallback_with_exception_object(self):
+        """When error_information is None but error_str is set, the
+        error_str field must win over str(exception). The two are
+        distinct strings here to prove the source of the stamped message."""
+
         class WeirdError(RuntimeError):
             pass
 
         try:
-            raise WeirdError("legacy payload")
+            # str(exception) is a different message from error_str; the test
+            # passes only if the implementation prefers error_str.
+            raise WeirdError("exception-side message")
         except WeirdError as exc:
             captured = exc
         kwargs = {
             "exception": captured,
             "standard_logging_object": {
                 "error_information": None,
-                "error_str": "legacy payload",
+                "error_str": "slp-side error_str message",
             },
         }
         span = self._record_and_get_span(kwargs)
-        assert span.attributes["error.message"] == "legacy payload"
-        assert span.attributes["exception.message"] == "legacy payload"
+        assert span.attributes["error.message"] == "slp-side error_str message"
+        assert span.attributes["exception.message"] == ("slp-side error_str message")
         assert span.attributes["error.type"] == "WeirdError"
         assert span.attributes["exception.type"] == "WeirdError"
+
+    def test_pure_error_str_no_exception_object(self):
+        """Pure error_str source — no exception, no error_information.
+        This is the older-payload edge case where the only signal we have is
+        the formatted message string. Both keysets must still get the message;
+        type/stack_trace remain absent because neither source supplies them."""
+        kwargs = {
+            "standard_logging_object": {
+                "error_information": None,
+                "error_str": "old payload only carried this",
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.message"] == "old payload only carried this"
+        assert span.attributes["exception.message"] == ("old payload only carried this")
+        # No exception class -> no error.type / exception.type.
+        assert "error.type" not in span.attributes
+        assert "exception.type" not in span.attributes
+        # No traceback source at all.
+        assert "error.stack_trace" not in span.attributes
+        assert "exception.stacktrace" not in span.attributes
+        # No OTEL exception event either (record_exception was not called).
+        assert not any(e.name == "exception" for e in span.events)
 
     def test_partial_error_information_falls_back_to_exception_class(self):
         class MyProviderError(Exception):

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5142,3 +5142,183 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
         span, exp = self._span()
         otel.set_preprocessing_duration_attribute(span, None)
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
+
+
+class TestRecordExceptionOnSpanNormalizationMatrix(unittest.TestCase):
+    """LIT-3199: ``_record_exception_on_span`` must normalize error/exception
+    span attributes across every failure source so downstream collectors
+    (Datadog, Tempo, Jaeger, etc.) see a consistent attribute set.
+
+    Matrix dimensions:
+      * input source: exception only / error_information only / error_str
+        fallback / exception+full info / partial error_information / nothing
+      * output check: ``error.*`` (legacy LiteLLM keys) AND ``exception.*``
+        (OTEL semconv keys) are both stamped from the same source-of-truth
+    """
+
+    def _record_and_get_span(self, kwargs):
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+
+        otel = OpenTelemetry()
+        span = tracer.start_span("Received Proxy Server Request")
+        otel._record_exception_on_span(span=span, kwargs=kwargs)
+        span.end()
+        finished = exporter.get_finished_spans()
+        assert len(finished) == 1
+        return finished[0]
+
+    def test_exception_only_stamps_both_error_and_exception_attrs(self):
+        """When only an exception object is available (no SLP at all), both
+        the legacy ``error.*`` and the OTEL ``exception.*`` attribute sets
+        must be stamped — previously only the ``exception`` event was
+        emitted and the queryable attrs were missing."""
+
+        class CustomBoom(ValueError):
+            pass
+
+        try:
+            raise CustomBoom("kaboom")
+        except CustomBoom as exc:
+            captured = exc
+        span = self._record_and_get_span({"exception": captured})
+        assert span.attributes["error.type"] == "CustomBoom"
+        assert span.attributes["exception.type"] == "CustomBoom"
+        assert span.attributes["error.message"] == "kaboom"
+        assert span.attributes["exception.message"] == "kaboom"
+        assert "error.stack_trace" in span.attributes
+        assert "exception.stacktrace" in span.attributes
+        assert "CustomBoom" in span.attributes["error.stack_trace"]
+        assert any(e.name == "exception" for e in span.events)
+
+    def test_full_error_information_stamps_both_keysets(self):
+        kwargs = {
+            "exception": ValueError("boom"),
+            "standard_logging_object": {
+                "error_information": {
+                    "error_code": "401",
+                    "error_class": "AuthenticationError",
+                    "error_message": "bad key",
+                    "llm_provider": "openai",
+                    "traceback": "Traceback (most recent call last)...",
+                }
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.type"] == "AuthenticationError"
+        assert span.attributes["error.message"] == "bad key"
+        assert span.attributes["error.code"] == "401"
+        assert span.attributes["error.llm_provider"] == "openai"
+        assert span.attributes["error.stack_trace"] == "Traceback (most recent call last)..."
+        assert span.attributes["exception.type"] == "AuthenticationError"
+        assert span.attributes["exception.message"] == "bad key"
+        assert span.attributes["exception.stacktrace"] == "Traceback (most recent call last)..."
+        assert span.attributes["http.response.status_code"] == 401
+
+    def test_error_str_fallback_with_exception_object(self):
+        class WeirdError(RuntimeError):
+            pass
+
+        try:
+            raise WeirdError("legacy payload")
+        except WeirdError as exc:
+            captured = exc
+        kwargs = {
+            "exception": captured,
+            "standard_logging_object": {
+                "error_information": None,
+                "error_str": "legacy payload",
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.message"] == "legacy payload"
+        assert span.attributes["exception.message"] == "legacy payload"
+        assert span.attributes["error.type"] == "WeirdError"
+        assert span.attributes["exception.type"] == "WeirdError"
+
+    def test_partial_error_information_falls_back_to_exception_class(self):
+        class MyProviderError(Exception):
+            pass
+
+        kwargs = {
+            "exception": MyProviderError("provider exploded"),
+            "standard_logging_object": {
+                "error_information": {"error_message": "provider exploded"},
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.message"] == "provider exploded"
+        assert span.attributes["error.type"] == "MyProviderError"
+        assert span.attributes["exception.type"] == "MyProviderError"
+        assert "error.code" not in span.attributes
+        assert "http.response.status_code" not in span.attributes
+
+    def test_http_status_only_no_exception(self):
+        """A guardrail / 4xx-on-response path can populate ``error_information``
+        with no Python exception attached. The OTel ``exception`` event won\u2019t
+        fire (no exception to record) but the ``exception.*`` attributes must
+        still be stamped."""
+        kwargs = {
+            "standard_logging_object": {
+                "error_information": {
+                    "error_code": "403",
+                    "error_class": "GuardrailIntervention",
+                    "error_message": "content blocked",
+                },
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert not any(e.name == "exception" for e in span.events)
+        assert span.attributes["error.type"] == "GuardrailIntervention"
+        assert span.attributes["exception.type"] == "GuardrailIntervention"
+        assert span.attributes["error.message"] == "content blocked"
+        assert span.attributes["exception.message"] == "content blocked"
+        assert span.attributes["error.code"] == "403"
+        assert span.attributes["http.response.status_code"] == 403
+
+    def test_non_numeric_error_code_keeps_legacy_only(self):
+        kwargs = {
+            "standard_logging_object": {
+                "error_information": {
+                    "error_code": "ContextWindowExceeded",
+                    "error_class": "ContextWindowExceededError",
+                    "error_message": "too long",
+                },
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.code"] == "ContextWindowExceeded"
+        assert "http.response.status_code" not in span.attributes
+        assert span.attributes["exception.type"] == "ContextWindowExceededError"
+
+    def test_no_inputs_is_noop(self):
+        span = self._record_and_get_span({})
+        for attr in (
+            "error.type", "error.message", "error.code", "error.stack_trace",
+            "exception.type", "exception.message", "exception.stacktrace",
+            "http.response.status_code",
+        ):
+            assert attr not in span.attributes
+
+    def test_empty_error_information_falls_back_to_exception(self):
+        kwargs = {
+            "exception": ValueError("via fallback"),
+            "standard_logging_object": {"error_information": {}},
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.type"] == "ValueError"
+        assert span.attributes["error.message"] == "via fallback"
+        assert span.attributes["exception.message"] == "via fallback"
+
+    def test_error_code_remains_string(self):
+        kwargs = {
+            "standard_logging_object": {
+                "error_information": {"error_code": "401"},
+            },
+        }
+        span = self._record_and_get_span(kwargs)
+        assert span.attributes["error.code"] == "401"
+        assert isinstance(span.attributes["error.code"], str)
+


### PR DESCRIPTION
## What

Normalize OTEL error/exception span attributes across every failure path so downstream collectors (Datadog APM, Grafana Tempo, Jaeger, etc.) see a consistent attribute set regardless of which input source the proxy populated.

## Why

`OpenTelemetry._record_exception_on_span` in `litellm/integrations/opentelemetry.py` is the sink for every error span we emit (proxy failure path, `_handle_failure`, `async_post_call_failure_hook`). It receives error info from four mutually exclusive sources:

1. an exception object (`kwargs["exception"]`)
2. a `StandardLoggingPayloadErrorInformation` block (proxy auth / LLM API error)
3. a fallback `error_str` only (older logging payloads)
4. an HTTP-status-only error with no Python exception (guardrail rejection, upstream 4xx returned as response body)

Before this PR each source took a different code path and produced a different attribute shape. Two real consequences:
- Datadog APM/Tempo `error.type` filters silently dropped a chunk of failed requests because the attribute was never stamped when only an exception was available, or when `error_class` was missing from the SLP.
- `exception.*` (OTEL semconv) attributes were never stamped at all, so anything keying off the OTEL standard exception attributes (Grafana Tempo TraceQL `{ exception.type = "..." }`, OTEL gateway routing rules) couldn't see LiteLLM errors as errors.

## Change

- Replaced `_record_exception_on_span` with a normalized-stamp version that, whenever ANY error info is present, stamps both keysets from a single source-of-truth:
  - `error.type` + `exception.type` from `error_information.error_class` -> `type(exception).__name__`
  - `error.message` + `exception.message` from `error_information.error_message` -> `error_str` -> `str(exception)`
  - `error.stack_trace` + `exception.stacktrace` from `error_information.traceback` -> `traceback.format_exception(exception)` (when `__traceback__` attached)
  - Preserves `error.code` (str, back-compat) + `http.response.status_code` (int, OTEL-standard, only when parseable)
- Added `_normalize_error_attributes` staticmethod that collapses every input source into one resolved tuple, so stamping is order-independent.
- Added `ExceptionAttributes` constant class in `litellm/integrations/_types/open_inference.py` for the OTEL semconv keys.
- `span.record_exception()` is still invoked whenever an exception object is supplied, so the OTEL `exception` event keeps working unchanged. Attribute stamping is purely additive.

## Tests

New `TestRecordExceptionOnSpanNormalizationMatrix` covers all 9 input/output combos: exception-only, full SLP, error_str fallback, partial SLP, HTTP-status-only (no exception), non-numeric error_code, zero-inputs noop, empty error_information dict, and `error.code` stays a string. All 9 new tests pass; the existing 205 tests in the file continue to pass (214 total). 16 pre-existing failures in `TestOpenTelemetryProtocolSelection` are unrelated to this change (verified by running stock main + this branch with the same `pytest` invocation - same 16 fail in both).

### Evidence

Runtime capture: `python3 repro.py` drives `_record_exception_on_span` against `InMemorySpanExporter` for each scenario and prints the exact attribute dict + events that downstream collectors would see.

**Before (stock main):**

```
=== A) exception-only (no standard_logging_object) ===
  events: ['exception']
  attributes:
    <empty - span carries no queryable error attrs>

=== B) full error_information (proxy auth path) ===
  events: ['exception']
  attributes:
    'error.code': '401'
    'error.llm_provider': 'openai'
    'error.message': 'bad key'
    'error.stack_trace': 'Traceback (most recent call last)...'
    'error.type': 'AuthenticationError'
    'http.response.status_code': 401

=== C) error_str fallback (error_information=None) ===
  events: ['exception']
  attributes:
    'error.message': 'legacy payload'
    <no error.type, no error.stack_trace>

=== D) partial error_information (error_message only) ===
  events: ['exception']
  attributes:
    'error.message': 'provider exploded'
    <no error.type, no error.stack_trace>

=== E) http-status-only (guardrail block, no exception) ===
  events: []
  attributes:
    'error.code': '403'
    'error.message': 'content blocked'
    'error.type': 'GuardrailIntervention'
    'http.response.status_code': 403
    <no exception.* mirrors>

=== F) non-numeric error_code ===
  events: []
  attributes:
    'error.code': 'ContextWindowExceeded'
    'error.message': 'too long'
    'error.type': 'ContextWindowExceededError'
    <no exception.* mirrors>
```

**After (this branch, same script, same kwargs):**

```
=== A) exception-only (no standard_logging_object) ===
  events: ['exception']
  attributes:
    'error.message': 'kaboom from upstream'
    'error.stack_trace': 'Traceback (most recent call last):...'
    'error.type': 'CustomBoom'
    'exception.message': 'kaboom from upstream'
    'exception.stacktrace': 'Traceback (most recent call last):...'
    'exception.type': 'CustomBoom'

=== B) full error_information (proxy auth path) ===
  events: ['exception']
  attributes:
    'error.code': '401'
    'error.llm_provider': 'openai'
    'error.message': 'bad key'
    'error.stack_trace': 'Traceback (most recent call last)...'
    'error.type': 'AuthenticationError'
    'exception.message': 'bad key'
    'exception.stacktrace': 'Traceback (most recent call last)...'
    'exception.type': 'AuthenticationError'
    'http.response.status_code': 401

=== C) error_str fallback (error_information=None) ===
  events: ['exception']
  attributes:
    'error.message': 'legacy payload'
    'error.stack_trace': 'Traceback (most recent call last):...'
    'error.type': 'WeirdError'
    'exception.message': 'legacy payload'
    'exception.stacktrace': 'Traceback (most recent call last):...'
    'exception.type': 'WeirdError'

=== D) partial error_information (error_message only) ===
  events: ['exception']
  attributes:
    'error.message': 'provider exploded'
    'error.type': 'MyProviderError'
    'exception.message': 'provider exploded'
    'exception.type': 'MyProviderError'

=== E) http-status-only (guardrail block, no exception) ===
  events: []
  attributes:
    'error.code': '403'
    'error.message': 'content blocked'
    'error.type': 'GuardrailIntervention'
    'exception.message': 'content blocked'
    'exception.type': 'GuardrailIntervention'
    'http.response.status_code': 403

=== F) non-numeric error_code ===
  events: []
  attributes:
    'error.code': 'ContextWindowExceeded'
    'error.message': 'too long'
    'error.type': 'ContextWindowExceededError'
    'exception.message': 'too long'
    'exception.type': 'ContextWindowExceededError'
```

Every scenario now emits the same normalized `error.* + exception.*` attribute pair. The noop / non-numeric / status-only edge cases preserve existing semantics.

## Notes

- **Branching note**: I pushed via `PUT /repos/{owner}/{repo}/contents/{path}` because the current `oss-agent-shin` `GITHUB_TOKEN` lacks `repo` scope for `git push`. Each file is one commit on the contents path, so the PR shows three small commits instead of one squash - squash-merge on the receiving side gets you the same result as a normal `git push`.

Refs: LIT-3199


### Verification (ship-pr)
- change-type: `litellm/integrations/opentelemetry.py` + `litellm/integrations/_types/open_inference.py` + `tests/test_litellm/integrations/test_opentelemetry.py` -> OTEL/observability change -> required evidence: span attribute capture from a running OTEL exporter
- evidence present: PASS (2 fenced blocks — Before stock-main capture + After this-branch capture, both from `python3 repro.py` driving `_record_exception_on_span` against `InMemorySpanExporter`)
- image sanity: N/A (no screenshots, terminal evidence only)
- image content matches caption: N/A (no screenshots)
- backend evidence from running system: PASS (`InMemorySpanExporter.get_finished_spans()` from a real OTEL `TracerProvider` + `SimpleSpanProcessor`, attributes dumped verbatim; the exact same script run on stock main vs this branch produces the Before/After blocks shown)
- hygiene: PASS (no external image hosts, only intentional files staged: 3 files / 392 additions / 54 deletions)
