### PR TITLE
fix(guardrails): redact full PEM private key block in hide_secrets

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -35,9 +35,14 @@ _PEM_BLOCK_RE = re.compile(
 )
 
 
-def _redact_pem_blocks(text: str) -> str:
-    """Replace every full PEM private-key block in ``text`` with ``[REDACTED]``."""
-    return _PEM_BLOCK_RE.sub("[REDACTED]", text)
+def _redact_pem_blocks(text: str) -> tuple[str, int]:
+    """Replace every full PEM private-key block in ``text`` with ``[REDACTED]``.
+
+    Returns ``(redacted_text, num_blocks_replaced)`` so callers can record
+    when the regex sweep caught a block that ``detect-secrets`` did not.
+    """
+    redacted, n = _PEM_BLOCK_RE.subn("[REDACTED]", text)
+    return redacted, n
 
 _custom_plugins_path = "file://" + os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "secrets_plugins"
@@ -500,13 +505,20 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
             # any full PEM block first so the body + footer go with the
             # header, then run the normal per-secret loop to handle the
             # non-PEM secret types.
-            text = _redact_pem_blocks(text)
+            text, pem_blocks_redacted = _redact_pem_blocks(text)
             for secret in detected_secrets:
                 text = text.replace(secret["value"], "[REDACTED]")
             if detected_secrets:
                 secret_types = [secret["type"] for secret in detected_secrets]
                 verbose_proxy_logger.warning(
                     f"Detected and redacted secrets in message: {secret_types}"
+                )
+            elif pem_blocks_redacted:
+                # Regex sweep caught a PEM block that detect-secrets missed —
+                # keep operator-visible evidence that something was scrubbed.
+                verbose_proxy_logger.warning(
+                    f"Redacted {pem_blocks_redacted} PEM private key block(s) "
+                    "in message that were not flagged by detect-secrets"
                 )
             return text
 
@@ -517,7 +529,9 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                 detected_secrets = self.scan_message_for_secrets(data["prompt"])
                 # Scrub any full PEM block first so body + END footer are
                 # removed alongside the BEGIN header.
-                data["prompt"] = _redact_pem_blocks(data["prompt"])
+                data["prompt"], pem_blocks_redacted = _redact_pem_blocks(
+                    data["prompt"]
+                )
                 for secret in detected_secrets:
                     data["prompt"] = data["prompt"].replace(
                         secret["value"], "[REDACTED]"
@@ -526,6 +540,11 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                     secret_types = [secret["type"] for secret in detected_secrets]
                     verbose_proxy_logger.warning(
                         f"Detected and redacted secrets in prompt: {secret_types}"
+                    )
+                elif pem_blocks_redacted:
+                    verbose_proxy_logger.warning(
+                        f"Redacted {pem_blocks_redacted} PEM private key block(s) "
+                        "in prompt that were not flagged by detect-secrets"
                     )
             elif isinstance(data["prompt"], list):
                 # Index back into the list — assigning to ``item`` would only
@@ -536,7 +555,7 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                         detected_secrets = self.scan_message_for_secrets(item)
                         # Scrub any full PEM block first so body + END footer
                         # are removed alongside the BEGIN header.
-                        item = _redact_pem_blocks(item)
+                        item, pem_blocks_redacted = _redact_pem_blocks(item)
                         for secret in detected_secrets:
                             item = item.replace(secret["value"], "[REDACTED]")
                         data["prompt"][idx] = item
@@ -546,6 +565,12 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                             ]
                             verbose_proxy_logger.warning(
                                 f"Detected and redacted secrets in prompt: {secret_types}"
+                            )
+                        elif pem_blocks_redacted:
+                            verbose_proxy_logger.warning(
+                                f"Redacted {pem_blocks_redacted} PEM private key "
+                                "block(s) in prompt that were not flagged by "
+                                "detect-secrets"
                             )
 
         # ``data["input"]`` (Responses API and embeddings/moderation) is

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -6,6 +6,7 @@
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
 
 import os
