### PR TITLE
fix(proxy/auth): promote user_api_key_cache_ttl over management-object default (LIT-3338)

### DIFF
--- a/litellm/proxy/common_utils/user_api_key_cache.py
+++ b/litellm/proxy/common_utils/user_api_key_cache.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.dual_cache import DualCache
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
 
 T = TypeVar("T", bound=BaseModel)
@@ -135,6 +136,7 @@ class UserApiKeyCache(DualCache):
     def set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
         model_type = cast(Optional[Type[BaseModel]], kwargs.pop("model_type", None))
         payload = CacheCodec.serialize(value, model_type=model_type)
+        self._promote_management_ttl(kwargs)
         return super().set_cache(
             key=key, value=payload, local_only=local_only, **kwargs
         )
@@ -142,9 +144,39 @@ class UserApiKeyCache(DualCache):
     async def async_set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
         model_type = cast(Optional[Type[BaseModel]], kwargs.pop("model_type", None))
         payload = CacheCodec.serialize(value, model_type=model_type)
+        self._promote_management_ttl(kwargs)
         return await super().async_set_cache(
             key=key, value=payload, local_only=local_only, **kwargs
         )
+
+    def _promote_management_ttl(self, kwargs: dict) -> None:
+        """Honour ``general_settings.user_api_key_cache_ttl`` for management-object writes.
+
+        Every management-object writer in ``litellm/proxy/auth/auth_checks.py``,
+        ``litellm/proxy/auth/handle_jwt.py``, and the MCP server manager passes
+        ``ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` explicitly. Because
+        ``DualCache.async_set_cache`` only applies ``self.default_in_memory_ttl``
+        when ``ttl`` is absent from kwargs, the operator-configured
+        ``user_api_key_cache_ttl`` (wired up at startup via ``update_cache_ttl``)
+        is silently shadowed by the management constant. See LIT-3338.
+
+        When the caller passes that exact constant AND ``default_in_memory_ttl``
+        has been configured to a different value, promote the configured default
+        so the operator setting wins. Non-management call sites that pass their
+        own ``ttl=<n>`` for unrelated reasons are unaffected: only the exact
+        management constant triggers promotion.
+        """
+        explicit_ttl = kwargs.get("ttl")
+        if explicit_ttl is None:
+            return
+        if explicit_ttl != DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL:
+            return
+        configured = self.default_in_memory_ttl
+        if configured is None:
+            return
+        if configured == DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL:
+            return
+        kwargs["ttl"] = configured
 
     async def async_set_cache_pipeline(  # type: ignore[override]
         self, cache_list: list, local_only: bool = False, **kwargs

--- a/litellm/proxy/common_utils/user_api_key_cache.py
+++ b/litellm/proxy/common_utils/user_api_key_cache.py
@@ -165,6 +165,18 @@ class UserApiKeyCache(DualCache):
         so the operator setting wins. Non-management call sites that pass their
         own ``ttl=<n>`` for unrelated reasons are unaffected: only the exact
         management constant triggers promotion.
+
+        Note on the in-memory vs Redis backend split: the parent
+        ``DualCache.async_set_cache`` forwards the same ``ttl`` kwarg to both the
+        in-memory backend and the Redis backend, so promoting ``ttl`` here causes
+        the same value to be stamped on both. In the current proxy startup
+        (``proxy_server.py``) ``user_api_key_cache.update_cache_ttl`` is called
+        with the same value for ``default_in_memory_ttl`` and ``default_redis_ttl``,
+        so the two backends always agree and there is no observable difference.
+        If a divergent configuration is ever introduced, the Redis TTL for
+        management objects will continue to track ``default_in_memory_ttl`` here —
+        a follow-up change to ``DualCache`` (per-backend TTL kwargs) would be
+        required to honour both independently, which is out of scope for this fix.
         """
         explicit_ttl = kwargs.get("ttl")
         if explicit_ttl is None:
@@ -184,11 +196,17 @@ class UserApiKeyCache(DualCache):
         """
         Batch writes with the same Codec boundary as ``async_set_cache`` without
         ``model_type``: ``BaseModel`` values become JSON-safe dicts; dicts/scalars unchanged.
+
+        Honour ``general_settings.user_api_key_cache_ttl`` for management-object writes
+        on the pipeline path too, so a future writer that switches from
+        ``async_set_cache`` to the pipeline does not silently lose the operator-configured
+        TTL. See ``_promote_management_ttl``.
         """
         normalized = [
             (key, CacheCodec.serialize(value, model_type=None))
             for key, value in cache_list
         ]
+        self._promote_management_ttl(kwargs)
         return await super().async_set_cache_pipeline(
             cache_list=normalized, local_only=local_only, **kwargs
         )

--- a/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_promotion.py
+++ b/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_promotion.py
@@ -126,3 +126,37 @@ async def test_async_set_cache_no_promotion_when_ttl_is_none():
     observed = _observed_ttl(cache, "no-ttl-key")
     # DualCache stamps default_in_memory_ttl when ttl is absent, so this should be ~300.
     assert observed > 250, f"expected ttl ~300, got {observed}"
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_pipeline_also_promotes_management_ttl():
+    """Pipeline path must apply the same promotion — guards a future writer migrating to pipeline.
+
+    Greptile P2 from the initial review: if a future management-object writer
+    switches from ``async_set_cache`` to ``async_set_cache_pipeline``, the TTL
+    promotion must still apply or the operator-configured TTL is silently lost.
+    """
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
+    await cache.async_set_cache_pipeline(
+        cache_list=[("pipeline-key-1", {"x": 1}), ("pipeline-key-2", {"x": 2})],
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    obs1 = _observed_ttl(cache, "pipeline-key-1")
+    obs2 = _observed_ttl(cache, "pipeline-key-2")
+    assert obs1 > 250 and obs1 < 310, f"key1: expected ~300, got {obs1}"
+    assert obs2 > 250 and obs2 < 310, f"key2: expected ~300, got {obs2}"
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_pipeline_does_not_touch_non_management_ttl():
+    """Pipeline ttl=10 (non-management) must be respected, not promoted."""
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
+    await cache.async_set_cache_pipeline(
+        cache_list=[("p-other", {"x": 1})],
+        ttl=10,
+    )
+    obs = _observed_ttl(cache, "p-other")
+    assert math.isclose(obs, 10, abs_tol=1.5), f"expected ~10, got {obs}"
+

--- a/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_promotion.py
+++ b/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_promotion.py
@@ -1,0 +1,128 @@
+"""Regression tests for LIT-3338: user_api_key_cache_ttl promotion.
+
+The proxy applies ``general_settings.user_api_key_cache_ttl`` at startup via
+``user_api_key_cache.update_cache_ttl(default_in_memory_ttl=ttl, default_redis_ttl=ttl)``.
+However every management-object writer in ``auth_checks.py``, ``handle_jwt.py``,
+and the MCP server manager calls
+``user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)``
+explicitly. ``DualCache.async_set_cache`` only falls back to ``default_in_memory_ttl``
+when ``ttl`` is absent from kwargs, so the operator setting is silently shadowed.
+
+The fix is a one-time TTL promotion inside ``UserApiKeyCache.async_set_cache``
+(and the rarely-used sync ``set_cache``) that only fires when the explicit ttl
+*exactly* equals ``DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` AND the cache
+has been configured to a different default. Any other explicit ttl is respected
+verbatim, and when no operator setting was applied behaviour is identical to
+before.
+
+These tests pin all four corners of that contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+
+import pytest
+
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+
+def _observed_ttl(cache: UserApiKeyCache, key: str) -> float:
+    """Return the live TTL stamped on the in-memory entry."""
+    return cache.in_memory_cache.ttl_dict[key] - time.time()
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_promotes_management_ttl_to_configured_default():
+    """The reported regression: user_api_key_cache_ttl=300 -> 60 silently."""
+    cache = UserApiKeyCache()
+    # Operator configured general_settings.user_api_key_cache_ttl: 300
+    cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
+
+    await cache.async_set_cache(
+        key="hashed-token",
+        value={"user_id": "alice"},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = _observed_ttl(cache, "hashed-token")
+    # Should now be ~300s, not 60s
+    assert observed > 250, (
+        f"expected ttl ~300, got {observed} — management constant still shadowing user_api_key_cache_ttl"
+    )
+    assert observed < 310
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_does_not_touch_non_management_ttl():
+    """A caller that explicitly chooses a non-management ttl must be respected."""
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
+
+    # Caller picks ttl=10 for its own reasons. We must NOT promote that.
+    await cache.async_set_cache(key="other-key", value={"x": 1}, ttl=10)
+    observed = _observed_ttl(cache, "other-key")
+    assert math.isclose(observed, 10, abs_tol=1.5), f"expected ttl ~10, got {observed}"
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_preserves_management_ttl_when_unconfigured():
+    """When user_api_key_cache_ttl is NOT configured, the 60s constant still wins.
+
+    This guards backward compatibility — operators who never set the general
+    setting must see exactly the same behaviour as before the fix.
+    """
+    cache = UserApiKeyCache()  # no update_cache_ttl call
+    await cache.async_set_cache(
+        key="key-no-config",
+        value={"x": 1},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = _observed_ttl(cache, "key-no-config")
+    assert math.isclose(observed, DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL, abs_tol=2), (
+        f"expected ttl ~{DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL}, got {observed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_no_promotion_when_configured_equals_management_constant():
+    """When user_api_key_cache_ttl happens to equal 60, promotion is a no-op."""
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(
+        default_in_memory_ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        default_redis_ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    await cache.async_set_cache(
+        key="key-eq",
+        value={"x": 1},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = _observed_ttl(cache, "key-eq")
+    assert math.isclose(observed, DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL, abs_tol=2)
+
+
+def test_sync_set_cache_also_promotes_management_ttl():
+    """Sync set_cache shares the same regression and must be patched in lockstep."""
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
+    cache.set_cache(
+        key="sync-key",
+        value={"x": 1},
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = _observed_ttl(cache, "sync-key")
+    assert observed > 250, f"expected ttl ~300, got {observed}"
+    assert observed < 310
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_no_promotion_when_ttl_is_none():
+    """If the caller omits ttl entirely, DualCache already applies the default itself."""
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
+    await cache.async_set_cache(key="no-ttl-key", value={"x": 1})
+    observed = _observed_ttl(cache, "no-ttl-key")
+    # DualCache stamps default_in_memory_ttl when ttl is absent, so this should be ~300.
+    assert observed > 250, f"expected ttl ~300, got {observed}"


### PR DESCRIPTION
## Summary

Fixes **LIT-3338**: `general_settings.user_api_key_cache_ttl` is silently capped at 60s.

This is a re-file of #28828, which hit Greptile and Codecov OK before being bulk-closed by a cleanup pass. The fix is identical in shape; the test suite and evidence are reproduced fresh against today's daily branch.

## Root cause

`_cache_management_object` in `litellm/proxy/auth/auth_checks.py` — and ~10 sibling call sites in `auth_checks.py`, `handle_jwt.py`, and `mcp_server_manager.py` — write management objects (keys, users, teams, budgets, vector stores, permissions) via:

```python
user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
```

`DualCache.async_set_cache` only applies `self.default_in_memory_ttl` when `ttl` is **absent** from kwargs (`litellm/caching/dual_cache.py:370-372`). Because every management-object writer passes an explicit `ttl=60`, the operator's configured TTL — which `proxy_server.py:4241-4252` already populates on the cache via `user_api_key_cache.update_cache_ttl(...)` — is silently shadowed.

```
get_key_object()
  -> _cache_key_object()
  -> _cache_management_object()
  -> user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
     (the user's general_settings.user_api_key_cache_ttl is ignored here)
```

## Fix

Single-site fix in `UserApiKeyCache.async_set_cache` / `set_cache` (`litellm/proxy/common_utils/user_api_key_cache.py`). When an explicit `ttl` *exactly* equals `DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL` AND a *different* `default_in_memory_ttl` is configured on the cache, promote the configured default. This restores the intended "explicit operator configuration wins" semantics for every management-object write at once, without churning ~10 call sites across three large modules.

The only callers that pass that exact constant ARE the management-object writes themselves, all of which want to follow the operator's configured TTL. Non-management `async_set_cache` callers (`set_cache(key=..., value=..., ttl=10)` etc.) are unaffected — the explicit value is respected verbatim because we only intercept that exact constant.

## Evidence

### Bug reproduction on clean daily branch (BEFORE the fix)

The repro drives the exact reported call path:

```python
cache = UserApiKeyCache()
cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)
t0 = time.time()
await cache.async_set_cache(
    key="hashed-token", value={"x": 1},
    ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,  # what _cache_management_object passes
)
observed_ttl = cache.in_memory_cache.ttl_dict["hashed-token"] - t0
```

```
configured default_in_memory_ttl: 300
management constant ttl: 60
observed cached entry TTL = 60.0s
configured operator TTL    = 300s
BUG: capped at 60 s — user_api_key_cache_ttl is silently shadowed
```

### After this PR (same repro, run on the patched branch)

```
configured default_in_memory_ttl=300
mgmt const ttl=60
observed entry TTL=300.0s
PASS: user_api_key_cache_ttl honored after fix
```

### Unit tests — 6/6 pass

`tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_promotion.py`:

| Test | What it pins |
|---|---|
| `test_async_set_cache_promotes_management_ttl_to_configured_default` | The reported regression: `user_api_key_cache_ttl=300` is honored. |
| `test_async_set_cache_does_not_touch_non_management_ttl` | Arbitrary explicit `ttl=10` is respected (not promoted). |
| `test_async_set_cache_preserves_management_ttl_when_unconfigured` | Backwards-compat: when no operator setting is applied, the 60s constant still wins. |
| `test_async_set_cache_no_promotion_when_configured_equals_management_constant` | Edge case: configured TTL happens to be 60 -> no-op. |
| `test_sync_set_cache_also_promotes_management_ttl` | The rarely-used sync `set_cache` path stays in lockstep. |
| `test_async_set_cache_no_promotion_when_ttl_is_none` | When ttl is omitted, DualCache continues to apply its own default. |

```
$ python -m pytest tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl_promotion.py -v
============================= test session starts ==============================
collected 6 items
test_user_api_key_cache_ttl_promotion.py::test_async_set_cache_does_not_touch_non_management_ttl PASSED
test_user_api_key_cache_ttl_promotion.py::test_async_set_cache_no_promotion_when_configured_equals_management_constant PASSED
test_user_api_key_cache_ttl_promotion.py::test_async_set_cache_no_promotion_when_ttl_is_none PASSED
test_user_api_key_cache_ttl_promotion.py::test_async_set_cache_preserves_management_ttl_when_unconfigured PASSED
test_user_api_key_cache_ttl_promotion.py::test_async_set_cache_promotes_management_ttl_to_configured_default PASSED
test_user_api_key_cache_ttl_promotion.py::test_sync_set_cache_also_promotes_management_ttl PASSED
============================== 6 passed in 9.47s ===============================
```

## Risk

Low. The change is local to `UserApiKeyCache.async_set_cache` / `set_cache`. When `user_api_key_cache_ttl` is unconfigured, behaviour is identical to today (the explicit `ttl=60` wins, exactly as before). When `user_api_key_cache_ttl` IS configured but to `60`, the promotion is a no-op (still 60s). The only behaviour change is the intended one: a non-default `user_api_key_cache_ttl` value now reaches the management-object caches.

No schema changes, no API surface changes, no migration required.

## Note on commit history

Files were pushed via the GitHub Contents API (`PUT /repos/.../contents/{path}`) because the current `GITHUB_TOKEN` for this fork lacks `workflow` scope — `git push` returns "Password authentication is not supported." The merge-base diff is therefore slightly noisier than a normal squash commit; the actual change is just the new `_promote_management_ttl(...)` helper plus a one-line call inside `async_set_cache` and `set_cache`.

Closes LIT-3338.
