### PR TITLE
feat(bedrock): forward document citations/context/title via OpenAI contract path (LIT-3401)

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4977,7 +4977,16 @@ class BedrockConverseMessagesProcessor:
         """Convert a document content block to a Bedrock DocumentBlock.
 
         Handles the Anthropic-style document format:
-        {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}
+        {
+            "type": "document",
+            "source": {"type": "base64", "media_type": "application/pdf", "data": "..."},
+            # optional — propagated to Bedrock Converse DocumentBlock so citations
+            # work via the OpenAI / `/v1/chat/completions` contract, not only via
+            # the Bedrock passthrough endpoint.
+            "title": "human-readable doc title",
+            "context": "free-form context the model should see for this document",
+            "citations": {"enabled": true},
+        }
         """
         source = element["source"]
         source_type = source.get("type")
@@ -4992,23 +5001,40 @@ class BedrockConverseMessagesProcessor:
             mime_type=media_type, image_format=media_type.split("/")[1]
         )
 
-        # Deterministic name using the same hashing pattern as _create_bedrock_block
-        HASH_SAMPLE_BYTES = 64 * 1024
-        normalized = "".join(data.split()).encode("utf-8")
-        sample = normalized[:HASH_SAMPLE_BYTES]
-        hasher = hashlib.sha256()
-        hasher.update(sample)
-        hasher.update(str(len(normalized)).encode("utf-8"))
-        content_hash = hasher.hexdigest()[:16]
-        document_name = f"Document_{content_hash}_{doc_format}"
+        # Prefer the caller-supplied title when present; otherwise fall back to a
+        # deterministic hash-based name (the previous default behavior).
+        title = element.get("title")
+        if isinstance(title, str) and title.strip():
+            document_name = title.strip()
+        else:
+            # Deterministic name using the same hashing pattern as _create_bedrock_block
+            HASH_SAMPLE_BYTES = 64 * 1024
+            normalized = "".join(data.split()).encode("utf-8")
+            sample = normalized[:HASH_SAMPLE_BYTES]
+            hasher = hashlib.sha256()
+            hasher.update(sample)
+            hasher.update(str(len(normalized)).encode("utf-8"))
+            content_hash = hasher.hexdigest()[:16]
+            document_name = f"Document_{content_hash}_{doc_format}"
 
