### PR TITLE
fix(spend-tracking): preserve x-litellm-spend-logs-metadata header on /v1/messages (LIT-3302)

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -203,8 +203,7 @@ def add_missing_spend_metadata_to_litellm_metadata(
             # already stripped from `metadata` upstream.
             litellm_metadata[key] = value
         elif (
-            key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE
-            and key not in litellm_metadata
+            key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE and key not in litellm_metadata
         ):
             # Header-derived spend keys: only copy when the destination does
             # not already have the key, to avoid letting a client-body

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -141,18 +141,74 @@ def remove_items_at_indices(items: Optional[List[Any]], indices: Iterable[int]) 
             items.pop(index)
 
 
+# Proxy-set metadata fields that live on `metadata` rather than `litellm_metadata`
+# on the endpoints where the metadata variable name is `"metadata"` (most
+# LiteLLM routes; see `get_metadata_variable_name_from_kwargs` below). When the
+# caller also populates `litellm_metadata` from the request body, these must
+# survive the merge so spend tracking and observability callbacks see them
+# downstream (e.g. the `x-litellm-spend-logs-metadata` header lands here).
+#
+# - `spend_logs_metadata`, `agent_id`, `trace_id`, `session_id` are written by
+#   `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers`
+#   (`LitellmMetadataFromRequestHeaders` TypedDict).
+# - `requester_ip_address` is written separately in `litellm_pre_call_utils.py`
+#   from `x-forwarded-for` / `request.client.host`.
+#
+# These keys are propagated with `setdefault` semantics (only when the
+# destination does NOT already have the key) so that on the inverse case --
+# routes where the metadata variable name is `"litellm_metadata"` (e.g.
+# `/v1/messages`, `batches`, `responses`, `files`) and the proxy-trusted
+# value lives on `litellm_metadata` instead -- a forged value passed by the
+# client on the body `metadata` cannot overwrite the real proxy-set value.
+# This matches the upstream pre_call_utils convention
+# (`if key not in data[_metadata_variable_name]: ...`).
+_PROXY_SET_METADATA_KEYS_TO_PRESERVE: frozenset = frozenset(
+    {
+        "spend_logs_metadata",
+        "agent_id",
+        "trace_id",
+        "session_id",
+        "requester_ip_address",
+    }
+)
+
+
 def add_missing_spend_metadata_to_litellm_metadata(
     litellm_metadata: dict, metadata: dict
 ) -> dict:
     """
-    Helper to get litellm metadata for spend tracking
+    Helper to get litellm metadata for spend tracking.
 
-    PATCH for issue where both `litellm_metadata` and `metadata` are present in the kwargs
-    and user_api_key values are in 'metadata'.
+    PATCH for the case where both `litellm_metadata` and `metadata` are present
+    in the request kwargs. The proxy populates spend-tracking and
+    header-derived fields onto whichever container is selected by
+    `get_metadata_variable_name_from_kwargs` for that route; the other
+    container may carry client-body metadata. This helper bridges proxy-set
+    fields from `metadata` -> `litellm_metadata` so a downstream reader of
+    `litellm_metadata` still sees them.
+
+    - `user_api_key*`: copied with overwrite. This is the existing behavior
+      and is safe because pre_call_utils strips any forged `user_api_key_*`
+      from both containers before this stage.
+    - `_PROXY_SET_METADATA_KEYS_TO_PRESERVE` (header-derived spend keys):
+      copied only when `litellm_metadata` does NOT already have the key, so
+      that on routes where `litellm_metadata` is the proxy-trusted container
+      (e.g. `/v1/messages`), a client-supplied `metadata.<key>` from the
+      request body cannot overwrite the real proxy-set value.
     """
     potential_spend_tracking_metadata_substring = "user_api_key"
     for key, value in metadata.items():
         if potential_spend_tracking_metadata_substring in key:
+            # Existing behavior: copy with overwrite. Forged values were
+            # already stripped from `metadata` upstream.
+            litellm_metadata[key] = value
+        elif (
+            key in _PROXY_SET_METADATA_KEYS_TO_PRESERVE
+            and key not in litellm_metadata
+        ):
+            # Header-derived spend keys: only copy when the destination does
+            # not already have the key, to avoid letting a client-body
+            # `metadata.<key>` overwrite a proxy-set `litellm_metadata.<key>`.
             litellm_metadata[key] = value
     return litellm_metadata
 

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -201,3 +201,199 @@ class TestRedactNestedMatchAndRegexKeys:
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
         assert redact_nested_match_and_regex_keys("plain") == "plain"
+
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for LIT-3302
+# (header-derived spend-tracking attributes dropped when both
+# `metadata` and `litellm_metadata` are present on a request, e.g. /v1/messages)
+# ---------------------------------------------------------------------------
+
+
+class TestAddMissingSpendMetadataToLitellmMetadata:
+    """Regression coverage for `add_missing_spend_metadata_to_litellm_metadata`.
+
+    The proxy puts spend-tracking + header-derived fields on `metadata`, while
+    some endpoints (e.g. Anthropic `/v1/messages`) also populate
+    `litellm_metadata`. The helper must preserve the proxy-set fields when
+    merging so they reach the spend logs.
+    """
+
+    def test_preserves_spend_logs_metadata_from_request_header(self):
+        """`spend_logs_metadata` (set from `x-litellm-spend-logs-metadata`) must
+        survive a merge when `litellm_metadata` is also present."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        header_attrs = {
+            "billing_uuid": "9af2b4e0-1c11-4d8b-bcb3-1234567890ab",
+            "agent_id": "agent-cogni-7",
+            "agent_owner_id": "owner-acme-42",
+            "request_type": "chat_completion",
+        }
+        metadata = {
+            "user_api_key": "sk-hashed-abc",
+            "user_api_key_alias": "test-key",
+            "spend_logs_metadata": header_attrs,
+        }
+        litellm_metadata = {"user_id": "anthropic-end-user"}
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        assert merged["spend_logs_metadata"] == header_attrs
+        assert merged["user_api_key"] == "sk-hashed-abc"
+        assert merged["user_api_key_alias"] == "test-key"
+        # Original litellm_metadata content stays untouched.
+        assert merged["user_id"] == "anthropic-end-user"
+
+    def test_preserves_other_proxy_header_metadata(self):
+        """`agent_id`, `trace_id`, `session_id`, `requester_ip_address` are all
+        proxy-populated and must also survive the merge."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        metadata = {
+            "user_api_key_team_id": "team-1",
+            "agent_id": "agent-7",
+            "trace_id": "trace-abc",
+            "session_id": "sess-xyz",
+            "requester_ip_address": "10.0.0.1",
+            "spend_logs_metadata": {"foo": "bar"},
+        }
+        litellm_metadata = {"user_id": "u"}
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        for key in (
+            "agent_id",
+            "trace_id",
+            "session_id",
+            "requester_ip_address",
+            "spend_logs_metadata",
+            "user_api_key_team_id",
+        ):
+            assert merged[key] == metadata[key]
+
+    def test_does_not_leak_unrelated_metadata_keys(self):
+        """Client-supplied (request body) keys on `metadata` that are not
+        spend-tracking or proxy-set must NOT clobber `litellm_metadata`."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        metadata = {
+            "user_api_key": "sk-hashed",
+            "user_id": "client-1",  # client-supplied body field
+            "custom_unrelated": "noise",
+        }
+        litellm_metadata = {"user_id": "proxy-set-user"}
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        # user_api_key still copied
+        assert merged["user_api_key"] == "sk-hashed"
+        # client-supplied body fields NOT propagated
+        assert merged["user_id"] == "proxy-set-user"
+        assert "custom_unrelated" not in merged
+
+    def test_get_litellm_metadata_from_kwargs_round_trip(self):
+        """End-to-end through `get_litellm_metadata_from_kwargs`: the merged
+        dict must include `spend_logs_metadata` for the LIT-3302 scenario."""
+        from litellm.litellm_core_utils.core_helpers import (
+            get_litellm_metadata_from_kwargs,
+        )
+
+        kwargs = {
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key": "sk-hashed",
+                    "spend_logs_metadata": {
+                        "billing_uuid": "uuid-1",
+                        "agent_id": "agent-1",
+                        "agent_owner_id": "owner-1",
+                        "request_type": "chat_completion",
+                    },
+                },
+                "litellm_metadata": {
+                    "user_id": "client",  # forces the merge path
+                },
+            }
+        }
+
+        result = get_litellm_metadata_from_kwargs(kwargs)
+        assert "spend_logs_metadata" in result
+        assert result["spend_logs_metadata"]["billing_uuid"] == "uuid-1"
+        assert result["user_api_key"] == "sk-hashed"
+
+    def test_does_not_overwrite_proxy_set_value_when_litellm_metadata_already_has_it(
+        self,
+    ):
+        """Inverse case: on `/v1/messages` (and other routes where
+        `_metadata_variable_name == "litellm_metadata"`) the proxy-trusted
+        values live on `litellm_metadata`. A client can forge body
+        `metadata.<key>` for one of the header-derived keys; the merge must
+        NOT overwrite the real proxy-set value with the forged one."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        # Proxy-set values on litellm_metadata (e.g. /v1/messages)
+        litellm_metadata = {
+            "user_api_key": "sk-hashed",
+            "agent_id": "agent-real-from-proxy",
+            "trace_id": "trace-real",
+            "session_id": "session-real",
+            "requester_ip_address": "10.0.0.1",
+            "spend_logs_metadata": {"billing_uuid": "real-bu"},
+        }
+        # Client-forged values on the body metadata
+        metadata = {
+            "agent_id": "agent-forged",
+            "trace_id": "trace-forged",
+            "session_id": "session-forged",
+            "requester_ip_address": "1.2.3.4",
+            "spend_logs_metadata": {"billing_uuid": "forged-bu"},
+        }
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        # Every proxy-set value is preserved unchanged.
+        assert merged["agent_id"] == "agent-real-from-proxy"
+        assert merged["trace_id"] == "trace-real"
+        assert merged["session_id"] == "session-real"
+        assert merged["requester_ip_address"] == "10.0.0.1"
+        assert merged["spend_logs_metadata"] == {"billing_uuid": "real-bu"}
+
+    def test_preserve_keys_use_setdefault_semantics(self):
+        """Even with only one proxy key already present on litellm_metadata,
+        only that one is left untouched; the others (absent on litellm_metadata)
+        are propagated from metadata."""
+        from litellm.litellm_core_utils.core_helpers import (
+            add_missing_spend_metadata_to_litellm_metadata,
+        )
+
+        litellm_metadata = {"agent_id": "agent-real"}  # only agent_id pre-set
+        metadata = {
+            "agent_id": "forged-agent",
+            "trace_id": "trace-from-metadata",  # not on litellm_metadata
+            "spend_logs_metadata": {"k": "v"},  # not on litellm_metadata
+        }
+
+        merged = add_missing_spend_metadata_to_litellm_metadata(
+            litellm_metadata, metadata
+        )
+
+        assert merged["agent_id"] == "agent-real"  # not overwritten
+        assert merged["trace_id"] == "trace-from-metadata"  # newly copied
+        assert merged["spend_logs_metadata"] == {"k": "v"}  # newly copied

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -176,7 +176,11 @@ class TestRedactNestedMatchAndRegexKeys:
                 {
                     "sensitiveInformationPolicy": {
                         "piiEntities": [
-                            {"type": "NAME", "match": "secret-name", "action": "BLOCKED"}
+                            {
+                                "type": "NAME",
+                                "match": "secret-name",
+                                "action": "BLOCKED",
+                            }
                         ]
                     },
                     "wordPolicy": {
@@ -187,21 +191,26 @@ class TestRedactNestedMatchAndRegexKeys:
             "regex": "should-redact-key-named-regex",
         }
         out = redact_nested_match_and_regex_keys(payload)
-        assert out["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][0][
-            "match"
-        ] == "[REDACTED]"
+        assert (
+            out["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][0][
+                "match"
+            ]
+            == "[REDACTED]"
+        )
         assert out["assessments"][0]["wordPolicy"]["customWords"][0]["match"] == (
             "[REDACTED]"
         )
         assert out["regex"] == "[REDACTED]"
-        assert payload["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][
-            0
-        ]["match"] == "secret-name"
+        assert (
+            payload["assessments"][0]["sensitiveInformationPolicy"]["piiEntities"][0][
+                "match"
+            ]
+            == "secret-name"
+        )
 
     def test_passes_through_none_and_str(self):
         assert redact_nested_match_and_regex_keys(None) is None
         assert redact_nested_match_and_regex_keys("plain") == "plain"
-
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`add_missing_spend_metadata_to_litellm_metadata` in `litellm/litellm_core_utils/core_helpers.py` only forwarded keys whose name contains the substring `"user_api_key"`. As a result, the proxy-set spend-tracking and header-derived fields — `spend_logs_metadata` (populated from the `x-litellm-spend-logs-metadata` header), `agent_id`, `trace_id`, `session_id`, `requester_ip_address` — were silently dropped from the merged metadata whenever a request also carried `litellm_metadata` (e.g. Anthropic `/v1/messages`, `batches`, `responses`, `files`). The dropped attributes never reached the `SpendLogsPayload` written to the DB.

## Root cause

`get_litellm_metadata_from_kwargs` merges `litellm_params.metadata` into `litellm_params.litellm_metadata` when both are present. The merge helper:

```python
potential_spend_tracking_metadata_substring = "user_api_key"
for key, value in metadata.items():
    if potential_spend_tracking_metadata_substring in key:
        litellm_metadata[key] = value
```

does substring matching on the **key name** — so anything not containing `user_api_key` is dropped. The proxy populates header-derived keys with descriptive names (`spend_logs_metadata`, `agent_id`, etc.) that never match.

## Fix

Add an explicit `_PROXY_SET_METADATA_KEYS_TO_PRESERVE` set containing the keys that are populated by `LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers` (`LitellmMetadataFromRequestHeaders` TypedDict) plus `requester_ip_address` (set in `litellm_pre_call_utils.py` from `x-forwarded-for` / `request.client.host`):

- `spend_logs_metadata`
- `agent_id`
- `trace_id`
- `session_id`
- `requester_ip_address`

These keys are propagated from `metadata` -> `litellm_metadata` with **setdefault semantics** (only when `litellm_metadata` does NOT already have the key). This protects the inverse case where the metadata variable for the route is `"litellm_metadata"` (e.g. `/v1/messages`): on those routes the proxy-trusted value lives on `litellm_metadata`, and a client-forged value on the body `metadata` must not be allowed to overwrite it. This matches the existing convention in `litellm_pre_call_utils.py` (`if key not in data[_metadata_variable_name]: ...`).

The existing `user_api_key*` behavior is unchanged (substring match, overwrite-on-collision); `pre_call_utils` already strips any forged `user_api_key_*` from both containers upstream before this stage.

## Tests

`tests/test_litellm/litellm_core_utils/test_core_helpers.py`: new `TestAddMissingSpendMetadataToLitellmMetadata` class with 6 cases covering:

1. `spend_logs_metadata` survives the merge.
2. All other proxy header-derived keys survive the merge.
3. Unrelated client-supplied body keys (e.g. `user_id`, arbitrary noise) do not leak into `litellm_metadata`.
4. End-to-end `get_litellm_metadata_from_kwargs` round-trip with both metadata containers populated.
5. **Security**: on the inverse case (proxy-trusted value on `litellm_metadata`), a forged value on body `metadata` does NOT overwrite it.
6. setdefault semantics applied per-key (not all-or-nothing).

### Evidence

The patched helper was executed end-to-end on the same `kwargs` shape produced by the proxy on a `/v1/messages` request with `x-litellm-spend-logs-metadata` and `litellm_metadata` in the body. The before/after below come from running the unmodified-vs-patched helper extracted by AST (so the function ran in isolation; no test-double).

**Before** — unmodified helper on the current daily-branch HEAD. Header-derived keys are silently dropped (the user request loses `spend_logs_metadata` etc. before reaching spend logs):

```
=== get_litellm_metadata_from_kwargs result ===
  user_api_key: 'sk-hashed-abc'
  user_api_key_alias: 'test-key'
  user_id: 'end-user-1'

Missing: spend_logs_metadata,agent_id,trace_id,session_id,requester_ip_address
```

**After** — this PR's helper. All 5 header-derived keys propagate to the merged dict, alongside the existing `user_api_key*` keys:

```
=== get_litellm_metadata_from_kwargs result ===
  agent_id: 'agent-xyz'
  requester_ip_address: '10.0.0.1'
  session_id: 'sess-abc'
  spend_logs_metadata: {'billing_uuid': 'bu-12345', 'agent_id': 'agent-xyz', 'request_type': 'chat_completion'}
  trace_id: 'trace-abc'
  user_api_key: 'sk-hashed-abc'
  user_api_key_alias: 'test-key'
  user_id: 'end-user-1'

All header keys present: spend_logs_metadata,agent_id,trace_id,session_id,requester_ip_address
```

**Inverse case (security check)** — on `/v1/messages` style routes the proxy-trusted values live on `litellm_metadata`; a client-forged value on body `metadata` must NOT overwrite them:

```
metadata          = {'agent_id': 'FORGED',          'trace_id': 'FORGED'}
litellm_metadata  = {'agent_id': 'real-from-proxy', 'trace_id': 'real-from-proxy'}
result.agent_id   = 'real-from-proxy'  (not overwritten)
result.trace_id   = 'real-from-proxy'  (not overwritten)
```

The 6-test regression class locks the same behavior in CI.

## Note on the diff

The token used by the agent lacks `repo` + `workflow` scopes, so the two changed files were pushed via the Contents API (one commit per file). Net working-tree change is exactly:

| File | Change |
| --- | --- |
| `litellm/litellm_core_utils/core_helpers.py` | rewrite `add_missing_spend_metadata_to_litellm_metadata` + add `_PROXY_SET_METADATA_KEYS_TO_PRESERVE` module-level constant |
| `tests/test_litellm/litellm_core_utils/test_core_helpers.py` | append `TestAddMissingSpendMetadataToLitellmMetadata` (6 cases) |

Fixes LIT-3302.

Refile of #28948 (bulk-closed; identical fix, customer name scrubbed from one test fixture).
