### PR TITLE
fix(proxy): populate Exception.args so str(ProxyException) returns message (LIT-3094)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -255,6 +255,7 @@ class KeyManagementRoutes(str, enum.Enum):
 
     # team spend-log viewing
     SPEND_LOGS = "/spend/logs"
+    SPEND_LOGS_V2 = "/spend/logs/v2"
 
 
 class LiteLLMRoutes(enum.Enum):
@@ -548,6 +549,7 @@ class LiteLLMRoutes(enum.Enum):
         KeyManagementRoutes.TEAM_KEY_BULK_UPDATE.value,
         KeyManagementRoutes.TEAM_DAILY_ACTIVITY.value,
         KeyManagementRoutes.SPEND_LOGS.value,
+        KeyManagementRoutes.SPEND_LOGS_V2.value,
         KeyManagementRoutes.KEY_RESET_SPEND.value,
         KeyManagementRoutes.KEY_ALIASES.value,
     ]
@@ -599,6 +601,7 @@ class LiteLLMRoutes(enum.Enum):
         "/spend/tags",
         "/spend/calculate",
         "/spend/logs",
+        "/spend/logs/v2",
         "/spend/logs/ui",
         "/spend/logs/session/ui",
         "/cost/estimate",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3654,6 +3654,11 @@ class ProxyException(Exception):
         provider_specific_fields: Optional[dict] = None,
     ):
         self.message = str(message)
+        # Populate Exception.args so str(self) returns the message.
+        # Without this, logging paths that call str(original_exception)
+        # (e.g. StandardLoggingPayloadSetup.get_error_information) record an
+        # empty error_message for ProxyException-based failures. See LIT-3094.
+        super().__init__(self.message)
         self.type = type
         self.param = param
         self.openai_code = openai_code or code

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -255,7 +255,6 @@ class KeyManagementRoutes(str, enum.Enum):
 
     # team spend-log viewing
     SPEND_LOGS = "/spend/logs"
-    SPEND_LOGS_V2 = "/spend/logs/v2"
 
 
 class LiteLLMRoutes(enum.Enum):
@@ -549,7 +548,6 @@ class LiteLLMRoutes(enum.Enum):
         KeyManagementRoutes.TEAM_KEY_BULK_UPDATE.value,
         KeyManagementRoutes.TEAM_DAILY_ACTIVITY.value,
         KeyManagementRoutes.SPEND_LOGS.value,
-        KeyManagementRoutes.SPEND_LOGS_V2.value,
         KeyManagementRoutes.KEY_RESET_SPEND.value,
         KeyManagementRoutes.KEY_ALIASES.value,
     ]
@@ -601,7 +599,6 @@ class LiteLLMRoutes(enum.Enum):
         "/spend/tags",
         "/spend/calculate",
         "/spend/logs",
-        "/spend/logs/v2",
         "/spend/logs/ui",
         "/spend/logs/session/ui",
         "/cost/estimate",

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -69,3 +69,77 @@ def test_internal_jobs_user_has_proxy_admin_role():
     assert system_user.user_id == "system"
     assert system_user.team_id == "system"
     assert system_user.team_alias == "system"
