### PR TITLE
fix(guardrails): redact full PEM private key block in hide_secrets, not just BEGIN header

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -6,13 +6,14 @@
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
 
 import os
+import re
 import sys
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import tempfile
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
@@ -21,6 +22,49 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails._content_utils import walk_user_text
 
 GUARDRAIL_NAME = "hide_secrets"
+
+# Matches a full PEM private-key block (header + base64 body + footer) across
+# multiple lines.  ``detect-secrets`` is line-based and, for ``Private Key``
+# entries, records only the ``-----BEGIN ... PRIVATE KEY-----`` armor header
+# as the secret value.  ``_expand_private_key_values`` uses this pattern to
+# promote that header-only value to the full block so every downstream
+# ``str.replace`` redacts the entire key (header + body + footer) rather than
+# just the first line.
+_PEM_BLOCK_RE = re.compile(
+    r"-----BEGIN[ A-Z]*PRIVATE KEY-----[\s\S]*?-----END[ A-Z]*PRIVATE KEY-----"
+)
+
+
+def _expand_private_key_values(
+    detected_secrets: List[Dict[str, Any]], text: str
+) -> List[Dict[str, Any]]:
+    """Expand ``Private Key`` detect-secrets entries from the BEGIN armor
+    header to the full PEM block found in ``text``.
+
+    ``detect-secrets`` scans line-by-line, so for PEM keys it records only
+    the ``-----BEGIN ... PRIVATE KEY-----`` armor header as the secret value.
+    Without this expansion, downstream ``str.replace`` calls strike only that
+    first line and leave the base64 body and ``END`` footer in the forwarded
+    request.
+
+    Each PEM block is claimed at most once -- if a message contains multiple
+    keys, expansion assigns blocks in order of appearance so every key gets
+    its own distinct full-block value and none are skipped.
+
+    All other secret types pass through unchanged.
+    """
+    pem_blocks = list(_PEM_BLOCK_RE.finditer(text))
+    claimed: set = set()
+    expanded: List[Dict[str, Any]] = []
+    for secret in detected_secrets:
+        if secret.get("type") == "Private Key":
+            for idx, match in enumerate(pem_blocks):
+                if idx not in claimed and secret.get("value") in match.group(0):
+                    secret = {**secret, "value": match.group(0)}
+                    claimed.add(idx)
+                    break
+        expanded.append(secret)
+    return expanded
 
 _custom_plugins_path = "file://" + os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "secrets_plugins"
@@ -453,7 +497,12 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                     {"type": found_secret.type, "value": found_secret.secret_value}
                 )
 
-        return detected_secrets
+        # detect-secrets is line-based and, for PEM ``Private Key`` entries,
+        # records only the ``-----BEGIN ... PRIVATE KEY-----`` header as the
+        # secret value.  Expand each Private Key entry to the full PEM block
+        # so downstream ``str.replace`` redacts header + body + footer rather
+        # than just the first line.
+        return _expand_private_key_values(detected_secrets, message_content)
 
     async def should_run_check(self, user_api_key_dict: UserAPIKeyAuth) -> bool:
         if user_api_key_dict.permissions is not None:

