### PR TITLE
Fix MCP tool response capture in standard logging

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5343,7 +5343,16 @@ def _extract_response_obj_and_hidden_params(
         hidden_params = getattr(init_response_obj, "_hidden_params", None)
     elif isinstance(init_response_obj, dict):
         response_obj = init_response_obj
+    elif callable(getattr(init_response_obj, "model_dump", None)):
+        response_obj = init_response_obj.model_dump()
+        hidden_params = getattr(init_response_obj, "_hidden_params", None)
+    elif callable(getattr(init_response_obj, "dict", None)):
+        response_obj = init_response_obj.dict()
+        hidden_params = getattr(init_response_obj, "_hidden_params", None)
     else:
+        response_obj = {}
+
+    if not isinstance(response_obj, dict):
         response_obj = {}
 
     if original_exception is not None and hidden_params is None:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2689,6 +2689,104 @@ def test_get_standard_logging_object_payload_includes_litellm_call_id(logging_ob
     assert payload["litellm_call_id"] == call_id
 
 
+def test_mcp_tool_model_dump_response_is_captured_in_standard_logging_payload(
+    logging_obj,
+):
+    """MCP SDK result objects should retain tool output in standard logging."""
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    class FakeMCPCallToolResult:
+        def model_dump(self):
+            return {
+                "content": [{"type": "text", "text": "42"}],
+                "structuredContent": {"answer": 42},
+                "isError": False,
+            }
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-response-call-id",
+            "model": "MCP: math/answer",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+            "mcp_tool_call_metadata": {
+                "name": "answer",
+                "arguments": {"question": "life"},
+                "mcp_server_name": "math",
+                "namespaced_tool_name": "math/answer",
+            },
+        },
+        init_response_obj=FakeMCPCallToolResult(),
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["call_type"] == CallTypes.call_mcp_tool.value
+    assert payload["status"] == "success"
+    assert payload["response"] == {
+        "content": [{"type": "text", "text": "42"}],
+        "structuredContent": {"answer": 42},
+        "isError": False,
+    }
+    assert payload["metadata"]["mcp_tool_call_metadata"] is not None
+    assert (
+        payload["metadata"]["mcp_tool_call_metadata"]["namespaced_tool_name"]
+        == "math/answer"
+    )
+
+
+def test_mcp_tool_dict_response_is_captured_in_standard_logging_payload(logging_obj):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-json-rpc-response-call-id",
+            "model": "MCP: search/query",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+        },
+        init_response_obj={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [{"type": "text", "text": "search result"}],
+                "structuredContent": {"ids": ["doc-1"]},
+                "isError": False,
+            },
+        },
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["response"] == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "content": [{"type": "text", "text": "search result"}],
+            "structuredContent": {"ids": ["doc-1"]},
+            "isError": False,
+        },
+    }
+
+
 def _make_dict_logging_obj():
     """Build a Logging instance configured for a non-streaming dict result."""
     obj = LitellmLogging(

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2744,6 +2744,78 @@ def test_mcp_tool_model_dump_response_is_captured_in_standard_logging_payload(
     )
 
 
+def test_mcp_tool_legacy_dict_response_is_captured_in_standard_logging_payload(
+    logging_obj,
+):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    class FakeLegacyMCPCallToolResult:
+        def dict(self):
+            return {
+                "content": [{"type": "text", "text": "legacy"}],
+                "structuredContent": {"runtime": "pydantic-v1"},
+                "isError": False,
+            }
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-legacy-response-call-id",
+            "model": "MCP: legacy/result",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+        },
+        init_response_obj=FakeLegacyMCPCallToolResult(),
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["response"] == {
+        "content": [{"type": "text", "text": "legacy"}],
+        "structuredContent": {"runtime": "pydantic-v1"},
+        "isError": False,
+    }
+
+
+def test_mcp_tool_non_mapping_model_dump_response_is_ignored(logging_obj):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+    from litellm.types.utils import CallTypes
+
+    class FakeMalformedMCPCallToolResult:
+        def model_dump(self):
+            return ["not", "a", "mapping"]
+
+    now = datetime.datetime.now()
+    payload = get_standard_logging_object_payload(
+        kwargs={
+            "litellm_call_id": "mcp-malformed-response-call-id",
+            "model": "MCP: malformed/result",
+            "messages": [],
+            "call_type": CallTypes.call_mcp_tool.value,
+        },
+        init_response_obj=FakeMalformedMCPCallToolResult(),
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["response"] == {}
+
+
 def test_mcp_tool_dict_response_is_captured_in_standard_logging_payload(logging_obj):
     import datetime
 


### PR DESCRIPTION
## Relevant issues

Fixes #28900

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - not run locally; see focused verification below
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Focused local checks:

```bash
/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m uv run pytest \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_mcp_tool_model_dump_response_is_captured_in_standard_logging_payload \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_mcp_tool_dict_response_is_captured_in_standard_logging_payload -q
# 2 passed in 0.24s
```

```bash
/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m uv run black --check \
  litellm/litellm_core_utils/litellm_logging.py \
  tests/test_litellm/litellm_core_utils/test_litellm_logging.py
# 2 files would be left unchanged
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Preserve MCP tool response objects in `standard_logging_object.response` when the response is a model-like SDK object exposing `model_dump()` or `dict()`.
- Keep existing dict response behavior for JSON-RPC envelopes, including `result.content`, `result.structuredContent`, and `result.isError`.
- Added regression coverage for both a model-like MCP tool result and a JSON-RPC envelope so downstream callbacks/loggers can inspect the actual tool output.

Contribution note: I used Codex to help implement and verify this focused patch.