+import re
 import sys
 
 sys.path.insert(
@@ -21,6 +22,22 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails._content_utils import walk_user_text
 
 GUARDRAIL_NAME = "hide_secrets"
+
+
+# Regex matching a full PEM private-key block (BEGIN/END pair with body in
+# between). detect-secrets' PrivateKeyDetector only returns the BEGIN header
+# line as the secret value, so a naive ``text.replace(secret_value, ...)``
+# leaves the base64 body and the END footer in the message. We sweep the
+# whole block in a first pass before the per-secret replacement loop so the
+# body and END footer are scrubbed alongside the header.
+_PEM_BLOCK_RE = re.compile(
+    r"-----BEGIN[^\n]*PRIVATE KEY-----[\s\S]*?-----END[^\n]*PRIVATE KEY-----",
+)
+
+
+def _redact_pem_blocks(text: str) -> str:
+    """Replace every full PEM private-key block in ``text`` with ``[REDACTED]``."""
+    return _PEM_BLOCK_RE.sub("[REDACTED]", text)
 
 _custom_plugins_path = "file://" + os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "secrets_plugins"
@@ -477,6 +494,13 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
         # Covers multimodal list content + Responses-API input.
         def _redact_message_text(text: str) -> str:
             detected_secrets = self.scan_message_for_secrets(text)
+            # detect-secrets' PrivateKeyDetector only returns the BEGIN header
+            # line as the secret value, so a per-secret ``str.replace`` would
+            # leave the base64 body and the END footer in the message. Scrub
+            # any full PEM block first so the body + footer go with the
+            # header, then run the normal per-secret loop to handle the
+            # non-PEM secret types.
+            text = _redact_pem_blocks(text)
             for secret in detected_secrets:
                 text = text.replace(secret["value"], "[REDACTED]")
             if detected_secrets:
@@ -491,6 +515,9 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
         if "prompt" in data:
             if isinstance(data["prompt"], str):
                 detected_secrets = self.scan_message_for_secrets(data["prompt"])
+                # Scrub any full PEM block first so body + END footer are
+                # removed alongside the BEGIN header.
+                data["prompt"] = _redact_pem_blocks(data["prompt"])
                 for secret in detected_secrets:
                     data["prompt"] = data["prompt"].replace(
                         secret["value"], "[REDACTED]"
@@ -507,6 +534,9 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                 for idx, item in enumerate(data["prompt"]):
                     if isinstance(item, str):
                         detected_secrets = self.scan_message_for_secrets(item)
+                        # Scrub any full PEM block first so body + END footer
+                        # are removed alongside the BEGIN header.
+                        item = _redact_pem_blocks(item)
                         for secret in detected_secrets:
                             item = item.replace(secret["value"], "[REDACTED]")
                         data["prompt"][idx] = item

--- a/tests/local_testing/test_secret_detect_hook.py
+++ b/tests/local_testing/test_secret_detect_hook.py
@@ -428,7 +428,9 @@ async def test_pem_private_key_full_block_redaction_in_prompt_list():
 
 def test_redact_pem_blocks_helper_is_pure_function():
     """Direct unit test of the helper so a regression in the regex is caught
-    even if the call-site integration is mocked away."""
+    even if the call-site integration is mocked away. The helper returns
+    ``(redacted_text, num_blocks_replaced)`` so callers can log when the
+    regex caught a block that detect-secrets missed."""
     from litellm_enterprise.enterprise_callbacks.secret_detection import (
         _redact_pem_blocks,
     )
@@ -439,9 +441,52 @@ def test_redact_pem_blocks_helper_is_pure_function():
         "ABCDEF\nGHIJKL\n"
         "-----END RSA PRIVATE KEY-----"
     )
-    assert _redact_pem_blocks(pem) == "[REDACTED]"
+    assert _redact_pem_blocks(pem) == ("[REDACTED]", 1)
     # Two blocks in one message
     two = pem + "\nmiddle\n" + pem
-    assert _redact_pem_blocks(two) == "[REDACTED]\nmiddle\n[REDACTED]"
-    # No PEM -> untouched
-    assert _redact_pem_blocks("hello world") == "hello world"
+    assert _redact_pem_blocks(two) == ("[REDACTED]\nmiddle\n[REDACTED]", 2)
+    # No PEM -> untouched, count == 0
+    assert _redact_pem_blocks("hello world") == ("hello world", 0)
+
+
+
+@pytest.mark.asyncio
+async def test_pem_only_catch_logs_warning(monkeypatch, caplog):
+    """When detect-secrets returns no secrets but the regex sweep still
+    redacts a PEM block (e.g., a malformed-but-readable block, or a future
+    detect-secrets version), the guardrail must emit a warning so operators
+    retain visibility into what was scrubbed.
+
+    Regression test for the observability gap flagged in Greptile review of
+    LIT-3292.
+    """
+    import logging
+
+    secret_instance = _ENTERPRISE_SecretDetection(
+        guardrail_name="hide_secrets", event_hook="pre_call"
+    )
+    # Force detect-secrets to report nothing so we test the elif branch.
+    monkeypatch.setattr(
+        secret_instance, "scan_message_for_secrets", lambda text: []
+    )
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "fakebase64bodyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    data = {"messages": [{"role": "user", "content": pem}]}
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        await secret_instance.async_pre_call_hook(
+            cache=DualCache(),
+            data=data,
+            call_type="completion",
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-fake"),
+        )
+    # Body must still be scrubbed even though detect-secrets returned nothing.
+    assert data["messages"][0]["content"].strip() == "[REDACTED]"
+    # And operators must see a warning that the regex caught something.
+    assert any(
+        "PEM private key block" in rec.getMessage()
+        and "not flagged by detect-secrets" in rec.getMessage()
+        for rec in caplog.records
+    ), [r.getMessage() for r in caplog.records]

--- a/tests/local_testing/test_secret_detect_hook.py
+++ b/tests/local_testing/test_secret_detect_hook.py
@@ -306,3 +306,142 @@ async def test_chat_completion_request_with_redaction():
         {"role": "user", "content": "Hello here is my OPENAI_API_KEY = [REDACTED]"}
     ]
     pass
+
+
+@pytest.mark.asyncio
+async def test_pem_private_key_full_block_redaction_in_message():
+    """LIT-3292: detect-secrets PrivateKeyDetector returns only the
+    `-----BEGIN ... PRIVATE KEY-----` header line as the secret value, so a
+    naive `str.replace(secret_value, "[REDACTED]")` leaves the base64 body
+    and `-----END ... PRIVATE KEY-----` footer in the message. The guardrail
+    must strip the whole PEM block, not just the header line.
+    """
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "fakebase64bodyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+        "fakebase64bodyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    secret_instance = _ENTERPRISE_SecretDetection(
+        guardrail_name="hide_secrets", event_hook="pre_call"
+    )
+    data = {
+        "messages": [
+            {"role": "user", "content": f"please review this key:\n{pem}\nthanks"}
+        ]
+    }
+    await secret_instance.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        call_type="completion",
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-fake"),
+    )
+    content = data["messages"][0]["content"]
+    assert "[REDACTED]" in content
+    # Full block must be gone: no header, no body, no footer line.
+    assert "-----BEGIN" not in content
+    assert "-----END" not in content
+    assert "fakebase64bodyA" not in content
+    assert "fakebase64bodyB" not in content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header",
+    [
+        "RSA PRIVATE KEY",
+        "EC PRIVATE KEY",
+        "DSA PRIVATE KEY",
+        "OPENSSH PRIVATE KEY",
+        "PRIVATE KEY",
+        "ENCRYPTED PRIVATE KEY",
+    ],
+)
+async def test_pem_private_key_full_block_redaction_all_pem_variants(header):
+    """LIT-3292: all PEM private-key flavours (RSA / EC / DSA / OPENSSH /
+    PKCS#8 / encrypted PKCS#8) must be redacted as a whole block."""
+    pem = (
+        f"-----BEGIN {header}-----\n"
+        "fakebase64bodyCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\n"
+        f"-----END {header}-----"
+    )
+    secret_instance = _ENTERPRISE_SecretDetection(
+        guardrail_name="hide_secrets", event_hook="pre_call"
+    )
+    data = {"messages": [{"role": "user", "content": pem}]}
+    await secret_instance.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        call_type="completion",
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-fake"),
+    )
+    content = data["messages"][0]["content"]
+    assert content.strip() == "[REDACTED]", content
+
+
+@pytest.mark.asyncio
+async def test_pem_private_key_full_block_redaction_in_prompt_str():
+    """The PEM full-block sweep must also cover the legacy `data['prompt']`
+    string branch (completion-style requests)."""
+    pem = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "fakebase64bodyDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD\n"
+        "-----END PRIVATE KEY-----"
+    )
+    secret_instance = _ENTERPRISE_SecretDetection(
+        guardrail_name="hide_secrets", event_hook="pre_call"
+    )
+    data = {"prompt": f"key follows: {pem}"}
+    await secret_instance.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        call_type="completion",
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-fake"),
+    )
+    assert "fakebase64body" not in data["prompt"]
+    assert "[REDACTED]" in data["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_pem_private_key_full_block_redaction_in_prompt_list():
+    """The PEM full-block sweep must also cover the `data['prompt']` list
+    branch (some legacy / multi-prompt completion shapes)."""
+    pem = (
+        "-----BEGIN EC PRIVATE KEY-----\n"
+        "fakebase64bodyEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE\n"
+        "-----END EC PRIVATE KEY-----"
+    )
+    secret_instance = _ENTERPRISE_SecretDetection(
+        guardrail_name="hide_secrets", event_hook="pre_call"
+    )
+    data = {"prompt": ["clean string", f"key follows: {pem}"]}
+    await secret_instance.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        call_type="completion",
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-fake"),
+    )
+    assert "fakebase64body" not in data["prompt"][1]
+    assert "[REDACTED]" in data["prompt"][1]
+    assert data["prompt"][0] == "clean string"
+
+
+def test_redact_pem_blocks_helper_is_pure_function():
+    """Direct unit test of the helper so a regression in the regex is caught
+    even if the call-site integration is mocked away."""
+    from litellm_enterprise.enterprise_callbacks.secret_detection import (
+        _redact_pem_blocks,
+    )
+
+    # Single block
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "ABCDEF\nGHIJKL\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    assert _redact_pem_blocks(pem) == "[REDACTED]"
+    # Two blocks in one message
+    two = pem + "\nmiddle\n" + pem
+    assert _redact_pem_blocks(two) == "[REDACTED]\nmiddle\n[REDACTED]"
+    # No PEM -> untouched
+    assert _redact_pem_blocks("hello world") == "hello world"


