### PR TITLE
fix(ui/add-model): stop vertex_ai-anthropic_models from leaking into Anthropic dropdown (LIT-3311)

### DIFF
--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -218,14 +218,83 @@ describe("provider_info_helpers", () => {
       expect(result).toEqual(["gpt-3.5-turbo", "gpt-4"]);
     });
 
-    it("should return models when litellm_provider includes the provider string", () => {
+    it("should return models whose litellm_provider is a prefix-anchored variant of the provider", () => {
       const modelMap = {
-        "custom-openai-model": { litellm_provider: "custom_openai_endpoint" },
-        "another-model": { litellm_provider: "openai" },
+        "anthropic-text-model": { litellm_provider: "anthropic_text" },
+        "claude-3-opus": { litellm_provider: "anthropic" },
+      };
+      const result = getProviderModels(Providers.Anthropic, modelMap);
+      expect(result).toContain("anthropic-text-model");
+      expect(result).toContain("claude-3-opus");
+    });
+
+    it("should not leak vertex_ai-anthropic_models into the Anthropic provider", () => {
+      const modelMap = {
+        "claude-3-opus": { litellm_provider: "anthropic" },
+        "vertex_ai/claude-3-5-sonnet": { litellm_provider: "vertex_ai-anthropic_models" },
+        "vertex_ai/claude-haiku-4-5": { litellm_provider: "vertex_ai-anthropic_models" },
+      };
+      const result = getProviderModels(Providers.Anthropic, modelMap);
+      expect(result).toEqual(["claude-3-opus"]);
+      expect(result).not.toContain("vertex_ai/claude-3-5-sonnet");
+      expect(result).not.toContain("vertex_ai/claude-haiku-4-5");
+    });
+
+    it("should not leak vertex_ai-openai_models into the OpenAI provider", () => {
+      const modelMap = {
+        "gpt-4": { litellm_provider: "openai" },
+        "vertex_ai/openai-something": { litellm_provider: "vertex_ai-openai_models" },
       };
       const result = getProviderModels(Providers.OpenAI, modelMap);
-      expect(result).toContain("custom-openai-model");
-      expect(result).toContain("another-model");
+      expect(result).toEqual(["gpt-4"]);
+      expect(result).not.toContain("vertex_ai/openai-something");
+    });
+
+    // Note on the next three tests: in production, AddModelForm passes the
+    // backend `provider` field (the provider_map *key*, e.g. "Vertex_AI",
+    // "Bedrock", "FireworksAI") into getProviderModels, not the Providers
+    // enum value. The `as Providers` cast in callers is misleading. We mirror
+    // the production shape here by passing the key directly.
+    it("should include all vertex_ai variants when called with 'Vertex_AI' provider key", () => {
+      const modelMap = {
+        "vertex_ai/gemini-pro": { litellm_provider: "vertex_ai" },
+        "vertex_ai/claude-3-5-sonnet": { litellm_provider: "vertex_ai-anthropic_models" },
+        "vertex_ai/text-bison": { litellm_provider: "vertex_ai-text-models" },
+        "vertex_ai_beta/something": { litellm_provider: "vertex_ai_beta" },
+        "anthropic-native": { litellm_provider: "anthropic" },
+      };
+      const result = getProviderModels("Vertex_AI" as Providers, modelMap);
+      expect(result).toContain("vertex_ai/gemini-pro");
+      expect(result).toContain("vertex_ai/claude-3-5-sonnet");
+      expect(result).toContain("vertex_ai/text-bison");
+      expect(result).toContain("vertex_ai_beta/something");
+      expect(result).not.toContain("anthropic-native");
+    });
+
+    it("should include bedrock variants (converse, mantle) when called with 'Bedrock' provider key", () => {
+      const modelMap = {
+        "bedrock-base": { litellm_provider: "bedrock" },
+        "bedrock-converse-model": { litellm_provider: "bedrock_converse" },
+        "bedrock-mantle-model": { litellm_provider: "bedrock_mantle" },
+        "openai-model": { litellm_provider: "openai" },
+      };
+      const result = getProviderModels("Bedrock" as Providers, modelMap);
+      expect(result).toContain("bedrock-base");
+      expect(result).toContain("bedrock-converse-model");
+      expect(result).toContain("bedrock-mantle-model");
+      expect(result).not.toContain("openai-model");
+    });
+
+    it("should include fireworks_ai-embedding-models when called with 'FireworksAI' provider key", () => {
+      const modelMap = {
+        "fireworks-base": { litellm_provider: "fireworks_ai" },
+        "fireworks-embed": { litellm_provider: "fireworks_ai-embedding-models" },
+        "openai-model": { litellm_provider: "openai" },
+      };
+      const result = getProviderModels("FireworksAI" as Providers, modelMap);
+      expect(result).toContain("fireworks-base");
+      expect(result).toContain("fireworks-embed");
+      expect(result).not.toContain("openai-model");
     });
 
     it("should filter out models with null values", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -389,7 +389,9 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
         const litellmProvider = (value as any)["litellm_provider"];
         if (
           litellmProvider === custom_llm_provider ||
-          (typeof litellmProvider === "string" && litellmProvider.includes(custom_llm_provider))
+          (typeof litellmProvider === "string" &&
+            (litellmProvider.startsWith(`${custom_llm_provider}_`) ||
+              litellmProvider.startsWith(`${custom_llm_provider}-`)))
         ) {
           providerModels.push(key);
         }


### PR DESCRIPTION
## What

`getProviderModels` in `provider_info_helpers.tsx` matched models against the
selected provider with a substring `litellmProvider.includes(custom_llm_provider)`
check. With `custom_llm_provider = "anthropic"`, this matched any model whose
`litellm_provider` field contained the substring `anthropic` — including the
29 `vertex_ai-anthropic_models` entries in `model_prices_and_context_window.json`.
The Add Model UI then surfaced all of those `vertex_ai/*` Claude entries under
the **Anthropic** provider, which is what the ticket reports.

## Fix

Replace the substring `.includes()` match with a separator-anchored prefix match
(`litellmProvider.startsWith(`${custom_llm_provider}_`)` or
`...startsWith(`${custom_llm_provider}-`)`).

So:
- `anthropic` -> matches `anthropic`, `anthropic_text` ✓
- `anthropic` -> does NOT match `vertex_ai-anthropic_models` ✓
- `vertex_ai` -> still matches `vertex_ai`, `vertex_ai-anthropic_models`,
  `vertex_ai-text-models`, `vertex_ai_beta` ✓
- `bedrock` -> still matches `bedrock`, `bedrock_converse`, `bedrock_mantle` ✓
- `fireworks_ai` -> still matches `fireworks_ai`, `fireworks_ai-embedding-models` ✓

This is the same fix that merged to `litellm_internal_staging` in #28723; the
bug is still present on `litellm_oss_agent_shin_daily_branch` because that
PR did not propagate.

## Refs

LIT-3311

## Evidence

The runtime surface for this bug is a pure helper in the dashboard JS bundle —
the model list under the Add Model -> Provider dropdown comes straight from
`getProviderModels(provider, modelMap)` (`ModelsAndEndpointsView.tsx:158`). The
helper is fed the in-tree `model_prices_and_context_window_backup.json`.

The evidence below was captured by running the exact match logic against the
production model_cost_map data — the same data the dashboard receives in the
browser — once with the buggy `.includes()` from `main`, once with the fix on
this branch:

```text
### BEFORE — current daily branch (`includes()` substring match)
`getProviderModels('Anthropic', model_cost_map)`
  total entries returned: 49
  vertex_ai/* models leaked into Anthropic dropdown: 29
  first leaked entries:
    - vertex_ai/claude-3-5-haiku
    - vertex_ai/claude-3-5-haiku@20241022
    - vertex_ai/claude-haiku-4-5
    - vertex_ai/claude-haiku-4-5@20251001
    - vertex_ai/claude-3-5-sonnet
    - vertex_ai/claude-3-5-sonnet@20240620
    - vertex_ai/claude-3-7-sonnet@20250219
    - vertex_ai/claude-3-haiku
    - vertex_ai/claude-3-haiku@20240307
    - vertex_ai/claude-3-opus
    ... and 19 more

### AFTER — with the fix on this branch (prefix-anchored match)
`getProviderModels('Anthropic', model_cost_map)`
  total entries returned: 20
  vertex_ai/* models leaked into Anthropic dropdown: 0
  first entries: ['claude-haiku-4-5-20251001', 'claude-haiku-4-5', 'claude-3-7-sonnet-20250219', 'claude-3-haiku-20240307', 'claude-3-opus-20240229', 'claude-4-opus-20250514']

### Sanity: Vertex_AI provider still shows its Claude models
  `getProviderModels('Vertex_AI', model_cost_map)` -> 153 entries
  `vertex_ai-anthropic_models` entries still under Vertex_AI: 29

### Unit tests
  src/components/provider_info_helpers.test.tsx: 52/52 passed (vitest)
  includes 6 new tests covering: anthropic prefix-anchor, vertex_ai-anthropic leak guard,
  vertex_ai-openai leak guard, Vertex_AI key full set, Bedrock variants, FireworksAI variants

```

### Why not a browser screenshot

The LiteLLM proxy could not be brought up in this sandbox: every
`litellm-up` run failed at the Prisma `health_check` call with
`prisma.engine.errors.EngineRequestError: 502: vault upstream:`. With no proxy,
the dashboard at `/ui/` is not reachable, so I could not drive a real browser
through Add Model -> Provider -> Anthropic. The Node-level reproduction above
exercises the same code path the UI runs (the helper is a single pure function
imported from the dropdown view) against the same data, so it is the same
behavioral capture, just one frame inboard of the rendered `<Select />`.

## Tests

`ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx` — **52/52
passed** under `vitest`. New tests added on top of the existing suite:

- `should not leak vertex_ai-anthropic_models into the Anthropic provider`
- `should not leak vertex_ai-openai_models into the OpenAI provider`
- `should include all vertex_ai variants when called with 'Vertex_AI' provider key`
- `should include bedrock variants (converse, mantle) when called with 'Bedrock' provider key`
- `should include fireworks_ai-embedding-models when called with 'FireworksAI' provider key`
- the previous `should return models when litellm_provider includes the provider string` test was renamed and rewritten to assert prefix-anchor semantics on Anthropic, since the old substring assertion would not have caught this bug.

## Note on push path

Used the GitHub Contents API (`PUT /repos/.../contents/{path}`) because the
current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes so `git push` 403s with
"Password authentication is not supported." Two commits, one per file —
reviewers may want to view them squashed.

Session: https://litellm-agent-platform.onrender.com/sessions/5d8e9bcd-a9b7-406b-b299-23d3f106bee3


### Verification (ship-pr)
- change-type: 2 files touched
  - `ui/litellm-dashboard/src/components/provider_info_helpers.tsx` — pure helper used by the Add Model UI dropdown
  - `ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx` — vitest tests
- evidence present: PASS (before/after fenced code block with concrete entry counts on production `model_prices_and_context_window_backup.json`)
- image sanity: N/A — proxy startup was blocked by `prisma.engine.errors.EngineRequestError: 502: vault upstream:`, so the `/ui/` dashboard was unreachable. The Node-level reproduction in the Evidence section runs the same pure helper imported by `ModelsAndEndpointsView.tsx:158` against the same data the UI receives.
- image content matches caption: N/A (no embedded images)
- backend evidence from running system: PASS — text capture is from running the patched and unpatched helper logic against the in-tree `model_prices_and_context_window_backup.json` shipped with this branch. Vitest run (`npx vitest run src/components/provider_info_helpers.test.tsx`) reported `Test Files  1 passed (1) | Tests  52 passed (52)`.
- hygiene: PASS — no external image hosts referenced; only the two files above modified
- CI: 44/44 green; Greptile 5/5; Veria AI ✅
