### PR TITLE
feat(provider): add Tensormesh as an OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -771,6 +771,7 @@ openai_compatible_endpoints: List = [
     "https://api.moonshot.ai/v1",
     "https://api.publicai.co/v1",
     "https://api.synthetic.new/openai/v1",
+    "https://serverless.tensormesh.ai/v1",
     "https://api.stima.tech/v1",
     "https://nano-gpt.com/api/v1",
     "https://api.poe.com/v1",
@@ -820,6 +821,7 @@ openai_compatible_providers: List = [
     "meta_llama",
     "publicai",  # PublicAI - JSON-configured provider
     "synthetic",  # Synthetic - JSON-configured provider
+    "tensormesh",  # Tensormesh - JSON-configured provider
     "apertis",  # Apertis - JSON-configured provider
     "nano-gpt",  # Nano-GPT - JSON-configured provider
     "poe",  # Poe - JSON-configured provider
@@ -855,6 +857,7 @@ openai_text_completion_compatible_providers: List = (
         "moonshot",
         "publicai",
         "synthetic",
+        "tensormesh",
         "apertis",
         "nano-gpt",
         "poe",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -114,5 +114,14 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "tensormesh": {
+    "base_url": "https://serverless.tensormesh.ai/v1",
+    "api_key_env": "TENSORMESH_INFERENCE_API_KEY",
+    "api_base_env": "TENSORMESH_SERVERLESS_BASE_URL",
+    "base_class": "openai_gpt",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3361,6 +3361,7 @@ class LlmProviders(str, Enum):
     POE = "poe"
     CHUTES = "chutes"
     XIAOMI_MIMO = "xiaomi_mimo"
+    TENSORMESH = "tensormesh"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2079,6 +2079,24 @@
         "a2a": false
       }
     },
+    "tensormesh": {
+      "display_name": "Tensormesh (`tensormesh`)",
+      "url": "https://docs.litellm.ai/docs/providers/tensormesh",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "text_completion": true
+      }
+    },
     "text-completion-codestral": {
       "display_name": "Text Completion Codestral (`text-completion-codestral`)",
       "url": "https://docs.litellm.ai/docs/providers/codestral",

--- a/tests/test_litellm/llms/openai_like/test_tensormesh_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_tensormesh_provider.py
@@ -1,0 +1,96 @@
+"""
+Tests for Tensormesh provider configuration and integration.
+"""
+
+import os
+import sys
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+# Add workspace to path
+workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, workspace_path)
+
+import litellm
+
+
+class TestTensormeshProviderConfig:
+    """Test Tensormesh provider configuration"""
+
+    def test_tensormesh_in_provider_list(self):
+        """Test that tensormesh is in the provider list"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "TENSORMESH")
+        assert LlmProviders.TENSORMESH.value == "tensormesh"
+        assert "tensormesh" in litellm.provider_list
+
+    def test_tensormesh_json_config_exists(self):
+        """Test that tensormesh is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("tensormesh")
+
+        tensormesh = JSONProviderRegistry.get("tensormesh")
+        assert tensormesh is not None
+        assert tensormesh.base_url == "https://serverless.tensormesh.ai/v1"
+        assert tensormesh.api_key_env == "TENSORMESH_INFERENCE_API_KEY"
+        assert tensormesh.api_base_env == "TENSORMESH_SERVERLESS_BASE_URL"
+        assert tensormesh.param_mappings.get("max_completion_tokens") == "max_tokens"
+
+    def test_tensormesh_provider_resolution(self):
+        """Test that provider resolution finds tensormesh and the default base URL"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="tensormesh/openai/gpt-oss-120b",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "openai/gpt-oss-120b"
+        assert provider == "tensormesh"
+        assert api_base == "https://serverless.tensormesh.ai/v1"
+
+    def test_tensormesh_api_base_override(self):
+        """Test that an explicit api_base / api_key overrides the serverless default"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="tensormesh/openai/gpt-oss-120b",
+            custom_llm_provider=None,
+            api_base="https://custom.example.com/v1",
+            api_key="sk-test",
+        )
+
+        assert provider == "tensormesh"
+        assert api_base == "https://custom.example.com/v1"
+        assert api_key == "sk-test"
+
+    def test_tensormesh_text_completion_enabled(self):
+        """Tensormesh is wired for the /completions (text completion) route,
+        matching the text_completion flag in provider_endpoints_support.json."""
+        assert "tensormesh" in litellm.openai_text_completion_compatible_providers
+
+    def test_tensormesh_router_config(self):
+        """Test that tensormesh can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "tensormesh-chat",
+                    "litellm_params": {
+                        "model": "tensormesh/openai/gpt-oss-120b",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "tensormesh-chat"

--- a/tests/test_litellm/llms/openai_like/test_tensormesh_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_tensormesh_provider.py
@@ -2,18 +2,6 @@
 Tests for Tensormesh provider configuration and integration.
 """
 