--- a/tests/test_litellm/test_secret_detection_pem.py
+++ b/tests/test_litellm/test_secret_detection_pem.py
@@ -1,0 +1,204 @@
+"""Unit tests for full-block PEM private-key redaction in the hide_secrets
+guardrail.
+
+Regression coverage for the LIT-3292 bug where ``detect-secrets`` (which
+scans line-by-line) returned only the ``-----BEGIN ... PRIVATE KEY-----``
+armor header as the secret value, and the subsequent ``str.replace`` call
+sites left the base64 body and ``END`` footer in the forwarded request.
+
+The fix (``_expand_private_key_values``) post-processes the detected secrets
+list and promotes every ``Private Key`` entry from the header-only value to
+the full PEM block found in the source text.
+"""
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.utils import hash_token
+from litellm_enterprise.enterprise_callbacks.secret_detection import (
+    _ENTERPRISE_SecretDetection,
+    _PEM_BLOCK_RE,
+    _expand_private_key_values,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures - bytes are placeholders, NOT a real key.
+# ---------------------------------------------------------------------------
+
+_PKCS8_BEGIN = "-----BEGIN PRIVATE KEY-----"
+
+_SAMPLE_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj\n"
+    "MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu\n"
+    "-----END PRIVATE KEY-----"
+)
+
+_SAMPLE_RSA_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEowIBAAKCAQEA2a2rwplBQLF29amygykEMmYz0+Kcj3bKBp29\n"
+    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+
+# ---------------------------------------------------------------------------
+# _expand_private_key_values - direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_expand_promotes_header_to_full_block():
+    """The BEGIN armor header is expanded to the whole PEM block."""
+    detected = [{"type": "Private Key", "value": _PKCS8_BEGIN}]
+    text = f"Here is a key:\n{_SAMPLE_PEM}\nEnd of message."
+
+    result = _expand_private_key_values(detected, text)
+
+    assert len(result) == 1
+    assert result[0]["value"] == _SAMPLE_PEM
+
+
+def test_expand_handles_rsa_private_key():
+    """Works for RSA PRIVATE KEY blocks, not just PKCS#8."""
+    header = "-----BEGIN RSA PRIVATE KEY-----"
+    detected = [{"type": "Private Key", "value": header}]
+    text = f"Key:\n{_SAMPLE_RSA_PEM}\n"
+
+    result = _expand_private_key_values(detected, text)
+
+    assert result[0]["value"] == _SAMPLE_RSA_PEM
+
+
+def test_expand_preserves_non_private_key_secrets():
+    """Non-PEM secret types are returned unchanged."""
+    detected = [
+        {"type": "AWS Access Key", "value": "AKIAIOSFODNN7EXAMPLE"},
+        {"type": "Private Key", "value": _PKCS8_BEGIN},
+    ]
+    text = f"key={_SAMPLE_PEM}"
+
+    result = _expand_private_key_values(detected, text)
+
+    assert result[0] == {"type": "AWS Access Key", "value": "AKIAIOSFODNN7EXAMPLE"}
+    assert result[1]["value"] == _SAMPLE_PEM
+
+
+def test_expand_no_match_leaves_secret_unchanged():
+    """If no enclosing PEM block is found, the entry is kept as-is."""
+    detected = [{"type": "Private Key", "value": _PKCS8_BEGIN}]
+    text = "no key here"
+
+    result = _expand_private_key_values(detected, text)
+
+    assert result == detected
+
+
+def test_expand_multiple_keys_each_claim_a_distinct_block():
+    """Two PEM keys in one message get two distinct full-block values."""
+    detected = [
+        {"type": "Private Key", "value": _PKCS8_BEGIN},
+        {"type": "Private Key", "value": _PKCS8_BEGIN},
+    ]
+    text = f"first:\n{_SAMPLE_PEM}\nsecond:\n{_SAMPLE_PEM}\n"
+
+    result = _expand_private_key_values(detected, text)
+
+    assert result[0]["value"] == _SAMPLE_PEM
+    assert result[1]["value"] == _SAMPLE_PEM
+
+
+def test_pem_block_regex_spans_newlines():
+    r"""The regex matches across newlines via the ``[\s\S]`` class."""
+    text = f"prefix {_SAMPLE_PEM} suffix"
+    m = _PEM_BLOCK_RE.search(text)
+
+    assert m is not None
+    assert m.group(0) == _SAMPLE_PEM
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via the real async_pre_call_hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_redacts_full_pem_block_in_chat_message():
+    """The proxy pre_call hook redacts the whole PEM block, not just the
+    BEGIN header line that detect-secrets returns."""
+    inst = _ENTERPRISE_SecretDetection()
+    data = {
+        "messages": [
+            {
+                "role": "user",
+                "content": f"Here is my key, please ignore:\n{_SAMPLE_PEM}\nThanks",
+            }
+        ],
+        "model": "gpt-3.5-turbo",
+    }
+
+    await inst.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(api_key=hash_token("sk-12345")),
+        call_type="completion",
+    )
+
+    out = data["messages"][0]["content"]
+    assert "-----BEGIN PRIVATE KEY-----" not in out
+    assert "-----END PRIVATE KEY-----" not in out
+    assert "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKc" not in out
+    assert "[REDACTED]" in out
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_redacts_full_pem_block_in_string_prompt():
+    """Same end-to-end check via the ``prompt`` shape (text-completion)."""
+    inst = _ENTERPRISE_SecretDetection()
+    data = {
+        "prompt": f"key={_SAMPLE_PEM}",
+        "model": "gpt-3.5-turbo",
+    }
+
+    await inst.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(api_key=hash_token("sk-12345")),
+        call_type="completion",
+    )
+
+    out = data["prompt"]
+    assert "-----BEGIN PRIVATE KEY-----" not in out
+    assert "-----END PRIVATE KEY-----" not in out
+    assert "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKc" not in out
+    assert "[REDACTED]" in out
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_non_pem_secrets_still_masked():
+    """Non-PEM secret types continue to be redacted; expansion does not
+    regress the existing detector behaviour."""
+    inst = _ENTERPRISE_SecretDetection()
+    data = {
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "AWS_ACCESS_KEY = 'AKIAIOSFODNN7EXAMPLE' and secret = "
+                    "'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
+                ),
+            }
+        ],
+        "model": "gpt-3.5-turbo",
+    }
+
+    await inst.async_pre_call_hook(
+        cache=DualCache(),
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(api_key=hash_token("sk-12345")),
+        call_type="completion",
+    )
+
+    out = data["messages"][0]["content"]
+    assert "AKIAIOSFODNN7EXAMPLE" not in out
+    assert "[REDACTED]" in out


