### PR TITLE
fix(bedrock): forward clear_tool_uses context_management on Invoke route

### DIFF
--- a/litellm/anthropic_beta_headers_config.json
+++ b/litellm/anthropic_beta_headers_config.json
@@ -102,7 +102,7 @@
     "computer-use-2025-01-24": "computer-use-2025-01-24",
     "computer-use-2025-11-24": "computer-use-2025-11-24",
     "context-1m-2025-08-07": "context-1m-2025-08-07",
-    "context-management-2025-06-27": null,
+    "context-management-2025-06-27": "context-management-2025-06-27",
     "effort-2025-11-24": "effort-2025-11-24",
     "fast-mode-2026-02-01": null,
     "files-api-2025-04-14": null,

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -415,18 +415,26 @@ class AmazonAnthropicClaudeMessagesConfig(
         beta_set: set,
     ) -> None:
         """
-        Bedrock InvokeModel accepts ``context_management`` only when it carries
-        ``compact_20260112`` edits paired with the ``compact-2026-01-12``
-        anthropic-beta header. Other edit types (notably ``clear_thinking_20251015``,
-        which Claude Code sends on every request) are LiteLLM-internal and would
-        cause Bedrock to 400 with ``"context_management: Extra inputs are not
-        permitted"``.
+        Bedrock InvokeModel supports two ``context_management`` edit types, each
+        gated behind its own anthropic-beta header:
 
-        Filter the edits list to the supported subset, add the beta header when
-        compact edits remain, and drop ``context_management`` entirely when no
-        supported edits are left so the safety-net allowlist can pass it through.
+        - ``compact_20260112`` (compaction) -> ``compact-2026-01-12``
+        - ``clear_tool_uses_20250919`` (automatic tool call clearing) ->
+          ``context-management-2025-06-27``
 
-        Ref: https://github.com/BerriAI/litellm/issues/27532
+        Other edit types (notably ``clear_thinking_20251015``, which Claude Code
+        sends on every request and is consumed via thinking injection upstream)
+        are not accepted by Bedrock InvokeModel and would cause it to 400 with
+        ``"context_management: Extra inputs are not permitted"``.
+
+        Filter the edits list to the Bedrock-supported subset, add the matching
+        beta header for each kind that survives, and drop ``context_management``
+        entirely when no supported edits are left so the safety-net allowlist can
+        pass it through.
+
+        Refs:
+            https://github.com/BerriAI/litellm/issues/27532
+            https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html
         """
         cm = anthropic_messages_request.get("context_management")
         if not isinstance(cm, dict):