-        return BedrockContentBlock(
-            document=BedrockDocumentBlock(
-                source=BedrockSourceBlock(bytes=data),
-                format=doc_format,
-                name=document_name,
-            )
+        document_block: BedrockDocumentBlock = BedrockDocumentBlock(
+            source=BedrockSourceBlock(bytes=data),
+            format=doc_format,
+            name=document_name,
         )
+
+        # Forward Bedrock-Converse-native fields when the caller provided them.
+        # These power Claude/Nova citation grounding (`citationsContent` in the
+        # response) and per-document context for retrieval-style prompts.
+        citations = element.get("citations")
+        if isinstance(citations, dict) and "enabled" in citations:
+            document_block["citations"] = {"enabled": bool(citations["enabled"])}
+
+        context = element.get("context")
+        if isinstance(context, str) and context:
+            document_block["context"] = context
+
+        return BedrockContentBlock(document=document_block)
 
     @staticmethod
     def add_thinking_blocks_to_assistant_content(

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5001,12 +5001,28 @@ class BedrockConverseMessagesProcessor:
             mime_type=media_type, image_format=media_type.split("/")[1]
         )
 
-        # Prefer the caller-supplied title when present; otherwise fall back to a
-        # deterministic hash-based name (the previous default behavior).
+        # Bedrock DocumentBlock.name has a strict allowlist:
+        #   [a-zA-Z0-9 ()\[\]-]  (no more than one consecutive whitespace), max 200 chars.
+        # Per https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
+        # If the caller passes a title, sanitize it down to the allowlist so common
+        # punctuation (`.`, `,`, `:`, `_`, `'`, etc.) does not trigger a 400 from
+        # Bedrock. If the sanitized result is empty, fall back to the deterministic
+        # hash-based name (the previous default behavior).
+        def _sanitize_bedrock_document_name(raw: str) -> str:
+            # 1) keep only Bedrock-allowed characters; replace the rest with a single space
+            cleaned = re.sub(r"[^A-Za-z0-9 \-()\[\]]", " ", raw)
+            # 2) collapse consecutive whitespace down to one space
+            cleaned = re.sub(r"\s+", " ", cleaned).strip()
+            # 3) clamp to Bedrock's 200-char hard limit
+            return cleaned[:200]
+
         title = element.get("title")
+        document_name: Optional[str] = None
         if isinstance(title, str) and title.strip():
-            document_name = title.strip()
-        else:
+            sanitized = _sanitize_bedrock_document_name(title)
+            if sanitized:
+                document_name = sanitized
+        if document_name is None:
             # Deterministic name using the same hashing pattern as _create_bedrock_block
             HASH_SAMPLE_BYTES = 64 * 1024
             normalized = "".join(data.split()).encode("utf-8")

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -43,10 +43,24 @@ BedrockDocumentTypes = Literal[
 ]
 
 
-class DocumentBlock(TypedDict):
-    format: Union[BedrockDocumentTypes, str]
-    source: SourceBlock
-    name: str
+class CitationsConfigBlock(TypedDict, total=False):
+    """Bedrock Converse DocumentBlock `citations` config.
+
+    Setting `enabled=True` instructs the model to emit `citationsContent`
+    blocks in the response that reference this document.
+    See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
+    """
+
+    enabled: bool
+
+
+class DocumentBlock(TypedDict, total=False):
+    format: Required[Union[BedrockDocumentTypes, str]]
+    source: Required[SourceBlock]
+    name: Required[str]
+    # Optional Bedrock Converse fields that drive citation grounding.
+    citations: CitationsConfigBlock
+    context: str
 
 
 class ToolResultContentBlock(TypedDict, total=False):

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2833,3 +2833,106 @@ def test_bedrock_converse_messages_pt_document_ignores_malformed_citations():
     assert "citations" not in document
     assert "context" not in document
     assert document["name"].startswith("Document_")
+
+
+def test_bedrock_converse_messages_pt_document_title_sanitized_for_bedrock_name():
+    """LIT-3401: Bedrock DocumentBlock.name must match `[a-zA-Z0-9 ()\\[\\]-]`
+    with no consecutive whitespace and max 200 chars. Caller titles containing
+    common punctuation (period, comma, colon, apostrophe, underscore, ...) must
+    be sanitized so we don't trigger a 400 from Bedrock.
+    """
+    pdf_b64 = (
+        "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoK"
+        "dHJhaWxlcgo8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+    )
+
+    cases = [
+        # raw_title, expected_name
+        ("Report: v2.0, by Jane", "Report v2 0 by Jane"),
+        ("Jane's_Notes (final).pdf", "Jane s Notes (final) pdf"),
+        ("file_2024.pdf", "file 2024 pdf"),
+        ("  multiple   spaces   between   words ", "multiple spaces between words"),
+        # Already-compliant titles must pass through unchanged.
+        ("My Research Paper", "My Research Paper"),
+        ("Doc [v1] (final)", "Doc [v1] (final)"),
+    ]
+
+    for raw, expected in cases:
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": pdf_b64,
+                        },
+                        "title": raw,
+                    },
+                ],
+            }
+        ]
+        result = _bedrock_converse_messages_pt(
+            messages, "anthropic.claude-sonnet-4-6", "bedrock"
+        )
+        document = result[0]["content"][0]["document"]
+        assert document["name"] == expected, (
+            f"title={raw!r} -> name={document['name']!r}, expected={expected!r}"
+        )
+
+
+def test_bedrock_converse_messages_pt_document_title_clamped_to_200_chars():
+    """Bedrock caps DocumentBlock.name at 200 characters."""
+    pdf_b64 = "JVBERi0xLjQK"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_b64,
+                    },
+                    "title": "A" * 300,
+                },
+            ],
+        }
+    ]
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    name = result[0]["content"][0]["document"]["name"]
+    assert len(name) == 200
+    assert name == "A" * 200
+
+
+def test_bedrock_converse_messages_pt_document_title_all_disallowed_falls_back_to_hash():
+    """If sanitizing the title strips every character (e.g. all-punctuation),
+    fall back to the deterministic hash-based name rather than sending an empty
+    string."""
+    pdf_b64 = "JVBERi0xLjQK"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_b64,
+                    },
+                    "title": "!@#$%^&*",  # nothing in the allowlist
+                },
+            ],
+        }
+    ]
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    name = result[0]["content"][0]["document"]["name"]
+    assert name.startswith("Document_")

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2680,3 +2680,156 @@ def test_bedrock_converse_messages_pt_document_rejects_url_source():
         _bedrock_converse_messages_pt(
             messages, "anthropic.claude-sonnet-4-6", "bedrock"
         )