### PR DESCRIPTION
## Summary

`hide_secrets` (the enterprise `_ENTERPRISE_SecretDetection` guardrail) detects PEM private keys, but only redacts the **`-----BEGIN ... PRIVATE KEY-----` header line**. The base64 key body and `-----END ... PRIVATE KEY-----` footer are forwarded downstream verbatim — even while the proxy logs claim the secret was "redacted." (LIT-3292)

### Root cause

`detect-secrets`' `PrivateKeyDetector` returns the **header line** as `secret.secret_value`. The guardrail's redaction loop then runs `str.replace(secret["value"], "[REDACTED]")`, which only replaces that one matched line:

```python
for secret in detected_secrets:
    text = text.replace(secret["value"], "[REDACTED]")
```

So for a PEM-bearing message, the message that reaches the downstream model becomes:

```
please review this key:
-----[REDACTED]-----
MIIEpAIBAAKCAQEAwHy4ALN6evVCkxk7VuMaRRTtN+ZdiPMPVfH+SaQH8Cb+W+Sg
fakebase64payload...
-----END RSA PRIVATE KEY-----
thanks
```

The base64 body and `-----END` footer are still there — the key data is leaked.

### Fix

Before the per-secret `str.replace` loop at each of the three redaction sites (`_redact_message_text`, `data["prompt"]` string branch, `data["prompt"]` list-item branch), run a regex sweep that replaces any full PEM block (BEGIN/body/END) with `[REDACTED]`. The regex is anchored on `-----BEGIN[^\n]*PRIVATE KEY-----[\s\S]*?-----END[^\n]*PRIVATE KEY-----` so it covers RSA, EC, DSA, OPENSSH, PKCS#8, and encrypted-PKCS#8 variants uniformly.

