### PR TITLE
fix(mcp): grant MCP server access via unified key/team access_group_ids (LIT-3399)

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1141,6 +1141,10 @@ class MCPRequestHandler:
             )
             return []
 
+    # Sentinel stored in cache when an org has no object_permission, so we
+    # don't re-query the DB on every MCP request for that org.
+    _ORG_NO_PERMISSION_SENTINEL = "__org_no_mcp_permission__"
+
     @staticmethod
     async def _get_org_object_permission(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -719,40 +719,6 @@ class MCPRequestHandler:
         return team_obj.object_permission
 
     @staticmethod
-    async def _get_team_object(
-        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
-    ) -> Optional["LiteLLM_TeamTable"]:
-        """
-        LIT-3399: fetch the full team row in a single cached call so callers
-        can read both .object_permission (legacy MCP grants) and
-        .access_group_ids (unified access-group grants) without a second
-        round-trip. Returns None if there is no team_id / no prisma_client /
-        no team row.
-        """
-        from litellm.proxy.auth.auth_checks import get_team_object
-        from litellm.proxy.proxy_server import (
-            prisma_client,
-            proxy_logging_obj,
-            user_api_key_cache,
-        )
-
-        if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
-            return None
-
-        try:
-            team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
-                team_id=user_api_key_auth.team_id,
-                prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
-                parent_otel_span=user_api_key_auth.parent_otel_span,
-                proxy_logging_obj=proxy_logging_obj,
-            )
-        except Exception:
-            return None
-
-        return team_obj or None
-
-    @staticmethod
     async def _get_team_unified_access_group_ids(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
     ) -> List[str]:
@@ -1079,23 +1045,24 @@ class MCPRequestHandler:
         Note: object_permission is automatically loaded by get_team_object() in main auth flow.
         """
         try:
-            # LIT-3399: fetch the team row exactly once and pull both the
-            # legacy object_permission and the unified access_group_ids off
-            # the same object, so the team MCP auth path makes a single
-            # cached get_team_object() call per request (Greptile P2).
-            team_obj = await MCPRequestHandler._get_team_object(user_api_key_auth)
-
-            object_permissions = (
-                team_obj.object_permission if team_obj is not None else None
+            # Get team object permission (already loaded in main auth flow)
+            object_permissions = await MCPRequestHandler._get_team_object_permission(
+                user_api_key_auth
             )
+
+            # LIT-3399: also resolve the team's unified access_group_ids ->
+            # MCP server IDs (mirrors can_team_access_model). This grants
+            # MCP servers via an access group attached to the team, without
+            # requiring the team to also be listed in the group's
+            # assigned_team_ids. Both this helper and
+            # _get_team_object_permission go through the same cached
+            # get_team_object() call, so the second call is served from
+            # cache.
             team_access_group_ids = (
-                list(team_obj.access_group_ids)
-                if team_obj is not None and team_obj.access_group_ids
-                else []
+                await MCPRequestHandler._get_team_unified_access_group_ids(
+                    user_api_key_auth
+                )
             )
-
-            # LIT-3399: resolve unified team.access_group_ids -> MCP server IDs.
-            # Mirrors can_team_access_model.
             unified_access_group_servers = await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
                 access_group_ids=team_access_group_ids,
             )

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -986,14 +986,12 @@ class MCPRequestHandler:
             # assigned_key_ids. Done independently of object_permission so a
             # key with ONLY unified access groups (no object_permission row)
             # still gets MCP access.
-            unified_access_group_servers = (
-                await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
-                    access_group_ids=(
-                        list(user_api_key_auth.access_group_ids)
-                        if user_api_key_auth and user_api_key_auth.access_group_ids
-                        else []
-                    ),
-                )
+            unified_access_group_servers = await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                access_group_ids=(
+                    list(user_api_key_auth.access_group_ids)
+                    if user_api_key_auth and user_api_key_auth.access_group_ids
+                    else []
+                ),
             )
 
             if key_object_permission is None:
@@ -1062,10 +1060,8 @@ class MCPRequestHandler:
                     user_api_key_auth
                 )
             )
-            unified_access_group_servers = (
-                await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
-                    access_group_ids=team_access_group_ids,
-                )
+            unified_access_group_servers = await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                access_group_ids=team_access_group_ids,
             )
 
             if object_permissions is None:

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -719,6 +719,40 @@ class MCPRequestHandler:
         return team_obj.object_permission
 
     @staticmethod
+    async def _get_team_object(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> Optional["LiteLLM_TeamTable"]:
+        """
+        LIT-3399: fetch the full team row in a single cached call so callers
+        can read both .object_permission (legacy MCP grants) and
+        .access_group_ids (unified access-group grants) without a second
+        round-trip. Returns None if there is no team_id / no prisma_client /
+        no team row.
+        """
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
+            return None
+
+        try:
+            team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
+                team_id=user_api_key_auth.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=user_api_key_auth.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception:
+            return None
+
+        return team_obj or None
+
+    @staticmethod
     async def _get_team_unified_access_group_ids(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
     ) -> List[str]:
@@ -1045,21 +1079,23 @@ class MCPRequestHandler:
         Note: object_permission is automatically loaded by get_team_object() in main auth flow.
         """
         try:
-            # Get team object permission (already loaded in main auth flow)
-            object_permissions = await MCPRequestHandler._get_team_object_permission(
-                user_api_key_auth
+            # LIT-3399: fetch the team row exactly once and pull both the
+            # legacy object_permission and the unified access_group_ids off
+            # the same object, so the team MCP auth path makes a single
+            # cached get_team_object() call per request (Greptile P2).
+            team_obj = await MCPRequestHandler._get_team_object(user_api_key_auth)
+
+            object_permissions = (
+                team_obj.object_permission if team_obj is not None else None
+            )
+            team_access_group_ids = (
+                list(team_obj.access_group_ids)
+                if team_obj is not None and team_obj.access_group_ids
+                else []
             )
 
-            # LIT-3399: also resolve the team's unified access_group_ids ->
-            # MCP server IDs (mirrors can_team_access_model). This grants
-            # MCP servers via an access group attached to the team, without
-            # requiring the team to also be listed in the group's
-            # assigned_team_ids.
-            team_access_group_ids = (
-                await MCPRequestHandler._get_team_unified_access_group_ids(
-                    user_api_key_auth
-                )
-            )
+            # LIT-3399: resolve unified team.access_group_ids -> MCP server IDs.
+            # Mirrors can_team_access_model.
             unified_access_group_servers = await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
                 access_group_ids=team_access_group_ids,
             )
@@ -1104,10 +1140,6 @@ class MCPRequestHandler:
                 f"Failed to get allowed MCP servers for team: {str(e)}"
             )
             return []
-
-    # Sentinel stored in cache when an org has no object_permission, so we
-    # don't re-query the DB on every MCP request for that org.
-    _ORG_NO_PERMISSION_SENTINEL = "__org_no_mcp_permission__"
 
     @staticmethod
     async def _get_org_object_permission(

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -719,6 +719,81 @@ class MCPRequestHandler:
         return team_obj.object_permission
 
     @staticmethod
+    async def _get_team_unified_access_group_ids(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[str]:
+        """
+        LIT-3399: fetch the unified access_group_ids attached to the team.
+        Returns [] if no team / no prisma / team has no unified access groups.
+
+        Uses the same cached get_team_object() call as _get_team_object_permission,
+        so this is not an extra DB round-trip in the hot path.
+        """
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
+            return []
+
+        try:
+            team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
+                team_id=user_api_key_auth.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=user_api_key_auth.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception:
+            return []
+
+        if team_obj is None:
+            return []
+        return list(getattr(team_obj, "access_group_ids", None) or [])
+
+    @staticmethod
+    async def _get_unified_access_group_mcp_servers_for_object(
+        access_group_ids: List[str],
+    ) -> List[str]:
+        """
+        Resolve unified access_group_ids (LiteLLM_AccessGroupTable rows) to the
+        MCP server IDs they grant, then expand any name/alias entries to
+        canonical server IDs via global_mcp_server_manager.
+
+        LIT-3399: a key or team that has an access group attached via its
+        `access_group_ids` field is granted that group's
+        `access_mcp_server_ids` without requiring the key/team to also be
+        listed in the group's `assigned_key_ids` / `assigned_team_ids`. This
+        matches the unified-access-group semantics already used for models in
+        `can_token_call_model` and `can_team_access_model`.
+        """
+        if not access_group_ids:
+            return []
+        try:
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                global_mcp_server_manager,
+            )
+            from litellm.proxy.auth.auth_checks import (
+                _get_mcp_server_ids_from_access_groups,
+            )
+
+            raw_ids = await _get_mcp_server_ids_from_access_groups(
+                access_group_ids=access_group_ids,
+            )
+            if not raw_ids:
+                return []
+            # Entries may be server_ids OR names/aliases — expand to ids.
+            return global_mcp_server_manager.expand_permission_list(raw_ids)
+        except Exception as e:
+            verbose_logger.warning(
+                f"Failed to resolve unified access_group_ids to MCP servers: {str(e)}"
+            )
+            return []
+
+    @staticmethod
     async def get_allowed_tools_for_server(
         server_id: str,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
@@ -902,8 +977,28 @@ class MCPRequestHandler:
                         parent_otel_span=user_api_key_auth.parent_otel_span,
                         proxy_logging_obj=proxy_logging_obj,
                     )
+
+            # LIT-3399: resolve unified key.access_group_ids -> MCP server IDs.
+            # This mirrors how can_token_call_model resolves unified access
+            # groups for models: an access group attached to the key (via
+            # access_group_ids) grants its access_mcp_server_ids without
+            # requiring the key to also be listed in the group's
+            # assigned_key_ids. Done independently of object_permission so a
+            # key with ONLY unified access groups (no object_permission row)
+            # still gets MCP access.
+            unified_access_group_servers = (
+                await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                    access_group_ids=(
+                        list(user_api_key_auth.access_group_ids)
+                        if user_api_key_auth and user_api_key_auth.access_group_ids
+                        else []
+                    ),
+                )
+            )
+
             if key_object_permission is None:
-                return []
+                # No legacy MCP grants; only unified access-group grants apply.
+                return list(set(unified_access_group_servers))
 
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -929,7 +1024,12 @@ class MCPRequestHandler:
             )
 
             # Combine all lists
-            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+            all_servers = (
+                direct_mcp_servers
+                + access_group_servers
+                + tool_perm_servers
+                + unified_access_group_servers
+            )
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(
@@ -952,8 +1052,25 @@ class MCPRequestHandler:
                 user_api_key_auth
             )
 
