### PR TITLE
fix(otel): propagate team_id/team_alias to service-hook child spans (LIT-3192)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1226,7 +1226,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         ):
             self._set_team_attributes_from_kwargs(proxy_span, kwargs)
 
-
     def _copy_team_attributes_from_parent_span(
         self,
         parent_span: Optional[Span],

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -592,6 +592,13 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                         key=key,
                         value=value,
                     )
+            # Propagate team_id / team_alias from the parent SERVER span so
+            # service-level child spans (db/redis/auth/pre-call/...) are
+            # team-filterable end-to-end, not just the root.
+            self._copy_team_attributes_from_parent_span(
+                parent_span=parent_otel_span,
+                target_span=service_logging_span,
+            )
             service_logging_span.set_status(Status(StatusCode.OK))
             service_logging_span.end(end_time=_end_time_ns)
 
@@ -656,6 +663,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                         value=value,
                     )
 
+            # Propagate team_id / team_alias from the parent SERVER span
+            # (see async_service_success_hook for context).
+            self._copy_team_attributes_from_parent_span(
+                parent_span=parent_otel_span,
+                target_span=service_logging_span,
+            )
             service_logging_span.set_status(Status(StatusCode.ERROR))
             service_logging_span.end(end_time=_end_time_ns)
 
@@ -1212,6 +1225,43 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             and proxy_span.is_recording()
         ):
             self._set_team_attributes_from_kwargs(proxy_span, kwargs)
