### PR TITLE
feat(complexity_router): add custom_technical_keywords config (LIT-3237)

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -92,9 +92,25 @@ class ComplexityRouter(CustomLogger):
         self.reasoning_keywords = (
             self.config.reasoning_keywords or DEFAULT_REASONING_KEYWORDS
         )
-        self.technical_keywords = (
+        _base_technical_keywords = (
             self.config.technical_keywords or DEFAULT_TECHNICAL_KEYWORDS
         )
+        if self.config.custom_technical_keywords:
+            # Append-not-replace: extend the effective technical keyword list
+            # with caller-provided domain-specific terms. De-duplicate while
+            # preserving order so repeated user entries (or overlap with the
+            # base list) do not double-count during keyword matching.
+            seen = set()
+            merged: List[str] = []
+            for kw in list(_base_technical_keywords) + list(
+                self.config.custom_technical_keywords
+            ):
+                if kw not in seen:
+                    seen.add(kw)
+                    merged.append(kw)
+            self.technical_keywords = merged
+        else:
+            self.technical_keywords = list(_base_technical_keywords)
         self.simple_keywords = self.config.simple_keywords or DEFAULT_SIMPLE_KEYWORDS
 
         # Pre-compile regex patterns for efficiency

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -240,10 +240,11 @@ class ComplexityRouterConfig(BaseModel):
     custom_technical_keywords: Optional[List[str]] = Field(
         default=None,
         description=(
-            "Additional technical keywords to append to the technical "
-            "keywords list. Unlike `technical_keywords` (which replaces "
-            "the defaults), this field extends them. Useful for "
-            "domain-specific terms such as udp, dns, ssl, kafka, redis."
+            "Additional technical keywords to append to the effective "
+            "technical keywords list. When `technical_keywords` is also "
+            "set, this field appends to that override list; otherwise it "
+            "appends to the built-in defaults. Useful for domain-specific "
+            "terms such as udp, dns, ssl, kafka, redis."
         ),
     )
     simple_keywords: Optional[List[str]] = Field(

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -237,6 +237,15 @@ class ComplexityRouterConfig(BaseModel):
         default=None,
         description="Keywords indicating technical content",
     )
+    custom_technical_keywords: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Additional technical keywords to append to the technical "
+            "keywords list. Unlike `technical_keywords` (which replaces "
+            "the defaults), this field extends them. Useful for "
+            "domain-specific terms such as udp, dns, ssl, kafka, redis."
+        ),
+    )
     simple_keywords: Optional[List[str]] = Field(
         default=None,
         description="Keywords indicating simple/basic queries",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1095,16 +1095,27 @@ class TestCustomTechnicalKeywords:
         ) + len(unique_new)
 
     def test_overlap_dedupes(self, mock_router_instance):
+        """Repeated entries or overlap with defaults are de-duplicated."""
         from litellm.router_strategy.complexity_router.config import (
             DEFAULT_TECHNICAL_KEYWORDS,
         )
+        custom = ["http", "kafka", "kafka", "redis"]
         router = self._make_router(
             mock_router_instance,
-            custom_technical_keywords=["http", "kafka", "kafka", "redis"],
+            custom_technical_keywords=custom,
         )
+        # Compute expected unique additions explicitly so the assertion stays
+        # correct even if DEFAULT_TECHNICAL_KEYWORDS later gains one of these
+        # terms. Mirrors the dedup logic in ComplexityRouter.__init__.
+        seen = set(DEFAULT_TECHNICAL_KEYWORDS)
+        unique_new = []
+        for kw in custom:
+            if kw not in seen:
+                seen.add(kw)
+                unique_new.append(kw)
         assert (
             len(router.technical_keywords)
-            == len(DEFAULT_TECHNICAL_KEYWORDS) + 2
+            == len(DEFAULT_TECHNICAL_KEYWORDS) + len(unique_new)
         )
         assert router.technical_keywords.count("kafka") == 1
         assert router.technical_keywords.count("redis") == 1

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1087,9 +1087,12 @@ class TestCustomTechnicalKeywords:
             assert kw in router.technical_keywords, f"default {kw!r} dropped"
         for kw in custom:
             assert kw in router.technical_keywords, f"custom {kw!r} missing"
