### PR TITLE
fix(observability): classify HTTPException(403) guardrail blocks as `guardrail_intervened` (LIT-3253)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -743,7 +743,15 @@ class CustomGuardrail(CustomLogger):
         Guardrails signal intentional blocks by raising:
         - GuardrailRaisedException (generic guardrail API, tool permission)
         - BlockedPiiEntityError (Presidio PII detection)
-        - HTTPException with status 400 (content policy violation)
+        - HTTPException with status 400 or 403 (content policy violation).
+          400 is the established convention for "content policy violation".
+          Several existing block paths (litellm_content_filter, akto)
+          raise 403 instead; both signal an intentional guardrail
+          block, not an upstream/API failure, so both must be
+          classified as ``guardrail_intervened`` (not
+          ``guardrail_failed_to_respond``, which is reserved for
+          upstream/API failures and surfaces as a failed request in
+          spend logs, OTEL traces, and the policy builder).
         - ModifyResponseException (passthrough mode violation)
         """
         if isinstance(e, ModifyResponseException):
@@ -753,7 +761,7 @@ class CustomGuardrail(CustomLogger):
         if (
             HTTPException is not None
             and isinstance(e, HTTPException)
-            and e.status_code == 400
+            and e.status_code in (400, 403)
         ):
             return True
         return False

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1190,3 +1190,157 @@ class TestCustomGuardrailSpendLogMatchRedaction:
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_response"]["filters"][0]["regex"] == "[REDACTED]"
         assert raw["filters"][0]["regex"] == r"\d{3}-\d{2}-\d{4}"
+
+
+class TestIsGuardrailIntervention:
+    """LIT-3253: HTTPException(403) raised by guardrail block paths
+    (litellm_content_filter, akto) must be classified as ``guardrail_intervened``
+    (intentional block), not ``guardrail_failed_to_respond`` (API/transport
+    failure). 5xx upstream failures are unchanged.
+    """
+
+    def _make_guardrail(self):
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+
+        class _FakeGuardrail(CustomGuardrail):
+            def __init__(self):
+                self.guardrail_name = "litellm_content_filter"
+                self.event_hook = None
+                self.optional_params = {}
+                self.default_on = True
+                self.guardrail_id = None
+                self.guardrail = None
+                self.mask_request_content = False
+                self.mask_response_content = False
+                self.mask_request = False
+                self.mask_response = False
+                self.config_file_path = None
+                self.guardrail_mode = "pre_call"
+                self.guardrail_info = None
+                self.start_time = None
+
+        return _FakeGuardrail()
+
+    def test_http_400_is_intervention(self):
+        from fastapi import HTTPException
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+
+        assert CustomGuardrail._is_guardrail_intervention(
+            HTTPException(status_code=400, detail="content policy")
+        ) is True
+
+    def test_http_403_is_intervention(self):
+        """LIT-3253 regression: 403 from content_filter / akto block path must
+        be an intervention, not a failure.
+        """
+        from fastapi import HTTPException
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+
+        assert CustomGuardrail._is_guardrail_intervention(
+            HTTPException(status_code=403, detail="Blocked by Akto Guardrails")
+        ) is True
+
+    def test_http_500_is_not_intervention(self):
+        """Upstream API failures stay classified as guardrail_failed_to_respond."""
+        from fastapi import HTTPException
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+
+        assert CustomGuardrail._is_guardrail_intervention(
+            HTTPException(status_code=500, detail="upstream timeout")
+        ) is False
+
+    def test_http_503_is_not_intervention(self):
+        from fastapi import HTTPException
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+
+        assert CustomGuardrail._is_guardrail_intervention(
+            HTTPException(status_code=503, detail="guardrail provider down")
+        ) is False
+
+    def test_process_error_marks_403_as_intervened(self):
+        """End-to-end via ``_process_error``: a 403 from a block path now writes
+        ``guardrail_intervened`` into ``StandardLoggingGuardrailInformation`` —
+        the field downstream Langfuse / OTEL / Prometheus / spend logs / policy
+        builder consume.
+        """
+        from fastapi import HTTPException
+
+        g = self._make_guardrail()
+        rd = {"litellm_metadata": {}, "metadata": {}}
+        try:
+            g._process_error(
+                e=HTTPException(status_code=403, detail="Blocked by Akto Guardrails"),
+                request_data=rd,
+                start_time=0.0,
+                end_time=0.0,
+                duration=0.0,
+                event_type=None,
+            )
+        except HTTPException:
+            pass
+
+        info = None
+        for v in rd.values():
+            if isinstance(v, dict) and "standard_logging_guardrail_information" in v:
+                info = v["standard_logging_guardrail_information"]
+                break
+        if isinstance(info, list):
+            info = info[-1] if info else None
+
+        assert info is not None
+        assert info["guardrail_status"] == "guardrail_intervened"
+
+    def test_process_error_marks_400_as_intervened(self):
+        from fastapi import HTTPException
+
+        g = self._make_guardrail()
+        rd = {"litellm_metadata": {}, "metadata": {}}
+        try:
+            g._process_error(
+                e=HTTPException(status_code=400, detail="content policy"),
+                request_data=rd,
+                start_time=0.0,
+                end_time=0.0,
+                duration=0.0,
+                event_type=None,
+            )
+        except HTTPException:
+            pass
+        info = None
+        for v in rd.values():
+            if isinstance(v, dict) and "standard_logging_guardrail_information" in v:
+                info = v["standard_logging_guardrail_information"]
+                break
+        if isinstance(info, list):
+            info = info[-1] if info else None
+        assert info is not None
+        assert info["guardrail_status"] == "guardrail_intervened"
+
+    def test_process_error_marks_500_as_failed_to_respond(self):
+        """Upstream / API failures still surface as failures — we did not
+        regress that path.
+        """
+        from fastapi import HTTPException
+
+        g = self._make_guardrail()
+        rd = {"litellm_metadata": {}, "metadata": {}}
+        try:
+            g._process_error(
+                e=HTTPException(status_code=500, detail="upstream timeout"),
+                request_data=rd,
+                start_time=0.0,
+                end_time=0.0,
+                duration=0.0,
+                event_type=None,
+            )
+        except HTTPException:
+            pass
+        info = None
+        for v in rd.values():
+            if isinstance(v, dict) and "standard_logging_guardrail_information" in v:
+                info = v["standard_logging_guardrail_information"]
+                break
+        if isinstance(info, list):
+            info = info[-1] if info else None
+        assert info is not None
+        assert info["guardrail_status"] == "guardrail_failed_to_respond"


### PR DESCRIPTION
## Summary

Fixes [LIT-3253](https://linear.app/litellm-ai/issue/LIT-3253/bug-litellm-topiccategory-based-guardrails-give-403-response-instead).

When a guardrail block raises ``HTTPException(status_code=403)`` (`litellm_content_filter`, `akto`), the request gets correctly rejected, but downstream observability (`StandardLoggingGuardrailInformation.guardrail_status`) records it as **`guardrail_failed_to_respond`** (an upstream API failure) instead of **`guardrail_intervened`** (an intentional block). This surfaces blocked requests as **API failures in the policy builder, spend logs, and OTEL traces** — the exact complaint on the ticket.

## Root cause

`_is_guardrail_intervention()` in `litellm/integrations/custom_guardrail.py` only recognizes `HTTPException(status_code=400)` as an intentional block:

```python
if (
    HTTPException is not None
    and isinstance(e, HTTPException)
    and e.status_code == 400
):
    return True
```

`_process_error()` consumes that result to write `guardrail_status` into `StandardLoggingGuardrailInformation`. Several existing block paths (`litellm_content_filter` has 5 raise sites; `akto` has the request-blocked path) raise `HTTPException(status_code=403)`, so all of them fell through and were tagged as failures.

## Fix

Single-line scope: `_is_guardrail_intervention()` now accepts both 400 and 403 as intentional interventions. 

```python
if (
    HTTPException is not None
    and isinstance(e, HTTPException)
    and e.status_code in (400, 403)
):
    return True
```

Notes on scope choice:
- The previous attempt at this fix ([#28663](https://github.com/BerriAI/litellm/pull/28663)) also changed the 5 `content_filter` raise sites and the `akto` block-raise site from 403 → 400. That changes the **user-visible HTTP status** returned for a block, which is a wire-contract change with broader risk and a lot of existing tests asserting `status_code == 403` (in `test_content_filter.py`, `test_competitor_intent.py`, `test_akto_guardrails.py`, `test_guardrail_endpoints.py`, `test_guardrail_exception_status_codes.py`). This PR deliberately keeps the wire status code at 403 for those callers and fixes only the classification, so it has zero impact on the response clients see today.
- A follow-up could converge the 403 sites to 400 if there's consensus on a status-code convention; that's intentionally out of scope here.

## Tests

`tests/test_litellm/integrations/test_custom_guardrail.py` — added `TestIsGuardrailIntervention` with 7 cases covering the unit-level predicate and the `_process_error` end-to-end recording into `StandardLoggingGuardrailInformation`:

- `test_http_400_is_intervention` (regression guard for the established convention)
- `test_http_403_is_intervention` (LIT-3253 fix)
- `test_http_500_is_not_intervention` (no regression on upstream failure)
- `test_http_503_is_not_intervention` (no regression on upstream failure)
- `test_process_error_marks_403_as_intervened` (end-to-end via `_process_error`)
- `test_process_error_marks_400_as_intervened`
- `test_process_error_marks_500_as_failed_to_respond`

## Evidence

Both before and after were captured by driving the real `_process_error` code path that emits the `StandardLoggingGuardrailInformation.guardrail_status` field consumed by Langfuse / OTEL / Prometheus / spend logs / the policy builder. The before run uses the unmodified daily-branch baseline (HEAD `6d98672`); the after run reimports the patched module.

### Evidence

```
=== BEFORE FIX (baseline daily-branch HEAD 6d98672) ===
Drives the actual `_process_error` code path that emits to
StandardLoggingGuardrailInformation, the field consumed by Langfuse / OTEL /
Prometheus / spend logs / policy builder.

content_filter HTTPException(403, "content_filter: blocked_word match")    -> guardrail_status = 'guardrail_failed_to_respond'
akto guardrail HTTPException(403, "Blocked by Akto Guardrails")            -> guardrail_status = 'guardrail_failed_to_respond'
reference      HTTPException(400, "content policy")                        -> guardrail_status = 'guardrail_intervened'
reference      HTTPException(500, "timeout")                               -> guardrail_status = 'guardrail_failed_to_respond'

>>> Bug: 403 blocks classified as 'guardrail_failed_to_respond' (API failure),
>>> not 'guardrail_intervened' (intentional block) -> the ticket complaint.

=== AFTER FIX ===
Same code path, same inputs; _is_guardrail_intervention now accepts 400 OR 403.

content_filter HTTPException(403, "content_filter: blocked_word match")    -> guardrail_status = 'guardrail_intervened'
akto guardrail HTTPException(403, "Blocked by Akto Guardrails")            -> guardrail_status = 'guardrail_intervened'
reference      HTTPException(400, "content policy")                        -> guardrail_status = 'guardrail_intervened'
reference      HTTPException(500, "timeout")                               -> guardrail_status = 'guardrail_failed_to_respond'

>>> Fixed: 403 blocks now classified as 'guardrail_intervened' (intervention).
>>> 400 still 'guardrail_intervened' (unchanged). 500 still 'guardrail_failed_to_respond'
>>> (no regression on the upstream-failure path).

```

### Tests

```
# Full test_custom_guardrail.py (with our new TestIsGuardrailIntervention class):
$ pytest tests/test_litellm/integrations/test_custom_guardrail.py --asyncio-mode=auto
...........................................                              [100%]
43 passed in 1.00s


# content_filter tests (unaffected, our scope avoids changing content_filter):
$ pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py --asyncio-mode=auto
.....................................................                    [100%]
53 passed in 8.09s

```

## Implementation note

This PR was pushed via the GitHub Contents API (one PUT per file) because the agent's `GITHUB_TOKEN` lacks the scopes for `git push` / workflow modification. Diff is two files only:

- `litellm/integrations/custom_guardrail.py` — one-line predicate change + docstring
- `tests/test_litellm/integrations/test_custom_guardrail.py` — appended `TestIsGuardrailIntervention` class

Closes LIT-3253.


### Verification (ship-pr)

- **change-type**: 2 files
  - `litellm/integrations/custom_guardrail.py` (logging/observability surface) → required: captured output from running module
  - `tests/test_litellm/integrations/test_custom_guardrail.py` → tests; corresponding pytest output
- **evidence present**: PASS — 3 fenced code blocks under `### Evidence` and `### Tests`
- **image sanity**: N/A — observability change, fenced text only (no images)
- **image content matches caption**: N/A
- **backend evidence from running system**: PASS — imported the real `litellm.integrations.custom_guardrail` module from the installed package (path matches production), patched the file in place, reimported, drove the actual `_process_error` code path. The captured `guardrail_status` flips from `'guardrail_failed_to_respond'` → `'guardrail_intervened'` for the same exception input. 500-path still classifies as failure (no regression).
- **no external image hosts**: PASS
- **no customer-name leak**: PASS (only `content_filter`, `file`, `files`, `GITHUB` substrings — no customer/project names)
