### PR TITLE
fix(proxy/google): honor client ?alt= on streamGenerateContent — raw JSON for SDKs that don't opt into SSE

### DIFF
--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -106,6 +106,17 @@ async def google_stream_generate_content(
         data["model"] = model_name
     data["stream"] = True
 
+    # Capture the client-requested response format. Per the Gemini REST API,
+    # `?alt=sse` opts into SSE-framed chunks; the documented default (omitted,
+    # or `alt=json`) returns raw JSON. The google-genai Python SDK omits `alt`
+    # and expects raw JSON. LiteLLM always streams from upstream with
+    # `alt=sse` so it can parse chunks server-side, then re-frames for the
+    # client based on what the client actually requested.
+    client_requested_alt = request.query_params.get("alt") or "json"
+    data.setdefault("litellm_metadata", {})[
+        "client_requested_stream_format"
+    ] = client_requested_alt
+
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
         return await processor.base_process_llm_request(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -241,10 +241,7 @@ from litellm.litellm_core_utils.core_helpers import (
 )
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.sensitive_data_masker import (
-    SensitiveDataMasker,
-    mask_sensitive_keys,
-)
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.proxy._types import *
@@ -991,15 +988,6 @@ _OPENAPI_HTTP_METHODS = {
     "put",
     "trace",
 }
-
-
-# Credentials surfaced by `/get/config/callbacks` in the alerting block: the
-# full Slack incoming-webhook URL is itself a credential, and the SMTP
-# password is a service password. Masked on read so plaintext never reaches
-# the UI. Kept here at module scope to match the analogous
-# `_SSO_SENSITIVE_FIELDS` / `_CACHE_SENSITIVE_FIELDS` constants in the SSO
-# and cache endpoint files.
-_ALERTING_SENSITIVE_VARS: Set[str] = {"SLACK_WEBHOOK_URL", "SMTP_PASSWORD"}
 
 
 def _strip_operation_id_method_suffix(operation_id: str) -> str:
@@ -14760,9 +14748,6 @@ async def get_config():  # noqa: PLR0915
                         value=env_variable, key=_var
                     )
                     _slack_env_vars[_var] = _decrypted_value
-            _slack_env_vars = mask_sensitive_keys(
-                _slack_env_vars, _ALERTING_SENSITIVE_VARS
-            )
 
             _alerting_types = proxy_logging_obj.slack_alerting_instance.alert_types
             _all_alert_types = (
@@ -14799,7 +14784,6 @@ async def get_config():  # noqa: PLR0915
                 # decode + decrypt the value
                 _decrypted_value = decrypt_value_helper(value=env_variable, key=_var)
                 _email_env_vars[_var] = _decrypted_value
-        _email_env_vars = mask_sensitive_keys(_email_env_vars, _ALERTING_SENSITIVE_VARS)
 
         alerting_data.append(
             {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -241,7 +241,10 @@ from litellm.litellm_core_utils.core_helpers import (
 )
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
+from litellm.litellm_core_utils.sensitive_data_masker import (
+    SensitiveDataMasker,
+    mask_sensitive_keys,
+)
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.proxy._types import *
@@ -988,6 +991,15 @@ _OPENAPI_HTTP_METHODS = {
     "put",
     "trace",
 }
+
+
+# Credentials surfaced by `/get/config/callbacks` in the alerting block: the
+# full Slack incoming-webhook URL is itself a credential, and the SMTP
+# password is a service password. Masked on read so plaintext never reaches
+# the UI. Kept here at module scope to match the analogous
+# `_SSO_SENSITIVE_FIELDS` / `_CACHE_SENSITIVE_FIELDS` constants in the SSO
+# and cache endpoint files.
+_ALERTING_SENSITIVE_VARS: Set[str] = {"SLACK_WEBHOOK_URL", "SMTP_PASSWORD"}
 
 
 def _strip_operation_id_method_suffix(operation_id: str) -> str:
@@ -6986,10 +6998,37 @@ async def async_data_generator(  # noqa: PLR0915
             elif isinstance(chunk, bytes):
                 # Some upstream streaming iterators (e.g. AsyncGoogleGenAIGenerateContentStreamingIterator
                 # for /v1beta/.../streamGenerateContent) yield raw SSE bytes from Gemini.
-                # Decode to str so the f-string below does not emit a Python b'...' literal,
-                # and pass already-formatted SSE through unchanged to avoid double "data:" prefix.
+                # Decode to str so the f-string below does not emit a Python b'...' literal.
                 chunk = chunk.decode("utf-8", errors="replace")
                 if chunk.startswith(("data:", "event:", ":")):
+                    # Honor the client-requested response format. Gemini's
+                    # `streamGenerateContent` returns raw JSON by default and
+                    # SSE only when the caller passes `?alt=sse`. LiteLLM
+                    # always calls upstream with `alt=sse` so it can parse
+                    # chunks server-side, so without this re-framing every
+                    # native streamGenerateContent reply arrives at the client
+                    # with `data: ` prefixes and the google-genai SDK fails to
+                    # JSON-parse it. When the client did NOT request SSE,
+                    # strip the framing and emit only the JSON payloads.
+                    _alt = (
+                        request_data.get("litellm_metadata", {}).get(
+                            "client_requested_stream_format"
+                        )
+                        if isinstance(request_data, dict)
+                        else None
+                    )
+                    if _alt is not None and _alt != "sse":
+                        json_payloads = []
+                        for line in chunk.splitlines():
+                            if line.startswith("data: "):
+                                json_payloads.append(line[len("data: "):])
+                            elif line.startswith("data:"):
+                                json_payloads.append(line[len("data:"):])
+                            # event:/comment (: prefix) lines are SSE control
+                            # frames; drop them for non-SSE clients.
+                        if json_payloads:
+                            yield "\n".join(json_payloads) + "\n"
+                        continue
                     yield chunk if chunk.endswith("\n\n") else chunk + "\n\n"
                     continue
             elif isinstance(chunk, str) and chunk.startswith("data: "):
@@ -7007,11 +7046,24 @@ async def async_data_generator(  # noqa: PLR0915
             # still flush their post-stream logging.
             ProxyLogging._fire_deferred_stream_logging(request_data)
 
-        # Streaming is done, yield the [DONE] chunk
+        # Streaming is done, yield the [DONE] chunk -- but only for SSE clients.
+        # For non-SSE callers (e.g. google-genai SDK against
+        # streamGenerateContent), appending "data: [DONE]" to a raw-JSON body
+        # would make the body un-parseable as JSON. The SDK detects
+        # end-of-stream from EOF.
+        _client_alt = (
+            request_data.get("litellm_metadata", {}).get(
+                "client_requested_stream_format"
+            )
+            if isinstance(request_data, dict)
+            else None
+        )
+        _is_non_sse_client = _client_alt is not None and _client_alt != "sse"
         if error_message is not None:
             yield error_message
-        done_message = "[DONE]"
-        yield f"data: {done_message}\n\n"
+        if not _is_non_sse_client:
+            done_message = "[DONE]"
+            yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.async_data_generator(): Exception occured - {}".format(
@@ -14708,6 +14760,9 @@ async def get_config():  # noqa: PLR0915
                         value=env_variable, key=_var
                     )
                     _slack_env_vars[_var] = _decrypted_value
+            _slack_env_vars = mask_sensitive_keys(
+                _slack_env_vars, _ALERTING_SENSITIVE_VARS
+            )
 
             _alerting_types = proxy_logging_obj.slack_alerting_instance.alert_types
             _all_alert_types = (
@@ -14744,6 +14799,7 @@ async def get_config():  # noqa: PLR0915
                 # decode + decrypt the value
                 _decrypted_value = decrypt_value_helper(value=env_variable, key=_var)
                 _email_env_vars[_var] = _decrypted_value
+        _email_env_vars = mask_sensitive_keys(_email_env_vars, _ALERTING_SENSITIVE_VARS)
 
         alerting_data.append(
             {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7009,9 +7009,9 @@ async def async_data_generator(  # noqa: PLR0915
                         json_payloads = []
                         for line in chunk.splitlines():
                             if line.startswith("data: "):
-                                json_payloads.append(line[len("data: "):])
+                                json_payloads.append(line[len("data: ") :])
                             elif line.startswith("data:"):
-                                json_payloads.append(line[len("data:"):])
+                                json_payloads.append(line[len("data:") :])
                             # event:/comment (: prefix) lines are SSE control
                             # frames; drop them for non-SSE clients.
                         if json_payloads:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7009,11 +7009,20 @@ async def async_data_generator(  # noqa: PLR0915
                         json_payloads = []
                         for line in chunk.splitlines():
                             if line.startswith("data: "):
-                                json_payloads.append(line[len("data: ") :])
+                                payload = line[len("data: ") :]
                             elif line.startswith("data:"):
-                                json_payloads.append(line[len("data:") :])
-                            # event:/comment (: prefix) lines are SSE control
-                            # frames; drop them for non-SSE clients.
+                                payload = line[len("data:") :]
+                            else:
+                                # event:/comment (: prefix) lines are SSE
+                                # control frames; drop them for non-SSE
+                                # clients.
+                                continue
+                            # Drop the SSE [DONE] sentinel if upstream ever
+                            # emits it as a chunk -- it is not valid JSON
+                            # and the non-SSE client detects EOF instead.
+                            if payload.strip() == "[DONE]":
+                                continue
+                            json_payloads.append(payload)
                         if json_payloads:
                             yield "\n".join(json_payloads) + "\n"
                         continue

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py
@@ -225,3 +225,35 @@ async def test_no_alt_metadata_keeps_existing_sse_behavior():
     body = "".join(out)
     assert 'data: {"candidates"' in body
     assert "data: [DONE]" in body
+
+
+@pytest.mark.asyncio
+async def test_strip_sse_drops_bare_done_sentinel_chunk():
+    """Defensive: if upstream Gemini ever emits a `data: [DONE]\n\n` chunk
+    while the client did not request SSE, that sentinel must be dropped --
+    `[DONE]` is not valid JSON and the SDK detects end-of-stream from EOF."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    request_data = _make_request_data(alt="json")
+    chunks_with_done = SSE_FROM_GEMINI + [b"data: [DONE]\n\n"]
+    iterator = _FakeAsyncIterator(chunks_with_done)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u")
+
+    out = []
+    async for piece in async_data_generator(
+        response=iterator,
+        user_api_key_dict=user_api_key_dict,
+        request_data=request_data,
+    ):
+        out.append(piece)
+
+    body = "".join(out)
+    assert "[DONE]" not in body, f"unexpected [DONE] in body: {body!r}"
+    import json
+
+    lines = [ln for ln in body.split("\n") if ln.strip()]
+    # 2 from SSE_FROM_GEMINI; the [DONE] chunk must be silently dropped.
+    assert len(lines) == 2, f"expected 2 JSON lines (DONE dropped), got {lines!r}"
+    for ln in lines:
+        json.loads(ln)  # must JSON-parse

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py
@@ -15,6 +15,7 @@ These tests exercise:
 2. `async_data_generator` strips SSE framing AND omits the `data: [DONE]`
    sentinel when the client did not request SSE; both are kept otherwise.
 """
+
 import os
 import sys
 from unittest.mock import AsyncMock, patch
@@ -169,6 +170,7 @@ async def test_strip_sse_when_client_did_not_request_sse():
     assert "data: " not in body, f"unexpected SSE prefix: {body!r}"
     assert "[DONE]" not in body, f"unexpected [DONE]: {body!r}"
     import json
+
     lines = [ln for ln in body.split("\n") if ln.strip()]
     assert len(lines) == 2, f"expected 2 JSON lines, got {lines!r}"
     parsed = [json.loads(ln) for ln in lines]

--- a/tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py
@@ -1,0 +1,225 @@
+"""
+Tests for client `?alt=` handling on the native
+`/v1beta/models/{model}:streamGenerateContent` endpoint.
+
+Background: LiteLLM streams from upstream Gemini with `alt=sse` so it can
+parse chunks server-side. When the client (e.g. the google-genai Python SDK)
+does not pass `?alt=sse`, Gemini's documented contract returns raw JSON, and
+the SDK relies on that. Without re-framing, LiteLLM would forward
+`data: {...}` SSE lines to the SDK and JSON parsing would fail with
+`google.genai.errors.UnknownApiResponseError: Failed to parse response as JSON`.
+
+These tests exercise:
+1. The endpoint captures `?alt=` and propagates it via `litellm_metadata`,
+   defaulting to "json" when the client omits it (Gemini's documented default).
+2. `async_data_generator` strips SSE framing AND omits the `data: [DONE]`
+   sentinel when the client did not request SSE; both are kept otherwise.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+
+def _build_test_client():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from litellm.proxy.google_endpoints.endpoints import router as google_router
+
+    app = FastAPI()
+    app.include_router(google_router)
+    return TestClient(app)
+
+
+def _patch_base_process(return_value=None):
+    if return_value is None:
+        return_value = {"test": "response"}
+    return patch(
+        "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+        new_callable=AsyncMock,
+        return_value=return_value,
+    )
+
+
+def test_stream_endpoint_records_alt_sse_in_metadata():
+    try:
+        client = _build_test_client()
+    except ImportError as e:
+        pytest.skip(f"Skipping test due to missing dependency: {e}")
+    with (
+        _patch_base_process(),
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.__init__",
+            return_value=None,
+        ) as mock_init,
+    ):
+        response = client.post(
+            "/v1beta/models/test-model:streamGenerateContent?alt=sse",
+            json={"contents": [{"role": "user", "parts": [{"text": "Hi"}]}]},
+        )
+        assert response.status_code == 200
+        init_kwargs = mock_init.call_args.kwargs
+        meta = init_kwargs["data"].get("litellm_metadata", {})
+        assert meta.get("client_requested_stream_format") == "sse"
+
+
+def test_stream_endpoint_records_alt_json_in_metadata():
+    try:
+        client = _build_test_client()
+    except ImportError as e:
+        pytest.skip(f"Skipping test due to missing dependency: {e}")
+    with (
+        _patch_base_process(),
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.__init__",
+            return_value=None,
+        ) as mock_init,
+    ):
+        response = client.post(
+            "/v1beta/models/test-model:streamGenerateContent?alt=json",
+            json={"contents": [{"role": "user", "parts": [{"text": "Hi"}]}]},
+        )
+        assert response.status_code == 200
+        init_kwargs = mock_init.call_args.kwargs
+        meta = init_kwargs["data"].get("litellm_metadata", {})
+        assert meta.get("client_requested_stream_format") == "json"
+
+
+def test_stream_endpoint_no_alt_defaults_to_json():
+    """When the client omits ?alt= (the google-genai SDK default), the proxy
+    must record "json" as the client-requested format. Per the Gemini REST
+    API contract, omitting `alt` means "return JSON" -- it is not a
+    "no preference, use server default" signal. This is the actual reported
+    bug: the SDK omits alt, expects JSON, but LiteLLM was returning SSE."""
+    try:
+        client = _build_test_client()
+    except ImportError as e:
+        pytest.skip(f"Skipping test due to missing dependency: {e}")
+    with (
+        _patch_base_process(),
+        patch(
+            "litellm.proxy.google_endpoints.endpoints.ProxyBaseLLMRequestProcessing.__init__",
+            return_value=None,
+        ) as mock_init,
+    ):
+        response = client.post(
+            "/v1beta/models/test-model:streamGenerateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "Hi"}]}]},
+        )
+        assert response.status_code == 200
+        init_kwargs = mock_init.call_args.kwargs
+        meta = init_kwargs["data"].get("litellm_metadata", {})
+        assert meta.get("client_requested_stream_format") == "json"
+
+
+class _FakeAsyncIterator:
+    """Yields a sequence of pre-prepared bytes chunks, then stops."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self):
+        return None
+
+
+SSE_FROM_GEMINI = [
+    b'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}\n\n',
+    b'data: {"candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"}}]}\n\n',
+]
+
+
+def _make_request_data(alt=None):
+    d = {"model": "gemini-pro", "stream": True}
+    if alt is not None:
+        d.setdefault("litellm_metadata", {})["client_requested_stream_format"] = alt
+    return d
+
+
+@pytest.mark.asyncio
+async def test_strip_sse_when_client_did_not_request_sse():
+    """alt=json: strip SSE framing, omit [DONE] sentinel, emit JSON only."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    request_data = _make_request_data(alt="json")
+    iterator = _FakeAsyncIterator(SSE_FROM_GEMINI)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u")
+
+    out = []
+    async for piece in async_data_generator(
+        response=iterator,
+        user_api_key_dict=user_api_key_dict,
+        request_data=request_data,
+    ):
+        out.append(piece)
+
+    body = "".join(out)
+    assert "data: " not in body, f"unexpected SSE prefix: {body!r}"
+    assert "[DONE]" not in body, f"unexpected [DONE]: {body!r}"
+    import json
+    lines = [ln for ln in body.split("\n") if ln.strip()]
+    assert len(lines) == 2, f"expected 2 JSON lines, got {lines!r}"
+    parsed = [json.loads(ln) for ln in lines]
+    assert parsed[0]["candidates"][0]["content"]["parts"][0]["text"] == "Hello"
+    assert parsed[1]["candidates"][0]["content"]["parts"][0]["text"] == " world"
+
+
+@pytest.mark.asyncio
+async def test_keep_sse_when_client_requested_sse():
+    """alt=sse: preserve SSE framing and `data: [DONE]` sentinel."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    request_data = _make_request_data(alt="sse")
+    iterator = _FakeAsyncIterator(SSE_FROM_GEMINI)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u")
+
+    out = []
+    async for piece in async_data_generator(
+        response=iterator,
+        user_api_key_dict=user_api_key_dict,
+        request_data=request_data,
+    ):
+        out.append(piece)
+
+    body = "".join(out)
+    assert 'data: {"candidates"' in body
+    assert '"text":"Hello"' in body
+    assert '"text":" world"' in body
+    assert "data: [DONE]" in body
+
+
+@pytest.mark.asyncio
+async def test_no_alt_metadata_keeps_existing_sse_behavior():
+    """No alt metadata at all (defensive path for non-google routes): keep
+    SSE framing and [DONE] sentinel -- fully backward-compatible."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.proxy_server import async_data_generator
+
+    request_data = _make_request_data(alt=None)
+    iterator = _FakeAsyncIterator(SSE_FROM_GEMINI)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u")
+
+    out = []
+    async for piece in async_data_generator(
+        response=iterator,
+        user_api_key_dict=user_api_key_dict,
+        request_data=request_data,
+    ):
+        out.append(piece)
+
+    body = "".join(out)
+    assert 'data: {"candidates"' in body
+    assert "data: [DONE]" in body


### PR DESCRIPTION
## Summary

Fix the native `/v1beta/models/{model}:streamGenerateContent` and
`/models/{model}:streamGenerateContent` endpoints so they honor the client's
`?alt=` query parameter. Per the [Gemini REST contract](https://ai.google.dev/api/generate-content#method:-models.streamgeneratecontent),
omitting `alt` (or passing `alt=json`) returns raw JSON; only `alt=sse` opts
into server-sent-events framing. The google-genai Python SDK omits `alt` and
relies on the JSON default — it body-parses each chunk with `json.loads`.

LiteLLM always calls upstream Gemini with `alt=sse` internally so it can
parse chunks server-side. Prior to this PR, the proxy was forwarding the
`data: ...\n\n` framing through to the client untouched, even when the
client did not ask for SSE. That breaks the google-genai SDK on every
streaming call:

```
google.genai.errors.UnknownApiResponseError: Failed to parse response as JSON.
Raw response: data: {"candidates": [...]}
```

Reported in [#28777](https://github.com/BerriAI/litellm/issues/28777).
Regressed in v1.86.0 (the new `google_ai_studio_endpoints.py` path).

## Fix

Two-stage:

1. `litellm/proxy/google_endpoints/endpoints.py`: capture
   `request.query_params.get("alt")` and stash it in
   `data["litellm_metadata"]["client_requested_stream_format"]`,
   defaulting to `"json"` when the client did not pass `alt=` (per the
   Gemini contract — omitting `alt` means JSON, not "no preference").
2. `litellm/proxy/proxy_server.py`: in `async_data_generator`, when the
   bytes-chunk path detects an upstream SSE frame, check the stashed
   client format. If the client did **not** request SSE, strip the
   `data: ` prefix and `\n\n` framing on each line, drop `event:` /
   comment lines, and emit the raw JSON payload. The synthetic
   `data: [DONE]` sentinel is also omitted in this branch — appending it
   to a JSON body would make the body un-parseable; the SDK detects
   end-of-stream from EOF.

For callers that explicitly pass `?alt=sse`, the existing SSE behavior is
preserved exactly. For non-Google routes (no metadata key set), behavior is
unchanged — fully backward-compatible.

## Evidence

End-to-end runtime reproduction driving the FastAPI endpoint through the
real `async_data_generator` against a deterministic fake upstream that
emits the same SSE bytes Gemini returns when LiteLLM calls it with
`alt=sse`. (Note: the working tree was uploaded via the GitHub Contents
API per the agent's scope fallback, so reviewers may see a noisier
merge-base diff than `git push` would produce.)

### Before (unpatched main): google-genai SDK call without `?alt=`

```
HTTP 200
Body:
data: {"candidates":[{"content":{"parts":[{"text":"The capital "}],"role":"model"}}]}

data: {"candidates":[{"content":{"parts":[{"text":"of France is "}],"role":"model"}}]}

data: {"candidates":[{"content":{"parts":[{"text":"Paris."}],"role":"model"}}],"usageMetadata":{"totalTokenCount":12}}

data: [DONE]
```

SDK perspective (per-line `json.loads`):
```
  line 0: PARSE FAIL (Expecting value: line 1 column 1 (char 0))
  line 1: PARSE FAIL (Expecting value: line 1 column 1 (char 0))
  line 2: PARSE FAIL (Expecting value: line 1 column 1 (char 0))
  line 3: PARSE FAIL (Expecting value: line 1 column 1 (char 0))
  total: 0/4 JSON-parseable lines
```

This is exactly the symptom in the linked GitHub issue.

### After (this PR): same SDK call, no `?alt=`

```
HTTP 200
Body:
{"candidates":[{"content":{"parts":[{"text":"The capital "}],"role":"model"}}]}
{"candidates":[{"content":{"parts":[{"text":"of France is "}],"role":"model"}}]}
{"candidates":[{"content":{"parts":[{"text":"Paris."}],"role":"model"}}],"usageMetadata":{"totalTokenCount":12}}
```

SDK perspective:
```
  line 0: OK; text='The capital '
  line 1: OK; text='of France is '
  line 2: OK; text='Paris.'
  total: 3/3 JSON-parseable lines
```

### After (this PR): explicit `?alt=sse` — unchanged

```
HTTP 200
Body:
data: {"candidates":[{"content":{"parts":[{"text":"The capital "}],"role":"model"}}]}

data: {"candidates":[{"content":{"parts":[{"text":"of France is "}],"role":"model"}}]}

data: {"candidates":[{"content":{"parts":[{"text":"Paris."}],"role":"model"}}],"usageMetadata":{"totalTokenCount":12}}

data: [DONE]
```

SSE clients keep getting SSE.

## Tests

New: `tests/test_litellm/proxy/google_endpoints/test_stream_alt_handling.py` (6 cases).

- `test_stream_endpoint_records_alt_sse_in_metadata` — `?alt=sse` → metadata records `sse`.
- `test_stream_endpoint_records_alt_json_in_metadata` — `?alt=json` → metadata records `json`.
- `test_stream_endpoint_no_alt_defaults_to_json` — no `alt` → metadata records `json` (the actual reported bug surface).
- `test_strip_sse_when_client_did_not_request_sse` — `alt=json` path strips `data: ` prefix, omits `[DONE]`, every chunk JSON-parses.
- `test_keep_sse_when_client_requested_sse` — `alt=sse` path preserves SSE framing and `[DONE]`.
- `test_no_alt_metadata_keeps_existing_sse_behavior` — no metadata at all → backward-compatible SSE pass-through for non-Google routes.

All 21 tests in `tests/test_litellm/proxy/google_endpoints/` pass.

## Relevant links

- Linear: LIT-3358
- GitHub issue: #28777
- Agent session: https://litellm-agent-platform.onrender.com/sessions/4165e7ef-68ee-47fd-8da1-ea54b8a7665b


### Verification (ship-pr)

- change-type: `litellm/proxy/google_endpoints/endpoints.py` (HTTP route) and `litellm/proxy/proxy_server.py` (response framing) → before/after request+response capture required; `tests/.../test_stream_alt_handling.py` → tests only, no runtime evidence required.
- evidence present: **PASS** (3 fenced captures: pre-fix no-alt, post-fix no-alt, post-fix alt=sse).
- image sanity: **N/A** (backend-only PR, no screenshots).
- backend evidence from running system: **PASS** — captured by driving the real FastAPI google endpoint router through the real `async_data_generator` and a real `StreamingResponse` against a deterministic fake upstream that emits exactly the bytes Gemini returns when LiteLLM calls upstream with `alt=sse`. Both the failing pre-fix path and the passing post-fix path were captured from the same harness in a single run; the file is preserved at `/home/user/work/evidence_full.txt` in the agent sandbox.
- hygiene: **PASS** — no external image hosts, diff is exactly the 3 intended files (`+298 / -6` total).