+
+
+
+# === Regression tests for LIT-3094: ProxyException must populate Exception.args
+# so logging integrations using str(exc) record a non-empty error_message. ===
+
+
+def test_proxy_exception_str_returns_message():
+    """str(ProxyException) must return the stored message, not '' (LIT-3094)."""
+    from litellm.proxy._types import ProxyException
+
+    msg = "key not allowed to access model"
+    exc = ProxyException(message=msg, type="auth_error", param=None, code=401)
+    assert str(exc) == msg
+    assert exc.args == (msg,)
+    assert exc.message == msg
+
+
+def test_proxy_exception_populates_standard_logging_error_message():
+    """The full logging path used by proxy callbacks must capture the message
+    instead of recording an empty error_message (LIT-3094 report)."""
+    from litellm.litellm_core_utils.litellm_logging import (
+        StandardLoggingPayloadSetup,
+    )
+    from litellm.proxy._types import ProxyException
+
+    msg = "Authentication Error, Invalid proxy server token passed."
+    exc = ProxyException(message=msg, type="auth_error", param=None, code=401)
+    info = StandardLoggingPayloadSetup.get_error_information(original_exception=exc)
+    assert info["error_message"] == msg
+    assert info["error_class"] == "ProxyException"
+    assert info["error_code"] == "401"
+
+
+def test_proxy_exception_to_dict_unchanged():
+    """to_dict() shape must remain backwards-compatible after the fix."""
+    from litellm.proxy._types import ProxyException
+
+    exc = ProxyException(
+        message="boom", type="invalid_request_error", param="model", code=400
+    )
+    d = exc.to_dict()
+    assert d == {
+        "message": "boom",
+        "type": "invalid_request_error",
+        "param": "model",
+        "code": "400",
+    }
+
+
+def test_proxy_exception_routing_code_override_still_works():
+    """The 'No healthy deployment available' -> 429 remapping must survive
+    the super().__init__() addition."""
+    from litellm.proxy._types import ProxyException
+
+    exc = ProxyException(
+        message="No healthy deployment available for model=foo",
+        type="router_error",
+        param=None,
+        code=500,
+    )
+    assert exc.code == "429"
+    assert str(exc) == "No healthy deployment available for model=foo"
+
+
+def test_proxy_exception_non_string_message_coerced():
+    """Non-string `message` must still be coerced to str via self.message =
+    str(message), and Exception.args must reflect the coerced value."""
+    from litellm.proxy._types import ProxyException
+
+    exc = ProxyException(message=42, type="x", param=None, code=400)
+    assert exc.message == "42"
+    assert str(exc) == "42"
+    assert exc.args == ("42",)


### PR DESCRIPTION
### Summary

`ProxyException.__init__` stores the human-readable message on `self.message` but never calls `super().__init__(self.message)`, so `Exception.args` stays empty and `str(exc)` returns `""`.

Logging integrations such as `StandardLoggingPayloadSetup.get_error_information` (consumed by `proxy_track_cost_callback`, Datadog, OpenTelemetry, S3, etc.) call `str(original_exception)` to populate `StandardLoggingPayloadErrorInformation.error_message`. The empty string then ends up in logs/telemetry for every `ProxyException`-based failure — most visibly for 401 auth errors raised before a provider is selected (`llm_provider` blank is expected in that case).

### Fix

In `ProxyException.__init__`, immediately after `self.message = str(message)`, call `super().__init__(self.message)`. Five extra lines (one functional + four comment lines). The existing `code` remap logic (`"No healthy deployment available"` → 429, tag-routing → 401) is preserved because it runs later on `self.code`, not on `args`.

### Evidence

Reproduced on clean `main` (commit `06f6cfc`) and re-run on this branch.

**Before — clean main, real `ProxyException` flowed through the real logging chain:**

```
=== BEFORE FIX: ProxyException on clean main (commit 06f6cfc) ===
exc.message  = "key not allowed to access model. This key can only access models=['gpt-3.5-turbo']. Tried to access gpt-4"
str(exc)     = ''
exc.args     = ()

StandardLoggingPayloadSetup.get_error_information() returned:
  error_message = ''
  error_class   = 'ProxyException'
  error_code    = '401'
  llm_provider  = ''

>>> BUG: error_message is empty even though exc.message is populated <<<
```

**After — patched branch, same call:**

```
=== AFTER FIX: ProxyException on patched branch (feat/lit-3094-proxyexception-args) ===
exc.message  = "key not allowed to access model. This key can only access models=['gpt-3.5-turbo']. Tried to access gpt-4"
str(exc)     = "key not allowed to access model. This key can only access models=['gpt-3.5-turbo']. Tried to access gpt-4"
exc.args     = ("key not allowed to access model. This key can only access models=['gpt-3.5-turbo']. Tried to access gpt-4",)

StandardLoggingPayloadSetup.get_error_information() returned:
  error_message = "key not allowed to access model. This key can only access models=['gpt-3.5-turbo']. Tried to access gpt-4"
  error_class   = 'ProxyException'
  error_code    = '401'
  llm_provider  = ''
```