+
+
+    def _copy_team_attributes_from_parent_span(
+        self,
+        parent_span: Optional[Span],
+        target_span: Span,
+    ) -> None:
+        """Copy ``metadata.user_api_key_team_id`` / ``metadata.user_api_key_team_alias``
+        from a parent span (typically the proxy SERVER span, already team-stamped
+        by ``_set_team_attributes_on_proxy_span_from_kwargs``) onto a child span
+        created in the service / pre-call hook path, where the caller passes only
+        ``parent_otel_span`` and not ``user_api_key_dict`` / ``kwargs``.
+
+        Reads the attributes off the live SDK span via ``parent_span.attributes``
+        (a ``MappingProxyType`` on ``opentelemetry.sdk.trace._Span``). Silently
+        no-ops if the parent is None, is not an SDK span (e.g. ``NonRecordingSpan``),
+        or does not expose ``attributes``.
+
+        Empty strings are skipped via ``_set_team_attributes_on_span``, which
+        treats them as absent -- a master-key request whose parent span has
+        ``user_api_key_team_id=""`` does not pollute child spans with empties.
+        """
+        if parent_span is None:
+            return
+        parent_attrs = getattr(parent_span, "attributes", None)
+        if not parent_attrs:
+            return
+        try:
+            team_id = parent_attrs.get("metadata.user_api_key_team_id")
+            team_alias = parent_attrs.get("metadata.user_api_key_team_alias")
+        except Exception:
+            return
+        self._set_team_attributes_on_span(
+            span=target_span,
+            team_id=team_id if isinstance(team_id, str) else None,
+            team_alias=team_alias if isinstance(team_alias, str) else None,
+        )
 
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
         duration_s = (end_time - start_time).total_seconds()

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5142,3 +5142,240 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
         span, exp = self._span()
         otel.set_preprocessing_duration_attribute(span, None)
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
+
+
+class TestServiceHookTeamAttributePropagation(unittest.TestCase):
+    """LIT-3192: team_id / team_alias must propagate from the parent SERVER span
+    onto every child span emitted by async_service_success_hook /
+    async_service_failure_hook so team-filtered observability dashboards cover
+    every service-level child span, not just the root."""
+
+    LITELLM_PROXY_REQUEST_SPAN_NAME = "litellm_request"
+
+    def _otel(self):
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+        from litellm.integrations.opentelemetry import OpenTelemetry
+
+        provider = TracerProvider()
+        exporter = InMemorySpanExporter()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        otel = OpenTelemetry()
+        otel.tracer = provider.get_tracer("litellm.test")
+        return otel, exporter
+
+    def _make_parent_span(self, otel, team_id, team_alias):
+        parent = otel.tracer.start_span(self.LITELLM_PROXY_REQUEST_SPAN_NAME)
+        if team_id is not None:
+            parent.set_attribute("metadata.user_api_key_team_id", team_id)
+        if team_alias is not None:
+            parent.set_attribute("metadata.user_api_key_team_alias", team_alias)
+        return parent
+
+    def _service_span_attrs(self, exporter, service_value):
+        spans = [s for s in exporter.get_finished_spans() if s.name == service_value]
+        assert len(spans) == 1, (
+            f"expected one {service_value!r} span, got {len(spans)}"
+        )
+        return dict(spans[0].attributes or {})
+
+    def _run(self, coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def _make_payload(self, service):
+        from litellm.types.services import ServiceLoggerPayload
+
+        return ServiceLoggerPayload(
+            is_error=False,
+            error=None,
+            service=service,
+            duration=0.05,
+            call_type="test_call",
+            event_metadata=None,
+        )
+
+    @parameterized.expand([
+        ("PROXY_PRE_CALL",),
+        ("DB",),
+        ("REDIS",),
+        ("AUTH",),
+        ("ROUTER",),
+        ("BATCH_WRITE_TO_DB",),
+        ("POD_LOCK_MANAGER",),
+    ])
+    def test_success_hook_stamps_team_attrs_on_every_service_type(self, name):
+        from litellm.types.services import ServiceTypes
+
+        otel, exporter = self._otel()
+        parent = self._make_parent_span(otel, "team-7", "alias-7")
+        service = getattr(ServiceTypes, name)
+        payload = self._make_payload(service)
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(milliseconds=50)
+        self._run(otel.async_service_success_hook(
+            payload=payload,
+            parent_otel_span=parent,
+            start_time=start,
+            end_time=end,
+            event_metadata=None,
+        ))
+        attrs = self._service_span_attrs(exporter, service.value)
+        assert attrs.get("metadata.user_api_key_team_id") == "team-7", attrs
+        assert attrs.get("metadata.user_api_key_team_alias") == "alias-7", attrs
+
+    def test_failure_hook_stamps_team_attrs(self):
+        from litellm.types.services import ServiceTypes
+
+        otel, exporter = self._otel()
+        parent = self._make_parent_span(otel, "team-9", "alias-9")
+        payload = self._make_payload(ServiceTypes.DB)
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(milliseconds=20)
+        self._run(otel.async_service_failure_hook(
+            payload=payload,
+            error="boom",
+            parent_otel_span=parent,
+            start_time=start,
+            end_time=end,
+            event_metadata=None,
+        ))
+        attrs = self._service_span_attrs(exporter, ServiceTypes.DB.value)
+        assert attrs.get("metadata.user_api_key_team_id") == "team-9"
+        assert attrs.get("metadata.user_api_key_team_alias") == "alias-9"
+        assert attrs.get("error") == "boom"
+
+    def test_empty_string_team_attrs_not_propagated(self):
+        from litellm.types.services import ServiceTypes
+
+        otel, exporter = self._otel()
+        parent = self._make_parent_span(otel, "", "")
+        payload = self._make_payload(ServiceTypes.REDIS)
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(milliseconds=10)
+        self._run(otel.async_service_success_hook(
+            payload=payload,
+            parent_otel_span=parent,
+            start_time=start,
+            end_time=end,
+        ))
+        attrs = self._service_span_attrs(exporter, ServiceTypes.REDIS.value)
+        assert "metadata.user_api_key_team_id" not in attrs
+        assert "metadata.user_api_key_team_alias" not in attrs
+
+    def test_no_team_attrs_on_parent_is_safe_noop(self):
+        from litellm.types.services import ServiceTypes
+
+        otel, exporter = self._otel()
+        parent = otel.tracer.start_span(self.LITELLM_PROXY_REQUEST_SPAN_NAME)
+        payload = self._make_payload(ServiceTypes.AUTH)
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(milliseconds=5)
+        self._run(otel.async_service_success_hook(
+            payload=payload,
+            parent_otel_span=parent,
+            start_time=start,
+            end_time=end,
+        ))
+        attrs = self._service_span_attrs(exporter, ServiceTypes.AUTH.value)
+        assert "metadata.user_api_key_team_id" not in attrs
+        assert "metadata.user_api_key_team_alias" not in attrs
+
+    def test_parent_is_none_hook_noop_does_not_emit_span(self):
+        from litellm.types.services import ServiceTypes
+
+        otel, exporter = self._otel()
+        payload = self._make_payload(ServiceTypes.DB)
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(milliseconds=5)
+        self._run(otel.async_service_success_hook(
+            payload=payload,
+            parent_otel_span=None,
+            start_time=start,
+            end_time=end,
+        ))
+        assert exporter.get_finished_spans() == ()
+
+    def test_non_recording_parent_does_not_crash_hook(self):
+        """A NonRecordingSpan parent has no .attributes; propagation helper must
+        silently no-op (no traceback) regardless of whether the hook emits a
+        child span at all."""
+        from litellm.types.services import ServiceTypes
+        from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+        otel, exporter = self._otel()
+        parent = NonRecordingSpan(SpanContext(
+            trace_id=0x1, span_id=0x2, is_remote=False,
+            trace_flags=TraceFlags(0x01),
+        ))
+        payload = self._make_payload(ServiceTypes.DB)
+        start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = start + timedelta(milliseconds=5)
+        self._run(otel.async_service_success_hook(
+            payload=payload,
+            parent_otel_span=parent,
+            start_time=start,
+            end_time=end,
+        ))
+        for span in exporter.get_finished_spans():
+            attrs = dict(span.attributes or {})
+            assert "metadata.user_api_key_team_id" not in attrs
+            assert "metadata.user_api_key_team_alias" not in attrs
+
+
+class TestCopyTeamAttributesFromParentSpanUnit(unittest.TestCase):
+    """Direct unit tests on the helper itself (no service-hook plumbing)."""
+
+    def _otel(self):
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        provider = TracerProvider()
+        exporter = InMemorySpanExporter()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        otel = OpenTelemetry()
+        otel.tracer = provider.get_tracer("t")
+        return otel, exporter
+
+    def test_helper_copies_team_attrs(self):
+        otel, exporter = self._otel()
+        parent = otel.tracer.start_span("p")
+        parent.set_attribute("metadata.user_api_key_team_id", "abc")
+        parent.set_attribute("metadata.user_api_key_team_alias", "xyz")
+        child = otel.tracer.start_span("c")
+        otel._copy_team_attributes_from_parent_span(parent, child)
+        child.end()
+        parent.end()
+        attrs = next(
+            dict(s.attributes or {})
+            for s in exporter.get_finished_spans()
+            if s.name == "c"
+        )
+        assert attrs["metadata.user_api_key_team_id"] == "abc"
+        assert attrs["metadata.user_api_key_team_alias"] == "xyz"
+
+    def test_helper_with_none_parent_is_noop(self):
+        otel, _exporter = self._otel()
+        child = otel.tracer.start_span("c")
+        otel._copy_team_attributes_from_parent_span(None, child)
+        child.end()
+
+    def test_helper_ignores_non_string_attrs(self):
+        otel, exporter = self._otel()
+        parent = otel.tracer.start_span("p")
+        parent.set_attribute("metadata.user_api_key_team_id", 12345)
+        child = otel.tracer.start_span("c")
+        otel._copy_team_attributes_from_parent_span(parent, child)
+        child.end()
+        parent.end()
+        attrs = next(
+            dict(s.attributes or {})
+            for s in exporter.get_finished_spans()
+            if s.name == "c"
+        )
+        assert "metadata.user_api_key_team_id" not in attrs

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5177,9 +5177,7 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
 
     def _service_span_attrs(self, exporter, service_value):
         spans = [s for s in exporter.get_finished_spans() if s.name == service_value]
-        assert len(spans) == 1, (
-            f"expected one {service_value!r} span, got {len(spans)}"
-        )
+        assert len(spans) == 1, f"expected one {service_value!r} span, got {len(spans)}"
         return dict(spans[0].attributes or {})
 
     def _run(self, coro):
@@ -5197,15 +5195,17 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
             event_metadata=None,
         )
 
