### PR TITLE
feat(complexity_router): add custom_technical_keywords config (LIT-3237)

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -92,9 +92,27 @@ class ComplexityRouter(CustomLogger):
         self.reasoning_keywords = (
             self.config.reasoning_keywords or DEFAULT_REASONING_KEYWORDS
         )
-        self.technical_keywords = (
-            self.config.technical_keywords or DEFAULT_TECHNICAL_KEYWORDS
+        # Base technical keyword list: explicit technical_keywords override or defaults.
+        base_technical = (
+            self.config.technical_keywords
+            if self.config.technical_keywords is not None
+            else DEFAULT_TECHNICAL_KEYWORDS
         )
+        if self.config.custom_technical_keywords:
+            # Append caller-supplied terms onto the base list, preserving order
+            # and de-duplicating overlap with the base list (case-insensitive).
+            existing_lower = {kw.lower() for kw in base_technical}
+            extras = []
+            seen_extras_lower = set()
+            for kw in self.config.custom_technical_keywords:
+                kw_lower = kw.lower()
+                if kw_lower in existing_lower or kw_lower in seen_extras_lower:
+                    continue
+                seen_extras_lower.add(kw_lower)
+                extras.append(kw)
+            self.technical_keywords = list(base_technical) + extras
+        else:
+            self.technical_keywords = list(base_technical)
         self.simple_keywords = self.config.simple_keywords or DEFAULT_SIMPLE_KEYWORDS
 
         # Pre-compile regex patterns for efficiency

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -93,11 +93,9 @@ class ComplexityRouter(CustomLogger):
             self.config.reasoning_keywords or DEFAULT_REASONING_KEYWORDS
         )
         # Base technical keyword list: explicit technical_keywords override or defaults.