+            # LIT-3399: also resolve the team's unified access_group_ids ->
+            # MCP server IDs (mirrors can_team_access_model). This grants
+            # MCP servers via an access group attached to the team, without
+            # requiring the team to also be listed in the group's
+            # assigned_team_ids.
+            team_access_group_ids = (
+                await MCPRequestHandler._get_team_unified_access_group_ids(
+                    user_api_key_auth
+                )
+            )
+            unified_access_group_servers = (
+                await MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                    access_group_ids=team_access_group_ids,
+                )
+            )
+
             if object_permissions is None:
-                return []
+                # No legacy MCP grants; only unified access-group grants apply.
+                return list(set(unified_access_group_servers))
 
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -979,7 +1096,12 @@ class MCPRequestHandler:
             )
 
             # Combine all lists
-            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+            all_servers = (
+                direct_mcp_servers
+                + access_group_servers
+                + tool_perm_servers
+                + unified_access_group_servers
+            )
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -3160,3 +3160,295 @@ class TestOrgMCPPermissions:
                 user_api_key_auth=auth,
             )
             assert sorted(result) == ["tool_a", "tool_b"]
+
+# ---------------------------------------------------------------------------
+# LIT-3399: unified key.access_group_ids / team.access_group_ids -> MCP servers
+# ---------------------------------------------------------------------------
+# Bug: attaching a unified access group G (with access_mcp_server_ids = [S])
+# to a virtual key K via key.access_group_ids did NOT grant MCP access — the
+# proxy returned 403 unless G.assigned_key_ids also included K. Same problem on
+# the team side. Fix: an inclusive (un-gated) resolution path that mirrors
+# can_token_call_model / can_team_access_model.
+# ---------------------------------------------------------------------------
+
+
+def _lit3399_make_unified_access_group(
+    *,
+    access_group_id,
+    access_mcp_server_ids=None,
+    assigned_team_ids=None,
+    assigned_key_ids=None,
+):
+    """Build a LiteLLM_AccessGroupTable row for tests."""
+    from litellm.proxy._types import LiteLLM_AccessGroupTable
+
+    return LiteLLM_AccessGroupTable(
+        access_group_id=access_group_id,
+        access_group_name=access_group_id,
+        access_model_names=[],
+        access_mcp_server_ids=access_mcp_server_ids or [],
+        access_agent_ids=[],
+        assigned_team_ids=assigned_team_ids or [],
+        assigned_key_ids=assigned_key_ids or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit3399_key_access_group_grants_mcp_without_assigned_key_ids():
+    """End-to-end repro: key K with access_group_ids=[G], G has
+    access_mcp_server_ids=[S] but G.assigned_key_ids is empty. Pre-fix the
+    allowed list was []; post-fix it contains S."""
+    auth = UserAPIKeyAuth(
+        api_key="sk-lit3399-fake",
+        token="sk-lit3399-fake",
+        access_group_ids=["group-G"],
+        team_id=None,
+        object_permission_id=None,
+    )
+
+    group = _lit3399_make_unified_access_group(
+        access_group_id="group-G",
+        access_mcp_server_ids=["server-S"],
+    )
+
+    mock_mgr = MagicMock()
+    mock_mgr.expand_permission_list = MagicMock(side_effect=lambda lst: list(lst or []))
+    mock_mgr.expand_tool_permissions = MagicMock(return_value={})
+    mock_mgr.config_mcp_servers = []
+
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), \
+         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()), \
+         patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()), \
+         patch(
+             "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+             mock_mgr,
+         ), \
+         patch(
+             "litellm.proxy.auth.auth_checks.get_access_object",
+             new=AsyncMock(return_value=group),
+         ):
+        result = await MCPRequestHandler.get_allowed_mcp_servers(
+            user_api_key_auth=auth
+        )
+
+    assert "server-S" in result, (
+        f"Expected server-S to be granted via unified key.access_group_ids, "
+        f"got {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit3399_key_no_unified_groups_returns_empty_when_no_object_perm():
+    """A key without unified access_group_ids and without object_permission still
+    returns []. LIT-3399 fix must not change the negative case."""
+    auth = UserAPIKeyAuth(
+        api_key="sk-empty-key",
+        token="sk-empty-key",
+        access_group_ids=None,
+        team_id=None,
+        object_permission_id=None,
+    )
+
+    mock_mgr = MagicMock()
+    mock_mgr.expand_permission_list = MagicMock(side_effect=lambda lst: list(lst or []))
+
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), \
+         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()), \
+         patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()), \
+         patch(
+             "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+             mock_mgr,
+         ):
+        result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(auth)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_lit3399_get_unified_helper_resolves_servers():
+    """_get_unified_access_group_mcp_servers_for_object resolves via
+    auth_checks._get_mcp_server_ids_from_access_groups, then expands each
+    server via global_mcp_server_manager.expand_permission_list."""
+    mock_mgr = MagicMock()
+    mock_mgr.expand_permission_list = MagicMock(
+        side_effect=lambda lst: [f"resolved-{x}" for x in (lst or [])]
+    )
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        mock_mgr,
+    ), patch(
+        "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+        new=AsyncMock(return_value=["raw-S1", "raw-S2"]),
+    ):
+        result = await (
+            MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                access_group_ids=["G1", "G2"],
+            )
+        )
+
+    assert set(result) == {"resolved-raw-S1", "resolved-raw-S2"}
+    mock_mgr.expand_permission_list.assert_called_once_with(["raw-S1", "raw-S2"])
+
+
+@pytest.mark.asyncio
+async def test_lit3399_get_unified_helper_empty_input_returns_empty():
+    """No access_group_ids -> no DB hit, returns []."""
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+        new=AsyncMock(return_value=["should-not-be-called"]),
+    ) as mock_resolve:
+        result = await (
+            MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                access_group_ids=[],
+            )
+        )
+    assert result == []
+    mock_resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lit3399_get_unified_helper_swallows_exceptions():
+    """Resolver throwing must not break MCP auth -> return []."""
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await (
+            MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                access_group_ids=["G1"],
+            )
+        )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_lit3399_key_with_object_perm_and_unified_groups_unions_both():
+    """A key that has BOTH a legacy object_permission AND unified
+    access_group_ids gets the union of both server sets."""
+    from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+    object_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="perm-1",
+        mcp_servers=["legacy-S"],
+        mcp_access_groups=[],
+        mcp_tool_permissions=None,
+    )
+    auth = UserAPIKeyAuth(
+        api_key="sk-both",
+        token="sk-both",
+        access_group_ids=["G-unified"],
+        team_id=None,
+        object_permission=object_permission,
+    )
+
+    mock_mgr = MagicMock()
+    mock_mgr.expand_permission_list = MagicMock(side_effect=lambda lst: list(lst or []))
+    mock_mgr.expand_tool_permissions = MagicMock(return_value={})
+    mock_mgr.config_mcp_servers = []
+
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), \
+         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()), \
+         patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()), \
+         patch(
+             "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+             mock_mgr,
+         ), \
+         patch.object(
+             MCPRequestHandler,
+             "_get_mcp_servers_from_access_groups",
+             new=AsyncMock(return_value=[]),
+         ), \
+         patch.object(
+             MCPRequestHandler,
+             "_get_unified_access_group_mcp_servers_for_object",
+             new=AsyncMock(return_value=["unified-S"]),
+         ):
+        result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(auth)
+
+    assert set(result) == {"legacy-S", "unified-S"}
+
+
+@pytest.mark.asyncio
+async def test_lit3399_team_unified_access_group_grants_mcp():
+    """Team has access_group_ids=[G] where G.access_mcp_server_ids=[S] but
+    G.assigned_team_ids is empty -> team gets server S."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+
+    auth = UserAPIKeyAuth(
+        api_key="sk-team-key",
+        token="sk-team-key",
+        team_id="team-T",
+        access_group_ids=None,
+    )
+
+    with patch.object(
+        MCPRequestHandler,
+        "_get_team_object_permission",
+        new=AsyncMock(return_value=None),
+    ), patch.object(
+        MCPRequestHandler,
+        "_get_team_unified_access_group_ids",
+        new=AsyncMock(return_value=["G-team"]),
+    ), patch.object(
+        MCPRequestHandler,
+        "_get_unified_access_group_mcp_servers_for_object",
+        new=AsyncMock(return_value=["team-server-S"]),
+    ):
+        result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
+
+    assert result == ["team-server-S"]
+
+
+@pytest.mark.asyncio
+async def test_lit3399_get_team_unified_access_group_ids_returns_empty_for_no_team():
+    """_get_team_unified_access_group_ids() returns [] when there is no team_id
+    or prisma_client."""
+    auth_no_team = UserAPIKeyAuth(api_key="sk", token="sk", team_id=None)
+
+    result = await MCPRequestHandler._get_team_unified_access_group_ids(auth_no_team)
+    assert result == []
+
+    auth = UserAPIKeyAuth(api_key="sk", token="sk", team_id="team-T")
+    with patch("litellm.proxy.proxy_server.prisma_client", None):
+        result = await MCPRequestHandler._get_team_unified_access_group_ids(auth)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_lit3399_get_team_unified_access_group_ids_reads_team_field():
+    """Returns team.access_group_ids when set; tolerates None (legacy teams)."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+
+    auth = UserAPIKeyAuth(api_key="sk", token="sk", team_id="team-T")
+
+    team_with = MagicMock(spec=LiteLLM_TeamTable)
+    team_with.access_group_ids = ["AG-1"]
+    team_without = MagicMock(spec=LiteLLM_TeamTable)
+    team_without.access_group_ids = None
+
+    common_patches = [
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+    ]
+
+    for p in common_patches:
+        p.start()
+    try:
+        with patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new=AsyncMock(return_value=team_with),
+        ):
+            out = await MCPRequestHandler._get_team_unified_access_group_ids(auth)
+        assert out == ["AG-1"]
+
+        with patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            new=AsyncMock(return_value=team_without),
+        ):
+            out = await MCPRequestHandler._get_team_unified_access_group_ids(auth)
+        assert out == []
+    finally:
+        for p in common_patches:
+            p.stop()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -2479,36 +2479,37 @@ async def test_get_allowed_mcp_servers_for_team_uses_helper():
             team_id="team-789",
         )
 
