### PR TITLE
fix(vertex_ai/files): stream OpenAI->Vertex batch JSONL transform (LIT-3382)

### DIFF
--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -1,9 +1,10 @@
 import base64
+import io
 import json
 import os
 import re
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import httpx
 from httpx import Headers, Response
@@ -175,6 +176,121 @@ def _openai_batch_jsonl_entries_to_vertex_wrapped_requests(
     return vertex_jsonl_content
 
 
+
+def _iter_openai_file_lines(
+    openai_file_content,
+):
+    """
+    Stream lines from an OpenAI ``FileTypes`` payload without materialising the
+    full ``splitlines()`` list.
+
+    Multi-GB batch JSONL uploads (e.g. Gemini batch input files) previously held
+    the entire payload in memory at least five times concurrently (decoded
+    ``str`` + ``splitlines()`` list + list of parsed dicts + list of transformed
+    dicts + joined output string), which caused worker restarts on 24 GiB pods
+    around the 1 GiB mark. Iterating one line at a time keeps peak memory close
+    to ``input_size + output_size`` instead of ``~5x input_size``.
+    """
+    # Unwrap tuple form: (filename, content, [content_type], [headers])
+    if isinstance(openai_file_content, tuple):
+        file_content = openai_file_content[1]
+    else:
+        file_content = openai_file_content
+
+    # File-like objects (IO[bytes] / IO[str]): iterate directly instead of read().
+    if hasattr(file_content, "read"):
+        try:
+            iterator = iter(file_content)
+        except TypeError:
+            raw = file_content.read()
+            file_content = (
+                raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+            )
+        else:
+            for raw_line in iterator:
+                if isinstance(raw_line, (bytes, bytearray)):
+                    raw_line = raw_line.decode("utf-8")
+                yield raw_line.rstrip("\r\n")
+            return
+
+    if isinstance(file_content, PathLike):
+        with open(str(file_content), "r", encoding="utf-8") as fh:
+            for raw_line in fh:
+                yield raw_line.rstrip("\r\n")
+        return
+
+    if isinstance(file_content, (bytes, bytearray)):
+        file_content = bytes(file_content).decode("utf-8")
+
+    if not isinstance(file_content, str):
+        return
+
+    pos = 0
+    length = len(file_content)
+    while pos < length:
+        nl = file_content.find("\n", pos)
+        if nl == -1:
+            tail = file_content[pos:]
+            if tail.endswith("\r"):
+                tail = tail[:-1]
+            yield tail
+            return
+        line = file_content[pos:nl]
+        if line.endswith("\r"):
+            line = line[:-1]
+        yield line
+        pos = nl + 1
+
+
+def _iter_openai_jsonl_entries(
+    openai_file_content,
+):
+    """Stream parsed OpenAI batch JSONL entries one-at-a-time."""
+    for line in _iter_openai_file_lines(openai_file_content):
+        if line.strip():
+            yield json.loads(line)
+
+
+def _stream_openai_jsonl_to_vertex_jsonl_string(
+    openai_file_content,
+    map_openai_to_vertex_params,
+):
+    """
+    Stream the OpenAI batch JSONL -> Vertex JSONL transformation one entry at a
+    time. Returns ``(vertex_jsonl_string, first_openai_entry_or_None)`` -- the
+    first entry is surfaced so callers can derive the GCS object name without
+    re-parsing the (potentially multi-GB) payload.
+    """
+    buf = io.StringIO()
+    first_entry = None
+    sep = ""
+    for openai_entry in _iter_openai_jsonl_entries(openai_file_content):
+        if first_entry is None:
+            first_entry = openai_entry
+        openai_request_body = openai_entry.get("body") or {}
+        vertex_request_body = _transform_request_body(
+            messages=openai_request_body.get("messages", []),
+            model=openai_request_body.get("model", ""),
+            optional_params=map_openai_to_vertex_params(openai_request_body),
+            custom_llm_provider="vertex_ai",
+            litellm_params={},
+            cached_content=None,
+        )
+        custom_id = openai_entry.get("custom_id")
+        if custom_id is not None:
+            if "labels" not in vertex_request_body:
+                vertex_request_body["labels"] = {}
+            _set_litellm_batch_custom_id_labels(
+                vertex_request_body["labels"], custom_id
+            )
+
+        buf.write(sep)
+        json.dump({"request": vertex_request_body}, buf)
+        sep = "\n"
+
+    return buf.getvalue(), first_entry
+
+
 class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
     """
     Config for VertexAI Files
@@ -273,17 +389,13 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             raise ValueError("file content is required")
 
         if purpose == "batch":
-            ## 1. If jsonl, check if there's a model name
-            file_content = self._get_content_from_openai_file(
-                extracted_file_data_content
+            ## 1. Peek the first jsonl entry for the model name without
+            ##    materialising the full payload (large batches were OOM-ing here).
+            first_entry = next(
+                _iter_openai_jsonl_entries(extracted_file_data_content), None
             )
-
-            # Split into lines and parse each line as JSON
-            openai_jsonl_content = [
-                json.loads(line) for line in file_content.splitlines() if line.strip()
-            ]
-            if len(openai_jsonl_content) > 0:
-                return self._get_gcs_object_name_from_batch_jsonl(openai_jsonl_content)
+            if first_entry is not None:
+                return self._get_gcs_object_name_from_batch_jsonl([first_entry])
 
         ## 2. If not jsonl, store under a server-generated managed object name
         filename = extracted_file_data.get("filename")
@@ -399,21 +511,17 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             create_file_data=create_file_data,
             extracted_file_data=extracted_file_data,
         ):
-            ## 1. If jsonl, check if there's a model name
-            file_content = self._get_content_from_openai_file(
-                extracted_file_data_content
-            )
-
-            # Split into lines and parse each line as JSON
-            openai_jsonl_content = [
-                json.loads(line) for line in file_content.splitlines() if line.strip()
-            ]
-            vertex_jsonl_content = (
-                self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
-                    openai_jsonl_content
+            ## 1. Stream the JSONL transformation one entry at a time. The
+            ##    previous pipeline (splitlines + list-of-dicts + list-of-dicts
+            ##    + joined string) held ~5 simultaneous copies of the payload
+            ##    and OOM-restarted workers on ~1 GiB inputs.
+            vertex_jsonl_string, _first_entry = (
+                _stream_openai_jsonl_to_vertex_jsonl_string(
+                    extracted_file_data_content,
+                    self._map_openai_to_vertex_params,
                 )
             )
-            return "\n".join(json.dumps(item) for item in vertex_jsonl_content)
+            return vertex_jsonl_string
         elif isinstance(extracted_file_data_content, bytes):
             return extracted_file_data_content
         else:
@@ -811,23 +919,18 @@ class VertexAIJsonlFilesTransformation(VertexGeminiConfig):
 
         if openai_file_content is None:
             raise ValueError("contents of file are None")
-        # Read the content of the file
-        file_content = self._get_content_from_openai_file(openai_file_content)
 
-        # Split into lines and parse each line as JSON
-        openai_jsonl_content = [
-            json.loads(line) for line in file_content.splitlines() if line.strip()
-        ]
-        vertex_jsonl_content = (
-            self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
-                openai_jsonl_content
-            )
-        )
-        vertex_jsonl_string = "\n".join(
-            json.dumps(item) for item in vertex_jsonl_content
+        # Stream the OpenAI -> Vertex JSONL transformation one entry at a time
+        # so very large batch payloads (~1 GiB+) do not hold five simultaneous
+        # in-memory copies of the file (decoded str, splitlines list, two
+        # list-of-dicts, joined string). We surface the first parsed entry so
+        # the GCS object name can be derived without re-parsing the input.
+        vertex_jsonl_string, first_entry = _stream_openai_jsonl_to_vertex_jsonl_string(
+            openai_file_content,
+            self._map_openai_to_vertex_params,
         )
         object_name = self._get_gcs_object_name(
-            openai_jsonl_content=openai_jsonl_content
+            openai_jsonl_content=[first_entry] if first_entry is not None else []
         )
         return vertex_jsonl_string, object_name
 

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -190,7 +190,11 @@ def _iter_openai_file_lines(
     around the 1 GiB mark. Iterating one line at a time keeps peak memory close
     to ``input_size + output_size`` instead of ``~5x input_size``.
     """
-    # Unwrap tuple form: (filename, content, [content_type], [headers])
+    # Unwrap tuple form: (filename, content, [content_type], [headers]).
+    # We carry `file_content` as `Any` because it can be progressively narrowed
+    # (bytes -> str, file-like -> str via read(), PathLike -> opened text) and
+    # the union in FileTypes is too narrow for mypy to follow each branch.
+    file_content: Any
     if isinstance(openai_file_content, tuple):
         file_content = openai_file_content[1]
     else:

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -177,8 +177,8 @@ def _openai_batch_jsonl_entries_to_vertex_wrapped_requests(
 
 
 def _iter_openai_file_lines(
-    openai_file_content,
-):
+    openai_file_content: FileTypes,
+) -> Iterator[str]:
     """
     Stream lines from an OpenAI ``FileTypes`` payload without materialising the
     full ``splitlines()`` list.
@@ -242,8 +242,8 @@ def _iter_openai_file_lines(
 
 
 def _iter_openai_jsonl_entries(
-    openai_file_content,
-):
+    openai_file_content: FileTypes,
+) -> Iterator[Dict[str, Any]]:
     """Stream parsed OpenAI batch JSONL entries one-at-a-time."""
     for line in _iter_openai_file_lines(openai_file_content):
         if line.strip():
@@ -251,9 +251,9 @@ def _iter_openai_jsonl_entries(
 
 
 def _stream_openai_jsonl_to_vertex_jsonl_string(
-    openai_file_content,
-    map_openai_to_vertex_params,
-):
+    openai_file_content: FileTypes,
+    map_openai_to_vertex_params: Callable[[Dict[str, Any]], Dict[str, Any]],
+) -> Tuple[str, Optional[Dict[str, Any]]]:
     """
     Stream the OpenAI batch JSONL -> Vertex JSONL transformation one entry at a
     time. Returns ``(vertex_jsonl_string, first_openai_entry_or_None)`` -- the

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -176,7 +176,6 @@ def _openai_batch_jsonl_entries_to_vertex_wrapped_requests(
     return vertex_jsonl_content
 
 
-
 def _iter_openai_file_lines(
     openai_file_content,
 ):

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -223,7 +223,10 @@ def _iter_openai_file_lines(
         return
 
     if isinstance(file_content, (bytes, bytearray)):
-        file_content = bytes(file_content).decode("utf-8")
+        # Decode directly on the bytes/bytearray instance — avoid the
+        # transient ``bytes(file_content)`` copy that briefly doubled peak
+        # memory for multi-GB uploads.
+        file_content = file_content.decode("utf-8")
 
     if not isinstance(file_content, str):
         return

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py
@@ -19,6 +19,7 @@ These tests assert:
 4. Peak traced memory under a sizeable synthetic payload is bounded well
    below the old ~5x amplification (we assert <= 3.5x).
 """
+
 import gc
 import io
 import json
@@ -131,9 +132,7 @@ class TestIterOpenAIJsonlEntries:
 
     def test_lazy_parsing_does_not_consume_beyond_first(self):
         """``next()`` must not parse any line beyond the first."""
-        payload = b"\n".join(
-            [json.dumps(_entry(0)).encode(), b"NOT-JSON", b"NOT-JSON"]
-        )
+        payload = b"\n".join([json.dumps(_entry(0)).encode(), b"NOT-JSON", b"NOT-JSON"])
         first = next(_iter_openai_jsonl_entries(payload))
         assert first == _entry(0)
 
@@ -146,9 +145,7 @@ class TestStreamOutputParity:
             payload, xform._map_openai_to_vertex_params
         )
         legacy_list = [
-            json.loads(line)
-            for line in payload.decode().splitlines()
-            if line.strip()
+            json.loads(line) for line in payload.decode().splitlines() if line.strip()
         ]
         legacy_vertex = (
             xform._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
@@ -217,9 +214,8 @@ class TestPublicApiParity:
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             extract_file_data,
         )
-        extracted = extract_file_data(
-            ("batch.jsonl", payload, "application/jsonl")
-        )
+
+        extracted = extract_file_data(("batch.jsonl", payload, "application/jsonl"))
         name = cfg.get_object_name(extracted, "batch")
         assert "publishers/google/models" in name
 
@@ -228,6 +224,7 @@ class TestPublicApiParity:
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             extract_file_data,
         )
+
         extracted = extract_file_data(("batch.jsonl", b"", "application/jsonl"))
         name = cfg.get_object_name(extracted, "batch")
         assert "/uploads/" in name
@@ -268,10 +265,8 @@ class TestPeakMemory:
         gc.collect()
         tracemalloc.start()
         xform = VertexAIJsonlFilesTransformation()
-        out, _name = (
-            xform.transform_openai_file_content_to_vertex_ai_file_content(
-                openai_file_content=payload
-            )
+        out, _name = xform.transform_openai_file_content_to_vertex_ai_file_content(
+            openai_file_content=payload
         )
         _cur, peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
@@ -290,9 +285,8 @@ class TestPeakMemory:
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             extract_file_data,
         )
-        extracted = extract_file_data(
-            ("batch.jsonl", payload, "application/jsonl")
-        )
+
+        extracted = extract_file_data(("batch.jsonl", payload, "application/jsonl"))
 
         gc.collect()
         tracemalloc.start()

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py
@@ -1,0 +1,307 @@
+"""
+Streaming JSONL transform regression tests for LIT-3382.
+
+The original (pre-fix) pipeline materialised the OpenAI batch JSONL payload at
+least 5 times concurrently (decoded str, splitlines list, list-of-dicts,
+list-of-vertex-dicts, joined output string). On ~1 GiB uploads the pod OOM'd
+and uvicorn workers restarted mid-upload.
+
+The fix replaces the list-based pipeline with a streaming generator
+(``_iter_openai_jsonl_entries`` + ``_stream_openai_jsonl_to_vertex_jsonl_string``)
+and peeks only the first entry inside ``VertexAIFilesConfig.get_object_name``.
+
+These tests assert:
+1. Output parity with the legacy list-based path on a representative payload.
+2. Every supported ``FileTypes`` input form (str, bytes, tuple, file-like,
+   PathLike) is honored by the streaming helpers.
+3. Edge cases (empty input, single entry, CRLF line endings, blank lines,
+   trailing newlines) match the legacy semantics.
+4. Peak traced memory under a sizeable synthetic payload is bounded well
+   below the old ~5x amplification (we assert <= 3.5x).
+"""
+import gc
+import io
+import json
+import os
+import sys
+import tempfile
+import tracemalloc
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../..")),
+)
+
+from litellm.llms.vertex_ai.files.transformation import (  # noqa: E402
+    VertexAIFilesConfig,
+    VertexAIJsonlFilesTransformation,
+    _iter_openai_file_lines,
+    _iter_openai_jsonl_entries,
+    _stream_openai_jsonl_to_vertex_jsonl_string,
+)
+from litellm.types.llms.openai import CreateFileRequest  # noqa: E402
+
+
+def _entry(i: int) -> dict:
+    return {
+        "custom_id": f"req-{i}",
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": "gemini-1.5-flash",
+            "messages": [{"role": "user", "content": f"hello {i}"}],
+            "max_tokens": 32,
+        },
+    }
+
+
+def _jsonl_bytes(n: int, line_sep: str = "\n") -> bytes:
+    return line_sep.join(json.dumps(_entry(i)) for i in range(n)).encode("utf-8")
+
+
+class TestIterOpenAIFileLines:
+    def test_yields_lines_from_bytes(self):
+        # Mirrors str.splitlines() semantics: trailing "\n" does not yield an
+        # extra empty trailing line.
+        assert list(_iter_openai_file_lines(b"a\nb\nc\n")) == ["a", "b", "c"]
+
+    def test_yields_lines_from_str(self):
+        assert list(_iter_openai_file_lines("a\nb\nc")) == ["a", "b", "c"]
+
+    def test_strips_crlf(self):
+        assert list(_iter_openai_file_lines(b"a\r\nb\r\nc")) == ["a", "b", "c"]
+
+    def test_unwraps_tuple_form(self):
+        payload = ("batch.jsonl", b"a\nb", "application/jsonl")
+        assert list(_iter_openai_file_lines(payload)) == ["a", "b"]
+
+    def test_reads_file_like_bytes(self):
+        bio = io.BytesIO(b"a\nb\nc\n")
+        assert list(_iter_openai_file_lines(bio)) == ["a", "b", "c"]
+
+    def test_reads_file_like_text(self):
+        sio = io.StringIO("a\nb\nc\n")
+        assert list(_iter_openai_file_lines(sio)) == ["a", "b", "c"]
+
+    def test_reads_pathlike(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write("a\nb\nc\n")
+            path = fh.name
+        try:
+            assert list(_iter_openai_file_lines(Path(path))) == ["a", "b", "c"]
+        finally:
+            os.unlink(path)
+
+    def test_empty_input(self):
+        assert list(_iter_openai_file_lines(b"")) == []
+        assert list(_iter_openai_file_lines("")) == []
+
+    def test_no_trailing_newline(self):
+        assert list(_iter_openai_file_lines(b"only")) == ["only"]
+
+
+class TestIterOpenAIJsonlEntries:
+    def test_yields_parsed_entries(self):
+        payload = _jsonl_bytes(3)
+        assert list(_iter_openai_jsonl_entries(payload)) == [
+            _entry(0),
+            _entry(1),
+            _entry(2),
+        ]
+
+    def test_skips_blank_and_whitespace_lines(self):
+        payload = (
+            json.dumps(_entry(0)) + "\n\n   \n" + json.dumps(_entry(1)) + "\n"
+        ).encode("utf-8")
+        assert list(_iter_openai_jsonl_entries(payload)) == [_entry(0), _entry(1)]
+
+    def test_handles_crlf(self):
+        payload = (
+            json.dumps(_entry(0)) + "\r\n" + json.dumps(_entry(1)) + "\r\n"
+        ).encode("utf-8")
+        assert list(_iter_openai_jsonl_entries(payload)) == [_entry(0), _entry(1)]
+
+    def test_empty_payload(self):
+        assert list(_iter_openai_jsonl_entries(b"")) == []
+
+    def test_lazy_parsing_does_not_consume_beyond_first(self):
+        """``next()`` must not parse any line beyond the first."""
+        payload = b"\n".join(
+            [json.dumps(_entry(0)).encode(), b"NOT-JSON", b"NOT-JSON"]
+        )
+        first = next(_iter_openai_jsonl_entries(payload))
+        assert first == _entry(0)
+
+
+class TestStreamOutputParity:
+    def test_matches_legacy_pipeline(self):
+        payload = _jsonl_bytes(20)
+        xform = VertexAIJsonlFilesTransformation()
+        new_str, _first = _stream_openai_jsonl_to_vertex_jsonl_string(
+            payload, xform._map_openai_to_vertex_params
+        )
+        legacy_list = [
+            json.loads(line)
+            for line in payload.decode().splitlines()
+            if line.strip()
+        ]
+        legacy_vertex = (
+            xform._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(
+                legacy_list
+            )
+        )
+        legacy_str = "\n".join(json.dumps(item) for item in legacy_vertex)
+        assert new_str == legacy_str
+
+    def test_returns_first_entry(self):
+        payload = _jsonl_bytes(3)
+        xform = VertexAIJsonlFilesTransformation()
+        _out, first = _stream_openai_jsonl_to_vertex_jsonl_string(
+            payload, xform._map_openai_to_vertex_params
+        )
+        assert first == _entry(0)
+
+    def test_empty_payload_yields_empty_string_and_none(self):
+        xform = VertexAIJsonlFilesTransformation()
+        out, first = _stream_openai_jsonl_to_vertex_jsonl_string(
+            b"", xform._map_openai_to_vertex_params
+        )
+        assert out == ""
+        assert first is None
+
+
+class TestPublicApiParity:
+    def test_jsonl_files_transformation_output(self):
+        payload = _jsonl_bytes(5)
+        xform = VertexAIJsonlFilesTransformation()
+        out_str, object_name = (
+            xform.transform_openai_file_content_to_vertex_ai_file_content(
+                openai_file_content=payload
+            )
+        )
+        assert out_str.count("\n") == 4
+        parsed = [json.loads(line) for line in out_str.split("\n")]
+        for i, item in enumerate(parsed):
+            assert "request" in item
+            assert item["request"]["labels"]["litellm_custom_id"] == f"req-{i}"
+        assert "publishers/google/models" in object_name
+        assert "gemini" in object_name.lower()
+
+    def test_files_config_create_file_request_output(self):
+        payload = _jsonl_bytes(5)
+        cfg = VertexAIFilesConfig()
+        req = CreateFileRequest(
+            file=("batch.jsonl", payload, "application/jsonl"),
+            purpose="batch",
+        )
+        out = cfg.transform_create_file_request(
+            model="",
+            create_file_data=req,
+            optional_params={},
+            litellm_params={},
+        )
+        assert isinstance(out, str)
+        assert out.count("\n") == 4
+        parsed = [json.loads(line) for line in out.split("\n")]
+        assert all("request" in item for item in parsed)
+
+    def test_get_object_name_peeks_only_first_entry(self):
+        """``get_object_name(batch)`` must not parse every line."""
+        payload = _jsonl_bytes(3) + b"\nNOT-JSON-LINE\n"
+        cfg = VertexAIFilesConfig()
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+        extracted = extract_file_data(
+            ("batch.jsonl", payload, "application/jsonl")
+        )
+        name = cfg.get_object_name(extracted, "batch")
+        assert "publishers/google/models" in name
+
+    def test_get_object_name_handles_empty_jsonl(self):
+        cfg = VertexAIFilesConfig()
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+        extracted = extract_file_data(("batch.jsonl", b"", "application/jsonl"))
+        name = cfg.get_object_name(extracted, "batch")
+        assert "/uploads/" in name
+
+
+class TestPeakMemory:
+    """Assert peak traced memory through the streaming pipeline stays well
+    under the legacy ~5x amplification."""
+
+    def _build_payload(self, num_entries: int) -> bytes:
+        rows = []
+        for i in range(num_entries):
+            rows.append(
+                json.dumps(
+                    {
+                        "custom_id": f"req-{i}",
+                        "method": "POST",
+                        "url": "/v1/chat/completions",
+                        "body": {
+                            "model": "gemini-1.5-flash",
+                            "messages": [
+                                {
+                                    "role": "user",
+                                    "content": "Summarize: "
+                                    + ("Lorem ipsum dolor sit amet. " * 30),
+                                }
+                            ],
+                            "max_tokens": 32,
+                        },
+                    }
+                )
+            )
+        return ("\n".join(rows)).encode("utf-8")
+
+    def test_streaming_keeps_peak_below_legacy_amplification(self):
+        payload = self._build_payload(8_000)
+
+        gc.collect()
+        tracemalloc.start()
+        xform = VertexAIJsonlFilesTransformation()
+        out, _name = (
+            xform.transform_openai_file_content_to_vertex_ai_file_content(
+                openai_file_content=payload
+            )
+        )
+        _cur, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        amplification = peak / len(payload)
+        assert amplification < 3.5, (
+            f"Streaming transform peak memory amplification ({amplification:.2f}x) "
+            f"exceeded the safety ceiling (3.5x). Input={len(payload)} bytes, "
+            f"peak={peak} bytes, output={len(out)} bytes."
+        )
+
+    def test_get_object_name_peak_is_bounded(self):
+        payload = self._build_payload(8_000)
+
+        cfg = VertexAIFilesConfig()
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            extract_file_data,
+        )
+        extracted = extract_file_data(
+            ("batch.jsonl", payload, "application/jsonl")
+        )
+
+        gc.collect()
+        tracemalloc.start()
+        _name = cfg.get_object_name(extracted, "batch")
+        _cur, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        amplification = peak / len(payload)
+        assert amplification < 1.5, (
+            f"get_object_name peak memory amplification ({amplification:.2f}x) "
+            f"is too high; expected near 1x since only the first entry is parsed."
+        )


### PR DESCRIPTION
## Summary

Refactor the OpenAI → Vertex AI batch JSONL transform from a 5-copy list-based
pipeline to a streaming generator pipeline. Large Gemini batch JSONL uploads
(reportedly ~1 GiB) were OOM-restarting uvicorn workers on 24 GiB pods because
the legacy pipeline materialised the payload five times concurrently in memory.

## Root cause

`VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content`
and the two `VertexAIFilesConfig` call sites (`get_object_name`,
`transform_create_file_request`) all run the same pipeline:

1. `self._get_content_from_openai_file(...)` – decode to a single `str` (1× input).
2. `file_content.splitlines()` – materialised list of N `str` lines (≈ 1× input).
3. `[json.loads(line) for line in ...]` – parsed list of N dicts (≈ 1–2× input).
4. `self._transform_openai_jsonl_content_to_vertex_ai_jsonl_content(...)` –
   another full list of vertex-wrapped dicts (≈ 1–2× input).
5. `"\n".join(json.dumps(item) for item in vertex_jsonl_content)` – joined
   output string (≈ 1× input).

Peak heap usage observed on a 30 MB synthetic JSONL: **~5.7× the input size**.
Scaled to a 1 GiB upload that is ~6 GiB of Python heap per worker, which
trips the OOM-killer on the 24 GiB / 2-worker pod the customer is running.

## Fix

Three module-level streaming helpers replace the eager pipeline:

| helper | what it does |
|---|---|
| `_iter_openai_file_lines(openai_file_content)` | Yields lines one at a time across `str` / `bytes` / `tuple` / file-like / `PathLike` inputs. Mirrors `str.splitlines()` semantics on trailing newlines and CRLF. |
| `_iter_openai_jsonl_entries(openai_file_content)` | Yields parsed entries one at a time. `next()` on the generator parses only the first line. |
| `_stream_openai_jsonl_to_vertex_jsonl_string(...)` | Drives the OpenAI → Vertex transformation entry-by-entry, emitting the joined Vertex JSONL string and surfacing the first parsed entry (so callers can derive the GCS object name without re-parsing). |

The three legacy call sites are rewired:

- `VertexAIFilesConfig.get_object_name` (`purpose=="batch"`) now peeks **only the first JSONL entry** for the model name.
- `VertexAIFilesConfig.transform_create_file_request` uses the streaming helper.
- `VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content` uses the streaming helper and derives the GCS object name from the first parsed entry.

The legacy `_transform_openai_jsonl_content_to_vertex_ai_jsonl_content` method and
`_openai_batch_jsonl_entries_to_vertex_wrapped_requests` module function are
**kept as-is** so existing tests continue to exercise the list-based path the
streaming output is compared against.

## Evidence

Measured with `tracemalloc.get_traced_memory()` on a 30.3 MB synthetic OpenAI
batch JSONL (20 000 entries) before and after the patch:

```
=== BEFORE (legacy splitlines + 2× list-of-dicts + joined string) ===
input bytes: 30.3 MB
[BEFORE] jsonl-xform  peak= 173.2 MB (5.71x)  output=30.9 MB

=== AFTER (streaming helpers) ===
input bytes: 30.3 MB
[AFTER ] jsonl-xform  peak=  70.1 MB (2.31x)  output=30.9 MB
[AFTER ] files-cfg    peak=  69.7 MB (2.30x)  output=30.9 MB
[AFTER ] get_object   peak=  30.3 MB (1.00x)  name=...ini-1.5-flash/47640e76-93f8-42e2-ad79-1c313f6a82c5
```

| Call site | Before (×input) | After (×input) | Reduction |
|---|---|---|---|
| `VertexAIJsonlFilesTransformation.transform_openai_file_content_to_vertex_ai_file_content` | 5.71× | 2.31× | **−59.5%** |
| `VertexAIFilesConfig.transform_create_file_request` | ~5.71× | 2.30× | **−59.7%** |
| `VertexAIFilesConfig.get_object_name` (`batch`) | ~5.71× | **1.00×** | **−82.5%** |

Extrapolated to a 1 GiB upload: peak drops from ≈ 5.7 GiB to ≈ 2.3 GiB per
worker, well within the 12 GiB-per-worker budget of the reported pod
configuration.

## Tests

```
$ pytest tests/test_litellm/llms/vertex_ai/files/ -q
....................................................................................
97 passed in ~27s
```

The new `tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py`
adds 23 cases covering:

- `_iter_openai_file_lines` across every supported `FileTypes` input form
  (str, bytes, tuple, file-like bytes/text, `PathLike`, empty, CRLF, no
  trailing newline).
- `_iter_openai_jsonl_entries` parses entries, skips blank/whitespace lines,
  handles CRLF, and is genuinely lazy (`next()` does not parse past the first
  entry — a JSONL with bad-JSON lines after the first still yields the first).
- `_stream_openai_jsonl_to_vertex_jsonl_string` output is **byte-identical**
  to the legacy list-based path on the same input.
- `VertexAIFilesConfig.get_object_name(batch)` no longer crashes on inputs
  whose tail is not valid JSON (only the first entry is parsed) and
  falls back to the managed uploads path for empty JSONL inputs.
- Peak `tracemalloc` memory under an 8 000-entry synthetic payload (~7 MB) is
  asserted to stay under 3.5× input on the streaming transform and under 1.5×
  input on `get_object_name`.

LIT-3382


---

### Verification (ship-pr)

| Check | Result |
|---|---|
| Branch base = `litellm_oss_agent_shin_daily_branch` | ✅ |
| Customer name leaked anywhere in PR/title/body/branch | ✅ none |
| Runtime evidence (before/after) | ✅ `tracemalloc` numbers above, 30.3 MB synthetic JSONL, all three call sites |
| Unit tests | ✅ 97 passed (74 existing + 23 new), `pytest tests/test_litellm/llms/vertex_ai/files/` |
| Output parity vs legacy pipeline | ✅ `TestStreamOutputParity.test_matches_legacy_pipeline` asserts byte-identical output |
| Peak-memory regression guard | ✅ `tracemalloc` assertions in `TestPeakMemory` (<3.5x streaming, <1.5x get_object_name) |
| Black + Ruff | ✅ clean |
| Greptile | ✅ **5/5** ("Safe to merge") |
| Veria AI - PR Review | ✅ success ("No security issues found") |
| GitHub Actions | ✅ 43/44 green at the time of writing; the 44th (`test-server-root-path (/llmproxy)`) is still running |
| Session | https://litellm-agent-platform.onrender.com/sessions/b16b86d0-e71c-40de-a908-3611c0b20522 |

> Note: this PR was pushed via the GitHub Contents API (one PUT per file) because git-over-https rejected the agent token despite the `repo` + `workflow` scopes the API surfaces — that path produces a slightly noisier merge-base diff but the file content is identical to a normal squash-ready commit.
