### PR TITLE
fix(otel): normalize unhashable scope in _emit_once (LIT-3299)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -928,7 +928,10 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         unhashable type: 'list'`` (returning HTTP 500).
 
         Conversions:
-          - ``list``                -> ``tuple``     (preserves order)
+          - ``list``                -> ``tuple``     (preserves order, recursive)
+          - ``tuple``               -> ``tuple``     (recursive, in case any
+                                                      element is itself
+                                                      unhashable e.g. a list)
           - ``set`` / ``frozenset`` -> ``frozenset`` (order-independent)
           - ``dict``                -> ``tuple`` of ``(key, value)`` pairs
                                       sorted by ``repr(key)`` so equivalent
@@ -937,7 +940,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                                       normalize without crashing.
           - everything else         -> returned unchanged (already-hashable
                                       scalars: ``None``, ``str``, ``int``,
-                                      ``float``, ``bool``, ``tuple``, ...).
+                                      ``float``, ``bool``, ...).
 
         The conversion is structural and equality-preserving for the common
         case (``list`` and its equivalent ``tuple`` collapse to the same
@@ -945,15 +948,17 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         """
         if isinstance(value, list):
             return tuple(OpenTelemetry._make_hashable(v) for v in value)
+        if isinstance(value, tuple):
+            # Tuples are already hashable iff every element is hashable; a
+            # tuple containing e.g. a list would still fail. Normalize each
+            # element so a tuple-of-lists is also safe.
+            return tuple(OpenTelemetry._make_hashable(v) for v in value)
         if isinstance(value, (set, frozenset)):
             return frozenset(OpenTelemetry._make_hashable(v) for v in value)
         if isinstance(value, dict):
             return tuple(
                 sorted(
-                    (
-                        (k, OpenTelemetry._make_hashable(v))
-                        for k, v in value.items()
-                    ),
+                    ((k, OpenTelemetry._make_hashable(v)) for k, v in value.items()),
                     key=lambda kv: repr(kv[0]),
                 )
             )

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -916,6 +916,49 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     # End of Team/Key Based Logging Control Flow
     #########################################################
 
+    @staticmethod
+    def _make_hashable(value):
+        """Recursively convert a scope element into a hashable form.
+
+        Used by :meth:`_emit_once` because callers pass scope elements that
+        come from user-supplied config (e.g. ``guardrail_mode`` which users
+        can configure as a list like ``["pre_call", "post_call"]``). Without
+        this normalization the resulting ``dedupe_key`` tuple contains an
+        unhashable element and ``spans_logged.get(...)`` raises ``TypeError:
+        unhashable type: 'list'`` (returning HTTP 500).
+
+        Conversions:
+          - ``list``                -> ``tuple``     (preserves order)
+          - ``set`` / ``frozenset`` -> ``frozenset`` (order-independent)
+          - ``dict``                -> ``tuple`` of ``(key, value)`` pairs
+                                      sorted by ``repr(key)`` so equivalent
+                                      dicts hash the same and dicts with
+                                      mixed-type / non-comparable keys still
+                                      normalize without crashing.
+          - everything else         -> returned unchanged (already-hashable
+                                      scalars: ``None``, ``str``, ``int``,
+                                      ``float``, ``bool``, ``tuple``, ...).
+
+        The conversion is structural and equality-preserving for the common
+        case (``list`` and its equivalent ``tuple`` collapse to the same
+        dedupe slot), so existing dedupe semantics are unchanged.
+        """
+        if isinstance(value, list):
+            return tuple(OpenTelemetry._make_hashable(v) for v in value)
+        if isinstance(value, (set, frozenset)):
+            return frozenset(OpenTelemetry._make_hashable(v) for v in value)
+        if isinstance(value, dict):
+            return tuple(
+                sorted(
+                    (
+                        (k, OpenTelemetry._make_hashable(v))
+                        for k, v in value.items()
+                    ),
+                    key=lambda kv: repr(kv[0]),
+                )
+            )
+        return value
+
     def _emit_once(self, kwargs: dict, *scope: object) -> bool:
         """Return True the first time this handler is asked to emit a span
         for the given (handler, scope) on this kwargs; False on repeats.
@@ -958,7 +1001,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             spans_logged = {}
             _otel_internal["spans_logged"] = spans_logged
 
-        dedupe_key = (self.__class__.__name__, id(self), *scope)
+        dedupe_key = (
+            self.__class__.__name__,
+            id(self),
+            *(self._make_hashable(s) for s in scope),
+        )
         if spans_logged.get(dedupe_key) is True:
             return False
 

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5142,3 +5142,127 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
         span, exp = self._span()
         otel.set_preprocessing_duration_attribute(span, None)
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
+
+
+# ---------------------------------------------------------------------------
+# LIT-3299: _emit_once must accept list/dict/set scope elements without crashing
+# ---------------------------------------------------------------------------
+
+import pytest as _lit_3299_pytest
+
+
+@_lit_3299_pytest.fixture
+def lit_3299_otel_handler():
+    """Build a real OpenTelemetry handler with span emission disabled.
+
+    Constructed via the real OpenTelemetry class so the test exercises the
+    actual ``_emit_once`` / ``_make_hashable`` path, not a stub.
+    """
+    from unittest.mock import patch
+    from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
+
+    with patch.object(OpenTelemetry, "_init_otel_logger_on_litellm_proxy"):
+        return OpenTelemetry(config=OpenTelemetryConfig(exporter="console"))
+
+
+def test_lit_3299_emit_once_handles_list_guardrail_mode(lit_3299_otel_handler):
+    """LIT-3299: a list-valued guardrail_mode in scope must not crash.
+
+    Before the fix this raised ``TypeError: unhashable type: 'list'`` at
+    ``spans_logged.get(dedupe_key)``, returning HTTP 500 from the proxy.
+    """
+    kwargs: dict = {}
+    assert lit_3299_otel_handler._emit_once(
+        kwargs, "guardrail", "my-guardrail", 1.0, ["pre_call", "post_call"],
+    ) is True
+    assert lit_3299_otel_handler._emit_once(
+        kwargs, "guardrail", "my-guardrail", 1.0, ["pre_call", "post_call"],
+    ) is False
+
+
+def test_lit_3299_list_and_tuple_collapse_to_same_slot(lit_3299_otel_handler):
+    """list and its equivalent tuple must dedupe to the same key.
+
+    Without this guarantee a single guardrail invocation whose ``mode``
+    varies in container type between calls would emit two spans rather
+    than one.
+    """
+    kwargs: dict = {}
+    assert lit_3299_otel_handler._emit_once(
+        kwargs, "guardrail", "g1", 1.0, ["pre_call", "post_call"]
+    ) is True
+    assert lit_3299_otel_handler._emit_once(
+        kwargs, "guardrail", "g1", 1.0, ("pre_call", "post_call")
+    ) is False
+
+
+def test_lit_3299_handles_nested_list(lit_3299_otel_handler):
+    """Nested list of lists must also normalize (defensive)."""
+    kwargs: dict = {}
+    assert lit_3299_otel_handler._emit_once(kwargs, [["a", "b"], "c"]) is True
+    assert lit_3299_otel_handler._emit_once(kwargs, [["a", "b"], "c"]) is False
+
+
+def test_lit_3299_handles_dict_scope(lit_3299_otel_handler):
+    """dict-valued scope element (e.g. arbitrary metadata) must not crash."""
+    kwargs: dict = {}
+    assert lit_3299_otel_handler._emit_once(kwargs, {"k": "v", "m": ["x", "y"]}) is True
+    # Equivalent dict (different insertion order) collapses to same slot.
+    assert lit_3299_otel_handler._emit_once(kwargs, {"m": ["x", "y"], "k": "v"}) is False
+
+
+def test_lit_3299_handles_set_scope(lit_3299_otel_handler):
+    """set-valued scope element must not crash and is order-independent."""
+    kwargs: dict = {}
+    assert lit_3299_otel_handler._emit_once(kwargs, {"pre_call", "post_call"}) is True
+    assert lit_3299_otel_handler._emit_once(kwargs, {"post_call", "pre_call"}) is False
+
+
+def test_lit_3299_make_hashable_returns_scalars_unchanged():
+    """Already-hashable scalars pass through untouched."""
+    from litellm.integrations.opentelemetry import OpenTelemetry as O
+    for v in (None, "x", 1, 1.5, True, ("a", "b"), b"bytes"):
+        assert O._make_hashable(v) == v
+
+
+def test_lit_3299_make_hashable_list_to_tuple():
+    """list -> tuple with element order preserved and recursive."""
+    from litellm.integrations.opentelemetry import OpenTelemetry as O
+    assert O._make_hashable(["a", "b"]) == ("a", "b")
+    assert O._make_hashable([["a", "b"], "c"]) == (("a", "b"), "c")
+
+
+def test_lit_3299_make_hashable_dict_to_sorted_pairs():
+    """dict -> tuple of (k, normalized v) pairs sorted by repr(k)."""
+    from litellm.integrations.opentelemetry import OpenTelemetry as O
+    assert O._make_hashable({"b": 2, "a": 1}) == (("a", 1), ("b", 2))
+    assert O._make_hashable({"a": ["x", "y"]}) == (("a", ("x", "y")),)
+
+
+def test_lit_3299_make_hashable_dict_with_mixed_type_keys():
+    """Defensive: dict with non-comparable mixed-type keys still normalizes.
+
+    A plain ``sorted(dict.items())`` would raise on Python 3 because str/int
+    aren't orderable. We sort by ``repr(key)`` instead so this path is
+    always safe.
+    """
+    from litellm.integrations.opentelemetry import OpenTelemetry as O
+    out = O._make_hashable({1: "a", "2": "b"})
+    assert isinstance(out, tuple)
+    {out: True}  # hashable -> usable as dict key
+
+
+def test_lit_3299_make_hashable_set_to_frozenset():
+    """set -> frozenset; order-independent and hashable."""
+    from litellm.integrations.opentelemetry import OpenTelemetry as O
+    assert O._make_hashable({"a", "b"}) == frozenset({"a", "b"})
+    assert O._make_hashable(frozenset({"a", "b"})) == frozenset({"a", "b"})
+
+
+def test_lit_3299_distinguishes_different_list_modes(lit_3299_otel_handler):
+    """Sanity: two different list-valued modes must NOT collapse to one slot."""
+    kwargs: dict = {}
+    assert lit_3299_otel_handler._emit_once(kwargs, "guardrail", "g", ["pre_call"]) is True
+    assert lit_3299_otel_handler._emit_once(
+        kwargs, "guardrail", "g", ["pre_call", "post_call"]
+    ) is True

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1,3 +1,4 @@
+import pytest
 import asyncio
 import json
 import os
@@ -5148,10 +5149,8 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
 # LIT-3299: _emit_once must accept list/dict/set scope elements without crashing
 # ---------------------------------------------------------------------------
 
-import pytest as _lit_3299_pytest
 
-
-@_lit_3299_pytest.fixture
+@pytest.fixture
 def lit_3299_otel_handler():
     """Build a real OpenTelemetry handler with span emission disabled.
 
@@ -5172,12 +5171,26 @@ def test_lit_3299_emit_once_handles_list_guardrail_mode(lit_3299_otel_handler):
     ``spans_logged.get(dedupe_key)``, returning HTTP 500 from the proxy.
     """
     kwargs: dict = {}
-    assert lit_3299_otel_handler._emit_once(
-        kwargs, "guardrail", "my-guardrail", 1.0, ["pre_call", "post_call"],
-    ) is True
-    assert lit_3299_otel_handler._emit_once(
-        kwargs, "guardrail", "my-guardrail", 1.0, ["pre_call", "post_call"],
-    ) is False
+    assert (
+        lit_3299_otel_handler._emit_once(
+            kwargs,
+            "guardrail",
+            "my-guardrail",
+            1.0,
+            ["pre_call", "post_call"],
+        )
+        is True
+    )
+    assert (
+        lit_3299_otel_handler._emit_once(
+            kwargs,
+            "guardrail",
+            "my-guardrail",
+            1.0,
+            ["pre_call", "post_call"],
+        )
+        is False
+    )
 
 
 def test_lit_3299_list_and_tuple_collapse_to_same_slot(lit_3299_otel_handler):
@@ -5188,12 +5201,18 @@ def test_lit_3299_list_and_tuple_collapse_to_same_slot(lit_3299_otel_handler):
     than one.
     """
     kwargs: dict = {}
-    assert lit_3299_otel_handler._emit_once(
-        kwargs, "guardrail", "g1", 1.0, ["pre_call", "post_call"]
-    ) is True
-    assert lit_3299_otel_handler._emit_once(
-        kwargs, "guardrail", "g1", 1.0, ("pre_call", "post_call")
-    ) is False
+    assert (
+        lit_3299_otel_handler._emit_once(
+            kwargs, "guardrail", "g1", 1.0, ["pre_call", "post_call"]
+        )
+        is True
+    )
+    assert (
+        lit_3299_otel_handler._emit_once(
+            kwargs, "guardrail", "g1", 1.0, ("pre_call", "post_call")
+        )
+        is False
+    )
 
 
 def test_lit_3299_handles_nested_list(lit_3299_otel_handler):
@@ -5208,7 +5227,9 @@ def test_lit_3299_handles_dict_scope(lit_3299_otel_handler):
     kwargs: dict = {}
     assert lit_3299_otel_handler._emit_once(kwargs, {"k": "v", "m": ["x", "y"]}) is True
     # Equivalent dict (different insertion order) collapses to same slot.
-    assert lit_3299_otel_handler._emit_once(kwargs, {"m": ["x", "y"], "k": "v"}) is False
+    assert (
+        lit_3299_otel_handler._emit_once(kwargs, {"m": ["x", "y"], "k": "v"}) is False
+    )
 
 
 def test_lit_3299_handles_set_scope(lit_3299_otel_handler):
@@ -5221,6 +5242,7 @@ def test_lit_3299_handles_set_scope(lit_3299_otel_handler):
 def test_lit_3299_make_hashable_returns_scalars_unchanged():
     """Already-hashable scalars pass through untouched."""
     from litellm.integrations.opentelemetry import OpenTelemetry as O
+
     for v in (None, "x", 1, 1.5, True, ("a", "b"), b"bytes"):
         assert O._make_hashable(v) == v
 
@@ -5228,6 +5250,7 @@ def test_lit_3299_make_hashable_returns_scalars_unchanged():
 def test_lit_3299_make_hashable_list_to_tuple():
     """list -> tuple with element order preserved and recursive."""
     from litellm.integrations.opentelemetry import OpenTelemetry as O
+
     assert O._make_hashable(["a", "b"]) == ("a", "b")
     assert O._make_hashable([["a", "b"], "c"]) == (("a", "b"), "c")
 
@@ -5235,6 +5258,7 @@ def test_lit_3299_make_hashable_list_to_tuple():
 def test_lit_3299_make_hashable_dict_to_sorted_pairs():
     """dict -> tuple of (k, normalized v) pairs sorted by repr(k)."""
     from litellm.integrations.opentelemetry import OpenTelemetry as O
+
     assert O._make_hashable({"b": 2, "a": 1}) == (("a", 1), ("b", 2))
     assert O._make_hashable({"a": ["x", "y"]}) == (("a", ("x", "y")),)
 
@@ -5247,6 +5271,7 @@ def test_lit_3299_make_hashable_dict_with_mixed_type_keys():
     always safe.
     """
     from litellm.integrations.opentelemetry import OpenTelemetry as O
+
     out = O._make_hashable({1: "a", "2": "b"})
     assert isinstance(out, tuple)
     {out: True}  # hashable -> usable as dict key
@@ -5255,6 +5280,7 @@ def test_lit_3299_make_hashable_dict_with_mixed_type_keys():
 def test_lit_3299_make_hashable_set_to_frozenset():
     """set -> frozenset; order-independent and hashable."""
     from litellm.integrations.opentelemetry import OpenTelemetry as O
+
     assert O._make_hashable({"a", "b"}) == frozenset({"a", "b"})
     assert O._make_hashable(frozenset({"a", "b"})) == frozenset({"a", "b"})
 
@@ -5262,7 +5288,38 @@ def test_lit_3299_make_hashable_set_to_frozenset():
 def test_lit_3299_distinguishes_different_list_modes(lit_3299_otel_handler):
     """Sanity: two different list-valued modes must NOT collapse to one slot."""
     kwargs: dict = {}
-    assert lit_3299_otel_handler._emit_once(kwargs, "guardrail", "g", ["pre_call"]) is True
-    assert lit_3299_otel_handler._emit_once(
-        kwargs, "guardrail", "g", ["pre_call", "post_call"]
-    ) is True
+    assert (
+        lit_3299_otel_handler._emit_once(kwargs, "guardrail", "g", ["pre_call"]) is True
+    )
+    assert (
+        lit_3299_otel_handler._emit_once(
+            kwargs, "guardrail", "g", ["pre_call", "post_call"]
+        )
+        is True
+    )
+
+
+def test_lit_3299_make_hashable_tuple_with_unhashable_element():
+    """Greptile P2 follow-up: a tuple whose elements are unhashable must
+    also normalize, not just top-level lists/dicts/sets."""
+    from litellm.integrations.opentelemetry import OpenTelemetry as O
+
+    # tuple-of-list -> tuple-of-tuple
+    assert O._make_hashable((["a", "b"], "c")) == (("a", "b"), "c")
+    # tuple-of-dict -> tuple-of-sorted-pairs
+    assert O._make_hashable(({"k": "v"},)) == ((("k", "v"),),)
+    # the result must itself be hashable
+    {O._make_hashable((["a"], {"b": "c"})): True}
+
+
+def test_lit_3299_emit_once_handles_tuple_with_inner_list(lit_3299_otel_handler):
+    """A tuple-of-list passed as a scope element must not crash _emit_once."""
+    kwargs: dict = {}
+    assert (
+        lit_3299_otel_handler._emit_once(kwargs, "guardrail", "g", (["a", "b"], "c"))
+        is True
+    )
+    assert (
+        lit_3299_otel_handler._emit_once(kwargs, "guardrail", "g", (["a", "b"], "c"))
+        is False
+    )


### PR DESCRIPTION
## What

Fix `TypeError: unhashable type: 'list'` (HTTP 500) in `OpenTelemetry._emit_once`
when a guardrail is configured with a list-valued `mode`
(e.g. `["pre_call", "post_call"]`).

Closes [LIT-3299](https://linear.app/litellm-ai/issue/LIT-3299). Original
GitHub issue: #28486. Prior PRs (#28676, #28677) targeted `main` and were
closed; this one targets `litellm_oss_agent_shin_daily_branch` as required.

## Why it crashed

`_emit_once` builds a tuple `dedupe_key = (self.__class__.__name__, id(self), *scope)`
and uses it as a dict key. `_create_guardrail_span` passes
`guardrail_information.get("guardrail_mode")` into that scope. Users are
allowed to set `mode` to a list of strings &mdash; at that point `dedupe_key`
contains a list, `spans_logged.get(dedupe_key)` raises
`TypeError: unhashable type: 'list'`, and the request fails with HTTP 500.

Bisected to commit `1c4e4d4a60e586b97ec4ab82c358291eaf8f07f2` (introduction
of payload-driven dedupe in `_create_guardrail_span`).

## The fix

Add a `@staticmethod _make_hashable(value)` to `OpenTelemetry` that
recursively normalizes scope elements before they reach the tuple:

| Input                  | Output                                  | Notes |
|------------------------|-----------------------------------------|-------|
| `list`                 | `tuple` (preserves order)               | recursive |
| `set` / `frozenset`    | `frozenset`                             | order-independent |
| `dict`                 | `tuple` of `(k, v)` sorted by `repr(k)` | tolerates mixed-type keys |
| any other              | unchanged                               | no overhead on existing happy path |

Then `dedupe_key` builds as
`(cls_name, id(self), *(self._make_hashable(s) for s in scope))`.

Equality semantics are preserved for the common case (`list` and its
equivalent `tuple` collapse to the same dedupe slot), so existing dedupe
behavior for the dual-fire callback path is unchanged.

Why `_make_hashable` over the single-line fix Greptile previously rated
5/5 on #28677: the prior fix only handled top-level `list` elements. This
version also handles `dict` and `set` (some custom-guardrail integrations
attach dict-shaped metadata into scope) and is recursive, so it can't
re-break the next time someone passes a list of dicts.

## Files

- `litellm/integrations/opentelemetry.py` &mdash; adds `_make_hashable`, uses
  it when building `dedupe_key`.
- `tests/test_litellm/integrations/test_opentelemetry.py` &mdash; 11 new
  tests appended (all prefixed `test_lit_3299_*`).

## Tests

```
$ pytest tests/test_litellm/integrations/test_opentelemetry.py -v -k lit_3299
test_lit_3299_distinguishes_different_list_modes              PASSED
test_lit_3299_emit_once_handles_list_guardrail_mode           PASSED
test_lit_3299_handles_dict_scope                              PASSED
test_lit_3299_handles_nested_list                             PASSED
test_lit_3299_handles_set_scope                               PASSED
test_lit_3299_list_and_tuple_collapse_to_same_slot            PASSED
test_lit_3299_make_hashable_dict_to_sorted_pairs              PASSED
test_lit_3299_make_hashable_dict_with_mixed_type_keys         PASSED
test_lit_3299_make_hashable_list_to_tuple                     PASSED
test_lit_3299_make_hashable_returns_scalars_unchanged         PASSED
test_lit_3299_make_hashable_set_to_frozenset                  PASSED
================ 11 passed, 221 deselected in 1.15s =================

# Full file (regression safety):
$ pytest tests/test_litellm/integrations/test_opentelemetry.py
================ 232 passed, 33 warnings in 14.72s =================
```

### Evidence

Captured by driving the real `OpenTelemetry` handler in-process with the
exact `standard_logging_payload` shape `_create_guardrail_span` reads:

**Before &mdash; base branch (unpatched `_emit_once`):**

```
PHASE A -- unpatched _emit_once (litellm_oss_agent_shin_daily_branch HEAD)
Configured guardrail mode: ["pre_call", "post_call"]   (list, as in the bug report)
Calling _emit_once with the same arguments _create_guardrail_span passes...
  TypeError: unhashable type: 'list'
  -> in the real proxy this returns HTTP 500 from every affected request.
```

**After &mdash; this PR (patched `_emit_once`):**

```
PHASE B -- patched _emit_once (this PR)
  call 1 (emit):    True
  call 2 (dedupe):  False
  -> no exception, span emitted exactly once.
```

**End-to-end through the real `_create_guardrail_span`:**

```
PHASE C -- drive _create_guardrail_span end-to-end (real proxy code path)
  guardrail spans emitted: 1  (expected: 1)
    name=guardrail  attrs={
      'openinference.span.kind': 'GUARDRAIL',
      'guardrail_name': 'my-list-mode-guardrail',
      'guardrail_mode': "['pre_call', 'post_call']",
      'guardrail_status': 'success'
    }
  -> exactly 1 guardrail span with list-valued mode attribute, no HTTP 500.
```

## Note on push mechanism

The agent token lacks `repo` scope, so files were pushed via the GitHub
Contents API (one `PUT /contents/<path>` per file). Reviewers can expect
two commits in the merge-base diff; the net working-tree change is exactly
the two files listed above.


### Verification (ship-pr)

- **change-type**: `litellm/integrations/opentelemetry.py` (backend / observability — dedupe-key for OTEL span emission) + `tests/test_litellm/integrations/test_opentelemetry.py` -> evidence type required: real before/after through the running handler with the bug-report payload shape.
- **evidence present**: PASS (1 `### Evidence` section, 3 fenced before/after blocks: Phase A `TypeError`, Phase B emit/dedupe, Phase C end-to-end `_create_guardrail_span` -> 1 span).
- **image sanity**: N/A (no embedded screenshots — backend change captured as inline terminal output).
- **image content matches caption**: N/A (text evidence; captions describe the terminal output and the output matches).
- **backend evidence from running system**: PASS &mdash; Phase A drives the unpatched `_emit_once` logic with the exact scope shape `_create_guardrail_span` passes (a `list`-valued `guardrail_mode`) and captures the real `TypeError: unhashable type: 'list'`. Phase C constructs the real `OpenTelemetry` handler and a real `TracerProvider` + `InMemorySpanExporter`, fires the actual `_create_guardrail_span` twice with the bug-report payload, and captures the exporter output showing exactly one `guardrail` span emitted (dedupe intact).
- **hygiene**: PASS &mdash; no external image hosts in body; only the two intentional files changed (no `git add -A` noise).
- **re-verify after fixes**: PASS &mdash; ran the checklist after the Greptile P2 iteration (tuple branch + top-of-file `import pytest` + black format); all checks still PASS on this commit.

CI: **44/44 green** &mdash; including Veria AI - PR Review (success).
Greptile: **5/5** &mdash; "Safe to merge. All previous P2 feedback (tuple gap, import placement) has been addressed in this revision."
