### PR TITLE
feat(bedrock): warn when stripping unsupported context_management edits

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -409,6 +409,14 @@ class AmazonAnthropicClaudeMessagesConfig(
             if self._supports_tool_search_on_bedrock(model):
                 beta_set.add("tool-search-tool-2025-10-19")
 
+    # Edit types that the proxy consumes/injects internally before sending the
+    # request upstream. Stripping these on Bedrock InvokeModel is expected and
+    # should NOT produce a warning, because the customer did not ask for them
+    # to run on Bedrock — Claude Code sends them on every request.
+    _LITELLM_INTERNAL_CONTEXT_MANAGEMENT_EDIT_TYPES = frozenset(
+        {"clear_thinking_20251015"}
+    )
+
     @staticmethod
     def _filter_context_management_for_bedrock_invoke(
         anthropic_messages_request: Dict,
@@ -426,6 +434,10 @@ class AmazonAnthropicClaudeMessagesConfig(
         compact edits remain, and drop ``context_management`` entirely when no
         supported edits are left so the safety-net allowlist can pass it through.
 
+        When customer-requested edit types (e.g. ``clear_tool_uses_20250919``)
+        get stripped because Bedrock InvokeModel does not support them, emit a
+        warning so the silent no-op is visible in the proxy logs.
+
         Ref: https://github.com/BerriAI/litellm/issues/27532
         """
         cm = anthropic_messages_request.get("context_management")
@@ -441,6 +453,45 @@ class AmazonAnthropicClaudeMessagesConfig(
             for e in edits
             if isinstance(e, dict) and e.get("type") == "compact_20260112"
         ]
+
+        # Identify edit types we are about to drop because Bedrock InvokeModel
+        # cannot accept them. Skip the LiteLLM-internal ones — those are
+        # consumed elsewhere in the pipeline and not stripping them on Bedrock
+        # is not surprising. Anything left is a customer-requested edit type
+        # that will silently not run on Bedrock InvokeModel, which is the
+        # exact case the warning is meant to surface.
+        dropped_edit_types: List[str] = []
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
+            edit_type = edit.get("type")
+            if edit_type == "compact_20260112":
+                continue
+            if (
+                isinstance(edit_type, str)
+                and edit_type
+                in AmazonAnthropicClaudeMessagesConfig._LITELLM_INTERNAL_CONTEXT_MANAGEMENT_EDIT_TYPES
+            ):
+                continue
+            if isinstance(edit_type, str) and edit_type:
+                dropped_edit_types.append(edit_type)
+            else:
+                dropped_edit_types.append("<unknown>")
+
+        if dropped_edit_types:
+            # Stable, de-duplicated order so the warning is short when a
+            # request repeats the same edit type and operators / tests can
+            # match against the message reliably.
+            unique_dropped = sorted(set(dropped_edit_types))
+            verbose_logger.warning(
+                "Bedrock InvokeModel does not support context_management "
+                "edit types %s; dropping them from the request. Supported "
+                "edit type on Bedrock InvokeModel is compact_20260112 "
+                "(paired with anthropic-beta compact-2026-01-12). "
+                "See https://github.com/BerriAI/litellm/issues/27532",
+                unique_dropped,
+            )
+
         if compact_edits:
             beta_set.add("compact-2026-01-12")
             anthropic_messages_request["context_management"] = {

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1497,3 +1497,138 @@ async def test_unified_bedrock_messages_sse_usage_and_cost_claude_sonnet_46():
         custom_llm_provider="bedrock",
     )
     assert cost == pytest.approx(0.052150725, rel=0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# LIT-3393: surface a warning when Bedrock InvokeModel silently strips
+# unsupported context_management edit types so the no-op is visible in logs.
+# ---------------------------------------------------------------------------
+
+
+def _run_filter_with_caplog(optional_params, caplog):
+    """Helper: drive _filter_context_management_for_bedrock_invoke through the
+    public transform path so we exercise the same call site Bedrock requests
+    take in production."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    with caplog.at_level("WARNING", logger="LiteLLM"):
+        return cfg.transform_anthropic_messages_request(
+            model="anthropic.claude-3-haiku-20240307-v1:0",
+            messages=messages,
+            anthropic_messages_optional_request_params=optional_params,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+
+def test_bedrock_messages_warns_on_dropped_clear_tool_uses_edit(caplog):
+    """LIT-3393: Bedrock InvokeModel does not support clear_tool_uses_20250919.
+    The transform must drop the edit AND log a warning so the silent no-op is
+    observable."""
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [{"type": "clear_tool_uses_20250919", "keep": 3}]
+        },
+    }
+    result = _run_filter_with_caplog(optional_params, caplog)
+    assert "context_management" not in result
+    warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING"
+        and "context_management" in r.getMessage()
+        and "clear_tool_uses_20250919" in r.getMessage()
+    ]
+    assert warnings, (
+        "expected a warning naming clear_tool_uses_20250919 when Bedrock "
+        f"strips it; got records: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_bedrock_messages_does_not_warn_on_internal_clear_thinking_edit(caplog):
+    """clear_thinking_20251015 is LiteLLM-internal (Claude Code sends it every
+    request and the proxy consumes it via thinking injection). Bedrock strips
+    it as before, but we MUST NOT warn — that would create per-request log
+    noise for every Claude Code call."""
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [{"type": "clear_thinking_20251015", "keep": "all"}]
+        },
+    }
+    result = _run_filter_with_caplog(optional_params, caplog)
+    assert "context_management" not in result
+    noise = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "context_management" in r.getMessage()
+    ]
+    assert not noise, (
+        "did not expect a warning for the LiteLLM-internal clear_thinking_20251015 "
+        f"edit type; got: {[r.getMessage() for r in noise]}"
+    )
+
+
+def test_bedrock_messages_warns_only_on_unsupported_when_mixed(caplog):
+    """Mixed list: compact_20260112 is kept (supported), clear_tool_uses_20250919
+    is dropped with a warning, clear_thinking_20251015 is dropped silently."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "clear_thinking_20251015", "keep": "all"},
+                {"type": "clear_tool_uses_20250919", "keep": 3},
+                {"type": "compact_20260112"},
+            ]
+        },
+    }
+    with caplog.at_level("WARNING", logger="LiteLLM"):
+        result = cfg.transform_anthropic_messages_request(
+            model="anthropic.claude-sonnet-4-6-20250929-v1:0",
+            messages=messages,
+            anthropic_messages_optional_request_params=optional_params,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+    # supported edit survives
+    assert result.get("context_management") == {
+        "edits": [{"type": "compact_20260112"}]
+    }
+    assert "compact-2026-01-12" in result.get("anthropic_beta", [])
+    # warning fires once, names clear_tool_uses_20250919, not clear_thinking_20251015
+    msgs = [
+        r.getMessage() for r in caplog.records
+        if r.levelname == "WARNING" and "context_management" in r.getMessage()
+    ]
+    assert any("clear_tool_uses_20250919" in m for m in msgs), msgs
+    assert not any("clear_thinking_20251015" in m for m in msgs), msgs
+
+
+def test_bedrock_messages_deduplicates_dropped_edit_types_in_warning(caplog):
+    """Repeated unsupported edit types should appear once in the warning."""
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "clear_tool_uses_20250919", "keep": 3},
+                {"type": "clear_tool_uses_20250919", "keep": 5},
+                {"type": "some_future_edit_2027"},
+            ]
+        },
+    }
+    result = _run_filter_with_caplog(optional_params, caplog)
+    assert "context_management" not in result
+    msgs = [
+        r.getMessage() for r in caplog.records
+        if r.levelname == "WARNING" and "context_management" in r.getMessage()
+    ]
+    assert len(msgs) == 1, f"expected exactly one warning, got {msgs}"
+    # both unique types named, no duplicate
+    assert "clear_tool_uses_20250919" in msgs[0]
+    assert "some_future_edit_2027" in msgs[0]
+    assert msgs[0].count("clear_tool_uses_20250919") == 1


### PR DESCRIPTION
## What

`AmazonAnthropicClaudeMessagesConfig._filter_context_management_for_bedrock_invoke` already strips `context_management` edit types that Bedrock InvokeModel rejects (issue #27532). The strip is silent — when a customer asks for `clear_tool_uses_20250919`, the request succeeds (no 400), but the tool-clearing never runs and there is nothing in the logs to tell anyone why.

This PR adds a `verbose_logger.warning` listing the dropped customer-requested edit types so the silent no-op becomes observable in proxy logs. The fix is log-only — no behaviour change to the request itself.

The LiteLLM-internal `clear_thinking_20251015` edit (which Claude Code sends on every request and the proxy consumes via thinking injection) is explicitly excluded from the warning so we don't create per-request log noise for every Claude Code call.

## Why

Refs:
- BerriAI/litellm#27532 — compaction support added; this is the follow-up "make the silent strip visible" action item.
- LIT-3393 — surface a warning when an unsupported edit type is stripped so it isn't silent.

Supported edit type on Bedrock InvokeModel today: `compact_20260112` (paired with `compact-2026-01-12` anthropic-beta header). Everything else is dropped.

## How

`litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py`:
- Added `_LITELLM_INTERNAL_CONTEXT_MANAGEMENT_EDIT_TYPES = frozenset({"clear_thinking_20251015"})` — set of internal-only edit types that should not trigger the warning.
- In `_filter_context_management_for_bedrock_invoke`, after computing `compact_edits`, walk the original `edits` once more and collect any non-compact, non-internal edit types into `dropped_edit_types`. If non-empty, emit a `verbose_logger.warning` with a stable, de-duplicated, sorted list. Existing behaviour (strip + add beta header for compact) is unchanged.

Tests in `tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py`:
- `test_bedrock_messages_warns_on_dropped_clear_tool_uses_edit` — the LIT-3393 repro: a single `clear_tool_uses_20250919` edit produces a warning naming it.
- `test_bedrock_messages_does_not_warn_on_internal_clear_thinking_edit` — Claude Code's `clear_thinking_20251015` is still stripped, but silently (no log noise).
- `test_bedrock_messages_warns_only_on_unsupported_when_mixed` — mixed list: `compact_20260112` survives + beta header added, `clear_tool_uses_20250919` triggers a warning, `clear_thinking_20251015` does not.
- `test_bedrock_messages_deduplicates_dropped_edit_types_in_warning` — repeated unsupported edit types appear once each in the warning, sorted.

### Evidence

### 1. Direct transform call — before vs. after

Same fixture (customer sends `clear_tool_uses_20250919`), driven through `AmazonAnthropicClaudeMessagesConfig.transform_anthropic_messages_request` exactly as it is invoked on every Bedrock InvokeModel request:

**Before (current `litellm_oss_agent_shin_daily_branch`)** — silent strip, nothing in stderr:
```
=== Case 1: customer sends clear_tool_uses_20250919 ===
result.context_management: None
result.anthropic_beta: None

=== Case 2: Claude Code clear_thinking_20251015 (internal) ===
result.context_management: None

=== Case 3: mixed list ===
result.context_management: {'edits': [{'type': 'compact_20260112'}]}
result.anthropic_beta: ['compact-2026-01-12']
```

**After (this branch)** — warning surfaces for the customer edit; internal edit stays silent:
```
=== Case 1: customer sends clear_tool_uses_20250919 ===
WARNING LiteLLM: Bedrock InvokeModel does not support context_management edit
types ['clear_tool_uses_20250919']; dropping them from the request. Supported
edit type on Bedrock InvokeModel is compact_20260112 (paired with anthropic-beta
compact-2026-01-12). See https://github.com/BerriAI/litellm/issues/27532
result.context_management: None
result.anthropic_beta: None

=== Case 2: Claude Code clear_thinking_20251015 (internal) ===
result.context_management: None       # <-- no warning, as designed

=== Case 3: mixed list ===
WARNING LiteLLM: Bedrock InvokeModel does not support context_management edit
types ['clear_tool_uses_20250919']; ...
result.context_management: {'edits': [{'type': 'compact_20260112'}]}
result.anthropic_beta: ['compact-2026-01-12']
```

### 2. Live proxy capture

Booted the proxy on this branch with a `bedrock-claude` model deployment (dummy creds — the SigV4 layer 403s, but the transform runs first):

```
$ curl http://localhost:4000/v1/messages -H 'Authorization: Bearer sk-1234' -d '{
    "model":"bedrock-claude","max_tokens":50,
    "messages":[{"role":"user","content":"hi"}],
    "context_management":{"edits":[{"type":"clear_tool_uses_20250919","keep":3}]}
  }'
HTTP 403   # expected — dummy AWS creds; we care about the warning the proxy emitted

# proxy.log:
21:23:17 - LiteLLM:WARNING: anthropic_claude3_transformation.py:486 - Bedrock InvokeModel does not support context_management edit types ['clear_tool_uses_20250919']; dropping them from the request. Supported edit type on Bedrock InvokeModel is compact_20260112 (paired with anthropic-beta compact-2026-01-12). See https://github.com/BerriAI/litellm/issues/27532
21:23:18 - LiteLLM:WARNING: anthropic_claude3_transformation.py:486 - Bedrock InvokeModel does not support context_management edit types ['clear_tool_uses_20250919']; ...
21:23:19 - LiteLLM:WARNING: anthropic_claude3_transformation.py:486 - Bedrock InvokeModel does not support context_management edit types ['clear_tool_uses_20250919']; ...
INFO:     127.0.0.1:48922 - "POST /v1/messages HTTP/1.1" 403 Forbidden
```

(The repeat is the AWS retry layer — `clear_tool_uses` was stripped once per attempt; the customer’s edit type appears once in each warning line because we de-dup inside the call.)

Control: same request but with the internal `clear_thinking_20251015` edit — `0` `context_management` warnings emitted after the barrier marker. Confirms the carve-out behaves.

### 3. Unit tests

```
$ pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py \
        -k "context_management or warns or deduplicates"
... 7 passed, 38 deselected
```

The 7 tests are the 3 existing `context_management` tests + the 4 new ones added in this PR.

## Push path

Pushed via `PUT /repos/{owner}/{repo}/contents/{path}` because the agent's `GITHUB_TOKEN` lacks `repo`/`workflow` scopes (known limit). Reviewers should expect a slightly noisier merge-base diff than a normal `git push` would produce.

## Linear

LIT-3393


### Verification (ship-pr)
- change-type: 2 files (`anthropic_claude3_transformation.py` source + matching test). Evidence type required: **backend / logging**.
- evidence present: PASS — `### Evidence` section, before+after direct-transform output, live proxy.log warning capture, control case showing no warning for the internal edit type.
- image sanity: N/A — backend logging change, no UI screenshots.
- image content matches caption: N/A — no screenshots.
- backend evidence from running system: PASS — proxy booted on this branch, real `POST /v1/messages` requests, warning lines emitted by `anthropic_claude3_transformation.py:486` captured from `/tmp/proxy.log`.