+        # Compute expected unique additions so the assertion stays correct
+        # even if DEFAULT_TECHNICAL_KEYWORDS later gains one of `custom`.
+        unique_new = [kw for kw in custom if kw not in DEFAULT_TECHNICAL_KEYWORDS]
         assert len(router.technical_keywords) == len(
             DEFAULT_TECHNICAL_KEYWORDS
-        ) + len(custom)
+        ) + len(unique_new)
 
     def test_overlap_dedupes(self, mock_router_instance):
         from litellm.router_strategy.complexity_router.config import (

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1047,3 +1047,114 @@ class TestExtractUserMessageAndSystemPrompt:
         )
         assert user_msg is None
         assert sys_prompt is None
+
+
+class TestCustomTechnicalKeywords:
+    """Tests for the `custom_technical_keywords` config field (LIT-3237)."""
+
+    def _make_router(self, mock_router_instance, **config_extras):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TIER_BOUNDARIES,
+            DEFAULT_TIER_MODELS,
+        )
+        config = {
+            "tiers": dict(DEFAULT_TIER_MODELS),
+            "tier_boundaries": dict(DEFAULT_TIER_BOUNDARIES),
+        }
+        config.update(config_extras)
+        return ComplexityRouter(
+            model_name="test",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=config,
+        )
+
+    def test_default_when_field_absent(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        router = self._make_router(mock_router_instance)
+        assert router.technical_keywords == list(DEFAULT_TECHNICAL_KEYWORDS)
+
+    def test_extends_defaults_not_replaces(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        custom = ["kafka", "redis", "postgresql"]
+        router = self._make_router(
+            mock_router_instance, custom_technical_keywords=custom
+        )
+        for kw in DEFAULT_TECHNICAL_KEYWORDS:
+            assert kw in router.technical_keywords, f"default {kw!r} dropped"
+        for kw in custom:
+            assert kw in router.technical_keywords, f"custom {kw!r} missing"
+        assert len(router.technical_keywords) == len(
+            DEFAULT_TECHNICAL_KEYWORDS
+        ) + len(custom)
+
+    def test_overlap_dedupes(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        router = self._make_router(
+            mock_router_instance,
+            custom_technical_keywords=["http", "kafka", "kafka", "redis"],
+        )
+        assert (
+            len(router.technical_keywords)
+            == len(DEFAULT_TECHNICAL_KEYWORDS) + 2
+        )
+        assert router.technical_keywords.count("kafka") == 1
+        assert router.technical_keywords.count("redis") == 1
+        assert router.technical_keywords.count("http") == 1
+
+    def test_combined_with_technical_keywords_override(self, mock_router_instance):
+        router = self._make_router(
+            mock_router_instance,
+            technical_keywords=["alpha", "beta"],
+            custom_technical_keywords=["gamma", "delta"],
+        )
+        assert router.technical_keywords == ["alpha", "beta", "gamma", "delta"]
+
+    def test_empty_list_is_treated_as_unset(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        router = self._make_router(
+            mock_router_instance, custom_technical_keywords=[]
+        )
+        assert router.technical_keywords == list(DEFAULT_TECHNICAL_KEYWORDS)
+
+    def test_verizon_keyword_list_round_trip(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.config import (
+            DEFAULT_TECHNICAL_KEYWORDS,
+        )
+        verizon = [
+            "udp", "dns", "ssl", "tls", "ssh", "rest",
+            "graphql", "kafka", "redis", "postgresql", "mongodb",
+        ]
+        router = self._make_router(
+            mock_router_instance, custom_technical_keywords=verizon
+        )
+        for kw in verizon:
+            assert kw in router.technical_keywords
+        for kw in DEFAULT_TECHNICAL_KEYWORDS:
+            assert kw in router.technical_keywords
+
+    def test_custom_keywords_increase_complexity_signal(self, mock_router_instance):
+        prompt = (
+            "How do I configure a Kafka consumer with Redis as a state store "
+            "to read from a Postgresql change-data-capture topic?"
+        )
+        without = self._make_router(mock_router_instance)
+        with_custom = self._make_router(
+            mock_router_instance,
+            custom_technical_keywords=["kafka", "redis", "postgresql"],
+        )
+        _, score_off, _ = without.classify(prompt)
+        _, score_on, _ = with_custom.classify(prompt)
+        assert score_on > score_off
+
+    def test_config_field_round_trip_in_pydantic(self):
+        cfg = ComplexityRouterConfig(custom_technical_keywords=["kafka"])
+        assert cfg.custom_technical_keywords == ["kafka"]
+        assert ComplexityRouterConfig().custom_technical_keywords is None

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1087,8 +1087,6 @@ class TestCustomTechnicalKeywords:
             assert kw in router.technical_keywords, f"default {kw!r} dropped"
         for kw in custom:
             assert kw in router.technical_keywords, f"custom {kw!r} missing"
-        # Compute expected unique additions so the assertion stays correct
-        # even if DEFAULT_TECHNICAL_KEYWORDS later gains one of `custom`.
         unique_new = [kw for kw in custom if kw not in DEFAULT_TECHNICAL_KEYWORDS]
         assert len(router.technical_keywords) == len(
             DEFAULT_TECHNICAL_KEYWORDS
@@ -1104,9 +1102,6 @@ class TestCustomTechnicalKeywords:
             mock_router_instance,
             custom_technical_keywords=custom,
         )
-        # Compute expected unique additions explicitly so the assertion stays
-        # correct even if DEFAULT_TECHNICAL_KEYWORDS later gains one of these
-        # terms. Mirrors the dedup logic in ComplexityRouter.__init__.
         seen = set(DEFAULT_TECHNICAL_KEYWORDS)
         unique_new = []
         for kw in custom:
@@ -1138,18 +1133,19 @@ class TestCustomTechnicalKeywords:
         )
         assert router.technical_keywords == list(DEFAULT_TECHNICAL_KEYWORDS)
 
-    def test_verizon_keyword_list_round_trip(self, mock_router_instance):
+    def test_example_network_keyword_list_round_trip(self, mock_router_instance):
+        """Network/storage domain terms drawn from the LIT-3237 example list."""
         from litellm.router_strategy.complexity_router.config import (
             DEFAULT_TECHNICAL_KEYWORDS,
         )
-        verizon = [
+        example_keywords = [
             "udp", "dns", "ssl", "tls", "ssh", "rest",
             "graphql", "kafka", "redis", "postgresql", "mongodb",
         ]
         router = self._make_router(
-            mock_router_instance, custom_technical_keywords=verizon
+            mock_router_instance, custom_technical_keywords=example_keywords
         )
-        for kw in verizon:
+        for kw in example_keywords:
             assert kw in router.technical_keywords
         for kw in DEFAULT_TECHNICAL_KEYWORDS:
             assert kw in router.technical_keywords


### PR DESCRIPTION
## Summary

Adds `custom_technical_keywords: Optional[List[str]]` to `ComplexityRouterConfig`. Unlike the existing `technical_keywords` (which **replaces** the default technical keyword list when set), `custom_technical_keywords` **appends** caller-supplied domain-specific terms on top of the defaults — preserving order and de-duplicating overlap.

Motivation from [LIT-3237](https://linear.app/litellm-ai/issue/LIT-3237): teams need to add terms like `udp`, `dns`, `ssl`, `tls`, `ssh`, `rest`, `graphql`, `kafka`, `redis`, `postgresql`, `mongodb` to the complexity router's technical signal without re-declaring the existing 28-entry default list.

```yaml
router_settings:
  routing_strategy: complexity-based-routing
  complexity_router_config:
    custom_technical_keywords:
      - udp
      - dns
      - ssl
      - tls
      - ssh
      - rest
      - graphql
      - kafka
      - redis
      - postgresql
      - mongodb
```

## Changes

- `litellm/router_strategy/complexity_router/config.py` — new optional pydantic field with a docstring that explicitly covers both the defaults-append case and the `technical_keywords`-override-append case.
- `litellm/router_strategy/complexity_router/complexity_router.py` — merge logic: take the effective base list (`technical_keywords` override OR `DEFAULT_TECHNICAL_KEYWORDS`), then append `custom_technical_keywords` while de-duplicating in order. Empty list is treated as unset, matching the existing `or`-guard pattern.
- `tests/test_litellm/router_strategy/test_complexity_router.py` — 8 new tests in `TestCustomTechnicalKeywords` covering: defaults preserved when field absent, append-not-replace, dedupe overlap+repeats, interaction with `technical_keywords` override, empty list = unset, the LIT-3237 example list round-trip, scoring delta on a kafka/redis/postgresql prompt, and pydantic round-trip.

## Notes for reviewers

- **Branch hygiene:** Pushed via the GitHub Contents API (one PUT per file). Current bot token lacks `repo`+`workflow` scope so plain `git push` fails — see "Scope fallback" in agent guidance. The on-branch HEAD is `17a0f756d2` and the three files are exactly the local diff (4 files, +148/−1 line in the working tree). Reviewers may see noisier merge-base diff in the PR; the substantive changes are still confined to the three files listed above.
- **No HTTP/UI surface.** This is a router-internal config field. There is no request/response path change. Evidence below is captured Python output of `ComplexityRouter.classify()` before vs after the field is set.

### Evidence

`classify()` driven against the actual `ComplexityRouter`, same code path used by routing decisions.

```
Scenario A  (custom_technical_keywords NOT set):
  effective technical_keywords count = 28
  default 'http' present?         True
  default 'architecture' present? True
  classify() tier=SIMPLE  score=0.0000  signals=[]

Scenario B  (custom_technical_keywords APPENDED with the LIT-3237 example list):
  effective technical_keywords count = 39
  default 'http' present?         True
  default 'architecture' present? True
  custom 'kafka'/'redis'/'postgresql' present? True
  classify() tier=SIMPLE  score=0.1250  signals=['technical (kafka, redis, postgresql)']

DELTA  score 0.0000 -> 0.1250  (+0.1250)   tier SIMPLE -> SIMPLE
```

Prompt used: `"How do I configure a Kafka consumer with Redis as a state store to read from a Postgresql change-data-capture topic?"`

The score moves from 0.0 → 0.125 because the `technicalTerms` dimension fires with 3 matches (kafka/redis/postgresql) at weight `0.25 × 0.5 = 0.125`. The tier doesn't change for this short prompt, but the signal is now wired correctly — longer / more-loaded prompts in the same domain will tip into `MEDIUM`/`COMPLEX` as intended.

#### Interaction with `technical_keywords` (replace) + `custom_technical_keywords` (append)
```
Scenario C  (technical_keywords=[alpha,beta] + custom_technical_keywords=[gamma,delta]):
  effective technical_keywords = ['alpha', 'beta', 'gamma', 'delta']
```

#### Dedupe on overlap with defaults
```
Scenario D  (overlap dedupe: custom=['http','kafka','kafka','redis']):
  effective count = 30 (defaults=28 + 2 unique new: kafka, redis)
  'http' count = 1 (defaults already had it; no dup)
  'kafka' count = 1 (deduped)
  'redis' count = 1 (deduped)
```

#### Test run

```
8 new tests in TestCustomTechnicalKeywords: PASSED
Full complexity_router suite: 75 passed in 2.83s
```

Linear: LIT-3237


### Verification (ship-pr)
- change-type: 3 backend Python files (router config + init + tests) → fenced code-block evidence (no UI/HTTP surface). PASS.
- evidence present: PASS — 5 fenced code blocks under `### Evidence` showing before-vs-after `ComplexityRouter.classify()` output, dedupe behaviour, override interaction, and 75/75 pytest run.
- image sanity: N/A (no screenshots; pure-Python config-flag change with no rendered UI).
- image content matches caption: N/A.
- backend evidence from running system: PASS — `classify()` output came from real `ComplexityRouter` instances (one with the field unset, one set to the LIT-3237 example list) instantiated through the public constructor path, not a unit-test harness.
- ci: 44/44 checks completed/success, 0 failures, `mergeable_state=clean`.
- greptile: 5/5 confidence, 0 review comments (https://github.com/BerriAI/litellm/pull/29023#issuecomment-4557883088).
- veria: completed/success.
- no customer name leaked in diff or PR body (substring scan over all changed files clean).

### Verification (ship-pr)

- **change-type**: 3 files touched
  - `litellm/router_strategy/complexity_router/config.py` (pydantic config field) -> routing-decision evidence required
  - `litellm/router_strategy/complexity_router/complexity_router.py` (router-internal merge logic in `__init__`) -> routing-decision evidence required
  - `tests/test_litellm/router_strategy/test_complexity_router.py` (tests only)
- **evidence present**: PASS - 4 captured `ComplexityRouter.classify()` scenarios (A unpatched baseline, B with `custom_technical_keywords` appended, C interaction with `technical_keywords` override, D overlap dedupe) shown inline as fenced code blocks above
- **image sanity**: N/A - no UI surface, no screenshots
- **image content matches caption**: N/A
- **backend evidence from running system**: PASS - output is from a standalone Python run of `ComplexityRouter(...)` against the patched code, not from the pytest runner. Same instance/code path used at routing-decision time. Score moves 0.0000 -> 0.1250 with the new field; defaults preserved (28 -> 39 effective entries); dedupe and override interaction confirmed.
- **hygiene**: PASS - no external image hosts; only the 3 intended files modified (+148/-1)
