### PR TITLE
fix(responses): emit x-litellm-overhead-duration-ms on /v1/responses (LIT-1756)

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1145,6 +1145,7 @@ class HTTPHandler:
         parts = urlsplit(url)
         return dict(parse_qsl(parts.query))
 
+    @track_llm_api_timing()
     def post(
         self,
         url: str,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2343,6 +2343,7 @@ class BaseLLMHTTPHandler:
                     timeout=timeout
                     or float(response_api_optional_request_params.get("timeout", 0)),
                     stream=stream,
+                    logging_obj=logging_obj,
                 )
                 if fake_stream is True:
                     return MockResponsesAPIStreamingIterator(
@@ -2374,6 +2375,7 @@ class BaseLLMHTTPHandler:
                     json=data,
                     timeout=timeout
                     or float(response_api_optional_request_params.get("timeout", 0)),
+                    logging_obj=logging_obj,
                 )
         except Exception as e:
             raise self._handle_error(
@@ -2489,6 +2491,7 @@ class BaseLLMHTTPHandler:
                     timeout=timeout
                     or float(response_api_optional_request_params.get("timeout", 0)),
                     stream=stream,
+                    logging_obj=logging_obj,
                 )
 
                 if fake_stream is True:
@@ -2522,6 +2525,7 @@ class BaseLLMHTTPHandler:
                     json=data,
                     timeout=timeout
                     or float(response_api_optional_request_params.get("timeout", 0)),
+                    logging_obj=logging_obj,
                 )
 
         except Exception as e:

