### PR TITLE
fix(aiohttp): honor global ssl_verify on aiohttp_openai provider path (LIT-3369)

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -55,13 +55,37 @@ class BaseLLMAIOHTTPHandler:
         )  # Track if we own the connector for cleanup
 
     def _get_or_create_transport(self) -> Optional[LiteLLMAiohttpTransport]:
-        """Get existing transport or create a new one if needed."""
+        """Get existing transport or create a new one if needed.
+
+        Resolves the global SSL configuration (``litellm.ssl_verify`` /
+        ``SSL_VERIFY`` env / ``SSL_CERT_FILE``) and threads it through to the
+        underlying transport so that ``ssl_verify: False`` set in
+        ``litellm_settings`` is honored on this aiohttp transport path
+        (matches what ``AsyncHTTPHandler.create_client`` already does).
+        """
         if self.transport:
             return self.transport
 
         # Create a transport using AsyncHTTPHandler's logic
         try:
-            self.transport = AsyncHTTPHandler._create_aiohttp_transport()
+            import ssl as _ssl
+
+            from litellm.llms.custom_httpx.http_handler import (
+                get_ssl_configuration,
+            )
+
+            # Resolve global ssl config the same way
+            # AsyncHTTPHandler.create_client does for the main transport path.
+            ssl_config = get_ssl_configuration(None)
+            ssl_context_arg = (
+                ssl_config if isinstance(ssl_config, _ssl.SSLContext) else None
+            )
+            ssl_verify_arg = ssl_config if isinstance(ssl_config, bool) else None
+
+            self.transport = AsyncHTTPHandler._create_aiohttp_transport(
+                ssl_verify=ssl_verify_arg,
+                ssl_context=ssl_context_arg,
+            )
             self._owns_transport = True
             return self.transport
         except Exception:
@@ -83,21 +107,39 @@ class BaseLLMAIOHTTPHandler:
         return None
 
     def _create_client_session_with_transport(self) -> ClientSession:
-        """Create a new client session using transport or connector configuration."""
-        connector = self._get_connector()
+        """Create a new client session using transport or connector configuration.
 
+        When no explicit transport, connector, or session was injected, lazily
+        create a transport so that the global SSL configuration
+        (``litellm.ssl_verify``, ``SSL_VERIFY`` env, ``SSL_CERT_FILE``) is
+        honored on the aiohttp_openai provider path (LIT-3369). Falls back to
+        the legacy bare ``aiohttp.ClientSession()`` when no event loop is
+        available so sync callers/tests still work.
+        """
+        # 1) Prefer an explicitly-injected transport (carries SSL config).
         if self.transport and hasattr(self.transport, "_get_valid_client_session"):
-            # Use transport's session creation if available
-            session = self.transport._get_valid_client_session()
-            return session
-        elif connector:
-            # Use provided connector
-            session = aiohttp.ClientSession(connector=connector)
-            return session
-        else:
-            # Default session creation
-            session = aiohttp.ClientSession()
-            return session
+            return self.transport._get_valid_client_session()
+
+        # 2) Prefer an explicitly-injected connector.
+        connector = self._get_connector()
+        if connector is not None:
+            return aiohttp.ClientSession(connector=connector)
+
+        # 3) Lazy-create a transport so global SSL config is honored.
+        if self._owns_transport:
+            try:
+                self._get_or_create_transport()
+                if self.transport and hasattr(
+                    self.transport, "_get_valid_client_session"
+                ):
+                    return self.transport._get_valid_client_session()
+            except RuntimeError:
+                # No running event loop (sync caller). Fall through to
+                # legacy default below.
+                pass
+
+        # 4) Legacy default: bare ClientSession (preserves old behavior).
+        return aiohttp.ClientSession()
 
     def _get_async_client_session(
         self, dynamic_client_session: Optional[ClientSession] = None

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -88,8 +88,23 @@ class BaseLLMAIOHTTPHandler:
             )
             self._owns_transport = True
             return self.transport
-        except Exception:
-            # If transport creation fails, return None (will use direct session)
+        except Exception as e:
+            # Surface the failure: callers will fall back to a bare
+            # `aiohttp.ClientSession()` which does not carry the resolved SSL
+            # configuration, so silently swallowing this would silently
+            # re-introduce the bug fixed in LIT-3369.
+            try:
+                from litellm._logging import verbose_logger
+
+                verbose_logger.warning(
+                    "Failed to create aiohttp transport with resolved SSL "
+                    "configuration; falling back to bare aiohttp.ClientSession "
+                    "(SSL settings may not apply): %s",
+                    e,
+                )
+            except Exception:
+                # logging must never break the fallback path
+                pass
             return None
 
     def _get_connector(self) -> Optional[aiohttp.BaseConnector]:
