### PR TITLE
fix(langfuse): preserve proxy auth metadata for /v1/messages and other litellm_metadata routes (LIT-3293)

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -24,6 +24,7 @@ from litellm.litellm_core_utils.core_helpers import (
     safe_deep_copy,
     reconstruct_model_name,
     filter_exceptions_from_params,
+    get_litellm_metadata_from_kwargs,
 )
 from litellm.litellm_core_utils.redact_messages import redact_user_api_key_info
 from litellm.integrations.langfuse.langfuse_mock_client import (
@@ -308,9 +309,17 @@ class LangFuseLogger:
 
             litellm_params = kwargs.get("litellm_params", {})
             litellm_call_id = kwargs.get("litellm_call_id", None)
-            metadata = (
-                litellm_params.get("metadata", {}) or {}
-            )  # if litellm_params['metadata'] == None
+            # Resolve metadata via the canonical helper so endpoints that store
+            # proxy auth context under ``litellm_metadata`` (e.g. ``/v1/messages``,
+            # ``/v1/responses``, batches, files) carry ``user_api_key_alias`` /
+            # ``user_api_key_user_id`` / ``user_api_key_team_id`` / ``...`` into
+            # the Langfuse generation just like ``/chat/completions`` does.
+            # ``get_litellm_metadata_from_kwargs`` returns ``litellm_metadata`` when
+            # set (merging any ``user_api_key_*`` fields that ended up on
+            # ``metadata``), otherwise falls back to ``metadata``. Existing callers
+            # that put proxy metadata directly on ``litellm_params['metadata']``
+            # (chat/completions, embeddings, etc.) continue to work unchanged.
+            metadata = get_litellm_metadata_from_kwargs(kwargs) or {}
             metadata = self.add_metadata_from_header(litellm_params, metadata)
             optional_params = safe_deep_copy(kwargs.get("optional_params", {}))
 

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -930,3 +930,280 @@ def test_max_langfuse_clients_limit():
         assert litellm.initialized_langfuse_clients == 2
 
     litellm.initialized_langfuse_clients = original_initialized_langfuse_clients
+
+
+class TestLangfuseLitellmMetadataResolution(unittest.TestCase):
+    """
+    Regression tests for LIT-3293: Preserve proxy auth metadata in Langfuse for
+    /v1/messages.
+
+    Endpoints like ``/v1/messages``, ``/v1/responses``, ``/v1/batches``, and
+    ``/v1/files`` store proxy auth context (``user_api_key_alias``,
+    ``user_api_key_user_id``, ``user_api_key_team_id``, ...) under
+    ``litellm_params['litellm_metadata']``. The Langfuse callback previously
+    read only ``litellm_params['metadata']`` and dropped proxy auth on the
+    floor for these routes.
+
+    These tests drive ``log_event_on_langfuse`` end-to-end against a mocked
+    Langfuse SDK and assert on what the callback would have created.
+    """
+
+    def setUp(self):
+        self.env_patcher = patch.dict(
+            "os.environ",
+            {
+                "LANGFUSE_SECRET_KEY": "test-secret-key",
+                "LANGFUSE_PUBLIC_KEY": "test-public-key",
+                "LANGFUSE_HOST": "https://test.langfuse.com",
+            },
+        )
+        self.env_patcher.start()
+
+        # Patch only the Langfuse client construction; keep the real
+        # ``langfuse`` and ``langfuse.model`` modules importable so the
+        # code path under test (``_add_prompt_to_generation_params``) still
+        # works.
+        self.mock_langfuse_client = MagicMock()
+        self.mock_langfuse_client.client = MagicMock()
+        self.langfuse_class_patcher = patch(
+            "langfuse.Langfuse", return_value=self.mock_langfuse_client
+        )
+        self.langfuse_class_patcher.start()
+
+        self.captured_trace_kwargs = {}
+        self.captured_generation_kwargs = {}
+
+        self.mock_trace = MagicMock()
+        self.mock_generation = MagicMock()
+        self.mock_generation.trace_id = "tr-test"
+
+        def _trace_side_effect(**kwargs):
+            self.captured_trace_kwargs.update(kwargs)
+            return self.mock_trace
+
+        def _generation_side_effect(**kwargs):
+            self.captured_generation_kwargs.update(kwargs)
+            return self.mock_generation
+
+        self.mock_langfuse_client.trace.side_effect = _trace_side_effect
+        self.mock_trace.generation.side_effect = _generation_side_effect
+
+        self._original_count = litellm.initialized_langfuse_clients
+        self.logger = LangFuseLogger()
+        self.logger.Langfuse = self.mock_langfuse_client
+        self.logger.langfuse_sdk_version = "3.0.0"
+
+        def _is_v2(self):
+            return True
+
+        self.logger._is_langfuse_v2 = types.MethodType(_is_v2, self.logger)
+
+    def tearDown(self):
+        litellm.initialized_langfuse_clients = self._original_count
+        self.env_patcher.stop()
+        self.langfuse_class_patcher.stop()
+
+    @staticmethod
+    def _fake_response_obj():
+        class _Usage:
+            prompt_tokens = 5
+            completion_tokens = 3
+            total_tokens = 8
+            cache_creation_input_tokens = 0
+            cache_read_input_tokens = 0
+            completion_tokens_details = None
+            prompt_tokens_details = None
+            model_extra: dict = {}
+
+            def get(self, k, default=None):
+                return getattr(self, k, default)
+
+        class _Resp:
+            id = "resp-1"
+            system_fingerprint = None
+            model = "claude-3-5-sonnet-20241022"
+            object = "chat.completion"
+            choices: list = []
+            usage = _Usage()
+            _hidden_params: dict = {}
+
+            def get(self, *a, **kw):
+                if a and a[0] == "id":
+                    return self.id
+                return None
+
+            def model_dump(self):
+                return {}
+
+        return _Resp()
+
+    def _build_kwargs(
+        self, metadata, litellm_metadata, call_type="anthropic_messages"
+    ):
+        return {
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "call_type": call_type,
+            "custom_llm_provider": "anthropic",
+            "litellm_call_id": "cid-1",
+            "litellm_params": {
+                "api_base": "",
+                "metadata": metadata,
+                "litellm_metadata": litellm_metadata,
+                "proxy_server_request": {},
+            },
+            "optional_params": {},
+            "standard_logging_object": {
+                "metadata": {},
+                "model_map_information": {},
+            },
+            "response_cost": 0,
+            "input": "hi",
+            "completion_start_time": datetime.datetime.now(),
+            "stream": False,
+        }
+
+    def test_v1_messages_proxy_auth_present_in_generation_metadata(self):
+        """
+        For /v1/messages, proxy auth lives in litellm_metadata while the request
+        body's own `metadata` (the Anthropic provider-level field) is in
+        litellm_params['metadata']. The Langfuse generation must still carry
+        user_api_key_alias / user_api_key_user_id / user_api_key_team_id.
+        """
+        proxy_litellm_metadata = {
+            "user_api_key_alias": "shin-key-alias",
+            "user_api_key_user_id": "shin-user-123",
+            "user_api_key_team_id": "team-eng",
+            "user_api_key_user_email": "shin@example.test",
+            "user_api_key_org_id": "org-acme",
+            "headers": {},
+            "endpoint": "/v1/messages",
+        }
+        client_metadata = {"user_id": "client-XYZ"}
+        kwargs = self._build_kwargs(client_metadata, proxy_litellm_metadata)
+        self.logger.log_event_on_langfuse(
+            kwargs=kwargs,
+            response_obj=self._fake_response_obj(),
+            start_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+            end_time=datetime.datetime.now(),
+            user_id="shin-user-123",
+            level="DEFAULT",
+            status_message=None,
+        )
+        gen_meta = self.captured_generation_kwargs.get("metadata") or {}
+        assert gen_meta.get("user_api_key_alias") == "shin-key-alias"
+        assert gen_meta.get("user_api_key_user_id") == "shin-user-123"
+        assert gen_meta.get("user_api_key_team_id") == "team-eng"
+        assert gen_meta.get("user_api_key_user_email") == "shin@example.test"
+        assert gen_meta.get("user_api_key_org_id") == "org-acme"
+
+    def test_v1_messages_generation_name_uses_key_alias(self):
+        """
+        Generation name should default to ``litellm:<user_api_key_alias>`` when
+        key_alias is present (matches /chat/completions behavior). Previously,
+        for /v1/messages it fell back to ``litellm-anthropic_messages``.
+        """
+        proxy_litellm_metadata = {
+            "user_api_key_alias": "shin-key-alias",
+            "user_api_key_user_id": "shin-user-123",
+            "headers": {},
+            "endpoint": "/v1/messages",
+        }
+        kwargs = self._build_kwargs({"user_id": "client-XYZ"}, proxy_litellm_metadata)
+        self.logger.log_event_on_langfuse(
+            kwargs=kwargs,
+            response_obj=self._fake_response_obj(),
+            start_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+            end_time=datetime.datetime.now(),
+            user_id="shin-user-123",
+            level="DEFAULT",
+            status_message=None,
+        )
+        assert (
+            self.captured_generation_kwargs.get("name") == "litellm:shin-key-alias"
+        ), self.captured_generation_kwargs.get("name")
+
+    def test_chat_completions_metadata_path_unchanged(self):
+        """
+        For /chat/completions, proxy auth lives directly in
+        ``litellm_params['metadata']``. The fix must keep this path working:
+        when ``litellm_metadata`` is absent, metadata fallback still drives the
+        generation name + auth fields.
+        """
+        proxy_metadata = {
+            "user_api_key_alias": "alpha-key-alias",
+            "user_api_key_user_id": "alpha-user",
+            "user_api_key_team_id": "team-alpha",
+            "headers": {},
+            "endpoint": "/chat/completions",
+        }
+        kwargs = self._build_kwargs(proxy_metadata, None, call_type="completion")
+        # Drop the None key to match real /chat/completions kwargs shape
+        kwargs["litellm_params"].pop("litellm_metadata")
+        self.logger.log_event_on_langfuse(
+            kwargs=kwargs,
+            response_obj=self._fake_response_obj(),
+            start_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+            end_time=datetime.datetime.now(),
+            user_id="alpha-user",
+            level="DEFAULT",
+            status_message=None,
+        )
+        assert (
+            self.captured_generation_kwargs.get("name") == "litellm:alpha-key-alias"
+        )
+        gen_meta = self.captured_generation_kwargs.get("metadata") or {}
+        assert gen_meta.get("user_api_key_alias") == "alpha-key-alias"
+        assert gen_meta.get("user_api_key_team_id") == "team-alpha"
+
+    def test_both_metadata_and_litellm_metadata_merge_user_api_key_fields(self):
+        """
+        When both ``metadata`` and ``litellm_metadata`` are present but
+        ``user_api_key_*`` fields live on ``metadata`` (some legacy paths), the
+        callback must still surface them via
+        ``add_missing_spend_metadata_to_litellm_metadata``.
+        """
+        proxy_metadata = {
+            "user_api_key_alias": "from-metadata-alias",
+            "user_api_key_user_id": "from-metadata-user",
+            "headers": {},
+        }
+        proxy_litellm_metadata = {
+            "endpoint": "/v1/messages",
+            "headers": {},
+            "some_other_field": "yes",
+        }
+        kwargs = self._build_kwargs(proxy_metadata, proxy_litellm_metadata)
+        self.logger.log_event_on_langfuse(
+            kwargs=kwargs,
+            response_obj=self._fake_response_obj(),
+            start_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+            end_time=datetime.datetime.now(),
+            user_id="from-metadata-user",
+            level="DEFAULT",
+            status_message=None,
+        )
+        gen_meta = self.captured_generation_kwargs.get("metadata") or {}
+        assert gen_meta.get("user_api_key_alias") == "from-metadata-alias"
+        assert gen_meta.get("user_api_key_user_id") == "from-metadata-user"
+        assert (
+            self.captured_generation_kwargs.get("name") == "litellm:from-metadata-alias"
+        )
+
+    def test_no_metadata_or_litellm_metadata_uses_default_generation_name(self):
+        """No metadata at all -> generation name falls back to ``litellm-<call_type>``."""
+        kwargs = self._build_kwargs({}, None, call_type="completion")
+        kwargs["litellm_params"].pop("litellm_metadata")
+        kwargs["litellm_params"]["metadata"] = {}
+        self.logger.log_event_on_langfuse(
+            kwargs=kwargs,
+            response_obj=self._fake_response_obj(),
+            start_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+            end_time=datetime.datetime.now(),
+            user_id=None,
+            level="DEFAULT",
+            status_message=None,
+        )
+        assert (
+            self.captured_generation_kwargs.get("name") == "litellm-completion"
+        ), self.captured_generation_kwargs.get("name")


### PR DESCRIPTION
## Summary

Fixes a bug where the Langfuse callback dropped proxy auth context
(`user_api_key_alias`, `user_api_key_user_id`, `user_api_key_team_id`,
`user_api_key_user_email`, `user_api_key_org_id`, …) for requests routed
through endpoints that store metadata under `litellm_metadata` instead of
`metadata` — `/v1/messages`, `/v1/responses`, `/v1/batches`, `/v1/files`.

Symptoms reported:
- Langfuse generations for `/v1/messages` are named
  `litellm-anthropic_messages` instead of `litellm:<key_alias>`.
- Spend logs show `user_api_key_alias` / `user_api_key_user_id`, but the
  matching Langfuse generation metadata is missing those fields.
- Per-user keys with `key_alias` set produce indistinguishable
  Langfuse observations unless the client separately sends
  `x-litellm-tags`.

Fixes: LIT-3293

## Root cause

For `/v1/messages` (and the other routes in `LITELLM_METADATA_ROUTES`),
`_get_metadata_variable_name()` returns `"litellm_metadata"`, so
`pre_call_utils` stores proxy auth fields (`user_api_key_*`, etc.) in
`data["litellm_metadata"]` — not `data["metadata"]`.

`function_setup()` in `litellm/utils.py` does promote
`kwargs["litellm_metadata"]` into `litellm_params["metadata"]` **only when
`metadata` is empty**. The Anthropic `/v1/messages` request body may include
its own provider-level `metadata` field (e.g. `{"user_id": "client-XYZ"}`).
With that field present, the promotion branch never fires and
`litellm_params["metadata"]` ends up holding the client's metadata while
proxy auth sits untouched on `litellm_params["litellm_metadata"]`.

`LangFuseLogger.log_event_on_langfuse` then reads only
`litellm_params.get("metadata", {})` and never sees the proxy auth fields.

## Fix

Resolve metadata in `log_event_on_langfuse` via the canonical helper
`get_litellm_metadata_from_kwargs` (already used by 9k+ lines of other code
in `litellm/utils.py`). The helper returns `litellm_metadata` when set
(merging any `user_api_key_*` fields that happened to be on `metadata`
via `add_missing_spend_metadata_to_litellm_metadata`) and falls back to
`metadata` otherwise. Existing `/chat/completions` callers — which put
proxy metadata directly on `litellm_params['metadata']` — are unaffected.

Single-call-site change: ~3 lines of actual logic, plus comment.

## Files changed

- `litellm/integrations/langfuse/langfuse.py` (+12 / −3): swap the
  `litellm_params.get("metadata", {})` read for
  `get_litellm_metadata_from_kwargs(kwargs)`, document why.
- `tests/test_litellm/integrations/test_langfuse.py` (+277): new
  `TestLangfuseLitellmMetadataResolution` test class — 5 tests covering
  the four flow shapes (`/v1/messages` proxy-auth present in generation
  metadata, generation name resolution to `litellm:<alias>`,
  `/chat/completions` path unchanged, both-dicts-present merge path, no
  metadata at all).

## Test plan

```
uv run pytest tests/test_litellm/integrations/test_langfuse.py::TestLangfuseLitellmMetadataResolution -v
# 5 passed
```

(Two unrelated failures in `test_async_log_failure_event_*` reproduce on
clean `litellm_oss_agent_shin_daily_branch` before this change — not
caused by this PR.)

## Why this approach (and not the prior PR #28616)

PR #28616 attempted to fix the same bug by mutating
`function_setup` / `update_from_kwargs` in core utils to merge
`litellm_metadata` into `metadata` whenever both were present. That had
broader merge semantics implications and was closed without merge.

The ticket itself suggests "update `litellm/integrations/langfuse/langfuse.py`
to read metadata via `get_litellm_metadata_from_kwargs(kwargs)` and then apply
`add_metadata_from_header(...)`" — i.e. the targeted, single-callback fix.
That's what this PR does.

## Note on push path

Used `PUT /repos/.../contents/{path}` to push because the current bot
token lacks `repo`+`workflow` git-push scopes. Two commits (one per
file) on the branch; merge into the daily branch will be a clean
combined patch.

### Evidence

Runtime repro: a script
([`/tmp/repro_lf.py`](#repro-script)) drives the real
`LangFuseLogger.log_event_on_langfuse` against an intercepted Langfuse
SDK, with the kwargs shape `pre_call_utils` actually produces for
`/v1/messages` (proxy auth fields under `litellm_metadata`, client's
provider-level metadata under `metadata`).

**BEFORE** — clean `litellm_oss_agent_shin_daily_branch`:

```
Using litellm at: /home/user/wrk/litellm/__init__.py
========================================================================
kwargs.litellm_params['metadata']          = {'user_id': 'client-XYZ'}
kwargs.litellm_params['litellm_metadata'] keys: ['endpoint', 'headers',
'litellm_api_version', 'user_api_key_alias', 'user_api_key_hash',
'user_api_key_org_id', 'user_api_key_team_id', 'user_api_key_user_email',
'user_api_key_user_id']
========================================================================

langfuse generation NAME = 'litellm-anthropic_messages'
langfuse generation METADATA — proxy auth fields:
  [MISSING] user_api_key_alias             = None
  [MISSING] user_api_key_user_id           = None
  [MISSING] user_api_key_team_id           = None
  [MISSING] user_api_key_user_email        = None
  [MISSING] user_api_key_org_id            = None

langfuse trace NAME    = 'litellm-anthropic_messages'
langfuse trace USER_ID = None

BUG_PRESENT: True
```

**AFTER** — same script, same kwargs, on this branch:

```
Using litellm at: /home/user/wrk/litellm/__init__.py
========================================================================
kwargs.litellm_params['metadata']          = {'user_id': 'client-XYZ'}
kwargs.litellm_params['litellm_metadata'] keys: ['endpoint', 'headers',
'litellm_api_version', 'user_api_key_alias', 'user_api_key_hash',
'user_api_key_org_id', 'user_api_key_team_id', 'user_api_key_user_email',
'user_api_key_user_id']
========================================================================

langfuse generation NAME = 'litellm:shin-key-alias'
langfuse generation METADATA — proxy auth fields:
  [PRESENT] user_api_key_alias             = 'shin-key-alias'
  [PRESENT] user_api_key_user_id           = 'shin-user-123'
  [PRESENT] user_api_key_team_id           = 'team-engineering'
  [PRESENT] user_api_key_user_email        = 'shin@example.test'
  [PRESENT] user_api_key_org_id            = 'org-acme'

langfuse trace NAME    = 'litellm-anthropic_messages'
langfuse trace USER_ID = None

BUG_PRESENT: False
```

`generation.name` flips from `litellm-anthropic_messages` to
`litellm:shin-key-alias`, and the five `user_api_key_*` fields go from
all-`MISSING` to all-`PRESENT` — exactly the symptom the ticket
describes.

(`trace.user_id` stays `None` because that field is populated from
end-user / customer identity (`standard_logging_object.metadata.user_api_key_end_user_id`),
not from the proxy key. The bug report is about the missing
`user_api_key_*` fields and the generation name; both are now fixed.)



### Verification (ship-pr)
- change-type: `litellm/integrations/langfuse/langfuse.py` is an observability callback (logging) → required evidence is captured collector / callback output. `tests/test_litellm/integrations/test_langfuse.py` is a test file → no runtime evidence required.
- evidence present: PASS — `### Evidence` section above with BEFORE / AFTER terminal captures from the real `LangFuseLogger.log_event_on_langfuse` path
- image sanity: N/A — no UI screenshots in this change (callback / logging only)
- image content matches caption: N/A
- backend evidence from running system: PASS — `python3 repro_lf.py` was run against the cloned `litellm_oss_agent_shin_daily_branch` checkout, `litellm` resolved to `/home/user/wrk/litellm/__init__.py` (confirmed in capture)
- hygiene: PASS — no external image hosts, two files staged (only the files changed)