@@ -436,16 +444,22 @@ class AmazonAnthropicClaudeMessagesConfig(
             anthropic_messages_request.pop("context_management", None)
             return
 
-        compact_edits = [
-            e
-            for e in edits
-            if isinstance(e, dict) and e.get("type") == "compact_20260112"
-        ]
-        if compact_edits:
-            beta_set.add("compact-2026-01-12")
+        supported_edits = []
+        for e in edits:
+            if not isinstance(e, dict):
+                continue
+            edit_type = e.get("type")
+            if edit_type == "compact_20260112":
+                beta_set.add("compact-2026-01-12")
+                supported_edits.append(e)
+            elif edit_type == "clear_tool_uses_20250919":
+                beta_set.add("context-management-2025-06-27")
+                supported_edits.append(e)
+
+        if supported_edits:
             anthropic_messages_request["context_management"] = {
                 **cm,
-                "edits": compact_edits,
+                "edits": supported_edits,
             }
         else:
             anthropic_messages_request.pop("context_management", None)

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -1043,9 +1043,10 @@ class BedrockInvokeAnthropicMessagesRequest(TypedDict, total=False):
     metadata: dict
     output_config: dict
 
-    # `context_management` is allowed for Bedrock InvokeModel only when it
-    # carries `compact_20260112` edits paired with the `compact-2026-01-12`
-    # anthropic-beta header. The Invoke transformation filters edits to the
-    # supported subset and strips the field entirely when nothing remains, so
-    # other edit types (e.g. `clear_thinking_20251015`) never reach Bedrock.
+    # `context_management` is allowed for Bedrock InvokeModel when it carries
+    # `compact_20260112` (paired with the `compact-2026-01-12` beta) and/or
+    # `clear_tool_uses_20250919` (paired with `context-management-2025-06-27`)
+    # edits. The Invoke transformation filters edits to that supported subset
+    # and strips the field entirely when nothing remains, so other edit types
+    # (e.g. `clear_thinking_20251015`) never reach Bedrock.
     context_management: dict

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1071,9 +1071,7 @@ def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
     optional_params = {
         "max_tokens": 4096,
-        "context_management": {
-            "edits": [{"type": "compact_20260112"}]
-        },
+        "context_management": {"edits": [{"type": "compact_20260112"}]},
     }
 
     result = cfg.transform_anthropic_messages_request(
@@ -1084,10 +1082,52 @@ def test_bedrock_messages_preserves_compact_context_management_and_adds_beta():
         headers={},
     )
 
-    assert result.get("context_management") == {
-        "edits": [{"type": "compact_20260112"}]
-    }
+    assert result.get("context_management") == {"edits": [{"type": "compact_20260112"}]}
     assert "compact-2026-01-12" in result.get("anthropic_beta", [])
+    assert result["max_tokens"] == 4096
+
+
+def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_beta(
+    monkeypatch,
+):
+    """
+    Bedrock InvokeModel supports automatic tool call clearing
+    (``clear_tool_uses_20250919``) when paired with the
+    ``context-management-2025-06-27`` anthropic-beta header. The transformation
+    should keep the edit in the body and auto-inject that beta header.
+
+    Ref: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html
+    """
+    from litellm import anthropic_beta_headers_manager
+    from litellm.types.router import GenericLiteLLMParams
+
+    # Pin to the bundled local config (the source of truth in this repo) instead
+    # of the remote copy fetched from main, which lags this change until merge.
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    monkeypatch.setattr(anthropic_beta_headers_manager, "_BETA_HEADERS_CONFIG", None)
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    edit = {
+        "type": "clear_tool_uses_20250919",
+        "trigger": {"type": "input_tokens", "value": 30000},
+        "keep": {"type": "tool_uses", "value": 3},
+    }
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {"edits": [edit]},
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("context_management") == {"edits": [edit]}
+    assert "context-management-2025-06-27" in result.get("anthropic_beta", [])
     assert result["max_tokens"] == 4096
 
 
@@ -1118,9 +1158,7 @@ def test_bedrock_messages_filters_unsupported_context_management_edits():
         headers={},
     )
 
-    assert result.get("context_management") == {
-        "edits": [{"type": "compact_20260112"}]
-    }
+    assert result.get("context_management") == {"edits": [{"type": "compact_20260112"}]}
     assert "compact-2026-01-12" in result.get("anthropic_beta", [])
 
 


### PR DESCRIPTION
## Summary

Bedrock InvokeModel supports automatic tool call clearing (`clear_tool_uses_20250919`) when paired with the `context-management-2025-06-27` beta header ([AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html), "Automatic tool call clearing"). LiteLLM was blocking it in two places:

1. `anthropic_beta_headers_config.json` mapped `context-management-2025-06-27` to `null` for the `bedrock` provider, so `filter_and_transform_beta_headers` dropped it from the request body.
2. `_filter_context_management_for_bedrock_invoke` stripped every non-compact `context_management` edit before signing.

Net effect: `/v1/messages` → `bedrock/invoke/` requests carrying `clear_tool_uses` 400'd with `context_management: Extra inputs are not permitted`, and after the field was stripped the edit silently never ran.

## Changes

- Flip the `bedrock` beta-header mapping so `context-management-2025-06-27` is forwarded (left `bedrock_converse` `null` — Converse genuinely lacks it).
- Keep `clear_tool_uses_20250919` edits in the Invoke body and auto-inject the `context-management-2025-06-27` beta, alongside the existing `compact_20260112` → `compact-2026-01-12` handling. Other internal edit types (e.g. `clear_thinking_20251015`) are still filtered out.
- Update the `BedrockInvokeAnthropicMessagesRequest` doc comment.
- Add a regression test (Claude Haiku 4.5) asserting the edit is preserved and the beta header is injected; pins to the local config since the runtime fetches the published copy from `main`.

This is the same class of bug as the compaction fix (#27532), applied to the tool-clearing edit type.

## Test plan

- [x] `pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py -k "context_management or clear_tool_uses or compact or allowlist or beta"` (7 passed)
- [x] `pytest tests/test_litellm/test_anthropic_beta_headers_filtering.py` (19 passed)
- [x] `black --check` clean

https://claude.ai/code/session_015VbTqXYwNLNP7LbqXkyUMN

---
_Generated by [Claude Code](https://claude.ai/code/session_015VbTqXYwNLNP7LbqXkyUMN)_