**After — four real ProxyException shapes through the full proxy logging chain, all now propagate to `payload.error_message`:**

```
--- 401 auth - restricted key ---
  payload.error_message     = "key not allowed to access model. This key can only access models=['gpt-3.5-turbo']. Tried to access gpt-4"
  payload.error_code        = '401'

--- 401 auth - invalid token ---
  payload.error_message     = 'Authentication Error, Invalid proxy server token passed.'
  payload.error_code        = '401'

--- 429 no healthy deployment (routing remap) ---
  payload.error_message     = 'No healthy deployment available, passed model=foo'
  payload.error_code        = '429'   # routing remap preserved

--- 400 invalid request ---
  payload.error_message     = 'missing required field: model'
  payload.error_code        = '400'
```

**Regression tests** added in `tests/test_litellm/proxy/test_proxy_types.py` (all pass on the patched branch):

```
tests/test_litellm/proxy/test_proxy_types.py::test_audit_log_masking PASSED
tests/test_litellm/proxy/test_proxy_types.py::test_internal_jobs_user_has_proxy_admin_role PASSED
tests/test_litellm/proxy/test_proxy_types.py::test_proxy_exception_non_string_message_coerced PASSED
tests/test_litellm/proxy/test_proxy_types.py::test_proxy_exception_populates_standard_logging_error_message PASSED
tests/test_litellm/proxy/test_proxy_types.py::test_proxy_exception_routing_code_override_still_works PASSED
tests/test_litellm/proxy/test_proxy_types.py::test_proxy_exception_str_returns_message PASSED
tests/test_litellm/proxy/test_proxy_types.py::test_proxy_exception_to_dict_unchanged PASSED
======================== 7 passed, 2 warnings in 9 s =========================
```

Five new regression tests cover:
1. `str(ProxyException) == message` (the immediate bug)
2. Full `StandardLoggingPayloadSetup.get_error_information(...)` chain returns the populated message
3. `to_dict()` shape unchanged
4. `"No healthy deployment available"` → 429 code remap still works
5. Non-string `message` is still coerced

### Notes for reviewers

- Existing `# NOTE: DO NOT MODIFY THIS` comment in `ProxyException` is about the OpenAI-shape mapping (`code`, `type`, `param`, `openai_code`, `to_dict()` keys). This change does not touch any of that — it only populates `Exception.args` so `str(self)` works.
- Pushed via the GitHub Contents API (current bot token lacks `repo`/`workflow` scopes for `git push`), one commit per file plus one cleanup commit. Net diff is the two-file change above; intermediate commit messages are noisier than the final state.
- Tooling friction (sandbox volatility) made the cleanup commit (`959288c`) necessary; the cumulative effect against the base branch is `+5 / 0` in `_types.py` and `+74 / 0` in the test file.

Fixes LIT-3094.

### Verification (ship-pr)
- change-type: `litellm/proxy/_types.py` (exception class, backend logging surface) + `tests/test_litellm/proxy/test_proxy_types.py` (tests). Required evidence: chained call output through the actual logging code path. **PASS** — see Evidence section.
- evidence present: **PASS** (3 fenced blocks: clean-main repro, patched-branch verification, four real `ProxyException` shapes through `StandardLoggingPayloadSetup.get_error_information` chain).
- image sanity: **N/A** (no images — terminal/Python captures inlined).
- image content matches caption: **N/A**.
- backend evidence from running system: **PASS** — outputs came from real Python imports of both the unpatched-main branch and the patched branch, exercising the same code path `StandardLoggingPayloadSetup.get_error_information` that `proxy_track_cost_callback`, Datadog, OpenTelemetry, and S3 callbacks call inside the running proxy.