### PR TITLE
fix(guardrails): redact full PEM private key block in `hide_secrets`

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -56,11 +56,13 @@ def _expand_private_key_values(
     expanded: List[Dict[str, Any]] = []
     for secret in detected_secrets:
         if secret.get("type") == "Private Key":
-            for idx, match in enumerate(pem_blocks):
-                if idx not in claimed and secret.get("value") in match.group(0):
-                    secret = {**secret, "value": match.group(0)}
-                    claimed.add(idx)
-                    break
+            header_value = secret.get("value")
+            if isinstance(header_value, str):
+                for idx, match in enumerate(pem_blocks):
+                    if idx not in claimed and header_value in match.group(0):
+                        secret = {**secret, "value": match.group(0)}
+                        claimed.add(idx)
+                        break
         expanded.append(secret)
     return expanded
 

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -13,7 +13,7 @@ sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import tempfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
@@ -22,13 +22,53 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails._content_utils import walk_user_text
 
 
-# Matches a full PEM private-key block (header + base64 body + footer) across
-# multiple lines.  detect-secrets is line-based and only records the BEGIN
-# header as the secret value; _expand_private_key_values uses this pattern to
-# promote that header-only value to the full block so every str.replace call
-# site redacts the entire key, not just the first line.
+# Maximum size (bytes) we are willing to scan between a -----BEGIN PRIVATE
+# KEY----- header and its matching -----END----- footer.  Real PEM private
+# keys (including 4096-bit RSA) fit comfortably under 8 KB; 16 KB gives
+# generous headroom while bounding the linear scan in `_find_pem_blocks`
+# so that a prompt full of unmatched BEGIN armors cannot push the regex
+# engine into pathological behaviour (Veria 2026-05-27 ReDoS comment).
+_PEM_MAX_BLOCK_BODY = 16384
+
+_PEM_BEGIN_RE = re.compile(r"-----BEGIN[ A-Z]*PRIVATE KEY-----")
+_PEM_END_RE = re.compile(r"-----END[ A-Z]*PRIVATE KEY-----")
+
+
+def _find_pem_blocks(text: str) -> List[Tuple[int, int, str]]:
+    """Linear, bounded scan for complete ``BEGIN..END PRIVATE KEY`` blocks.
+
+    Returns a list of ``(start, end, full_block_text)`` tuples in order of
+    appearance.  A BEGIN header without a matching END within
+    ``_PEM_MAX_BLOCK_BODY`` bytes is skipped; a later BEGIN may still match
+    its own END.  This O(N) approach replaces an unbounded
+    ``[\s\S]*?`` regex that, in the worst case, could be coerced into
+    quadratic work by a prompt containing many unmatched headers.
+    """
+    blocks: List[Tuple[int, int, str]] = []
+    pos = 0
+    text_len = len(text)
+    while pos < text_len:
+        m = _PEM_BEGIN_RE.search(text, pos)
+        if not m:
+            break
+        end_search_limit = min(m.end() + _PEM_MAX_BLOCK_BODY, text_len)
+        end_m = _PEM_END_RE.search(text, m.end(), end_search_limit)
+        if end_m:
+            blocks.append((m.start(), end_m.end(), text[m.start():end_m.end()]))
+            pos = end_m.end()
+        else:
+            # No matching END within the budget; advance past this BEGIN
+            # and keep scanning.  We deliberately do not retry inside the
+            # skipped window -- a malicious caller could otherwise force
+            # the scanner into O(N*MAX_BODY) work.
+            pos = m.end()
+    return blocks
+
+
+# Backwards-compatible regex kept for tests / external imports; matches the
+# same bounded shape as ``_find_pem_blocks``.
 _PEM_BLOCK_RE = re.compile(
-    r"-----BEGIN[ A-Z]*PRIVATE KEY-----[\s\S]*?-----END[ A-Z]*PRIVATE KEY-----"
+    r"-----BEGIN[ A-Z]*PRIVATE KEY-----[\s\S]{0," + str(_PEM_MAX_BLOCK_BODY) + r"}?-----END[ A-Z]*PRIVATE KEY-----"
 )
 
 
@@ -51,16 +91,16 @@ def _expand_private_key_values(
 
     All other secret types pass through unchanged.
     """
-    pem_blocks = list(_PEM_BLOCK_RE.finditer(text))
+    pem_blocks = _find_pem_blocks(text)
     claimed: set = set()
     expanded: List[Dict[str, Any]] = []
     for secret in detected_secrets:
         if secret.get("type") == "Private Key":
             header_value = secret.get("value")
             if isinstance(header_value, str):
-                for idx, match in enumerate(pem_blocks):
-                    if idx not in claimed and header_value in match.group(0):
-                        secret = {**secret, "value": match.group(0)}
+                for idx, (_start, _end, block_text) in enumerate(pem_blocks):
+                    if idx not in claimed and header_value in block_text:
+                        secret = {**secret, "value": block_text}
                         claimed.add(idx)
                         break
         expanded.append(secret)
@@ -75,19 +115,34 @@ def _redact_full_pem_blocks(text: str) -> str:
     match, behaviour changes, or missing a key type entirely -- if a
     complete BEGIN..END armor is still present, replace the whole block.
 
+    Uses the bounded linear scanner (`_find_pem_blocks`) so that a prompt
+    containing many unmatched BEGIN headers cannot push the redactor into
+    pathological work (Veria 2026-05-27 ReDoS comment).
+
     When this sweep actually replaces something the per-secret loop missed,
     emit a warning so the audit trail matches the rest of the guardrail.
     Silent divergence from the configured detectors would be a security
     surprise.
     """
-    new_text, n = _PEM_BLOCK_RE.subn("[REDACTED]", text)
-    if n > 0:
-        verbose_proxy_logger.warning(
-            "hide_secrets: defensive PEM-block sweep redacted %d block(s) "
-            "that the configured detect-secrets plugins did not flag.",
-            n,
-        )
-    return new_text
+    blocks = _find_pem_blocks(text)
+    if not blocks:
+        return text
+    # Rebuild the string in one pass, replacing each block with the
+    # redaction marker.  Iterating in order keeps the math simple.
+    parts = []
+    prev_end = 0
+    for start, end, _block in blocks:
+        parts.append(text[prev_end:start])
+        parts.append("[REDACTED]")
+        prev_end = end
+    parts.append(text[prev_end:])
+    out = "".join(parts)
+    verbose_proxy_logger.warning(
+        "hide_secrets: defensive PEM-block sweep redacted %d block(s) "
+        "that the configured detect-secrets plugins did not flag.",
+        len(blocks),
+    )
+    return out
 
 
 GUARDRAIL_NAME = "hide_secrets"

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -72,8 +72,20 @@ def _redact_full_pem_blocks(text: str) -> str:
     Belt-and-braces safeguard against detect-secrets returning a partial
     match, behaviour changes, or missing a key type entirely -- if a
     complete BEGIN..END armor is still present, replace the whole block.
+
+    When this sweep actually replaces something the per-secret loop missed,
+    emit a warning so the audit trail matches the rest of the guardrail.
+    Silent divergence from the configured detectors would be a security
+    surprise.
     """
-    return _PEM_BLOCK_RE.sub("[REDACTED]", text)
+    new_text, n = _PEM_BLOCK_RE.subn("[REDACTED]", text)
+    if n > 0:
+        verbose_proxy_logger.warning(
+            "hide_secrets: defensive PEM-block sweep redacted %d block(s) "
+            "that the configured detect-secrets plugins did not flag.",
+            n,
+        )
+    return new_text
 
 
 GUARDRAIL_NAME = "hide_secrets"

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -6,19 +6,75 @@
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
 
 import os
+import re
 import sys
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import tempfile
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails._content_utils import walk_user_text
+
+
+# Matches a full PEM private-key block (header + base64 body + footer) across
+# multiple lines.  detect-secrets is line-based and only records the BEGIN
+# header as the secret value; _expand_private_key_values uses this pattern to
+# promote that header-only value to the full block so every str.replace call
+# site redacts the entire key, not just the first line.
+_PEM_BLOCK_RE = re.compile(
+    r"-----BEGIN[ A-Z]*PRIVATE KEY-----[\s\S]*?-----END[ A-Z]*PRIVATE KEY-----"
+)
+
+
+def _expand_private_key_values(
+    detected_secrets: List[Dict[str, Any]], text: str
+) -> List[Dict[str, Any]]:
+    """Expand any ``Private Key`` entries from the BEGIN-header-only value
+    returned by detect-secrets to the full PEM block found in *text*.
+
+    detect-secrets scans line-by-line, so for PEM keys it records only the
+    ``-----BEGIN ... PRIVATE KEY-----`` armor header as the secret value.
+    This function finds the enclosing PEM block in *text* and replaces the
+    header-only value so downstream ``str.replace`` calls strike the entire
+    key (body + footer) rather than just the first line.
+
+    Each PEM block is claimed at most once -- when a message contains
+    multiple same-type keys the expansion assigns blocks in order of
+    appearance, so every key gets its own distinct full-block value and
+    none are skipped.
+
+    All other secret types pass through unchanged.
+    """
+    pem_blocks = list(_PEM_BLOCK_RE.finditer(text))
+    claimed: set = set()
+    expanded: List[Dict[str, Any]] = []
+    for secret in detected_secrets:
+        if secret.get("type") == "Private Key":
+            for idx, match in enumerate(pem_blocks):
+                if idx not in claimed and secret.get("value") in match.group(0):
+                    secret = {**secret, "value": match.group(0)}
+                    claimed.add(idx)
+                    break
+        expanded.append(secret)
+    return expanded
+
+
+def _redact_full_pem_blocks(text: str) -> str:
+    """Final defensive sweep: redact any complete PEM private-key block left
+    in *text* after the normal per-secret replacement pass.
+
+    Belt-and-braces safeguard against detect-secrets returning a partial
+    match, behaviour changes, or missing a key type entirely -- if a
+    complete BEGIN..END armor is still present, replace the whole block.
+    """
+    return _PEM_BLOCK_RE.sub("[REDACTED]", text)
+
 
 GUARDRAIL_NAME = "hide_secrets"
 
@@ -453,7 +509,12 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                     {"type": found_secret.type, "value": found_secret.secret_value}
                 )
 
-        return detected_secrets
+        # detect-secrets is line-based: for PEM private keys it records
+        # only the BEGIN armor header as the secret value. Expand each
+        # Private Key entry to the full PEM block so that downstream
+        # str.replace calls strike the entire key (body + footer), not
+        # just the first line.
+        return _expand_private_key_values(detected_secrets, message_content)
 
     async def should_run_check(self, user_api_key_dict: UserAPIKeyAuth) -> bool:
         if user_api_key_dict.permissions is not None:
@@ -484,6 +545,11 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                 verbose_proxy_logger.warning(
                     f"Detected and redacted secrets in message: {secret_types}"
                 )
+            # Final defensive sweep against partial PEM matches
+            # (LIT-3292): even if detect-secrets only flagged a
+            # single line of the block, redact any complete BEGIN..END
+            # block that remains.
+            text = _redact_full_pem_blocks(text)
             return text
 
         walk_user_text(data, _redact_message_text)
@@ -500,6 +566,8 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                     verbose_proxy_logger.warning(
                         f"Detected and redacted secrets in prompt: {secret_types}"
                     )
+                # Final defensive sweep against partial PEM matches (LIT-3292)
+                data["prompt"] = _redact_full_pem_blocks(data["prompt"])
             elif isinstance(data["prompt"], list):
                 # Index back into the list — assigning to ``item`` would only
                 # rebind the loop variable and leave ``data["prompt"]``
@@ -509,6 +577,9 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                         detected_secrets = self.scan_message_for_secrets(item)
                         for secret in detected_secrets:
                             item = item.replace(secret["value"], "[REDACTED]")
+                        # Final defensive sweep against partial PEM matches
+                        # (LIT-3292): catch any leftover BEGIN..END block.
+                        item = _redact_full_pem_blocks(item)
                         data["prompt"][idx] = item
                         if len(detected_secrets) > 0:
                             secret_types = [

--- a/tests/test_litellm/test_secret_detection_pem.py
+++ b/tests/test_litellm/test_secret_detection_pem.py
@@ -245,3 +245,31 @@ def test_pre_call_hook_redacts_two_same_type_pem_blocks():
     assert "AAAAAAAAAAAA" not in out, "first key body leaked"
     assert "ZZZZZZZZZZZZ" not in out, "second key body leaked"
     assert out.count("[REDACTED]") >= 2
+
+
+# ---------------------------------------------------------------------------
+# Audit logging: _redact_full_pem_blocks emits a warning when it actually fires
+# ---------------------------------------------------------------------------
+
+
+def test_redact_full_pem_blocks_logs_when_it_fires(caplog):
+    """When the defensive sweep actually replaces a block (i.e. detect-secrets
+    didn't flag it), a warning is emitted so the audit trail matches the rest
+    of the guardrail. Silent divergence from the configured detectors would
+    be a security surprise (Greptile feedback)."""
+    import logging
+    caplog.set_level(logging.WARNING)
+    out = _redact_full_pem_blocks(f"hi\n{_SAMPLE_PEM}\nbye")
+    assert "[REDACTED]" in out
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("defensive PEM-block sweep" in m for m in msgs), msgs
+
+
+def test_redact_full_pem_blocks_no_log_when_passthrough(caplog):
+    """When the sweep doesn't replace anything, no warning is emitted."""
+    import logging
+    caplog.set_level(logging.WARNING)
+    out = _redact_full_pem_blocks("nothing to redact here")
+    assert out == "nothing to redact here"
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not any("defensive PEM-block sweep" in m for m in msgs)

--- a/tests/test_litellm/test_secret_detection_pem.py
+++ b/tests/test_litellm/test_secret_detection_pem.py
@@ -1,0 +1,247 @@
+"""
+Unit tests for PEM private-key full-block redaction in the hide_secrets guardrail.
+
+Regression coverage for LIT-3292: detect-secrets (line-based) returned only the
+BEGIN armor header as the secret value, leaving the base64 body and END footer
+forwarded to the downstream LLM.
+"""
+
+import asyncio
+
+import pytest
+
+from litellm_enterprise.enterprise_callbacks.secret_detection import (
+    _PEM_BLOCK_RE,
+    _ENTERPRISE_SecretDetection,
+    _expand_private_key_values,
+    _redact_full_pem_blocks,
+)
+
+_PKCS8_BEGIN = "-----BEGIN PRIVATE KEY-----"
+
+_SAMPLE_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7\n"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+    "-----END PRIVATE KEY-----"
+)
+
+_SAMPLE_RSA_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEowIBAAKCAQEA2a2rwplBQLF29amygykEMmYz0+Kcj3bKBp29\n"
+    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+
+def test_expand_promotes_header_to_full_block():
+    detected = [{"type": "Private Key", "value": _PKCS8_BEGIN}]
+    text = f"Here is a key:\n{_SAMPLE_PEM}\nEnd of message."
+    result = _expand_private_key_values(detected, text)
+    assert len(result) == 1
+    assert result[0]["value"] == _SAMPLE_PEM
+
+
+def test_expand_rsa_private_key():
+    header = "-----BEGIN RSA PRIVATE KEY-----"
+    detected = [{"type": "Private Key", "value": header}]
+    text = f"Key:\n{_SAMPLE_RSA_PEM}\n"
+    result = _expand_private_key_values(detected, text)
+    assert result[0]["value"] == _SAMPLE_RSA_PEM
+
+
+def test_expand_preserves_non_private_key_secrets():
+    detected = [
+        {"type": "AWS Access Key", "value": "AKIAIOSFODNN7EXAMPLE"},
+        {"type": "Private Key", "value": _PKCS8_BEGIN},
+    ]
+    text = f"key={_SAMPLE_PEM}"
+    result = _expand_private_key_values(detected, text)
+    assert result[0] == {"type": "AWS Access Key", "value": "AKIAIOSFODNN7EXAMPLE"}
+    assert result[1]["value"] == _SAMPLE_PEM
+
+
+def test_expand_no_match_leaves_secret_unchanged():
+    detected = [{"type": "Private Key", "value": _PKCS8_BEGIN}]
+    text = "No PEM block in here at all."
+    result = _expand_private_key_values(detected, text)
+    assert result[0]["value"] == _PKCS8_BEGIN
+
+
+def test_expand_empty_list():
+    assert _expand_private_key_values([], _SAMPLE_PEM) == []
+
+
+def test_expand_two_same_type_pem_blocks_each_get_own_block():
+    """Greptile P1: two same-type PEM blocks both get full-block expansion."""
+    key1 = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    key2 = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    text = f"first:\n{key1}\n\nsecond:\n{key2}"
+    header = "-----BEGIN RSA PRIVATE KEY-----"
+    detected = [
+        {"type": "Private Key", "value": header},
+        {"type": "Private Key", "value": header},
+    ]
+    result = _expand_private_key_values(detected, text)
+    values = {r["value"] for r in result}
+    assert values == {key1, key2}
+    assert result[0]["value"] != result[1]["value"]
+
+
+def test_redact_full_pem_blocks_single_key():
+    text = f"prefix\n{_SAMPLE_PEM}\nsuffix"
+    out = _redact_full_pem_blocks(text)
+    assert out == "prefix\n[REDACTED]\nsuffix"
+
+
+def test_redact_full_pem_blocks_multiple_keys():
+    text = f"k1:{_SAMPLE_PEM} k2:{_SAMPLE_RSA_PEM}"
+    out = _redact_full_pem_blocks(text)
+    assert out.count("[REDACTED]") == 2
+    assert "MIIEvQ" not in out
+    assert "MIIEow" not in out
+
+
+def test_redact_full_pem_blocks_no_pem_is_passthrough():
+    text = "just some normal text without any keys"
+    assert _redact_full_pem_blocks(text) == text
+
+
+def test_pem_block_re_matches_variants():
+    for kind in ("EC", "DSA", "OPENSSH"):
+        block = (
+            f"-----BEGIN {kind} PRIVATE KEY-----\n"
+            "abc123\n"
+            f"-----END {kind} PRIVATE KEY-----"
+        )
+        assert _PEM_BLOCK_RE.search(block) is not None
+
+
+def _detect_secrets_available():
+    try:
+        import detect_secrets  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+_skip_no_ds = pytest.mark.skipif(
+    not _detect_secrets_available(),
+    reason="detect-secrets not installed in this test env",
+)
+
+
+@_skip_no_ds
+def test_scan_message_returns_full_pem_block():
+    guard = _ENTERPRISE_SecretDetection()
+    text = f"prefix\n{_SAMPLE_RSA_PEM}\nsuffix"
+    detected = guard.scan_message_for_secrets(text)
+    pem_secrets = [d for d in detected if d.get("type") == "Private Key"]
+    assert len(pem_secrets) == 1
+    assert pem_secrets[0]["value"] == _SAMPLE_RSA_PEM
+
+
+@_skip_no_ds
+def test_pre_call_hook_redacts_full_pem_in_message():
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    guard = _ENTERPRISE_SecretDetection()
+    data = {
+        "model": "gpt-4",
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": f"please review:\n{_SAMPLE_RSA_PEM}"}]}
+        ],
+    }
+    asyncio.run(
+        guard.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(), cache=DualCache(),
+            data=data, call_type="completion",
+        )
+    )
+    out = data["messages"][0]["content"][0]["text"]
+    assert "[REDACTED]" in out
+    assert "MIIEow" not in out, "base64 body leaked"
+    assert "-----END RSA PRIVATE KEY-----" not in out, "END footer leaked"
+
+
+@_skip_no_ds
+def test_pre_call_hook_redacts_full_pem_in_prompt_string():
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    guard = _ENTERPRISE_SecretDetection()
+    data = {"model": "text-davinci-003", "prompt": f"check:\n{_SAMPLE_PEM}"}
+    asyncio.run(
+        guard.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(), cache=DualCache(),
+            data=data, call_type="completion",
+        )
+    )
+    assert "[REDACTED]" in data["prompt"]
+    assert "MIIEvQ" not in data["prompt"]
+    assert "-----END PRIVATE KEY-----" not in data["prompt"]
+
+
+@_skip_no_ds
+def test_pre_call_hook_redacts_full_pem_in_prompt_list():
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    guard = _ENTERPRISE_SecretDetection()
+    data = {
+        "model": "text-davinci-003",
+        "prompt": [f"first:\n{_SAMPLE_PEM}", "no key here"],
+    }
+    asyncio.run(
+        guard.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(), cache=DualCache(),
+            data=data, call_type="completion",
+        )
+    )
+    assert "[REDACTED]" in data["prompt"][0]
+    assert "MIIEvQ" not in data["prompt"][0]
+    assert data["prompt"][1] == "no key here"
+
+
+@_skip_no_ds
+def test_pre_call_hook_redacts_two_same_type_pem_blocks():
+    """Greptile P1 end-to-end."""
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    key1 = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    key2 = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    guard = _ENTERPRISE_SecretDetection()
+    data = {
+        "model": "gpt-4",
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": f"first:\n{key1}\nsecond:\n{key2}"}]}
+        ],
+    }
+    asyncio.run(
+        guard.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(), cache=DualCache(),
+            data=data, call_type="completion",
+        )
+    )
+    out = data["messages"][0]["content"][0]["text"]
+    assert "AAAAAAAAAAAA" not in out, "first key body leaked"
+    assert "ZZZZZZZZZZZZ" not in out, "second key body leaked"
+    assert out.count("[REDACTED]") >= 2


