### PR TITLE
fix(proxy): narrow /team/list response for non-admin callers (LIT-2553)

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4286,9 +4286,7 @@ async def _authorize_and_filter_teams(
             )
 
     # LIT-2553: narrow only when the caller is a non-admin / non-org-admin.
-    should_narrow_for_internal_user = (
-        not is_proxy_admin and allowed_org_ids is None
-    )
+    should_narrow_for_internal_user = not is_proxy_admin and allowed_org_ids is None
 
     if allowed_org_ids is not None:
         org_teams = await prisma_client.db.litellm_teamtable.find_many(
@@ -4314,11 +4312,14 @@ async def _authorize_and_filter_teams(
             and any(m.get("user_id") == user_id for m in team.members_with_roles)
         ], should_narrow_for_internal_user
     else:
-        return list(
-            await prisma_client.db.litellm_teamtable.find_many(
-                include={"litellm_model_table": True}
-            )
-        ), should_narrow_for_internal_user
+        return (
+            list(
+                await prisma_client.db.litellm_teamtable.find_many(
+                    include={"litellm_model_table": True}
+                )
+            ),
+            should_narrow_for_internal_user,
+        )
 
 
 def _narrow_team_list_response_for_internal_user(
@@ -4346,9 +4347,7 @@ def _narrow_team_list_response_for_internal_user(
     response.team_memberships = [
         tm for tm in (response.team_memberships or []) if _entry_uid(tm) == target_uid
     ]
-    response.keys = [
-        k for k in (response.keys or []) if _entry_uid(k) == target_uid
-    ]
+    response.keys = [k for k in (response.keys or []) if _entry_uid(k) == target_uid]
 
     response.team_member_permissions = None
     response.metadata = None
@@ -4395,12 +4394,14 @@ async def list_team(
             detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
 
-    filtered_response, should_narrow_for_internal_user = await _authorize_and_filter_teams(
-        user_api_key_dict=user_api_key_dict,
-        user_id=user_id,
-        prisma_client=prisma_client,
-        user_api_key_cache=user_api_key_cache,
-        proxy_logging_obj=proxy_logging_obj,
+    filtered_response, should_narrow_for_internal_user = (
+        await _authorize_and_filter_teams(
+            user_api_key_dict=user_api_key_dict,
+            user_id=user_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
     )
 
     _team_ids = [team.team_id for team in filtered_response]

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4237,14 +4237,15 @@ async def _authorize_and_filter_teams(
     prisma_client: Any,
     user_api_key_cache: Any,
     proxy_logging_obj: Any,
-) -> list:
+) -> Tuple[list, bool]:
     """
-    Authorize the /team/list request and return filtered teams.
+    Authorize the /team/list request and return filtered teams plus a flag
+    indicating whether the response must be narrowed for an internal user.
 
-    - Proxy admins: all teams (or filtered by user_id if provided).
-    - Org admins: teams from their orgs (scoped to user_id if provided).
-    - Own query (user_id matches caller): teams the user is a member of.
-    - Others: 401.
+    Returns a tuple ``(teams, should_narrow_for_internal_user)`` where
+    ``should_narrow_for_internal_user`` is ``True`` only when the caller is a
+    non-admin (not ``proxy_admin``/``proxy_admin_viewer``, not ``org_admin``
+    in any org) and is allowed to see their own teams. See LIT-2553.
     """
     is_proxy_admin = _user_has_admin_view(user_api_key_dict)
     allowed_org_ids: Optional[List[str]] = None
@@ -4256,7 +4257,6 @@ async def _authorize_and_filter_teams(
             and user_api_key_dict.user_id == user_id
         )
 
-        # Check if user is an org admin (even for own queries, so they see org teams)
         if user_api_key_dict.user_id is not None:
             caller_user = await get_user_object(
                 user_id=user_api_key_dict.user_id,
@@ -4285,23 +4285,25 @@ async def _authorize_and_filter_teams(
                 },
             )
 
+    # LIT-2553: narrow only when the caller is a non-admin / non-org-admin.
+    should_narrow_for_internal_user = (
+        not is_proxy_admin and allowed_org_ids is None
+    )
+
     if allowed_org_ids is not None:
-        # Org admin: query DB for teams in their orgs
         org_teams = await prisma_client.db.litellm_teamtable.find_many(
             where={"organization_id": {"in": allowed_org_ids}},
             include={"litellm_model_table": True},
         )
         if not user_id:
-            return list(org_teams)
-        # Filter org teams to only those where the target user is a member
+            return list(org_teams), should_narrow_for_internal_user
         return [
             team
             for team in org_teams
             if team.members_with_roles
             and any(m.get("user_id") == user_id for m in team.members_with_roles)
-        ]
+        ], should_narrow_for_internal_user
     elif user_id:
-        # Regular user: fetch all and filter by membership (Prisma can't filter JSON arrays)
         response = await prisma_client.db.litellm_teamtable.find_many(
             include={"litellm_model_table": True}
         )
@@ -4310,14 +4312,53 @@ async def _authorize_and_filter_teams(
             for team in response
             if team.members_with_roles
             and any(m.get("user_id") == user_id for m in team.members_with_roles)
-        ]
+        ], should_narrow_for_internal_user
     else:
-        # Proxy admin: all teams
         return list(
             await prisma_client.db.litellm_teamtable.find_many(
                 include={"litellm_model_table": True}
             )
-        )
+        ), should_narrow_for_internal_user
+
+
+def _narrow_team_list_response_for_internal_user(
+    response: "TeamListResponseObject",
+    caller_user_id: Optional[str],
+) -> "TeamListResponseObject":
+    """
+    Narrow a /team/list response item so a non-admin caller only sees data
+    scoped to their own membership. Tracking ticket: LIT-2553.
+    """
+    target_uid: str = (
+        caller_user_id if caller_user_id is not None else "\x00__never_matches__"
+    )
+
+    def _entry_uid(entry: Any) -> Optional[str]:
+        if isinstance(entry, dict):
+            return entry.get("user_id")
+        return getattr(entry, "user_id", None)
+
+    response.members_with_roles = [
+        m for m in (response.members_with_roles or []) if _entry_uid(m) == target_uid
+    ]
+    response.admins = [u for u in (response.admins or []) if u == target_uid]
+    response.members = [u for u in (response.members or []) if u == target_uid]
+    response.team_memberships = [
+        tm for tm in (response.team_memberships or []) if _entry_uid(tm) == target_uid
+    ]
+    response.keys = [
+        k for k in (response.keys or []) if _entry_uid(k) == target_uid
+    ]
+
+    response.team_member_permissions = None
+    response.metadata = None
+    response.router_settings = None
+    response.object_permission = None
+    response.object_permission_id = None
+    response.litellm_model_table = None
+    response.budget_limits = None
+
+    return response
 
 
 @router.get(
@@ -4354,7 +4395,7 @@ async def list_team(
             detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
 
-    filtered_response = await _authorize_and_filter_teams(
+    filtered_response, should_narrow_for_internal_user = await _authorize_and_filter_teams(
         user_api_key_dict=user_api_key_dict,
         user_id=user_id,
         prisma_client=prisma_client,
@@ -4407,6 +4448,14 @@ async def list_team(
                 for team in returned_responses
                 if team.organization_id == organization_id
             ]
+
+    # LIT-2553: narrow each response object for non-admin callers so they only
+    # see their own membership, their own keys, and no other-member info or
+    # admin-only team fields. Admin / org-admin callers are untouched.
+    if should_narrow_for_internal_user:
+        caller_user_id = user_api_key_dict.user_id
+        for resp in returned_responses:
+            _narrow_team_list_response_for_internal_user(resp, caller_user_id)
 
     return returned_responses
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4328,27 +4328,70 @@ def _narrow_team_list_response_for_internal_user(
 ) -> "TeamListResponseObject":
     """
     Narrow a /team/list response item so a non-admin caller only sees data
-    scoped to their own membership. Tracking ticket: LIT-2553.
+    scoped to their own membership. Mutates ``response`` in place and
+    returns it.
+
+    Filtered to caller_user_id only:
+        - members_with_roles, admins, members, team_memberships
+        - keys (verification tokens whose owner is the caller)
+
+    Redacted (set to None / cleared):
+        team_member_permissions, metadata, router_settings,
+        object_permission, object_permission_id, litellm_model_table,
+        budget_limits
+
+    Preserved (sufficient for the UI to render the team header + the
+    caller's own membership):
+        team_id, team_alias, organization_id, models, model_aliases,
+        access_group_ids, default_team_member_models, blocked,
+        tpm_limit, rpm_limit, max_budget, soft_budget, budget_duration,
+        budget_reset_at, model_max_budget, spend, created_at, updated_at.
+
+    Tracking ticket: LIT-2553.
     """
-    target_uid: str = (
-        caller_user_id if caller_user_id is not None else "\x00__never_matches__"
-    )
 
     def _entry_uid(entry: Any) -> Optional[str]:
+        # Each list element may be a raw user_id string (admins / members),
+        # a Member / LiteLLM_TeamMembership pydantic object, or a plain
+        # dict (raw prisma row). Handle all three shapes uniformly so the
+        # filter is consistent across every member-identifying field.
+        if isinstance(entry, str):
+            return entry
         if isinstance(entry, dict):
             return entry.get("user_id")
         return getattr(entry, "user_id", None)
 
-    response.members_with_roles = [
-        m for m in (response.members_with_roles or []) if _entry_uid(m) == target_uid
-    ]
-    response.admins = [u for u in (response.admins or []) if u == target_uid]
-    response.members = [u for u in (response.members or []) if u == target_uid]
-    response.team_memberships = [
-        tm for tm in (response.team_memberships or []) if _entry_uid(tm) == target_uid
-    ]
-    response.keys = [k for k in (response.keys or []) if _entry_uid(k) == target_uid]
+    # Defensive: if we can't identify the caller, drop every member-scoped
+    # entry rather than risking a leak. Sensitive team-level fields below
+    # still get redacted.
+    if caller_user_id is None:
+        response.members_with_roles = []
+        response.admins = []
+        response.members = []
+        response.team_memberships = []
+        response.keys = []
+    else:
+        response.members_with_roles = [
+            m
+            for m in (response.members_with_roles or [])
+            if _entry_uid(m) == caller_user_id
+        ]
+        response.admins = [
+            u for u in (response.admins or []) if _entry_uid(u) == caller_user_id
+        ]
+        response.members = [
+            u for u in (response.members or []) if _entry_uid(u) == caller_user_id
+        ]
+        response.team_memberships = [
+            tm
+            for tm in (response.team_memberships or [])
+            if _entry_uid(tm) == caller_user_id
+        ]
+        response.keys = [
+            k for k in (response.keys or []) if _entry_uid(k) == caller_user_id
+        ]
 
+    # Redact admin-only / sensitive fields.
     response.team_member_permissions = None
     response.metadata = None
     response.router_settings = None

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -7333,7 +7333,7 @@ async def test_list_team_v1_batches_key_queries():
         patch(
             "litellm.proxy.management_endpoints.team_endpoints._authorize_and_filter_teams",
             new_callable=AsyncMock,
-            return_value=[team1, team2],
+            return_value=([team1, team2], False),
         ),
         patch(
             "litellm.proxy.management_endpoints.team_endpoints.get_all_team_memberships",

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -8010,6 +8010,8 @@ async def test_new_team_encrypts_callback_vars(
     assert cv["langfuse_secret_key"] != "sk-real"
     recovered = decrypt_callback_vars(metadata)["logging"][0]["callback_vars"]
     assert recovered["langfuse_secret_key"] == "sk-real"
+
+
 def _non_admin_auth():
     return UserAPIKeyAuth(
         user_id="u-team-admin", user_role=LitellmUserRoles.INTERNAL_USER

--- a/tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py
@@ -5,6 +5,7 @@ callers so they only see their own membership, their own keys, and no
 other-member or admin-only fields. proxy_admin and org_admin callers
 keep full visibility.
 """
+
 import os
 import sys
 from datetime import datetime, timezone

--- a/tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py
@@ -1,0 +1,366 @@
+"""Regression tests for LIT-2553.
+
+/team/list must narrow data for internal_user / internal_user_viewer
+callers so they only see their own membership, their own keys, and no
+other-member or admin-only fields. proxy_admin and org_admin callers
+keep full visibility.
+"""
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.proxy._types import (
+    LiteLLM_BudgetTable,
+    LiteLLM_OrganizationMembershipTable,
+    LiteLLM_TeamMembership,
+    LiteLLM_UserTable,
+    LitellmUserRoles,
+    Member,
+    TeamListResponseObject,
+    UserAPIKeyAuth,
+)
+
+
+def _build_response_object(
+    caller_user_id: str = "alice",
+    team_id: str = "team-1",
+) -> TeamListResponseObject:
+    alice_membership = LiteLLM_TeamMembership(
+        user_id=caller_user_id,
+        team_id=team_id,
+        budget_id="b-alice",
+        spend=12.5,
+        total_spend=44.0,
+        litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
+    )
+    bob_membership = LiteLLM_TeamMembership(
+        user_id="bob",
+        team_id=team_id,
+        budget_id="b-bob",
+        spend=99.0,
+        total_spend=200.0,
+        litellm_budget_table=LiteLLM_BudgetTable(max_budget=500.0),
+    )
+    alice_key = {
+        "token": "sk-alice-hash",
+        "key_alias": "alice-key",
+        "user_id": caller_user_id,
+        "team_id": team_id,
+        "spend": 1.0,
+    }
+    bob_key = {
+        "token": "sk-bob-hash",
+        "key_alias": "bob-key",
+        "user_id": "bob",
+        "team_id": team_id,
+        "spend": 2.0,
+    }
+    return TeamListResponseObject(
+        team_id=team_id,
+        team_alias="my-team",
+        organization_id="org-1",
+        admins=[caller_user_id, "bob"],
+        members=[caller_user_id, "bob"],
+        members_with_roles=[
+            Member(user_id=caller_user_id, role="user"),
+            Member(user_id="bob", role="admin"),
+        ],
+        team_member_permissions=["/key/generate", "/key/update"],
+        metadata={"secret": "internal", "team_default_budget_id": "b-default"},
+        models=["gpt-4o"],
+        blocked=False,
+        max_budget=1000.0,
+        soft_budget=800.0,
+        budget_duration="30d",
+        spend=400.0,
+        tpm_limit=100,
+        rpm_limit=10,
+        router_settings={"timeout": 30},
+        team_memberships=[alice_membership, bob_membership],
+        keys=[alice_key, bob_key],
+    )
+
+
+def _build_team_row(team_id: str = "team-1", caller: str = "alice"):
+    row = MagicMock()
+    row.team_id = team_id
+    row.organization_id = "org-1"
+    row.members_with_roles = [
+        {"user_id": caller, "role": "user"},
+        {"user_id": "bob", "role": "admin"},
+    ]
+    row.model_dump = lambda: {
+        "team_id": team_id,
+        "team_alias": "my-team",
+        "organization_id": "org-1",
+        "admins": [caller, "bob"],
+        "members": [caller, "bob"],
+        "members_with_roles": [
+            {"user_id": caller, "role": "user"},
+            {"user_id": "bob", "role": "admin"},
+        ],
+        "team_member_permissions": ["/key/generate"],
+        "metadata": {"secret": "value"},
+        "models": ["gpt-4o"],
+        "blocked": False,
+        "max_budget": 1000.0,
+        "spend": 400.0,
+        "tpm_limit": 100,
+        "rpm_limit": 10,
+        "router_settings": {"timeout": 30},
+    }
+    return row
+
+
+def _build_membership(user_id: str, team_id: str = "team-1"):
+    row = MagicMock()
+    row.team_id = team_id
+    row.model_dump = lambda: {
+        "user_id": user_id,
+        "team_id": team_id,
+        "budget_id": f"b-{user_id}",
+        "spend": 12.5,
+        "total_spend": 44.0,
+        "litellm_budget_table": None,
+    }
+    return row
+
+
+def _build_key(user_id: str, team_id: str = "team-1"):
+    return {
+        "token": f"sk-{user_id}-hash",
+        "key_alias": f"{user_id}-key",
+        "user_id": user_id,
+        "team_id": team_id,
+        "spend": 0.0,
+    }
+
+
+@pytest.fixture
+def mock_request():
+    from fastapi import Request
+
+    return MagicMock(spec=Request)
+
+
+def test_narrowing_helper_filters_to_caller_only():
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _narrow_team_list_response_for_internal_user,
+    )
+
+    resp = _build_response_object(caller_user_id="alice")
+    out = _narrow_team_list_response_for_internal_user(resp, "alice")
+
+    assert out.team_id == "team-1"
+    assert out.team_alias == "my-team"
+    assert out.organization_id == "org-1"
+    assert out.models == ["gpt-4o"]
+    assert out.max_budget == 1000.0
+    assert out.blocked is False
+
+    assert out.admins == ["alice"]
+    assert out.members == ["alice"]
+    assert len(out.members_with_roles) == 1
+    assert out.members_with_roles[0].user_id == "alice"
+
+    assert len(out.team_memberships) == 1
+    assert out.team_memberships[0].user_id == "alice"
+
+    assert len(out.keys) == 1
+    assert out.keys[0]["user_id"] == "alice"
+
+    assert out.team_member_permissions is None
+    assert out.metadata is None
+    assert out.router_settings is None
+
+
+def test_narrowing_helper_with_missing_caller_user_id_strips_everything():
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _narrow_team_list_response_for_internal_user,
+    )
+
+    resp = _build_response_object(caller_user_id="alice")
+    out = _narrow_team_list_response_for_internal_user(resp, None)
+
+    assert out.admins == []
+    assert out.members == []
+    assert out.members_with_roles == []
+    assert out.team_memberships == []
+    assert out.keys == []
+    assert out.metadata is None
+    assert out.team_member_permissions is None
+
+
+def test_narrowing_helper_drops_keys_owned_by_other_users():
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _narrow_team_list_response_for_internal_user,
+    )
+
+    resp = _build_response_object(caller_user_id="alice")
+    out = _narrow_team_list_response_for_internal_user(resp, "alice")
+
+    key_owners = [k.get("user_id") for k in out.keys]
+    assert key_owners == ["alice"]
+    assert "bob" not in key_owners
+
+
+@pytest.mark.asyncio
+async def test_list_team_narrows_response_for_internal_user(mock_request):
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="alice",
+    )
+
+    team_row = _build_team_row(caller="alice")
+    memberships = [_build_membership("alice"), _build_membership("bob")]
+    keys = [_build_key("alice"), _build_key("bob")]
+
+    caller_user = LiteLLM_UserTable(
+        user_id="alice",
+        teams=["team-1"],
+        organization_memberships=[],
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        mock_db = MagicMock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[team_row])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=memberships)
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=keys)
+
+        with patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            new_callable=AsyncMock,
+            return_value=caller_user,
+        ):
+            result = await list_team(
+                http_request=mock_request,
+                user_id="alice",
+                organization_id=None,
+                user_api_key_dict=user_api_key_dict,
+            )
+
+    assert len(result) == 1
+    team = result[0]
+
+    assert [m.user_id for m in team.members_with_roles] == ["alice"]
+    assert team.admins == ["alice"]
+    assert team.members == ["alice"]
+
+    assert [tm.user_id for tm in team.team_memberships] == ["alice"]
+    key_uids = [
+        (k.get("user_id") if isinstance(k, dict) else getattr(k, "user_id", None))
+        for k in team.keys
+    ]
+    assert key_uids == ["alice"]
+
+    assert team.team_member_permissions is None
+    assert team.metadata is None
+    assert team.router_settings is None
+
+    assert team.team_id == "team-1"
+    assert team.team_alias == "my-team"
+    assert team.organization_id == "org-1"
+    assert team.models == ["gpt-4o"]
+    assert team.max_budget == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_list_team_does_not_narrow_for_proxy_admin(mock_request):
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-1",
+    )
+
+    team_row = _build_team_row(caller="alice")
+    memberships = [_build_membership("alice"), _build_membership("bob")]
+    keys = [_build_key("alice"), _build_key("bob")]
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        mock_db = MagicMock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[team_row])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=memberships)
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=keys)
+
+        result = await list_team(
+            http_request=mock_request,
+            user_id=None,
+            organization_id=None,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    assert len(result) == 1
+    team = result[0]
+    assert sorted(m.user_id for m in team.members_with_roles) == ["alice", "bob"]
+    assert sorted(team.admins) == ["alice", "bob"]
+    assert sorted(tm.user_id for tm in team.team_memberships) == ["alice", "bob"]
+    key_uids = [
+        (k.get("user_id") if isinstance(k, dict) else getattr(k, "user_id", None))
+        for k in team.keys
+    ]
+    assert sorted(key_uids) == ["alice", "bob"]
+    assert team.team_member_permissions == ["/key/generate"]
+    assert team.metadata == {"secret": "value"}
+
+
+@pytest.mark.asyncio
+async def test_list_team_does_not_narrow_for_org_admin(mock_request):
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="alice",
+    )
+
+    team_row = _build_team_row(caller="alice")
+    memberships = [_build_membership("alice"), _build_membership("bob")]
+    keys = [_build_key("alice"), _build_key("bob")]
+
+    org_admin_user = LiteLLM_UserTable(
+        user_id="alice",
+        teams=["team-1"],
+        organization_memberships=[
+            LiteLLM_OrganizationMembershipTable(
+                user_id="alice",
+                organization_id="org-1",
+                user_role=LitellmUserRoles.ORG_ADMIN.value,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+        ],
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        mock_db = MagicMock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[team_row])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=memberships)
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=keys)
+
+        with patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            new_callable=AsyncMock,
+            return_value=org_admin_user,
+        ):
+            result = await list_team(
+                http_request=mock_request,
+                user_id="alice",
+                organization_id=None,
+                user_api_key_dict=user_api_key_dict,
+            )
+
+    assert len(result) == 1
+    team = result[0]
+    assert sorted(m.user_id for m in team.members_with_roles) == ["alice", "bob"]
+    assert team.metadata == {"secret": "value"}
+    assert team.team_member_permissions == ["/key/generate"]

--- a/tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py
@@ -365,3 +365,47 @@ async def test_list_team_does_not_narrow_for_org_admin(mock_request):
     assert sorted(m.user_id for m in team.members_with_roles) == ["alice", "bob"]
     assert team.metadata == {"secret": "value"}
     assert team.team_member_permissions == ["/key/generate"]
+
+
+@pytest.mark.asyncio
+async def test_list_team_does_not_narrow_for_proxy_admin_view_only(mock_request):
+    """LIT-2553: PROXY_ADMIN_VIEW_ONLY callers also keep full visibility
+    (they pass `_user_has_admin_view`, same as PROXY_ADMIN). Regression
+    guard from Greptile review on PR #29117."""
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        user_id="viewer-admin",
+    )
+
+    team_row = _build_team_row(caller="alice")
+    memberships = [_build_membership("alice"), _build_membership("bob")]
+    keys = [_build_key("alice"), _build_key("bob")]
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        mock_db = MagicMock()
+        mock_prisma_client.db = mock_db
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[team_row])
+        mock_db.litellm_teammembership.find_many = AsyncMock(return_value=memberships)
+        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=keys)
+
+        result = await list_team(
+            http_request=mock_request,
+            user_id=None,
+            organization_id=None,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    assert len(result) == 1
+    team = result[0]
+    assert sorted(m.user_id for m in team.members_with_roles) == ["alice", "bob"]
+    assert sorted(team.admins) == ["alice", "bob"]
+    assert sorted(tm.user_id for tm in team.team_memberships) == ["alice", "bob"]
+    key_uids = [
+        (k.get("user_id") if isinstance(k, dict) else getattr(k, "user_id", None))
+        for k in team.keys
+    ]
+    assert sorted(key_uids) == ["alice", "bob"]
+    assert team.metadata == {"secret": "value"}
+    assert team.team_member_permissions == ["/key/generate"]


### PR DESCRIPTION
## Linear ticket

Resolves [LIT-2553](https://linear.app/litellm-ai/issue/LIT-2553).

## Bug

An `internal_user` calling `GET /team/list?user_id=<their_user_id>` got the full team objects for every team they belong to, including:

- `members_with_roles` / `admins` / `members` — every other member's `user_id`
- `team_memberships` — every other member's per-member budget and spend rows
- `keys` — **every team key**, including keys owned by other users
- `team_member_permissions` — the team-level permission list
- `metadata` — arbitrary team metadata (can contain secrets / config tokens)
- `router_settings`, `object_permission`, `litellm_model_table`, `budget_limits`

Operationally this is a least-privilege leak; the UI only needs the caller's own membership/keys to render the team page.

## Fix

`litellm/proxy/management_endpoints/team_endpoints.py`:

1. `_authorize_and_filter_teams` now returns a tuple `(teams, should_narrow_for_internal_user)`. `should_narrow_for_internal_user` is `True` **only** when the caller is *not* `proxy_admin` / `proxy_admin_viewer` **and** is not org admin in any org (i.e. an `internal_user` / `internal_user_viewer` doing their own-user query — the LIT-2553 leak path).
2. New helper `_narrow_team_list_response_for_internal_user(response, caller_user_id)` mutates a `TeamListResponseObject` in place:
   - filters `members_with_roles`, `admins`, `members`, `team_memberships`, and `keys` to entries whose `user_id` matches the caller
   - sets `team_member_permissions`, `metadata`, `router_settings`, `object_permission`, `object_permission_id`, `litellm_model_table`, and `budget_limits` to `None`
   - **preserves** the public team header the UI needs: `team_id`, `team_alias`, `organization_id`, `models`, `model_aliases`, `access_group_ids`, `default_team_member_models`, `blocked`, `tpm_limit`, `rpm_limit`, `max_budget`, `soft_budget`, `budget_duration`, `budget_reset_at`, `model_max_budget`, `spend`, `created_at`, `updated_at`.
   - defensive: if `caller_user_id` is `None`, narrow to no members/keys rather than risk leaking.
3. `list_team` (`GET /team/list`) calls the helper on every response object when `should_narrow_for_internal_user` is `True`. Admin / org-admin callers are completely untouched.

## Scope

- `GET /team/list` only.
- `GET /v2/team/list` already returns a flatter shape (no `team_memberships`, no `keys`) and isn't affected.
- `GET /team/info` is admin-gated and out of scope.

## Tests

`tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py` — 6 new tests:

- helper-level (pure): caller-only filtering; missing caller is fully stripped; bob's keys never leak through.
- route-level (mocked prisma): `internal_user` gets narrowed, `proxy_admin` keeps full data, `org_admin` (via `organization_memberships`) keeps full data.

`tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py::test_list_team_v1_batches_key_queries` already mocked `_authorize_and_filter_teams`; updated its `return_value` from `[team1, team2]` to `([team1, team2], False)` to match the new tuple signature. **The mock is the only test in the repo that touches the function directly.**

Local run on the patched branch (full `list_team*` slice of `test_team_endpoints.py` + the new file):

```
tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py ............  [12 passed]
tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py ......   [6 passed]
============================== 18 passed ===============================
```

## Evidence

Driving the real `list_team` route handler with the proxy's auth path, against a mocked prisma where a team has two members `alice` (caller) and `bob`, both with team memberships and keys.

### BEFORE (clean `litellm_oss_agent_shin_daily_branch` tip)

```json
[
  {
    "team_id": "team-1",
    "team_alias": "my-team",
    "admins": ["alice", "bob"],
    "members": ["alice", "bob"],
    "members_with_roles_user_ids": ["alice", "bob"],
    "team_memberships_user_ids": ["alice", "bob"],
    "keys_user_ids": ["alice", "bob"],
    "team_member_permissions": ["/key/generate", "/key/update"],
    "metadata": {
      "secret": "internal-token-xyz",
      "default_models": ["claude-opus-4-5"]
    },
    "router_settings": { "timeout": 30, "retries": 3 },
    "models": ["gpt-4o"],
    "max_budget": 1000.0
  }
]
```

The `internal_user` caller sees:
- the other member's `user_id` in three places (`admins`, `members`, `members_with_roles`)
- the other member's per-member budget/spend row (`team_memberships`)
- **the other member's API key** (`keys`)
- team `metadata` containing a fake secret token
- team `team_member_permissions` and `router_settings`

### AFTER (this PR)

```json
[
  {
    "team_id": "team-1",
    "team_alias": "my-team",
    "admins": ["alice"],
    "members": ["alice"],
    "members_with_roles_user_ids": ["alice"],
    "team_memberships_user_ids": ["alice"],
    "keys_user_ids": ["alice"],
    "team_member_permissions": null,
    "metadata": null,
    "router_settings": null,
    "models": ["gpt-4o"],
    "max_budget": 1000.0
  }
]
```

The caller now only sees their own membership row, their own key, and the team header (alias / models / max_budget). Every other leaked field is either filtered to the caller or set to `null`. The proxy-admin path was re-checked in `test_list_team_does_not_narrow_for_proxy_admin` and the org-admin path in `test_list_team_does_not_narrow_for_org_admin` — both still see full data.

## Notes for reviewer

- Token used to push lacks `repo` + `workflow` scope, so the branch was created via `POST /git/refs` and the 3 modified files were pushed via `PUT /repos/{owner}/{repo}/contents/{path}`. Three commits land on the branch, one per file. The merge-base diff is therefore a little noisier than a normal squash — the actual change is exactly:
  - `litellm/proxy/management_endpoints/team_endpoints.py` (+~80 LOC for the narrowing helper + 2 call-site lines)
  - `tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py` (1-line mock fixup)
  - `tests/test_litellm/proxy/management_endpoints/test_team_list_narrowing.py` (new)


---

### Verification (ship-pr)

- ✅ **Greptile**: 5/5 — "Safe to merge — the narrowing is correctly scoped to the least-privilege leak path and admin/org-admin callers are untouched. ... All three P2 items from the prior review round are addressed. No files require special attention." (last reviewed: `14ba8589`)
- ✅ **Veria AI - PR Review**: success ("No security issues found")
- ✅ **GitHub Actions**: 44/44 check-runs green, 0 failures (lint, code-quality, all proxy/responses/auth/test suites incl. test-server-root-path)
- ✅ **mergeable_state**: `clean` (no merge conflicts)
- ✅ **Base branch**: `litellm_oss_agent_shin_daily_branch` (Verify-PR-source-branch passes)
- ✅ **Runtime evidence captured**: real `list_team` route exercised pre/post-fix; before/after JSON in `### Evidence` above
- ✅ **Tests**: 7 new regression tests + 12 existing `list_team*` tests → 19/19 pass locally on patched branch
- ✅ **No customer name** anywhere in the PR (title, body, branch, commits)
- ✅ **No secrets** leaked in PR or evidence
- ⚠️ **Slack #eng-pr-reviews posting**: Slack MCP (`mcp__lap-slack__*`) is not exposed in this agent's toolset (known recurring platform issue, already filed). Reviewer ping in #eng-pr-reviews will need to be posted manually if desired. This does NOT block merge.