--- a/tests/test_litellm/llms/test_responses_api_overhead_header.py
+++ b/tests/test_litellm/llms/test_responses_api_overhead_header.py
@@ -1,0 +1,202 @@
+"""LIT-1756 regression tests.
+
+The bug: ``BaseLLMHTTPHandler.{async_,}response_api_handler`` called
+``(a)sync_httpx_client.post(...)`` at four call sites without forwarding
+``logging_obj=``.  The ``@track_llm_api_timing()`` decorator on
+``AsyncHTTPHandler.post`` (and now on ``HTTPHandler.post``) reads
+``logging_obj`` from kwargs to record ``llm_api_duration_ms``.  Without it
+``response_metadata.set_timing_metrics`` leaves
+``_hidden_params["litellm_overhead_time_ms"]`` as ``None`` and the proxy's
+``get_custom_headers`` omits ``x-litellm-overhead-duration-ms`` from
+``/v1/responses`` responses (chat completions are fine because that path
+already forwards ``logging_obj``).
+"""
+import asyncio
+import ast
+import pathlib
+import time
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
+    HTTPHandler,
+)
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+
+def _fake_responses_payload() -> dict:
+    return {
+        "id": "resp_test_001",
+        "object": "response",
+        "created_at": int(time.time()),
+        "model": "gpt-4o",
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "id": "m1",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {"type": "output_text", "text": "Hello", "annotations": []}
+                ],
+            }
+        ],
+        "usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+    }
+
+
+# ---- Decorator presence ----------------------------------------------------
+
+def test_async_post_has_track_llm_api_timing_decorator() -> None:
+    """``AsyncHTTPHandler.post`` must carry ``@track_llm_api_timing()``."""
+    assert hasattr(AsyncHTTPHandler.post, "__wrapped__"), (
+        "AsyncHTTPHandler.post is not decorated — track_llm_api_timing missing"
+    )
+
+
+def test_sync_post_has_track_llm_api_timing_decorator() -> None:
+    """``HTTPHandler.post`` (sync) must also carry ``@track_llm_api_timing()``.
+
+    Before LIT-1756 only the async post was decorated, so the sync code path
+    in ``response_api_handler`` could never populate ``llm_api_duration_ms``.
+    """
+    assert hasattr(HTTPHandler.post, "__wrapped__"), (
+        "HTTPHandler.post is not decorated — track_llm_api_timing missing"
+    )
+
+
+# ---- Call-site forwarding (source-level) -----------------------------------
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["response_api_handler", "async_response_api_handler"],
+    ids=["sync", "async"],
+)
+def test_responses_api_handler_passes_logging_obj_to_post(method_name: str) -> None:
+    """Every ``(a)sync_httpx_client.post(...)`` call inside the responses API
+    handlers must include ``logging_obj=logging_obj`` as a kwarg.
+
+    Source-level assertion via ``ast.parse`` so we don't depend on whether a
+    given runtime test path exercises the streaming / fake-stream branches.
+    """
+    src_path = pathlib.Path(BaseLLMHTTPHandler.__module__.replace(".", "/") + ".py")
+    if not src_path.exists():
+        import litellm.llms.custom_httpx.llm_http_handler as _m
+        src_path = pathlib.Path(_m.__file__)
+    module_src = src_path.read_text()
+    tree = ast.parse(module_src)
+    target = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == method_name
+        ):
+            target = node
+            break
+    assert target is not None, f"could not find {method_name} in source"
+
+    # Walk every Call node inside the method.
+    httpx_post_calls = []
+    for sub in ast.walk(target):
+        if not isinstance(sub, ast.Call):
+            continue
+        f = sub.func
+        # match `<name>_httpx_client.post(...)` calls
+        if isinstance(f, ast.Attribute) and f.attr == "post":
+            value = f.value
+            if isinstance(value, ast.Name) and value.id.endswith("_httpx_client"):
+                httpx_post_calls.append(sub)
+    assert httpx_post_calls, (
+        f"{method_name}: no `_httpx_client.post(...)` call sites found — "
+        "test scaffolding may be stale"
+    )
+    for call in httpx_post_calls:
+        kw_names = [kw.arg for kw in call.keywords]
+        assert "logging_obj" in kw_names, (
+            f"{method_name}: a `*_httpx_client.post(...)` site at line "
+            f"{call.lineno} does not forward `logging_obj=` "
+            f"(kwargs present: {kw_names}). This re-introduces LIT-1756."
+        )
+
+
+# ---- Behavioural regression via direct handler call ------------------------
+
+@pytest.mark.asyncio
+async def test_async_response_api_handler_records_llm_api_duration_ms() -> None:
+    """End-to-end on ``async_response_api_handler``: stub the upstream httpx
+    send and assert the decorator has set ``llm_api_duration_ms`` on the
+    logging object after the handler returns. Before the fix this stayed
+    ``None``; after the fix it must be a positive number.
+    """
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging as LiteLLMLoggingObj,
+    )
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+
+    class StubResponsesAPIConfig:
+        def validate_environment(self, headers, model, litellm_params):
+            return headers or {}
+
+        def get_complete_url(self, api_base, litellm_params):
+            return f"{api_base}/responses"
+
+        def transform_responses_api_request(
+            self, model, input, response_api_optional_request_params,
+            litellm_params, headers,
+        ):
+            return {"model": model, "input": input}
+
+        def transform_response_api_response(self, model, raw_response, logging_obj):
+            body = raw_response.json()
+            return ResponsesAPIResponse(
+                id=body["id"], object=body["object"],
+                created_at=body["created_at"], model=body["model"],
+                status=body["status"], output=body["output"],
+                usage=ResponseAPIUsage(**body["usage"]),
+            )
+
+        def should_fake_stream(self, *a, **k):
+            return False
+
+    logging_obj = LiteLLMLoggingObj(
+        model="gpt-4o", messages=[], stream=False, call_type="aresponses",
+        start_time=None, litellm_call_id="test-call-id", function_id="fn",
+    )
+    logging_obj.model_call_details = {}
+
+    handler = AsyncHTTPHandler()
+
+    async def fake_send(self, request, **_kwargs):
+        await asyncio.sleep(0.05)
+        return httpx.Response(
+            200, json=_fake_responses_payload(), request=request
+        )
+
+    base = BaseLLMHTTPHandler()
+    with patch.object(httpx.AsyncClient, "send", fake_send):
+        await base.async_response_api_handler(
+            model="gpt-4o", input="hi",
+            responses_api_provider_config=StubResponsesAPIConfig(),
+            response_api_optional_request_params={},
+            custom_llm_provider="openai",
+            litellm_params=GenericLiteLLMParams(
+                api_base="http://stub.invalid", api_key="sk-x"
+            ),
+            logging_obj=logging_obj,
+            client=handler,
+        )
+
+    duration = logging_obj.model_call_details.get("llm_api_duration_ms")
+    assert duration is not None, (
+        "llm_api_duration_ms not set on logging_obj after handler call — "
+        "track_llm_api_timing did not see logging_obj because it was not "
+        "forwarded to post() (LIT-1756)"
+    )
+    assert isinstance(duration, (int, float)) and duration > 0, (
+        f"llm_api_duration_ms must be a positive number, got {duration!r}"
+    )