-    @parameterized.expand([
-        ("PROXY_PRE_CALL",),
-        ("DB",),
-        ("REDIS",),
-        ("AUTH",),
-        ("ROUTER",),
-        ("BATCH_WRITE_TO_DB",),
-        ("POD_LOCK_MANAGER",),
-    ])
+    @parameterized.expand(
+        [
+            ("PROXY_PRE_CALL",),
+            ("DB",),
+            ("REDIS",),
+            ("AUTH",),
+            ("ROUTER",),
+            ("BATCH_WRITE_TO_DB",),
+            ("POD_LOCK_MANAGER",),
+        ]
+    )
     def test_success_hook_stamps_team_attrs_on_every_service_type(self, name):
         from litellm.types.services import ServiceTypes
 
@@ -5215,13 +5215,15 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         payload = self._make_payload(service)
         start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end = start + timedelta(milliseconds=50)
-        self._run(otel.async_service_success_hook(
-            payload=payload,
-            parent_otel_span=parent,
-            start_time=start,
-            end_time=end,
-            event_metadata=None,
-        ))
+        self._run(
+            otel.async_service_success_hook(
+                payload=payload,
+                parent_otel_span=parent,
+                start_time=start,
+                end_time=end,
+                event_metadata=None,
+            )
+        )
         attrs = self._service_span_attrs(exporter, service.value)
         assert attrs.get("metadata.user_api_key_team_id") == "team-7", attrs
         assert attrs.get("metadata.user_api_key_team_alias") == "alias-7", attrs
