### PR TITLE
fix(ui): default invited user role to internal_user (LIT-3149)

### DIFF
--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -476,4 +476,73 @@ describe("CreateUserButton", () => {
       expect(within(dialog).getByRole("checkbox", { name: /send invitation email/i })).toBeChecked();
     });
   });
+
+  describe("default user role (LIT-3149)", () => {
+    const possibleUIRoles = {
+      internal_user: { ui_label: "Internal User", description: "Owns keys" },
+      internal_user_viewer: { ui_label: "Internal Viewer", description: "Read-only" },
+    };
+
+    it("submits user_role=internal_user when the embedded form is left at its default", async () => {
+      const user = userEvent.setup();
+      mockUserCreateCall.mockResolvedValue({ data: { user_id: "embedded-default" } });
+      mockInvitationCreateCall.mockResolvedValue({
+        id: "inv-embedded-default",
+        user_id: "embedded-default",
+        has_user_setup_sso: false,
+      } as any);
+
+      renderWithProviders(
+        <CreateUserButton {...defaultProps} possibleUIRoles={possibleUIRoles} isEmbedded />,
+      );
+
+      await user.type(screen.getByLabelText(/user email/i), "embedded-default@example.com");
+      await user.click(screen.getByRole("button", { name: /create user/i }));
+
+      await waitFor(() => {
+        expect(mockUserCreateCall).toHaveBeenCalledWith(
+          "token",
+          null,
+          expect.objectContaining({
+            user_email: "embedded-default@example.com",
+            user_role: "internal_user",
+          }),
+        );
+      });
+    });
+
+    it("submits user_role=internal_user when the standalone modal form is left at its default", async () => {
+      const user = userEvent.setup();
+      mockUserCreateCall.mockResolvedValue({ data: { user_id: "standalone-default" } });
+      mockInvitationCreateCall.mockResolvedValue({
+        id: "inv-standalone-default",
+        user_id: "standalone-default",
+        has_user_setup_sso: false,
+      } as any);
+
+      renderWithProviders(
+        <CreateUserButton {...defaultProps} possibleUIRoles={possibleUIRoles} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+      const dialog = screen.getByRole("dialog", { name: /invite user/i });
+      await user.type(within(dialog).getByLabelText(/user email/i), "standalone-default@example.com");
+      await user.click(within(dialog).getByRole("button", { name: /create user/i }));
+
+      await waitFor(() => {
+        expect(mockUserCreateCall).toHaveBeenCalledWith(
+          "token",
+          null,
+          expect.objectContaining({
+            user_email: "standalone-default@example.com",
+            user_role: "internal_user",
+          }),
+        );
+      });
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -182,7 +182,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
         labelCol={{ span: 8 }}
         wrapperCol={{ span: 16 }}
         labelAlign="left"
-        initialValues={{ user_role: "internal_user_viewer", send_invite_email: true }}
+        initialValues={{ user_role: "internal_user", send_invite_email: true }}
       >
         <Alert
           message="Email invitations"
@@ -279,7 +279,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
           labelCol={{ span: 8 }}
           wrapperCol={{ span: 16 }}
           labelAlign="left"
-          initialValues={{ user_role: "internal_user_viewer", send_invite_email: true }}
+          initialValues={{ user_role: "internal_user", send_invite_email: true }}
         >
           <Form.Item label="User Email" name="user_email">
             <Input />


### PR DESCRIPTION
## Summary

Fixes [LIT-3149](https://linear.app/litellm-ai/issue/LIT-3149/internal-users-appear-as-internal-viewers) — "Internal users appear as internal viewers". Refile of #28819 (closed in bulk cleanup; Greptile 5/5 at the time) against `litellm_oss_agent_shin_daily_branch` per Shin policy.

### Root cause

Both invite forms in `ui/litellm-dashboard/src/components/CreateUserButton.tsx` seed `Form.initialValues` with the view-only role:

```tsx
initialValues={{ user_role: "internal_user_viewer", send_invite_email: true }}
```

When an admin opens **+ Invite User**, fills in just the email, and submits, the form posts `user_role: "internal_user_viewer"` — so every default invite becomes a view-only account. The user then shows up as **"Internal User (View Only)"** in the Internal Users table, matching the report.

### Fix

Switch both `initialValues` (embedded form, line 185; standalone modal, line 282) to the regular `internal_user` role. The dropdown still exposes every role from `possibleUIRoles` including view-only — only the default changes.

### Why this and not a backend change

`DefaultInternalUserParams.user_role` in `litellm/proxy/_types.py` is `INTERNAL_USER_VIEW_ONLY`, but that's pinned by `test_get_internal_user_settings_fresh_db_defaults_to_viewer` to match the runtime SSO/SCIM/JWT fallback ("The Pydantic default must match the runtime fallback"). Touching it would ripple through several auth paths. The ticket is specifically about the admin-facing invite UX, so this PR limits scope to the invite form.

### Changes

| File | Change |
|---|---|
| `ui/litellm-dashboard/src/components/CreateUserButton.tsx` | `initialValues.user_role`: `internal_user_viewer` → `internal_user` in both the embedded and modal forms |
| `ui/litellm-dashboard/src/components/CreateUserButton.test.tsx` | Two regression tests asserting the form submits `user_role: 'internal_user'` when the admin leaves the dropdown at its default — one for the embedded form, one for the standalone "+ Invite User" modal |

> Note on push path: pushed via the GitHub Contents API (one PUT per file) because the current `GITHUB_TOKEN` lacks `repo` + `workflow` scope for `git push`. Reviewers should expect a noisier merge-base diff (one commit per file) but the net diff is two source files.

### Evidence

Captured live against the LiteLLM proxy running at `http://127.0.0.1:4000/ui/users` → **+ Invite User**, Playwright headless on the prebuilt `_experimental/out` UI bundle in the sandbox. To produce the AFTER frame the bundle's `initialValues:{user_role:"internal_user_viewer",send_invite_email:!0}` literal was sed-replaced to `internal_user` in every chunk that contained it (7 chunks × 1 occurrence each — verified `grep -c` afterwards) — i.e. the exact same string substitution the source change produces after `next build`.

**Before** (clean `litellm_oss_agent_shin_daily_branch` bundle — dropdown defaults to `Internal User (View Only)`):

![before invite modal](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3149/before.png)

DOM read-back from Playwright (`.ant-modal .ant-select-selection-item`):

```json
{
  "role_select_inner_text": [
    "Internal User (View Only) - view their own keys, view their own spend"
  ]
}
```

**After** (`user_role: "internal_user"` patch applied to the same bundle — dropdown defaults to `Internal User (Create/Delete/View)`):

![after invite modal](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3149/after.png)

DOM read-back:

```json
{
  "role_select_inner_text": [
    "Internal User (Create/Delete/View) - view/create/delete their own keys, view their own spend"
  ]
}
```

The role dropdown still lists every role from `possibleUIRoles` — admins can still pick view-only explicitly. Only the default the form starts with has changed.

## Pre-Submission checklist

- [x] Adds testing in `ui/litellm-dashboard/src/components/CreateUserButton.test.tsx` (two regression tests covering the embedded and standalone forms).
- [x] PR scope is isolated — single behaviour change in one UI component.
- [x] PR has the relevant Linear ticket linked.

@greptileai please review


### Verification (ship-pr)

| Check | Result |
|---|---|
| Greptile score | ✅ **5/5** ("Safe to merge — a targeted two-line default change in the invite form with matching regression tests and no backend impact") |
| Veria AI - PR Review | ✅ success |
| GitHub Actions | ✅ **43/44 completed and green**, 0 failed. One job (`test-server-root-path (/api/v1)`) is stuck-in-progress since 05:16Z — the `/llmproxy` variant of the *same* workflow finished green in 5 min, and three other concurrent PRs (`shin/lit-3401-bedrock-citation`, `shin/lit-2820-key-update-alias`, `litellm_context_management_2`) are also stuck on the same job at the same start timestamp, so this is a runner-side flake, not a regression in this PR. |
| Base branch | ✅ `litellm_oss_agent_shin_daily_branch` (per Shin policy) |
| Runtime before/after evidence | ✅ Real Playwright screenshots of the actual `/ui/users` → **+ Invite User** modal embedded above; `.ant-select-selection-item` DOM read-back captured for both states |
| Regression tests | ✅ Two new tests in `CreateUserButton.test.tsx` (`default user role (LIT-3149)` describe block) covering embedded + standalone modes |
| Customer name leaked | ✅ None — PR body and Linear comments use generic phrasing |
| Secrets leaked | ✅ None |
| Push path note | ⚠️ Pushed via Contents API (one PUT per file) because `GITHUB_TOKEN` lacks `repo`+`workflow` scope for `git push`. Two-commit history reflects this; the net source diff is two files. |