@@ -134,8 +149,12 @@ class BaseLLMAIOHTTPHandler:
                 ):
                     return self.transport._get_valid_client_session()
             except RuntimeError:
-                # No running event loop (sync caller). Fall through to
-                # legacy default below.
+                # Most commonly raised by `asyncio.get_running_loop()` when
+                # this method is invoked outside of an async context (e.g.,
+                # sync callers / unit tests that don't drive an event loop).
+                # In that case we fall through to the legacy bare
+                # `ClientSession()` so back-compat with sync callers is
+                # preserved.
                 pass
 
         # 4) Legacy default: bare ClientSession (preserves old behavior).

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_handler_ssl_verify_lit_3369.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_handler_ssl_verify_lit_3369.py
@@ -1,0 +1,178 @@
+"""
+Regression tests for LIT-3369.
+
+Setting `ssl_verify: False` (or `SSL_VERIFY` env var) globally in
+`litellm_settings` should disable SSL verification on the
+``aiohttp_openai`` provider path, which uses
+``BaseLLMAIOHTTPHandler`` rather than ``AsyncHTTPHandler.create_client``.
+
+Pre-fix: ``BaseLLMAIOHTTPHandler._create_client_session_with_transport``
+fell through to a bare ``aiohttp.ClientSession()`` with the default
+verifying SSL context, so the global setting was silently ignored.
+
+Post-fix: it lazily creates a transport via
+``BaseLLMAIOHTTPHandler._get_or_create_transport``, which calls
+``get_ssl_configuration(None)`` to honor ``litellm.ssl_verify``,
+``SSL_VERIFY`` env, ``SSL_CERT_FILE``, etc.
+"""
+import asyncio
+import ssl
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.llms.custom_httpx.aiohttp_handler import BaseLLMAIOHTTPHandler
+from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_ssl_verify():
+    """Restore litellm.ssl_verify after each test."""
+    original = litellm.ssl_verify
+    yield
+    litellm.ssl_verify = original
+
+
+def _create_owned_transport(handler: BaseLLMAIOHTTPHandler) -> LiteLLMAiohttpTransport:
+    """Drive the lazy-create path used at runtime by
+    ``_create_client_session_with_transport``."""
+    handler._get_or_create_transport()
+    assert handler.transport is not None, "transport should be created"
+    return handler.transport
+
+
+class TestLit3369GlobalSSLVerifyHonored:
+    def test_ssl_verify_false_propagates_to_transport(self):
+        """`litellm.ssl_verify = False` -> transport's per-request override is False."""
+        litellm.ssl_verify = False
+        handler = BaseLLMAIOHTTPHandler()
+        transport = _create_owned_transport(handler)
+        assert transport._ssl_verify is False, (
+            "Expected per-request ssl override to be False, "
+            f"got {transport._ssl_verify!r}"
+        )
+
+    def test_ssl_verify_false_via_env_propagates_to_transport(self, monkeypatch):
+        """`SSL_VERIFY` env var also disables verification on this path."""
+        litellm.ssl_verify = True
+        monkeypatch.setenv("SSL_VERIFY", "False")
+        handler = BaseLLMAIOHTTPHandler()
+        transport = _create_owned_transport(handler)
+        assert transport._ssl_verify is False
+
+    def test_ssl_verify_true_does_not_force_disable(self):
+        """Default (verify=True) -> transport must NOT collapse to ssl=False.
+        Ensures the fix does not silently weaken TLS verification for users
+        who did not opt out."""
+        litellm.ssl_verify = True
+        handler = BaseLLMAIOHTTPHandler()
+        transport = _create_owned_transport(handler)
+        assert transport._ssl_verify is not False, (
+            "Default ssl_verify=True must not collapse to ssl=False; "
+            f"got {transport._ssl_verify!r}"
+        )
+
+    def test_lazy_transport_used_by_session_factory(self):
+        """`_create_client_session_with_transport` must drive the transport
+        path (which carries SSL config), not the bare ClientSession fallback."""
+        litellm.ssl_verify = False
+        handler = BaseLLMAIOHTTPHandler()
+
+        sentinel_session = MagicMock(name="sentinel_session")
+
+        def _install_mock(self):
+            mock_transport = MagicMock(spec=LiteLLMAiohttpTransport)
+            mock_transport._get_valid_client_session.return_value = sentinel_session
+            self.transport = mock_transport
+            self._owns_transport = True
+            return mock_transport
+
+        with patch.object(
+            BaseLLMAIOHTTPHandler,
+            "_get_or_create_transport",
+            _install_mock,
+        ):
+            got = handler._create_client_session_with_transport()
+
+        assert got is sentinel_session, (
+            "Expected the transport's session factory to be used; "
+            f"got {got!r}"
+        )
+
+    def test_externally_supplied_transport_is_not_overwritten(self):
+        """If a transport was injected at construction time, the lazy
+        create-on-demand path must not replace it."""
+        injected = MagicMock(spec=LiteLLMAiohttpTransport)
+        injected._get_valid_client_session.return_value = MagicMock(name="inj")
+        handler = BaseLLMAIOHTTPHandler(transport=injected)
+        assert handler._owns_transport is False
+        before = handler.transport
+        _ = handler._create_client_session_with_transport()
+        assert handler.transport is before, "Injected transport must be preserved"
+
+    def test_externally_supplied_connector_is_used(self):
+        """If a connector was injected at construction time, the new code
+        path must still use it (not lazily create a different transport)."""
+        import aiohttp as _aiohttp
+
+        mock_connector = MagicMock(spec=_aiohttp.BaseConnector)
+        handler = BaseLLMAIOHTTPHandler(connector=mock_connector)
+        assert handler._owns_connector is False
+
+        with patch(
+            "litellm.llms.custom_httpx.aiohttp_handler.aiohttp.ClientSession"
+        ) as mock_cs:
+            mock_session = MagicMock()
+            mock_cs.return_value = mock_session
+            session = handler._create_client_session_with_transport()
+
+        mock_cs.assert_called_once_with(connector=mock_connector)
+        assert session is mock_session
+
+    def test_owned_transport_creation_failure_falls_back_to_default_session(self):
+        """If transport creation raises, we still return a usable session
+        (back-compat with the legacy `aiohttp.ClientSession()` fallback)."""
+        litellm.ssl_verify = False
+
+        async def _drive():
+            handler = BaseLLMAIOHTTPHandler()
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler._create_aiohttp_transport",
+                side_effect=RuntimeError("simulated"),
+            ):
+                session = handler._create_client_session_with_transport()
+            try:
+                assert session is not None
+                # transport creation bailed -> stays None
+                assert handler.transport is None
+            finally:
+                if session is not None and not session.closed:
+                    await session.close()
+
+        asyncio.run(_drive())
+
+
+class TestLit3369GetOrCreateTransportSSLResolution:
+    """Direct unit tests on _get_or_create_transport's SSL resolution."""
+
+    def test_get_or_create_transport_with_ssl_verify_false_yields_ssl_false_kwargs(self):
+        """When the global is False, the transport's connector kwargs include ssl=False."""
+        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        litellm.ssl_verify = False
+        kwargs = AsyncHTTPHandler._get_ssl_connector_kwargs(
+            ssl_verify=False, ssl_context=None
+        )
+        assert kwargs.get("ssl") is False
+
+    def test_get_ssl_configuration_returns_context_for_default_verify_true(self):
+        """When the global is True (default), get_ssl_configuration yields an SSLContext."""
+        from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
+
+        litellm.ssl_verify = True
+        resolved = get_ssl_configuration(None)
+        assert isinstance(resolved, ssl.SSLContext), (
+            "Expected SSLContext for ssl_verify=True; got "
+            f"{type(resolved).__name__}"
+        )


