### PR TITLE
fix(proxy): opt-out flag to skip background health-check DB writes (LIT-3078)

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2840,8 +2840,21 @@ def _schedule_background_health_check_db_save(
     healthy_endpoints: list,
     unhealthy_endpoints: list,
 ):
-    """Fire-and-forget: persist health check results to DB if prisma is available."""
+    """Fire-and-forget: persist health check results to DB if prisma is available.
+
+    Opt-out: setups with many models and frequent background health checks can
+    generate enough writes to ``LiteLLM_HealthCheckTable`` to dominate database
+    ACU usage. Setting ``general_settings.disable_background_health_check_db_save:
+    true`` skips the per-cycle DB write path entirely (both the
+    ``get_all_latest_health_checks()`` SELECT and the per-model UPSERTs). The
+    on-demand ``/health/*`` endpoint write path is unaffected.
+    """
     if prisma_client is None:
+        return
+    if general_settings.get("disable_background_health_check_db_save", False) is True:
+        verbose_proxy_logger.debug(
+            "background_health_check_db_save_disabled cycle skipped via general_settings.disable_background_health_check_db_save=True"
+        )
         return
     import time as time_module
 

--- a/tests/test_litellm/proxy/test_health_check_functions.py
+++ b/tests/test_litellm/proxy/test_health_check_functions.py
@@ -628,3 +628,174 @@ async def test_perform_health_check_and_save_forwards_skip_disabled_background_f
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+# ---------------------------------------------------------------------------
+# LIT-3078: gating background health-check DB writes via general_settings
+# ---------------------------------------------------------------------------
+
+
+class _SentinelPrisma:
+    """Truthy stand-in for a configured prisma client. The function under test
+    only checks ``is None``, so any non-None value is sufficient."""
+
+
+@pytest.mark.asyncio
+async def test_schedule_background_health_check_db_save_default_back_compat(monkeypatch):
+    """Default behavior (flag absent) MUST still dispatch the DB-save coroutine."""
+    from litellm.proxy import proxy_server
+    import litellm.proxy.health_endpoints._health_endpoints as he_mod
+
+    scheduled = []
+
+    async def _fake_save(prisma_client, model_list, healthy, unhealthy, start_time, checked_by=None):
+        scheduled.append({"models": len(model_list), "healthy": len(healthy), "unhealthy": len(unhealthy), "checked_by": checked_by})
+
+    monkeypatch.setattr(he_mod, "_save_background_health_checks_to_db", _fake_save)
+    monkeypatch.setattr(proxy_server, "general_settings", {})
+
+    proxy_server._schedule_background_health_check_db_save(
+        prisma_client=_SentinelPrisma(),
+        shared_health_manager=None,
+        model_list=[{"model_name": "gpt-4", "model_info": {"id": "id-1"}, "litellm_params": {"model": "gpt-4"}}],
+        healthy_endpoints=[{"model": "gpt-4"}],
+        unhealthy_endpoints=[],
+    )
+    await asyncio.sleep(0.01)
+    assert len(scheduled) == 1
+    assert scheduled[0]["checked_by"] == "background_health_check"
+
+
+@pytest.mark.asyncio
+async def test_schedule_background_health_check_db_save_disabled_via_flag(monkeypatch):
+    """With ``disable_background_health_check_db_save: True``, NO DB-save coroutine is dispatched."""
+    from litellm.proxy import proxy_server
+    import litellm.proxy.health_endpoints._health_endpoints as he_mod
+
+    scheduled = []
+
+    async def _fake_save(prisma_client, model_list, healthy, unhealthy, start_time, checked_by=None):
+        scheduled.append(1)
+
+    monkeypatch.setattr(he_mod, "_save_background_health_checks_to_db", _fake_save)
+    monkeypatch.setattr(
+        proxy_server,
+        "general_settings",
+        {"disable_background_health_check_db_save": True},
+    )
+
+    for _ in range(5):
+        proxy_server._schedule_background_health_check_db_save(
+            prisma_client=_SentinelPrisma(),
+            shared_health_manager=None,
+            model_list=[{"model_name": "gpt-4", "model_info": {"id": "id-1"}, "litellm_params": {"model": "gpt-4"}}],
+            healthy_endpoints=[{"model": "gpt-4"}],
+            unhealthy_endpoints=[],
+        )
+    await asyncio.sleep(0.01)
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_background_health_check_db_save_flag_false_dispatches(monkeypatch):
+    """Explicit ``disable_background_health_check_db_save: False`` keeps the dispatch."""
+    from litellm.proxy import proxy_server
+    import litellm.proxy.health_endpoints._health_endpoints as he_mod
+
+    scheduled = []
+
+    async def _fake_save(prisma_client, model_list, healthy, unhealthy, start_time, checked_by=None):
+        scheduled.append(1)
+
+    monkeypatch.setattr(he_mod, "_save_background_health_checks_to_db", _fake_save)
+    monkeypatch.setattr(
+        proxy_server,
+        "general_settings",
+        {"disable_background_health_check_db_save": False},
+    )
+
+    proxy_server._schedule_background_health_check_db_save(
+        prisma_client=_SentinelPrisma(),
+        shared_health_manager=None,
+        model_list=[{"model_name": "gpt-4", "model_info": {"id": "id-1"}, "litellm_params": {"model": "gpt-4"}}],
+        healthy_endpoints=[{"model": "gpt-4"}],
+        unhealthy_endpoints=[],
+    )
+    await asyncio.sleep(0.01)
+    assert scheduled == [1]
+
+
+@pytest.mark.asyncio
+async def test_schedule_background_health_check_db_save_flag_only_python_true_disables(monkeypatch):
+    """Only the literal Python ``True`` disables. Truthy-but-not-True ("true", 1)
+    must NOT silently disable - config flag is explicit."""
+    from litellm.proxy import proxy_server
+    import litellm.proxy.health_endpoints._health_endpoints as he_mod
+
+    scheduled = []
+
+    async def _fake_save(prisma_client, model_list, healthy, unhealthy, start_time, checked_by=None):
+        scheduled.append(1)
+
+    monkeypatch.setattr(he_mod, "_save_background_health_checks_to_db", _fake_save)
+
+    for not_true in (False, None, 0, "", "true", "True", 1):
+        scheduled.clear()
+        monkeypatch.setattr(
+            proxy_server,
+            "general_settings",
+            {"disable_background_health_check_db_save": not_true},
+        )
+        proxy_server._schedule_background_health_check_db_save(
+            prisma_client=_SentinelPrisma(),
+            shared_health_manager=None,
+            model_list=[{"model_name": "gpt-4", "model_info": {"id": "id-1"}, "litellm_params": {"model": "gpt-4"}}],
+            healthy_endpoints=[{"model": "gpt-4"}],
+            unhealthy_endpoints=[],
+        )
+        await asyncio.sleep(0.01)
+        assert scheduled == [1], f"value={not_true!r} should NOT disable; only Python True does."
+
+    scheduled.clear()
+    monkeypatch.setattr(
+        proxy_server,
+        "general_settings",
+        {"disable_background_health_check_db_save": True},
+    )
+    proxy_server._schedule_background_health_check_db_save(
+        prisma_client=_SentinelPrisma(),
+        shared_health_manager=None,
+        model_list=[{"model_name": "gpt-4", "model_info": {"id": "id-1"}, "litellm_params": {"model": "gpt-4"}}],
+        healthy_endpoints=[{"model": "gpt-4"}],
+        unhealthy_endpoints=[],
+    )
+    await asyncio.sleep(0.01)
+    assert scheduled == []
+
+
+def test_schedule_background_health_check_db_save_none_prisma_short_circuits(monkeypatch):
+    """Pre-existing behavior: prisma_client is None -> no-op, regardless of flag."""
+    from litellm.proxy import proxy_server
+    import litellm.proxy.health_endpoints._health_endpoints as he_mod
+
+    scheduled = []
+
+    async def _fake_save(*a, **k):
+        scheduled.append(1)
+
+    monkeypatch.setattr(he_mod, "_save_background_health_checks_to_db", _fake_save)
+    monkeypatch.setattr(
+        proxy_server,
+        "general_settings",
+        {"disable_background_health_check_db_save": False},
+    )
+
+    proxy_server._schedule_background_health_check_db_save(
+        prisma_client=None,
+        shared_health_manager=None,
+        model_list=[],
+        healthy_endpoints=[],
+        unhealthy_endpoints=[],
+    )
+    assert scheduled == []
+


