### PR TITLE
fix(vertex-ai): use DB credentials in video handlers + implement Veo video edit

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -133,6 +133,8 @@ _VIDEO_CALL_TYPES = frozenset(
     {
         CallTypes.create_video.value,
         CallTypes.acreate_video.value,
+        CallTypes.video_edit.value,
+        CallTypes.avideo_edit.value,
         CallTypes.video_remix.value,
         CallTypes.avideo_remix.value,
     }

--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -361,6 +361,7 @@ class BaseVideoConfig(ABC):
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
         custom_llm_provider: Optional[str] = None,
+        request_data: Optional[Dict] = None,
     ) -> VideoObject:
         raise NotImplementedError("video edit is not supported for this provider")
 

--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -321,6 +321,23 @@ class BaseVideoConfig(ABC):
             "video get character is not supported for this provider"
         )
 
+    def get_video_edit_prefetch_params(
+        self,
+        video_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Optional[Tuple[str, Dict]]:
+        """
+        Return (url, body) for a pre-fetch HTTP call that must be made before
+        transform_video_edit_request, or None if no pre-fetch is required.
+
+        Providers that need to retrieve the source video before constructing the
+        edit request (e.g. Vertex AI) should override this method.  The handler
+        uses the existing shared httpx client so the call is properly async.
+        """
+        return None
+
     def transform_video_edit_request(
         self,
         prompt: str,
@@ -329,6 +346,7 @@ class BaseVideoConfig(ABC):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
         extra_body: Optional[Dict[str, Any]] = None,
+        prefetched_source_data: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, Dict]:
         """
         Transform the video edit request into a URL and JSON data.

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -7092,6 +7092,7 @@ class BaseLLMHTTPHandler:
                 raw_response=response,
                 logging_obj=logging_obj,
                 custom_llm_provider=custom_llm_provider,
+                request_data=data,
             )
         except Exception as e:
             raise self._handle_error(e=e, provider_config=video_provider_config)
@@ -7187,6 +7188,7 @@ class BaseLLMHTTPHandler:
                 raw_response=response,
                 logging_obj=logging_obj,
                 custom_llm_provider=custom_llm_provider,
+                request_data=data,
             )
         except Exception as e:
             raise self._handle_error(e=e, provider_config=video_provider_config)

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -7038,46 +7038,46 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
-        prefetched_source_data = None
-        prefetch_params = video_provider_config.get_video_edit_prefetch_params(
-            video_id=video_id,
-            api_base=api_base,
-            litellm_params=litellm_params,
-            headers=headers,
-        )
-        if prefetch_params is not None:
-            prefetch_url, prefetch_body = prefetch_params
-            prefetch_resp = sync_httpx_client.post(
-                url=prefetch_url,
-                headers=headers,
-                json=prefetch_body,
-                timeout=timeout,
-            )
-            prefetch_resp.raise_for_status()
-            prefetched_source_data = prefetch_resp.json()
-
-        url, data = video_provider_config.transform_video_edit_request(
-            prompt=prompt,
-            video_id=video_id,
-            api_base=api_base,
-            litellm_params=litellm_params,
-            headers=headers,
-            extra_body=extra_body,
-            prefetched_source_data=prefetched_source_data,
-        )
-
-        logging_obj.pre_call(
-            input=prompt,
-            api_key="",
-            additional_args={
-                "complete_input_dict": data,
-                "api_base": url,
-                "headers": headers,
-                "video_id": video_id,
-            },
-        )
-
         try:
+            prefetched_source_data = None
+            prefetch_params = video_provider_config.get_video_edit_prefetch_params(
+                video_id=video_id,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                headers=headers,
+            )
+            if prefetch_params is not None:
+                prefetch_url, prefetch_body = prefetch_params
+                prefetch_resp = sync_httpx_client.post(
+                    url=prefetch_url,
+                    headers=headers,
+                    json=prefetch_body,
+                    timeout=timeout,
+                )
+                prefetch_resp.raise_for_status()
+                prefetched_source_data = prefetch_resp.json()
+
+            url, data = video_provider_config.transform_video_edit_request(
+                prompt=prompt,
+                video_id=video_id,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                headers=headers,
+                extra_body=extra_body,
+                prefetched_source_data=prefetched_source_data,
+            )
+
+            logging_obj.pre_call(
+                input=prompt,
+                api_key="",
+                additional_args={
+                    "complete_input_dict": data,
+                    "api_base": url,
+                    "headers": headers,
+                    "video_id": video_id,
+                },
+            )
+
             response = sync_httpx_client.post(
                 url=url,
                 headers=headers,
@@ -7130,46 +7130,46 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
-        prefetched_source_data = None
-        prefetch_params = video_provider_config.get_video_edit_prefetch_params(
-            video_id=video_id,
-            api_base=api_base,
-            litellm_params=litellm_params,
-            headers=headers,
-        )
-        if prefetch_params is not None:
-            prefetch_url, prefetch_body = prefetch_params
-            prefetch_resp = await async_httpx_client.post(
-                url=prefetch_url,
-                headers=headers,
-                json=prefetch_body,
-                timeout=timeout,
-            )
-            prefetch_resp.raise_for_status()
-            prefetched_source_data = prefetch_resp.json()
-
-        url, data = video_provider_config.transform_video_edit_request(
-            prompt=prompt,
-            video_id=video_id,
-            api_base=api_base,
-            litellm_params=litellm_params,
-            headers=headers,
-            extra_body=extra_body,
-            prefetched_source_data=prefetched_source_data,
-        )
-
-        logging_obj.pre_call(
-            input=prompt,
-            api_key="",
-            additional_args={
-                "complete_input_dict": data,
-                "api_base": url,
-                "headers": headers,
-                "video_id": video_id,
-            },
-        )
-
         try:
+            prefetched_source_data = None
+            prefetch_params = video_provider_config.get_video_edit_prefetch_params(
+                video_id=video_id,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                headers=headers,
+            )
+            if prefetch_params is not None:
+                prefetch_url, prefetch_body = prefetch_params
+                prefetch_resp = await async_httpx_client.post(
+                    url=prefetch_url,
+                    headers=headers,
+                    json=prefetch_body,
+                    timeout=timeout,
+                )
+                prefetch_resp.raise_for_status()
+                prefetched_source_data = prefetch_resp.json()
+
+            url, data = video_provider_config.transform_video_edit_request(
+                prompt=prompt,
+                video_id=video_id,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                headers=headers,
+                extra_body=extra_body,
+                prefetched_source_data=prefetched_source_data,
+            )
+
+            logging_obj.pre_call(
+                input=prompt,
+                api_key="",
+                additional_args={
+                    "complete_input_dict": data,
+                    "api_base": url,
+                    "headers": headers,
+                    "video_id": video_id,
+                },
+            )
+
             response = await async_httpx_client.post(
                 url=url,
                 headers=headers,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -6560,6 +6560,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
 
         if extra_headers:
@@ -6642,6 +6643,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
 
         if extra_headers:
@@ -6734,6 +6736,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -6805,6 +6808,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -6888,6 +6892,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -6945,6 +6950,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -7021,6 +7027,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -7093,6 +7100,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -7182,6 +7190,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -7256,6 +7265,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key or litellm_params.get("api_key", None),
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
         if extra_headers:
             headers.update(extra_headers)
@@ -7467,6 +7477,7 @@ class BaseLLMHTTPHandler:
             api_key=api_key,
             headers=extra_headers or {},
             model="",
+            litellm_params=litellm_params,
         )
 
         if extra_headers:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -7038,16 +7038,16 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
-        try:
-            prefetched_source_data = None
-            prefetch_params = video_provider_config.get_video_edit_prefetch_params(
-                video_id=video_id,
-                api_base=api_base,
-                litellm_params=litellm_params,
-                headers=headers,
-            )
-            if prefetch_params is not None:
-                prefetch_url, prefetch_body = prefetch_params
+        prefetched_source_data = None
+        prefetch_params = video_provider_config.get_video_edit_prefetch_params(
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        if prefetch_params is not None:
+            prefetch_url, prefetch_body = prefetch_params
+            try:
                 prefetch_resp = sync_httpx_client.post(
                     url=prefetch_url,
                     headers=headers,
@@ -7055,29 +7055,32 @@ class BaseLLMHTTPHandler:
                     timeout=timeout,
                 )
                 prefetch_resp.raise_for_status()
-                prefetched_source_data = prefetch_resp.json()
+            except Exception as e:
+                raise self._handle_error(e=e, provider_config=video_provider_config)
+            prefetched_source_data = prefetch_resp.json()
 
-            url, data = video_provider_config.transform_video_edit_request(
-                prompt=prompt,
-                video_id=video_id,
-                api_base=api_base,
-                litellm_params=litellm_params,
-                headers=headers,
-                extra_body=extra_body,
-                prefetched_source_data=prefetched_source_data,
-            )
+        url, data = video_provider_config.transform_video_edit_request(
+            prompt=prompt,
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+            extra_body=extra_body,
+            prefetched_source_data=prefetched_source_data,
+        )
 
-            logging_obj.pre_call(
-                input=prompt,
-                api_key="",
-                additional_args={
-                    "complete_input_dict": data,
-                    "api_base": url,
-                    "headers": headers,
-                    "video_id": video_id,
-                },
-            )
+        logging_obj.pre_call(
+            input=prompt,
+            api_key="",
+            additional_args={
+                "complete_input_dict": data,
+                "api_base": url,
+                "headers": headers,
+                "video_id": video_id,
+            },
+        )
 
+        try:
             response = sync_httpx_client.post(
                 url=url,
                 headers=headers,
@@ -7130,16 +7133,16 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
-        try:
-            prefetched_source_data = None
-            prefetch_params = video_provider_config.get_video_edit_prefetch_params(
-                video_id=video_id,
-                api_base=api_base,
-                litellm_params=litellm_params,
-                headers=headers,
-            )
-            if prefetch_params is not None:
-                prefetch_url, prefetch_body = prefetch_params
+        prefetched_source_data = None
+        prefetch_params = video_provider_config.get_video_edit_prefetch_params(
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        if prefetch_params is not None:
+            prefetch_url, prefetch_body = prefetch_params
+            try:
                 prefetch_resp = await async_httpx_client.post(
                     url=prefetch_url,
                     headers=headers,
@@ -7147,29 +7150,32 @@ class BaseLLMHTTPHandler:
                     timeout=timeout,
                 )
                 prefetch_resp.raise_for_status()
-                prefetched_source_data = prefetch_resp.json()
+            except Exception as e:
+                raise self._handle_error(e=e, provider_config=video_provider_config)
+            prefetched_source_data = prefetch_resp.json()
 
-            url, data = video_provider_config.transform_video_edit_request(
-                prompt=prompt,
-                video_id=video_id,
-                api_base=api_base,
-                litellm_params=litellm_params,
-                headers=headers,
-                extra_body=extra_body,
-                prefetched_source_data=prefetched_source_data,
-            )
+        url, data = video_provider_config.transform_video_edit_request(
+            prompt=prompt,
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+            extra_body=extra_body,
+            prefetched_source_data=prefetched_source_data,
+        )
 
-            logging_obj.pre_call(
-                input=prompt,
-                api_key="",
-                additional_args={
-                    "complete_input_dict": data,
-                    "api_base": url,
-                    "headers": headers,
-                    "video_id": video_id,
-                },
-            )
+        logging_obj.pre_call(
+            input=prompt,
+            api_key="",
+            additional_args={
+                "complete_input_dict": data,
+                "api_base": url,
+                "headers": headers,
+                "video_id": video_id,
+            },
+        )
 
+        try:
             response = await async_httpx_client.post(
                 url=url,
                 headers=headers,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -7038,6 +7038,24 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
+        prefetched_source_data = None
+        prefetch_params = video_provider_config.get_video_edit_prefetch_params(
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        if prefetch_params is not None:
+            prefetch_url, prefetch_body = prefetch_params
+            prefetch_resp = sync_httpx_client.post(
+                url=prefetch_url,
+                headers=headers,
+                json=prefetch_body,
+                timeout=timeout,
+            )
+            prefetch_resp.raise_for_status()
+            prefetched_source_data = prefetch_resp.json()
+
         url, data = video_provider_config.transform_video_edit_request(
             prompt=prompt,
             video_id=video_id,
@@ -7045,6 +7063,7 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             headers=headers,
             extra_body=extra_body,
+            prefetched_source_data=prefetched_source_data,
         )
 
         logging_obj.pre_call(
@@ -7111,6 +7130,24 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
+        prefetched_source_data = None
+        prefetch_params = video_provider_config.get_video_edit_prefetch_params(
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        if prefetch_params is not None:
+            prefetch_url, prefetch_body = prefetch_params
+            prefetch_resp = await async_httpx_client.post(
+                url=prefetch_url,
+                headers=headers,
+                json=prefetch_body,
+                timeout=timeout,
+            )
+            prefetch_resp.raise_for_status()
+            prefetched_source_data = prefetch_resp.json()
+
         url, data = video_provider_config.transform_video_edit_request(
             prompt=prompt,
             video_id=video_id,
@@ -7118,6 +7155,7 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             headers=headers,
             extra_body=extra_body,
+            prefetched_source_data=prefetched_source_data,
         )
 
         logging_obj.pre_call(

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -7059,28 +7059,28 @@ class BaseLLMHTTPHandler:
                 raise self._handle_error(e=e, provider_config=video_provider_config)
             prefetched_source_data = prefetch_resp.json()
 
-        url, data = video_provider_config.transform_video_edit_request(
-            prompt=prompt,
-            video_id=video_id,
-            api_base=api_base,
-            litellm_params=litellm_params,
-            headers=headers,
-            extra_body=extra_body,
-            prefetched_source_data=prefetched_source_data,
-        )
-
-        logging_obj.pre_call(
-            input=prompt,
-            api_key="",
-            additional_args={
-                "complete_input_dict": data,
-                "api_base": url,
-                "headers": headers,
-                "video_id": video_id,
-            },
-        )
-
         try:
+            url, data = video_provider_config.transform_video_edit_request(
+                prompt=prompt,
+                video_id=video_id,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                headers=headers,
+                extra_body=extra_body,
+                prefetched_source_data=prefetched_source_data,
+            )
+
+            logging_obj.pre_call(
+                input=prompt,
+                api_key="",
+                additional_args={
+                    "complete_input_dict": data,
+                    "api_base": url,
+                    "headers": headers,
+                    "video_id": video_id,
+                },
+            )
+
             response = sync_httpx_client.post(
                 url=url,
                 headers=headers,
@@ -7155,28 +7155,28 @@ class BaseLLMHTTPHandler:
                 raise self._handle_error(e=e, provider_config=video_provider_config)
             prefetched_source_data = prefetch_resp.json()
 
-        url, data = video_provider_config.transform_video_edit_request(
-            prompt=prompt,
-            video_id=video_id,
-            api_base=api_base,
-            litellm_params=litellm_params,
-            headers=headers,
-            extra_body=extra_body,
-            prefetched_source_data=prefetched_source_data,
-        )
-
-        logging_obj.pre_call(
-            input=prompt,
-            api_key="",
-            additional_args={
-                "complete_input_dict": data,
-                "api_base": url,
-                "headers": headers,
-                "video_id": video_id,
-            },
-        )
-
         try:
+            url, data = video_provider_config.transform_video_edit_request(
+                prompt=prompt,
+                video_id=video_id,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                headers=headers,
+                extra_body=extra_body,
+                prefetched_source_data=prefetched_source_data,
+            )
+
+            logging_obj.pre_call(
+                input=prompt,
+                api_key="",
+                additional_args={
+                    "complete_input_dict": data,
+                    "api_base": url,
+                    "headers": headers,
+                    "video_id": video_id,
+                },
+            )
+
             response = await async_httpx_client.post(
                 url=url,
                 headers=headers,

--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -581,7 +581,14 @@ class GeminiVideoConfig(BaseVideoConfig):
         raise NotImplementedError("video get character is not supported for Gemini")
 
     def transform_video_edit_request(
-        self, prompt, video_id, api_base, litellm_params, headers, extra_body=None
+        self,
+        prompt,
+        video_id,
+        api_base,
+        litellm_params,
+        headers,
+        extra_body=None,
+        prefetched_source_data=None,
     ):
         raise NotImplementedError("video edit is not supported for Gemini")
 

--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -593,7 +593,11 @@ class GeminiVideoConfig(BaseVideoConfig):
         raise NotImplementedError("video edit is not supported for Gemini")
 
     def transform_video_edit_response(
-        self, raw_response, logging_obj, custom_llm_provider=None
+        self,
+        raw_response,
+        logging_obj,
+        custom_llm_provider=None,
+        request_data=None,
     ):
         raise NotImplementedError("video edit is not supported for Gemini")
 

--- a/litellm/llms/openai/videos/transformation.py
+++ b/litellm/llms/openai/videos/transformation.py
@@ -548,6 +548,7 @@ class OpenAIVideoConfig(BaseVideoConfig):
         raw_response: httpx.Response,
         logging_obj: Any,
         custom_llm_provider: Optional[str] = None,
+        request_data: Optional[Dict] = None,
     ) -> VideoObject:
         video_obj = VideoObject(**raw_response.json())
         if custom_llm_provider and video_obj.id:

--- a/litellm/llms/openai/videos/transformation.py
+++ b/litellm/llms/openai/videos/transformation.py
@@ -534,6 +534,7 @@ class OpenAIVideoConfig(BaseVideoConfig):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
         extra_body: Optional[Dict[str, Any]] = None,
+        prefetched_source_data: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, Dict]:
         original_video_id = extract_original_video_id(video_id)
         url = f"{api_base.rstrip('/')}/edits"

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -635,7 +635,11 @@ class RunwayMLVideoConfig(BaseVideoConfig):
         raise NotImplementedError("video edit is not supported for RunwayML")
 
     def transform_video_edit_response(
-        self, raw_response, logging_obj, custom_llm_provider=None
+        self,
+        raw_response,
+        logging_obj,
+        custom_llm_provider=None,
+        request_data=None,
     ):
         raise NotImplementedError("video edit is not supported for RunwayML")
 

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -623,7 +623,14 @@ class RunwayMLVideoConfig(BaseVideoConfig):
         raise NotImplementedError("video get character is not supported for RunwayML")
 
     def transform_video_edit_request(
-        self, prompt, video_id, api_base, litellm_params, headers, extra_body=None
+        self,
+        prompt,
+        video_id,
+        api_base,
+        litellm_params,
+        headers,
+        extra_body=None,
+        prefetched_source_data=None,
     ):
         raise NotImplementedError("video edit is not supported for RunwayML")
 

--- a/litellm/llms/vertex_ai/videos/transformation.py
+++ b/litellm/llms/vertex_ai/videos/transformation.py
@@ -40,6 +40,29 @@ else:
     BaseLLMException = Any
 
 
+def _build_vertex_video_usage_from_request_data(
+    request_data: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build usage metadata (duration, resolution) for video cost calculation."""
+    usage_data: Dict[str, Any] = {}
+    if not request_data:
+        return usage_data
+
+    parameters = request_data.get("parameters", {})
+    duration = (
+        parameters.get("durationSeconds") or DEFAULT_GOOGLE_VIDEO_DURATION_SECONDS
+    )
+    if duration is not None:
+        try:
+            usage_data["duration_seconds"] = float(duration)
+        except (ValueError, TypeError):
+            pass
+    res = parameters.get("resolution")
+    if res is not None and str(res).strip() != "":
+        usage_data["video_resolution"] = str(res).strip().lower()
+    return usage_data
+
+
 def _convert_image_to_vertex_format(image_file) -> Dict[str, str]:
     """
     Convert image file to Vertex AI format with base64 encoding and MIME type.
@@ -363,23 +386,7 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
             id=video_id, object="video", status="processing", model=model
         )
 
-        usage_data: Dict[str, Any] = {}
-        if request_data:
-            parameters = request_data.get("parameters", {})
-            duration = (
-                parameters.get("durationSeconds")
-                or DEFAULT_GOOGLE_VIDEO_DURATION_SECONDS
-            )
-            if duration is not None:
-                try:
-                    usage_data["duration_seconds"] = float(duration)
-                except (ValueError, TypeError):
-                    pass
-            res = parameters.get("resolution")
-            if res is not None and str(res).strip() != "":
-                usage_data["video_resolution"] = str(res).strip().lower()
-
-        video_obj.usage = usage_data
+        video_obj.usage = _build_vertex_video_usage_from_request_data(request_data)
         return video_obj
 
     def transform_video_status_retrieve_request(
@@ -730,12 +737,16 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
         custom_llm_provider: Optional[str] = None,
+        request_data: Optional[Dict] = None,
     ) -> VideoObject:
         """
         Transform the Veo video edit response.
 
         Veo returns the same operation response as video generation:
         {"name": "projects/.../operations/OPERATION_ID"}
+
+        usage includes duration_seconds and optional video_resolution from the
+        edit request parameters for cost calculation.
         """
         response_data = raw_response.json()
 
@@ -752,12 +763,14 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
         else:
             video_id = operation_name
 
-        return VideoObject(
+        video_obj = VideoObject(
             id=video_id,
             object="video",
             status="processing",
             model=model,
         )
+        video_obj.usage = _build_vertex_video_usage_from_request_data(request_data)
+        return video_obj
 
     def transform_video_extension_request(
         self,

--- a/litellm/llms/vertex_ai/videos/transformation.py
+++ b/litellm/llms/vertex_ai/videos/transformation.py
@@ -647,26 +647,14 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
     def transform_video_get_character_response(self, raw_response, logging_obj):
         raise NotImplementedError("video get character is not supported for Vertex AI")
 
-    def transform_video_edit_request(
+    def get_video_edit_prefetch_params(
         self,
-        prompt: str,
         video_id: str,
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
-        extra_body: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, Dict]:
-        """
-        Transform the video edit request for Veo API.
-
-        Veo does not have a dedicated edit endpoint. Instead, this implementation:
-        1. Fetches the source video from the completed operation via fetchPredictOperation
-        2. Constructs a new predictLongRunning request using the source video as input
-
-        The source video is passed as bytesBase64Encoded (or gcsUri if available).
-        """
-        import httpx as _httpx
-
+        """Return the fetchPredictOperation URL and body needed to retrieve the source video."""
         operation_name = extract_original_video_id(video_id)
         model = self.extract_model_from_operation_name(operation_name)
 
@@ -676,27 +664,38 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
                 "Expected format: projects/PROJECT/locations/LOCATION/publishers/google/models/MODEL/operations/OPERATION_ID"
             )
 
-        # Step 1: Fetch the source video data from the completed operation
         fetch_url = f"{api_base.rstrip('/')}/{model}:fetchPredictOperation"
-        with _httpx.Client() as client:
-            fetch_response = client.post(
-                url=fetch_url,
-                headers=headers,
-                json={"operationName": operation_name},
-                timeout=30,
+        return fetch_url, {"operationName": operation_name}
+
+    def transform_video_edit_request(
+        self,
+        prompt: str,
+        video_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        extra_body: Optional[Dict[str, Any]] = None,
+        prefetched_source_data: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, Dict]:
+        """
+        Build a predictLongRunning edit request from the pre-fetched source video.
+
+        The actual fetchPredictOperation HTTP call is hoisted into the handler so
+        it can use the shared async/sync httpx client instead of blocking the loop.
+        """
+        if prefetched_source_data is None:
+            raise ValueError(
+                "prefetched_source_data is required for Vertex AI video edit. "
+                "Ensure get_video_edit_prefetch_params is called by the handler."
             )
-            fetch_response.raise_for_status()
 
-        fetch_data = fetch_response.json()
-
-        if not fetch_data.get("done", False):
+        if not prefetched_source_data.get("done", False):
             raise ValueError(
                 "Source video generation is not complete yet. "
                 "Check the video status before editing."
             )
 
-        response_data = fetch_data.get("response", {})
-        videos = response_data.get("videos", [])
+        videos = prefetched_source_data.get("response", {}).get("videos", [])
         if not videos:
             raise ValueError("No videos found in the completed operation. Cannot edit.")
 
@@ -712,18 +711,19 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
                 "Source video has neither gcsUri nor bytesBase64Encoded. Cannot edit."
             )
 
-        # Step 2: Build the edit request using the same predictLongRunning endpoint
-        instance_dict: Dict[str, Any] = {"prompt": prompt, "video": video_input}
+        operation_name = extract_original_video_id(video_id)
+        model = self.extract_model_from_operation_name(operation_name) or ""
 
+        instance_dict: Dict[str, Any] = {"prompt": prompt, "video": video_input}
         request_data: Dict[str, Any] = {"instances": [instance_dict]}
 
-        # Allow caller to pass extra parameters (e.g. durationSeconds, aspectRatio)
         if extra_body:
-            nested_params = extra_body.pop("parameters", None)
+            extra_body_copy = dict(extra_body)
+            nested_params = extra_body_copy.pop("parameters", None)
             vertex_params: Dict[str, Any] = {}
             if isinstance(nested_params, dict):
                 vertex_params.update(nested_params)
-            vertex_params.update(extra_body)
+            vertex_params.update(extra_body_copy)
             if vertex_params:
                 request_data["parameters"] = vertex_params
 

--- a/litellm/llms/vertex_ai/videos/transformation.py
+++ b/litellm/llms/vertex_ai/videos/transformation.py
@@ -655,17 +655,12 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
         headers: dict,
     ) -> Tuple[str, Dict]:
         """Return the fetchPredictOperation URL and body needed to retrieve the source video."""
-        operation_name = extract_original_video_id(video_id)
-        model = self.extract_model_from_operation_name(operation_name)
-
-        if not model:
-            raise ValueError(
-                f"Cannot extract model from operation name: {operation_name}. "
-                "Expected format: projects/PROJECT/locations/LOCATION/publishers/google/models/MODEL/operations/OPERATION_ID"
-            )
-
-        fetch_url = f"{api_base.rstrip('/')}/{model}:fetchPredictOperation"
-        return fetch_url, {"operationName": operation_name}
+        return self.transform_video_status_retrieve_request(
+            video_id=video_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
 
     def transform_video_edit_request(
         self,

--- a/litellm/llms/vertex_ai/videos/transformation.py
+++ b/litellm/llms/vertex_ai/videos/transformation.py
@@ -648,14 +648,121 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
         raise NotImplementedError("video get character is not supported for Vertex AI")
 
     def transform_video_edit_request(
-        self, prompt, video_id, api_base, litellm_params, headers, extra_body=None
-    ):
-        raise NotImplementedError("video edit is not supported for Vertex AI")
+        self,
+        prompt: str,
+        video_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        extra_body: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, Dict]:
+        """
+        Transform the video edit request for Veo API.
+
+        Veo does not have a dedicated edit endpoint. Instead, this implementation:
+        1. Fetches the source video from the completed operation via fetchPredictOperation
+        2. Constructs a new predictLongRunning request using the source video as input
+
+        The source video is passed as bytesBase64Encoded (or gcsUri if available).
+        """
+        import httpx as _httpx
+
+        operation_name = extract_original_video_id(video_id)
+        model = self.extract_model_from_operation_name(operation_name)
+
+        if not model:
+            raise ValueError(
+                f"Cannot extract model from operation name: {operation_name}. "
+                "Expected format: projects/PROJECT/locations/LOCATION/publishers/google/models/MODEL/operations/OPERATION_ID"
+            )
+
+        # Step 1: Fetch the source video data from the completed operation
+        fetch_url = f"{api_base.rstrip('/')}/{model}:fetchPredictOperation"
+        with _httpx.Client() as client:
+            fetch_response = client.post(
+                url=fetch_url,
+                headers=headers,
+                json={"operationName": operation_name},
+                timeout=30,
+            )
+            fetch_response.raise_for_status()
+
+        fetch_data = fetch_response.json()
+
+        if not fetch_data.get("done", False):
+            raise ValueError(
+                "Source video generation is not complete yet. "
+                "Check the video status before editing."
+            )
+
+        response_data = fetch_data.get("response", {})
+        videos = response_data.get("videos", [])
+        if not videos:
+            raise ValueError("No videos found in the completed operation. Cannot edit.")
+
+        source_video = videos[0]
+        video_input: Dict[str, Any] = {}
+        if "gcsUri" in source_video:
+            video_input["gcsUri"] = source_video["gcsUri"]
+        elif "bytesBase64Encoded" in source_video:
+            video_input["bytesBase64Encoded"] = source_video["bytesBase64Encoded"]
+            video_input["mimeType"] = source_video.get("mimeType", "video/mp4")
+        else:
+            raise ValueError(
+                "Source video has neither gcsUri nor bytesBase64Encoded. Cannot edit."
+            )
+
+        # Step 2: Build the edit request using the same predictLongRunning endpoint
+        instance_dict: Dict[str, Any] = {"prompt": prompt, "video": video_input}
+
+        request_data: Dict[str, Any] = {"instances": [instance_dict]}
+
+        # Allow caller to pass extra parameters (e.g. durationSeconds, aspectRatio)
+        if extra_body:
+            nested_params = extra_body.pop("parameters", None)
+            vertex_params: Dict[str, Any] = {}
+            if isinstance(nested_params, dict):
+                vertex_params.update(nested_params)
+            vertex_params.update(extra_body)
+            if vertex_params:
+                request_data["parameters"] = vertex_params
+
+        edit_url = f"{api_base.rstrip('/')}/{model}:predictLongRunning"
+        return edit_url, request_data
 
     def transform_video_edit_response(
-        self, raw_response, logging_obj, custom_llm_provider=None
-    ):
-        raise NotImplementedError("video edit is not supported for Vertex AI")
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
+    ) -> VideoObject:
+        """
+        Transform the Veo video edit response.
+
+        Veo returns the same operation response as video generation:
+        {"name": "projects/.../operations/OPERATION_ID"}
+        """
+        response_data = raw_response.json()
+
+        operation_name = response_data.get("name")
+        if not operation_name:
+            raise ValueError(f"No operation name in Veo edit response: {response_data}")
+
+        model = self.extract_model_from_operation_name(operation_name) or ""
+
+        if custom_llm_provider:
+            video_id = encode_video_id_with_provider(
+                operation_name, custom_llm_provider, model
+            )
+        else:
+            video_id = operation_name
+
+        return VideoObject(
+            id=video_id,
+            object="video",
+            status="processing",
+            model=model,
+        )
 
     def transform_video_extension_request(
         self,

--- a/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
@@ -556,6 +556,27 @@ class TestVertexAIVideoConfig:
         assert video_obj.id
         assert video_obj.model == "veo-3.1-generate-001"
 
+    def test_transform_video_edit_response_includes_usage_for_cost(self):
+        """Edit responses include duration/resolution usage for spend accounting."""
+        operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/new-op-123"
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = {"name": operation_name}
+        request_data = {
+            "instances": [{"prompt": "Make it brighter", "video": {}}],
+            "parameters": {"durationSeconds": 8, "resolution": "1080p"},
+        }
+
+        video_obj = self.config.transform_video_edit_response(
+            raw_response=mock_response,
+            logging_obj=self.mock_logging_obj,
+            custom_llm_provider="vertex_ai",
+            request_data=request_data,
+        )
+
+        assert video_obj.usage is not None
+        assert video_obj.usage["duration_seconds"] == 8.0
+        assert video_obj.usage["video_resolution"] == "1080p"
+
     def test_transform_video_remix_request_not_supported(self):
         """Test that video remix raises NotImplementedError."""
         with pytest.raises(NotImplementedError, match="Video remix is not supported"):

--- a/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
@@ -456,38 +456,43 @@ class TestVertexAIVideoConfig:
                 raw_response=mock_response, logging_obj=self.mock_logging_obj
             )
 
+    def test_get_video_edit_prefetch_params(self):
+        """Test that prefetch params returns the fetchPredictOperation URL and body."""
+        operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-123"
+        api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
+
+        fetch_url, fetch_body = self.config.get_video_edit_prefetch_params(
+            video_id=operation_name,
+            api_base=api_base,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "fetchPredictOperation" in fetch_url
+        assert "veo-3.1-generate-001" in fetch_url
+        assert fetch_body == {"operationName": operation_name}
+
     def test_transform_video_edit_request_with_bytes(self):
-        """Test video edit request fetches source video and builds predictLongRunning body."""
+        """Test video edit request builds predictLongRunning body from pre-fetched bytes."""
         operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-123"
         api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
         fake_bytes = base64.b64encode(b"fake_video").decode()
 
-        fetch_payload = {
-            "name": operation_name,
+        prefetched = {
             "done": True,
             "response": {
                 "videos": [{"bytesBase64Encoded": fake_bytes, "mimeType": "video/mp4"}]
             },
         }
 
-        mock_fetch_response = Mock(spec=httpx.Response)
-        mock_fetch_response.json.return_value = fetch_payload
-        mock_fetch_response.raise_for_status = Mock()
-
-        with patch("httpx.Client") as mock_client_cls:
-            mock_client = Mock()
-            mock_client.__enter__ = Mock(return_value=mock_client)
-            mock_client.__exit__ = Mock(return_value=False)
-            mock_client.post.return_value = mock_fetch_response
-            mock_client_cls.return_value = mock_client
-
-            url, data = self.config.transform_video_edit_request(
-                prompt="Make it brighter",
-                video_id=operation_name,
-                api_base=api_base,
-                litellm_params=GenericLiteLLMParams(),
-                headers={"Authorization": "Bearer token"},
-            )
+        url, data = self.config.transform_video_edit_request(
+            prompt="Make it brighter",
+            video_id=operation_name,
+            api_base=api_base,
+            litellm_params=GenericLiteLLMParams(),
+            headers={"Authorization": "Bearer token"},
+            prefetched_source_data=prefetched,
+        )
 
         assert url.endswith(":predictLongRunning")
         assert "veo-3.1-generate-001" in url
@@ -497,41 +502,25 @@ class TestVertexAIVideoConfig:
         assert instance["video"]["mimeType"] == "video/mp4"
 
     def test_transform_video_edit_request_with_gcs_uri(self):
-        """Test that gcsUri is preferred over bytes when present in source video."""
+        """Test that gcsUri is used when present in source video."""
         operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-456"
         api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
 
-        fetch_payload = {
-            "name": operation_name,
+        prefetched = {
             "done": True,
             "response": {
-                "videos": [
-                    {
-                        "gcsUri": "gs://bucket/video.mp4",
-                        "mimeType": "video/mp4",
-                    }
-                ]
+                "videos": [{"gcsUri": "gs://bucket/video.mp4", "mimeType": "video/mp4"}]
             },
         }
 
-        mock_fetch_response = Mock(spec=httpx.Response)
-        mock_fetch_response.json.return_value = fetch_payload
-        mock_fetch_response.raise_for_status = Mock()
-
-        with patch("httpx.Client") as mock_client_cls:
-            mock_client = Mock()
-            mock_client.__enter__ = Mock(return_value=mock_client)
-            mock_client.__exit__ = Mock(return_value=False)
-            mock_client.post.return_value = mock_fetch_response
-            mock_client_cls.return_value = mock_client
-
-            url, data = self.config.transform_video_edit_request(
-                prompt="Make it darker",
-                video_id=operation_name,
-                api_base=api_base,
-                litellm_params=GenericLiteLLMParams(),
-                headers={"Authorization": "Bearer token"},
-            )
+        _, data = self.config.transform_video_edit_request(
+            prompt="Make it darker",
+            video_id=operation_name,
+            api_base=api_base,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+            prefetched_source_data=prefetched,
+        )
 
         assert data["instances"][0]["video"] == {"gcsUri": "gs://bucket/video.mp4"}
 
@@ -540,25 +529,15 @@ class TestVertexAIVideoConfig:
         operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-789"
         api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
 
-        mock_fetch_response = Mock(spec=httpx.Response)
-        mock_fetch_response.json.return_value = {"name": operation_name, "done": False}
-        mock_fetch_response.raise_for_status = Mock()
-
-        with patch("httpx.Client") as mock_client_cls:
-            mock_client = Mock()
-            mock_client.__enter__ = Mock(return_value=mock_client)
-            mock_client.__exit__ = Mock(return_value=False)
-            mock_client.post.return_value = mock_fetch_response
-            mock_client_cls.return_value = mock_client
-
-            with pytest.raises(ValueError, match="not complete yet"):
-                self.config.transform_video_edit_request(
-                    prompt="Make it brighter",
-                    video_id=operation_name,
-                    api_base=api_base,
-                    litellm_params=GenericLiteLLMParams(),
-                    headers={"Authorization": "Bearer token"},
-                )
+        with pytest.raises(ValueError, match="not complete yet"):
+            self.config.transform_video_edit_request(
+                prompt="Make it brighter",
+                video_id=operation_name,
+                api_base=api_base,
+                litellm_params=GenericLiteLLMParams(),
+                headers={},
+                prefetched_source_data={"done": False},
+            )
 
     def test_transform_video_edit_response(self):
         """Test that edit response returns a processing VideoObject with encoded ID."""

--- a/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
@@ -456,6 +456,127 @@ class TestVertexAIVideoConfig:
                 raw_response=mock_response, logging_obj=self.mock_logging_obj
             )
 
+    def test_transform_video_edit_request_with_bytes(self):
+        """Test video edit request fetches source video and builds predictLongRunning body."""
+        operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-123"
+        api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
+        fake_bytes = base64.b64encode(b"fake_video").decode()
+
+        fetch_payload = {
+            "name": operation_name,
+            "done": True,
+            "response": {
+                "videos": [{"bytesBase64Encoded": fake_bytes, "mimeType": "video/mp4"}]
+            },
+        }
+
+        mock_fetch_response = Mock(spec=httpx.Response)
+        mock_fetch_response.json.return_value = fetch_payload
+        mock_fetch_response.raise_for_status = Mock()
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = Mock()
+            mock_client.__enter__ = Mock(return_value=mock_client)
+            mock_client.__exit__ = Mock(return_value=False)
+            mock_client.post.return_value = mock_fetch_response
+            mock_client_cls.return_value = mock_client
+
+            url, data = self.config.transform_video_edit_request(
+                prompt="Make it brighter",
+                video_id=operation_name,
+                api_base=api_base,
+                litellm_params=GenericLiteLLMParams(),
+                headers={"Authorization": "Bearer token"},
+            )
+
+        assert url.endswith(":predictLongRunning")
+        assert "veo-3.1-generate-001" in url
+        instance = data["instances"][0]
+        assert instance["prompt"] == "Make it brighter"
+        assert instance["video"]["bytesBase64Encoded"] == fake_bytes
+        assert instance["video"]["mimeType"] == "video/mp4"
+
+    def test_transform_video_edit_request_with_gcs_uri(self):
+        """Test that gcsUri is preferred over bytes when present in source video."""
+        operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-456"
+        api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
+
+        fetch_payload = {
+            "name": operation_name,
+            "done": True,
+            "response": {
+                "videos": [
+                    {
+                        "gcsUri": "gs://bucket/video.mp4",
+                        "mimeType": "video/mp4",
+                    }
+                ]
+            },
+        }
+
+        mock_fetch_response = Mock(spec=httpx.Response)
+        mock_fetch_response.json.return_value = fetch_payload
+        mock_fetch_response.raise_for_status = Mock()
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = Mock()
+            mock_client.__enter__ = Mock(return_value=mock_client)
+            mock_client.__exit__ = Mock(return_value=False)
+            mock_client.post.return_value = mock_fetch_response
+            mock_client_cls.return_value = mock_client
+
+            url, data = self.config.transform_video_edit_request(
+                prompt="Make it darker",
+                video_id=operation_name,
+                api_base=api_base,
+                litellm_params=GenericLiteLLMParams(),
+                headers={"Authorization": "Bearer token"},
+            )
+
+        assert data["instances"][0]["video"] == {"gcsUri": "gs://bucket/video.mp4"}
+
+    def test_transform_video_edit_request_source_not_done_raises(self):
+        """Test that editing an in-progress video raises a clear error."""
+        operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/op-789"
+        api_base = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models"
+
+        mock_fetch_response = Mock(spec=httpx.Response)
+        mock_fetch_response.json.return_value = {"name": operation_name, "done": False}
+        mock_fetch_response.raise_for_status = Mock()
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = Mock()
+            mock_client.__enter__ = Mock(return_value=mock_client)
+            mock_client.__exit__ = Mock(return_value=False)
+            mock_client.post.return_value = mock_fetch_response
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ValueError, match="not complete yet"):
+                self.config.transform_video_edit_request(
+                    prompt="Make it brighter",
+                    video_id=operation_name,
+                    api_base=api_base,
+                    litellm_params=GenericLiteLLMParams(),
+                    headers={"Authorization": "Bearer token"},
+                )
+
+    def test_transform_video_edit_response(self):
+        """Test that edit response returns a processing VideoObject with encoded ID."""
+        operation_name = "projects/test-project/locations/us-central1/publishers/google/models/veo-3.1-generate-001/operations/new-op-123"
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = {"name": operation_name}
+
+        video_obj = self.config.transform_video_edit_response(
+            raw_response=mock_response,
+            logging_obj=self.mock_logging_obj,
+            custom_llm_provider="vertex_ai",
+        )
+
+        assert isinstance(video_obj, VideoObject)
+        assert video_obj.status == "processing"
+        assert video_obj.id
+        assert video_obj.model == "veo-3.1-generate-001"
+
     def test_transform_video_remix_request_not_supported(self):
         """Test that video remix raises NotImplementedError."""
         with pytest.raises(NotImplementedError, match="Video remix is not supported"):

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -398,6 +398,34 @@ class TestVideoGeneration:
         )
         assert abs(cost - 0.8) < 0.001
 
+    def test_completion_cost_video_edit_uses_video_calculator(self):
+        """video_edit is charged via the same video cost path as create_video."""
+        from litellm.cost_calculator import completion_cost
+
+        mock_response = MagicMock()
+        mock_response.usage = MagicMock()
+        mock_response.usage.duration_seconds = 10.0
+        type(mock_response)._hidden_params = {}
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.litellm_params = {
+            "metadata": {
+                "model_info": {
+                    "output_cost_per_video_per_second": 0.05,
+                }
+            }
+        }
+
+        cost = completion_cost(
+            completion_response=mock_response,
+            model="vertex_ai/veo-3.1-generate-001",
+            call_type="video_edit",
+            custom_llm_provider="vertex_ai",
+            custom_pricing=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        assert cost == 0.5
+
     def test_video_generation_with_files(self):
         """Test video generation with file uploads."""
         config = OpenAIVideoConfig()


### PR DESCRIPTION
## Problem

Two bugs in Vertex AI video endpoints:

1. **Wrong credentials**: 10 video handler call sites (`remix`, `create_character`, `get_character`, `edit`, `extension`, `delete`) in `llm_http_handler.py` called `validate_environment` without passing `litellm_params`. This caused Vertex AI to ignore DB-stored credentials and fall back to application default credentials (ADC), resulting in `RefreshError` failures when ADC was not configured.

2. **NotImplementedError on video edit**: `transform_video_edit_request` for Vertex AI raised `NotImplementedError`, so `/v1/videos/edits` always failed for Vertex AI models.

## Fix

- Pass `litellm_params=litellm_params` to all 11 affected `validate_environment` call sites so DB-stored `vertex_project` / `vertex_credentials` are used correctly.
- Implement `transform_video_edit_request` and `transform_video_edit_response` for Vertex AI: the handler first calls `fetchPredictOperation` to retrieve the completed source video (bytes or GCS URI), then submits a new `predictLongRunning` request with the source video + edit prompt, returning a new operation ID that can be polled for status.

## Tests

Added 4 unit tests to `tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py`:
- `test_transform_video_edit_request_with_bytes` — edit using base64 video bytes
- `test_transform_video_edit_request_with_gcs_uri` — edit using GCS URI
- `test_transform_video_edit_request_source_not_done_raises` — clear error when source video is still processing
- `test_transform_video_edit_response` — response encodes new operation ID correctly

Fixed it here
<img width="1149" height="252" alt="image" src="https://github.com/user-attachments/assets/0f1b773a-cc51-431d-8f2f-96fcfa517fe7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared video HTTP paths and credential resolution for multiple operations; Vertex edit adds a two-step API flow and validates completed source video data before submit.
> 
> **Overview**
> Video HTTP handlers now pass **`litellm_params`** into **`validate_environment`** across remix, character, edit, extension, delete, and related paths so Vertex (and other providers) can use DB-stored project/credentials instead of defaulting to ADC.
> 
> **Vertex AI Veo video edit** is implemented end-to-end: a new optional **`get_video_edit_prefetch_params`** hook lets the shared sync/async httpx handler run **`fetchPredictOperation`** before **`transform_video_edit_request`**, which builds a **`predictLongRunning`** edit from the completed source video (GCS URI or base64 bytes) and returns a processing **`VideoObject`** from the new operation name. Other providers only accept the new **`prefetched_source_data`** parameter on edit transforms.
> 
> Unit tests cover prefetch params, edit request/response shapes, and errors when the source operation is not done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7543fe0c03ef21a66d8a2edb3585af385e662385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->