### PR TITLE
fix(langfuse): hold HTTPHandler reference to prevent premature client closure

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -155,6 +155,16 @@ class LangFuseLogger:
             self.is_mock_mode = True
         else:
             http_client = _get_httpx_client()
+            # Hold a strong reference to the wrapping HTTPHandler so its
+            # __del__ (which calls self.client.close()) cannot fire while
+            # this Langfuse logger is still alive. Without this, the
+            # HTTPHandler exists only in litellm.in_memory_llm_clients_cache,
+            # and once that cache entry is evicted (TTL, restart, manual
+            # flush) the underlying httpx.Client is closed out from under
+            # the Langfuse SDK’s background flush thread, surfacing as
+            # RuntimeError: Cannot send a request, as the client has
+            # been closed.
+            self._langfuse_http_handler = http_client
             self.langfuse_client = http_client.client
             self.is_mock_mode = False
 

--- a/tests/test_litellm/test_langfuse_httpx_client_lifetime.py
+++ b/tests/test_litellm/test_langfuse_httpx_client_lifetime.py
@@ -1,0 +1,121 @@
+"""Regression tests: Langfuse trace sending fails with closed client.
+
+Bug: ``LangFuseLogger`` held only the inner ``httpx.Client`` and not the
+wrapping ``HTTPHandler``. The HTTPHandler was kept alive only by
+``litellm.in_memory_llm_clients_cache``. When that cache entry expired the
+HTTPHandler was garbage collected, its ``__del__`` called
+``self.client.close()``, and Langfuse’s background flush thread surfaced
+the now-closed client as
+``RuntimeError: Cannot send a request, as the client has been closed.``
+
+The fix stores a strong reference to the wrapping HTTPHandler on the
+LangFuseLogger instance.
+"""
+from __future__ import annotations
+
+import gc
+import sys
+import types
+
+import httpx
+import pytest
+
+
+def _stub_langfuse_module() -> None:
+    """Stub the ``langfuse`` package so ``LangFuseLogger.__init__`` can run
+    without a real langfuse SDK install."""
+    fake = types.ModuleType("langfuse")
+
+    class _FakeLangfuse:
+        def __init__(self, **kwargs):
+            self._init_kwargs = kwargs
+
+        def trace(self, **kwargs):  # pragma: no cover - not exercised here
+            return None
+
+    fake.Langfuse = _FakeLangfuse  # type: ignore[attr-defined]
+    fake.client = types.SimpleNamespace()  # type: ignore[attr-defined]
+    fake.version = types.SimpleNamespace(__version__="2.59.7")  # type: ignore[attr-defined]
+    sys.modules["langfuse"] = fake
+    sys.modules["langfuse.client"] = fake.client
+    sys.modules["langfuse.version"] = fake.version
+
+
+@pytest.fixture
+def langfuse_env(monkeypatch):
+    _stub_langfuse_module()
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_HOST", "http://example.invalid")
+    yield
+
+
+def _evict_httpx_client_cache() -> None:
+    """Drop all entries from ``litellm.in_memory_llm_clients_cache``."""
+    import litellm
+
+    cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+    if cache is None:
+        return
+    for fn in ("flush_cache", "clear_cache"):
+        try:
+            getattr(cache, fn)()
+        except Exception:
+            pass
+    for attr in ("cache_dict",):
+        try:
+            getattr(cache, attr).clear()
+        except Exception:
+            pass
+    try:
+        cache.in_memory_cache.cache_dict.clear()
+    except Exception:
+        pass
+
+
+def test_langfuse_logger_keeps_http_handler_reference(langfuse_env):
+    """LangFuseLogger must keep a strong reference to the wrapping HTTPHandler
+    so its __del__ cannot close the underlying httpx.Client out from under the
+    Langfuse SDK while this logger is alive."""
+    from litellm.integrations.langfuse.langfuse import LangFuseLogger
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    logger = LangFuseLogger()
+    handler = getattr(logger, "_langfuse_http_handler", None)
+    assert isinstance(handler, HTTPHandler), (
+        "LangFuseLogger must hold a strong reference to the wrapping "
+        "HTTPHandler (attribute `_langfuse_http_handler`)."
+    )
+    assert handler.client is logger.langfuse_client
+
+
+def test_langfuse_client_survives_cache_eviction_and_gc(langfuse_env):
+    """End-to-end lifecycle test: evict the litellm HTTPHandler cache and
+    force GC. The httpx.Client Langfuse holds must remain open and usable."""
+    from litellm.integrations.langfuse.langfuse import LangFuseLogger
+
+    logger = LangFuseLogger()
+    client = logger.langfuse_client
+    assert client.is_closed is False, "httpx.Client should start open"
+
+    _evict_httpx_client_cache()
+    gc.collect()
+    gc.collect()
+
+    assert client.is_closed is False, (
+        "httpx.Client was closed after the litellm HTTPHandler cache was "
+        "evicted and garbage collected. LangFuseLogger must hold a strong "
+        "reference to the wrapping HTTPHandler."
+    )
+
+    req = httpx.Request("POST", "http://127.0.0.1:1/")
+    try:
+        client.send(req)
+    except RuntimeError as e:
+        pytest.fail(
+            f"closed-client RuntimeError after cache eviction + GC: {e}"
+        )
+    except httpx.HTTPError:
+        # Any transport-layer error is fine; we only guard against the
+        # closed-client RuntimeError.
+        pass


