### PR TITLE
fix(vertex_ai): Bake tool_choice into Gemini CachedContent body to prevent silent drop

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -337,6 +337,7 @@ class ContextCachingEndpoints(VertexBase):
             return messages, optional_params, None
 
         tools = optional_params.pop("tools", None)
+        tool_choice = optional_params.pop("tool_choice", None)
 
         ## AUTHORIZATION ##
         token, url = self._get_token_and_url_context_caching(
@@ -371,7 +372,7 @@ class ContextCachingEndpoints(VertexBase):
 
         ## CHECK IF CACHED ALREADY
         generated_cache_key = local_cache_obj.get_cache_key(
-            messages=cached_messages, tools=tools, model=model
+            messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
         google_cache_name = self.check_cache(
             cache_key=generated_cache_key,
@@ -402,6 +403,8 @@ class ContextCachingEndpoints(VertexBase):
         )
 
         cached_content_request_body["tools"] = tools
+        if tool_choice is not None:
+            cached_content_request_body["toolConfig"] = tool_choice
 
         ## LOGGING
         logging_obj.pre_call(
@@ -487,6 +490,7 @@ class ContextCachingEndpoints(VertexBase):
             return messages, optional_params, None
 
         tools = optional_params.pop("tools", None)
+        tool_choice = optional_params.pop("tool_choice", None)
 
         ## AUTHORIZATION ##
         token, url = self._get_token_and_url_context_caching(
@@ -518,7 +522,7 @@ class ContextCachingEndpoints(VertexBase):
 
         ## CHECK IF CACHED ALREADY
         generated_cache_key = local_cache_obj.get_cache_key(
-            messages=cached_messages, tools=tools, model=model
+            messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
         google_cache_name = await self.async_check_cache(
             cache_key=generated_cache_key,
@@ -550,6 +554,8 @@ class ContextCachingEndpoints(VertexBase):
         )
 
         cached_content_request_body["tools"] = tools
+        if tool_choice is not None:
+            cached_content_request_body["toolConfig"] = tool_choice
 
         ## LOGGING
         logging_obj.pre_call(

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -201,9 +201,12 @@ class TestContextCachingEndpoints:
         assert returned_params == optional_params
         assert returned_cache == "existing_cache_name"
 
-        # Verify cache key was generated with tools and model
+        # Verify cache key was generated with tools, tool_choice and model
         mock_cache_obj.get_cache_key.assert_called_once_with(
-            messages=cached_messages, tools=self.sample_tools, model="gemini-1.5-pro"
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=None,
+            model="gemini-1.5-pro",
         )
 
     @pytest.mark.parametrize(
@@ -474,9 +477,12 @@ class TestContextCachingEndpoints:
         assert returned_params == optional_params
         assert returned_cache == "existing_cache_name"
 
-        # Verify cache key was generated with tools and model
+        # Verify cache key was generated with tools, tool_choice and model
         mock_cache_obj.get_cache_key.assert_called_once_with(
-            messages=cached_messages, tools=self.sample_tools, model="gemini-1.5-pro"
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=None,
+            model="gemini-1.5-pro",
         )
 
     @pytest.mark.asyncio
@@ -799,6 +805,453 @@ class TestContextCachingEndpoints:
 
             # But original tools should still be available for comparison
             assert original_tools == self.sample_tools
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    def test_check_and_create_cache_tool_choice_popped_from_optional_params(
+        self, custom_llm_provider
+    ):
+        """tool_choice is popped from optional_params when cached messages exist."""
+        with patch(
+            "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+        ) as mock_separate:
+            cached_messages = [self.sample_messages[0]]
+            non_cached_messages = [self.sample_messages[1]]
+            mock_separate.return_value = (cached_messages, non_cached_messages)
+
+            optional_params = self.sample_optional_params.copy()
+            optional_params["tool_choice"] = "required"
+
+            with patch.object(
+                self.context_caching, "check_cache", return_value="existing_cache"
+            ):
+                self.context_caching.check_and_create_cache(
+                    messages=self.sample_messages,
+                    optional_params=optional_params,
+                    api_key="test_key",
+                    api_base=None,
+                    model="gemini-1.5-pro",
+                    client=self.mock_client,
+                    timeout=30.0,
+                    logging_obj=self.mock_logging,
+                    custom_llm_provider=custom_llm_provider,
+                    vertex_project="test_project",
+                    vertex_location="test_location",
+                    vertex_auth_header="vertext_test_token",
+                )
+
+            assert "tool_choice" not in optional_params
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    def test_check_and_create_cache_tool_choice_not_popped_when_no_cached_messages(
+        self, custom_llm_provider
+    ):
+        """tool_choice is NOT popped when there are no cached messages (early return)."""
+        with patch(
+            "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+        ) as mock_separate:
+            mock_separate.return_value = ([], self.sample_messages)
+
+            optional_params = self.sample_optional_params.copy()
+            optional_params["tool_choice"] = "auto"
+
+            self.context_caching.check_and_create_cache(
+                messages=self.sample_messages,
+                optional_params=optional_params,
+                api_key="test_key",
+                api_base=None,
+                model="gemini-1.5-pro",
+                client=self.mock_client,
+                timeout=30.0,
+                logging_obj=self.mock_logging,
+                custom_llm_provider=custom_llm_provider,
+                vertex_project="test_project",
+                vertex_location="test_location",
+                vertex_auth_header="vertext_test_token",
+            )
+
+            assert optional_params.get("tool_choice") == "auto"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    async def test_async_check_and_create_cache_tool_choice_popped_from_optional_params(
+        self, custom_llm_provider
+    ):
+        """Async equivalent of test_check_and_create_cache_tool_choice_popped_from_optional_params."""
+        with patch(
+            "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+        ) as mock_separate:
+            cached_messages = [self.sample_messages[0]]
+            non_cached_messages = [self.sample_messages[1]]
+            mock_separate.return_value = (cached_messages, non_cached_messages)
+
+            optional_params = self.sample_optional_params.copy()
+            optional_params["tool_choice"] = "required"
+
+            with patch.object(
+                self.context_caching, "async_check_cache", return_value="existing_cache"
+            ):
+                await self.context_caching.async_check_and_create_cache(
+                    messages=self.sample_messages,
+                    optional_params=optional_params,
+                    api_key="test_key",
+                    api_base=None,
+                    model="gemini-1.5-pro",
+                    client=self.mock_async_client,
+                    timeout=30.0,
+                    logging_obj=self.mock_logging,
+                    custom_llm_provider=custom_llm_provider,
+                    vertex_project="test_project",
+                    vertex_location="test_location",
+                    vertex_auth_header="vertext_test_token",
+                )
+
+            assert "tool_choice" not in optional_params
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    async def test_async_check_and_create_cache_tool_choice_not_popped_when_no_cached_messages(
+        self, custom_llm_provider
+    ):
+        """Async equivalent of test_check_and_create_cache_tool_choice_not_popped_when_no_cached_messages."""
+        with patch(
+            "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+        ) as mock_separate:
+            mock_separate.return_value = ([], self.sample_messages)
+
+            optional_params = self.sample_optional_params.copy()
+            optional_params["tool_choice"] = "auto"
+
+            await self.context_caching.async_check_and_create_cache(
+                messages=self.sample_messages,
+                optional_params=optional_params,
+                api_key="test_key",
+                api_base=None,
+                model="gemini-1.5-pro",
+                client=self.mock_async_client,
+                timeout=30.0,
+                logging_obj=self.mock_logging,
+                custom_llm_provider=custom_llm_provider,
+                vertex_project="test_project",
+                vertex_location="test_location",
+                vertex_auth_header="vertext_test_token",
+            )
+
+            assert optional_params.get("tool_choice") == "auto"
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    def test_check_and_create_cache_tool_choice_in_request_body(
+        self,
+        mock_get_token_url,
+        mock_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """End-to-end: tool_choice ends up as `toolConfig` on the cache-creation HTTP POST body."""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = None  # cache miss -> create new
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_client.post.return_value = mock_response
+
+        optional_params = self.sample_optional_params.copy()
+        optional_params["tool_choice"] = "required"
+
+        self.context_caching.check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        self.mock_client.post.assert_called_once()
+        call_args = self.mock_client.post.call_args
+        assert call_args.kwargs["json"]["tools"] == self.sample_tools
+        assert call_args.kwargs["json"]["toolConfig"] == "required"
+        mock_cache_obj.get_cache_key.assert_called_once_with(
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice="required",
+            model="gemini-1.5-pro",
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "async_check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    async def test_async_check_and_create_cache_tool_choice_in_request_body(
+        self,
+        mock_get_token_url,
+        mock_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """Async equivalent of test_check_and_create_cache_tool_choice_in_request_body."""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = None
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_async_client.post = AsyncMock(return_value=mock_response)
+
+        optional_params = self.sample_optional_params.copy()
+        optional_params["tool_choice"] = "required"
+
+        await self.context_caching.async_check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_async_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        call_args = self.mock_async_client.post.call_args
+        assert call_args.kwargs["json"]["tools"] == self.sample_tools
+        assert call_args.kwargs["json"]["toolConfig"] == "required"
+        mock_cache_obj.get_cache_key.assert_called_once_with(
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice="required",
+            model="gemini-1.5-pro",
+        )
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    def test_check_and_create_cache_omits_tool_config_when_tool_choice_unset(
+        self,
+        mock_get_token_url,
+        mock_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """When the caller didn't pass tool_choice, toolConfig must NOT appear in the cache body."""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = None
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_client.post.return_value = mock_response
+
+        optional_params = self.sample_optional_params.copy()
+
+        self.context_caching.check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        call_args = self.mock_client.post.call_args
+        assert "tools" in call_args.kwargs["json"]
+        assert "toolConfig" not in call_args.kwargs["json"]
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    def test_check_and_create_cache_tool_choice_function_pin(
+        self,
+        mock_get_token_url,
+        mock_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """tool_choice as a function-pin dict survives the cache body intact."""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = None
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_client.post.return_value = mock_response
+
+        function_pin = {"type": "function", "function": {"name": "get_current_weather"}}
+        optional_params = self.sample_optional_params.copy()
+        optional_params["tool_choice"] = function_pin
+
+        self.context_caching.check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        call_args = self.mock_client.post.call_args
+        assert call_args.kwargs["json"]["toolConfig"] == function_pin
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_check_and_create_cache_distinct_tool_choices_use_distinct_keys(
+        self,
+        mock_check_cache,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """Two requests with different tool_choice values must produce different cache keys."""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = "existing_cache"
+
+        for choice in ("auto", "required"):
+            optional_params = self.sample_optional_params.copy()
+            optional_params["tool_choice"] = choice
+            self.context_caching.check_and_create_cache(
+                messages=self.sample_messages,
+                optional_params=optional_params,
+                api_key="test_key",
+                api_base=None,
+                model="gemini-1.5-pro",
+                client=self.mock_client,
+                timeout=30.0,
+                logging_obj=self.mock_logging,
+                custom_llm_provider=custom_llm_provider,
+                vertex_project="test_project",
+                vertex_location="test_location",
+                vertex_auth_header="vertext_test_token",
+            )
+
+        call_arg_lists = mock_cache_obj.get_cache_key.call_args_list
+        assert len(call_arg_lists) == 2
+        first_tool_choice = call_arg_lists[0].kwargs["tool_choice"]
+        second_tool_choice = call_arg_lists[1].kwargs["tool_choice"]
+        assert first_tool_choice == "auto"
+        assert second_tool_choice == "required"
+        assert first_tool_choice != second_tool_choice
 
     @pytest.mark.parametrize(
         "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1218,6 +1218,90 @@ class TestContextCachingEndpoints:
     @patch(
         "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
     )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    def test_check_and_create_cache_tool_choice_typed_constructor(
+        self,
+        mock_get_token_url,
+        mock_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """Exercise the actual ToolConfig(FunctionCallingConfig(...)) constructor that map_tool_choice_values produces.
+
+        ToolConfig / FunctionCallingConfig are TypedDicts (litellm/types/llms/vertex_ai.py:158, 277)
+        so this is functionally identical to the dict-literal tests above at
+        runtime — but exercising the typed constructor pins the test to the
+        same call shape map_tool_choice_values uses and auto-follows if
+        either type ever migrates to a Pydantic model upstream.
+        """
+        from litellm.types.llms.vertex_ai import (
+            FunctionCallingConfig,
+            ToolConfig,
+        )
+
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = None
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_client.post.return_value = mock_response
+
+        tool_choice = ToolConfig(
+            functionCallingConfig=FunctionCallingConfig(mode="ANY")
+        )
+        optional_params = self.sample_optional_params.copy()
+        optional_params["tool_choice"] = tool_choice
+
+        self.context_caching.check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        call_args = self.mock_client.post.call_args
+        assert call_args.kwargs["json"]["toolConfig"] == tool_choice
+        assert call_args.kwargs["json"]["toolConfig"] == {
+            "functionCallingConfig": {"mode": "ANY"}
+        }
+        mock_cache_obj.get_cache_key.assert_called_once_with(
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=tool_choice,
+            model="gemini-1.5-pro",
+        )
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
     @patch.object(ContextCachingEndpoints, "check_cache")
     def test_check_and_create_cache_distinct_tool_choices_use_distinct_keys(
         self,

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -821,7 +821,7 @@ class TestContextCachingEndpoints:
             mock_separate.return_value = (cached_messages, non_cached_messages)
 
             optional_params = self.sample_optional_params.copy()
-            optional_params["tool_choice"] = "required"
+            optional_params["tool_choice"] = {"functionCallingConfig": {"mode": "ANY"}}
 
             with patch.object(
                 self.context_caching, "check_cache", return_value="existing_cache"
@@ -855,8 +855,9 @@ class TestContextCachingEndpoints:
         ) as mock_separate:
             mock_separate.return_value = ([], self.sample_messages)
 
+            tool_choice = {"functionCallingConfig": {"mode": "AUTO"}}
             optional_params = self.sample_optional_params.copy()
-            optional_params["tool_choice"] = "auto"
+            optional_params["tool_choice"] = tool_choice
 
             self.context_caching.check_and_create_cache(
                 messages=self.sample_messages,
@@ -873,7 +874,7 @@ class TestContextCachingEndpoints:
                 vertex_auth_header="vertext_test_token",
             )
 
-            assert optional_params.get("tool_choice") == "auto"
+            assert optional_params.get("tool_choice") == tool_choice
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -891,7 +892,7 @@ class TestContextCachingEndpoints:
             mock_separate.return_value = (cached_messages, non_cached_messages)
 
             optional_params = self.sample_optional_params.copy()
-            optional_params["tool_choice"] = "required"
+            optional_params["tool_choice"] = {"functionCallingConfig": {"mode": "ANY"}}
 
             with patch.object(
                 self.context_caching, "async_check_cache", return_value="existing_cache"
@@ -926,8 +927,9 @@ class TestContextCachingEndpoints:
         ) as mock_separate:
             mock_separate.return_value = ([], self.sample_messages)
 
+            tool_choice = {"functionCallingConfig": {"mode": "AUTO"}}
             optional_params = self.sample_optional_params.copy()
-            optional_params["tool_choice"] = "auto"
+            optional_params["tool_choice"] = tool_choice
 
             await self.context_caching.async_check_and_create_cache(
                 messages=self.sample_messages,
@@ -944,7 +946,7 @@ class TestContextCachingEndpoints:
                 vertex_auth_header="vertext_test_token",
             )
 
-            assert optional_params.get("tool_choice") == "auto"
+            assert optional_params.get("tool_choice") == tool_choice
 
     @pytest.mark.parametrize(
         "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
@@ -985,8 +987,9 @@ class TestContextCachingEndpoints:
         }
         self.mock_client.post.return_value = mock_response
 
+        tool_choice = {"functionCallingConfig": {"mode": "ANY"}}
         optional_params = self.sample_optional_params.copy()
-        optional_params["tool_choice"] = "required"
+        optional_params["tool_choice"] = tool_choice
 
         self.context_caching.check_and_create_cache(
             messages=self.sample_messages,
@@ -1006,11 +1009,11 @@ class TestContextCachingEndpoints:
         self.mock_client.post.assert_called_once()
         call_args = self.mock_client.post.call_args
         assert call_args.kwargs["json"]["tools"] == self.sample_tools
-        assert call_args.kwargs["json"]["toolConfig"] == "required"
+        assert call_args.kwargs["json"]["toolConfig"] == tool_choice
         mock_cache_obj.get_cache_key.assert_called_once_with(
             messages=cached_messages,
             tools=self.sample_tools,
-            tool_choice="required",
+            tool_choice=tool_choice,
             model="gemini-1.5-pro",
         )
 
@@ -1054,8 +1057,9 @@ class TestContextCachingEndpoints:
         }
         self.mock_async_client.post = AsyncMock(return_value=mock_response)
 
+        tool_choice = {"functionCallingConfig": {"mode": "ANY"}}
         optional_params = self.sample_optional_params.copy()
-        optional_params["tool_choice"] = "required"
+        optional_params["tool_choice"] = tool_choice
 
         await self.context_caching.async_check_and_create_cache(
             messages=self.sample_messages,
@@ -1074,11 +1078,11 @@ class TestContextCachingEndpoints:
 
         call_args = self.mock_async_client.post.call_args
         assert call_args.kwargs["json"]["tools"] == self.sample_tools
-        assert call_args.kwargs["json"]["toolConfig"] == "required"
+        assert call_args.kwargs["json"]["toolConfig"] == tool_choice
         mock_cache_obj.get_cache_key.assert_called_once_with(
             messages=cached_messages,
             tools=self.sample_tools,
-            tool_choice="required",
+            tool_choice=tool_choice,
             model="gemini-1.5-pro",
         )
 
@@ -1181,7 +1185,12 @@ class TestContextCachingEndpoints:
         }
         self.mock_client.post.return_value = mock_response
 
-        function_pin = {"type": "function", "function": {"name": "get_current_weather"}}
+        function_pin = {
+            "functionCallingConfig": {
+                "mode": "ANY",
+                "allowed_function_names": ["get_current_weather"],
+            }
+        }
         optional_params = self.sample_optional_params.copy()
         optional_params["tool_choice"] = function_pin
 
@@ -1209,25 +1218,27 @@ class TestContextCachingEndpoints:
     @patch(
         "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
     )
-    @patch(
-        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
-    )
     @patch.object(ContextCachingEndpoints, "check_cache")
     def test_check_and_create_cache_distinct_tool_choices_use_distinct_keys(
         self,
         mock_check_cache,
-        mock_cache_obj,
         mock_separate,
         custom_llm_provider,
     ):
-        """Two requests with different tool_choice values must produce different cache keys."""
+        """Two requests with different tool_choice values must produce different cache keys.
+
+        Runs the real local_cache_obj.get_cache_key to verify the hashed
+        output actually differs — mocking it would only prove that distinct
+        arguments are forwarded, not that they produce distinct keys.
+        """
         cached_messages = [self.sample_messages[0]]
         non_cached_messages = [self.sample_messages[1]]
         mock_separate.return_value = (cached_messages, non_cached_messages)
-        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
         mock_check_cache.return_value = "existing_cache"
 
-        for choice in ("auto", "required"):
+        auto_tool_choice = {"functionCallingConfig": {"mode": "AUTO"}}
+        any_tool_choice = {"functionCallingConfig": {"mode": "ANY"}}
+        for choice in (auto_tool_choice, any_tool_choice):
             optional_params = self.sample_optional_params.copy()
             optional_params["tool_choice"] = choice
             self.context_caching.check_and_create_cache(
@@ -1245,13 +1256,11 @@ class TestContextCachingEndpoints:
                 vertex_auth_header="vertext_test_token",
             )
 
-        call_arg_lists = mock_cache_obj.get_cache_key.call_args_list
-        assert len(call_arg_lists) == 2
-        first_tool_choice = call_arg_lists[0].kwargs["tool_choice"]
-        second_tool_choice = call_arg_lists[1].kwargs["tool_choice"]
-        assert first_tool_choice == "auto"
-        assert second_tool_choice == "required"
-        assert first_tool_choice != second_tool_choice
+        check_cache_calls = mock_check_cache.call_args_list
+        assert len(check_cache_calls) == 2
+        first_cache_key = check_cache_calls[0].kwargs["cache_key"]
+        second_cache_key = check_cache_calls[1].kwargs["cache_key"]
+        assert first_cache_key != second_cache_key
 
     @pytest.mark.parametrize(
         "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]


### PR DESCRIPTION
## Relevant issues

Fixes:

- https://github.com/BerriAI/litellm/issues/29088

This PR is inspired by this PR which fixes the issue but has merge conflicts: https://github.com/BerriAI/litellm/pull/25659

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

https://github.com/user-attachments/assets/4fa96a6e-5dec-4248-bdd7-f150916bbc6a


https://github.com/user-attachments/assets/1f606c7b-e80d-4e1f-8c99-2f6343595608



Save as `repro.py`, then run with `GEMINI_API_KEY=... python repro.py`:
```python
import litellm
litellm.modify_params = True   # engage the #26077 guard
MODEL = "gemini/gemini-2.5-flash"
LONG_SYSTEM = (
    "You are a deterministic test fixture. Always respond with one short sentence. "
    "Never volunteer tool calls unless explicitly asked. " * 200
)
TOOL = {
    "type": "function",
    "function": {
        "name": "log_test_event",
        "description": "Internal logging tool.",
        "parameters": {
            "type": "object",
            "properties": {"event_name": {"type": "string"}},
            "required": ["event_name"],
        },
    },
}
def run(label, cache_control, tool_choice):
    sys_block = {"type": "text", "text": LONG_SYSTEM}
    if cache_control:
        sys_block["cache_control"] = {"type": "ephemeral"}
    kwargs = {
        "model": MODEL,
        "messages": [
            {"role": "system", "content": [sys_block]},
            {"role": "user", "content": "Hi, how are you?"},
        ],
        "tools": [TOOL],
    }
    if tool_choice:
        kwargs["tool_choice"] = tool_choice
    resp = litellm.completion(**kwargs)
    msg = resp.choices[0].message
    print(f"{label}: tool_calls={len(msg.tool_calls or [])}, content={(msg.content or '')[:60]!r}")
run("C (no cache, required)", cache_control=False, tool_choice="required")
run("B (cache, no choice)",    cache_control=True,  tool_choice=None)
run("A (cache, required)",     cache_control=True,  tool_choice="required")
```

**Before this fix:**
```
C (no cache, required): tool_calls=1, content=''
B (cache, no choice):   tool_calls=0, content='I am functioning correctly.'
A (cache, required):    tool_calls=0, content='I am functioning correctly.'   ← BUG: tool_choice dropped
```
A vs C is the smoking gun: identical `tool_choice="required"`, but adding the `cache_control` marker silently drops the value. A and B return identical content, proving the request reaching Gemini was the same in both cases — `tool_choice` never made it on the wire.
**After this fix:**
```
C (no cache, required): tool_calls=1, content=''
B (cache, no choice):   tool_calls=0, content='I am functioning correctly.'
A (cache, required):    tool_calls=1, content=''                              ← FIX: tool call now made via log_test_event
```
`usage.cached_tokens` remains non-zero on B and A, confirming the cache still engages — the fix preserves all caching benefits while restoring `tool_choice` semantics on cached requests.

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

LiteLLM's Gemini context-caching path correctly pops `tools` from `optional_params` and bakes them into the `CachedContent` body but does the same for `tool_choice` for neither the sync nor async path. The value stays in `optional_params`, gets translated to `toolConfig` by `_transform_request_body`, and either:

1. Pre-1.84.0 / `modify_params=False`: ends up on the follow-up `generateContent` call alongside `cachedContent` → Vertex 400 `INVALID_ARGUMENT "Tool config, tools and system instruction should not be set in the request when using cached content."`
2. 1.84.0+ with `modify_params=True` (#26077): defensively stripped from the generate body, but never written to the cache either. The net effect is that `tool_choice` is **silently dropped** on every cached request. Gemini receives no `function_calling_config` and falls back to its implicit default regardless of what the caller asked for.

This PR closes that asymmetry by treating `tool_choice` symmetrically with `tools` at cache-creation time:
- **Pop `tool_choice`** from `optional_params` in both `check_and_create_cache` and `async_check_and_create_cache`.
- **Include `tool_choice` in the local cache key** so two requests with different tool_choice values (e.g. `"auto"` vs `"required"`) produce distinct cache entries — without this, the second request silently reuses the first cache's `toolConfig`.
- **Bake `tool_choice` into the `CachedContent` body** as `toolConfig` so cache hits inherit the caller's tool_choice semantics. The #26077 generate-side guard then continues to work as designed (omits the field from the follow-up generate body because it's already in the cache).

Applied to both the sync and async code paths.

For testing, in addition to the above script I added 8 new mocked tests in 
-`tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py`, all parametrized across `gemini`, `vertex_ai`, and `vertex_ai_beta` providers:
- `test_check_and_create_cache_tool_choice_popped_from_optional_params` — sync, with cached messages: `tool_choice` is popped.
- `test_check_and_create_cache_tool_choice_not_popped_when_no_cached_messages` — sync, no cached messages: `tool_choice` is **not** popped (early-return).
- `test_async_check_and_create_cache_tool_choice_popped_from_optional_params` — async equivalent of the first.
- `test_async_check_and_create_cache_tool_choice_not_popped_when_no_cached_messages` — async equivalent of the second.
- `test_check_and_create_cache_tool_choice_in_request_body` — sync end-to-end: `toolConfig` appears in the cache-creation HTTP POST body and the cache key includes `tool_choice`.
- `test_async_check_and_create_cache_tool_choice_in_request_body` — async equivalent.
- `test_check_and_create_cache_omits_tool_config_when_tool_choice_unset` — when caller doesn't pass `tool_choice`, no `toolConfig` is written to the cache body.
- `test_check_and_create_cache_tool_choice_function_pin` — `tool_choice` as a function-pin dict (`{"type": "function", "function": {"name": "..."}}`) survives the cache body intact.
- `test_check_and_create_cache_distinct_tool_choices_use_distinct_keys` — two requests with different `tool_choice` values produce different cache keys (regression guard for the cache-key-collision scenario flagged in #25659's review).
Also updated two existing `mock_cache_obj.get_cache_key.assert_called_once_with` assertions to include `tool_choice=None` in the expected signature (the local cache key now always has it as a positional named argument, even when the caller didn't pass one).

Adding `tool_choice` to `local_cache_obj.get_cache_key(...)` changes the hash for every cached entry — pre-fix entries will miss once on the first request after deploy, then resume normal cache-read behavior. This is intentional:

- Pre-fix `CachedContent` objects were created without `toolConfig` baked in. Reusing them post-fix would silently reproduce the bug this PR is fixing.
- Cost impact is bounded: one cache-creation call per unique `(messages, tools, tool_choice, model)` tuple, the first time it's seen after deploy. No recurring overhead.
- Stale pre-fix entries expire on their own via Vertex's CachedContent TTL (default 5 min). No cleanup pass needed.

In short: a one-time re-cache on deploy is the correct migration. Reusing pre-fix entries would perpetuate the bug.