### PR TITLE
feat(playground/ui): add non-streaming response toggle (LIT-3251)

### DIFF
--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.test.tsx
@@ -98,4 +98,27 @@ describe("AdditionalModelSettings", () => {
       expect(onMockTestFallbacksChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it("should not show 'Stream response' toggle when onStreamChange is not provided", () => {
+    render(<AdditionalModelSettings />);
+    expect(screen.queryByText(/Stream response/i)).not.toBeInTheDocument();
+  });
+
+  it("should render 'Stream response' toggle and reflect stream prop", () => {
+    render(<AdditionalModelSettings stream={true} onStreamChange={vi.fn()} />);
+    const checkbox = screen.getByRole("checkbox", { name: /Stream response/i });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toBeChecked();
+  });
+
+  it("should treat stream=false prop as unchecked and call onStreamChange when toggled", async () => {
+    const user = userEvent.setup();
+    const onStreamChange = vi.fn();
+    render(<AdditionalModelSettings stream={false} onStreamChange={onStreamChange} />);
+    const checkbox = screen.getByRole("checkbox", { name: /Stream response/i });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(onStreamChange).toHaveBeenCalledWith(true);
+  });
 });

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.tsx
@@ -75,7 +75,7 @@ const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
       {onStreamChange && (
         <div className="flex items-center gap-1">
           <Checkbox
-            checked={stream !== false}
+            checked={stream ?? true}
             onChange={(e) => onStreamChange(e.target.checked)}
           >
             <span className="font-medium">Stream response</span>

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.tsx
@@ -12,6 +12,8 @@ interface AdditionalModelSettingsProps {
   onUseAdvancedParamsChange?: (value: boolean) => void;
   mockTestFallbacks?: boolean;
   onMockTestFallbacksChange?: (value: boolean) => void;
+  stream?: boolean;
+  onStreamChange?: (value: boolean) => void;
 }
 
 const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
@@ -23,6 +25,8 @@ const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
   onUseAdvancedParamsChange,
   mockTestFallbacks,
   onMockTestFallbacksChange,
+  stream,
+  onStreamChange,
 }) => {
   const [internalUseAdvancedParams, setInternalUseAdvancedParams] = useState(false);
   const useAdvancedParams =
@@ -67,6 +71,35 @@ const AdditionalModelSettings: React.FC<AdditionalModelSettingsProps> = ({
       <Checkbox checked={useAdvancedParams} onChange={(e) => handleUseAdvancedParamsChange(e.target.checked)}>
         <span className="font-medium">Use Advanced Parameters</span>
       </Checkbox>
+
+      {onStreamChange && (
+        <div className="flex items-center gap-1">
+          <Checkbox
+            checked={stream !== false}
+            onChange={(e) => onStreamChange(e.target.checked)}
+          >
+            <span className="font-medium">Stream response</span>
+          </Checkbox>
+          <Popover
+            trigger="hover"
+            placement="right"
+            content={
+              <div style={{ maxWidth: 340 }}>
+                <Typography.Paragraph className="text-sm" style={{ marginBottom: 0 }}>
+                  Enable Server-Sent Events streaming. Disable to receive the full
+                  response in a single chunk &mdash; useful when comparing streaming
+                  vs. non-streaming behavior.
+                </Typography.Paragraph>
+              </div>
+            }
+          >
+            <InfoCircleOutlined
+              className="text-xs text-gray-400 cursor-pointer shrink-0 hover:text-gray-600"
+              aria-label="Help: Stream response"
+            />
+          </Popover>
+        </div>
+      )}
 
       {onMockTestFallbacksChange && (
         <div className="flex items-center gap-1">

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
@@ -1214,7 +1214,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
                             mockTestFallbacks={mockTestFallbacks}
                             onMockTestFallbacksChange={setMockTestFallbacks}
                             stream={streamEnabled}
-                            onStreamChange={setStreamEnabled}
+                            onStreamChange={
+                              endpointType === EndpointType.CHAT ? setStreamEnabled : undefined
+                            }
                           />
                         }
                         title="Model Settings"

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
@@ -255,6 +255,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const [maxTokens, setMaxTokens] = useState<number>(2048);
   const [useAdvancedParams, setUseAdvancedParams] = useState<boolean>(false);
   const [mockTestFallbacks, setMockTestFallbacks] = useState<boolean>(false);
+  const [streamEnabled, setStreamEnabled] = useState<boolean>(true);
 
   // Code Interpreter state (using custom hook)
   const codeInterpreter = useCodeInterpreter();
@@ -783,6 +784,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
             handleMCPEvent,
             mockTestFallbacks,
             mcpToolsets,
+            streamEnabled,
           );
         } else if (endpointType === EndpointType.IMAGE) {
           // For image generation
@@ -1211,6 +1213,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
                             onUseAdvancedParamsChange={setUseAdvancedParams}
                             mockTestFallbacks={mockTestFallbacks}
                             onMockTestFallbacksChange={setMockTestFallbacks}
+                            stream={streamEnabled}
+                            onStreamChange={setStreamEnabled}
                           />
                         }
                         title="Model Settings"

--- a/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.test.tsx
+++ b/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.test.tsx
@@ -256,4 +256,116 @@ describe("chat_completion", () => {
     const callArgs = mockCreate.mock.calls[0][0];
     expect(callArgs).not.toHaveProperty("mock_testing_fallbacks");
   });
+
+  it("should default to streaming when stream parameter is undefined", async () => {
+    await makeOpenAIChatCompletionRequest(mockChatHistory, mockUpdateUI, "gpt-4", "test-token");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.stream).toBe(true);
+    expect(callArgs.stream_options).toEqual({ include_usage: true });
+  });
+
+  it("should still stream when stream=true is passed explicitly", async () => {
+    await makeOpenAIChatCompletionRequest(
+      mockChatHistory,
+      mockUpdateUI,
+      "gpt-4",
+      "test-token",
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined,
+      true, // stream
+    );
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.stream).toBe(true);
+    expect(callArgs.stream_options).toEqual({ include_usage: true });
+  });
+
+  it("should send stream:false and process a single response when stream=false", async () => {
+    const onUsageData = vi.fn();
+    const onTimingData = vi.fn();
+    const onTotalLatency = vi.fn();
+
+    mockCreate.mockReset();
+    mockCreate.mockResolvedValue({
+      id: "chatcmpl-1",
+      model: "gpt-4",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "Hello world" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+    });
+
+    await makeOpenAIChatCompletionRequest(
+      mockChatHistory,
+      mockUpdateUI,
+      "gpt-4",
+      "test-token",
+      undefined, undefined, undefined, onTimingData, onUsageData,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, onTotalLatency, undefined, undefined,
+      undefined, undefined, undefined, undefined,
+      false, // stream
+    );
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.stream).toBe(false);
+    expect(callArgs).not.toHaveProperty("stream_options");
+
+    expect(mockUpdateUI).toHaveBeenCalledTimes(1);
+    expect(mockUpdateUI).toHaveBeenCalledWith("Hello world", "gpt-4");
+
+    expect(onUsageData).toHaveBeenCalledTimes(1);
+    expect(onUsageData).toHaveBeenCalledWith({
+      completionTokens: 2,
+      promptTokens: 3,
+      totalTokens: 5,
+    });
+
+    expect(onTimingData).toHaveBeenCalledTimes(1);
+    expect(onTotalLatency).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-streaming branch should still invoke reasoning callback when reasoning_content is present", async () => {
+    const onReasoningContent = vi.fn();
+    mockCreate.mockReset();
+    mockCreate.mockResolvedValue({
+      id: "chatcmpl-2",
+      model: "gpt-4",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Answer",
+            reasoning_content: "thought process",
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+
+    await makeOpenAIChatCompletionRequest(
+      mockChatHistory,
+      mockUpdateUI,
+      "gpt-4",
+      "test-token",
+      undefined, undefined, onReasoningContent, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined,
+      false, // stream
+    );
+
+    expect(onReasoningContent).toHaveBeenCalledTimes(1);
+    expect(onReasoningContent).toHaveBeenCalledWith("thought process");
+  });
 });