@@ -5234,14 +5236,16 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         payload = self._make_payload(ServiceTypes.DB)
         start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end = start + timedelta(milliseconds=20)
-        self._run(otel.async_service_failure_hook(
-            payload=payload,
-            error="boom",
-            parent_otel_span=parent,
-            start_time=start,
-            end_time=end,
-            event_metadata=None,
-        ))
+        self._run(
+            otel.async_service_failure_hook(
+                payload=payload,
+                error="boom",
+                parent_otel_span=parent,
+                start_time=start,
+                end_time=end,
+                event_metadata=None,
+            )
+        )
         attrs = self._service_span_attrs(exporter, ServiceTypes.DB.value)
         assert attrs.get("metadata.user_api_key_team_id") == "team-9"
         assert attrs.get("metadata.user_api_key_team_alias") == "alias-9"
@@ -5255,12 +5259,14 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         payload = self._make_payload(ServiceTypes.REDIS)
         start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end = start + timedelta(milliseconds=10)
-        self._run(otel.async_service_success_hook(
-            payload=payload,
-            parent_otel_span=parent,
-            start_time=start,
-            end_time=end,
-        ))
+        self._run(
+            otel.async_service_success_hook(
+                payload=payload,
+                parent_otel_span=parent,
+                start_time=start,
+                end_time=end,
+            )
+        )
         attrs = self._service_span_attrs(exporter, ServiceTypes.REDIS.value)
         assert "metadata.user_api_key_team_id" not in attrs
         assert "metadata.user_api_key_team_alias" not in attrs
@@ -5273,12 +5279,14 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         payload = self._make_payload(ServiceTypes.AUTH)
         start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end = start + timedelta(milliseconds=5)
-        self._run(otel.async_service_success_hook(
-            payload=payload,
-            parent_otel_span=parent,
-            start_time=start,
-            end_time=end,
-        ))
+        self._run(
+            otel.async_service_success_hook(
+                payload=payload,
+                parent_otel_span=parent,
+                start_time=start,
+                end_time=end,
+            )
+        )
         attrs = self._service_span_attrs(exporter, ServiceTypes.AUTH.value)
         assert "metadata.user_api_key_team_id" not in attrs
         assert "metadata.user_api_key_team_alias" not in attrs
