### PR TITLE
test(e2e): cover Internal User key modal, team info, key page

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/helpers/navigation.ts
+++ b/ui/litellm-dashboard/e2e_tests/helpers/navigation.ts
@@ -23,3 +23,15 @@ export async function dismissFeedbackPopup(page: PlaywrightPage): Promise<void> 
     await expect(dismissButton).not.toBeVisible({ timeout: 2_000 }).catch(() => {});
   }
 }
+
+/**
+ * Click on a team ID in the table. Team IDs are rendered differently depending
+ * on the component version — try button first (Tremor Button), fall back to
+ * clickable span (OldTeams Typography.Text).
+ */
+export async function clickTeamId(page: PlaywrightPage, teamId: string): Promise<void> {
+  const cell = page.locator("td").filter({ hasText: teamId }).first();
+  await expect(cell).toBeVisible({ timeout: 10_000 });
+  await cell.click();
+  await expect(page.getByText("Back to Teams")).toBeVisible({ timeout: 10_000 });
+}

--- a/ui/litellm-dashboard/e2e_tests/tests/internal-user/internalUser.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/internal-user/internalUser.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import {
+  E2E_TEAM_CRUD_ALIAS,
+  E2E_TEAM_CRUD_ID,
+  INTERNAL_USER_STORAGE_PATH,
+} from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage, dismissFeedbackPopup } from "../../helpers/navigation";
+
+async function clickTeamId(page: import("@playwright/test").Page, teamId: string) {
+  const cell = page.locator("td").filter({ hasText: teamId }).first();
+  await expect(cell).toBeVisible({ timeout: 10_000 });
+  await cell.click();
+  await expect(page.getByText("Back to Teams")).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Internal User", () => {
+  test.use({ storageState: INTERNAL_USER_STORAGE_PATH });
+
+  test("Create Key modal shows the team dropdown populated with the user's teams", async ({ page }) => {
+    await navigateToPage(page, Page.ApiKeys);
+    await dismissFeedbackPopup(page);
+
+    await page.getByRole("button", { name: /Create New Key/i }).click();
+    await expect(page.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
+
+    // Open the team dropdown — seeded internal user is a member of
+    // e2e-team-crud and e2e-team-org, so we expect at least the CRUD alias.
+    const teamSelect = page.locator(".ant-select", { hasText: "Search or select a team" });
+    await teamSelect.click();
+    await page.keyboard.type(E2E_TEAM_CRUD_ALIAS);
+    await expect(
+      page.locator(".ant-select-dropdown:visible").getByText(E2E_TEAM_CRUD_ALIAS).first(),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("Team info page omits the Settings tab for non-admin members", async ({ page }) => {
+    await navigateToPage(page, Page.Teams);
+    await dismissFeedbackPopup(page);
+
+    await clickTeamId(page, E2E_TEAM_CRUD_ID);
+
+    // Overview / My User / Virtual Keys are always visible; Settings is gated
+    // on canEditTeam and must NOT render for a regular team member.
+    await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole("tab", { name: "Settings" })).not.toBeVisible();
+    await expect(page.getByRole("tab", { name: "Members" })).not.toBeVisible();
+  });
+
+  test("Virtual Keys page does not surface litellm-dashboard team keys", async ({ page }) => {
+    await navigateToPage(page, Page.ApiKeys);
+    await dismissFeedbackPopup(page);
+
+    // The litellm-dashboard team is the proxy's internal bookkeeping team —
+    // its keys must never leak into an internal user's Virtual Keys table.
+    await expect(page.locator("table tbody")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("table tbody").getByText("litellm-dashboard")).toHaveCount(0);
+  });
+});

--- a/ui/litellm-dashboard/e2e_tests/tests/internal-user/internalUser.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/internal-user/internalUser.spec.ts
@@ -1,25 +1,18 @@
 import { test, expect } from "@playwright/test";
 import {
+  E2E_INTERNAL_USER_KEY_ALIAS,
   E2E_TEAM_CRUD_ALIAS,
   E2E_TEAM_CRUD_ID,
   INTERNAL_USER_STORAGE_PATH,
 } from "../../constants";
 import { Page } from "../../fixtures/pages";
-import { navigateToPage, dismissFeedbackPopup } from "../../helpers/navigation";
-
-async function clickTeamId(page: import("@playwright/test").Page, teamId: string) {
-  const cell = page.locator("td").filter({ hasText: teamId }).first();
-  await expect(cell).toBeVisible({ timeout: 10_000 });
-  await cell.click();
-  await expect(page.getByText("Back to Teams")).toBeVisible({ timeout: 10_000 });
-}
+import { navigateToPage, clickTeamId } from "../../helpers/navigation";
 
 test.describe("Internal User", () => {
   test.use({ storageState: INTERNAL_USER_STORAGE_PATH });
 
   test("Create Key modal shows the team dropdown populated with the user's teams", async ({ page }) => {
     await navigateToPage(page, Page.ApiKeys);
-    await dismissFeedbackPopup(page);
 
     await page.getByRole("button", { name: /Create New Key/i }).click();
     await expect(page.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
@@ -36,7 +29,6 @@ test.describe("Internal User", () => {
 
   test("Team info page omits the Settings tab for non-admin members", async ({ page }) => {
     await navigateToPage(page, Page.Teams);
-    await dismissFeedbackPopup(page);
 
     await clickTeamId(page, E2E_TEAM_CRUD_ID);
 
@@ -49,11 +41,15 @@ test.describe("Internal User", () => {
 
   test("Virtual Keys page does not surface litellm-dashboard team keys", async ({ page }) => {
     await navigateToPage(page, Page.ApiKeys);
-    await dismissFeedbackPopup(page);
+
+    // Anchor on the user's own seeded key so the absence check below cannot
+    // pass vacuously against an empty table.
+    await expect(
+      page.locator("table tbody").getByText(E2E_INTERNAL_USER_KEY_ALIAS).first(),
+    ).toBeVisible({ timeout: 10_000 });
 
     // The litellm-dashboard team is the proxy's internal bookkeeping team —
     // its keys must never leak into an internal user's Virtual Keys table.
-    await expect(page.locator("table tbody")).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("table tbody").getByText("litellm-dashboard")).toHaveCount(0);
   });
 });

--- a/ui/litellm-dashboard/e2e_tests/tests/proxy-admin/teams.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/proxy-admin/teams.spec.ts
@@ -7,19 +7,7 @@ import {
   E2E_TEAM_ORG_ID,
 } from "../../constants";
 import { Page } from "../../fixtures/pages";
-import { navigateToPage, dismissFeedbackPopup } from "../../helpers/navigation";
-
-/**
- * Click on a team ID in the table. Team IDs are rendered differently depending
- * on the component version — try button first (Tremor Button), fall back to
- * clickable span (OldTeams Typography.Text).
- */
-async function clickTeamId(page: import("@playwright/test").Page, teamId: string) {
-  const cell = page.locator("td").filter({ hasText: teamId }).first();
-  await expect(cell).toBeVisible({ timeout: 10_000 });
-  await cell.click();
-  await expect(page.getByText("Back to Teams")).toBeVisible({ timeout: 10_000 });
-}
+import { navigateToPage, dismissFeedbackPopup, clickTeamId } from "../../helpers/navigation";
 
 test.describe("Proxy Admin - Teams", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH });


### PR DESCRIPTION
## Summary

Adds e2e coverage for three previously-uncovered Internal User manual-QA items, using `INTERNAL_USER_STORAGE_PATH`:

## Test plan
- [x] `e2e_tests/tests/internal-user/internalUser.spec.ts::Create Key modal shows the team dropdown populated with the user's teams`
- [x] `e2e_tests/tests/internal-user/internalUser.spec.ts::Team info page omits the Settings tab for non-admin members`
- [x] `e2e_tests/tests/internal-user/internalUser.spec.ts::Virtual Keys page does not surface litellm-dashboard team keys`

Refs LIT-3093