### PR TITLE
fix(auth): expand LiteLLMRoutes bucket names in non_proxy_admin_allowed_routes_check (LIT-3300)

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -143,6 +143,45 @@ class RouteChecks:
         )
 
     @staticmethod
+    def _check_allowed_routes_match(route: str, allowed_routes: List) -> bool:
+        """LIT-3300 helper. Returns True if ``route`` matches any entry in
+        ``allowed_routes`` using:
+
+        1. Bucket-name expansion (e.g. ``"management_routes"`` ->
+           ``LiteLLMRoutes.management_routes.value``). Bucket names that
+           don't match the route are NOT then re-checked as literal paths.
+        2. Exact / prefix match (``_route_matches_allowed_route``).
+        3. Wildcard pattern match (``_route_matches_wildcard_pattern``).
+
+        Used by ``non_proxy_admin_allowed_routes_check`` as the fallback
+        when no earlier role-based gate has accepted the request.
+        """
+        for allowed_route in allowed_routes:
+            if (
+                isinstance(allowed_route, str)
+                and allowed_route in LiteLLMRoutes._member_names_
+            ):
+                if RouteChecks.check_route_access(
+                    route=route,
+                    allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
+                ):
+                    return True
+                # bucket name handled - do not also try to literal-match it
+                continue
+
+            if RouteChecks._route_matches_allowed_route(
+                route=route, allowed_route=allowed_route
+            ):
+                return True
+
+            if RouteChecks._route_matches_wildcard_pattern(
+                route=route, pattern=allowed_route
+            ):
+                return True
+
+        return False
+
+    @staticmethod
     def _mask_user_id(user_id: str) -> str:
         """
         Mask user_id to prevent leaking sensitive information in error messages
@@ -281,22 +320,15 @@ class RouteChecks:
         ):
             pass
         elif valid_token.allowed_routes is not None:
-            # check if route is in allowed_routes (exact match or prefix match)
-            route_allowed = False
-            for allowed_route in valid_token.allowed_routes:
-                if RouteChecks._route_matches_allowed_route(
-                    route=route, allowed_route=allowed_route
-                ):
-                    route_allowed = True
-                    break
-
-                if RouteChecks._route_matches_wildcard_pattern(
-                    route=route, pattern=allowed_route
-                ):
-                    route_allowed = True
-                    break
-
-            if not route_allowed:
+            # LIT-3300: allowed_routes may contain LiteLLMRoutes enum-member NAMES
+            # (e.g. "management_routes", "llm_api_routes", "info_routes") written by
+            # handle_key_type() in key_management_endpoints.py. _check_allowed_routes_match
+            # expands any bucket name to its concrete route list before doing the regular
+            # exact / prefix / wildcard checks. Mirrors the symmetric expansion already
+            # done by is_virtual_key_allowed_to_call_route.
+            if not RouteChecks._check_allowed_routes_match(
+                route=route, allowed_routes=valid_token.allowed_routes
+            ):
                 RouteChecks._raise_admin_only_route_exception(
                     user_obj=user_obj, route=route
                 )

--- a/tests/test_litellm/proxy/auth/test_lit_3300_bucket_expansion.py
+++ b/tests/test_litellm/proxy/auth/test_lit_3300_bucket_expansion.py
@@ -1,0 +1,172 @@
+"""Regression tests for LIT-3300.
+
+Virtual keys created with key_type=management / key_type=llm_api / key_type=read_only
+get `allowed_routes` set to LiteLLMRoutes enum-member NAMES like "management_routes",
+"llm_api_routes", "info_routes" (by handle_key_type in key_management_endpoints.py).
+
+`is_virtual_key_allowed_to_call_route` (first gate) already expands those names to
+the concrete route list. The fallback `non_proxy_admin_allowed_routes_check` did not —
+it compared the bucket-name string against the request path, which always failed,
+so callers saw 401 on routes the bucket should cover.
+
+These tests cover the fallback bucket-name expansion.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import pytest
+from fastapi import Request
+
+from litellm.proxy._types import (
+    LiteLLM_UserTable,
+    LiteLLMRoutes,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.auth.route_checks import RouteChecks
+
+
+def _make_request() -> Request:
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    return request
+
+
+def _make_token(allowed_routes):
+    return UserAPIKeyAuth(
+        api_key="sk-test",
+        user_id=None,
+        allowed_routes=allowed_routes,
+        team_id=None,
+        key_name=None,
+        permissions={},
+        models=[],
+    )
+
+
+def _call(allowed_routes, route, user_role=None):
+    user_obj = None
+    if user_role is not None:
+        user_obj = LiteLLM_UserTable(
+            user_id="u1",
+            user_email=None,
+            user_role=user_role,
+        )
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=user_role,
+        route=route,
+        request=_make_request(),
+        valid_token=_make_token(allowed_routes),
+        request_data={},
+    )
+    return "ALLOW"
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/team/new",
+        "/team/delete",
+        "/team/block",
+        "/team/unblock",
+        "/key/generate",
+        "/key/delete",
+        "/key/regenerate",
+    ],
+)
+def test_management_routes_bucket_allows_management_routes(route):
+    """Bucket-name 'management_routes' should allow any route covered by management_routes."""
+    assert _call(["management_routes"], route) == "ALLOW"
+
+
+def test_info_routes_bucket_allows_key_info():
+    assert _call(["info_routes"], "/key/info") == "ALLOW"
+
+
+def test_info_routes_bucket_denies_management_route():
+    """info_routes (a strict subset of management_routes) should NOT allow /team/new."""
+    with pytest.raises(Exception) as exc_info:
+        _call(["info_routes"], "/team/new")
+    assert "Only proxy admin" in str(exc_info.value)
+
+
+def test_management_routes_bucket_denies_unknown_route():
+    """management_routes does not contain '/some/random/route' — must deny."""
+    with pytest.raises(Exception) as exc_info:
+        _call(["management_routes"], "/some/random/route")
+    assert "Only proxy admin" in str(exc_info.value)
+
+
+def test_unknown_bucket_string_falls_through_to_literal_match_and_denies():
+    """A string that looks like a bucket name but is not a LiteLLMRoutes member
+    should fall through to literal-path matching; since it doesn't match the
+    request path either, the request must be denied."""
+    with pytest.raises(Exception):
+        _call(["not_a_real_bucket"], "/team/new")
+
+
+def test_mixed_bucket_and_explicit_path_allows_bucket_route():
+    """allowed_routes = ['management_routes', '/custom/route'] — /team/new (in bucket) allowed."""
+    assert _call(["management_routes", "/custom/route"], "/team/new") == "ALLOW"
+
+
+def test_mixed_bucket_and_explicit_path_allows_explicit_route():
+    """allowed_routes = ['info_routes', '/custom/route'] — /custom/route (explicit) allowed."""
+    assert _call(["info_routes", "/custom/route"], "/custom/route") == "ALLOW"
+
+
+def test_mixed_bucket_and_wildcard_allows_wildcard_match():
+    """allowed_routes = ['info_routes', '/admin/*'] — /admin/foo matched via wildcard."""
+    assert _call(["info_routes", "/admin/*"], "/admin/foo") == "ALLOW"
+
+
+def test_exact_match_still_works():
+    assert _call(["/team/new"], "/team/new") == "ALLOW"
+
+
+def test_wildcard_match_still_works():
+    assert _call(["/team/*"], "/team/new") == "ALLOW"
+
+
+def test_no_match_still_denies():
+    with pytest.raises(Exception):
+        _call(["/admin/x"], "/team/new")
+
+
+def test_non_string_entries_are_skipped_safely():
+    """allowed_routes could (in theory) contain a non-string entry; bucket
+    expansion must require isinstance(str) and skip safely."""
+    with pytest.raises(Exception):
+        _call([123, None], "/team/new")
+
+
+def test_bucket_name_then_explicit_path_allows_explicit():
+    assert _call(["info_routes", "/team/new"], "/team/new") == "ALLOW"
+
+
+def test_llm_api_routes_bucket_does_not_grant_arbitrary_passthrough():
+    """A key with allowed_routes=['llm_api_routes'] must NOT be granted access to an
+    arbitrary route via the fallback. Pass-through access is governed by
+    check_passthrough_route_access (earlier gate), which consults explicit per-key
+    / per-team allowed_passthrough_routes. The fallback must not have a blanket
+    carve-out that bypasses that — Veria flagged exactly this in PR #28949 review.
+    """
+    arbitrary_route = "/azure-passthrough-only-explicitly-allowed/v1/whatever"
+    assert arbitrary_route not in LiteLLMRoutes.llm_api_routes.value
+    with pytest.raises(Exception) as exc_info:
+        _call(["llm_api_routes"], arbitrary_route)
+    assert "Only proxy admin" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "bucket", ["management_routes", "info_routes", "llm_api_routes"]
+)
+def test_bucket_names_are_valid_litellm_routes_members(bucket):
+    """If this assertion ever fails, handle_key_type wrote a bucket name that the
+    expansion path doesn't recognize, and LIT-3300 would resurface."""
+    assert bucket in LiteLLMRoutes._member_names_