@@ -5290,12 +5298,14 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         payload = self._make_payload(ServiceTypes.DB)
         start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end = start + timedelta(milliseconds=5)
-        self._run(otel.async_service_success_hook(
-            payload=payload,
-            parent_otel_span=None,
-            start_time=start,
-            end_time=end,
-        ))
+        self._run(
+            otel.async_service_success_hook(
+                payload=payload,
+                parent_otel_span=None,
+                start_time=start,
+                end_time=end,
+            )
+        )
         assert exporter.get_finished_spans() == ()
 
     def test_non_recording_parent_does_not_crash_hook(self):
@@ -5306,19 +5316,25 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
         otel, exporter = self._otel()
-        parent = NonRecordingSpan(SpanContext(
-            trace_id=0x1, span_id=0x2, is_remote=False,
-            trace_flags=TraceFlags(0x01),
-        ))
+        parent = NonRecordingSpan(
+            SpanContext(
+                trace_id=0x1,
+                span_id=0x2,
+                is_remote=False,
+                trace_flags=TraceFlags(0x01),
+            )
+        )
         payload = self._make_payload(ServiceTypes.DB)
         start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end = start + timedelta(milliseconds=5)
-        self._run(otel.async_service_success_hook(
-            payload=payload,
-            parent_otel_span=parent,
-            start_time=start,
-            end_time=end,
-        ))
+        self._run(
+            otel.async_service_success_hook(
+                payload=payload,
+                parent_otel_span=parent,
+                start_time=start,
+                end_time=end,
+            )
+        )
         for span in exporter.get_finished_spans():
             attrs = dict(span.attributes or {})
             assert "metadata.user_api_key_team_id" not in attrs

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5181,7 +5181,11 @@ class TestServiceHookTeamAttributePropagation(unittest.TestCase):
         return dict(spans[0].attributes or {})
 
     def _run(self, coro):
-        return asyncio.new_event_loop().run_until_complete(coro)
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
     def _make_payload(self, service):
         from litellm.types.services import ServiceLoggerPayload


### PR DESCRIPTION
## What

The proxy SERVER (root) span gets `metadata.user_api_key_team_id` /
`metadata.user_api_key_team_alias` stamped via
`_set_team_attributes_on_proxy_span_from_kwargs` (see
`litellm/integrations/opentelemetry.py:1196`).

Service-hook callers (`proxy_pre_call`, `db`, `redis`, `auth`, `router`,
`batch_write_to_db`, `pod_lock_manager`, ...) only pass `parent_otel_span`
into `async_service_success_hook` / `async_service_failure_hook` — never
`user_api_key_dict` or `kwargs` — so the child `service_logging_span`
created in those hooks never carried team attrs. Result: every team-filtered
observability dashboard only matched the root span; the child service spans
under each request were dropped.

## Fix

New helper `_copy_team_attributes_from_parent_span` reads
`metadata.user_api_key_team_id` / `metadata.user_api_key_team_alias` off
`parent_otel_span.attributes` (a `MappingProxyType` on the SDK `_Span`) and
stamps them onto the child span via the existing
`_set_team_attributes_on_span` guard — which already treats empty strings
as absent, so a master-key request (`user_api_key_team_id=""`) does not get
empty-string attrs propagated.

Helper is called from both `async_service_success_hook` and
`async_service_failure_hook` right before `set_status` / `end`. Silently
no-ops when:
- `parent_otel_span is None`
- parent is a `NonRecordingSpan` (no `.attributes`)
- parent has no team attrs at all
- parent's team attrs are not strings (defensive)

## Tests

`tests/test_litellm/integrations/test_opentelemetry.py` gains a
parameterised matrix covering every relevant `ServiceTypes` member
(`PROXY_PRE_CALL`, `DB`, `REDIS`, `AUTH`, `ROUTER`, `BATCH_WRITE_TO_DB`,
`POD_LOCK_MANAGER`) plus failure-hook, empty-string, no-team-attrs,
`None` parent, `NonRecordingSpan` parent, and direct-helper edge cases.
15 assertions, all green:

