### PR TITLE
fix: mark MCP tool isError observability status

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5368,28 +5368,15 @@ def _extract_response_obj_and_hidden_params(
     return response_obj, hidden_params
 
 
-def _extract_mcp_tool_error_message(response_obj: dict) -> Optional[str]:
-    """Return an upstream MCP tool error message when result.isError is true."""
+MCP_TOOL_ERROR_LOGGING_MESSAGE = "MCP tool returned isError=true"
+
+
+def _has_mcp_tool_error(response_obj: dict) -> bool:
+    """Return True when an MCP tool result reports isError."""
     result_obj = response_obj.get("result", response_obj)
     if not isinstance(result_obj, dict) or result_obj.get("isError") is not True:
-        return None
-
-    content = result_obj.get("content")
-    messages: List[str] = []
-    if isinstance(content, list):
-        for item in content:
-            if isinstance(item, dict):
-                text = item.get("text") or item.get("message")
-                if isinstance(text, str) and text.strip():
-                    messages.append(text.strip())
-            elif isinstance(item, str) and item.strip():
-                messages.append(item.strip())
-    elif isinstance(content, str) and content.strip():
-        messages.append(content.strip())
-
-    if messages:
-        return " ".join(messages)
-    return "MCP tool returned isError=true"
+        return False
+    return True
 
 
 def _get_mcp_tool_call_logging_status(
@@ -5406,8 +5393,7 @@ def _get_mcp_tool_call_logging_status(
     if call_type != CallTypes.call_mcp_tool.value:
         return call_type, status, error_str, None
 
-    mcp_tool_error_message = _extract_mcp_tool_error_message(response_obj)
-    if mcp_tool_error_message is None:
+    if _has_mcp_tool_error(response_obj) is False:
         return call_type, status, error_str, None
 
     error_information = StandardLoggingPayloadErrorInformation(
@@ -5415,9 +5401,14 @@ def _get_mcp_tool_call_logging_status(
         error_class="MCPToolError",
         llm_provider="mcp",
         traceback="",
-        error_message=mcp_tool_error_message,
+        error_message=MCP_TOOL_ERROR_LOGGING_MESSAGE,
     )
-    return call_type, "failure", error_str or mcp_tool_error_message, error_information
+    return (
+        call_type,
+        "failure",
+        error_str or MCP_TOOL_ERROR_LOGGING_MESSAGE,
+        error_information,
+    )
 
 
 def get_standard_logging_object_payload(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5368,6 +5368,58 @@ def _extract_response_obj_and_hidden_params(
     return response_obj, hidden_params
 
 
+def _extract_mcp_tool_error_message(response_obj: dict) -> Optional[str]:
+    """Return an upstream MCP tool error message when result.isError is true."""
+    result_obj = response_obj.get("result", response_obj)
+    if not isinstance(result_obj, dict) or result_obj.get("isError") is not True:
+        return None
+
+    content = result_obj.get("content")
+    messages: List[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("message")
+                if isinstance(text, str) and text.strip():
+                    messages.append(text.strip())
+            elif isinstance(item, str) and item.strip():
+                messages.append(item.strip())
+    elif isinstance(content, str) and content.strip():
+        messages.append(content.strip())
+
+    if messages:
+        return " ".join(messages)
+    return "MCP tool returned isError=true"
+
+
+def _get_mcp_tool_call_logging_status(
+    call_type: Optional[str],
+    response_obj: dict,
+    status: StandardLoggingPayloadStatus,
+    error_str: Optional[str],
+) -> Tuple[
+    Optional[str],
+    StandardLoggingPayloadStatus,
+    Optional[str],
+    Optional[StandardLoggingPayloadErrorInformation],
+]:
+    if call_type != CallTypes.call_mcp_tool.value:
+        return call_type, status, error_str, None
+
+    mcp_tool_error_message = _extract_mcp_tool_error_message(response_obj)
+    if mcp_tool_error_message is None:
+        return call_type, status, error_str, None
+
+    error_information = StandardLoggingPayloadErrorInformation(
+        error_code="",
+        error_class="MCPToolError",
+        llm_provider="mcp",
+        traceback="",
+        error_message=mcp_tool_error_message,
+    )
+    return call_type, "failure", error_str or mcp_tool_error_message, error_information
+
+
 def get_standard_logging_object_payload(
     kwargs: Optional[dict],
     init_response_obj: Union[Any, BaseModel, dict],
@@ -5396,7 +5448,14 @@ def get_standard_logging_object_payload(
         )
 
         completion_start_time = kwargs.get("completion_start_time", end_time)
-        call_type = kwargs.get("call_type")
+        call_type, status, error_str, mcp_tool_error_information = (
+            _get_mcp_tool_call_logging_status(
+                call_type=kwargs.get("call_type"),
+                response_obj=response_obj,
+                status=status,
+                error_str=error_str,
+            )
+        )
         cache_hit = kwargs.get("cache_hit", False)
         # Extract usage as a plain dict, avoiding Pydantic round-trip
         usage_dict = StandardLoggingPayloadSetup.get_usage_as_dict(
@@ -5488,6 +5547,8 @@ def get_standard_logging_object_payload(
         error_information = StandardLoggingPayloadSetup.get_error_information(
             original_exception=original_exception,
         )
+        if mcp_tool_error_information is not None:
+            error_information = mcp_tool_error_information
 
         ## get final response object ##
         final_response_obj = StandardLoggingPayloadSetup.get_final_response_obj(

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2729,12 +2729,12 @@ def test_mcp_tool_is_error_marks_standard_logging_payload_as_failure(logging_obj
     assert payload is not None
     assert payload["status"] == "failure"
     assert payload["status_fields"]["llm_api_status"] == "failure"
-    assert payload["error_str"] == "Input validation error: 'query' is required"
+    assert payload["error_str"] == "MCP tool returned isError=true"
     assert payload["error_information"] is not None
     assert payload["error_information"]["error_class"] == "MCPToolError"
     assert (
         payload["error_information"]["error_message"]
-        == "Input validation error: 'query' is required"
+        == "MCP tool returned isError=true"
     )
     assert payload["metadata"]["mcp_tool_call_metadata"] is not None
     assert (
@@ -2766,7 +2766,7 @@ def test_mcp_tool_json_rpc_is_error_envelope_marks_payload_as_failure(logging_ob
                 "content": [
                     {
                         "type": "text",
-                        "text": "Permission denied for repository",
+                        "text": "Permission denied for repository sk-live-secret",
                     }
                 ],
                 "isError": True,
@@ -2784,8 +2784,11 @@ def test_mcp_tool_json_rpc_is_error_envelope_marks_payload_as_failure(logging_ob
     assert payload["error_information"]["error_class"] == "MCPToolError"
     assert (
         payload["error_information"]["error_message"]
-        == "Permission denied for repository"
+        == "MCP tool returned isError=true"
     )
+    assert payload["error_str"] == "MCP tool returned isError=true"
+    assert "sk-live-secret" not in payload["error_str"]
+    assert "sk-live-secret" not in payload["error_information"]["error_message"]
 
 
 def test_mcp_tool_success_keeps_standard_logging_payload_success(logging_obj):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2689,6 +2689,138 @@ def test_get_standard_logging_object_payload_includes_litellm_call_id(logging_ob
     assert payload["litellm_call_id"] == call_id
 
 
+def test_mcp_tool_is_error_marks_standard_logging_payload_as_failure(logging_obj):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-call-id",
+            "model": "MCP: deepwiki/search",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+            "mcp_tool_call_metadata": {
+                "name": "search",
+                "arguments": {"NOT_a_real_arg": "x"},
+                "mcp_server_name": "deepwiki",
+                "namespaced_tool_name": "deepwiki/search",
+            },
+        },
+        init_response_obj={
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Input validation error: 'query' is required",
+                }
+            ],
+            "isError": True,
+        },
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["status"] == "failure"
+    assert payload["status_fields"]["llm_api_status"] == "failure"
+    assert payload["error_str"] == "Input validation error: 'query' is required"
+    assert payload["error_information"] is not None
+    assert payload["error_information"]["error_class"] == "MCPToolError"
+    assert (
+        payload["error_information"]["error_message"]
+        == "Input validation error: 'query' is required"
+    )
+    assert payload["metadata"]["mcp_tool_call_metadata"] is not None
+    assert (
+        payload["metadata"]["mcp_tool_call_metadata"]["namespaced_tool_name"]
+        == "deepwiki/search"
+    )
+
+
+def test_mcp_tool_json_rpc_is_error_envelope_marks_payload_as_failure(logging_obj):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-json-rpc-call-id",
+            "model": "MCP: github/create_issue",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+        },
+        init_response_obj={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Permission denied for repository",
+                    }
+                ],
+                "isError": True,
+            },
+        },
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["status"] == "failure"
+    assert payload["error_information"] is not None
+    assert payload["error_information"]["error_class"] == "MCPToolError"
+    assert (
+        payload["error_information"]["error_message"]
+        == "Permission denied for repository"
+    )
+
+
+def test_mcp_tool_success_keeps_standard_logging_payload_success(logging_obj):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-success-call-id",
+            "model": "MCP: deepwiki/search",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+        },
+        init_response_obj={
+            "content": [{"type": "text", "text": "Search result"}],
+            "isError": False,
+        },
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["status"] == "success"
+    assert payload["error_str"] is None
+    assert payload["error_information"] is not None
+    assert payload["error_information"]["error_message"] == ""
+
+
 def _make_dict_logging_obj():
     """Build a Logging instance configured for a non-streaming dict result."""
     obj = LitellmLogging(


### PR DESCRIPTION
## Relevant issues

Fixes #28927

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - not run locally; see focused verification below
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Focused local checks:

```bash
/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m uv run pytest \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_mcp_tool_is_error_marks_standard_logging_payload_as_failure \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_mcp_tool_json_rpc_is_error_envelope_marks_payload_as_failure \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_mcp_tool_success_keeps_standard_logging_payload_success -q
# 3 passed in 0.21s
```

```bash
/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m uv run black --check \
  litellm/litellm_core_utils/litellm_logging.py \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py
# 2 files would be left unchanged
```

```bash
/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m uv run ruff check --select PLR0915 \
  litellm/litellm_core_utils/litellm_logging.py
# All checks passed
```

Note: a broad `ruff check` on `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` reports pre-existing lint in older tests (`print`, `== True`, `type(x) == str`). I did not modify those unrelated sections.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Detect MCP `tools/call` responses where the upstream tool returned `isError: true`, even when the transport/JSON-RPC request itself succeeded.
- Mark the standard logging payload as `status: "failure"`, set `status_fields.llm_api_status` to failure, and populate `error_information` with an `MCPToolError` message extracted from `content[*].text`.
- Preserve the existing `mcp_tool_call_metadata` so dashboards and callbacks can still attribute the failure to the tool/server/arguments.
- Added regression coverage for both direct `CallToolResult`-style responses and JSON-RPC envelopes, plus a non-error MCP success guard.

Contribution note: I used Codex to help implement and verify this focused patch.