-        # _get_team_object replaced _get_team_object_permission inside
-        # _get_allowed_mcp_servers_for_team in the LIT-3399 Greptile-P2 fix
-        # (single cached team fetch). Test mocks the new helper.
-        fake_team_obj = MagicMock()
-        fake_team_obj.object_permission = mock_object_permission
-        fake_team_obj.access_group_ids = []  # no unified access groups
+        # Mock the helper methods
         with patch.object(
-            MCPRequestHandler,
-            "_get_team_object",
-            new=AsyncMock(return_value=fake_team_obj),
-        ) as mock_get_team_obj:
+            MCPRequestHandler, "_get_team_object_permission"
+        ) as mock_get_team_perm:
             with patch.object(
                 MCPRequestHandler, "_get_mcp_servers_from_access_groups"
             ) as mock_get_access_group_servers:
+                # Configure mocks
+                mock_get_team_perm.return_value = mock_object_permission
                 mock_get_access_group_servers.return_value = [
                     "group-server1",
                     "group-server2",
                 ]
 
+                # Call the method
                 result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(
                     mock_user_auth
                 )
 
+                # Assert the result contains both direct and access group servers
                 assert set(result) == {
                     "direct-server1",
                     "direct-server2",
                     "group-server1",
                     "group-server2",
                 }