The sweep runs **before** the per-secret loop so the BEGIN header is still in `-----BEGIN ... PRIVATE KEY-----` form when the regex matches. After the sweep, the per-secret loop still handles every non-PEM secret type (AWS keys, JWTs, etc.) exactly as before.

### Evidence

The runtime hook (`_ENTERPRISE_SecretDetection.async_pre_call_hook`) is the actual code path the proxy invokes on every `/chat/completions`. The proxy in this sandbox kept OOMing on `litellm-up`, so the evidence below was captured by importing the same class from a freshly-cloned `BerriAI/litellm` and driving the hook directly with a PEM-bearing message.

**Before (clean main, commit `6d98672`):** the guardrail logs `redacted secrets in message: ['Private Key']`, but the **base64 body and `-----END` footer leak**:

```
=== guardrail.async_pre_call_hook on a PEM block (clean main) ===
please review this key:
-----[REDACTED]-----
MIIEpAIBAAKCAQEAwHy4ALN6evVCkxk7VuMaRRTtN+ZdiPMPVfH+SaQH8Cb+W+Sg
fakebase64payloadAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
moreFakebodyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
-----END RSA PRIVATE KEY-----
thanks

Summary: {
  "BEGIN_line_present": false,
  "END_line_present":   true,
  "base64_body_leaked": true,
  "REDACTED_inserted":  true
}
```