+
+
+def test_bedrock_converse_messages_pt_document_forwards_citations_context_title():
+    """LIT-3401: an OpenAI-contract document block with `citations`, `context`,
+    and `title` must surface those fields on the Bedrock Converse DocumentBlock.
+
+    Without this, Bedrock will not emit `citationsContent` in the response when
+    callers go through `/v1/chat/completions`, even though the passthrough path
+    already supports it natively.
+    """
+    pdf_b64 = (
+        "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoK"
+        "dHJhaWxlcgo8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_b64,
+                    },
+                    "title": "My Research Paper",
+                    "context": "Authored by Jane Doe in 2024.",
+                    "citations": {"enabled": True},
+                },
+                {"type": "text", "text": "Summarize with citations."},
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    document = result[0]["content"][0]["document"]
+    # Caller-supplied title overrides the hashed default and is forwarded.
+    assert document["name"] == "My Research Paper"
+    assert document["format"] == "pdf"
+    # Citation grounding now reaches Bedrock.
+    assert document["citations"] == {"enabled": True}
+    assert document["context"] == "Authored by Jane Doe in 2024."
+
+
+def test_bedrock_converse_messages_pt_document_citations_disabled_is_forwarded():
+    """`citations: {enabled: False}` must be forwarded explicitly so callers can
+    opt out (the Bedrock default is False, but being explicit is allowed and
+    safer for tooling that diffs payloads)."""
+    pdf_b64 = (
+        "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoK"
+        "dHJhaWxlcgo8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_b64,
+                    },
+                    "citations": {"enabled": False},
+                },
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    document = result[0]["content"][0]["document"]
+    assert document["citations"] == {"enabled": False}
+    # No `context` provided → not present.
+    assert "context" not in document
+    # No `title` provided → fall back to hashed name.
+    assert document["name"].startswith("Document_")
+
+
+def test_bedrock_converse_messages_pt_document_no_citations_omits_field():
+    """Backwards-compat: when the caller does not include `citations`/`context`/
+    `title`, the produced DocumentBlock must not contain those keys (it must be
+    byte-for-byte the same shape as before LIT-3401)."""
+    pdf_b64 = (
+        "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoK"
+        "dHJhaWxlcgo8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_b64,
+                    },
+                },
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    document = result[0]["content"][0]["document"]
+    assert "citations" not in document
+    assert "context" not in document
+    assert document["name"].startswith("Document_")
+
+
+def test_bedrock_converse_messages_pt_document_ignores_malformed_citations():
+    """`citations` without an `enabled` key (or non-dict citations) must not
+    crash and must not be forwarded — the Bedrock API would 400 on an empty
+    citations object."""
+    pdf_b64 = (
+        "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoK"
+        "dHJhaWxlcgo8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_b64,
+                    },
+                    "citations": {"unrelated": "field"},
+                    "context": "",  # empty string - should be ignored
+                    "title": "   ",  # whitespace-only - should be ignored
+                },
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    document = result[0]["content"][0]["document"]
+    assert "citations" not in document
+    assert "context" not in document
+    assert document["name"].startswith("Document_")


### PR DESCRIPTION
## Summary

Bedrock Converse `DocumentBlock` natively supports `citations: {enabled: bool}` and `context: str` for citation grounding, but the OpenAI-contract request path (`_process_document_message` in `litellm/litellm_core_utils/prompt_templates/factory.py`) was only forwarding `format`/`source`/`name`. Citations, context, and caller-supplied `title` were silently dropped, so users could only get document citations through the Bedrock passthrough endpoint — not through `/v1/chat/completions`. Closes **LIT-3401**.

The response-side wiring (`citationsContent` → `provider_specific_fields["citationsContent"]`) was already in place in `converse_transformation.py`, so this PR is request-side only.

## What changed

- **`litellm/types/llms/bedrock.py`**: add `CitationsConfigBlock` TypedDict and extend `DocumentBlock` with optional `citations` / `context` fields. Original three fields (`format`/`source`/`name`) are marked `Required[...]` and the class is `total=False` so existing usage is byte-for-byte compatible.
- **`litellm/litellm_core_utils/prompt_templates/factory.py`** (`_process_document_message`): forward `citations.enabled`, `context`, and `title` (→ Bedrock `name`) when the caller provides them. When `title` is missing/whitespace, the existing hashed-name fallback is preserved.
- **Tests**: 4 new unit tests (enabled, disabled, omitted, malformed inputs).

## Evidence

### BEFORE (unmodified `litellm_oss_agent_shin_daily_branch`)

```
BEFORE (unmodified daily branch) outbound DocumentBlock keys: ['format', 'name', 'source']
{
  "source": "<base64 pdf elided>",
  "format": "pdf",
  "name": "Document_e999d2a1c1775518_pdf"
}
# citations dropped: True
# context dropped: True
# title->name dropped: True
```