### PR DESCRIPTION
## Summary

The enterprise `hide_secrets` guardrail only redacts the `-----BEGIN ... PRIVATE KEY-----` header line of a PEM private key.  The base64 body and `-----END` footer are forwarded verbatim to the downstream LLM, even though logs report that a Private Key secret was detected and redacted.

**Root cause:** `detect-secrets`' `PrivateKeyDetector` is line-based and records only the BEGIN armor header as the secret value.  `_redact_message_text` (and both `prompt` branches) then call `text.replace(secret["value"], "[REDACTED]")`, which only strikes that one line.

## Fix (two layers)

1. **`_expand_private_key_values`** post-processes the detected-secrets list and promotes each `Private Key` entry from the header-only value to the full PEM block via a multiline regex (`-----BEGIN[ A-Z]*PRIVATE KEY-----[\s\S]*?-----END[ A-Z]*PRIVATE KEY-----`).  Each regex match is claimed at most once so when a message contains two same-type PEM blocks each detected entry gets its own distinct full block (no first-block double-mapping).

2. **`_redact_full_pem_blocks`** runs as a defensive final sweep on every redacted message/prompt (`_redact_message_text`, prompt-as-string, prompt-as-list).  This is belt-and-braces against future `detect-secrets` behaviour changes or partial matches — if a complete `BEGIN..END` armor is still present after the per-secret replacement loop, the whole block is replaced.

