### PR TITLE
fix(langfuse): preserve proxy auth metadata from litellm_metadata for /v1/messages (with mutation guard)

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -315,12 +315,30 @@ class LangFuseLogger:
             # ``/assistant*``) surface the same ``user_api_key_alias``,
             # ``user_api_key_user_id``, ``user_api_key_team_id`` etc. as the
             # endpoints that still use ``metadata``.
+            #
             # ``get_litellm_metadata_from_kwargs`` prefers ``litellm_metadata``
             # and falls back to ``metadata``; when both are present it merges
-            # the spend-tracking fields into the ``litellm_metadata`` copy.
-            metadata = get_litellm_metadata_from_kwargs(kwargs) or {}
-            # Defensive copy: downstream code pops keys off ``metadata`` /
-            # ``clean_metadata`` and we do not want to mutate the caller dict.
+            # spend-tracking fields (any key containing ``user_api_key``) from
+            # ``metadata`` into ``litellm_metadata`` via
+            # ``add_missing_spend_metadata_to_litellm_metadata``, which mutates
+            # its first argument in-place. To keep our callback side-effect
+            # free (other callbacks and the spend logger read from
+            # ``litellm_params["litellm_metadata"]``), feed the helper a shallow
+            # copy of ``litellm_params`` with shallow copies of both metadata
+            # dicts so any in-place mutation lands on disposable dicts.
+            safe_litellm_params = dict(litellm_params)
+            if isinstance(safe_litellm_params.get("metadata"), dict):
+                safe_litellm_params["metadata"] = dict(safe_litellm_params["metadata"])
+            if isinstance(safe_litellm_params.get("litellm_metadata"), dict):
+                safe_litellm_params["litellm_metadata"] = dict(
+                    safe_litellm_params["litellm_metadata"]
+                )
+            metadata = get_litellm_metadata_from_kwargs(
+                {**kwargs, "litellm_params": safe_litellm_params}
+            ) or {}
+            # Final defensive copy: downstream code pops keys off ``metadata`` /
+            # ``clean_metadata``; the helper may return one of the dicts we
+            # already copied above, but be explicit.
             metadata = dict(metadata)
             metadata = self.add_metadata_from_header(litellm_params, metadata)
             optional_params = safe_deep_copy(kwargs.get("optional_params", {}))

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -333,9 +333,12 @@ class LangFuseLogger:
                 safe_litellm_params["litellm_metadata"] = dict(
                     safe_litellm_params["litellm_metadata"]
                 )
