### PR TITLE
fix(otel): handle unhashable scope parts in _emit_once dedupe key (LIT-3299)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -944,9 +944,9 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         except TypeError:
             pass
 
-        if isinstance(value, list):
+        if isinstance(value, (list, tuple)):
             return tuple(OpenTelemetry._make_hashable(v) for v in value)
-        if isinstance(value, set):
+        if isinstance(value, (set, frozenset)):
             return frozenset(OpenTelemetry._make_hashable(v) for v in value)
         if isinstance(value, dict):
             return frozenset(

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -916,6 +916,48 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     # End of Team/Key Based Logging Control Flow
     #########################################################
 
+    @staticmethod
+    def _make_hashable(value: object) -> object:
+        """Recursively coerce ``value`` to a hashable form for use in dedupe keys.
+
+        ``_emit_once`` builds a tuple from arbitrary caller-supplied ``scope``
+        parts and uses it as a ``dict`` key. Some of those parts come from
+        free-form payloads (e.g. ``guardrail_mode``) and can legitimately be
+        a list (``["pre_call", "post_call"]``), a dict, or a set — all of
+        which are unhashable in Python and would otherwise raise
+        ``TypeError: unhashable type`` and turn every request into HTTP 500.
+
+        The coercion is conservative:
+          * ``list`` / ``tuple`` -> tuple of recursively-hashable elements
+          * ``set`` / ``frozenset`` -> ``frozenset`` of recursively-hashable elements
+          * ``dict`` -> ``frozenset`` of ``(key, value)`` pairs, both made hashable
+          * everything else: returned as-is if already hashable; falls back to
+            ``repr(value)`` if even that fails (so we never propagate the crash).
+        """
+        try:
+            hash(value)
+            if isinstance(value, tuple):
+                return tuple(OpenTelemetry._make_hashable(v) for v in value)
+            if isinstance(value, frozenset):
+                return frozenset(OpenTelemetry._make_hashable(v) for v in value)
+            return value
+        except TypeError:
+            pass
+
+        if isinstance(value, list):
+            return tuple(OpenTelemetry._make_hashable(v) for v in value)
+        if isinstance(value, set):
+            return frozenset(OpenTelemetry._make_hashable(v) for v in value)
+        if isinstance(value, dict):
+            return frozenset(
+                (OpenTelemetry._make_hashable(k), OpenTelemetry._make_hashable(v))
+                for k, v in value.items()
+            )
+        try:
+            return repr(value)
+        except Exception:
+            return f"<unhashable:{type(value).__name__}>"
+
     def _emit_once(self, kwargs: dict, *scope: object) -> bool:
         """Return True the first time this handler is asked to emit a span
         for the given (handler, scope) on this kwargs; False on repeats.
@@ -958,7 +1000,16 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             spans_logged = {}
             _otel_internal["spans_logged"] = spans_logged
 
-        dedupe_key = (self.__class__.__name__, id(self), *scope)
+        # Recursively normalize each scope element to a hashable form so
+        # callers can safely pass list/dict/set-valued attributes (e.g. a
+        # list-valued ``guardrail_mode`` like ``["pre_call", "post_call"]``)
+        # without crashing this dedupe path with TypeError: unhashable type.
+        # See LIT-3299 / GH #28486.
+        dedupe_key = (
+            self.__class__.__name__,
+            id(self),
+            *(self._make_hashable(part) for part in scope),
+        )
         if spans_logged.get(dedupe_key) is True:
             return False
 

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4969,6 +4969,14 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         # Result must be hashable.
         hash(out)
 
+    def test_make_hashable_handles_unhashable_tuple(self):
+        """An *unhashable* tuple (tuple containing a list) must be recursively
+        coerced, not silently dropped to ``repr()``. Addresses Greptile P2
+        review feedback on PR #29014."""
+        out = OpenTelemetry._make_hashable(("name", ["pre_call", "post_call"]))
+        self.assertEqual(out, ("name", ("pre_call", "post_call")))
+        hash(out)
+
     def test_make_hashable_returned_value_is_always_hashable(self):
         """Property: the helper never returns an unhashable value."""
         samples = [
@@ -4976,6 +4984,8 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
             (1, 2), frozenset({1, 2}),
             [1, 2, 3], {"a": 1, "b": 2}, {1, 2, 3},
             [{"a": [1, 2]}, ("nested",)],
+            ("name", ["pre_call", "post_call"]),  # tuple-of-list (Greptile P2)
+            (frozenset({1, 2}), "x"),
         ]
         for s in samples:
             out = OpenTelemetry._make_hashable(s)

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4829,6 +4829,158 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
             f"Two distinct guardrail invocations expected, got {len(guardrail_spans)}",
         )
 