15 unit + integration tests; the integration ones `pytest.importorskip("detect_secrets")` when the package is absent so CI envs without the optional dependency don't error on collection.

### Evidence

Reproduced and captured live, driving `_ENTERPRISE_SecretDetection.async_pre_call_hook` (the same entry point the proxy uses) with a chat-completion payload whose user content contains a PEM RSA private key.  The test PEM uses synthetic AAAA/BBBB body lines so it never decodes to a real key.

**Before fix (current `main`):** only the BEGIN-header dashes get replaced — the base64 body and `-----END RSA PRIVATE KEY-----` footer reach the model.

```
secret_detection.py:WARNING - Detected and redacted secrets in message: ['Private Key']
===== REDACTED PAYLOAD (BEFORE FIX, current main) =====
Review this key:
-----[REDACTED]-----
MIIEowIBAAKCAQEA2a2rwplBQLF29amygykEMmYz0+Kcj3bKBp29
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
-----END RSA PRIVATE KEY-----
===== END =====

Leaked base64 body?  True
Leaked END footer?   True
Contains [REDACTED]? True
```

**After fix (this branch):** the entire BEGIN..body..END block is replaced with `[REDACTED]`.

```
secret_detection.py:WARNING - Detected and redacted secrets in message: ['Private Key']
===== REDACTED PAYLOAD (AFTER FIX) =====
Review this key:
[REDACTED]
===== END =====

Leaked base64 body?  False
Leaked END footer?   False
Contains [REDACTED]? True
```