-            metadata = get_litellm_metadata_from_kwargs(
-                {**kwargs, "litellm_params": safe_litellm_params}
-            ) or {}
+            metadata = (
+                get_litellm_metadata_from_kwargs(
+                    {**kwargs, "litellm_params": safe_litellm_params}
+                )
+                or {}
+            )
             # Final defensive copy: downstream code pops keys off ``metadata`` /
             # ``clean_metadata``; the helper may return one of the dicts we
             # already copied above, but be explicit.

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -24,6 +24,7 @@ from litellm.litellm_core_utils.core_helpers import (
     safe_deep_copy,
     reconstruct_model_name,
     filter_exceptions_from_params,
+    get_litellm_metadata_from_kwargs,
 )
 from litellm.litellm_core_utils.redact_messages import redact_user_api_key_info
 from litellm.integrations.langfuse.langfuse_mock_client import (
@@ -308,9 +309,19 @@ class LangFuseLogger:
 
             litellm_params = kwargs.get("litellm_params", {})
             litellm_call_id = kwargs.get("litellm_call_id", None)
-            metadata = (
-                litellm_params.get("metadata", {}) or {}
-            )  # if litellm_params['metadata'] == None
+            # Read metadata via the canonical helper so endpoints that store
+            # proxy-auth metadata under ``litellm_metadata`` (e.g. ``/v1/messages``,
+            # ``/v1/responses``, ``/v1/batches``, ``/v1/files``, ``/thread*``,
+            # ``/assistant*``) surface the same ``user_api_key_alias``,
+            # ``user_api_key_user_id``, ``user_api_key_team_id`` etc. as the
+            # endpoints that still use ``metadata``.
+            # ``get_litellm_metadata_from_kwargs`` prefers ``litellm_metadata``
+            # and falls back to ``metadata``; when both are present it merges
+            # the spend-tracking fields into the ``litellm_metadata`` copy.
+            metadata = get_litellm_metadata_from_kwargs(kwargs) or {}
+            # Defensive copy: downstream code pops keys off ``metadata`` /
+            # ``clean_metadata`` and we do not want to mutate the caller dict.
+            metadata = dict(metadata)
             metadata = self.add_metadata_from_header(litellm_params, metadata)
             optional_params = safe_deep_copy(kwargs.get("optional_params", {}))
 

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
@@ -15,6 +15,7 @@ The fix routes metadata extraction through
 which prefers ``litellm_metadata`` and merges spend-tracking fields
 from ``metadata`` when both are present.
 """
+
 import os
 from datetime import datetime
 from unittest.mock import MagicMock

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
@@ -1,0 +1,188 @@
+"""Regression tests for LIT-3293.
+
+The Langfuse callback used to read proxy-auth metadata only from
+``litellm_params["metadata"]``. New endpoints (``/v1/messages``,
+``/v1/responses``, ``/v1/batches``, ``/v1/files``, ``/thread*``,
+``/assistant*`` — see ``LITELLM_METADATA_ROUTES`` in
+``litellm.proxy.litellm_pre_call_utils``) store proxy auth under
+``litellm_params["litellm_metadata"]`` instead, so the auth fields
+(``user_api_key_alias``, ``user_api_key_user_id``, …) were dropped and
+the Langfuse generation name fell back to ``litellm-<call_type>``
+instead of ``litellm:<key_alias>``.
+
+The fix routes metadata extraction through
+``litellm.litellm_core_utils.core_helpers.get_litellm_metadata_from_kwargs``
+which prefers ``litellm_metadata`` and merges spend-tracking fields
+from ``metadata`` when both are present.
+"""
+import os
+from datetime import datetime
+from unittest.mock import MagicMock
+
+os.environ.setdefault("LANGFUSE_PUBLIC_KEY", "pk-test")
+os.environ.setdefault("LANGFUSE_SECRET_KEY", "sk-test")
+os.environ.setdefault("LANGFUSE_MOCK", "true")
+
+from litellm.integrations.langfuse.langfuse import LangFuseLogger  # noqa: E402
+from litellm.types.utils import (  # noqa: E402
+    Choices,
+    Message,
+    ModelResponse,
+    Usage,
+)
+
+
+PROXY_AUTH_META = {
+    "user_api_key": "hashed-key",
+    "user_api_key_hash": "hashed-key",
+    "user_api_key_alias": "engineering-prod-key",
+    "user_api_key_user_id": "user@example.com",
+    "user_api_key_team_id": "team-eng",
+    "user_api_key_team_alias": "engineering",
+    "user_api_key_org_id": None,
+    "user_api_key_end_user_id": None,
+    "user_api_key_request_route": "/v1/messages",
+}
+
+
+def _build_response() -> ModelResponse:
+    return ModelResponse(
+        id="msg_test_123",
+        created=int(datetime.now().timestamp()),
+        model="claude-3-5-sonnet-latest",
+        choices=[Choices(index=0, message=Message(role="assistant", content="Hi!"))],
+        usage=Usage(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+    )
+
+
+def _build_kwargs(*, litellm_metadata, metadata, call_type="anthropic_messages",
+                  model="claude-3-5-sonnet-latest", provider="anthropic"):
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": "ping"}],
+        "litellm_params": {
+            "metadata": dict(metadata) if metadata else {},
+            "litellm_metadata": dict(litellm_metadata) if litellm_metadata else {},
+            "proxy_server_request": {},
+            "api_base": "https://api.anthropic.com",
+            "custom_llm_provider": provider,
+        },
+        "litellm_call_id": "call-abc-123",
+        "call_type": call_type,
+        "optional_params": {"stream": False},
+        "standard_logging_object": {
+            "messages": [{"role": "user", "content": "ping"}],
+            "metadata": dict(litellm_metadata or metadata or {}),
+        },
+        "start_time": datetime.now(),
+        "end_time": datetime.now(),
+        "custom_llm_provider": provider,
+        "user": "user@example.com",
+    }
+
+
+def _run_logger(kwargs, response):
+    logger = LangFuseLogger()
+    captured = {"trace": None, "generation": None}
+    fake_generation = MagicMock()
+    fake_trace = MagicMock()
+
+    def cap_gen(**g):
+        captured["generation"] = g
+        return fake_generation
+
+    def cap_trace(**t):
+        captured["trace"] = t
+        return fake_trace
+
+    fake_trace.generation = cap_gen
+    logger.Langfuse = MagicMock()
+    logger.Langfuse.trace = cap_trace
+    logger.log_event_on_langfuse(
+        kwargs=kwargs,
+        response_obj=response,
+        start_time=kwargs["start_time"],
+        end_time=kwargs["end_time"],
+        user_id=kwargs.get("user"),
+        level="DEFAULT",
+        status_message=None,
+    )
+    return captured
+
+
+class TestLangfuseLitellmMetadata:
+    """Regression: Langfuse must pick up proxy-auth fields from litellm_metadata."""
+
+    def test_v1_messages_surfaces_user_api_key_alias_in_generation_name(self):
+        kwargs = _build_kwargs(
+            litellm_metadata=PROXY_AUTH_META,
+            metadata={},
+            call_type="anthropic_messages",
+        )
+        captured = _run_logger(kwargs, _build_response())
+        assert captured["generation"] is not None
+        assert captured["generation"]["name"] == "litellm:engineering-prod-key"
+
+    def test_v1_messages_includes_user_api_key_fields_in_generation_metadata(self):
+        kwargs = _build_kwargs(
+            litellm_metadata=PROXY_AUTH_META,
+            metadata={},
+            call_type="anthropic_messages",
+        )
+        captured = _run_logger(kwargs, _build_response())
+        gen_md = captured["generation"]["metadata"]
+        assert gen_md["user_api_key_alias"] == "engineering-prod-key"
+        assert gen_md["user_api_key_user_id"] == "user@example.com"
+        assert gen_md["user_api_key_team_id"] == "team-eng"
+        assert gen_md["user_api_key_team_alias"] == "engineering"
+
+    def test_chat_completions_metadata_still_works(self):
+        legacy_meta = {
+            "user_api_key_alias": "my-chat-key",
+            "user_api_key_user_id": "alice",
+            "user_api_key_team_id": "t",
+        }
+        kwargs = _build_kwargs(
+            litellm_metadata={},
+            metadata=legacy_meta,
+            call_type="completion",
+            model="gpt-4o",
+            provider="openai",
+        )
+        captured = _run_logger(kwargs, _build_response())
+        assert captured["generation"]["name"] == "litellm:my-chat-key"
+        gen_md = captured["generation"]["metadata"]
+        assert gen_md["user_api_key_alias"] == "my-chat-key"
+        assert gen_md["user_api_key_user_id"] == "alice"
+
+    def test_both_present_picks_litellm_metadata(self):
+        kwargs = _build_kwargs(
+            litellm_metadata=PROXY_AUTH_META,
+            metadata={"requester_metadata": {"client": "claude-code"}},
+            call_type="anthropic_messages",
+        )
+        captured = _run_logger(kwargs, _build_response())
+        assert captured["generation"]["name"] == "litellm:engineering-prod-key"
+
+    def test_no_metadata_at_all_still_renders_safe_default(self):
+        kwargs = _build_kwargs(
+            litellm_metadata={},
+            metadata={},
+            call_type="anthropic_messages",
+        )
+        captured = _run_logger(kwargs, _build_response())
+        assert captured["generation"]["name"] == "litellm-anthropic_messages"
+
+    def test_caller_owned_litellm_metadata_not_mutated(self):
+        kwargs = _build_kwargs(
+            litellm_metadata=dict(PROXY_AUTH_META),
+            metadata={},
+            call_type="anthropic_messages",
+        )
+        captured_lm = kwargs["litellm_params"]["litellm_metadata"]
+        before_keys = set(captured_lm.keys())
+        before_values = dict(captured_lm)
+        _run_logger(kwargs, _build_response())
+        assert set(captured_lm.keys()) == before_keys
+        for k, v in before_values.items():
+            assert captured_lm.get(k) == v

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
@@ -173,7 +173,9 @@ class TestLangfuseLitellmMetadata:
         captured = _run_logger(kwargs, _build_response())
         assert captured["generation"]["name"] == "litellm-anthropic_messages"
 
-    def test_caller_owned_litellm_metadata_not_mutated(self):
+    def test_caller_owned_litellm_metadata_not_mutated_empty_metadata_branch(self):
+        """When metadata is empty, the helper returns litellm_metadata directly —
+        the callback must not mutate it."""
         kwargs = _build_kwargs(
             litellm_metadata=dict(PROXY_AUTH_META),
             metadata={},
@@ -186,3 +188,48 @@ class TestLangfuseLitellmMetadata:
         assert set(captured_lm.keys()) == before_keys
         for k, v in before_values.items():
             assert captured_lm.get(k) == v
+
+    def test_caller_owned_litellm_metadata_not_mutated_merge_branch(self):
+        """When BOTH metadata and litellm_metadata are populated,
+        ``get_litellm_metadata_from_kwargs`` invokes
+        ``add_missing_spend_metadata_to_litellm_metadata``, which mutates
+        its first argument in place. The Langfuse callback must guard
+        against this so the caller-owned dict is unchanged.
+
+        Setup: put proxy-auth fields in ``litellm_metadata`` and a *second*
+        proxy-auth field only in ``metadata`` — without the guard,
+        ``litellm_metadata`` would silently gain ``user_api_key_metadata``
+        after the callback runs.
+        """
+        existing_litellm_md = dict(PROXY_AUTH_META)
+        extra_in_metadata = {
+            # this matches the "user_api_key" substring used by
+            # add_missing_spend_metadata_to_litellm_metadata as a merge filter
+            "user_api_key_metadata": {"src": "request-headers"},
+            # non-matching key — should never leak into litellm_metadata
+            "requester_metadata": {"client": "claude-code"},
+        }
+        kwargs = _build_kwargs(
+            litellm_metadata=existing_litellm_md,
+            metadata=extra_in_metadata,
+            call_type="anthropic_messages",
+        )
+        captured_lm = kwargs["litellm_params"]["litellm_metadata"]
+        captured_md = kwargs["litellm_params"]["metadata"]
+        before_lm_keys = set(captured_lm.keys())
+        before_lm_values = dict(captured_lm)
+        before_md_keys = set(captured_md.keys())
+        before_md_values = dict(captured_md)
+        _run_logger(kwargs, _build_response())
+        # litellm_metadata is the dict the merge helper mutates — assert no
+        # extra keys leaked in.
+        assert set(captured_lm.keys()) == before_lm_keys, (
+            "Langfuse callback mutated litellm_params['litellm_metadata'] "
+            f"(added keys: {set(captured_lm.keys()) - before_lm_keys})"
+        )
+        for k, v in before_lm_values.items():
+            assert captured_lm.get(k) == v
+        # metadata is read-only in the helper but assert it too for symmetry.
+        assert set(captured_md.keys()) == before_md_keys
+        for k, v in before_md_values.items():
+            assert captured_md.get(k) == v


### PR DESCRIPTION
## Summary

For requests through `/v1/messages` (and other endpoints in
`LITELLM_METADATA_ROUTES` — `/v1/responses`, `/v1/batches`, `/v1/files`,
`/thread*`, `/assistant*`), the proxy writes user-API-key auth metadata
to `data["litellm_metadata"]` instead of `data["metadata"]`. The Langfuse
callback only read from `litellm_params["metadata"]`, so it dropped
`user_api_key_alias`, `user_api_key_user_id`, `user_api_key_team_id`, etc.,
and the Langfuse generation name fell back to the `litellm-<call_type>`
default (`litellm-anthropic_messages`) instead of `litellm:<key_alias>`.

This patches `litellm/integrations/langfuse/langfuse.py` to extract
metadata via `get_litellm_metadata_from_kwargs(kwargs)` from
`litellm.litellm_core_utils.core_helpers` (the exact fix suggested in
the Linear ticket), with a **shallow-copy guard** in front of the call
so the helper's in-place merge
(`add_missing_spend_metadata_to_litellm_metadata`) cannot mutate the
caller-owned `litellm_params["litellm_metadata"]` that other callbacks
and the spend logger read from.

Closes LIT-3293.

> **Context — duplicate PRs**: Four other parallel Shin sessions filed
> PRs for this ticket today (#29036, #29043, #29044, #29045). This is
> the only one with the mutation-guard fix and a dedicated test that
> **fails on the unguarded code** (verified locally — reverting just
> the safe-copy block produces an AssertionError on the
> `not_mutated_merge_branch` test). My previous PR #29020 was
> auto-closed when a parallel session force-pushed the shared fork
> branch; this branch is session-prefixed
> (`shin/lit-3293-langfuse-metadata-d5ece08d`) to avoid further
> collisions.

## Files changed

- `litellm/integrations/langfuse/langfuse.py` — ~25 lines: replaces a
  direct `litellm_params.get("metadata")` read with
  `get_litellm_metadata_from_kwargs` fed a shallow-copied
  `litellm_params` (with shallow-copied `metadata` /
  `litellm_metadata`) so the helper's in-place merge lands on
  disposable copies. Final `dict(metadata)` defensive copy preserved.
- `tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py`
  — 7 regression tests covering both new (`/v1/messages`) and legacy
  (`/v1/chat/completions`) paths, the both-populated merge case, the
  safe-default case, and **two no-mutation invariants**: one for the
  empty-metadata branch (helper returns `litellm_metadata` directly)
  and one for the both-populated merge branch (helper invokes
  `add_missing_spend_metadata_to_litellm_metadata` which would
  otherwise mutate the caller dict in-place).

> Note: pushed via the GitHub Contents API (one file per commit)
> because the current agent `GITHUB_TOKEN` lacks `repo`+`workflow`
> scopes — the merge-base diff is noisier than a single squash, but
> Files Changed shows only the two files above.

### Evidence

Direct unit-level runtime evidence — drive
`LangFuseLogger.log_event_on_langfuse()` with a `kwargs` dict that
mimics what the proxy produces for `/v1/messages`
(`litellm_params["metadata"] == {}`, proxy-auth fields under
`litellm_params["litellm_metadata"]`), capture the args passed to the
Langfuse SDK client (`Langfuse.trace(**t).generation(**g)`).

**BEFORE** — clean `litellm_oss_agent_shin_daily_branch`:

```
================================================================
Simulated /v1/messages kwargs:
  litellm_params['metadata']                       = {}
  litellm_params['litellm_metadata'].user_api_key_alias = engineering-prod-key
================================================================
What Langfuse received:
  trace.name                              = litellm-anthropic_messages
  trace.user_id                           = None
  trace.metadata.user_api_key_alias       = None
  generation.name                         = litellm-anthropic_messages
  generation.metadata proxy-auth keys     = <EMPTY>
================================================================
alias surfaces in generation/trace name?  False
proxy-auth fields appear in generation metadata?  False
EXIT: 1
```

**AFTER** — this branch:

```
================================================================
Simulated /v1/messages kwargs:
  litellm_params['metadata']                       = {}
  litellm_params['litellm_metadata'].user_api_key_alias = engineering-prod-key
================================================================
What Langfuse received:
  trace.name                              = litellm-anthropic_messages
  trace.user_id                           = None
  generation.name                         = litellm:engineering-prod-key
  generation.metadata proxy-auth keys     = {
    'user_api_key': 'hashed-key',
    'user_api_key_hash': 'hashed-key',
    'user_api_key_alias': 'engineering-prod-key',
    'user_api_key_user_id': 'user@example.com',
    'user_api_key_team_id': 'team-eng',
    'user_api_key_team_alias': 'engineering',
    'user_api_key_org_id': None,
    'user_api_key_end_user_id': None,
    'user_api_key_request_route': '/v1/messages'
  }
================================================================
alias surfaces in generation/trace name?  True
proxy-auth fields appear in generation metadata?  True
EXIT: 0
```

### Mutation-guard verification

The mutation-guard claim (that
`add_missing_spend_metadata_to_litellm_metadata` would mutate the
caller dict without the safe-copy in this PR) is verified by reverting
just the safe-copy block to the previous unconditional
`get_litellm_metadata_from_kwargs(kwargs)` call and re-running the
test:

```
==== running merge-branch test on the VULNERABLE code (should FAIL) ====
FAILED tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py::TestLangfuseLitellmMetadata::test_caller_owned_litellm_metadata_not_mutated_merge_branch
======================== 1 failed in 1.60s ====================================
EXIT: 1
```

…and re-applying the safe-copy block makes the same test pass.

### Unit tests on this branch

```
tests/test_litellm/integrations/langfuse/test_langfuse_metadata_litellm_v1_messages.py
::TestLangfuseLitellmMetadata::test_both_present_picks_litellm_metadata                                  PASSED
::TestLangfuseLitellmMetadata::test_caller_owned_litellm_metadata_not_mutated_empty_metadata_branch       PASSED
::TestLangfuseLitellmMetadata::test_caller_owned_litellm_metadata_not_mutated_merge_branch               PASSED
::TestLangfuseLitellmMetadata::test_chat_completions_metadata_still_works                                PASSED
::TestLangfuseLitellmMetadata::test_no_metadata_at_all_still_renders_safe_default                        PASSED
::TestLangfuseLitellmMetadata::test_v1_messages_includes_user_api_key_fields_in_generation_metadata     PASSED
::TestLangfuseLitellmMetadata::test_v1_messages_surfaces_user_api_key_alias_in_generation_name          PASSED
============================== 7 passed in 1.21s ===============================
```

Session: https://litellm-agent-platform.onrender.com/sessions/d5ece08d-9b09-4aa3-a0d9-ebe7ad925caa


### Verification (ship-pr)
- change-type: `langfuse.py` (callback / logging) → telemetry capture required; tests-only path → no runtime evidence required
- evidence present: PASS (BEFORE/AFTER blocks above + mutation-guard counter-test block — 3 captured runs total)
- image sanity: N/A (no UI surface, no screenshots)
- image content matches caption: N/A (no screenshots)
- backend evidence from running system: PASS — captures are from direct Python execution of `LangFuseLogger.log_event_on_langfuse()` with a kwargs dict that mimics the proxy's `/v1/messages` codepath, intercepting the args passed to `Langfuse.trace(...).generation(...)`. Not from the unit test runner; not fabricated. The mutation-guard counter-test additionally proves the test fails on the unguarded code.
- hygiene: PASS (no external image hosts in body; diff is exactly the two intended files — 2 files changed, +34/-2 in `langfuse.py`, +236 in the test file)
