### PR TITLE
fix(check_batch_cost): route managed-file id normalization through ensure_batch_response_managed_file_ids (LIT-3386)

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -300,41 +300,61 @@ class CheckBatchCost:
                     custom_llm_provider=custom_llm_provider,
                 )
 
-                # CheckBatchCost bypasses async_post_call_success_hook, so convert raw
-                # output/error file IDs to managed base64 IDs before the DB write here.
+                # CheckBatchCost bypasses async_post_call_success_hook, so reconcile any
+                # raw provider file IDs on the response (input_file_id, output_file_id,
+                # error_file_id) with managed unified IDs before the DB write here.
+                # Delegate to ensure_batch_response_managed_file_ids — the same helper
+                # update_batch_in_database uses on the retrieve/cancel HTTP path — so
+                # CheckBatchCost picks up any managed_file row that already exists for
+                # a raw ID (avoiding duplicate rows), resolves input_file_id (the
+                # legacy manual block only handled output/error), and only registers a
+                # new managed row when none exists — using the batch creators
+                # UserAPIKeyAuth as the auth context so registered rows are owned by
+                # the real user (not default_user_id).
                 managed_files_hook = self.proxy_logging_obj.get_proxy_hook("managed_files")
                 if managed_files_hook is not None:
                     from litellm.proxy._types import UserAPIKeyAuth
+                    from litellm.proxy.openai_files_endpoints.common_utils import (
+                        ensure_batch_response_managed_file_ids,
+                    )
                     _minimal_auth = UserAPIKeyAuth(
                         user_id=job.created_by or "default-user-id",
                         team_id=getattr(job, "team_id", None),
                     )
-                    for _file_attr in ["output_file_id", "error_file_id"]:
-                        _raw_file_id = getattr(response, _file_attr, None)
-                        if _raw_file_id and not _is_base64_encoded_unified_file_id(_raw_file_id):
-                            try:
-                                _unified_file_id = managed_files_hook.get_unified_output_file_id(
-                                    output_file_id=_raw_file_id,
-                                    model_id=model_id,
-                                    model_name=str(model_name) if model_name else deployment_info.model_name or None,
-                                )
-                                await managed_files_hook.store_unified_file_id(
-                                    file_id=_unified_file_id,
-                                    file_object=None,
-                                    litellm_parent_otel_span=None,
-                                    model_mappings={model_id: _raw_file_id},
-                                    user_api_key_dict=_minimal_auth,
-                                )
-                                setattr(response, _file_attr, _unified_file_id)
-                                verbose_proxy_logger.info(
-                                    f"CheckBatchCost: converted {_file_attr} "
-                                    f"{_raw_file_id!r} -> managed ID for batch {batch_id}"
-                                )
-                            except Exception as _e:
-                                verbose_proxy_logger.warning(
-                                    f"CheckBatchCost: failed to create managed file ID for "
-                                    f"{_file_attr}={_raw_file_id!r}: {_e}"
-                                )
+                    # ensure_batch_response_managed_file_ids reads model_id/model_name
+                    # from response._hidden_params to know which deployment to map raw
+                    # IDs against. The provider transformations typically set this,
+                    # but populate defensively from the deployment we just resolved so
+                    # the helper has the metadata it needs to register new rows.
+                    _hidden_params = getattr(response, "_hidden_params", None)
+                    if _hidden_params is None:
+                        _hidden_params = {}
+                        try:
+                            response._hidden_params = _hidden_params
+                        except Exception:
+                            _hidden_params = None
+                    if _hidden_params is not None:
+                        _hidden_params.setdefault("model_id", model_id)
+                        _resolved_model_name = (
+                            str(model_name)
+                            if model_name
+                            else (getattr(deployment_info, "model_name", None) or None)
+                        )
+                        if _resolved_model_name and "model_name" not in _hidden_params:
+                            _hidden_params["model_name"] = _resolved_model_name
+                    try:
+                        await ensure_batch_response_managed_file_ids(
+                            response=response,
+                            managed_files_obj=managed_files_hook,
+                            prisma_client=self.prisma_client,
+                            verbose_proxy_logger=verbose_proxy_logger,
+                            user_api_key_dict=_minimal_auth,
+                        )
+                    except Exception as _e:
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: ensure_batch_response_managed_file_ids "
+                            f"failed for batch {batch_id}: {_e}"
+                        )
 
                 # Pass deployment model_info so custom batch pricing
                 # (input_cost_per_token_batches etc.) is used for cost calc

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -331,7 +331,12 @@ class CheckBatchCost:
                         _hidden_params = {}
                         try:
                             response._hidden_params = _hidden_params