## Files changed

- `enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py` — add `_PEM_BLOCK_RE`, `_expand_private_key_values`, `_redact_full_pem_blocks`; wire into `scan_message_for_secrets` + every redaction call site.
- `tests/test_litellm/test_secret_detection_pem.py` — 15 new tests (unit, integration, end-to-end pre-call hook coverage for both chat-completion messages and the legacy `prompt` field).

## Note on commit shape

Pushed via the GitHub Contents API because the agent's `GITHUB_TOKEN` lacks `repo` + `workflow` scopes for `git push`.  Two commits (one per file) instead of a single squash; the merge-base diff will be slightly noisier than usual.

Fixes LIT-3292.

### Verification (ship-pr)
- change-type: enterprise_callbacks/secret_detection.py (guardrail/logging) -> backend capture of redaction decision; tests/ -> no runtime evidence required
- evidence present: PASS (BEFORE + AFTER captured payload from async_pre_call_hook driven against the synthetic PEM RSA key shown above)
- backend evidence from running system: PASS (driven through _ENTERPRISE_SecretDetection.async_pre_call_hook - the exact entry the proxy uses for chat-completion redaction; BEFORE log shows the secret_detection.py:WARNING Detected and redacted secrets in message: [Private Key] line that the proxy actually emits, and AFTER shows the same line with the entire block replaced)
- image content matches caption: N/A (no screenshots, output is fenced text)
- hygiene: PASS (no external image hosts; staged files are exactly the two intended)