### PR DESCRIPTION
## Summary

[LIT-3078](https://linear.app/litellm-ai/issue/LIT-3078) — `[Performance] ACU utilisation up to 100%` from `LiteLLM_HealthChecksTable`.

When the background health-check loop is enabled with many models and a short interval, every cycle calls `_schedule_background_health_check_db_save`, which in turn issues:
- 1x `get_all_latest_health_checks()` SELECT against `LiteLLM_HealthCheckTable`
- per-model UPSERTs (one row per configured model) into `LiteLLM_HealthCheckTable` (the "save if status changed" check still requires the SELECT to run every cycle)

For ACU-bound RDS / Aurora deployments this is the dominant write driver — the prior session profiling pointed to it driving the entire DB to 100% utilization.

## Fix

Add an opt-out flag: when `general_settings.disable_background_health_check_db_save: true`, `_schedule_background_health_check_db_save` short-circuits at the top — no SELECT, no per-model UPSERTs, no `asyncio.create_task` for the save coroutine. The on-demand `/health/*` endpoint write path is a separate code path and is untouched.

The check uses `is True` (not truthy), so the gate is explicit — only the literal boolean `True` disables, matching the YAML-loaded `true`. The default `False` preserves existing behavior exactly.

```python
def _schedule_background_health_check_db_save(...):
    if prisma_client is None:
        return
    if general_settings.get("disable_background_health_check_db_save", False) is True:
        verbose_proxy_logger.debug("background_health_check_db_save_disabled cycle skipped ...")
        return
    # ... existing path unchanged
```

## Evidence

Runtime behavior of the *real* `_schedule_background_health_check_db_save` function (only the inner DB-save coroutine is stubbed so the dispatch is observable without a Postgres):

```
================================================================
DEFAULT (flag absent - pre-existing behavior, back-compat)
  config: general_settings = {}
================================================================
  [DB-SAVE] dispatched: models=50 healthy=45 unhealthy=5 checked_by='background_health_check'
  [DB-SAVE] dispatched: models=50 healthy=45 unhealthy=5 checked_by='background_health_check'
  [DB-SAVE] dispatched: models=50 healthy=45 unhealthy=5 checked_by='background_health_check'
  -> 3 DB-save coroutines dispatched over 3 background cycles
     Each dispatch runs: 1x get_all_latest_health_checks() SELECT + per-model UPSERTs against LiteLLM_HealthCheckTable

================================================================
OPT-OUT (new flag: general_settings.disable_background_health_check_db_save: true)
  config: general_settings = {'disable_background_health_check_db_save': True}
================================================================
  -> 0 DB-save coroutines dispatched over 3 cycles. DB-write path eliminated.

VERIFIED: default=3/3 dispatches; opt-out=0/3 dispatches.
```

Unit tests (5/5 pass), against the patched branch:

```
tests/test_litellm/proxy/test_health_check_functions.py::test_schedule_background_health_check_db_save_default_back_compat PASSED
tests/test_litellm/proxy/test_health_check_functions.py::test_schedule_background_health_check_db_save_disabled_via_flag PASSED
tests/test_litellm/proxy/test_health_check_functions.py::test_schedule_background_health_check_db_save_flag_false_dispatches PASSED
tests/test_litellm/proxy/test_health_check_functions.py::test_schedule_background_health_check_db_save_flag_only_python_true_disables PASSED
tests/test_litellm/proxy/test_health_check_functions.py::test_schedule_background_health_check_db_save_none_prisma_short_circuits PASSED
====================== 5 passed, 24 deselected in 11.94s =======================
```

Coverage:
- Back-compat: flag absent -> dispatch happens (pre-existing behavior).
- Opt-out: flag `True` -> 5 consecutive cycles produce 0 dispatches.
- Explicit-off: flag `False` -> dispatch happens.
- Truthy-but-not-True (`"true"`, `1`, etc.) -> dispatch happens (explicit boolean only).
- `prisma_client=None` -> still no-op regardless of flag (pre-existing path).

## Linear

- LIT-3078 — `[Performance] ACU utilisation up to 100%`

## Notes for reviewer

- This was filed via the GitHub Contents API (no `git push` scope on the agent's `GITHUB_TOKEN`). The diff is still minimal: two files, +14/-1 in `proxy_server.py` and +171/-0 in the test file.
- Session: https://litellm-agent-platform.onrender.com/sessions/ac94dfb0-35e3-4147-a29e-3a2b6f9cdcb2

### Verification (ship-pr)
- change-type: `litellm/proxy/proxy_server.py` (backend dispatcher gate) -> captured dispatch log; `tests/.../test_health_check_functions.py` (unit tests) -> pytest output
- evidence present: PASS (fenced block with before-3/3 / after-0/3 dispatch counts, plus 5/5 pytest output)
- image sanity: N/A (no screenshots; backend logic gate)
- image content matches caption: N/A
- backend evidence from running system: PASS - real `_schedule_background_health_check_db_save` is exercised against the patched branch in the sandbox (`/tmp/litellm-3078`); only the inner `_save_background_health_checks_to_db` coroutine is stubbed so the dispatch decision is observable. Gate logic, `general_settings.get()` lookup, and `asyncio.create_task` call are all real code.
- hygiene: 2 files changed, no external image hosts, no `git add -A`.