### PR DESCRIPTION
## Summary

The enterprise `hide_secrets` guardrail (`_ENTERPRISE_SecretDetection`) uses [`detect-secrets`](https://github.com/Yelp/detect-secrets), which scans line-by-line. For PEM private keys the detector returns only the `-----BEGIN ... PRIVATE KEY-----` armor header as the secret value, and the redaction call sites then ran a single `str.replace(secret["value"], "[REDACTED]")` -- replacing only that first line. The base64 body and `-----END PRIVATE KEY-----` footer were forwarded downstream to the LLM even though the proxy log reported the key as detected and redacted.

This change adds `_expand_private_key_values`, which post-processes the list returned by `scan_message_for_secrets`. Each `Private Key` entry is promoted from the header-only value to the full enclosing PEM block (matched by `_PEM_BLOCK_RE`, which spans newlines via `[\s\S]`), so every downstream `str.replace` redacts header + body + footer. Each PEM match in the source text is claimed at most once so multiple distinct keys in one message all get redacted. Non-`Private Key` entries pass through unchanged.

Refs LIT-3292.

## Evidence

Runtime evidence captured from the real production code path -- `_ENTERPRISE_SecretDetection.async_pre_call_hook` invoked exactly as `litellm.proxy` invokes it on every incoming `/chat/completions` request, with a chat-completion payload containing a PEM private key.

**Before (clean `main`, `_expand_private_key_values` not present):** detect-secrets matched only the BEGIN line, the `str.replace` only struck that one line, and the base64 body + END footer leaked through to the upstream LLM:

```text
# code path: /usr/local/lib/python3.13/site-packages/litellm_enterprise/enterprise_callbacks/secret_detection.py
# has _expand_private_key_values: False
WARNING - secret_detection.py - Detected and redacted secrets in message: ['Private Key']

------------------------------------------------------------
[BEFORE] Forwarded message content after hide_secrets pre_call hook:
------------------------------------------------------------
Here is my key, please ignore:
-----[REDACTED]-----
MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj
MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
-----END PRIVATE KEY-----
Thanks
------------------------------------------------------------
[BEFORE] contains '-----BEGIN PRIVATE KEY-----' : False
[BEFORE] contains '-----END PRIVATE KEY-----'   : True
[BEFORE] contains base64 body 'MIIEvQIBADAN...' : True
[BEFORE] contains '[REDACTED]'                  : True
```

**After (this branch, `_expand_private_key_values` applied):** the detected value is promoted to the full PEM block, the existing `str.replace` then strikes the whole block, and nothing PEM-shaped survives:

```text
# code path: /usr/local/lib/python3.13/site-packages/litellm_enterprise/enterprise_callbacks/secret_detection.py
# has _expand_private_key_values: True
WARNING - secret_detection.py - Detected and redacted secrets in message: ['Private Key']

------------------------------------------------------------
[AFTER] Forwarded message content after hide_secrets pre_call hook:
------------------------------------------------------------
Here is my key, please ignore:
[REDACTED]
Thanks
------------------------------------------------------------
[AFTER] contains '-----BEGIN PRIVATE KEY-----' : False
[AFTER] contains '-----END PRIVATE KEY-----'   : False
[AFTER] contains base64 body 'MIIEvQIBADAN...' : False
[AFTER] contains '[REDACTED]'                  : True
```

Both captures came from the same `_ENTERPRISE_SecretDetection.async_pre_call_hook` Python entry point that `litellm.proxy` invokes -- the only difference between the two runs is whether the patched `secret_detection.py` is present.

## Tests

`tests/test_litellm/test_secret_detection_pem.py` (new):

- Direct `_expand_private_key_values` coverage: header to full-block expansion, `RSA PRIVATE KEY` variant, multi-key messages, non-PEM passthrough, no-match leaves entry unchanged.
- `_PEM_BLOCK_RE` newline-spanning check.
- End-to-end against the real `async_pre_call_hook` for the chat-message shape, the string `prompt` shape, and a non-PEM (AWS key) sanity case.

## Notes for reviewers

- Files were uploaded via the GitHub contents API (current `GITHUB_TOKEN` lacks `repo`/`workflow` scopes for `git push`), so the merge-base diff is two single-file commits stacked on top of `litellm_oss_agent_shin_daily_branch`.
- Filed by Shin from session: https://litellm-agent-platform.onrender.com/sessions/1dc5ad4e-1d3b-48ad-bd4e-d952af2e76f7