```
python3 -m pytest -q tests/test_litellm/integrations/test_opentelemetry.py::TestServiceHookTeamAttributePropagation tests/test_litellm/integrations/test_opentelemetry.py::TestCopyTeamAttributesFromParentSpanUnit
...............                                                          [100%]
15 passed in 8.13s
```

## Evidence

Real captures from two **independent fresh clones** — one of the base
branch (no fix), one of this PR's head branch (with fix). Each clone
calls `async_service_success_hook` once per service type and once on the
failure hook, against a `litellm_request` parent span whose team attrs
are stamped exactly like the proxy stamps them in production. Spans go to
an `InMemorySpanExporter`; we then dump every emitted span's `.attributes`
and check for the team keys.

### Before — clean clone of `litellm_oss_agent_shin_daily_branch`

```
BEFORE FIX (litellm_oss_agent_shin_daily_branch, clean clone)
======================================================================
  child   name=<ServiceTypes.PROXY_PRE_CALL: 'proxy_pre_call'>  team_id=False  team_alias=False
  child   name=<ServiceTypes.DB: 'postgres'>        team_id=False  team_alias=False
  child   name=<ServiceTypes.REDIS: 'redis'>        team_id=False  team_alias=False
  child   name=<ServiceTypes.AUTH: 'auth'>          team_id=False  team_alias=False
  child   name=<ServiceTypes.ROUTER: 'router'>      team_id=False  team_alias=False
  PARENT  name='litellm_request'                    team_id=True   team_alias=True
  child   name=<ServiceTypes.DB: 'postgres'>        team_id=False  team_alias=False

Summary: 1 / 7 spans carry metadata.user_api_key_team_id
Summary: 1 / 7 spans carry metadata.user_api_key_team_alias
```

### After — clean clone of this PR's head branch

```
AFTER FIX (lit-3192-team-metadata-service-spans @ oss-agent-shin)
======================================================================
  child   name=<ServiceTypes.PROXY_PRE_CALL: 'proxy_pre_call'>  team_id=True   team_alias=True
  child   name=<ServiceTypes.DB: 'postgres'>        team_id=True   team_alias=True
  child   name=<ServiceTypes.REDIS: 'redis'>        team_id=True   team_alias=True
  child   name=<ServiceTypes.AUTH: 'auth'>          team_id=True   team_alias=True
  child   name=<ServiceTypes.ROUTER: 'router'>      team_id=True   team_alias=True
  PARENT  name='litellm_request'                    team_id=True   team_alias=True
  child   name=<ServiceTypes.DB: 'postgres'>        team_id=True   team_alias=True

Summary: 7 / 7 spans carry metadata.user_api_key_team_id
Summary: 7 / 7 spans carry metadata.user_api_key_team_alias
```

The delta is exactly the propagation predicted by the diff: the 6 child
service spans flip from `False` to `True` for both team attrs; the parent
`litellm_request` is unchanged. The bug is reproduced on main and not on
this branch.

## Note on push path

Pushed via the GitHub Contents API (`PUT /repos/.../contents/{path}`)
because the agent's `GITHUB_TOKEN` lacks `repo`/`workflow` scopes. The
commit history on the head branch is therefore one commit per file
(opentelemetry.py + tests). Diff vs base is clean — only the two files.

Closes LIT-3192.


### Verification (ship-pr)
- change-type: `litellm/integrations/opentelemetry.py` (telemetry) -> required: collector/telemetry capture. tests (no separate evidence)
- evidence present: PASS (before + after fenced blocks under `### Evidence`; 1/7 -> 7/7 spans team-stamped)
- image sanity: N/A (backend/telemetry change, no screenshots)
- image content matches caption: N/A
- backend evidence from running system: PASS — captures came from two independent fresh `git clone` checkouts (base branch + PR head branch), driving the real `async_service_success_hook` / `async_service_failure_hook` against an `InMemorySpanExporter`; not fabricated
- hygiene: PASS (no external image hosts; only the two intentionally modified files in the diff)