--- a/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx
@@ -31,6 +31,7 @@ export async function makeOpenAIChatCompletionRequest(
   onMCPEvent?: (event: MCPEvent) => void,
   mockTestFallbacks?: boolean,
   mcpToolsets?: MCPToolset[],
+  stream?: boolean,
 ) {
   // base url should be the current base_url
   const isLocal = process.env.NODE_ENV === "development";
@@ -112,28 +113,120 @@ export async function makeOpenAIChatCompletionRequest(
       }
     }
 
-    // @ts-ignore
-    const response = await client.chat.completions.create(
-      {
-        model: selectedModel,
-        stream: true,
-        stream_options: {
-          include_usage: true,
-        },
-        litellm_trace_id: traceId,
-        messages: chatHistory as ChatCompletionMessageParam[],
-        ...(vector_store_ids ? { vector_store_ids } : {}),
-        ...(guardrails ? { guardrails } : {}),
-        ...(policies ? { policies } : {}),
-        ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
-        ...(temperature !== undefined ? { temperature } : {}),
-        ...(max_tokens !== undefined ? { max_tokens } : {}),
-        ...(mockTestFallbacks ? { mock_testing_fallbacks: true } : {}),
-      },
-      { signal },
-    );
+    // Default to streaming so existing callers/UX are unchanged.
+    const useStream = stream !== false;
+    const baseRequest = {
+      model: selectedModel,
+      litellm_trace_id: traceId,
+      messages: chatHistory as ChatCompletionMessageParam[],
+      ...(vector_store_ids ? { vector_store_ids } : {}),
+      ...(guardrails ? { guardrails } : {}),
+      ...(policies ? { policies } : {}),
+      ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
+      ...(temperature !== undefined ? { temperature } : {}),
+      ...(max_tokens !== undefined ? { max_tokens } : {}),
+      ...(mockTestFallbacks ? { mock_testing_fallbacks: true } : {}),
+    } as any;
 