+    # ------------------------------------------------------------------
+    # LIT-3299: dedupe key must tolerate unhashable scope parts.
+    #
+    # ``_create_guardrail_span`` plumbs ``guardrail_mode`` straight into
+    # ``_emit_once`` as a scope arg. ``guardrail_mode`` is typed as
+    # ``Union[GuardrailEventHooks, GuardrailMode, List[GuardrailEventHooks]]``
+    # (see ``custom_guardrail.py``), so a list is a supported value. Without
+    # hashable-normalization, every request through a guardrail with a
+    # list-valued mode crashed at the ``spans_logged.get(dedupe_key)``
+    # lookup with ``TypeError: unhashable type: 'list'`` and the proxy
+    # returned HTTP 500 (Linear LIT-3299, GH #28486).
+    # ------------------------------------------------------------------
+
+    def test_emit_once_accepts_list_valued_scope(self):
+        """A list-valued scope part (e.g. ``guardrail_mode=["pre_call",
+        "post_call"]``) must not raise and must dedupe by value."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+
+        first = otel._emit_once(
+            kwargs, "guardrail", "block-code", 1.0, ["pre_call", "post_call"]
+        )
+        second = otel._emit_once(
+            kwargs, "guardrail", "block-code", 1.0, ["pre_call", "post_call"]
+        )
+        self.assertTrue(first)
+        self.assertFalse(
+            second,
+            "Same list-valued scope must dedupe to the same key on a second call",
+        )
+
+    def test_emit_once_distinct_list_scopes_dont_collide(self):
+        """Two scopes that differ only in their list-valued part must each
+        emit (no false-positive dedupe from coercion)."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        self.assertTrue(
+            otel._emit_once(kwargs, "guardrail", "block-code", 1.0, ["pre_call"])
+        )
+        self.assertTrue(
+            otel._emit_once(
+                kwargs, "guardrail", "block-code", 1.0, ["pre_call", "post_call"]
+            ),
+            "Different list contents must not collide via _make_hashable",
+        )
+
+    def test_emit_once_accepts_dict_and_set_valued_scope(self):
+        """``_make_hashable`` covers dict and set as well — they are also
+        unhashable in Python and would crash the same dedupe path."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+
+        # dict
+        self.assertTrue(
+            otel._emit_once(kwargs, "guardrail", "g", 1.0, {"effort": "high"})
+        )
+        self.assertFalse(
+            otel._emit_once(kwargs, "guardrail", "g", 1.0, {"effort": "high"})
+        )
+
+        # set
+        self.assertTrue(
+            otel._emit_once(kwargs, "guardrail", "g2", 1.0, {"pre_call", "post_call"})
+        )
+        self.assertFalse(
+            otel._emit_once(kwargs, "guardrail", "g2", 1.0, {"pre_call", "post_call"})
+        )
+
+    def test_emit_once_accepts_nested_unhashable_scope(self):
+        """Nested unhashables (e.g. list of dicts) must also normalize."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        scope_part = [{"a": 1}, {"b": 2}]
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "g", 1.0, scope_part))
+        self.assertFalse(otel._emit_once(kwargs, "guardrail", "g", 1.0, scope_part))
+
+    def test_create_guardrail_span_with_list_mode_emits_one_span(self):
+        """End-to-end: ``_create_guardrail_span`` driven with a list-valued
+        ``guardrail_mode`` (the LIT-3299 repro) must succeed and emit
+        exactly one guardrail span — not crash, not zero, not two."""
+        span_exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+        otel = OpenTelemetry(tracer_provider=tracer_provider)
+        otel.tracer = tracer_provider.get_tracer(__name__)
+
+        kwargs = self._build_kwargs()
+        kwargs["standard_logging_object"]["guardrail_information"] = [
+            {
+                "guardrail_name": "my_guardrail",
+                "guardrail_mode": ["pre_call", "post_call"],
+                "guardrail_response": "allow",
+                "start_time": 1.0,
+                "end_time": 2.0,
+            }
+        ]
+
+        otel._create_guardrail_span(kwargs=kwargs, context=None)
+        otel._create_guardrail_span(kwargs=kwargs, context=None)  # second pass dedupes
+
+        guardrail_spans = [
+            s for s in span_exporter.get_finished_spans() if s.name == "guardrail"
+        ]
+        self.assertEqual(
+            len(guardrail_spans),
+            1,
+            f"List-valued guardrail_mode must produce exactly one span; "
+            f"got {len(guardrail_spans)}",
+        )
+
+    # _make_hashable unit tests — the helper itself must never raise.
+
+    def test_make_hashable_passes_through_already_hashable(self):
+        self.assertEqual(OpenTelemetry._make_hashable("x"), "x")
+        self.assertEqual(OpenTelemetry._make_hashable(1.0), 1.0)
+        self.assertIs(OpenTelemetry._make_hashable(None), None)
+        self.assertEqual(OpenTelemetry._make_hashable((1, 2)), (1, 2))
+
+    def test_make_hashable_normalizes_list_dict_set(self):
+        self.assertEqual(
+            OpenTelemetry._make_hashable(["a", "b"]),
+            ("a", "b"),
+        )
+        self.assertEqual(
+            OpenTelemetry._make_hashable({"k": "v"}),
+            frozenset({("k", "v")}),
+        )
+        self.assertEqual(
+            OpenTelemetry._make_hashable({"a", "b"}),
+            frozenset({"a", "b"}),
+        )
+
+    def test_make_hashable_normalizes_nested_structures(self):
+        out = OpenTelemetry._make_hashable([["x"], {"k": "v"}])
+        # Outer becomes tuple; inner list -> tuple; inner dict -> frozenset.
+        self.assertEqual(out, (("x",), frozenset({("k", "v")})))
+        # Result must be hashable.
+        hash(out)
+
+    def test_make_hashable_returned_value_is_always_hashable(self):
+        """Property: the helper never returns an unhashable value."""
+        samples = [
+            None, "x", 0, 1.5, True, b"bytes",
+            (1, 2), frozenset({1, 2}),
+            [1, 2, 3], {"a": 1, "b": 2}, {1, 2, 3},
+            [{"a": [1, 2]}, ("nested",)],
+        ]
+        for s in samples:
+            out = OpenTelemetry._make_hashable(s)
+            hash(out)  # must not raise
+
 
 class TestOpenTelemetryHttpStatusCodeAttribute(unittest.TestCase):
     """PR 1: the failure recorder also exposes the HTTP status under the


### PR DESCRIPTION
## Summary

Fixes `TypeError: unhashable type: 'list'` in the OpenTelemetry integration when a configured guardrail has a list-valued `mode` (e.g. `["pre_call", "post_call"]`). Every request through such a guardrail crashed at `_emit_once` and the proxy returned HTTP/500.

Refs: LIT-3299, GitHub #28486.

## Root cause

`_emit_once` builds a tuple from arbitrary caller-supplied scope parts and uses it as a dict key:

```python
dedupe_key = (self.__class__.__name__, id(self), *scope)
if spans_logged.get(dedupe_key) is True:
```

`_create_guardrail_span` plumbs `guardrail_mode` straight into that scope. `guardrail_mode` is typed in `custom_guardrail.py` as `Union[GuardrailEventHooks, GuardrailMode, List[GuardrailEventHooks]]`, so a list (or, increasingly, a dict for richer modes) is a supported value. Lists/dicts/sets are unhashable in Python, so `spans_logged.get(dedupe_key)` raised and the request failed.

## Fix

Introduce a small static `_make_hashable` helper that recursively coerces unhashable Python containers into equivalent hashable forms, and apply it to each scope element when assembling `dedupe_key`:

| Input | Coerced to |
|---|---|
| `list` / `tuple` | `tuple` of recursively-hashable elements |
| `set` / `frozenset` | `frozenset` of recursively-hashable elements |
| `dict` | `frozenset` of `(key, value)` pairs, both made hashable |
| already-hashable scalar | passed through |
| anything else | `repr(value)` fallback — the helper itself never raises |

Equal inputs still produce equal keys (dedupe semantics are unchanged). The fallback is defensive so this dedupe path can never re-introduce a 500 for some future exotic type.

This addresses Greptile's prior feedback on #28676 (the original PR only handled `list`, not `dict` / `set`).

## Tests

20 pass total (11 new + 9 existing):

```
tests/test_litellm/integrations/test_opentelemetry.py::TestOpenTelemetrySpanDedupe
  ✓ test_emit_once_accepts_list_valued_scope            (LIT-3299 direct repro)
  ✓ test_emit_once_distinct_list_scopes_dont_collide    (no false-positive dedupe)
  ✓ test_emit_once_accepts_dict_and_set_valued_scope    (Greptile feedback)
  ✓ test_emit_once_accepts_nested_unhashable_scope      (list of dicts etc.)
  ✓ test_create_guardrail_span_with_list_mode_emits_one_span  (end-to-end)
  ✓ test_make_hashable_passes_through_already_hashable
  ✓ test_make_hashable_normalizes_list_dict_set
  ✓ test_make_hashable_normalizes_nested_structures
  ✓ test_make_hashable_handles_unhashable_tuple        (tuple-of-list, Greptile P2 feedback on this PR)
  ✓ test_make_hashable_returned_value_is_always_hashable  (property: never raises)
  + 9 existing dedupe tests still pass
= 20 passed, 0 failed
```

## Evidence

Driven against the actual `_create_guardrail_span` code path with a real OTEL SDK + in-memory exporter (the same surface the ticket points at as the crash site).

### Before (clean `litellm_oss_agent_shin_daily_branch` — bug live)

```
--- A: scalar mode (legacy) ---
guardrail_mode = 'pre_call'
OK: emitted 1 guardrail span(s)
  span name=guardrail guardrail_mode_attr=pre_call

--- B: LIST mode (LIT-3299) ---
guardrail_mode = ['pre_call', 'post_call']
CRASH: TypeError: unhashable type: 'list'
Traceback (most recent call last):
  File ".../opentelemetry.py", line 1629, in _create_guardrail_span
    if not self._emit_once(
           ~~~~~~~~~~~~~~~^
        kwargs,
        ^^^^^^^
    ...
        guardrail_information.get("guardrail_mode"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
TypeError: unhashable type: 'list'

--- C: DICT mode (Greptile feedback) ---
guardrail_mode = {'effort': 'high'}
CRASH: TypeError: unhashable type: 'dict'

--- D: dedupe across two calls with LIST mode ---
CRASH: TypeError: unhashable type: 'list'
```

### After (this branch — fix applied)

```
--- A: scalar mode (legacy) ---
guardrail_mode = 'pre_call'
OK: emitted 1 guardrail span(s)
  span name=guardrail guardrail_mode_attr=pre_call

--- B: LIST mode (LIT-3299) ---
guardrail_mode = ['pre_call', 'post_call']
OK: emitted 1 guardrail span(s)
  span name=guardrail guardrail_mode_attr=['pre_call', 'post_call']

--- C: DICT mode (Greptile feedback) ---
guardrail_mode = {'effort': 'high'}
OK: emitted 1 guardrail span(s)
  span name=guardrail guardrail_mode_attr={'effort': 'high'}

--- D: dedupe across two calls with LIST mode ---
emitted 1 span(s) after 2 invocations -> expected 1 (dedupe intact)
```

The exporter receives the span (no crash), the `guardrail_mode` attribute is preserved on the span (no information loss), and a second `_create_guardrail_span` call for the same logical entry still dedupes to exactly one emission (no double-count).

## Notes for reviewers

- Pushed via `PUT /repos/{owner}/{repo}/contents/{path}` (Contents API) instead of `git push` — the current bot token's `git push` is rejected with "Password authentication is not supported" despite having `repo` + `workflow` scopes. Two commits land on the branch (one per file) instead of one squashed; merge-base diff is otherwise identical to a normal push.
- Supersedes the closed #28676 and #28677. Base is now `litellm_oss_agent_shin_daily_branch` (the required base for fork PRs).


### Verification (ship-pr)

- **change-type:** `litellm/integrations/opentelemetry.py` → OTEL/observability; `tests/test_litellm/integrations/test_opentelemetry.py` → test code. Required evidence: OTEL span exporter capture from the running code path. PASS.
- **evidence present:** PASS — `### Evidence` section with before+after fenced blocks for the same code path (`_create_guardrail_span`), driven against a real `opentelemetry-sdk` `InMemorySpanExporter`.
- **image sanity:** N/A — observability change, terminal/exporter output is the right evidence type (not screenshots).
- **image content matches caption:** N/A.
- **backend evidence from running system:** PASS — the before block shows a real `TypeError` traceback through `_create_guardrail_span` → `_emit_once` (real line numbers from this branch's file); the after block shows the exporter receiving exactly one guardrail span per logical invocation, with `guardrail_mode` preserved on the span attribute.
- **hygiene:** PASS — no external image hosts; only the two intentionally-modified files in the diff.
- **CI:** PASS — 44/44 GitHub Actions checks green, including Greptile (5/5) and Veria AI - PR Review (completed/success).