-                mock_get_team_obj.assert_called_once_with(mock_user_auth)
+
+                # Verify _get_team_object_permission was called (the helper we fixed)
+                mock_get_team_perm.assert_called_once_with(mock_user_auth)
+
+                # Verify access groups were resolved
                 mock_get_access_group_servers.assert_called_once_with(["dev-group"])
     finally:
         for sid in ("direct-server1", "direct-server2"):
@@ -2528,18 +2529,22 @@ async def test_get_allowed_mcp_servers_for_team_with_no_object_permission():
         team_id="team-no-perm",
     )
 
-    # _get_team_object replaced _get_team_object_permission in
-    # _get_allowed_mcp_servers_for_team (LIT-3399 Greptile-P2 fix).
+    # Mock the helper to return None (no object permission)
     with patch.object(
-        MCPRequestHandler,
-        "_get_team_object",
-        new=AsyncMock(return_value=None),
-    ) as mock_get_team_obj:
+        MCPRequestHandler, "_get_team_object_permission"
+    ) as mock_get_team_perm:
+        mock_get_team_perm.return_value = None
+
+        # Call the method
         result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(
             mock_user_auth
         )
+
+        # Assert empty list is returned
         assert result == []
-        mock_get_team_obj.assert_called_once_with(mock_user_auth)
+
+        # Verify the helper was called
+        mock_get_team_perm.assert_called_once_with(mock_user_auth)
 
 
 @pytest.mark.asyncio
@@ -3391,14 +3396,16 @@ async def test_lit3399_team_unified_access_group_grants_mcp():
         access_group_ids=None,
     )
 
-    fake_team_obj = MagicMock()
-    fake_team_obj.object_permission = None
-    fake_team_obj.access_group_ids = ["G-team"]
     with (
         patch.object(
             MCPRequestHandler,
-            "_get_team_object",
-            new=AsyncMock(return_value=fake_team_obj),
+            "_get_team_object_permission",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_team_unified_access_group_ids",
+            new=AsyncMock(return_value=["G-team"]),
         ),
         patch.object(
             MCPRequestHandler,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -2479,37 +2479,36 @@ async def test_get_allowed_mcp_servers_for_team_uses_helper():
             team_id="team-789",
         )
 
-        # Mock the helper methods
+        # _get_team_object replaced _get_team_object_permission inside
+        # _get_allowed_mcp_servers_for_team in the LIT-3399 Greptile-P2 fix
+        # (single cached team fetch). Test mocks the new helper.
+        fake_team_obj = MagicMock()
+        fake_team_obj.object_permission = mock_object_permission
+        fake_team_obj.access_group_ids = []  # no unified access groups
         with patch.object(
-            MCPRequestHandler, "_get_team_object_permission"
-        ) as mock_get_team_perm:
+            MCPRequestHandler,
+            "_get_team_object",
+            new=AsyncMock(return_value=fake_team_obj),
+        ) as mock_get_team_obj:
             with patch.object(
                 MCPRequestHandler, "_get_mcp_servers_from_access_groups"
             ) as mock_get_access_group_servers:
-                # Configure mocks
-                mock_get_team_perm.return_value = mock_object_permission
                 mock_get_access_group_servers.return_value = [
                     "group-server1",
                     "group-server2",
                 ]
 
-                # Call the method
                 result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(
                     mock_user_auth
                 )
 
-                # Assert the result contains both direct and access group servers
                 assert set(result) == {
                     "direct-server1",
                     "direct-server2",
                     "group-server1",
                     "group-server2",
                 }
-
-                # Verify _get_team_object_permission was called (the helper we fixed)
-                mock_get_team_perm.assert_called_once_with(mock_user_auth)
-
-                # Verify access groups were resolved
+                mock_get_team_obj.assert_called_once_with(mock_user_auth)
                 mock_get_access_group_servers.assert_called_once_with(["dev-group"])
     finally:
         for sid in ("direct-server1", "direct-server2"):
@@ -2529,22 +2528,18 @@ async def test_get_allowed_mcp_servers_for_team_with_no_object_permission():
         team_id="team-no-perm",
     )
 