### PR DESCRIPTION
## Summary

Virtual keys created via `/key/generate` with `key_type=management` (UI label "Management") or `key_type=llm_api` (UI label "AI APIs") returned **401 Unauthorized** on routes that the key's bucket should already cover (`mgmt` key -> `POST /key/generate` -> 401 *"Only proxy admin can be used to..."*; `mgmt` key -> `POST /team/new` -> 401). Keys created with `key_type=default` ("All APIs") worked because they leave `allowed_routes` empty.

Fixes LIT-3300.

## Root cause

`handle_key_type` in `litellm/proxy/management_endpoints/key_management_endpoints.py` writes a `LiteLLMRoutes` enum-member **NAME** onto the token, not a list of concrete paths:

```python
if key_type == LiteLLMKeyType.LLM_API:
    data_json["allowed_routes"] = ["llm_api_routes"]
elif key_type == LiteLLMKeyType.MANAGEMENT:
    data_json["allowed_routes"] = ["management_routes"]
elif key_type == LiteLLMKeyType.READ_ONLY:
    data_json["allowed_routes"] = ["info_routes"]
```

`is_virtual_key_allowed_to_call_route` (the first gate) already expands those bucket names via `LiteLLMRoutes._member_names_` / `_member_map_[name].value`. But the **second-pass fallback** in `non_proxy_admin_allowed_routes_check` did not: it ran `_route_matches_allowed_route(route, "management_routes")` which compares the bucket-name string directly against the request path. That comparison can never succeed, so the call fell through to `_raise_admin_only_route_exception` and the user saw 401.