### PR DESCRIPTION
## What

Fix a long-standing lifecycle bug where the Langfuse callback could try to send traces on an already-closed `httpx.Client`, surfacing as:

```
builtins.RuntimeError: Cannot send a request, as the client has been closed.
```

## Root cause

`LangFuseLogger.__init__` calls `_get_httpx_client()` and stores only the inner `httpx.Client`:

```python
http_client = _get_httpx_client()
self.langfuse_client = http_client.client
```

`_get_httpx_client()` returns an `HTTPHandler` whose only strong reference outside the caller is the global `litellm.in_memory_llm_clients_cache` (TTL `_DEFAULT_TTL_FOR_HTTPX_CLIENTS`, ~1h). `HTTPHandler.__del__` calls `self.client.close()` (see `litellm/llms/custom_httpx/http_handler.py:1313`). When that cache entry is evicted and the `HTTPHandler` is garbage collected, the underlying `httpx.Client` is closed out from under Langfuse's background flush thread — which then surfaces the closed client as the `RuntimeError` above.

## Fix

Store a strong reference to the wrapping `HTTPHandler` on the `LangFuseLogger` instance. That keeps the wrapper alive — and therefore prevents its `__del__` from closing the shared `httpx.Client` — for as long as the logger itself is alive.

```python
http_client = _get_httpx_client()
self._langfuse_http_handler = http_client   # NEW: strong ref to the wrapper
self.langfuse_client = http_client.client
```

Surgical: one new attribute on `LangFuseLogger`, no behavior change anywhere else.

## Evidence

Repro mirrors the real `LangFuseLogger.__init__` path (the `langfuse` SDK is stubbed so we can run with no network) and forces the lifecycle the bug requires:
1. Build a `LangFuseLogger` (which calls `_get_httpx_client()` and stores `http_client.client`).
2. Drop the litellm in-memory client cache (simulating TTL expiry).
3. Force GC.
4. Try to use the `httpx.Client` Langfuse is still holding.

### Before (clean `main`)

```
[setup] mode=main source=litellm_main client.is_closed=False has_handler_ref=False
[after eviction+gc] client.is_closed=True
[result] RuntimeError: Cannot send a request, as the client has been closed.
```

### After (this branch)

```
[setup] mode=patched source=litellm client.is_closed=False has_handler_ref=True
[after eviction+gc] client.is_closed=False
[result] send() returned without error
```

The fix flips `has_handler_ref` to `True`, keeps the client open across cache eviction + GC, and the same lifecycle that raised the closed-client `RuntimeError` on main now sends cleanly.

### Unit tests

`tests/test_litellm/test_langfuse_httpx_client_lifetime.py` — 2 new regression tests:

- `test_langfuse_logger_keeps_http_handler_reference` — asserts `LangFuseLogger._langfuse_http_handler` is the `HTTPHandler` that owns `langfuse_client`.
- `test_langfuse_client_survives_cache_eviction_and_gc` — full lifecycle: build logger, evict cache, GC, assert `client.is_closed is False` and that `client.send(...)` does not raise the closed-client `RuntimeError`.

```
$ pytest tests/test_litellm/test_langfuse_httpx_client_lifetime.py -q
..                                                                       [100%]
2 passed in 1.34s
```

## Notes

- Filed via the GitHub Contents API (`PUT /repos/.../contents/...`) — the agent's token lacks `repo`+`workflow` scopes, so direct `git push` and `update-branch` are not available. Expect a slightly noisier merge-base diff than a normal force-push branch would produce.
- Targets `litellm_oss_agent_shin_daily_branch` per the fork-PR rule.

Refs prior closed PR #28638 (same fix idea; this is a clean refile with a stronger regression test that exercises the actual lifecycle rather than just the attribute presence).