-    # Mock the helper to return None (no object permission)
+    # _get_team_object replaced _get_team_object_permission in
+    # _get_allowed_mcp_servers_for_team (LIT-3399 Greptile-P2 fix).
     with patch.object(
-        MCPRequestHandler, "_get_team_object_permission"
-    ) as mock_get_team_perm:
-        mock_get_team_perm.return_value = None
-
-        # Call the method
+        MCPRequestHandler,
+        "_get_team_object",
+        new=AsyncMock(return_value=None),
+    ) as mock_get_team_obj:
         result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(
             mock_user_auth
         )
-
-        # Assert empty list is returned
         assert result == []
-
-        # Verify the helper was called
-        mock_get_team_perm.assert_called_once_with(mock_user_auth)
+        mock_get_team_obj.assert_called_once_with(mock_user_auth)
 
 
 @pytest.mark.asyncio
@@ -3396,16 +3391,14 @@ async def test_lit3399_team_unified_access_group_grants_mcp():
         access_group_ids=None,
     )
 
+    fake_team_obj = MagicMock()
+    fake_team_obj.object_permission = None
+    fake_team_obj.access_group_ids = ["G-team"]
     with (
         patch.object(
             MCPRequestHandler,
-            "_get_team_object_permission",
-            new=AsyncMock(return_value=None),
-        ),
-        patch.object(
-            MCPRequestHandler,
-            "_get_team_unified_access_group_ids",
-            new=AsyncMock(return_value=["G-team"]),
+            "_get_team_object",
+            new=AsyncMock(return_value=fake_team_obj),
         ),
         patch.object(
             MCPRequestHandler,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -880,7 +880,7 @@ class TestMCPPublicRouteGuard:
         with patch(
             "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
         ) as mock_auth:
-            (auth_result, *_rest) = await MCPRequestHandler.process_mcp_request(scope)
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(scope)
             mock_auth.assert_not_called()
             assert isinstance(auth_result, UserAPIKeyAuth)
 
@@ -997,7 +997,7 @@ class TestMCPOAuth2FallbackTargetGating:
             mock_mgr.get_mcp_server_by_name.return_value = (
                 TestMCPOAuth2FallbackTargetGating._make_server(MCPAuth.oauth2)
             )
-            (auth_result, *_rest) = await MCPRequestHandler.process_mcp_request(scope)
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(scope)
             assert isinstance(auth_result, UserAPIKeyAuth)
 
     async def test_fallback_blocked_when_any_target_in_header_is_not_oauth2(self):
@@ -1157,7 +1157,7 @@ class TestMCPDelegateAuthToUpstream:
                     delegate_auth_to_upstream=True,
                 )
             )
-            (auth_result, *_rest) = await MCPRequestHandler.process_mcp_request(scope)
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(scope)
             assert isinstance(auth_result, UserAPIKeyAuth)
             mock_auth.assert_not_called()
 
@@ -1400,7 +1400,7 @@ class TestMCPDelegateAuthToUpstream:
                     delegate_auth_to_upstream=True,
                 )
             )
-            (auth_result, *_rest) = await MCPRequestHandler.process_mcp_request(scope)
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(scope)
             assert isinstance(auth_result, UserAPIKeyAuth)
             assert auth_result.user_id == "real-user"
             mock_auth.assert_called_once()
@@ -1437,7 +1437,7 @@ class TestMCPDelegateAuthToUpstream:
                     delegate_auth_to_upstream=True,
                 )
             )
-            (auth_result, *_rest) = await MCPRequestHandler.process_mcp_request(scope)
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(scope)
             assert isinstance(auth_result, UserAPIKeyAuth)
             assert auth_result.user_id == "real-user"
             mock_auth.assert_called_once()
@@ -3161,6 +3161,7 @@ class TestOrgMCPPermissions:
             )
             assert sorted(result) == ["tool_a", "tool_b"]
 
+
 # ---------------------------------------------------------------------------
 # LIT-3399: unified key.access_group_ids / team.access_group_ids -> MCP servers
 # ---------------------------------------------------------------------------
@@ -3216,20 +3217,20 @@ async def test_lit3399_key_access_group_grants_mcp_without_assigned_key_ids():
     mock_mgr.expand_tool_permissions = MagicMock(return_value={})
     mock_mgr.config_mcp_servers = []
 
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), \
-         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()), \
-         patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()), \
-         patch(
-             "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
-             mock_mgr,
-         ), \
-         patch(
-             "litellm.proxy.auth.auth_checks.get_access_object",
-             new=AsyncMock(return_value=group),
-         ):
-        result = await MCPRequestHandler.get_allowed_mcp_servers(
-            user_api_key_auth=auth
-        )
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_mgr,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_access_object",
+            new=AsyncMock(return_value=group),
+        ),
+    ):
+        result = await MCPRequestHandler.get_allowed_mcp_servers(user_api_key_auth=auth)
 
     assert "server-S" in result, (
         f"Expected server-S to be granted via unified key.access_group_ids, "
@@ -3252,13 +3253,15 @@ async def test_lit3399_key_no_unified_groups_returns_empty_when_no_object_perm()
     mock_mgr = MagicMock()
     mock_mgr.expand_permission_list = MagicMock(side_effect=lambda lst: list(lst or []))
 
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), \
-         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()), \
-         patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()), \
-         patch(
-             "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
-             mock_mgr,
-         ):
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_mgr,
+        ),
+    ):
         result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(auth)
 
     assert result == []
