### PR TITLE
fix(guardrails): hide_secrets redacts full PEM private-key block

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -6,6 +6,7 @@
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
 
 import os
+import re
 import sys
 
 sys.path.insert(
@@ -421,6 +422,59 @@ _default_detect_secrets_config = {
 }
 
 
+
+# PEM private-key blocks are multi-line, but ``detect-secrets`` is strictly
+# line-based: ``PrivateKeyDetector`` returns only the ``-----BEGIN ... PRIVATE
+# KEY-----`` armor header as the matched ``secret_value``. The downstream
+# ``str.replace(secret["value"], "[REDACTED]")`` call sites therefore only
+# strike that one line and forward the base64 body + ``-----END`` footer
+# verbatim. To fix that without touching every call site, we expand any
+# ``Private Key`` entry to span the entire PEM block found in the original
+# message text before the replace calls run.
+_PEM_BLOCK_RE = re.compile(
+    r"-----BEGIN[^\n]*PRIVATE KEY-----[\s\S]*?-----END[^\n]*PRIVATE KEY-----"
+)
+
+
+def _expand_private_key_values(
+    message_content: str, detected_secrets: list
+) -> list:
+    """Replace each ``Private Key`` entry header-only value with the full PEM
+    block from ``message_content``. Non-PEM secrets are returned unchanged.
+
+    If multiple PEM blocks appear in ``message_content`` we emit one entry per
+    block so every block gets redacted by the existing replace loop.
+    """
+    if not detected_secrets:
+        return detected_secrets
+
+    has_private_key = any(
+        s.get("type") == "Private Key" for s in detected_secrets
+    )
+    if not has_private_key:
+        return detected_secrets
+
+    pem_blocks = _PEM_BLOCK_RE.findall(message_content)
+    if not pem_blocks:
+        # Detector flagged a header but no full block exists - leave as-is so
+        # the existing header-line redaction still runs.
+        return detected_secrets
+
+    expanded: list = []
+    consumed_private_key = False
+    for secret in detected_secrets:
+        if secret.get("type") == "Private Key" and not consumed_private_key:
+            for block in pem_blocks:
+                expanded.append({"type": "Private Key", "value": block})
+            consumed_private_key = True
+        elif secret.get("type") == "Private Key":
+            # Additional header matches are covered by per-block entries above.
+            continue
+        else:
+            expanded.append(secret)
+    return expanded
+
+
 class _ENTERPRISE_SecretDetection(CustomGuardrail):
     def __init__(self, detect_secrets_config: Optional[dict] = None, **kwargs):
         self.user_defined_detect_secrets_config = detect_secrets_config
@@ -452,6 +506,13 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                 detected_secrets.append(
                     {"type": found_secret.type, "value": found_secret.secret_value}
                 )
+
+        # Expand any ``Private Key`` entry (which ``detect-secrets`` only flags
+        # by its BEGIN-header line) to the full PEM block so the call-site
+        # ``str.replace(secret["value"], ...)`` strikes header + body + footer.
+        detected_secrets = _expand_private_key_values(
+            message_content, detected_secrets
+        )
 
         return detected_secrets
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_hide_secrets_pem_block.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_hide_secrets_pem_block.py
@@ -1,0 +1,114 @@
+"""Regression tests for LIT-3292: ``hide_secrets`` must redact the FULL PEM
+private-key block (header + base64 body + footer), not only the BEGIN-armor
+line that ``detect-secrets`` exposes as the matched secret value.
+"""
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+ENT = os.path.join(ROOT, "enterprise")
+if ENT not in sys.path:
+    sys.path.insert(0, ENT)
+
+from litellm_enterprise.enterprise_callbacks.secret_detection import (  # noqa: E402
+    _ENTERPRISE_SecretDetection,
+    _PEM_BLOCK_RE,
+    _expand_private_key_values,
+)
+
+
+PEM_BLOCK = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEowIBAAKCAQEAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"
+    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n"
+    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+
+def _apply_naive_replace(text, secrets):
+    out = text
+    for s in secrets:
+        out = out.replace(s["value"], "[REDACTED]")
+    return out
+
+
+def test_pem_block_regex_matches_full_block():
+    text = "prefix\n" + PEM_BLOCK + "\nsuffix"
+    matches = _PEM_BLOCK_RE.findall(text)
+    assert len(matches) == 1
+    assert matches[0].startswith("-----BEGIN RSA PRIVATE KEY-----")
+    assert matches[0].endswith("-----END RSA PRIVATE KEY-----")
+
+
+def test_pem_block_regex_matches_multiple_blocks():
+    text = PEM_BLOCK + "\nmiddle\n" + PEM_BLOCK
+    matches = _PEM_BLOCK_RE.findall(text)
+    assert len(matches) == 2
+
+
+def test_expand_private_key_values_replaces_header_with_block():
+    text = "Key:\n" + PEM_BLOCK + "\nbye"
+    detected = [{"type": "Private Key", "value": "BEGIN RSA PRIVATE KEY"}]
+    expanded = _expand_private_key_values(text, detected)
+    assert len(expanded) == 1
+    assert expanded[0]["type"] == "Private Key"
+    assert expanded[0]["value"] == PEM_BLOCK
+
+
+def test_expand_private_key_values_emits_one_entry_per_block():
+    text = PEM_BLOCK + "\n---\n" + PEM_BLOCK
+    detected = [{"type": "Private Key", "value": "BEGIN RSA PRIVATE KEY"}]
+    expanded = _expand_private_key_values(text, detected)
+    assert len(expanded) == 2
+    assert all(e["value"] == PEM_BLOCK for e in expanded)
+
+
+def test_expand_private_key_values_preserves_other_secrets():
+    text = "key " + PEM_BLOCK + " aws=AKIAIOSFODNN7EXAMPLE"
+    detected = [
+        {"type": "AWS Access Key", "value": "AKIAIOSFODNN7EXAMPLE"},
+        {"type": "Private Key", "value": "BEGIN RSA PRIVATE KEY"},
+    ]
+    expanded = _expand_private_key_values(text, detected)
+    types = sorted(e["type"] for e in expanded)
+    assert types == ["AWS Access Key", "Private Key"]
+    assert any(e["value"] == PEM_BLOCK for e in expanded)
+    assert any(e["value"] == "AKIAIOSFODNN7EXAMPLE" for e in expanded)
+
+
+def test_expand_private_key_values_passthrough_when_no_pem_in_text():
+    detected = [{"type": "Private Key", "value": "BEGIN RSA PRIVATE KEY"}]
+    expanded = _expand_private_key_values("no key here at all", detected)
+    assert expanded == detected
+
+
+def test_expand_private_key_values_passthrough_when_no_private_key():
+    detected = [{"type": "AWS Access Key", "value": "AKIA..."}]
+    expanded = _expand_private_key_values("something", detected)
+    assert expanded == detected
+
+
+def test_scan_message_for_secrets_redacts_full_pem_block():
+    inst = _ENTERPRISE_SecretDetection()
+    msg = "Here is my key:\n" + PEM_BLOCK + "\nplease keep it safe."
+    secrets = inst.scan_message_for_secrets(msg)
+    pk_entries = [s for s in secrets if s["type"] == "Private Key"]
+    assert pk_entries, "PrivateKeyDetector did not fire"
+    assert any(e["value"] == PEM_BLOCK for e in pk_entries)
+    redacted = _apply_naive_replace(msg, secrets)
+    assert "-----BEGIN RSA PRIVATE KEY-----" not in redacted
+    assert "-----END RSA PRIVATE KEY-----" not in redacted
+    assert "MIIEowIBAAKCAQEAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_scan_handles_multiple_pem_blocks():
+    inst = _ENTERPRISE_SecretDetection()
+    msg = "first:\n" + PEM_BLOCK + "\nsecond:\n" + PEM_BLOCK + "\nend."
+    secrets = inst.scan_message_for_secrets(msg)
+    pk_entries = [s for s in secrets if s["type"] == "Private Key"]
+    assert len(pk_entries) >= 2
+    redacted = _apply_naive_replace(msg, secrets)
+    assert "MIIEowIBAAKCAQEA" not in redacted
+    assert "-----END RSA PRIVATE KEY-----" not in redacted

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_hide_secrets_pem_block.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_hide_secrets_pem_block.py
@@ -5,7 +5,7 @@ line that ``detect-secrets`` exposes as the matched secret value.
 import os
 import sys
 
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
 ENT = os.path.join(ROOT, "enterprise")
 if ENT not in sys.path:
     sys.path.insert(0, ENT)


### PR DESCRIPTION
## Summary

The enterprise `hide_secrets` guardrail flags PEM private keys in user messages but **only redacts the `-----BEGIN ... PRIVATE KEY-----` header line**. The base64 body and `-----END ... PRIVATE KEY-----` footer pass through to the downstream model verbatim, even though logs report that the secret was detected and redacted.

**Root cause.** `detect-secrets` is strictly line-based: `PrivateKeyDetector` returns only the BEGIN-armor line as the matched `secret_value`. The three replacement call sites in `async_pre_call_hook` then do:

```python
text = text.replace(secret["value"], "[REDACTED]")
```

which strikes only that one line and leaves the rest of the PEM block intact.

**Fix.** A new helper, `_expand_private_key_values`, runs inside `scan_message_for_secrets` (the single chokepoint) and, whenever the detector reports a `Private Key`, looks up the full PEM block in the original message via a multiline regex and substitutes the header-only value with the entire block (one entry per block when multiple are present). The three call sites are unchanged - they still do `str.replace(secret["value"], "[REDACTED]")`, but `secret["value"]` is now the complete block, so header + base64 body + footer are all redacted in one pass.

This keeps the helper colocated with the scanner, costs one extra regex pass only when a `Private Key` is reported, and stays a no-op for any non-PEM secret.

## Evidence

Runtime evidence captured by exercising `_ENTERPRISE_SecretDetection.scan_message_for_secrets` against the exact code path used by `async_pre_call_hook`, on the same checkout, with only the patched file swapped between runs.

### Before (base, buggy)

`PrivateKeyDetector` returns only the 21-byte header line as the matched value, so the naive replace leaves the base64 body and END footer untouched:

```
=== DETECTED ===
  type='Private Key' len=21 starts='BEGIN RSA PRIVATE KEY' ends='BEGIN RSA PRIVATE KEY'
=== REDACTED OUTPUT ===
Here is my key:
-----[REDACTED]-----
MIIEowIBAAKCAQEAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-----END RSA PRIVATE KEY-----
please keep it safe.
=== ASSERTIONS ===
base64 body removed: False
END footer removed : False
BEGIN header removed: True
[REDACTED] present : True
```

### After (this branch, fixed)

The detector entry now carries the full 268-byte PEM block as its value, so the same replace strips header, body and footer:

```
=== DETECTED ===
  type='Private Key' len=268 starts='-----BEGIN RSA PRIVATE KEY----' ends='\n-----END RSA PRIVATE KEY-----'
=== REDACTED OUTPUT ===
Here is my key:
[REDACTED]
please keep it safe.
=== ASSERTIONS ===
base64 body removed: True
END footer removed : True
BEGIN header removed: True
[REDACTED] present : True
```

### Unit tests (9 / 9 passing)

```
tests/.../test_hide_secrets_pem_block.py::test_pem_block_regex_matches_full_block PASSED
tests/.../test_hide_secrets_pem_block.py::test_pem_block_regex_matches_multiple_blocks PASSED
tests/.../test_hide_secrets_pem_block.py::test_expand_private_key_values_replaces_header_with_block PASSED
tests/.../test_hide_secrets_pem_block.py::test_expand_private_key_values_emits_one_entry_per_block PASSED
tests/.../test_hide_secrets_pem_block.py::test_expand_private_key_values_preserves_other_secrets PASSED
tests/.../test_hide_secrets_pem_block.py::test_expand_private_key_values_passthrough_when_no_pem_in_text PASSED
tests/.../test_hide_secrets_pem_block.py::test_expand_private_key_values_passthrough_when_no_private_key PASSED
tests/.../test_hide_secrets_pem_block.py::test_scan_message_for_secrets_redacts_full_pem_block PASSED
tests/.../test_hide_secrets_pem_block.py::test_scan_handles_multiple_pem_blocks PASSED

9 passed in 8.91s
```

## Linear

LIT-3292


_Note: this branch was pushed via the GitHub Contents API (one commit per file) because the agent's token lacks `workflow` scope, which produces a noisier merge-base diff than a single squashed commit._


### Verification (ship-pr)
- **change-type**: backend / guardrail callback (`enterprise/.../secret_detection.py`) + regression tests. Required evidence: real request showing decision, not images.
- **evidence present**: PASS — fenced BEFORE block shows `base64 body removed: False`, AFTER block shows `base64 body removed: True`; 9/9 unit tests reproduced in body.
- **image sanity**: N/A (no UI surface)
- **image content matches caption**: N/A (no UI surface)
- **backend evidence from running system**: PASS — the captured BEFORE/AFTER blocks come from a real `_ENTERPRISE_SecretDetection.scan_message_for_secrets(...)` call on the same checkout, with only the patched file swapped between runs; this is the exact code path `async_pre_call_hook` exercises.
- **hygiene**: PASS — no external image hosts; staged files are exactly the 2 intended changes.