-                        except Exception:
+                        except Exception as _hp_err:
+                            verbose_proxy_logger.warning(
+                                f"CheckBatchCost: could not set _hidden_params on response "
+                                f"for batch {batch_id}; output/error file IDs may not be "
+                                f"registered as new managed rows: {_hp_err}"
+                            )
                             _hidden_params = None
                     if _hidden_params is not None:
                         _hidden_params.setdefault("model_id", model_id)

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -391,6 +391,15 @@ class TestCheckBatchCost:
         mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
             return_value=None
         )
+        # LIT-3386: CheckBatchCost now routes raw->managed conversion through
+        # ensure_batch_response_managed_file_ids, which looks up
+        # litellm_managedfiletable to dedupe. None = no existing row, so the
+        # helper falls through to register new managed rows (the behavior
+        # this test pins).
+        mock_prisma_client.db.litellm_managedfiletable = MagicMock()
+        mock_prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(
+            return_value=None
+        )
 
         mock_job = MagicMock()
         mock_job.id = "job-raw-file-1"
@@ -408,12 +417,21 @@ class TestCheckBatchCost:
         fake_managed_output_id = "bGl0ZWxsbV9wcm94eTo6b3V0cHV0"
         fake_managed_error_id = "bGl0ZWxsbV9wcm94eTo6ZXJyb3I="
 
