### PR TITLE
fix(ui): scope provider-model match to token-prefix boundary (LIT-3311)

### DIFF
--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -218,14 +218,62 @@ describe("provider_info_helpers", () => {
       expect(result).toEqual(["gpt-3.5-turbo", "gpt-4"]);
     });
 
-    it("should return models when litellm_provider includes the provider string", () => {
+    it("should return models when litellm_provider matches the provider via a token-prefix boundary", () => {
+      // Sub-flavor providers (`<provider>_*` or `<provider>-*`) are grouped
+      // under their parent provider, but unrelated providers that merely
+      // *contain* the parent name as a substring are NOT pulled in.
       const modelMap = {
-        "custom-openai-model": { litellm_provider: "custom_openai_endpoint" },
-        "another-model": { litellm_provider: "openai" },
+        "bedrock-base-model": { litellm_provider: "bedrock" },
+        "bedrock-converse-model": { litellm_provider: "bedrock_converse" },
+        "fireworks-embed-model": { litellm_provider: "fireworks_ai-embedding-models" },
+        "openai-model": { litellm_provider: "openai" },
+      };
+      const bedrockResult = getProviderModels(Providers.Bedrock, modelMap);
+      expect(bedrockResult).toContain("bedrock-base-model");
+      expect(bedrockResult).toContain("bedrock-converse-model");
+      expect(bedrockResult).not.toContain("openai-model");
+
+      const fireworksResult = getProviderModels(Providers.FireworksAI, modelMap);
+      expect(fireworksResult).toContain("fireworks-embed-model");
+    });
+
+    it("should not leak vertex_ai-anthropic_models into the Anthropic provider", () => {
+      // Regression: previously the `.includes()` substring check pulled every
+      // `vertex_ai-anthropic_models` entry (e.g. `vertex_ai/claude-3-5-haiku`)
+      // into the Anthropic dropdown of the Add Model UI.
+      const modelMap = {
+        "claude-3-opus": { litellm_provider: "anthropic" },
+        "vertex_ai/claude-3-5-haiku": { litellm_provider: "vertex_ai-anthropic_models" },
+        "vertex_ai/claude-haiku-4-5": { litellm_provider: "vertex_ai-anthropic_models" },
+      };
+      const result = getProviderModels(Providers.Anthropic, modelMap);
+      expect(result).toEqual(["claude-3-opus"]);
+      expect(result).not.toContain("vertex_ai/claude-3-5-haiku");
+      expect(result).not.toContain("vertex_ai/claude-haiku-4-5");
+    });
+
+    it("should not leak vertex_ai-openai_models into the OpenAI provider", () => {
+      const modelMap = {
+        "gpt-4": { litellm_provider: "openai" },
+        "vertex_ai/gpt-4o-mini": { litellm_provider: "vertex_ai-openai_models" },
       };
       const result = getProviderModels(Providers.OpenAI, modelMap);
-      expect(result).toContain("custom-openai-model");
-      expect(result).toContain("another-model");
+      expect(result).toEqual(["gpt-4"]);
+      expect(result).not.toContain("vertex_ai/gpt-4o-mini");
+    });
+
+    it("should still include all vertex_ai-* sub-providers under the Vertex AI provider", () => {
+      const modelMap = {
+        "vertex_ai/gemini-pro": { litellm_provider: "vertex_ai" },
+        "vertex_ai/claude-3-5-haiku": { litellm_provider: "vertex_ai-anthropic_models" },
+        "vertex_ai/llama-3": { litellm_provider: "vertex_ai-llama_models" },
+        "anthropic/claude-3-opus": { litellm_provider: "anthropic" },
+      };
+      const result = getProviderModels(Providers.Vertex_AI, modelMap);
+      expect(result).toContain("vertex_ai/gemini-pro");
+      expect(result).toContain("vertex_ai/claude-3-5-haiku");
+      expect(result).toContain("vertex_ai/llama-3");
+      expect(result).not.toContain("anthropic/claude-3-opus");
     });
 
     it("should filter out models with null values", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -387,9 +387,20 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
     Object.entries(modelMap).forEach(([key, value]) => {
       if (value !== null && typeof value === "object" && "litellm_provider" in (value as object)) {
         const litellmProvider = (value as any)["litellm_provider"];
+        // Match by exact equality or by a token-prefix boundary (`<provider>_*`
+        // or `<provider>-*`). This keeps sub-flavor providers like
+        // `bedrock_converse`, `fireworks_ai-embedding-models`, and
+        // `vertex_ai-anthropic_models` grouped under their parent provider
+        // (`bedrock`, `fireworks_ai`, `vertex_ai`), but stops the previous
+        // unbounded `.includes()` from pulling in unrelated providers whose
+        // name merely contains the parent as a substring (e.g.
+        // `vertex_ai-anthropic_models` under `anthropic`, or
+        // `vertex_ai-openai_models` under `openai`).
         if (
-          litellmProvider === custom_llm_provider ||
-          (typeof litellmProvider === "string" && litellmProvider.includes(custom_llm_provider))
+          typeof litellmProvider === "string" &&
+          (litellmProvider === custom_llm_provider ||
+            litellmProvider.startsWith(custom_llm_provider + "_") ||
+            litellmProvider.startsWith(custom_llm_provider + "-"))
         ) {
           providerModels.push(key);
         }


### PR DESCRIPTION
## Summary

Fixes [LIT-3311](https://linear.app/litellm-ai/issue/LIT-3311) — *"Anthropic provider shows Vertex AI models"*.

Selecting the **Anthropic** provider in the Add Model UI was showing `vertex_ai/claude-*` entries in the model dropdown instead of just Anthropic models. Root cause is the unbounded `.includes()` substring match in `getProviderModels`:

```ts
litellmProvider === custom_llm_provider ||
(typeof litellmProvider === "string" && litellmProvider.includes(custom_llm_provider))
```

For the Anthropic provider, `custom_llm_provider === "anthropic"`. Vertex's Anthropic-on-Vertex catalog entries have `litellm_provider === "vertex_ai-anthropic_models"`, and `"vertex_ai-anthropic_models".includes("anthropic")` returns `true`, so the `vertex_ai/claude-*` entries were pulled into the Anthropic dropdown. The same bug also leaks `vertex_ai-openai_models` into the OpenAI dropdown, `vertex_ai-mistral_models` into MistralAI, `vertex_ai-ai21_models` into AI21, etc.

## Fix

Replace the substring `.includes()` with a **token-prefix boundary** match: equal, or starts with `<provider>_`, or starts with `<provider>-`. This keeps the sub-flavor providers that the UI was always intended to group with their parent (`bedrock_converse`/`bedrock_mantle` under Bedrock, `fireworks_ai-embedding-models` under Fireworks AI, `vertex_ai-*_models` under Vertex AI) and rejects matches that are merely substring-positional.

`ui/litellm-dashboard/src/components/provider_info_helpers.tsx`:
```ts
const litellmProvider = (value as any)["litellm_provider"];
if (
  typeof litellmProvider === "string" &&
  (litellmProvider === custom_llm_provider ||
    litellmProvider.startsWith(custom_llm_provider + "_") ||
    litellmProvider.startsWith(custom_llm_provider + "-"))
) {
  providerModels.push(key);
}
```

## Evidence

The matching predicate is a pure function of `litellm_provider` strings against `custom_llm_provider`. To verify the change end-to-end I ran the **actual** predicate (ported 1:1 from the JS) against the **actual** `model_prices_and_context_window.json` that the dashboard loads at runtime. This is the same data the UI dropdown is fed, exercised by the same logic.

```text
$ # ─── BEFORE FIX (litellm_oss_agent_shin_daily_branch HEAD) ─────────────────
$ # provider_info_helpers.tsx :: getProviderModels(Providers.Anthropic, modelMap)
$ #   match predicate: `litellmProvider === "anthropic" || litellmProvider.includes("anthropic")`

Anthropic dropdown total = 49 models
vertex_ai/* entries leaking in = 29
  - vertex_ai/claude-3-5-haiku             (litellm_provider="vertex_ai-anthropic_models")
  - vertex_ai/claude-3-5-haiku@20241022    (litellm_provider="vertex_ai-anthropic_models")
  - vertex_ai/claude-3-5-sonnet            (litellm_provider="vertex_ai-anthropic_models")
  - vertex_ai/claude-3-5-sonnet@20240620   (litellm_provider="vertex_ai-anthropic_models")
  - vertex_ai/claude-3-7-sonnet@20250219   (litellm_provider="vertex_ai-anthropic_models")
  - vertex_ai/claude-3-haiku               (litellm_provider="vertex_ai-anthropic_models")
  ... and 23 more

$ # ─── AFTER FIX (this branch) ────────────────────────────────────────────────
$ #   match predicate: `litellmProvider === "anthropic"
$ #                  || litellmProvider.startsWith("anthropic_")
$ #                  || litellmProvider.startsWith("anthropic-")`

Anthropic dropdown total = 20 models
vertex_ai/* entries leaking in = 0
```

```text
$ # No regression for sub-flavor providers (they still resolve correctly):
vertex_ai          before=153   after=153   (unchanged)
bedrock            before=391   after=391   (unchanged)   # incl. bedrock_converse, bedrock_mantle
fireworks_ai       before=278   after=278   (unchanged)   # incl. fireworks_ai-embedding-models

$ # Intentional cleanup: legacy text-completion-* providers no longer appear under
$ # their chat counterparts (they remain available under their own provider entry):
OpenAI dropdown:    220 -> 212  (drops `text-completion-openai`, `vertex_ai-openai_models`)
                                 text-completion-openai models stay reachable via the
                                 "OpenAI Text" provider entry (provider_map: OpenAI_Text).
Codestral dropdown:   4 ->   2  (drops `text-completion-codestral`)
                                 still reachable via "Text-Completion-Codestral".
```

## Tests

Added regression coverage in `ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx`:

- `should not leak vertex_ai-anthropic_models into the Anthropic provider`
- `should not leak vertex_ai-openai_models into the OpenAI provider`
- `should still include all vertex_ai-* sub-providers under the Vertex AI provider`
- token-prefix boundary test covering `bedrock_converse`, `fireworks_ai-embedding-models`, exclusion of unrelated providers

The legacy `custom_openai_endpoint` substring-match test is replaced by the token-prefix test — `custom_openai_endpoint` is not a real value in production (`grep -c custom_openai model_prices_and_context_window.json` → 0) and only existed because the previous loose `.includes()` matched it accidentally.

## Notes

* This PR was filed via the GitHub Contents API rather than `git push` because the current `GITHUB_TOKEN` lacks `repo`+`workflow` scopes. The merge-base diff is identical to two normal commits.
* I could not capture a live UI screenshot of the Add Model dropdown in this sandbox — the LiteLLM proxy could not be kept alive long enough across the harness's volatile sandbox handles (the proxy process kept being terminated by the sandbox before `/health/readiness` flipped to 200). The function-level evidence above exercises the exact same predicate over the exact same JSON the UI consumes, and unit tests cover the React-side contract.

Session: https://litellm-agent-platform.onrender.com/sessions/a69771dc-48dd-49eb-bd23-6615105c8c34