### AFTER (this PR)

```
===== A) BEFORE-style request: plain document (backwards-compat) =====
→ URL: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20240620-v1%3A0/converse
→ Outbound DocumentBlock keys: ['format', 'name', 'source']
→ Outbound DocumentBlock (source elided):
{
  "source": "<base64 pdf elided>",
  "format": "pdf",
  "name": "Document_e999d2a1c1775518_pdf"
}
→ Response provider_specific_fields keys: ['citationsContent']
→ provider_specific_fields.citationsContent[0]: {
  "content": [
    {
      "text": "X happened."
    }
  ],
  "citations": [
    {
      "title": "My Research Paper",
      "sourceContent": [
        {
          "text": "X happened on page 1."
        }
      ],
      "location": {
        "documentChar": {
          "documentIndex": 0,
          "start": 0,
          "end": 16
        }
      }
    }
  ]
}

===== B) AFTER fix (LIT-3401): citations + context + title forwarded =====
→ URL: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20240620-v1%3A0/converse
→ Outbound DocumentBlock keys: ['citations', 'context', 'format', 'name', 'source']
→ Outbound DocumentBlock (source elided):
{
  "source": "<base64 pdf elided>",
  "format": "pdf",
  "name": "My Research Paper",
  "citations": {
    "enabled": true
  },
  "context": "Authored by Jane Doe in 2024."
}
→ Response provider_specific_fields keys: ['citationsContent']
→ provider_specific_fields.citationsContent[0]: {
  "content": [
    {
      "text": "X happened."
    }
  ],
  "citations": [
    {
      "title": "My Research Paper",
      "sourceContent": [
        {
          "text": "X happened on page 1."
        }
      ],
      "location": {
        "documentChar": {
          "documentIndex": 0,
          "start": 0,
          "end": 16
        }
      }
    }
  ]
}
```

Key diff visible in the captured payloads:

- BEFORE — outbound `DocumentBlock` keys: `['format', 'name', 'source']` (citations dropped, context dropped, title dropped → hashed name)
- AFTER — outbound `DocumentBlock` keys: `['citations', 'context', 'format', 'name', 'source']` with `name == "My Research Paper"` (caller title honored), `citations == {"enabled": true}`, `context == "Authored by Jane Doe in 2024."`

Backwards-compat case (no `citations`/`context`/`title` supplied) produces the same `{format, name, source}` block as today — covered by the dedicated `_no_citations_omits_field` test.

## Test runs

```
$ python3 -m pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py \
    tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py \
    tests/test_litellm/llms/test_file_content_block.py \
    tests/litellm_core_utils/test_bedrock_converse_dedup_factory.py
235 passed in 22.06s
```

## Notes for reviewers

- Pushed via the GitHub Contents API because the current `GITHUB_TOKEN` lacks `repo`/`workflow` scopes (known limitation in the agent harness). Merge-base diff will be slightly noisier than a plain `git push` would produce.
- Async (`_bedrock_converse_messages_pt_async`) calls the same `_process_document_message`, so it picks up the fix without separate changes.

Linear: LIT-3401


### Verification (ship-pr)

- [x] Base branch is `litellm_oss_agent_shin_daily_branch` (verified by the "Verify PR source branch" check)
- [x] No customer/account names anywhere in the diff or PR body (grep over body + diff for the standard customer watchlist returned 0 hits)
- [x] No API keys / tokens / AWS credentials in the diff or PR body (regex sweep clean; sample base64 PDF in tests is the empty 1-page PDF; the example `aws_access_key_id="AKIAFAKE"` in evidence is a fixture string, not a real key)
- [x] Runtime evidence (before+after) inline in the PR body — captured against a mocked Bedrock Converse upstream so the outbound HTTP body LiteLLM would send to AWS is observable
- [x] Unit tests added (4 cases: enabled / disabled / omitted / malformed inputs) — but not used as a substitute for runtime evidence
- [x] Backwards compatibility: when caller does not provide `citations`/`context`/`title`, the produced `DocumentBlock` shape is byte-for-byte the same as before (covered by `test_..._no_citations_omits_field`)
- [x] Async path covered: `_bedrock_converse_messages_pt_async` calls the same `_process_document_message`, so the fix lands on both sync and async ingress paths without separate changes
- [x] Mergeable: `True` (no conflicts against `litellm_oss_agent_shin_daily_branch`)
- [x] Pushed via Contents API (token lacks `repo`/`workflow` scopes — noted in PR body)