-import os
-import sys
-
-try:
-    import pytest
-except ImportError:
-    pytest = None
-
-# Add workspace to path
-workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-sys.path.insert(0, workspace_path)
-
 import litellm
 
 


### PR DESCRIPTION
## Relevant issues

N/A — adds a new OpenAI-compatible provider.

## Linear ticket

<!-- external contributor — no Linear ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — `tests/test_litellm/llms/openai_like/test_tensormesh_provider.py` (6 tests)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) <!-- 7506 passed; the only failures are pre-existing `httpx.ConnectError` in two proxy tests (`test_key_rotation_e2e`, `test_health_liveliness_endpoint`) that require local DB/server infra — unrelated to this change -->
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem — registers a single provider
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Validated locally against the Tensormesh serverless endpoint. Script (API key read from the environment, not hardcoded):

```python
import os, litellm

MODEL = "tensormesh/openai/gpt-oss-120b"  # a Tensormesh serverless model
# export TENSORMESH_INFERENCE_API_KEY=... before running

# chat completion
r = litellm.completion(model=MODEL, messages=[{"role": "user", "content": "Say hello in one sentence."}])
print("CHAT:", r.choices[0].message.content)

# streaming
print("STREAM: ", end="")
for c in litellm.completion(model=MODEL, messages=[{"role": "user", "content": "Count to three."}], stream=True):
    print(c.choices[0].delta.content or "", end="")
print()

# text completion (/completions)
t = litellm.text_completion(model=MODEL, prompt="Fast inference matters because", max_tokens=20)
print("TEXT:", t.choices[0].text)
```

Output:

```
CHAT: Hello! I'm glad you're here and hope you have a wonderful day.
STREAM: 1
2
3
TEXT:  on RAM it's fine: 162 key-value pairs and a hash value for each get operation in
```

<img width="619" height="93" alt="Screenshot 2026-05-28 at 02 54 08" src="https://github.com/user-attachments/assets/ed3985c8-71c7-441d-a9c7-0357073f4011" />

## Type

🆕 New Feature

## Changes

Registers Tensormesh (`tensormesh`) as a JSON-configured OpenAI-compatible provider, following the existing pattern (`veniceai`, `scaleway`, `telnyx`):

- **`litellm/llms/openai_like/providers.json`** — provider entry: serverless base URL `https://serverless.tensormesh.ai/v1`, `TENSORMESH_INFERENCE_API_KEY`, optional `TENSORMESH_SERVERLESS_BASE_URL` override, and `max_completion_tokens` → `max_tokens` mapping
- **`litellm/types/utils.py`** — `LlmProviders.TENSORMESH`
- **`litellm/constants.py`** — added to `openai_compatible_endpoints`, `openai_compatible_providers`, and `openai_text_completion_compatible_providers`
- **`provider_endpoints_support.json`** — endpoint support metadata (`chat_completions`, `text_completion`, and the `/v1/messages` adapter)
- **`tests/test_litellm/llms/openai_like/test_tensormesh_provider.py`** — unit tests: provider registration, `providers.json` config, `tensormesh/<model>` resolution → serverless base URL, `api_base`/`api_key` override, text-completion wiring, Router config

Usage:

```python
from litellm import completion

response = completion(
    model="tensormesh/<model>",
    messages=[{"role": "user", "content": "hello"}],
)
```

Per-model pricing + tool-calling capability flags, and `/v1/responses` support, will follow in separate PRs to keep this change focused.