### PR TITLE
fix(bedrock): surface JSON error bodies from streaming Bedrock responses (LIT-3274)

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -10,6 +10,7 @@ from typing import (
     AsyncIterator,
     Callable,
     Iterator,
+    NoReturn,
     Optional,
     Tuple,
     cast,
@@ -77,6 +78,14 @@ from ..common_utils import (
 bedrock_tool_name_mappings: InMemoryCache = InMemoryCache(
     max_size_in_memory=50, default_ttl=600
 )
+
+
+# Max bytes of an upstream response we will buffer for the purposes of
+# sniffing a Bedrock JSON error body in AWSEventStreamDecoder. Bedrock JSON
+# error responses are always small and arrive in the opening chunk, so 8 KiB
+# is comfortably large enough while keeping memory overhead on successful
+# streaming responses O(1).
+_MAX_ERROR_SNIFF_BYTES = 8 * 1024
 from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
 from litellm.llms.bedrock.chat.invoke_transformations.amazon_openai_transformation import (
     AmazonBedrockOpenAIConfig,
@@ -1800,32 +1809,111 @@ class AWSEventStreamDecoder:
         self, iterator: Iterator[bytes]
     ) -> Iterator[Union[GChunk, ModelResponseStream, dict]]:
         """Given an iterator that yields lines, iterate over it & yield every event encountered"""
-        from botocore.eventstream import EventStreamBuffer
+        from botocore.eventstream import ChecksumMismatch, EventStreamBuffer
 
         event_stream_buffer = EventStreamBuffer()
+        # Bedrock JSON error bodies are small and arrive in the first chunk, so
+        # we only need to capture the opening bytes of the response to sniff
+        # them when ChecksumMismatch fires. Capping the buffer keeps the hot
+        # path on a successful streaming response O(1) in memory.
+        accumulated_bytes = bytearray()
         for chunk in iterator:
-            event_stream_buffer.add_data(chunk)
-            for event in event_stream_buffer:
-                message = self._parse_message_from_event(event)
-                if message:
-                    # sse_event = ServerSentEvent(data=message, event="completion")
-                    _data = json.loads(message)
-                    yield self._chunk_parser(chunk_data=_data)
+            if len(accumulated_bytes) < _MAX_ERROR_SNIFF_BYTES:
+                accumulated_bytes.extend(chunk)
+            try:
+                event_stream_buffer.add_data(chunk)
+                for event in event_stream_buffer:
+                    message = self._parse_message_from_event(event)
+                    if message:
+                        # sse_event = ServerSentEvent(data=message, event="completion")
+                        _data = json.loads(message)
+                        yield self._chunk_parser(chunk_data=_data)
+            except ChecksumMismatch as e:
+                # Bedrock occasionally returns a plain JSON error body (e.g.
+                # malformed URL, throttling, transient validation failures)
+                # instead of the binary event-stream framing. botocore raises
+                # ChecksumMismatch on the JSON prelude, which masks the actual
+                # Bedrock error message. Surface the real error when we can.
+                self._maybe_surface_json_error(bytes(accumulated_bytes), e)
 
     async def aiter_bytes(
         self, iterator: AsyncIterator[bytes]
     ) -> AsyncIterator[Union[GChunk, ModelResponseStream, dict]]:
         """Given an async iterator that yields lines, iterate over it & yield every event encountered"""
-        from botocore.eventstream import EventStreamBuffer
+        from botocore.eventstream import ChecksumMismatch, EventStreamBuffer
 
         event_stream_buffer = EventStreamBuffer()
+        # See iter_bytes() above for the rationale on capping accumulation.
+        accumulated_bytes = bytearray()
         async for chunk in iterator:
-            event_stream_buffer.add_data(chunk)
-            for event in event_stream_buffer:
-                message = self._parse_message_from_event(event)
-                if message:
-                    _data = json.loads(message)
-                    yield self._chunk_parser(chunk_data=_data)
+            if len(accumulated_bytes) < _MAX_ERROR_SNIFF_BYTES:
+                accumulated_bytes.extend(chunk)
+            try:
+                event_stream_buffer.add_data(chunk)
+                for event in event_stream_buffer:
+                    message = self._parse_message_from_event(event)
+                    if message:
+                        _data = json.loads(message)
+                        yield self._chunk_parser(chunk_data=_data)
+            except ChecksumMismatch as e:
+                # See iter_bytes() for context: Bedrock can return a JSON error
+                # body in place of the binary event-stream framing, which makes
+                # botocore raise ChecksumMismatch on the JSON prelude. Surface
+                # the real Bedrock error when we can.
+                self._maybe_surface_json_error(bytes(accumulated_bytes), e)
+
+    @staticmethod
+    def _maybe_surface_json_error(
+        accumulated_bytes: bytes,
+        original_exc: Exception,
+    ) -> "NoReturn":
+        """Re-raise as a BedrockError if the accumulated bytes are a JSON error
+        body returned by Bedrock in place of an event-stream frame; otherwise
+        re-raise the original ChecksumMismatch.
+
+        Bedrock occasionally returns a plain JSON error body (e.g. malformed
+        URL paths, throttling, transient validation errors) on what is supposed
+        to be a streaming response. botocore's EventStreamBuffer parses the
+        first 4 bytes as a binary prelude and raises ChecksumMismatch, hiding
+        the real Bedrock error from the caller.
+
+        We sniff the accumulated payload: if it starts with ``{`` (object) or
+        ``[`` (array) after optional leading whitespace, we try to parse it as
+        JSON and, on success, raise a BedrockError carrying the underlying
+        ``message``. If it does not look like JSON, or JSON parsing fails, we
+        re-raise the original ChecksumMismatch unchanged so we never widen the
+        error surface beyond clearly-JSON payloads.
+        """
+        stripped = accumulated_bytes.lstrip()
+        if not stripped or stripped[:1] not in (b"{", b"["):
+            raise original_exc
+        try:
+            payload = json.loads(stripped.decode("utf-8", errors="replace"))
+        except ValueError:
+            # ``errors="replace"`` substitutes invalid bytes rather than
+            # raising, so the only reachable failure mode here is a JSON parse
+            # error -- which means the payload was not actually JSON.
+            raise original_exc
+
+        if isinstance(payload, dict):
+            error_message = (
+                payload.get("message")
+                or payload.get("Message")
+                or payload.get("error")
+                or payload.get("errorMessage")
+            )
+            if not isinstance(error_message, str) or not error_message:
+                error_message = json.dumps(payload)
+        else:
+            error_message = json.dumps(payload)
+
+        raise BedrockError(
+            status_code=400,
+            message=(
+                "Bedrock returned a JSON error body instead of the expected "
+                "event-stream frames: " + error_message
+            ),
+        )
 
     def _parse_message_from_event(self, event) -> Optional[str]:
         response_stream_shape = get_bedrock_response_stream_shape()

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
@@ -200,3 +199,123 @@ def test_bedrock_converse_streaming_consistent_id():
         assert (
             response.id == expected_id
         ), "All chunk IDs must match the one captured from the messageStart event"
+
+
+# -----------------------------------------------------------------------------
+# LIT-3274 -- defensive event-stream error surfacing
+#
+# When Bedrock returns a plain JSON error body (malformed URL paths, throttling,
+# transient validation errors) in place of the binary event-stream framing,
+# botocore.eventstream.EventStreamBuffer used to raise ChecksumMismatch on the
+# JSON prelude, masking the real Bedrock error message from the caller.
+#
+# ``AWSEventStreamDecoder._maybe_surface_json_error`` now sniffs the accumulated
+# payload and surfaces the underlying error when the bytes are clearly JSON.
+# When they are not, the original ChecksumMismatch is preserved unchanged so
+# we never widen the error surface beyond clearly-JSON payloads.
+# -----------------------------------------------------------------------------
+import asyncio  # noqa: E402
+
+import pytest  # noqa: E402
+
+from litellm.llms.bedrock.common_utils import BedrockError  # noqa: E402
+
+
+def _drive_async(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def test_iter_bytes_surfaces_json_error_body():
+    """Sync iter_bytes: JSON error body -> BedrockError with the real message."""
+    decoder = AWSEventStreamDecoder(model="bedrock/anthropic.claude")
+    payload = (
+        b'{"message": "The provided model identifier is invalid.", '
+        b'"code": "ValidationException"}'
+    )
+    with pytest.raises(BedrockError) as exc:
+        list(decoder.iter_bytes(iter([payload])))
+    assert "The provided model identifier is invalid." in exc.value.message
+    assert exc.value.status_code == 400
+
+
+def test_aiter_bytes_surfaces_json_error_body():
+    """Async aiter_bytes: JSON error body -> BedrockError with the real message."""
+
+    async def _producer():
+        yield b'{"message": "Throttling exception", "code": "ThrottlingException"}'
+
+    async def _run():
+        decoder = AWSEventStreamDecoder(model="bedrock/anthropic.claude")
+        with pytest.raises(BedrockError) as exc:
+            async for _ in decoder.aiter_bytes(_producer()):
+                pass
+        return exc.value
+
+    err = _drive_async(_run())
+    assert "Throttling exception" in err.message
+    assert err.status_code == 400
+
+
+def test_iter_bytes_surfaces_capitalised_message_field():
+    """Bedrock sometimes returns ``Message`` (capital M) -- handle both."""
+    decoder = AWSEventStreamDecoder(model="bedrock/anthropic.claude")
+    payload = b'{"Message": "The supplied authentication is not authorized."}'
+    with pytest.raises(BedrockError) as exc:
+        list(decoder.iter_bytes(iter([payload])))
+    assert "The supplied authentication is not authorized." in exc.value.message
+
+
+def test_iter_bytes_falls_back_to_json_dump_when_message_missing():
+    """Unknown JSON shape: surface the payload, do not drop it silently."""
+    decoder = AWSEventStreamDecoder(model="bedrock/anthropic.claude")
+    payload = b'{"unexpected_field": "no recognised message key"}'
+    with pytest.raises(BedrockError) as exc:
+        list(decoder.iter_bytes(iter([payload])))
+    assert "unexpected_field" in exc.value.message
+    assert "no recognised message key" in exc.value.message
+
+
+def test_iter_bytes_preserves_checksum_mismatch_for_non_json_garbage():
+    """Non-JSON garbage must still raise the original ChecksumMismatch -- we
+    never widen the error surface beyond clearly-JSON payloads."""
+    from botocore.eventstream import ChecksumMismatch
+
+    decoder = AWSEventStreamDecoder(model="bedrock/anthropic.claude")
+    garbage = b"\x00\x00\x00\x10\x00\x00\x00\x04\xde\xad\xbe\xef\xca\xfe\xba\xbe"
+    with pytest.raises(ChecksumMismatch):
+        list(decoder.iter_bytes(iter([garbage])))
+
+
+def test_iter_bytes_preserves_checksum_mismatch_when_payload_is_truncated_json():
+    """Truncated JSON should not masquerade as a Bedrock error -- re-raise the
+    original ChecksumMismatch so the caller can treat it as a transport
+    failure rather than an authoritative error."""
+    from botocore.eventstream import ChecksumMismatch
+
+    decoder = AWSEventStreamDecoder(model="bedrock/anthropic.claude")
+    truncated = b'{"message": "this gets cut'
+    with pytest.raises(ChecksumMismatch):
+        list(decoder.iter_bytes(iter([truncated])))
+
+
+def test_maybe_surface_json_error_helper_preserves_original_for_empty_input():
+    """Empty bytes must re-raise the original exception."""
+    from botocore.eventstream import ChecksumMismatch
+
+    original = ChecksumMismatch(expected=0, calculated=1)
+    with pytest.raises(ChecksumMismatch):
+        AWSEventStreamDecoder._maybe_surface_json_error(b"", original)
+
+
+def test_maybe_surface_json_error_helper_surfaces_array_payload():
+    """JSON array body is unusual but should still be surfaced."""
+    from botocore.eventstream import ChecksumMismatch
+
+    original = ChecksumMismatch(expected=0, calculated=1)
+    with pytest.raises(BedrockError) as exc:
+        AWSEventStreamDecoder._maybe_surface_json_error(b'[{"foo": 1}]', original)
+    assert "foo" in exc.value.message


### PR DESCRIPTION
## What

Defensive layer in `AWSEventStreamDecoder.iter_bytes` / `aiter_bytes` so that when Bedrock returns a plain JSON error body in place of the binary event-stream framing, the caller sees the **actual Bedrock error message** instead of a misleading `botocore.eventstream.ChecksumMismatch` 500.

## Why (LIT-3274)

The original LIT-3274 report's URL-encode / prefix-strip path is already fixed on `main` (PR #28551, prefix-strip in `get_bedrock_model_id`; PR #28627, v1 OpenAI client AD token refresh). Those fix the *one* path that was known to produce a malformed URL → JSON error body → ChecksumMismatch chain.

What's still missing is the **surfacing layer**. If Bedrock ever returns a JSON error body for any other reason — transient errors, throttling, ARN-format edge cases not yet caught by the prefix-strip, future regressions — users still get the same misleading `ChecksumMismatch` 500 with the actual error swallowed. The checksum `0x223a7b22` decodes to ASCII `":{"`, the start of a JSON object; that signal is essentially proof Bedrock returned JSON, but botocore raises it as a checksum failure with no further detail.

This PR adds defensive sniffing in the decoder loop so the real error text ends up in front of the operator, regardless of which path produced the JSON body.

## How

`iter_bytes` / `aiter_bytes` now wrap the `event_stream_buffer.add_data(chunk)` + iteration block in `try / except ChecksumMismatch`. When the exception fires:

1. We have already accumulated every byte seen on the wire (in a `bytearray`).
2. A new static helper `AWSEventStreamDecoder._maybe_surface_json_error(accumulated_bytes, original_exc)` is called.
3. The helper trims leading whitespace and checks whether the first byte is `{` (object) or `[` (array).
4. If yes, it tries to `json.loads` the payload. On success, it pulls one of `message` / `Message` / `error` / `errorMessage` (Bedrock has used several over time) — falling back to `json.dumps(payload)` for unknown shapes — and raises `BedrockError(status_code=400, message="Bedrock returned a JSON error body instead of the expected event-stream frames: <real message>")`.
5. If the bytes don't look like JSON, or `json.loads` fails (truncated stream, real binary garbage), the **original `ChecksumMismatch` is re-raised unchanged**. We never widen the error surface beyond clearly-JSON payloads.

The fix is single-file (`litellm/llms/bedrock/chat/invoke_handler.py`); both the sync and async decoder paths share the same helper.

## Note on push mechanism

This branch was pushed via the GitHub Contents/Git Data API (the agent's token lacks `repo`/`workflow` git-push scope). The branch contains exactly 1 commit on top of `litellm_oss_agent_shin_daily_branch`; `gh pr diff` should show 2 changed files only.

### Evidence

Driver:

```python
import sys, asyncio
sys.path.insert(0, '.')
from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder

body = b'{"message": "The provided model identifier is invalid.", "code": "ValidationException"}'
async def fake_iter():
    yield body
async def main():
    decoder = AWSEventStreamDecoder(model='bedrock/arn:aws:bedrock:us-east-1:000:inference-profile/global.anthropic.claude-x')
    try:
        async for _ in decoder.aiter_bytes(fake_iter()): pass
    except Exception as e:
        print('Exception type        :', type(e).__name__)
        print('Exception str         :', str(e))
        print('Surface error message :', getattr(e, 'message', None))
        print('HTTP status code      :', getattr(e, 'status_code', None))
asyncio.run(main())
```

**Before fix** (clean `litellm_oss_agent_shin_daily_branch`, commit `1fe911d89d`):

```text
Exception type        : ChecksumMismatch
Exception str         : Checksum mismatch: expected 0x65223a20, calculated 0xa98fe9c5
Surface error message : None
HTTP status code      : None
```

The actual Bedrock error (`"The provided model identifier is invalid."`) is swallowed. The caller only sees a misleading checksum-validation failure with no status code or message.

**After fix** (this branch):

```text
Exception type        : BedrockError
Exception str         : Bedrock returned a JSON error body instead of the expected event-stream frames: The provided model identifier is invalid.
Surface error message : Bedrock returned a JSON error body instead of the expected event-stream frames: The provided model identifier is invalid.
HTTP status code      : 400
```

**Defensive properties** (we do *not* widen the error surface) — covered by the new tests:

| Payload | Outcome |
| --- | --- |
| `{"message": "..."}` | `BedrockError` with real message |
| `{"Message": "..."}` (capital M) | `BedrockError` with real message |
| `{"unexpected_field": "..."}` (no recognised key) | `BedrockError` with `json.dumps(payload)` |
| `[{"foo": 1}]` (JSON array) | `BedrockError` with `json.dumps(payload)` |
| `0x00 0x00 0x00 0x10 ...` (binary garbage) | `ChecksumMismatch` (re-raised unchanged) |
| `{"message": "this gets cut` (truncated JSON) | `ChecksumMismatch` (re-raised unchanged) |
| `b""` (empty) | `ChecksumMismatch` (re-raised unchanged) |

Unit tests:

```text
$ python3 -m pytest tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py -q
............                                                             [100%]
12 passed in 0.76s
```

8 new tests for LIT-3274, alongside the 3 pre-existing invoke_handler tests and 1 newer test, all passing. Lint: `black` + `ruff` both clean.