### PR DESCRIPTION
## Linear ticket

Resolves LIT-1756 — *`[Bug] Note receiving x-litellm-overhead-duration-ms response header for v1/responses endpoint.`*

## Root cause

`x-litellm-overhead-duration-ms` is built by `ProxyBaseLLMRequestProcessing.get_custom_headers` from `_hidden_params["litellm_overhead_time_ms"]`. That field is populated by `response_metadata.set_timing_metrics` only when `logging_obj.model_call_details["llm_api_duration_ms"]` is set, which itself is set by the `@track_llm_api_timing()` decorator on the HTTP handler `post` methods.

Two gaps caused the header to silently disappear on `/v1/responses`:

1. **Missing kwarg forwarding** — `BaseLLMHTTPHandler.{async_,}response_api_handler` calls `(a)sync_httpx_client.post(...)` at **four** sites (sync × streaming, sync × non-streaming, async × streaming, async × non-streaming), none of which forward `logging_obj=`. The decorator reads `kwargs.get("logging_obj")`; with `None` it short-circuits.
2. **Missing decorator** — only `AsyncHTTPHandler.post` had `@track_llm_api_timing()`. The sync `HTTPHandler.post` was undecorated, so the two sync sites would *also* not record the duration even after fix #1.

Chat completions never hit this because their post sites already forward `logging_obj` and the async decorator was already in place.

## Fix

| File | Change |
|---|---|
| `litellm/llms/custom_httpx/llm_http_handler.py` | Add `logging_obj=logging_obj` to all four `(a)sync_httpx_client.post(...)` call sites inside `response_api_handler` / `async_response_api_handler` |
| `litellm/llms/custom_httpx/http_handler.py` | Decorate sync `HTTPHandler.post` with `@track_llm_api_timing()` (mirrors `AsyncHTTPHandler.post:606`) |
| `tests/test_litellm/llms/test_responses_api_overhead_header.py` | 5 regression tests: decorator presence on both handlers, source-level AST assertion that every `_httpx_client.post(...)` site in the responses handlers forwards `logging_obj=`, and an end-to-end behavioural test that drives `async_response_api_handler` with a stubbed `httpx` and asserts `llm_api_duration_ms` is recorded on the logging object |

Net diff: **+5 lines** in product code, +202 lines of new tests.

> Note: this PR was pushed via the GitHub Contents API (one commit per file) because the agent's token lacks `repo` push scope. The merge-base diff will show three small commits instead of one squash — content is identical.

## Evidence

Driven against the proxy with a stub upstream that returns a canned `/v1/responses` payload after a 70ms artificial latency. Same model config, same curl request, only the litellm source differs.

### Before (on `litellm_oss_agent_shin_daily_branch` HEAD, unmodified)

```
status: 200
x-litellm-call-id:               d4bc5c44-74f6-4df9-8a50-3faf13e7c008
x-litellm-model-id:              696bcaee75d6...
x-litellm-version:               1.87.0
x-litellm-response-cost:         1.25e-05
x-litellm-key-spend:             1.25e-05
x-litellm-response-duration-ms:  75.772
x-litellm-callback-duration-ms:  0.0
x-litellm-model-group:           test-resp
x-litellm-attempted-retries:     0
x-litellm-attempted-fallbacks:   0
# ← NO x-litellm-overhead-duration-ms (bug reproduced)
```

### After (with this PR applied, same harness)

```
status: 200
x-litellm-call-id:               9eda1cd3-f7e5-400c-8e87-fa6845104148
x-litellm-model-id:              696bcaee75d6...
x-litellm-version:               1.87.0
x-litellm-response-cost:         1.25e-05
x-litellm-key-spend:             1.25e-05
x-litellm-response-duration-ms:  76.321
x-litellm-overhead-duration-ms:  5.676   ← NEW
x-litellm-callback-duration-ms:  0.0
x-litellm-model-group:           test-resp
x-litellm-attempted-retries:     0
x-litellm-attempted-fallbacks:   0
```

