### PR TITLE
fix(proxy/auth): honour user_api_key_cache_ttl in management-object caches (LIT-3338)

### DIFF
--- a/litellm/proxy/common_utils/user_api_key_cache.py
+++ b/litellm/proxy/common_utils/user_api_key_cache.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.dual_cache import DualCache
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
 
 T = TypeVar("T", bound=BaseModel)
@@ -142,9 +143,54 @@ class UserApiKeyCache(DualCache):
     async def async_set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
         model_type = cast(Optional[Type[BaseModel]], kwargs.pop("model_type", None))
         payload = CacheCodec.serialize(value, model_type=model_type)
+        self._honour_configured_management_ttl(kwargs, model_type=model_type)
         return await super().async_set_cache(
             key=key, value=payload, local_only=local_only, **kwargs
         )
+
+    def _honour_configured_management_ttl(
+        self,
+        kwargs: dict,
+        *,
+        model_type: Optional[Type[BaseModel]],
+    ) -> None:
+        """
+        LIT-3338: ``general_settings.user_api_key_cache_ttl`` (set on
+        ``self.default_in_memory_ttl`` at proxy startup via
+        ``proxy_server.py``'s ``update_cache_ttl(...)`` call) was silently
+        ignored by management-object writes.
+
+        Several call sites in ``litellm/proxy/auth/auth_checks.py`` and
+        ``litellm/proxy/auth/handle_jwt.py`` pass an explicit
+        ``ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL`` (60s).  Because
+        ``DualCache.async_set_cache`` only consults
+        ``self.default_in_memory_ttl`` when ``ttl`` is *absent* from kwargs,
+        the explicit 60 always shadows a user-configured 300s TTL.
+
+        Promote the configured default only when:
+
+        1. an explicit ``ttl == DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL``
+           was passed, AND
+        2. a different ``default_in_memory_ttl`` is configured on the cache,
+           AND
+        3. the write carried a ``model_type`` (i.e. it is a Pydantic-typed
+           management-object write).
+
+        Gating on ``model_type`` avoids inadvertently extending the lifetime
+        of short-lived non-management writes that also happen to use
+        ``ttl=60`` literally — most notably the single-use SSO/v3-login code
+        entries in ``proxy_server.py`` / ``ui_sso.py``, whose 60-second
+        expiry is advertised to clients via ``expires_in: 60``.
+        """
+        if model_type is None:
+            return
+        if (
+            "ttl" in kwargs
+            and self.default_in_memory_ttl is not None
+            and kwargs["ttl"] == DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+            and self.default_in_memory_ttl != DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+        ):
+            kwargs["ttl"] = self.default_in_memory_ttl
 
     async def async_set_cache_pipeline(  # type: ignore[override]
         self, cache_list: list, local_only: bool = False, **kwargs

--- a/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl.py
+++ b/tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl.py
@@ -1,0 +1,124 @@
+"""Regression coverage for LIT-3338.
+
+`general_settings.user_api_key_cache_ttl: 300` was silently capped at 60s
+because management-object cache writes pass an explicit
+`ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL` that shadowed
+`UserApiKeyCache.default_in_memory_ttl` (the value populated from the user's
+config at proxy startup). The fix is in `UserApiKeyCache.async_set_cache`:
+when the explicit `ttl` matches the historical management-object default,
+a different default is configured, AND the write is Pydantic-typed (i.e.
+``model_type=`` was passed), promote the configured value. The
+``model_type`` gate is what keeps short-lived non-management writes (e.g.
+single-use SSO login codes that also happen to use ``ttl=60``) on their
+intended TTL.
+"""
+import time
+
+import pytest
+
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+
+def _make_configured_cache(ttl_seconds):
+    """Mirror what proxy_server.py does when user_api_key_cache_ttl is set."""
+    cache = UserApiKeyCache()
+    cache.update_cache_ttl(
+        default_in_memory_ttl=ttl_seconds,
+        default_redis_ttl=ttl_seconds,
+    )
+    return cache
+
+
+@pytest.mark.asyncio
+async def test_management_ttl_promoted_to_configured_value():
+    """user_api_key_cache_ttl=300 -> Pydantic-typed write with ttl=60 lands at ~300s."""
+    cache = _make_configured_cache(300)
+    t0 = time.time()
+    await cache.async_set_cache(
+        key="hashed-token",
+        value=UserAPIKeyAuth(token="sk-x", api_key="sk-x"),
+        model_type=UserAPIKeyAuth,
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = cache.in_memory_cache.ttl_dict["hashed-token"] - t0
+    assert 295 <= observed <= 305, (
+        f"expected ~300s TTL (configured user_api_key_cache_ttl), got {observed:.1f}s "
+        f"(LIT-3338 regression)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_management_ttl_not_overridden():
+    """Arbitrary explicit ttl (not the management default) is respected verbatim."""
+    cache = _make_configured_cache(300)
+    t0 = time.time()
+    await cache.async_set_cache(
+        key="other-key",
+        value=UserAPIKeyAuth(token="sk-y", api_key="sk-y"),
+        model_type=UserAPIKeyAuth,
+        ttl=10,
+    )
+    observed = cache.in_memory_cache.ttl_dict["other-key"] - t0
+    assert 8 <= observed <= 12, f"expected ~10s TTL (respected), got {observed:.1f}s"
+
+
+@pytest.mark.asyncio
+async def test_default_60s_preserved_when_unconfigured():
+    """No user_api_key_cache_ttl set -> ttl=60 still wins (backward compat)."""
+    cache = UserApiKeyCache()
+    assert cache.default_in_memory_ttl is None
+    t0 = time.time()
+    await cache.async_set_cache(
+        key="default-key",
+        value=UserAPIKeyAuth(token="sk-z", api_key="sk-z"),
+        model_type=UserAPIKeyAuth,
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = cache.in_memory_cache.ttl_dict["default-key"] - t0
+    assert 55 <= observed <= 65, (
+        f"unconfigured cache should keep the 60s default, got {observed:.1f}s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_promotion_when_configured_value_matches_management_default():
+    """Edge case: if the user happens to configure user_api_key_cache_ttl=60,
+    promotion is a no-op (still 60s, same as before)."""
+    cache = _make_configured_cache(60)
+    t0 = time.time()
+    await cache.async_set_cache(
+        key="match-key",
+        value=UserAPIKeyAuth(token="sk-a", api_key="sk-a"),
+        model_type=UserAPIKeyAuth,
+        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    )
+    observed = cache.in_memory_cache.ttl_dict["match-key"] - t0
+    assert 55 <= observed <= 65, f"got {observed:.1f}s, expected ~60s"
+
+
+@pytest.mark.asyncio
+async def test_no_promotion_for_writes_without_model_type():
+    """LIT-3338 (Greptile follow-up): a non-management write that uses ttl=60
+    as a bare literal MUST NOT be promoted to the configured cache TTL.
+
+    Pins the security-sensitive case Greptile flagged: short-lived single-use
+    login codes (`proxy_server.py:login_v3`, `ui_sso.py`) write to the same
+    `user_api_key_cache` with `ttl=60` and advertise `expires_in: 60` to the
+    client. Their lifetime must stay at 60s, even when the operator has
+    bumped `user_api_key_cache_ttl` to 300s for the auth-cache hot path.
+    """
+    cache = _make_configured_cache(300)
+    t0 = time.time()
+    # Mirrors the proxy_server.login_v3 / ui_sso login-code write: no model_type.
+    await cache.async_set_cache(
+        key="login_code:xyz",
+        value={"token": "jwt", "redirect_url": "/ui/?login=success"},
+        ttl=60,
+    )
+    observed = cache.in_memory_cache.ttl_dict["login_code:xyz"] - t0
+    assert 55 <= observed <= 65, (
+        f"non-management ttl=60 write was unexpectedly promoted to {observed:.1f}s "
+        f"(LIT-3338 over-match regression)"
+    )


### PR DESCRIPTION
## Summary

Fixes **LIT-3338**: when an operator sets `general_settings.user_api_key_cache_ttl: <N>` in the proxy config, the configured value is silently capped at 60 s for every management-object cache write (keys, users, teams, budgets, vector stores, permissions).

## Root cause

`proxy_server.py` already wires the configured TTL onto the cache instance via `user_api_key_cache.update_cache_ttl(default_in_memory_ttl=<N>)`. However, every management-object writer in `litellm/proxy/auth/auth_checks.py`, `litellm/proxy/auth/handle_jwt.py`, and `litellm/proxy/_experimental/mcp_server/mcp_server_manager.py` calls:

```python
user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
```

`DualCache.async_set_cache` (`litellm/caching/dual_cache.py:370-372`) only falls back to `self.default_in_memory_ttl` when `ttl` is *absent* from kwargs. So the explicit 60 always shadows the configured value.

```
get_key_object()
  -> _cache_key_object()
  -> _cache_management_object()
  -> user_api_key_cache.async_set_cache(..., ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL)
     (operator's general_settings.user_api_key_cache_ttl is silently dropped)
```

## Fix

Single-site override in `UserApiKeyCache.async_set_cache` (`litellm/proxy/common_utils/user_api_key_cache.py`). When **all three** of the following hold, promote the configured `default_in_memory_ttl`:

1. explicit `ttl == DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL` (60), AND
2. a different `default_in_memory_ttl` is configured on the cache, AND
3. the write carries a `model_type` (i.e. it is a Pydantic-typed management-object write).

Condition (3) protects short-lived non-management writes that also happen to use `ttl=60` literally — most notably the single-use SSO/v3 login-code entries in `proxy_server.py:login_v3` and `ui_sso.py`, whose 60 s expiry is advertised to clients via `expires_in: 60`. Greptile flagged the over-match risk on a prior iteration of this fix and the `model_type` gate is the response.

Non-management `async_set_cache` callers with any other explicit TTL are untouched.

## Evidence

### Reproduction on the daily branch base (BEFORE the fix)

Real `UserApiKeyCache` driven through the public `async_set_cache` API the way `_cache_management_object` drives it (Pydantic-typed write, `ttl=60`):

```
===== BEFORE (litellm_oss_agent_shin_daily_branch HEAD, pre-fix) =====
configured cache.default_in_memory_ttl=300s
DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL=60s
observed cached TTL = 60.0s
FAIL: configured 300s ignored; capped at ~60s
```

### Same code path on this branch (AFTER the fix)

```
===== AFTER (shin/lit-3338-cache-ttl-daily HEAD) =====
configured cache.default_in_memory_ttl=300s
DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL=60s
observed cached TTL = 300.0s
PASS: configured 300s honored

--- SSO login-code regression: ttl=60 + no model_type ---
observed login-code TTL = 60.0s
PASS: login-code NOT promoted
```

The same `cache.async_set_cache(...)` call now returns the operator-configured TTL for management-object writes, while non-management `ttl=60` writes (no `model_type`) stay at 60 s.

### Unit tests (5 new, all passing locally)

`tests/test_litellm/proxy/common_utils/test_user_api_key_cache_ttl.py` — runs through the public API:

| test | what it pins |
| --- | --- |
| `test_management_ttl_promoted_to_configured_value` | configured 300s + `ttl=60` + `model_type=` -> ~300s |
| `test_non_management_ttl_not_overridden` | configured 300s + `ttl=10` -> ~10s (verbatim) |
| `test_default_60s_preserved_when_unconfigured` | no config + `ttl=60` -> ~60s (backward compat) |
| `test_no_promotion_when_configured_value_matches_management_default` | configured 60s + `ttl=60` -> ~60s (idempotent edge) |
| `test_no_promotion_for_writes_without_model_type` | configured 300s + `ttl=60` + **no** `model_type` -> ~60s (SSO login-code guard) |

## Notes

- Targets `litellm_oss_agent_shin_daily_branch` (required for the "Verify PR source branch" check on fork PRs).
- Files were pushed via the GitHub contents API because the agent token lacks `repo` push scope; expect the merge-base diff to look like two single-file commits.