-    for await (const chunk of response) {
+    if (!useStream) {
+      // Non-streaming branch — single response object, no async iteration.
+      // @ts-ignore
+      const response = await client.chat.completions.create(
+        { ...baseRequest, stream: false },
+        { signal },
+      );
+      const choice = (response as any)?.choices?.[0];
+      const message = choice?.message ?? {};
+      const responseModel = (response as any)?.model ?? selectedModel;
+
+      // Surface time-to-first-token for parity with streaming UX (non-stream returns everything at once).
+      timeToFirstToken = Date.now() - startTime;
+      if (onTimingData) {
+        onTimingData(timeToFirstToken);
+      }
+      firstTokenReceived = true;
+
+      const content = typeof message.content === "string" ? message.content : "";
+      if (content) {
+        updateUI(content, responseModel);
+        fullResponseContent = content;
+      }
+
+      if (message.reasoning_content && onReasoningContent) {
+        onReasoningContent(message.reasoning_content);
+        fullReasoningContent = String(message.reasoning_content);
+      }
+
+      // Provider-specific fields can also appear on non-streaming responses.
+      const providerFields = message.provider_specific_fields;
+      if (providerFields) {
+        if (providerFields.search_results && onSearchResults) {
+          onSearchResults(providerFields.search_results);
+        }
+        if (providerFields.mcp_list_tools) {
+          mcpMetadata.mcp_list_tools = providerFields.mcp_list_tools;
+          if (onMCPEvent && !mcpListToolsProcessed) {
+            mcpListToolsProcessed = true;
+            const toolsEvent: MCPEvent = {
+              type: "response.output_item.done",
+              item_id: "mcp_list_tools",
+              item: {
+                type: "mcp_list_tools",
+                tools: providerFields.mcp_list_tools.map((tool: any) => ({
+                  name: tool.function?.name || tool.name || "",
+                  description: tool.function?.description || tool.description || "",
+                  input_schema: tool.function?.parameters || tool.input_schema || {},
+                })),
+              },
+              timestamp: Date.now(),
+            };
+            onMCPEvent(toolsEvent);
+          }
+        }
+        if (providerFields.mcp_tool_calls) {
+          mcpMetadata.mcp_tool_calls = providerFields.mcp_tool_calls;
+        }
+        if (providerFields.mcp_call_results) {
+          mcpMetadata.mcp_call_results = providerFields.mcp_call_results;
+        }
+      }
+
+      // Image generation on non-streaming responses (delta.image equivalent).
+      const messageImage = (message as any).image;
+      if (messageImage?.url && onImageGenerated) {
+        onImageGenerated(messageImage.url, responseModel);
+      }
+
+      const responseUsage = (response as any)?.usage;
+      if (responseUsage && onUsageData) {
+        const usageData: TokenUsage = {
+          completionTokens: responseUsage.completion_tokens,
+          promptTokens: responseUsage.prompt_tokens,
+          totalTokens: responseUsage.total_tokens,
+        };
+        if (responseUsage.completion_tokens_details?.reasoning_tokens) {
+          usageData.reasoningTokens = responseUsage.completion_tokens_details.reasoning_tokens;
+        }
+        if (responseUsage.cost !== undefined && responseUsage.cost !== null) {
+          usageData.cost = parseFloat(responseUsage.cost);
+        }
+        onUsageData(usageData);
+      }
+    } else {
+      // Streaming branch — existing behavior, unchanged.
+      // @ts-ignore
+      const response = await client.chat.completions.create(
+        {
+          ...baseRequest,
+          stream: true,
+          stream_options: {
+            include_usage: true,
+          },
+        },
+        { signal },
+      );
+
+      for await (const chunk of response as any) {
       console.log("Stream chunk:", chunk);
 
       // Process content and measure time to first token
@@ -252,6 +345,7 @@ export async function makeOpenAIChatCompletionRequest(
         onUsageData(usageData);
       }
     }
+    } // end stream branch
 
     // Process remaining MCP metadata (mcp_tool_calls and mcp_call_results) after stream completes
     // Note: mcp_list_tools is already processed when found in the first chunk

--- a/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx
@@ -227,124 +227,124 @@ export async function makeOpenAIChatCompletionRequest(
       );
 
       for await (const chunk of response as any) {
-      console.log("Stream chunk:", chunk);
+        console.log("Stream chunk:", chunk);
 
-      // Process content and measure time to first token
-      const delta = chunk.choices[0]?.delta as any;
+        // Process content and measure time to first token
+        const delta = chunk.choices[0]?.delta as any;
 
-      // Debug what's in the delta
-      console.log("Delta content:", chunk.choices[0]?.delta?.content);
-      console.log("Delta reasoning content:", delta?.reasoning_content);
+        // Debug what's in the delta
+        console.log("Delta content:", chunk.choices[0]?.delta?.content);
+        console.log("Delta reasoning content:", delta?.reasoning_content);
 
-      // Measure time to first token for either content or reasoning_content
-      if (!firstTokenReceived && (chunk.choices[0]?.delta?.content || (delta && delta.reasoning_content))) {
-        firstTokenReceived = true;
-        timeToFirstToken = Date.now() - startTime;
-        console.log("First token received! Time:", timeToFirstToken, "ms");
-        if (onTimingData) {
-          console.log("Calling onTimingData with:", timeToFirstToken);
-          onTimingData(timeToFirstToken);
-        } else {
-          console.log("onTimingData callback is not defined!");
-        }
-      }
-
-      // Process content
-      if (chunk.choices[0]?.delta?.content) {
-        const content = chunk.choices[0].delta.content;
-        updateUI(content, chunk.model);
-        fullResponseContent += content;
-      }
-
-      // Process image generation if present
-      if (delta && delta.image && onImageGenerated) {
-        console.log("Image generated:", delta.image);
-        onImageGenerated(delta.image.url, chunk.model);
-      }
-
-      // Process reasoning content if present - using type assertion
-      if (delta && delta.reasoning_content) {
-        const reasoningContent = delta.reasoning_content;
-        if (onReasoningContent) {
-          onReasoningContent(reasoningContent);
-        }
-        fullReasoningContent += reasoningContent;
-      }
-
-      // Check for search results in provider_specific_fields
-      if (delta && delta.provider_specific_fields?.search_results && onSearchResults) {
-        console.log("Search results found:", delta.provider_specific_fields.search_results);
-        onSearchResults(delta.provider_specific_fields.search_results);
-      }
-
-      // Check for MCP metadata in provider_specific_fields
-      if (delta && delta.provider_specific_fields) {
-        const providerFields = delta.provider_specific_fields;
-        
-        // Merge MCP metadata cumulatively (don't overwrite)
-        if (providerFields.mcp_list_tools && !mcpMetadata.mcp_list_tools) {
-          mcpMetadata.mcp_list_tools = providerFields.mcp_list_tools;
-          // Process mcp_list_tools immediately when found (typically in first chunk)
-          if (onMCPEvent && !mcpListToolsProcessed) {
-            mcpListToolsProcessed = true;
-            const toolsEvent: MCPEvent = {
-              type: "response.output_item.done",
-              item_id: "mcp_list_tools", // Add item_id to prevent duplicate detection issues
-              item: {
-                type: "mcp_list_tools",
-                tools: providerFields.mcp_list_tools.map((tool: any) => ({
-                  name: tool.function?.name || tool.name || "",
-                  description: tool.function?.description || tool.description || "",
-                  input_schema: tool.function?.parameters || tool.input_schema || {},
-                })),
-              },
-              timestamp: Date.now(),
-            };
-            onMCPEvent(toolsEvent);
-            console.log("MCP list_tools event sent:", toolsEvent);
+        // Measure time to first token for either content or reasoning_content
+        if (!firstTokenReceived && (chunk.choices[0]?.delta?.content || (delta && delta.reasoning_content))) {
+          firstTokenReceived = true;
+          timeToFirstToken = Date.now() - startTime;
+          console.log("First token received! Time:", timeToFirstToken, "ms");
+          if (onTimingData) {
+            console.log("Calling onTimingData with:", timeToFirstToken);
+            onTimingData(timeToFirstToken);
+          } else {
+            console.log("onTimingData callback is not defined!");
           }
         }
-        
-        if (providerFields.mcp_tool_calls) {
-          mcpMetadata.mcp_tool_calls = providerFields.mcp_tool_calls;
+
+        // Process content
+        if (chunk.choices[0]?.delta?.content) {
+          const content = chunk.choices[0].delta.content;
+          updateUI(content, chunk.model);
+          fullResponseContent += content;
         }
-        
-        if (providerFields.mcp_call_results) {
-          mcpMetadata.mcp_call_results = providerFields.mcp_call_results;
+
+        // Process image generation if present
+        if (delta && delta.image && onImageGenerated) {
+          console.log("Image generated:", delta.image);
+          onImageGenerated(delta.image.url, chunk.model);
         }
-        
-        if (providerFields.mcp_list_tools || providerFields.mcp_tool_calls || providerFields.mcp_call_results) {
-          console.log("MCP metadata found in chunk:", {
-            mcp_list_tools: providerFields.mcp_list_tools ? "present" : "absent",
-            mcp_tool_calls: providerFields.mcp_tool_calls ? "present" : "absent",
-            mcp_call_results: providerFields.mcp_call_results ? "present" : "absent",
-          });
+
+        // Process reasoning content if present - using type assertion
+        if (delta && delta.reasoning_content) {
+          const reasoningContent = delta.reasoning_content;
+          if (onReasoningContent) {
+            onReasoningContent(reasoningContent);
+          }
+          fullReasoningContent += reasoningContent;
+        }
+
+        // Check for search results in provider_specific_fields
+        if (delta && delta.provider_specific_fields?.search_results && onSearchResults) {
+          console.log("Search results found:", delta.provider_specific_fields.search_results);
+          onSearchResults(delta.provider_specific_fields.search_results);
+        }
+
+        // Check for MCP metadata in provider_specific_fields
+        if (delta && delta.provider_specific_fields) {
+          const providerFields = delta.provider_specific_fields;
+          
+          // Merge MCP metadata cumulatively (don't overwrite)
+          if (providerFields.mcp_list_tools && !mcpMetadata.mcp_list_tools) {
+            mcpMetadata.mcp_list_tools = providerFields.mcp_list_tools;
+            // Process mcp_list_tools immediately when found (typically in first chunk)
+            if (onMCPEvent && !mcpListToolsProcessed) {
+              mcpListToolsProcessed = true;
+              const toolsEvent: MCPEvent = {
+                type: "response.output_item.done",
+                item_id: "mcp_list_tools", // Add item_id to prevent duplicate detection issues
+                item: {
+                  type: "mcp_list_tools",
+                  tools: providerFields.mcp_list_tools.map((tool: any) => ({
+                    name: tool.function?.name || tool.name || "",
+                    description: tool.function?.description || tool.description || "",
+                    input_schema: tool.function?.parameters || tool.input_schema || {},
+                  })),
+                },
+                timestamp: Date.now(),
+              };
+              onMCPEvent(toolsEvent);
+              console.log("MCP list_tools event sent:", toolsEvent);
+            }
+          }
+          
+          if (providerFields.mcp_tool_calls) {
+            mcpMetadata.mcp_tool_calls = providerFields.mcp_tool_calls;
+          }
+          
+          if (providerFields.mcp_call_results) {
+            mcpMetadata.mcp_call_results = providerFields.mcp_call_results;
+          }
+          
+          if (providerFields.mcp_list_tools || providerFields.mcp_tool_calls || providerFields.mcp_call_results) {
+            console.log("MCP metadata found in chunk:", {
+              mcp_list_tools: providerFields.mcp_list_tools ? "present" : "absent",
+              mcp_tool_calls: providerFields.mcp_tool_calls ? "present" : "absent",
+              mcp_call_results: providerFields.mcp_call_results ? "present" : "absent",
+            });
+          }
+        }
+
+        // Check for usage data using type assertion
+        const chunkWithUsage = chunk as any;
+        if (chunkWithUsage.usage && onUsageData) {
+          console.log("Usage data found:", chunkWithUsage.usage);
+          const usageData: TokenUsage = {
+            completionTokens: chunkWithUsage.usage.completion_tokens,
+            promptTokens: chunkWithUsage.usage.prompt_tokens,
+            totalTokens: chunkWithUsage.usage.total_tokens,
+          };
+
+          // Check for reasoning tokens
+          if (chunkWithUsage.usage.completion_tokens_details?.reasoning_tokens) {
+            usageData.reasoningTokens = chunkWithUsage.usage.completion_tokens_details.reasoning_tokens;
+          }
+
+          // Extract cost from usage object if available
+          if (chunkWithUsage.usage.cost !== undefined && chunkWithUsage.usage.cost !== null) {
+            usageData.cost = parseFloat(chunkWithUsage.usage.cost);
+          }
+
+          onUsageData(usageData);
         }
       }
-
-      // Check for usage data using type assertion
-      const chunkWithUsage = chunk as any;
-      if (chunkWithUsage.usage && onUsageData) {
-        console.log("Usage data found:", chunkWithUsage.usage);
-        const usageData: TokenUsage = {
-          completionTokens: chunkWithUsage.usage.completion_tokens,
-          promptTokens: chunkWithUsage.usage.prompt_tokens,
-          totalTokens: chunkWithUsage.usage.total_tokens,
-        };
-
-        // Check for reasoning tokens
-        if (chunkWithUsage.usage.completion_tokens_details?.reasoning_tokens) {
-          usageData.reasoningTokens = chunkWithUsage.usage.completion_tokens_details.reasoning_tokens;
-        }
-
-        // Extract cost from usage object if available
-        if (chunkWithUsage.usage.cost !== undefined && chunkWithUsage.usage.cost !== null) {
-          usageData.cost = parseFloat(chunkWithUsage.usage.cost);
-        }
-
-        onUsageData(usageData);
-      }
-    }
     } // end stream branch
 
     // Process remaining MCP metadata (mcp_tool_calls and mcp_call_results) after stream completes


### PR DESCRIPTION
## Why

Closes [LIT-3251](https://linear.app/litellm-ai/issue/LIT-3251). Today the playground always calls `chat.completions.create` with `stream: true`. There's no way to compare streaming vs. non-streaming responses for the same prompt/model without leaving the UI — which makes it harder to triage bugs that surface only on one transport.

## What changed

Add an opt-in **Stream response** checkbox to the playground's *Model Settings* popover (Chat Completions endpoint). Default keeps existing behavior (`stream: true`); when unchecked, the request is sent with `stream: false` and the full response is rendered as a single update, with usage, `reasoning_content`, MCP metadata, and provider-specific fields surfaced the same way as in the streaming branch.

Files:
- `ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx` — add `stream?: boolean` (last positional param). When `stream === false`, call `client.chat.completions.create({ ...baseRequest, stream: false })` and process the single response object (content, reasoning, MCP, usage, image). Streaming branch is unchanged.
- `ui/litellm-dashboard/src/components/playground/chat_ui/AdditionalModelSettings.tsx` — new `stream` / `onStreamChange` props; render the "Stream response" Checkbox + tooltip only when `onStreamChange` is provided (so the component stays backward-compatible everywhere else it's reused).
- `ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx` — add `streamEnabled` state (defaults to `true`), wire it into the popover and into the `makeOpenAIChatCompletionRequest(...)` call as the new last positional arg.
- Tests:
  - `chat_completion.test.tsx` — 4 new tests (default streams, explicit `stream:true`, `stream:false` sends correct payload and processes content/usage/timing/total-latency once, `stream:false` still surfaces `reasoning_content`).
  - `AdditionalModelSettings.test.tsx` — 3 new tests (toggle absent when no callback, reflects prop, calls `onStreamChange` on user click).

Behavior is unchanged for every existing caller and for every other endpoint (responses_api, anthropic_messages, image_generation, etc.) — those paths weren't part of the requested scope and aren't touched.

## Evidence

### UI: before vs after

Playground &gt; Model Settings popover, rendered with React's static markup pipeline (Tailwind + Ant Design CSS via CDN — slider visuals are simplified vs. the live app, but the toggle structure is what matters here):

**Before** — current `main`, no Stream toggle:

![before](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3251/before.png)

**After** — same component on this branch with `onStreamChange` wired in by `ChatUI.tsx`, new "Stream response" toggle visible (checked by default = current behavior):

![after](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3251/after.png)

### Behavioral: what the toggle actually sends

The unit tests assert the request payload the OpenAI client receives. Excerpts (all 9 tests in `chat_completion.test.tsx` pass; 7/7 in `AdditionalModelSettings.test.tsx`):

```
✓ src/components/playground/llm_calls/chat_completion.test.tsx (9 tests) 12ms
  ✓ should make a basic chat completion request
  ✓ should include temperature and max_tokens when provided
  ✓ should configure MCP tools per server with restrictions
  ✓ should include mock_testing_fallbacks ... when mockTestFallbacks is true
  ✓ should not include mock_testing_fallbacks ... when false or undefined
  ✓ should default to streaming when stream parameter is undefined          ← new
  ✓ should still stream when stream=true is passed explicitly                ← new
  ✓ should send stream:false and process a single response when stream=false ← new
  ✓ non-streaming branch should still invoke reasoning callback              ← new

✓ src/components/playground/chat_ui/AdditionalModelSettings.test.tsx (7 tests)
  ...
  ✓ should not show 'Stream response' toggle when onStreamChange is not provided ← new
  ✓ should render 'Stream response' toggle and reflect stream prop               ← new
  ✓ should treat stream=false as unchecked and call onStreamChange when toggled  ← new

 Test Files  2 passed (2)
      Tests  16 passed (16)
```

Key assertion from the new `stream:false` test (line-equivalent):

```ts
const callArgs = mockCreate.mock.calls[0][0];
expect(callArgs.stream).toBe(false);
expect(callArgs).not.toHaveProperty("stream_options"); // not allowed in non-streaming requests
expect(mockUpdateUI).toHaveBeenCalledWith("Hello world", "gpt-4"); // single update, full content
expect(onUsageData).toHaveBeenCalledWith({ completionTokens: 2, promptTokens: 3, totalTokens: 5 });
```

## Notes for reviewers

- Branch was pushed via the GitHub REST API (Git Data API: blobs → tree → commit → ref) because this token lacks `repo` + `workflow` scopes for `git push`. PNG assets live on an orphan branch `pr-assets-lit-3251` on the fork so they're not part of this PR's file diff.
- Scope intentionally tight: only the Chat Completions playground path is wired through. Extending the toggle to Responses / Anthropic Messages / A2A is a clean follow-up if desired — the `AdditionalModelSettings` prop is already there.


### Verification (ship-pr)

- [x] **Scope:** 5 files modified (3 src + 2 tests), no unrelated changes — `git status` clean apart from the intentional edits.
- [x] **Base branch:** `litellm_oss_agent_shin_daily_branch` (Verify PR source branch check passes).
- [x] **Unit tests:** 16/16 pass (`chat_completion.test.tsx` + `AdditionalModelSettings.test.tsx`); 7 of those are new tests for this PR.
- [x] **GitHub Actions:** 44/44 green on head `f33ce47` (lint, code-quality, semgrep, secret-scan, unit-test, integration, build-ui, validate-model-prices-json, Codecov, etc.).
- [x] **Veria AI – PR Review:** ✅ success.
- [x] **Greptile:** **5/5** on commit `f33ce47` — "Safe to merge. Previously flagged issues are resolved in this revision."
- [x] **CLA:** signed.
- [x] **Mergeable state:** clean.
- [x] **Backwards compatibility:** default is `stream: true`; all existing callers / endpoints that don't pass `onStreamChange` see no UI or behavioral change.
- [x] **Evidence:** before/after screenshots of the playground Model Settings popover embedded above; behavioral assertions covered by the 4 new `chat_completion.test.tsx` tests (payload shape, single-update content, usage + timing callbacks, reasoning_content surfacing).