-        base_technical = (
-            self.config.technical_keywords
-            if self.config.technical_keywords is not None
-            else DEFAULT_TECHNICAL_KEYWORDS
-        )
+        # Use the same falsy-fallback semantics as code_keywords/reasoning_keywords/simple_keywords
+        # so an empty list falls back to the defaults consistently across all keyword fields.
+        base_technical = self.config.technical_keywords or DEFAULT_TECHNICAL_KEYWORDS
         if self.config.custom_technical_keywords:
             # Append caller-supplied terms onto the base list, preserving order
             # and de-duplicating overlap with the base list (case-insensitive).

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -235,7 +235,20 @@ class ComplexityRouterConfig(BaseModel):
     )
     technical_keywords: Optional[List[str]] = Field(
         default=None,
-        description="Keywords indicating technical content",
+        description=(
+            "Keywords indicating technical content. When set, REPLACES the default "
+            "technical keyword list - use `custom_technical_keywords` to extend instead."
+        ),
+    )
+    custom_technical_keywords: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Domain-specific technical keywords to APPEND to the effective technical "
+            "keyword list (defaults, or `technical_keywords` if set). Order is preserved; "
+            "duplicates against the base list are dropped (case-insensitive). Use this to "
+            "extend the technical signal with terms like `udp`, `dns`, `kafka`, `postgresql` "
+            "without re-declaring the default list."
+        ),
     )
     simple_keywords: Optional[List[str]] = Field(
         default=None,

--- a/tests/test_litellm/router_strategy/test_custom_technical_keywords.py
+++ b/tests/test_litellm/router_strategy/test_custom_technical_keywords.py
@@ -1,0 +1,105 @@
+"""Tests for custom_technical_keywords on ComplexityRouter (LIT-3237)."""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.router_strategy.complexity_router.complexity_router import (
+    ComplexityRouter,
+)
+from litellm.router_strategy.complexity_router.config import (
+    DEFAULT_TECHNICAL_KEYWORDS,
+)
+
+
+BASE_CONFIG = {
+    "tiers": {
+        "SIMPLE": "gpt-4o-mini",
+        "MEDIUM": "gpt-4o",
+        "COMPLEX": "claude-sonnet-4-20250514",
+        "REASONING": "o1-preview",
+    },
+}
+
+
+def _router(extra_cfg=None):
+    cfg = dict(BASE_CONFIG)
+    if extra_cfg:
+        cfg.update(extra_cfg)
+    return ComplexityRouter(
+        model_name="test",
+        litellm_router_instance=MagicMock(),
+        complexity_router_config=cfg,
+    )
+
+
+class TestCustomTechnicalKeywords:
+    """Behavioural tests for ComplexityRouterConfig.custom_technical_keywords."""
+
+    def test_defaults_unchanged_when_field_absent(self):
+        r = _router()
+        assert list(r.technical_keywords) == list(DEFAULT_TECHNICAL_KEYWORDS)
+
+    def test_extends_defaults_not_replaces(self):
+        custom = ["udp", "dns", "kafka", "postgresql"]
+        r = _router({"custom_technical_keywords": custom})
+        for kw in DEFAULT_TECHNICAL_KEYWORDS:
+            assert kw in r.technical_keywords, f"default '{kw}' was dropped"
+        for kw in custom:
+            assert kw in r.technical_keywords, f"custom '{kw}' missing"
+        unique_new = [k for k in custom if k.lower() not in {d.lower() for d in DEFAULT_TECHNICAL_KEYWORDS}]
+        assert len(r.technical_keywords) == len(DEFAULT_TECHNICAL_KEYWORDS) + len(unique_new)
+
+    def test_overrides_then_extends_with_technical_keywords_set(self):
+        override = ["protocol", "encryption"]
+        custom = ["udp", "dns"]
+        r = _router({"technical_keywords": override, "custom_technical_keywords": custom})
+        assert r.technical_keywords == ["protocol", "encryption", "udp", "dns"]
+        assert "architecture" not in r.technical_keywords
+        assert "microservice" not in r.technical_keywords
+
+    def test_deduplicates_against_base_case_insensitive(self):
+        custom = ["Architecture", "udp", "ARCHITECTURE", "udp"]
+        r = _router({"custom_technical_keywords": custom})
+        assert "architecture" in r.technical_keywords
+        assert r.technical_keywords.count("udp") == 1
+        assert sum(1 for k in r.technical_keywords if k.lower() == "architecture") == 1
+
+    def test_preserves_order_of_custom_terms(self):
+        custom = ["zeta", "alpha", "mu"]
+        r = _router({"custom_technical_keywords": custom})
+        tech = r.technical_keywords
+        z_idx = tech.index("zeta")
+        a_idx = tech.index("alpha")
+        m_idx = tech.index("mu")
+        assert z_idx < a_idx < m_idx
+        last_default_idx = max(tech.index(d) for d in DEFAULT_TECHNICAL_KEYWORDS)
+        assert last_default_idx < z_idx
+
+    def test_empty_list_is_noop(self):
+        r = _router({"custom_technical_keywords": []})
+        assert list(r.technical_keywords) == list(DEFAULT_TECHNICAL_KEYWORDS)
+
+    def test_runtime_classify_changes_with_custom_terms(self):
+        prompt = (
+            "Diagnose a UDP packet loss issue between two services over DNS, "
+            "with TLS termination and SSH tunneling."
+        )
+        r_defaults = _router()
+        _, _, signals_before = r_defaults.classify(prompt)
+        assert not any(s.startswith("technical (") for s in signals_before)
+        r_custom = _router({"custom_technical_keywords": ["udp", "dns", "tls", "ssh"]})
+        _, _, signals_after = r_custom.classify(prompt)
+        assert any(s.startswith("technical (") for s in signals_after)
+
+    def test_arch_prompt_still_triggers_when_custom_added(self):
+        prompt = (
+            "Design a scalable distributed microservice architecture with "
+            "strong authentication and authorization."
+        )
+        r = _router({"custom_technical_keywords": ["udp", "dns"]})
+        _, _, signals = r.classify(prompt)
+        assert any(s.startswith("technical (") for s in signals)

--- a/tests/test_litellm/router_strategy/test_custom_technical_keywords.py
+++ b/tests/test_litellm/router_strategy/test_custom_technical_keywords.py
@@ -79,6 +79,15 @@ class TestCustomTechnicalKeywords:
         last_default_idx = max(tech.index(d) for d in DEFAULT_TECHNICAL_KEYWORDS)
         assert last_default_idx < z_idx
 
+    def test_empty_technical_keywords_falls_back_to_defaults_symmetrically(self):
+        """Symmetry with code_keywords/reasoning_keywords/simple_keywords:
+        an empty technical_keywords list falls back to defaults (truthy-fallback).
+        """
+        r = _router({"technical_keywords": [], "custom_technical_keywords": ["udp"]})
+        # Defaults still active because empty list is falsy -> falls back.
+        assert "architecture" in r.technical_keywords
+        assert "udp" in r.technical_keywords
+
     def test_empty_list_is_noop(self):
         r = _router({"custom_technical_keywords": []})
         assert list(r.technical_keywords) == list(DEFAULT_TECHNICAL_KEYWORDS)


### PR DESCRIPTION
## Summary

Adds an `Optional[List[str]]` `custom_technical_keywords` field to `ComplexityRouterConfig`. Unlike the existing `technical_keywords` (which **replaces** the default technical-keyword list when set), `custom_technical_keywords` **appends** caller-supplied domain terms to the effective list — preserving order, dropping overlap with the base list case-insensitively, and dropping intra-custom duplicates.

The customer ask was straightforward: extend the technical signal with terms like `udp`, `dns`, `kafka`, `postgresql` without re-declaring the full default list. With the existing `technical_keywords` field, doing so forced replacing the 28 default keywords (and stale-on-upgrade config files).

```yaml
router_settings:
  routing_strategy: complexity-based-routing
  complexity_router_config:
    custom_technical_keywords:
      - udp
      - dns
      - ssl
      - tls
      - ssh
      - rest
      - graphql
      - kafka
      - redis
      - postgresql
      - mongodb
```

## Changes

- `litellm/router_strategy/complexity_router/config.py`
  - New `custom_technical_keywords: Optional[List[str]] = None` field.
  - Updated `technical_keywords` docstring to call out the override semantics and point at `custom_technical_keywords` as the extend-style alternative.
- `litellm/router_strategy/complexity_router/complexity_router.py`
  - In `__init__`, build `base_technical` from `technical_keywords` (if set) or the defaults, then **append** `custom_technical_keywords` with order-preserving, case-insensitive de-dup against the base list and intra-custom duplicates.
- `tests/test_litellm/router_strategy/test_custom_technical_keywords.py`
  - 8 new tests covering: defaults unchanged when field absent; extend semantics; override-then-extend semantics; case-insensitive de-dup against base; order preservation; empty list is no-op; end-to-end `classify()` flips the technical signal on/off as expected; defaults coverage not regressed when custom is added.

> **Note on push path:** This PR was filed via the GitHub Contents API because the agent's `GITHUB_TOKEN` lacks `repo`/`workflow` scopes (a known sandbox limitation). The branch therefore carries 3 sequential commits (one per file) rather than a single squashed commit. Squashing on merge is recommended.

## Evidence

`classify()` runs against the running `ComplexityRouter` on **the daily branch (before)** and **this fix branch (after)** with the customer-style config from the ticket. Two prompts are used:

- `NETOPS` — *"Diagnose UDP packet loss between two services using DNS over TLS, REST APIs, and SSH tunneling."*
- `ARCH` — *"Design a scalable distributed microservice architecture with strong authentication and authorization."*

### Before (daily branch / pre-fix)

```
==============================================================================
BEFORE: complexity_router on `the daily branch` prior to the fix
==============================================================================
Config field exists: False (no field on main)
DEFAULT_TECHNICAL_KEYWORDS size = 28
None of CUSTOM terms are in defaults: any?= False

[A] defaults-only (no custom field available on main)
    netops: tier=SIMPLE score=0.000 signals=[]

[B] technical_keywords=CUSTOM  (only option on main; REPLACES defaults)
    effective list size = 11  (lost 28 defaults)
    netops: tier=MEDIUM score=0.250  signals=['technical (udp, dns, tls)']
    arch:   tier=SIMPLE score=0.000  signals=[]

--> Customer is forced to choose: (A) keep defaults and get no coverage for UDP/DNS prompts,
    OR (B) replace defaults and lose coverage for arch/microservice prompts.
    No way to express the desired union.
```

### After (this branch)

```
==============================================================================
AFTER: complexity_router on the fix branch
==============================================================================

[A] Defaults only (no custom)
    netops: tier=SIMPLE score=0.000 signals=[]
    technical_keywords size = 28 (defaults intact)

[B] custom_technical_keywords=['udp', 'dns', 'ssl', 'tls', 'ssh', 'rest', 'graphql', 'kafka', 'redis', 'postgresql', 'mongodb']
    netops: tier=MEDIUM score=0.250  signals=['technical (udp, dns, tls)']
    arch:   tier=MEDIUM score=0.250  signals=['technical (architecture, distributed, scalable)']
    effective list size = 39 (defaults 28 + appended)

[C] technical_keywords=['protocol','encryption']  +  custom_technical_keywords=['udp','dns']
    effective list = ['protocol', 'encryption', 'udp', 'dns']

[D] custom_technical_keywords=['Architecture','udp','ARCHITECTURE','udp']  (overlap+dupes)
    'architecture' count = 1 (expect 1)
    'udp' count = 1 (expect 1)

All runtime assertions passed.
```

### Unit tests

```
$ PYTHONPATH=. python3 -m pytest tests/test_litellm/router_strategy/test_custom_technical_keywords.py tests/test_litellm/router_strategy/test_complexity_router.py -q
...........................................................................  [ 96%]
...                                                                          [100%]
75 passed in 12.32s
```

8 new behavioural tests for the merge logic + all 67 existing `ComplexityRouter` tests still pass.

## Linear

Closes LIT-3237.


### Verification (ship-pr)
- **change-type:** config schema + routing-decision logic (no UI surface, no HTTP endpoint, no metrics) → required evidence type is captured `classify()` runs from a running `ComplexityRouter` against the customer-style config.
- **evidence present:** PASS (2 fenced text captures: BEFORE on the daily branch, AFTER on this branch).
- **image sanity:** N/A (text capture only; no screenshots needed for this change).
- **content matches caption:** PASS (read-back confirms tier flip SIMPLE→MEDIUM, technical-signal flip [] → ['technical (udp, dns, tls)'], list-size 28 → 39, and case-insensitive de-dup all observable in the output).
- **backend evidence from a running system:** PASS (`python3 /tmp/before.py` against a fresh `litellm_oss_agent_shin_daily_branch` clone, `python3 /tmp/after.py` against this fix branch — both real router instantiations exercising the changed code path).
- **re-verify after Greptile P2 fix:** PASS (76/76 tests after symmetry change; Greptile re-reviewed to 5/5).