### PR DESCRIPTION
## Summary

Fixes **LIT-3369**: setting `ssl_verify: false` (or `SSL_VERIFY=False` env, or `SSL_CERT_FILE`) globally in `litellm_settings` had no effect on the `aiohttp_openai` provider path. Hardcoding `ssl=False` inside `_make_aiohttp_request` worked, which pointed straight at the `BaseLLMAIOHTTPHandler` transport plumbing.

## Root cause

`BaseLLMAIOHTTPHandler._create_client_session_with_transport()` fell through to a bare `aiohttp.ClientSession()` whenever no transport / connector / session was explicitly injected. The bare session uses a default verifying SSL context, and `litellm.ssl_verify` was never consulted on this path — even though `AsyncHTTPHandler.create_client` (the openai/anthropic/etc. path) correctly resolves it via `get_ssl_configuration`.

`base_llm_aiohttp_handler` is module-global (`litellm/main.py:317`), so the unconfigured session was then reused across the whole process.

## Fix

`litellm/llms/custom_httpx/aiohttp_handler.py`:

1. `_get_or_create_transport()` now calls `get_ssl_configuration(None)` and forwards `ssl_verify` / `ssl_context` to `AsyncHTTPHandler._create_aiohttp_transport()` — matching what `AsyncHTTPHandler.create_client` already does for the main path.
2. `_create_client_session_with_transport()` lazily drives `_get_or_create_transport()` (and the transport's session factory) when no transport / connector was injected, so the global SSL config actually reaches the connector and the per-request override. Explicit transport / connector / session injection is preserved (order: injected transport ▸ injected connector ▸ lazy-created transport ▸ legacy bare `ClientSession` fallback). `RuntimeError` (no running event loop in sync-only callers / tests) is caught and falls back to the legacy default, so no caller is forced into an event-loop context.

No external API surface change. No new dependencies.

## Tests

`tests/test_litellm/llms/custom_httpx/test_aiohttp_handler_ssl_verify_lit_3369.py` (9 cases):

- `litellm.ssl_verify = False` → transport's per-request override is `False`
- `SSL_VERIFY` env var also disables verification
- Default `ssl_verify=True` does **not** collapse to `ssl=False` (no security regression)
- Lazy-create path actually drives the transport's session factory (not the bare `ClientSession` fallback)
- Injected transport / connector are not overwritten by the lazy path
- Transport-creation failure falls back to the legacy `aiohttp.ClientSession()` so sync callers still work
- Connector kwargs include `ssl=False` when global is False
- `get_ssl_configuration(None)` yields an `SSLContext` for default `verify=True`

```
$ pytest tests/test_litellm/llms/custom_httpx/test_aiohttp_handler_ssl_verify_lit_3369.py -q
9 passed
$ pytest tests/test_litellm/llms/custom_httpx/test_aiohttp_handler.py \
        tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py \
        tests/test_litellm/llms/custom_httpx/test_http_handler.py \
        tests/test_litellm/test_ssl_verify_unit.py \
        tests/test_litellm/llms/bedrock/test_bedrock_ssl_verify.py \
        --asyncio-mode=auto -q
107 passed, 1 pre-existing flake (test_handle_async_request_streaming_does_not_timeout_on_total_duration — fails identically on clean main)
```

### Evidence

Self-signed HTTPS mock server on `127.0.0.1:8443`. `litellm.ssl_verify = False` is the global config equivalent of `litellm_settings.ssl_verify: false`.

**BEFORE (clean main, `06f6cfc5ae`):**
```
[setup] litellm.ssl_verify = False
[result] FAILED: APIConnectionError - Cannot connect to host 127.0.0.1:8443
         ssl:True [SSLCertVerificationError: certificate verify failed: self-signed certificate]
```

**AFTER (this PR):**
```
[setup] litellm.ssl_verify = False
[result] SUCCESS: Hello from mock HTTPS!
```

**SAFETY — AFTER with default `ssl_verify=True` (must still reject self-signed):**
```
[setup] litellm.ssl_verify = True (default)
[result] FAILED: SSLCertVerificationError    ← TLS still verified
```

**AFTER with `SSL_VERIFY=False` env var:**
```
[setup] SSL_VERIFY env = False, litellm.ssl_verify(default)=True
[result] SUCCESS: Hello from mock HTTPS!
```

### Push note

Files pushed via the GitHub Contents API (one PUT per file) because the agent token lacks `repo` + `workflow` scopes — expect a noisier merge-base diff against `litellm_oss_agent_shin_daily_branch`, but the actual change is exactly the 2 files listed above.


---

### Verification (ship-pr)

- [x] **Base branch correct**: `litellm_oss_agent_shin_daily_branch` (per Shin fork policy)
- [x] **Customer name not leaked**: PR title / body / commits / file paths mention only `LIT-3369` and the technical surface; no customer name appears anywhere
- [x] **Runtime evidence captured**: before/after curl-style transcripts in the `Evidence` section above, driving a real self-signed HTTPS server through `litellm.acompletion(model="aiohttp_openai/...")`
- [x] **Unit tests**: 9 new regression tests in `test_aiohttp_handler_ssl_verify_lit_3369.py`, plus 28 pre-existing `test_aiohttp_handler.py` cases still pass (no regressions). 1 unrelated pre-existing flake (`test_handle_async_request_streaming_does_not_timeout_on_total_duration`) exists on clean main as well — not introduced by this PR
- [x] **Safety regression guard**: default `ssl_verify=True` explicitly verified to still reject self-signed certs (no security weakening)
- [x] **GitHub Actions**: 44/44 green on commit `9d2ac433`
- [x] **Veria AI - PR Review**: ✅ success — "No security issues found"
- [x] **Greptile**: 5/5 — "Safe to merge — narrowly scoped to lazy SSL transport creation on the aiohttp path"
- [x] **mergeable_state**: `clean`