-        mock_response = MagicMock()
-        mock_response.status = "completed"
-        mock_response.output_file_id = raw_output_file_id
-        mock_response.error_file_id = raw_error_file_id
-        mock_response.model_dump_json.return_value = (
-            '{"id":"batch-1","status":"completed"}'
+        # LIT-3386: helper reads input_file_id/output_file_id/error_file_id via
+        # getattr — use a real LiteLLMBatch so the helper sees strings, not
+        # MagicMock attributes.
+        from litellm.types.utils import LiteLLMBatch
+        mock_response = LiteLLMBatch(
+            id="batch-456",
+            completion_window="24h",
+            created_at=1700000000,
+            endpoint="/v1/chat/completions",
+            input_file_id="file-input-fake",
+            object="batch",
+            status="completed",
+            completed_at=1700001000,
+            output_file_id=raw_output_file_id,
+            error_file_id=raw_error_file_id,
         )
 
         mock_llm_router.aretrieve_batch = AsyncMock(return_value=mock_response)
@@ -445,9 +463,11 @@ class TestCheckBatchCost:
         with (
             patch(
                 "litellm.proxy.openai_files_endpoints.common_utils._is_base64_encoded_unified_file_id",
-                # call 1: job unified_object_id decode, call 2: existing raw check for output_file_id,
-                # call 3: fix guard for output_file_id, call 4: fix guard for error_file_id
-                side_effect=[decoded_id, None, None, None],
+                # LIT-3386: ensure_batch_response_managed_file_ids calls this helper
+                # multiple times (once for the job unified id, then for input/output/
+                # error inside the resolve_* + register loops). Use a callable so the
+                # iterator never exhausts.
+                side_effect=lambda v: decoded_id if v == "dW5pZmllZF9iYXRjaF9pZA==" else False,
             ),
             patch(
                 "litellm.proxy.openai_files_endpoints.common_utils.get_model_id_from_unified_batch_id",

--- a/tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py
@@ -1,5 +1,4 @@
-"""
-Regression tests for LIT-3386: CheckBatchCost background poller must route
+"""Regression tests for LIT-3386: CheckBatchCost background poller must route
 managed-file-id normalization through ensure_batch_response_managed_file_ids
 (the same helper update_batch_in_database uses on the retrieve/cancel HTTP
 path) so that:
@@ -43,7 +42,6 @@ EXISTING_MANAGED_INPUT = (
 
 
 def _make_response():
-    """Fresh LiteLLMBatch with raw provider file IDs (what providers return)."""
     from litellm.types.utils import LiteLLMBatch
 
     return LiteLLMBatch(
@@ -61,8 +59,6 @@ def _make_response():
 
 
 def _build_environment(input_has_existing_managed_row: bool = True):
-    """Build the full CheckBatchCost mock environment (prisma, router, hook)."""
-    # -- prisma --
     prisma = MagicMock()
     prisma.db = MagicMock()
     prisma.db.litellm_managedobjecttable = MagicMock()
@@ -93,7 +89,6 @@ def _build_environment(input_has_existing_managed_row: bool = True):
     job.team_id = "team-lit-3386"
     prisma.db.litellm_managedobjecttable.find_many = AsyncMock(return_value=[job])
 
-    # -- router --
     router = MagicMock()
     response = _make_response()
     router.aretrieve_batch = AsyncMock(return_value=response)
@@ -107,7 +102,6 @@ def _build_environment(input_has_existing_managed_row: bool = True):
     deployment.model_info.model_dump.return_value = {}
     router.get_deployment = MagicMock(return_value=deployment)
 
-    # -- managed_files hook --
     hook = MagicMock()
 
     def _gen_unified_id(output_file_id, model_id, model_name):
@@ -244,8 +238,9 @@ async def test_lit_3386_output_and_error_use_creator_auth():
     await _run_check_batch_cost(env)
 
     store_calls = env["store_calls"]
-    assert len(store_calls) >= 2, (
-        f"expected ≥2 store_unified_file_id calls (output + error), got {len(store_calls)}"
+    assert len(store_calls) == 2, (
+        f"expected exactly 2 store_unified_file_id calls (output + error), "
+        f"got {len(store_calls)}"
     )
     for c in store_calls:
         assert c["user_id"] == "shin-real-user-id", (

--- a/tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py
@@ -1,0 +1,289 @@
+"""
+Regression tests for LIT-3386: CheckBatchCost background poller must route
+managed-file-id normalization through ensure_batch_response_managed_file_ids
+(the same helper update_batch_in_database uses on the retrieve/cancel HTTP
+path) so that:
+
+  1. input_file_id is resolved to an existing managed unified ID when a
+     managed_file row exists for the raw provider ID (the legacy manual
+     block in CheckBatchCost only handled output_file_id and error_file_id,
+     leaving input_file_id raw).
+  2. output_file_id / error_file_id continue to be registered with the
+     batch creator's UserAPIKeyAuth as the auth context (created_by =
+     real user, not default_user_id).
+  3. Failures in ensure_batch_response_managed_file_ids do NOT abort the
+     poller — they should log a warning and continue (the cost-tracking
+     path and DB write must still happen).
+"""
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+UNIFIED_JOB_ID_RAW = (
+    "litellm_proxy;model_id:model-abc123;llm_batch_id:batch_xyz789;"
+    "llm_output_file_id:placeholder"
+)
+UNIFIED_JOB_ID_B64 = (
+    base64.urlsafe_b64encode(UNIFIED_JOB_ID_RAW.encode()).decode().rstrip("=")
+)
+
+RAW_INPUT = "file-bedrock-input-bbb111"
+RAW_OUTPUT = "file-bedrock-output-aaa222"
+RAW_ERROR = "file-bedrock-error-ccc333"
+EXISTING_MANAGED_INPUT_RAW = (
+    "litellm_proxy:application/jsonl;unified_id,aaa11111-bbbb-2222;"
+    "target_model_names,claude-sonnet"
+)
+EXISTING_MANAGED_INPUT = (
+    base64.urlsafe_b64encode(EXISTING_MANAGED_INPUT_RAW.encode()).decode().rstrip("=")
+)
+
+
+def _make_response():
+    """Fresh LiteLLMBatch with raw provider file IDs (what providers return)."""
+    from litellm.types.utils import LiteLLMBatch
+
+    return LiteLLMBatch(
+        id="batch_xyz789",
+        completion_window="24h",
+        created_at=1700000000,
+        endpoint="/v1/chat/completions",
+        input_file_id=RAW_INPUT,
+        object="batch",
+        status="completed",
+        completed_at=1700001000,
+        output_file_id=RAW_OUTPUT,
+        error_file_id=RAW_ERROR,
+    )
+
+
+def _build_environment(input_has_existing_managed_row: bool = True):
+    """Build the full CheckBatchCost mock environment (prisma, router, hook)."""
+    # -- prisma --
+    prisma = MagicMock()
+    prisma.db = MagicMock()
+    prisma.db.litellm_managedobjecttable = MagicMock()
+    prisma.db.litellm_usertable = MagicMock()
+    prisma.db.litellm_managedfiletable = MagicMock()
+    prisma.db.litellm_managedobjecttable.update_many = AsyncMock(return_value=0)
+    prisma.db.litellm_managedobjecttable.update = AsyncMock()
+    prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+
+    async def find_first(where, **kw):
+        ids = (where or {}).get("flat_model_file_ids", {})
+        if (
+            input_has_existing_managed_row
+            and isinstance(ids, dict)
+            and ids.get("has") == RAW_INPUT
+        ):
+            row = MagicMock()
+            row.unified_file_id = EXISTING_MANAGED_INPUT
+            return row
+        return None
+
+    prisma.db.litellm_managedfiletable.find_first = AsyncMock(side_effect=find_first)
+
+    job = MagicMock()
+    job.id = "job-lit-3386-1"
+    job.unified_object_id = UNIFIED_JOB_ID_B64
+    job.created_by = "shin-real-user-id"
+    job.team_id = "team-lit-3386"
+    prisma.db.litellm_managedobjecttable.find_many = AsyncMock(return_value=[job])
+
+    # -- router --
+    router = MagicMock()
+    response = _make_response()
+    router.aretrieve_batch = AsyncMock(return_value=response)
+    router.get_deployment_credentials_with_provider = MagicMock(
+        return_value={"api_key": "sk-test"}
+    )
+    deployment = MagicMock()
+    deployment.litellm_params.custom_llm_provider = "bedrock"
+    deployment.litellm_params.model = "bedrock/claude-sonnet"
+    deployment.model_name = "claude-sonnet-batch"
+    deployment.model_info.model_dump.return_value = {}
+    router.get_deployment = MagicMock(return_value=deployment)
+
+    # -- managed_files hook --
+    hook = MagicMock()
+
+    def _gen_unified_id(output_file_id, model_id, model_name):
+        unified = f"litellm_proxy::managed_for::{output_file_id}::on::{model_id}"
+        return base64.urlsafe_b64encode(unified.encode()).decode().rstrip("=")
+
+    hook.get_unified_output_file_id = MagicMock(side_effect=_gen_unified_id)
+    store_calls = []
+
+    async def _store(file_id, file_object, litellm_parent_otel_span,
+                     model_mappings, user_api_key_dict):
+        store_calls.append(
+            {
+                "file_id": file_id,
+                "model_mappings": model_mappings,
+                "user_id": user_api_key_dict.user_id,
+                "team_id": user_api_key_dict.team_id,
+            }
+        )
+
+    hook.store_unified_file_id = AsyncMock(side_effect=_store)
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.get_proxy_hook = MagicMock(return_value=hook)
+
+    return {
+        "prisma": prisma,
+        "router": router,
+        "hook": hook,
+        "proxy_logging_obj": proxy_logging_obj,
+        "response": response,
+        "store_calls": store_calls,
+    }
+
+
+async def _run_check_batch_cost(env):
+    from litellm_enterprise.proxy.common_utils.check_batch_cost import CheckBatchCost
+
+    file_content = MagicMock()
+    file_content.content = b'{"id": "req-1"}'
+
+    cbc = CheckBatchCost(
+        proxy_logging_obj=env["proxy_logging_obj"],
+        prisma_client=env["prisma"],
+        llm_router=env["router"],
+    )
+
+    with (
+        patch("litellm.files.main.afile_content",
+              new_callable=AsyncMock, return_value=file_content),
+        patch("litellm.batches.batch_utils._get_file_content_as_dictionary",
+              return_value=[{"id": "req-1"}]),
+        patch("litellm.batches.batch_utils.calculate_batch_cost_and_usage",
+              new_callable=AsyncMock,
+              return_value=(0.01, {"prompt_tokens": 10, "completion_tokens": 5},
+                            ["claude-sonnet"])),
+        patch("litellm.litellm_core_utils.get_llm_provider_logic.get_llm_provider",
+              return_value=("claude-sonnet", "bedrock", None, None)),
+        patch("litellm.litellm_core_utils.litellm_logging.Logging") as mock_logging_cls,
+    ):
+        logging_obj = MagicMock()
+        logging_obj.async_success_handler = AsyncMock()
+        mock_logging_cls.return_value = logging_obj
+        await cbc.check_batch_cost()
+
+
+@pytest.mark.asyncio
+async def test_lit_3386_input_file_id_resolves_to_existing_managed_row():
+    """When a managed_file row exists for the raw input_file_id (because the
+    user uploaded the file via the proxy), CheckBatchCost MUST persist the
+    managed unified ID, NOT the raw provider ID, into file_object.input_file_id.
+
+    Pre-fix: the poller's manual block only iterated output_file_id and
+    error_file_id, so input_file_id was never normalized and stayed raw —
+    causing GET /v1/batches/{id} to leak the provider ID to the user.
+    """
+    env = _build_environment(input_has_existing_managed_row=True)
+
+    await _run_check_batch_cost(env)
+
+    update_calls = env["prisma"].db.litellm_managedobjecttable.update.call_args_list
+    assert len(update_calls) == 1, f"expected one DB write, got {len(update_calls)}"
+    persisted = json.loads(update_calls[0][1]["data"]["file_object"])
+    assert persisted["input_file_id"] == EXISTING_MANAGED_INPUT, (
+        f"input_file_id was not normalized to existing managed unified id; "
+        f"persisted={persisted['input_file_id']!r}"
+    )
+    assert persisted["input_file_id"] != RAW_INPUT, (
+        "regression: input_file_id is still the raw provider id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit_3386_invokes_ensure_batch_response_managed_file_ids():
+    """The poller must route normalization through
+    ensure_batch_response_managed_file_ids — the same helper
+    update_batch_in_database uses on the retrieve/cancel HTTP path — so the
+    HTTP path and the background poller stay in sync.
+    """
+    env = _build_environment(input_has_existing_managed_row=True)
+
+    import litellm.proxy.openai_files_endpoints.common_utils as _cu
+    real_fn = _cu.ensure_batch_response_managed_file_ids
+    call_args_list = []
+
+    async def _wrapped(*a, **kw):
+        call_args_list.append({
+            "user_id": getattr(kw.get("user_api_key_dict"), "user_id", None),
+        })
+        return await real_fn(*a, **kw)
+
+    with patch.object(_cu, "ensure_batch_response_managed_file_ids",
+                      side_effect=_wrapped):
+        await _run_check_batch_cost(env)
+
+    assert len(call_args_list) == 1, (
+        f"ensure_batch_response_managed_file_ids must be called exactly once "
+        f"per finished batch; got {len(call_args_list)} call(s)"
+    )
+    assert call_args_list[0]["user_id"] == "shin-real-user-id", (
+        "auth context user_id must be the batch creator (job.created_by), "
+        "not default_user_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit_3386_output_and_error_use_creator_auth():
+    """store_unified_file_id (the call that writes the managed_file row to DB)
+    must be invoked with UserAPIKeyAuth whose user_id is the batch creator —
+    so the new managed-file row is owned by the real user.
+    """
+    env = _build_environment(input_has_existing_managed_row=False)
+
+    await _run_check_batch_cost(env)
+
+    store_calls = env["store_calls"]
+    assert len(store_calls) >= 2, (
+        f"expected ≥2 store_unified_file_id calls (output + error), got {len(store_calls)}"
+    )
+    for c in store_calls:
+        assert c["user_id"] == "shin-real-user-id", (
+            f"store_unified_file_id was called with wrong auth context: {c['user_id']!r}"
+        )
+        assert c["team_id"] == "team-lit-3386", (
+            f"store_unified_file_id was called with wrong team_id: {c['team_id']!r}"
+        )
+
+    update_calls = env["prisma"].db.litellm_managedobjecttable.update.call_args_list
+    persisted = json.loads(update_calls[0][1]["data"]["file_object"])
+    assert persisted["output_file_id"] != RAW_OUTPUT
+    assert persisted["error_file_id"] != RAW_ERROR
+
+
+@pytest.mark.asyncio
+async def test_lit_3386_helper_failure_does_not_abort_poller():
+    """If ensure_batch_response_managed_file_ids raises, the poller must
+    still complete the cost-tracking pipeline and write the job row to the
+    DB. The helper's failures should be logged + swallowed, never aborting
+    the poll cycle for other batches.
+    """
+    env = _build_environment(input_has_existing_managed_row=True)
+
+    import litellm.proxy.openai_files_endpoints.common_utils as _cu
+
+    async def _boom(*a, **kw):
+        raise RuntimeError("simulated managed-files-hook failure")
+
+    with patch.object(_cu, "ensure_batch_response_managed_file_ids",
+                      side_effect=_boom):
+        await _run_check_batch_cost(env)
+
+    # The DB update should still happen — the poller must not abort on
+    # helper failures (the existing cost-tracking pipeline still needs to
+    # mark the batch processed).
+    update_calls = env["prisma"].db.litellm_managedobjecttable.update.call_args_list
+    assert len(update_calls) == 1, (
+        f"poller aborted on managed-files helper failure; "
+        f"expected 1 update call, got {len(update_calls)}"
+    )


### PR DESCRIPTION
## What
CheckBatchCost background poller now routes raw->managed unified-id conversion through the central `ensure_batch_response_managed_file_ids` helper (the same one `update_batch_in_database` uses on the retrieve/cancel HTTP path).

## Why (LIT-3386)
The legacy duplicated block in `check_batch_cost.py` only normalized `output_file_id` and `error_file_id`. It never touched `input_file_id`, and it never consulted `LiteLLM_ManagedFileTable` to see whether a managed_file row already existed for a raw provider id.

Two concrete consequences on clean `main` (HEAD `5699a06`):

1. When the user uploaded the batch input file through the proxy (the canonical flow), there IS a managed_file row with the user-facing unified id. The poller would still persist `file_object.input_file_id = <raw provider id>`, so `GET /v1/batches/{id}` (which reads `file_object` from DB) leaked the provider id back to the user.
2. The HTTP retrieve/cancel path and the background poller had two divergent normalization implementations, so any future fix to one would have silently bypassed the other.

The fix delegates to `ensure_batch_response_managed_file_ids` with the batch creator's `UserAPIKeyAuth` so:
- `input_file_id` is resolved to an existing managed unified id when a managed_file row exists (input was uploaded via the proxy).
- `output_file_id` / `error_file_id` are registered only when no managed_file row exists yet, owned by the real `job.created_by` user (not `default_user_id`).
- A single helper now serves both code paths. Failures of the helper are logged + swallowed so the cost-tracking pipeline + DB write are not aborted (test pins this).

## Evidence

Runtime harness drives the real `CheckBatchCost.check_batch_cost()` against a mock prisma + router + managed_files_hook that mirror the production data path (poller cycle: `find_many` returns a finished batch, `aretrieve_batch` returns provider response with raw input/output/error file ids; `managedfiletable.find_first` simulates that ONE managed_file row already exists for the raw input — the user-upload scenario). Captures the JSON `file_object` payload that `litellm_managedobjecttable.update()` receives.

### BEFORE (clean main `5699a06`)

```text
update() call count = 1
response.input_file_id  AFTER CheckBatchCost: 'file-bedrock-input-bbb111'
response.output_file_id AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
response.error_file_id  AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
persisted file_object.input_file_id  = 'file-bedrock-input-bbb111'        # <-- raw provider id leaks to user
persisted file_object.output_file_id = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
persisted file_object.error_file_id  = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
store_unified_file_id call count     = 2
ensure_batch_response_managed_file_ids invocations = 0                    # <-- divergent helper never called
FLAG_INPUT_IS_RAW=True
FLAG_INPUT_IS_MANAGED=False
```

### AFTER (fix applied)

```text
update() call count = 1
response.input_file_id  AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29ubDt1bmlmaWVkX2lkLGFhYTExMTExLWJiYmItMjIyMjt0YXJnZXRfbW9kZWxfbmFtZXMsY2xhdWRlLXNvbm5ldA'
response.output_file_id AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
response.error_file_id  AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
persisted file_object.input_file_id  = 'bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29ubDt1bmlmaWVkX2lkLGFhYTExMTExLWJiYmItMjIyMjt0YXJnZXRfbW9kZWxfbmFtZXMsY2xhdWRlLXNvbm5ldA'  # <-- existing managed unified id
persisted file_object.output_file_id = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
persisted file_object.error_file_id  = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
store_unified_file_id call count     = 2                                  # output + error rows registered as before
ensure_batch_response_managed_file_ids invocations = 1                    # <-- now routed through central helper
  ensure(): auth.user_id=shin-real-user-id                                # <-- batch creator, not default_user_id
FLAG_INPUT_IS_RAW=False
FLAG_INPUT_IS_MANAGED=True
```

Diff: `FLAG_INPUT_IS_RAW: True -> False`, `FLAG_INPUT_IS_MANAGED: False -> True`, helper invocations `0 -> 1`. `output_file_id` / `error_file_id` flags unchanged (no regression on the previously-working path).

## Tests

`tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py` — 4 new cases:

- `test_lit_3386_input_file_id_resolves_to_existing_managed_row` — pins the input-file regression.
- `test_lit_3386_invokes_ensure_batch_response_managed_file_ids` — pins that the central helper is invoked exactly once per finished batch with the correct creator auth.
- `test_lit_3386_output_and_error_use_creator_auth` — pins that `store_unified_file_id` is called with `UserAPIKeyAuth(user_id=job.created_by, team_id=job.team_id)` for both output and error.
- `test_lit_3386_helper_failure_does_not_abort_poller` — pins that helper exceptions are swallowed so the cost-tracking pipeline + DB write still complete.

```text
$ pytest tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py -v
4 passed in 0.21s

$ pytest tests/proxy_unit_tests/test_check_batch_cost.py          tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py          tests/test_litellm/enterprise/proxy/test_managed_files_access_check.py
22 passed in 10.39s
```

## Notes

- Pushed via the GitHub Contents API (current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes), one PUT per file. Diff is exactly the two files listed above.
- Base branch: `litellm_oss_agent_shin_daily_branch` per Shin fork policy.

---

### Verification (ship-pr)

- **Base branch** `litellm_oss_agent_shin_daily_branch` per Shin fork policy — verified by "Verify PR source branch" check (passed)
- **No customer name in PR title/body** — verified, only LIT-3386 ID is referenced
- **Tests pass locally**: `pytest tests/proxy_unit_tests/test_check_batch_cost.py tests/proxy_unit_tests/test_check_batch_cost_lit_3386.py -n 2 --reruns 1` → 11 passed in 18.32s (CI-style parallel mode + reruns)
- **Runtime evidence captured** (before+after) — see `### Evidence` section above with BEFORE on clean main `5699a06` and AFTER on this branch, showing the persisted `file_object.input_file_id` flip from raw → managed unified id and `ensure_batch_response_managed_file_ids` invocations going from 0 → 1
- **Greptile: 5/5** — re-reviewed last commit `182d72f61d`; "Safe to merge — the change is a targeted consolidation onto an existing tested helper with no new external dependencies or auth-boundary changes." Both P2 comments (silent exception swallow + `>=2` precision) addressed and re-reviewed.
- **Veria AI - PR Review: ✅ success** — security analysis completed
- **GitHub Actions: 44/44 green** on head `182d72f61d`, 0 failures
- **mergeable_state**: `clean`
- **No secrets in diff/comments/Linear** — verified