### Unit tests

Locked the fix at three levels (decorator presence, source-level kwarg forwarding, behavioural). With the fix applied, all 5 pass:

```
tests/test_litellm/llms/test_responses_api_overhead_header.py::test_async_post_has_track_llm_api_timing_decorator PASSED
tests/test_litellm/llms/test_responses_api_overhead_header.py::test_sync_post_has_track_llm_api_timing_decorator PASSED
tests/test_litellm/llms/test_responses_api_overhead_header.py::test_responses_api_handler_passes_logging_obj_to_post[sync] PASSED
tests/test_litellm/llms/test_responses_api_overhead_header.py::test_responses_api_handler_passes_logging_obj_to_post[async] PASSED
tests/test_litellm/llms/test_responses_api_overhead_header.py::test_async_response_api_handler_records_llm_api_duration_ms PASSED
============================== 5 passed in 1.00s ===============================
```

With the product changes reverted (clean base branch) the tests fail with explicit `LIT-1756` messages:

```
FAILED test_sync_post_has_track_llm_api_timing_decorator
   AssertionError: HTTPHandler.post is not decorated — track_llm_api_timing missing
FAILED test_responses_api_handler_passes_logging_obj_to_post[sync]
   AssertionError: response_api_handler: a `*_httpx_client.post(...)` site at line 2339 does not forward `logging_obj=` (kwargs present: ['url', 'headers', 'json', 'timeout', 'stream']). This re-introduces LIT-1756.
FAILED test_responses_api_handler_passes_logging_obj_to_post[async]
   AssertionError: async_response_api_handler: a `*_httpx_client.post(...)` site at line 2485 does not forward `logging_obj=` (kwargs present: ['url', 'headers', 'json', 'timeout', 'stream']). This re-introduces LIT-1756.
FAILED test_async_response_api_handler_records_llm_api_duration_ms
   AssertionError: llm_api_duration_ms not set on logging_obj after handler call — track_llm_api_timing did not see logging_obj because it was not forwarded to post() (LIT-1756)
4 failed, 1 passed
```

## Pre-Submission checklist

- [x] Tests in `tests/test_litellm/` (5 new)
- [x] Regression-validated: tests fail without the product change, pass with it
- [x] Runtime evidence captured (before + after curl-equivalent HTTP response headers)
- [x] Scope is isolated — single ticket, two source files, one test file
- [x] Will request Greptile review (`@greptileai`) once CI starts

## Session

Agent session: https://litellm-agent-platform.onrender.com/sessions/b9119ea3-7ea3-47ea-9378-e43ffb130232


### Verification (ship-pr)

- [x] PR base = `litellm_oss_agent_shin_daily_branch` (head=`c6bd5dc6`, base=`1fe911d8`, merge-base diff = +207 / -0 across 3 files).
- [x] All GitHub Actions green — 44/44 checks completed `success`, including Veria AI - PR Review, secret-scan, lint, test, unit-test, validate-model-prices-json, build-ui, semgrep, code-quality, documentation, and every per-suite `Run tests` job (proxy-*, integrations, core-utils, Vertex AI, All Other Providers, responses-caching-types, proxy-auth, proxy-mgmt-behavior, proxy-endpoints, proxy-infra, enterprise-routing, test-server-root-path × 2).
- [x] Greptile ≥ 4/5 — two reviews on commit `c6bd5dc6`, both Confidence Score 4/5, "Safe to merge". No P1/P2 blockers; only nit on the AST guard's robustness to future refactors.
- [x] Runtime evidence captured before + after on a live `litellm --config` proxy on :4000 against a mock OpenAI on :8001 — header `x-litellm-overhead-duration-ms` absent on /v1/responses on base SHA, present (`5.449` ms) after this patch. Inline in PR body.
- [x] Codecov: patch coverage 100% on the source-file deltas.
- [x] No customer name in PR title/body. No secrets in diff or evidence; `Authorization: Bearer sk-1234` is the locally-set `LITELLM_MASTER_KEY` for the dev proxy, not a real key.
- [x] Mergeable state: `clean`.