@@ -3274,16 +3277,21 @@ async def test_lit3399_get_unified_helper_resolves_servers():
         side_effect=lambda lst: [f"resolved-{x}" for x in (lst or [])]
     )
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
-        mock_mgr,
-    ), patch(
-        "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
-        new=AsyncMock(return_value=["raw-S1", "raw-S2"]),
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_mgr,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+            new=AsyncMock(return_value=["raw-S1", "raw-S2"]),
+        ),
     ):
-        result = await (
-            MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
-                access_group_ids=["G1", "G2"],
+        result = (
+            await (
+                MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                    access_group_ids=["G1", "G2"],
+                )
             )
         )
 
@@ -3298,9 +3306,11 @@ async def test_lit3399_get_unified_helper_empty_input_returns_empty():
         "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
         new=AsyncMock(return_value=["should-not-be-called"]),
     ) as mock_resolve:
-        result = await (
-            MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
-                access_group_ids=[],
+        result = (
+            await (
+                MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                    access_group_ids=[],
+                )
             )
         )
     assert result == []
@@ -3314,9 +3324,11 @@ async def test_lit3399_get_unified_helper_swallows_exceptions():
         "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
         new=AsyncMock(side_effect=RuntimeError("boom")),
     ):
-        result = await (
-            MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
-                access_group_ids=["G1"],
+        result = (
+            await (
+                MCPRequestHandler._get_unified_access_group_mcp_servers_for_object(
+                    access_group_ids=["G1"],
+                )
             )
         )
     assert result == []
@@ -3347,23 +3359,25 @@ async def test_lit3399_key_with_object_perm_and_unified_groups_unions_both():
     mock_mgr.expand_tool_permissions = MagicMock(return_value={})
     mock_mgr.config_mcp_servers = []
 
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), \
-         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()), \
-         patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()), \
-         patch(
-             "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
-             mock_mgr,
-         ), \
-         patch.object(
-             MCPRequestHandler,
-             "_get_mcp_servers_from_access_groups",
-             new=AsyncMock(return_value=[]),
-         ), \
-         patch.object(
-             MCPRequestHandler,
-             "_get_unified_access_group_mcp_servers_for_object",
-             new=AsyncMock(return_value=["unified-S"]),
-         ):
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_mgr,
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_mcp_servers_from_access_groups",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_unified_access_group_mcp_servers_for_object",
+            new=AsyncMock(return_value=["unified-S"]),
+        ),
+    ):
         result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(auth)
 
     assert set(result) == {"legacy-S", "unified-S"}
@@ -3382,18 +3396,22 @@ async def test_lit3399_team_unified_access_group_grants_mcp():
         access_group_ids=None,
     )
 
