### PR TITLE
fix(responses): use responses_api_request metadata instead of raw kwargs in bridge path

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -215,7 +215,7 @@ class LiteLLMCompletionResponsesConfig:
             "parallel_tool_calls": responses_api_request.get("parallel_tool_calls"),
             "max_tokens": responses_api_request.get("max_output_tokens"),
             "stream": stream,
-            "metadata": kwargs.get("metadata"),
+            "metadata": responses_api_request.get("metadata"),
             "service_tier": kwargs.get("service_tier"),
             "web_search_options": web_search_options,
             "response_format": response_format,


### PR DESCRIPTION
## bug

**request**

```
curl -X POST '/v1/responses'  -d '{
  "model": "openai/gpt-5.3-codex",
  "input": "hello"
}'
```

** response

```
{
  "error": {
    "message": "litellm.BadRequestError: OpenAIException - {\"error\":{\"message\":\"{\\\"detail\\\":\\\"Unsupported parameter: metadata\\\"}（traceid: xxx）\",\"type\":\"rix_api_error\",\"param\":\"\",\"code\":null}}. Received Model Group=openai/gpt-5.3-codex\nAvailable Model Group Fallbacks=None",
    "type": null,
    "param": null,
    "code": "400"
  }
}
```
 

## Fix Summary

  > File: litellm/responses/litellm_completion_transformation/transformation.py:218                                                                                                                                            

  ## Changed:
 - Before:                                                                                                                                                                                                                  
  "metadata": kwargs.get("metadata"),
  - After:                                                                                                                                                                                                                                          
  "metadata": responses_api_request.get("metadata"),

  ## Changed:
  - Before:                                                                                                                                                                                                                                         
  "metadata": kwargs.get("metadata"),
  - After:                                                                                                                                                                                                                                          
  "metadata": responses_api_request.get("metadata"),

  ## Root Cause

  When the /v1/responses endpoint routes through the chat completions bridge (because the model/deployment has use_chat_completions_api: true or the provider lacks native Responses API support), the
  LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request function built the chat completion request from raw **kwargs instead of the validated responses_api_request params.

  The **kwargs dict contains everything from the proxy's request pipeline — including data["metadata"] set by pre-call hooks like parallel_request_limiter (litellm/proxy/hooks/parallel_request_limiter.py:344-346), which adds data["metadata"] = 
  {} with remaining token/request limits. This empty dict {} passed the is not None filter at line 242 and was forwarded to the upstream as "metadata": {}, which the RIX API rejected.

## 