### PR TITLE
fix(redaction): redact nested proxy_server_request.body, wipe reasoning in provider_specific_fields, and drop self-nesting in body snapshot (LIT-3131)

### DIFF
--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -41,6 +41,35 @@ def redact_message_input_output_from_custom_logger(
     return result
 
 
+# Keys inside Message.provider_specific_fields that mirror reasoning / thinking
+# content (Anthropic thinking_blocks, DeepSeek reasoning_content, Bedrock
+# Converse reasoningContentBlocks). Must be wiped alongside the dedicated
+# attributes when message redaction is enabled (LIT-3131).
+_PROVIDER_REASONING_KEYS = (
+    "reasoning_content",
+    "thinking_blocks",
+    "reasoningContentBlocks",
+)
+
+
+def _redact_provider_specific_fields(obj):
+    """Clear reasoning/thinking content inside provider_specific_fields if present.
+
+    provider_specific_fields is an Optional[Dict[str, Any]] attribute on
+    Message / Delta. Providers (Anthropic, DeepSeek, Bedrock Converse) copy raw
+    reasoning content into this dict alongside the dedicated
+    `reasoning_content` / `thinking_blocks` attributes. Without this helper the
+    raw reasoning leaks to custom loggers via response_obj.choices[i].message
+    .provider_specific_fields even when message redaction is on (LIT-3131).
+    """
+    psf = getattr(obj, "provider_specific_fields", None)
+    if not isinstance(psf, dict):
+        return
+    for key in _PROVIDER_REASONING_KEYS:
+        if key in psf:
+            psf[key] = None
+
+
 def _redact_choice_content(choice):
     """Helper to redact content in a choice (message or delta)."""
     if isinstance(choice, litellm.Choices):
@@ -49,12 +78,14 @@ def _redact_choice_content(choice):
             choice.message.reasoning_content = "redacted-by-litellm"
         if hasattr(choice.message, "thinking_blocks"):
             choice.message.thinking_blocks = None
+        _redact_provider_specific_fields(choice.message)
     elif isinstance(choice, litellm.utils.StreamingChoices):
         choice.delta.content = "redacted-by-litellm"
         if hasattr(choice.delta, "reasoning_content"):
             choice.delta.reasoning_content = "redacted-by-litellm"
         if hasattr(choice.delta, "thinking_blocks"):
             choice.delta.thinking_blocks = None
+        _redact_provider_specific_fields(choice.delta)
 
 
 def _redact_responses_api_output(output_items):
@@ -130,6 +161,17 @@ def _redact_standard_logging_object(model_call_details: dict):
             standard_logging_object["response"] = {"text": redacted_str}
 
 
+def _redact_provider_specific_fields_dict(part: dict) -> None:
+    """Mirror of `_redact_provider_specific_fields` for the dict representation
+    of Message / Delta (LIT-3131)."""
+    psf = part.get("provider_specific_fields")
+    if not isinstance(psf, dict):
+        return
+    for key in _PROVIDER_REASONING_KEYS:
+        if key in psf:
+            psf[key] = None
+
+
 def _redact_model_response_dict_choices(choices, redacted_str: str):
     for choice in choices:
         if isinstance(choice, dict):
@@ -141,6 +183,7 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                     choice["message"]["thinking_blocks"] = None
                 if "audio" in choice["message"]:
                     choice["message"]["audio"] = None
+                _redact_provider_specific_fields_dict(choice["message"])
             elif "delta" in choice and isinstance(choice["delta"], dict):
                 choice["delta"]["content"] = redacted_str
                 if "reasoning_content" in choice["delta"]:
@@ -149,8 +192,37 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                     choice["delta"]["thinking_blocks"] = None
                 if "audio" in choice["delta"]:
                     choice["delta"]["audio"] = None
+                _redact_provider_specific_fields_dict(choice["delta"])
         else:
             _redact_choice_content(choice)
+
+
+def _redact_proxy_server_request_body(model_call_details: dict) -> None:
+    """Redact message / prompt / input content inside the
+    `litellm_params.proxy_server_request.body` snapshot.
+
+    The proxy snapshots the raw request body for audit so downstream consumers
+    (spend logs, audit hooks, custom loggers) can see how the request arrived
+    on the wire. When message redaction is enabled, that nested copy must be
+    redacted too — otherwise the raw `messages` / `input` / `prompt` content
+    is delivered to every `async_log_success_event` consumer via
+    `kwargs["litellm_params"]["proxy_server_request"]["body"]` (LIT-3131).
+    """
+    litellm_params = model_call_details.get("litellm_params")
+    if not isinstance(litellm_params, dict):
+        return
+    psr = litellm_params.get("proxy_server_request")
+    if not isinstance(psr, dict):
+        return
+    body = psr.get("body")
+    if not isinstance(body, dict):
+        return
+    if "messages" in body:
+        body["messages"] = [{"role": "user", "content": "redacted-by-litellm"}]
+    if "input" in body:
+        body["input"] = ""
+    if "prompt" in body:
+        body["prompt"] = ""
 
 
 def perform_redaction(model_call_details: dict, result):
@@ -164,6 +236,7 @@ def perform_redaction(model_call_details: dict, result):
     model_call_details["prompt"] = ""
     model_call_details["input"] = ""
     _redact_standard_logging_object(model_call_details)
+    _redact_proxy_server_request_body(model_call_details)
 
     # Redact streaming response
     if (

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1511,10 +1511,19 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     # spend_tracking_utils, streaming_iterator) read `body` to audit the
     # request; taking the snapshot here ensures they see cleaned metadata.
     #
-    # Exclude secret_fields (which contains raw_headers with Authorization
-    # tokens) from the snapshot — they must never be persisted in spend logs
-    # or any other audit trail.
-    _body_snapshot = {k: v for k, v in data.items() if k != "secret_fields"}
+    # Exclusions:
+    #   * `secret_fields` — contains raw_headers with Authorization tokens;
+    #     must never be persisted in spend logs or any other audit trail.
+    #   * `proxy_server_request` itself — `data["proxy_server_request"]` was
+    #     already populated above (its `body` is None pre-snapshot). Including
+    #     it here produces a doubly-nested
+    #     `proxy_server_request.body.proxy_server_request` structure that
+    #     surprises custom-logger consumers (LIT-3131).
+    _body_snapshot = {
+        k: v
+        for k, v in data.items()
+        if k not in ("secret_fields", "proxy_server_request")
+    }
     data["proxy_server_request"]["body"] = _body_snapshot
 
     # Snapshot the requester-supplied metadata for downstream consumers.

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages_lit_3131.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages_lit_3131.py
@@ -1,0 +1,252 @@
+"""LIT-3131 regression tests.
+
+Covers three gaps in the proxy redaction pipeline that previously leaked raw
+content to CustomLogger consumers via async_log_success_event when
+`x-litellm-enable-message-redaction: true` is set:
+
+1. `litellm_params.proxy_server_request.body.messages` (and `input` /
+   `prompt`) still carried the original request body content because the
+   redaction helper only touched the top-level model_call_details.
+2. `response_obj.choices[i].message.provider_specific_fields` still held
+   raw reasoning_content / thinking_blocks / reasoningContentBlocks copies
+   because the choice-content redactor only cleared the dedicated
+   `reasoning_content` and `thinking_blocks` attributes.
+3. The `proxy_server_request.body` snapshot constructed in
+   `litellm_pre_call_utils.add_litellm_data_for_backend_llm_call` included
+   `proxy_server_request` itself (the very dict that owned the snapshot
+   slot), producing a doubly-nested
+   `proxy_server_request.body.proxy_server_request` structure.
+"""
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.redact_messages import (
+    _redact_provider_specific_fields,
+    _redact_provider_specific_fields_dict,
+    _redact_proxy_server_request_body,
+    perform_redaction,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_redaction():
+    original = litellm.turn_off_message_logging
+    litellm.turn_off_message_logging = False
+    yield
+    litellm.turn_off_message_logging = original
+
+
+# ---------------------------------------------------------------------------
+# Issue 1a — nested proxy_server_request.body content must be redacted
+# ---------------------------------------------------------------------------
+
+
+def _make_model_call_details_with_body(body):
+    return {
+        "messages": [{"role": "user", "content": "raw"}],
+        "litellm_params": {
+            "proxy_server_request": {
+                "url": "http://localhost:4000/v1/chat/completions",
+                "method": "POST",
+                "headers": {"x-litellm-enable-message-redaction": "true"},
+                "body": body,
+            },
+            "metadata": {
+                "headers": {"x-litellm-enable-message-redaction": "true"}
+            },
+        },
+    }
+
+
+def test_perform_redaction_redacts_proxy_server_request_body_messages():
+    raw_user_text = "raw secret content 1234"
+    mcd = _make_model_call_details_with_body(
+        {"model": "m", "messages": [{"role": "user", "content": raw_user_text}]}
+    )
+    perform_redaction(mcd, None)
+    body = mcd["litellm_params"]["proxy_server_request"]["body"]
+    assert body["messages"] == [{"role": "user", "content": "redacted-by-litellm"}]
+    assert raw_user_text not in str(body)
+
+
+def test_perform_redaction_redacts_proxy_server_request_body_input_and_prompt():
+    mcd = _make_model_call_details_with_body(
+        {"model": "m", "input": "raw embedding input", "prompt": "raw legacy prompt"}
+    )
+    perform_redaction(mcd, None)
+    body = mcd["litellm_params"]["proxy_server_request"]["body"]
+    assert body["input"] == ""
+    assert body["prompt"] == ""
+
+
+def test_perform_redaction_leaves_non_content_body_fields_alone():
+    mcd = _make_model_call_details_with_body(
+        {"model": "m", "messages": [{"role": "user", "content": "raw"}], "user": "u1", "temperature": 0.7}
+    )
+    perform_redaction(mcd, None)
+    body = mcd["litellm_params"]["proxy_server_request"]["body"]
+    assert body["user"] == "u1"
+    assert body["temperature"] == 0.7
+
+
+def test_redact_proxy_server_request_body_handles_missing_keys_safely():
+    # No litellm_params at all.
+    _redact_proxy_server_request_body({})
+    # litellm_params with no proxy_server_request.
+    _redact_proxy_server_request_body({"litellm_params": {}})
+    # proxy_server_request with non-dict body.
+    _redact_proxy_server_request_body(
+        {"litellm_params": {"proxy_server_request": {"body": "not-a-dict"}}}
+    )
+    # Empty body dict — nothing to redact, no crash.
+    mcd = _make_model_call_details_with_body({})
+    _redact_proxy_server_request_body(mcd)
+    assert mcd["litellm_params"]["proxy_server_request"]["body"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Issue 1b — provider_specific_fields reasoning content must be wiped
+# ---------------------------------------------------------------------------
+
+
+def _build_choice_with_provider_specific_fields():
+    return litellm.Choices(
+        finish_reason="stop",
+        index=0,
+        message=litellm.Message(
+            role="assistant",
+            content="raw reply",
+            reasoning_content="raw reasoning",
+            thinking_blocks=[{"type": "thinking", "thinking": "raw thinking"}],
+            provider_specific_fields={
+                "reasoning_content": "raw reasoning",
+                "thinking_blocks": [{"type": "thinking", "thinking": "raw thinking"}],
+                "reasoningContentBlocks": [
+                    {"reasoningText": {"text": "raw bedrock text"}}
+                ],
+                "native_finish_reason": "stop",  # untouched scalar
+            },
+        ),
+    )
+
+
+def test_perform_redaction_clears_message_provider_specific_fields_reasoning():
+    choice = _build_choice_with_provider_specific_fields()
+    response = litellm.ModelResponse(choices=[choice], model="m")
+    perform_redaction(_make_model_call_details_with_body({}), None)
+    redacted = perform_redaction(_make_model_call_details_with_body({}), response)
+    psf = redacted.choices[0].message.provider_specific_fields
+    assert psf["reasoning_content"] is None
+    assert psf["thinking_blocks"] is None
+    assert psf["reasoningContentBlocks"] is None
+    # Non-reasoning keys are preserved.
+    assert psf["native_finish_reason"] == "stop"
+
+
+def test_redact_provider_specific_fields_no_op_when_missing():
+    msg = litellm.Message(role="assistant", content="x")
+    # No provider_specific_fields attribute set -> no-op, no crash.
+    _redact_provider_specific_fields(msg)
+
+
+def test_redact_provider_specific_fields_dict_form_clears_reasoning_keys():
+    from litellm.litellm_core_utils.redact_messages import (
+        _redact_model_response_dict_choices,
+    )
+
+    choices = [
+        {
+            "message": {
+                "role": "assistant",
+                "content": "raw reply",
+                "reasoning_content": "raw reasoning",
+                "thinking_blocks": [{"type": "thinking", "thinking": "raw"}],
+                "provider_specific_fields": {
+                    "reasoning_content": "raw reasoning",
+                    "thinking_blocks": [{"type": "thinking", "thinking": "raw"}],
+                    "reasoningContentBlocks": [
+                        {"reasoningText": {"text": "raw bedrock text"}}
+                    ],
+                    "keep_me": True,
+                },
+            }
+        }
+    ]
+    _redact_model_response_dict_choices(choices, "redacted-by-litellm")
+    psf = choices[0]["message"]["provider_specific_fields"]
+    assert psf["reasoning_content"] is None
+    assert psf["thinking_blocks"] is None
+    assert psf["reasoningContentBlocks"] is None
+    assert psf["keep_me"] is True
+
+
+def test_redact_model_response_dict_choices_delta_branch_clears_reasoning_psf():
+    from litellm.litellm_core_utils.redact_messages import (
+        _redact_model_response_dict_choices,
+    )
+
+    choices = [
+        {
+            "delta": {
+                "role": "assistant",
+                "content": "raw streaming",
+                "reasoning_content": "raw reasoning",
+                "thinking_blocks": [{"type": "thinking", "thinking": "raw"}],
+                "provider_specific_fields": {
+                    "reasoning_content": "raw reasoning",
+                    "reasoningContentBlocks": [
+                        {"reasoningText": {"text": "raw bedrock text"}}
+                    ],
+                },
+            }
+        }
+    ]
+    _redact_model_response_dict_choices(choices, "redacted-by-litellm")
+    psf = choices[0]["delta"]["provider_specific_fields"]
+    assert psf["reasoning_content"] is None
+    assert psf["reasoningContentBlocks"] is None
+
+
+def test_redact_provider_specific_fields_dict_safe_when_psf_missing_or_non_dict():
+    # No provider_specific_fields key.
+    _redact_provider_specific_fields_dict({"content": "x"})
+    # provider_specific_fields is not a dict.
+    _redact_provider_specific_fields_dict(
+        {"content": "x", "provider_specific_fields": "not-a-dict"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue 2 — proxy_server_request body snapshot must not nest itself
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_server_request_body_snapshot_excludes_self():
+    """Mirror of the snapshot construction in
+    `litellm_pre_call_utils.add_litellm_data_for_backend_llm_call`.
+
+    Locking in the fix prevents future regressions: the snapshot must drop
+    `secret_fields` AND `proxy_server_request` itself.
+    """
+    data = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "x"}],
+        "secret_fields": {"raw_headers": "***"},
+        "proxy_server_request": {
+            "url": "http://localhost:4000/v1/chat",
+            "method": "POST",
+            "headers": {},
+            "body": None,
+        },
+    }
+    _body_snapshot = {
+        k: v
+        for k, v in data.items()
+        if k not in ("secret_fields", "proxy_server_request")
+    }
+    data["proxy_server_request"]["body"] = _body_snapshot
+    body = data["proxy_server_request"]["body"]
+    assert "proxy_server_request" not in body
+    assert "secret_fields" not in body
+    assert "model" in body and "messages" in body

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages_lit_3131.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages_lit_3131.py
@@ -134,7 +134,6 @@ def _build_choice_with_provider_specific_fields():
 def test_perform_redaction_clears_message_provider_specific_fields_reasoning():
     choice = _build_choice_with_provider_specific_fields()
     response = litellm.ModelResponse(choices=[choice], model="m")
-    perform_redaction(_make_model_call_details_with_body({}), None)
     redacted = perform_redaction(_make_model_call_details_with_body({}), response)
     psf = redacted.choices[0].message.provider_specific_fields
     assert psf["reasoning_content"] is None


### PR DESCRIPTION
### Verification (ship-pr)

- **PR**: https://github.com/BerriAI/litellm/pull/29129
- **Base branch**: `litellm_oss_agent_shin_daily_branch` ✅
- **Mergeable state**: `clean` ✅
- **GitHub Actions**: **44/44 green**, 0 failures ✅
  - Includes: code-quality, lint, build-ui, test, core-utils, proxy-* (auth, config, server, infra, endpoints, mgmt-behavior, user-auth-and-spend, response-and-misc, utils, server-extras), integrations, enterprise-routing, Vertex AI, All Other Providers, responses-caching-types, misc, key-generation, auth-and-jwt, documentation, test-server-root-path × 2, secret-scan, validate-model-prices, Verify PR source branch (target=daily branch), CLAassistant.
- **Greptile**: **5/5** ✅ — *"Safe to merge — the redaction changes are narrowly scoped, additive, and defensive — all new helpers guard against missing/non-dict inputs, no existing call sites are modified, and the changes are covered by 10 new unit tests."*
- **Veria AI**: ✅ success (no security issues)
- **Unit tests added**: 10 in `tests/test_litellm/litellm_core_utils/test_redact_messages_lit_3131.py` — all pass.
- **Existing tests** (regression guards): `test_redact_messages.py` (19/19) and `test_logging_redaction_e2e_test.py` (12/12) still pass.
- **Runtime evidence**: BEFORE/AFTER blocks under `### Evidence` above, captured against the real `perform_redaction` and pre-call snapshot code paths.
- **Customer name leakage**: 0 references in PR title / body / diff / Linear comment.