-    with patch.object(
-        MCPRequestHandler,
-        "_get_team_object_permission",
-        new=AsyncMock(return_value=None),
-    ), patch.object(
-        MCPRequestHandler,
-        "_get_team_unified_access_group_ids",
-        new=AsyncMock(return_value=["G-team"]),
-    ), patch.object(
-        MCPRequestHandler,
-        "_get_unified_access_group_mcp_servers_for_object",
-        new=AsyncMock(return_value=["team-server-S"]),
+    with (
+        patch.object(
+            MCPRequestHandler,
+            "_get_team_object_permission",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_team_unified_access_group_ids",
+            new=AsyncMock(return_value=["G-team"]),
+        ),
+        patch.object(
+            MCPRequestHandler,
+            "_get_unified_access_group_mcp_servers_for_object",
+            new=AsyncMock(return_value=["team-server-S"]),
+        ),
     ):
         result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
 


### PR DESCRIPTION
## Summary

Fixes LIT-3399: assigning a unified access group to a virtual key (`key.access_group_ids`) — or to a team (`team.access_group_ids`) — did not grant access to the MCP servers listed on that access group. The proxy returned HTTP 403 `access_denied` from `/v1/mcp/server` and the MCP tool routes unless the same key/team was ALSO listed on the access group's `assigned_key_ids` / `assigned_team_ids`. From the operator's perspective the attachment looked complete but enforcement denied access.

The fix adds an inclusive (un-gated) resolution path that mirrors the model-side semantics already used by `can_token_call_model` and `can_team_access_model`: when a key/team has an access group attached via `access_group_ids`, the group's `access_mcp_server_ids` are granted, independently of `assigned_*`.

## Root cause

`_get_allowed_mcp_servers_for_key` and `_get_allowed_mcp_servers_for_team` in `litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py` only read MCP grants from the **legacy** `object_permission` row (`mcp_servers`, `mcp_access_groups` MCP-name tags, `mcp_tool_permissions`). They never consulted the **unified** `access_group_ids` field that the Admin UI writes when an admin attaches an access group via "Access Groups" on the key edit screen. `auth_checks._get_mcp_server_ids_from_access_groups()` already exists for this purpose but was never wired into the MCP path. Additionally, the existing `_get_allowed_mcp_servers_for_key` short-circuited and returned `[]` whenever `key_object_permission is None`, so a key whose ONLY MCP grant was through a unified access group got nothing.

## Fix

`litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py`:
- New static helper `_get_unified_access_group_mcp_servers_for_object(access_group_ids)` → calls `auth_checks._get_mcp_server_ids_from_access_groups` then runs each result through `global_mcp_server_manager.expand_permission_list` for name/alias → server_id normalization. Errors swallowed and return `[]` (auth path must not 500).
- New static helper `_get_team_unified_access_group_ids(user_api_key_auth)` → fetches the team object via the same cached `get_team_object()` call already used by `_get_team_object_permission`, returns `team.access_group_ids or []`.
- `_get_allowed_mcp_servers_for_key`: removed the short-circuit-on-None for `key_object_permission`; the unified access-group resolution now runs regardless. When `key_object_permission is None` the unified-only set is returned; otherwise both sets are unioned.
- `_get_allowed_mcp_servers_for_team`: same shape — unioned the unified-access-group set with the legacy `object_permission` set.

The existing gated `_get_key_access_group_mcp_server_extras` path (added in PR #28890 / #28997 against `litellm_internal_staging`) is intentionally untouched. That path serves a different purpose (allowing a key's access group to bypass the team-MCP intersection ceiling when the key is explicitly assigned) and is not present in this branch yet anyway. This patch is the inclusive owner-style path that mirrors model semantics.

## Evidence

Driving `MCPRequestHandler.get_allowed_mcp_servers()` end-to-end against the exact ticket scenario (key K has `access_group_ids = [G]`, G has `access_mcp_server_ids = [S]` and **empty** `assigned_*`, no team, no `object_permission`):

**BEFORE (clean `litellm_oss_agent_shin_daily_branch`, HEAD `1fe911d`):**
```
$ python3 repro.py
ALLOWED_MCP_SERVERS: []
SERVER_S_IN_LIST: False
```
This is what the bug reporter sees as HTTP 403 / empty discovery.

**AFTER (this PR):**
```
$ python3 repro.py
ALLOWED_MCP_SERVERS: ['server-S-uuid']
SERVER_S_IN_LIST: True
```
Server `S` is now granted via the unified `access_group_ids` attachment alone, with no `assigned_key_ids` change.

## Tests

`tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py` — appended 9 regression tests under the `LIT-3399` header:

- `test_lit3399_key_access_group_grants_mcp_without_assigned_key_ids` — top-level repro through `MCPRequestHandler.get_allowed_mcp_servers`
- `test_lit3399_key_no_unified_groups_returns_empty_when_no_object_perm` — negative case unchanged
- `test_lit3399_get_unified_helper_resolves_servers` — helper resolves via `_get_mcp_server_ids_from_access_groups` + `expand_permission_list`
- `test_lit3399_get_unified_helper_empty_input_returns_empty` — short-circuit for empty input
- `test_lit3399_get_unified_helper_swallows_exceptions` — resolver errors must not break auth
- `test_lit3399_key_with_object_perm_and_unified_groups_unions_both` — union semantics
- `test_lit3399_team_unified_access_group_grants_mcp` — team-side equivalent
- `test_lit3399_get_team_unified_access_group_ids_returns_empty_for_no_team` — guard clauses
- `test_lit3399_get_team_unified_access_group_ids_reads_team_field` — happy path + None-tolerant

Full mcp_server/auth test directory: **149 passed**, 0 failed.

```
$ python3 -m pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/ -q
149 passed, 1 warning in 30.17s
```

## Branch / scope

- Base: `litellm_oss_agent_shin_daily_branch` (per Shin fork policy)
- Head: `oss-agent-shin:shin/lit-3399-mcp-unified-access-groups`
- Pushed via GitHub Contents API (one PUT per file) because the agent's `GITHUB_TOKEN` lacks `repo`+`workflow` scopes for `git push`. Reviewers should expect a noisier merge-base diff than a normal fast-forward; the actual change is the two files listed above.

Files changed: 2

### Verification (ship-pr)

- **Repro on `litellm_oss_agent_shin_daily_branch` (HEAD `1fe911d`):** `MCPRequestHandler.get_allowed_mcp_servers()` returns `[]` for a key with `access_group_ids=[G]`, G grants `access_mcp_server_ids=[S]`, no team, empty `assigned_*`. Matches the 403 the bug reporter sees.
- **Repro after fix:** same call returns `['server-S-uuid']` — server S is granted via the unified access-group attachment alone, with no `assigned_key_ids` change. Inline in the Evidence section above.
- **Unit tests:** 9 new LIT-3399 regression tests in `tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py` cover positive, negative, union, exception-swallow, and team/key paths. `136 passed` across the auth tests + the three pre-existing JWT MCP enforcement tests.
- **CI:** **43/44 green** at HEAD `ad5f61b`, including all lint / mypy / proxy-* test suites. Remaining check is Veria AI - PR Review, still running.
- **Greptile:** 4/5 ("safe to merge", "fix correctly mirrors the model-access semantics and is well-tested"). One P2 note on the redundant cached `get_team_object` call addressed in a PR comment (see thread): the two calls hit the same `user_api_key_cache` key, so per-request behavior is 1 DB round-trip + 1 cache hit, not 2 DB queries. Collapsing them into one helper broke 3 existing JWT MCP tests that mock `_get_team_object_permission`, so the two-helper structure was kept.
- **Base branch:** `litellm_oss_agent_shin_daily_branch` (Shin fork policy).
- **Pushed via Contents API** because the agent's `GITHUB_TOKEN` lacks `repo`+`workflow` scopes. Final diff: 2 files, +500/−4 (the test additions account for ~480 of the +500).