**After (this branch):** the full block — header, body, **and** footer — collapses to `[REDACTED]`:

```
=== guardrail.async_pre_call_hook on a PEM block (patched) ===
please review this key:
[REDACTED]
thanks

Summary: {
  "BEGIN_line_present": false,
  "END_line_present":   false,
  "base64_body_leaked": false,
  "REDACTED_inserted":  true
}
```

Cross-flavour sanity, same code path:

```
--- RSA PRIVATE KEY block ---     -> [REDACTED]            (body_leak=False)
--- EC PRIVATE KEY block ---      -> [REDACTED]            (body_leak=False)
--- Generic PRIVATE KEY block --- -> [REDACTED]            (body_leak=False)
--- AWS-like access key (non-PEM, regression check) ---
Here is an AWS access key: [REDACTED] and secret wJalrXUtnFEMI/...    (still works)
```

### Tests

`tests/local_testing/test_secret_detect_hook.py`:

- `test_pem_private_key_full_block_redaction_in_message` — message-content path, asserts BEGIN/body/END all gone.
- `test_pem_private_key_full_block_redaction_all_pem_variants` — parametrised over RSA / EC / DSA / OPENSSH / PKCS#8 / encrypted PKCS#8.
- `test_pem_private_key_full_block_redaction_in_prompt_str` — legacy `data["prompt"]` string path.
- `test_pem_private_key_full_block_redaction_in_prompt_list` — `data["prompt"]` list-item path.
- `test_redact_pem_blocks_helper_is_pure_function` — direct unit on the helper (single, double, no-block).

```
$ pytest tests/local_testing/test_secret_detect_hook.py
...............                                                          [100%]
15 passed in 13.89s
```

(10 new + 5 existing; existing ones still pass.)

### Notes for reviewers

- This PR was uploaded via the GitHub Contents API (one PUT per file), not `git push`, because the sandbox token's credential helper kept getting `Password authentication is not supported` from GitHub. The merge-base diff may look a touch noisier than a clean `git push` would produce.
- No new dependencies; the helper uses only the stdlib `re` module that was already imported.

Fixes LIT-3292.


### Verification (ship-pr)

- **change-type**: `enterprise/.../secret_detection.py` (guardrails) -> real request + decision; `tests/local_testing/test_secret_detect_hook.py` (tests, no separate evidence).
- **evidence present**: PASS — `### Evidence` block has BEFORE and AFTER fenced captures from the same `async_pre_call_hook` code path on the same PEM input.
- **image sanity**: N/A — backend guardrail change; no UI surface.
- **content matches caption**: PASS — BEFORE caption "base64 body and -----END footer leak" matches the block; AFTER caption "full block collapses to [REDACTED]" matches the block.
- **backend evidence from running system**: PASS — evidence captured by driving the real `_ENTERPRISE_SecretDetection.async_pre_call_hook` (the proxy's pre-call hook) on a PEM-bearing message; same code that runs on every `/chat/completions`. Sandbox `litellm-up` OOMed so the proxy boot path could not be used; the hook is the actual runtime surface for this fix.
- **CI**: 44/44 green on head `74b5fae`. Greptile 5/5 ("Safe to merge"). Veria 0 issues ("No security issues found").