## Fix

In `non_proxy_admin_allowed_routes_check` (`litellm/proxy/auth/route_checks.py`), when an entry in `valid_token.allowed_routes` is a `LiteLLMRoutes` enum-member name, expand it to that bucket's `.value` list and check via `RouteChecks.check_route_access`. Mirrors the symmetric expansion already done by `is_virtual_key_allowed_to_call_route`. **Pass-through access remains governed by `check_passthrough_route_access` (earlier in the same function), which consults per-key/per-team `allowed_passthrough_routes`.** This fallback intentionally does NOT carry a blanket pass-through carve-out — a prior PR review flagged exactly that as a HIGH issue, so the new bucket check ignores pass-through paths and lets the earlier gate stay authoritative.

```python
elif valid_token.allowed_routes is not None:
    route_allowed = False
    for allowed_route in valid_token.allowed_routes:
        # 1. Bucket-name expansion (LIT-3300)
        if (
            isinstance(allowed_route, str)
            and allowed_route in LiteLLMRoutes._member_names_
        ):
            if RouteChecks.check_route_access(
                route=route,
                allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
            ):
                route_allowed = True
                break
            continue  # bucket name handled — do not literal-match it
        # 2. Exact / prefix match (existing)
        # 3. Wildcard pattern match (existing)
```

## Evidence

Reproduced and captured before/after by calling `RouteChecks.non_proxy_admin_allowed_routes_check` directly with a token whose `allowed_routes=['management_routes']` (the exact shape `handle_key_type` writes). Same token, same routes, before vs. after the patch:

**Before — clean `litellm_oss_agent_shin_daily_branch` at `6d9867237b1f7cf4c28ad4c75059930e28823d0c`:**

```
allowed_routes               route                        result                 expectation
--------------------------------------------------------------------------------------------------------------
['management_routes']        /team/new                    DENY (Only proxy admin can be used to generate, delete, update info for...) POS bucket allows mgmt route
['management_routes']        /team/delete                 DENY (Only proxy admin can be used to generate, delete, update info for...) POS bucket allows mgmt route
['management_routes']        /team/block                  DENY (Only proxy admin can be used to generate, delete, update info for...) POS bucket allows mgmt route
['management_routes']        /team/unblock                DENY (Only proxy admin can be used to generate, delete, update info for...) POS bucket allows mgmt route
['management_routes']        /key/generate                DENY (Only proxy admin can be used to generate, delete, update info for...) POS bucket allows mgmt route
['info_routes']              /key/info                    ALLOW                  POS info bucket allows /key/info
['management_routes']        /some/random/route           DENY (Only proxy admin can be used to generate, delete, update info for...) NEG bucket does not over-reach
['info_routes']              /team/new                    DENY (Only proxy admin can be used to generate, delete, update info for...) NEG info bucket cannot reach mgmt
['/team/new']                /team/new                    ALLOW                  PRESERVE exact match still works
['/team/*']                  /team/new                    ALLOW                  PRESERVE wildcard still works
```

**After — same scenarios, with the patch on `shin/lit-3300-v2`:**

```
allowed_routes               route                        result                 expectation
--------------------------------------------------------------------------------------------------------------
['management_routes']        /team/new                    ALLOW                  POS bucket allows mgmt route
['management_routes']        /team/delete                 ALLOW                  POS bucket allows mgmt route
['management_routes']        /team/block                  ALLOW                  POS bucket allows mgmt route
['management_routes']        /team/unblock                ALLOW                  POS bucket allows mgmt route
['management_routes']        /key/generate                ALLOW                  POS bucket allows mgmt route
['info_routes']              /key/info                    ALLOW                  POS info bucket allows /key/info
['management_routes']        /some/random/route           DENY (Only proxy admin can be used to generate, delete, update info for...) NEG bucket does not over-reach
['info_routes']              /team/new                    DENY (Only proxy admin can be used to generate, delete, update info for...) NEG info bucket cannot reach mgmt
['/team/new']                /team/new                    ALLOW                  PRESERVE exact match still works
['/team/*']                  /team/new                    ALLOW                  PRESERVE wildcard still works
```

All POS-bucket rows flip DENY -> ALLOW. NEG rows correctly stay DENY (the bucket does not over-reach). Existing exact-match and wildcard behavior is preserved (both ALLOW before and after).

## Tests

- 23 new regression tests in `tests/test_litellm/proxy/auth/test_lit_3300_bucket_expansion.py` cover:
  - positive expansion for `management_routes` (parametrised over 7 routes) + `info_routes`
  - negative no-over-reach for `info_routes` -> `/team/new` and `management_routes` -> `/some/random/route`
  - mixed bucket + explicit-path / bucket + wildcard
  - existing exact / prefix / wildcard behaviour unchanged
  - non-string entries skipped safely
  - **security guard**: `['llm_api_routes']` does NOT bypass `check_passthrough_route_access` (the Veria-flagged regression from prior PR #28949)
  - sanity: bucket names are valid `LiteLLMRoutes` member names

```
tests/test_litellm/proxy/auth/test_lit_3300_bucket_expansion.py
23 passed in 8.12s
```

- Full existing `test_route_checks.py` suite: 267 passed, 1 failed (unrelated pre-existing pytest-asyncio plugin issue on `test_initialize_pass_through_registers_wildcard_for_auth_subpath`).

## Note on push path

This branch was created via the GitHub Git Data API (blob -> tree -> commit -> ref) — the agent's token lacks `repo` scope for direct `git push`. The base tree is the daily-branch HEAD, so the merge-base diff is exactly the 2 files in the commit (`route_checks.py` + the new test file).

### Verification (ship-pr)
- change-type: backend auth check (`litellm/proxy/auth/route_checks.py`) -> evidence type required: captured request/response (text)
- evidence present: PASS (before + after blocks; same 10 scenarios)
- backend evidence from running system: PASS (function under test called directly with the exact shape `handle_key_type` writes; outputs captured on disk in `/tmp/before.txt` and `/tmp/after.txt` during this session)
- screenshots: N/A (no UI surface)
- hygiene: PASS (commit is exactly 2 intended files: `route_checks.py` + new test file)
