### PR TITLE
fix(check_batch_cost): delegate file-id reconciliation to ensure_batch_response_managed_file_ids (LIT-3386)

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -326,13 +326,23 @@ class CheckBatchCost:
                     # IDs against. The provider transformations typically set this,
                     # but populate defensively from the deployment we just resolved so
                     # the helper has the metadata it needs to register new rows.
-                    _hidden_params = getattr(response, "_hidden_params", None)
-                    if _hidden_params is None:
-                        _hidden_params = {}
-                        try:
-                            response._hidden_params = _hidden_params
-                        except Exception:
-                            _hidden_params = None
+                    # Copy-on-read so we never mutate a class-level default dict that
+                    # might be shared by another LiteLLMBatch instance in the same poll
+                    # cycle (Greptile P2).
+                    _hidden_params = dict(getattr(response, "_hidden_params", None) or {})
+                    try:
+                        response._hidden_params = _hidden_params
+                    except Exception:
+                        # response disallows attribute assignment (e.g. __slots__).
+                        # The helper will then see whatever was already on the response
+                        # (possibly empty) and silently skip new managed-row creation;
+                        # surface that so operators can tell.
+                        _hidden_params = None
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: could not attach _hidden_params to "
+                            f"response for batch {batch_id}; managed-file registration "
+                            "may be skipped for raw provider IDs"
+                        )
                     if _hidden_params is not None:
                         _hidden_params.setdefault("model_id", model_id)
                         _resolved_model_name = (

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -300,41 +300,61 @@ class CheckBatchCost:
                     custom_llm_provider=custom_llm_provider,
                 )
 
-                # CheckBatchCost bypasses async_post_call_success_hook, so convert raw
-                # output/error file IDs to managed base64 IDs before the DB write here.
+                # CheckBatchCost bypasses async_post_call_success_hook, so reconcile any
+                # raw provider file IDs on the response (input_file_id, output_file_id,
+                # error_file_id) with managed unified IDs before the DB write here.
+                # Delegate to ensure_batch_response_managed_file_ids - the same helper
+                # update_batch_in_database uses on the retrieve/cancel HTTP path - so
+                # CheckBatchCost picks up any managed_file row that already exists for
+                # a raw ID (avoiding duplicate rows), resolves input_file_id (the
+                # legacy manual block only handled output/error), and only registers a
+                # new managed row when none exists - using the batch creator UserAPIKeyAuth
+                # as the auth context so registered rows are owned by the real user
+                # (not default_user_id).
                 managed_files_hook = self.proxy_logging_obj.get_proxy_hook("managed_files")
                 if managed_files_hook is not None:
                     from litellm.proxy._types import UserAPIKeyAuth
+                    from litellm.proxy.openai_files_endpoints.common_utils import (
+                        ensure_batch_response_managed_file_ids,
+                    )
                     _minimal_auth = UserAPIKeyAuth(
                         user_id=job.created_by or "default-user-id",
                         team_id=getattr(job, "team_id", None),
                     )
-                    for _file_attr in ["output_file_id", "error_file_id"]:
-                        _raw_file_id = getattr(response, _file_attr, None)
-                        if _raw_file_id and not _is_base64_encoded_unified_file_id(_raw_file_id):
-                            try:
-                                _unified_file_id = managed_files_hook.get_unified_output_file_id(
-                                    output_file_id=_raw_file_id,
-                                    model_id=model_id,
-                                    model_name=str(model_name) if model_name else deployment_info.model_name or None,
-                                )
-                                await managed_files_hook.store_unified_file_id(
-                                    file_id=_unified_file_id,
-                                    file_object=None,
-                                    litellm_parent_otel_span=None,
-                                    model_mappings={model_id: _raw_file_id},
-                                    user_api_key_dict=_minimal_auth,
-                                )
-                                setattr(response, _file_attr, _unified_file_id)
-                                verbose_proxy_logger.info(
-                                    f"CheckBatchCost: converted {_file_attr} "
-                                    f"{_raw_file_id!r} -> managed ID for batch {batch_id}"
-                                )
-                            except Exception as _e:
-                                verbose_proxy_logger.warning(
-                                    f"CheckBatchCost: failed to create managed file ID for "
-                                    f"{_file_attr}={_raw_file_id!r}: {_e}"
-                                )
+                    # ensure_batch_response_managed_file_ids reads model_id/model_name
+                    # from response._hidden_params to know which deployment to map raw
+                    # IDs against. The provider transformations typically set this,
+                    # but populate defensively from the deployment we just resolved so
+                    # the helper has the metadata it needs to register new rows.
+                    _hidden_params = getattr(response, "_hidden_params", None)
+                    if _hidden_params is None:
+                        _hidden_params = {}
+                        try:
+                            response._hidden_params = _hidden_params
+                        except Exception:
+                            _hidden_params = None
+                    if _hidden_params is not None:
+                        _hidden_params.setdefault("model_id", model_id)
+                        _resolved_model_name = (
+                            str(model_name)
+                            if model_name
+                            else (getattr(deployment_info, "model_name", None) or None)
+                        )
+                        if _resolved_model_name and "model_name" not in _hidden_params:
+                            _hidden_params["model_name"] = _resolved_model_name
+                    try:
+                        await ensure_batch_response_managed_file_ids(
+                            response=response,
+                            managed_files_obj=managed_files_hook,
+                            prisma_client=self.prisma_client,
+                            verbose_proxy_logger=verbose_proxy_logger,
+                            user_api_key_dict=_minimal_auth,
+                        )
+                    except Exception as _e:
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: ensure_batch_response_managed_file_ids "
+                            f"failed for batch {batch_id}: {_e}"
+                        )
 
                 # Pass deployment model_info so custom batch pricing
                 # (input_cost_per_token_batches etc.) is used for cost calc

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -379,11 +379,11 @@ class TestCheckBatchCost:
     async def test_raw_output_file_id_converted_to_managed_id(
         self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
     ):
-        """CheckBatchCost must convert a raw provider output_file_id to a managed base64 ID.
-
-        Without this, GET /batches/{id} returns a raw file ID that cannot be routed
-        through the proxy, causing API_KEY errors when clients call GET /files/{id}/content.
+        """CheckBatchCost must register managed unified IDs for raw provider
+        output_file_id / error_file_id when no managed_file row already exists,
+        using the batch creator as the auth context.
         """
+        import base64
         mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
             return_value=0
         )
@@ -391,10 +391,24 @@ class TestCheckBatchCost:
         mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
             return_value=None
         )
+        # No existing managed_file rows — resolve_* finds nothing, so the helper
+        # registers new managed IDs for output/error.
+        mock_prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(
+            return_value=None
+        )
+
+        unified_object_id_raw = (
+            "litellm_proxy;model_id:model-123;llm_batch_id:batch-456"
+        )
+        unified_object_id = (
+            base64.urlsafe_b64encode(unified_object_id_raw.encode())
+            .decode()
+            .rstrip("=")
+        )
 
         mock_job = MagicMock()
         mock_job.id = "job-raw-file-1"
-        mock_job.unified_object_id = "dW5pZmllZF9iYXRjaF9pZA=="
+        mock_job.unified_object_id = unified_object_id
         mock_job.created_by = "user-1"
         mock_job.team_id = None
 
@@ -405,15 +419,21 @@ class TestCheckBatchCost:
 
         raw_output_file_id = "file-batch-output-abc123"
         raw_error_file_id = "file-batch-error-xyz456"
-        fake_managed_output_id = "bGl0ZWxsbV9wcm94eTo6b3V0cHV0"
-        fake_managed_error_id = "bGl0ZWxsbV9wcm94eTo6ZXJyb3I="
+        fake_managed_output_id = "bGl0ZWxsbV9wcm94eTo6bw=="
+        fake_managed_error_id = "bGl0ZWxsbV9wcm94eTo6ZQ=="
 
-        mock_response = MagicMock()
-        mock_response.status = "completed"
-        mock_response.output_file_id = raw_output_file_id
-        mock_response.error_file_id = raw_error_file_id
-        mock_response.model_dump_json.return_value = (
-            '{"id":"batch-1","status":"completed"}'
+        from litellm.types.utils import LiteLLMBatch
+        mock_response = LiteLLMBatch(
+            id="batch-456",
+            completion_window="24h",
+            created_at=1700000000,
+            endpoint="/v1/chat/completions",
+            input_file_id="file-batch-input-raw",
+            object="batch",
+            status="completed",
+            completed_at=1700001000,
+            output_file_id=raw_output_file_id,
+            error_file_id=raw_error_file_id,
         )
 
         mock_llm_router.aretrieve_batch = AsyncMock(return_value=mock_response)
@@ -440,23 +460,8 @@ class TestCheckBatchCost:
 
         mock_file_content = MagicMock()
         mock_file_content.content = b'{"id":"req-1"}'
-        decoded_id = "llm_model_id,model-123;llm_batch_id,batch-456;"
 
         with (
-            patch(
-                "litellm.proxy.openai_files_endpoints.common_utils._is_base64_encoded_unified_file_id",
-                # call 1: job unified_object_id decode, call 2: existing raw check for output_file_id,
-                # call 3: fix guard for output_file_id, call 4: fix guard for error_file_id
-                side_effect=[decoded_id, None, None, None],
-            ),
-            patch(
-                "litellm.proxy.openai_files_endpoints.common_utils.get_model_id_from_unified_batch_id",
-                return_value="model-123",
-            ),
-            patch(
-                "litellm.proxy.openai_files_endpoints.common_utils.get_batch_id_from_unified_batch_id",
-                return_value="batch-456",
-            ),
             patch(
                 "litellm.files.main.afile_content",
                 new_callable=AsyncMock,
@@ -501,7 +506,6 @@ class TestCheckBatchCost:
             model_name="gpt-5-mini",
         )
         assert mock_hook.store_unified_file_id.await_count == 2
-        # {raw_file_id: managed_file_id} for each store call
         stored = {
             next(iter(c[1]["model_mappings"].values())): c[1]["file_id"]
             for c in mock_hook.store_unified_file_id.call_args_list
@@ -510,5 +514,214 @@ class TestCheckBatchCost:
             raw_output_file_id: fake_managed_output_id,
             raw_error_file_id: fake_managed_error_id,
         }
+        for c in mock_hook.store_unified_file_id.call_args_list:
+            assert c[1]["user_api_key_dict"].user_id == "user-1"
         assert mock_response.output_file_id == fake_managed_output_id
         assert mock_response.error_file_id == fake_managed_error_id
+
+    @pytest.mark.asyncio
+    async def test_input_file_id_resolved_to_existing_managed_id(
+        self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
+    ):
+        """LIT-3386: when the raw input_file_id has a managed_file row (the user
+        uploaded the file through the proxy and got back a unified ID),
+        CheckBatchCost must resolve it to that managed ID before persisting the
+        batch's file_object — otherwise GET /v1/batches/{id} returns the raw
+        provider ID for input_file_id and the user cannot correlate it back to
+        their managed upload.
+
+        The retrieve/cancel HTTP path already does this via
+        ensure_batch_response_managed_file_ids; CheckBatchCost must too.
+        """
+        import base64, json
+        mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
+            return_value=0
+        )
+        mock_prisma_client.db.litellm_managedobjecttable.update = AsyncMock()
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=None
+        )
+
+        raw_input_file_id = "file-batch-input-raw-aaa"
+        raw_output_file_id = "file-batch-output-raw-bbb"
+        managed_input_unified_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29ubDt1bmlmaWVkX2lkLGFiYy0xMjM7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00"  # base64-encoded form actually stored in DB
+
+        async def _find_first(where, **kw):
+            ids = (where or {}).get("flat_model_file_ids", {})
+            if isinstance(ids, dict) and ids.get("has") == raw_input_file_id:
+                row = MagicMock()
+                row.unified_file_id = managed_input_unified_id
+                return row
+            return None
+
+        mock_prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(
+            side_effect=_find_first
+        )
+
+        unified_object_id_raw = (
+            "litellm_proxy;model_id:model-x;llm_batch_id:batch-y"
+        )
+        unified_object_id = (
+            base64.urlsafe_b64encode(unified_object_id_raw.encode())
+            .decode()
+            .rstrip("=")
+        )
+
+        mock_job = MagicMock()
+        mock_job.id = "job-input-resolve-1"
+        mock_job.unified_object_id = unified_object_id
+        mock_job.created_by = "shin-real-user"
+        mock_job.team_id = "team-1"
+
+        check_batch_cost_instance._has_batch_processed_column = True
+        mock_prisma_client.db.litellm_managedobjecttable.find_many = AsyncMock(
+            return_value=[mock_job]
+        )
+
+        from litellm.types.utils import LiteLLMBatch
+        response = LiteLLMBatch(
+            id="batch-y",
+            completion_window="24h",
+            created_at=1700000000,
+            endpoint="/v1/chat/completions",
+            input_file_id=raw_input_file_id,
+            object="batch",
+            status="completed",
+            completed_at=1700001000,
+            output_file_id=raw_output_file_id,
+        )
+        mock_llm_router.aretrieve_batch = AsyncMock(return_value=response)
+        mock_llm_router.get_deployment_credentials_with_provider = MagicMock(
+            return_value={"api_key": "sk-test"}
+        )
+        deployment = MagicMock()
+        deployment.litellm_params.custom_llm_provider = "openai"
+        deployment.litellm_params.model = "gpt-4"
+        deployment.model_name = "gpt-4-batch"
+        deployment.model_info.model_dump.return_value = {}
+        mock_llm_router.get_deployment = MagicMock(return_value=deployment)
+
+        hook = MagicMock()
+        hook.get_unified_output_file_id.return_value = "bGl0ZWxsbV9wcm94eTo6bw=="
+        hook.store_unified_file_id = AsyncMock()
+        check_batch_cost_instance.proxy_logging_obj.get_proxy_hook.return_value = hook
+
+        file_content = MagicMock()
+        file_content.content = b'{"id":"req-1"}'
+
+        with (
+            patch("litellm.files.main.afile_content", new_callable=AsyncMock, return_value=file_content),
+            patch("litellm.batches.batch_utils._get_file_content_as_dictionary", return_value=[{"id": "req-1"}]),
+            patch("litellm.batches.batch_utils.calculate_batch_cost_and_usage", new_callable=AsyncMock, return_value=(0.01, {"prompt_tokens": 1, "completion_tokens": 1}, ["gpt-4"])),
+            patch("litellm.litellm_core_utils.get_llm_provider_logic.get_llm_provider", return_value=("gpt-4", "openai", None, None)),
+            patch("litellm.litellm_core_utils.litellm_logging.Logging") as mock_logging_cls,
+        ):
+            mock_logging_obj = MagicMock()
+            mock_logging_obj.async_success_handler = AsyncMock()
+            mock_logging_cls.return_value = mock_logging_obj
+            await check_batch_cost_instance.check_batch_cost()
+
+        # The persisted file_object must carry the managed input_file_id, not the raw provider value.
+        assert mock_prisma_client.db.litellm_managedobjecttable.update.await_count == 1
+        update_data = mock_prisma_client.db.litellm_managedobjecttable.update.call_args[1]["data"]
+        persisted = json.loads(update_data["file_object"])
+        assert persisted["input_file_id"] == managed_input_unified_id, (
+            f"expected managed unified id, got {persisted}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_existing_output_managed_row_is_reused_not_duplicated(
+        self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
+    ):
+        """LIT-3386: when a managed_file row already exists for the raw
+        output_file_id (e.g. the retrieve_batch HTTP path ran first),
+        CheckBatchCost must reuse that row instead of registering a new one
+        (which would double-write).
+        """
+        import base64
+        mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
+            return_value=0
+        )
+        mock_prisma_client.db.litellm_managedobjecttable.update = AsyncMock()
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=None
+        )
+
+        raw_output_file_id = "file-output-raw-xxx"
+        existing_managed_output_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29ubDt1bmlmaWVkX2lkLG91dC0xO3RhcmdldF9tb2RlbF9uYW1lcyxncHQtNA"  # base64-encoded form actually stored in DB
+
+        async def _find_first(where, **kw):
+            ids = (where or {}).get("flat_model_file_ids", {})
+            if isinstance(ids, dict) and ids.get("has") == raw_output_file_id:
+                row = MagicMock()
+                row.unified_file_id = existing_managed_output_id
+                return row
+            return None
+
+        mock_prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(
+            side_effect=_find_first
+        )
+
+        unified_object_id_raw = "litellm_proxy;model_id:m-1;llm_batch_id:b-1"
+        unified_object_id = base64.urlsafe_b64encode(
+            unified_object_id_raw.encode()
+        ).decode().rstrip("=")
+
+        mock_job = MagicMock()
+        mock_job.id = "job-dedup-1"
+        mock_job.unified_object_id = unified_object_id
+        mock_job.created_by = "user-1"
+        mock_job.team_id = None
+        check_batch_cost_instance._has_batch_processed_column = True
+        mock_prisma_client.db.litellm_managedobjecttable.find_many = AsyncMock(
+            return_value=[mock_job]
+        )
+
+        from litellm.types.utils import LiteLLMBatch
+        response = LiteLLMBatch(
+            id="b-1",
+            completion_window="24h",
+            created_at=1700000000,
+            endpoint="/v1/chat/completions",
+            input_file_id="file-input-irrelevant",
+            object="batch",
+            status="completed",
+            completed_at=1700001000,
+            output_file_id=raw_output_file_id,
+        )
+        mock_llm_router.aretrieve_batch = AsyncMock(return_value=response)
+        mock_llm_router.get_deployment_credentials_with_provider = MagicMock(
+            return_value={"api_key": "sk-test"}
+        )
+        deployment = MagicMock()
+        deployment.litellm_params.custom_llm_provider = "openai"
+        deployment.litellm_params.model = "gpt-4"
+        deployment.model_name = "gpt-4-batch"
+        deployment.model_info.model_dump.return_value = {}
+        mock_llm_router.get_deployment = MagicMock(return_value=deployment)
+
+        hook = MagicMock()
+        hook.get_unified_output_file_id.return_value = "SHOULD-NOT-BE-CALLED"
+        hook.store_unified_file_id = AsyncMock()
+        check_batch_cost_instance.proxy_logging_obj.get_proxy_hook.return_value = hook
+
+        file_content = MagicMock()
+        file_content.content = b'{"id":"req-1"}'
+
+        with (
+            patch("litellm.files.main.afile_content", new_callable=AsyncMock, return_value=file_content),
+            patch("litellm.batches.batch_utils._get_file_content_as_dictionary", return_value=[{"id": "req-1"}]),
+            patch("litellm.batches.batch_utils.calculate_batch_cost_and_usage", new_callable=AsyncMock, return_value=(0.01, {"prompt_tokens": 1, "completion_tokens": 1}, ["gpt-4"])),
+            patch("litellm.litellm_core_utils.get_llm_provider_logic.get_llm_provider", return_value=("gpt-4", "openai", None, None)),
+            patch("litellm.litellm_core_utils.litellm_logging.Logging") as mock_logging_cls,
+        ):
+            mock_logging_obj = MagicMock()
+            mock_logging_obj.async_success_handler = AsyncMock()
+            mock_logging_cls.return_value = mock_logging_obj
+            await check_batch_cost_instance.check_batch_cost()
+
+        # Existing managed row was reused: response.output_file_id is the existing managed id,
+        # and we did NOT call store_unified_file_id / get_unified_output_file_id for output.
+        assert response.output_file_id == existing_managed_output_id
+        assert hook.store_unified_file_id.await_count == 0
+        assert hook.get_unified_output_file_id.call_count == 0


### PR DESCRIPTION
## What

When the user has uploaded the batch input file through the proxy (so a `LiteLLM_ManagedFileTable` row exists for the raw provider `input_file_id`), the `CheckBatchCost` background poller currently persists the **raw provider** `input_file_id` in `LiteLLM_ManagedObjectTable.file_object` instead of the managed unified ID. `GET /v1/batches/{id}` then returns a raw `input_file_id` that the user cannot correlate back to their managed upload, and listing endpoints can't round-trip it.

`update_batch_in_database` (used by the retrieve/cancel HTTP path) already does this reconciliation via the central helper `ensure_batch_response_managed_file_ids`. `CheckBatchCost` had its own partial reconciliation block from #27984 that only covered `output_file_id` / `error_file_id` and didn't consult existing managed_file rows — missing both `input_file_id` and dedup behavior.

Closes the remaining gap called out at the bottom of #28294 ("PR does not touch check_batch_cost.py") for LiteLLM ticket LIT-3386.

## Change

`enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py`: replace the partial in-place output/error registration with a single call to `ensure_batch_response_managed_file_ids` (the same helper `update_batch_in_database` uses on the retrieve/cancel HTTP path). The helper:

1. resolves the response's raw `input_file_id` to the existing managed unified ID (the gap the legacy block missed),
2. resolves raw `output_file_id` / `error_file_id` to existing managed rows when one already exists (avoiding duplicate writes by parallel paths),
3. only registers a brand-new managed_file row when no existing row maps to a raw ID.

Auth context (`UserAPIKeyAuth.user_id = job.created_by`) is unchanged — still anchored on the batch creator so managed rows are owned by the real user, not `default_user_id`. `response._hidden_params["model_id"]` is populated defensively from the deployment we just resolved so the helper has all the metadata it needs to register new rows when the provider transformation didn't set it.

## Files

- `enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py` — swap manual reconciliation block for `ensure_batch_response_managed_file_ids`.
- `tests/proxy_unit_tests/test_check_batch_cost.py` — update the existing raw-output coverage to the new code path; add 2 new tests for input-file-id resolution and reuse-dedup behavior.

> Files pushed via the GitHub Contents API (current token lacks `repo`+`workflow` scopes) — the diff itself is exactly the 2 files above.

### Evidence

Runtime evidence harness drives the real `CheckBatchCost.check_batch_cost()` against a mock prisma + router that mirrors the production data path (the poller has no HTTP trigger by design, so this is the closest practical reproduction). Captures the JSON `file_object` payload that `CheckBatchCost` persists to `litellm_managedobjecttable.update()`. The setup pre-populates a managed_file row for the raw input file id (simulating a user who uploaded their batch input through the proxy first).

**BEFORE** — clean upstream main HEAD `5699a06`:

```
--- BEFORE (clean main 5699a06) ---
update() call count = 1
response.input_file_id  AFTER CheckBatchCost: 'file-bedrock-input-bbb111'
response.output_file_id AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
response.error_file_id  AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
persisted file_object.input_file_id  = 'file-bedrock-input-bbb111'
persisted file_object.output_file_id = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
persisted file_object.error_file_id  = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
store_unified_file_id call count     = 2
  store_unified_file_id: file_id=bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZp... mappings={'model-abc123': 'file-bedrock-output-aaa222'} user_id=shin-real-user-id
  store_unified_file_id: file_id=bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZp... mappings={'model-abc123': 'file-bedrock-error-ccc333'} user_id=shin-real-user-id
ensure_batch_response_managed_file_ids invocations = 0
FLAG_INPUT_IS_RAW=True
FLAG_INPUT_IS_MANAGED=False
FLAG_OUTPUT_IS_RAW=False
FLAG_ERROR_IS_RAW=False
```

**AFTER** — with this fix:

```
--- AFTER (fix applied — calls ensure_batch_response_managed_file_ids) ---
update() call count = 1
response.input_file_id  AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29ubDt1bmlmaWVkX2lkLGFhYTExMTExLWJiYmItMjIyMjt0YXJnZXRfbW9kZWxfbmFtZXMsY2xhdWRlLXNvbm5ldA'
response.output_file_id AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
response.error_file_id  AFTER CheckBatchCost: 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
persisted file_object.input_file_id  = 'bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29ubDt1bmlmaWVkX2lkLGFhYTExMTExLWJiYmItMjIyMjt0YXJnZXRfbW9kZWxfbmFtZXMsY2xhdWRlLXNvbm5ldA'
persisted file_object.output_file_id = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1vdXRwdXQtYWFhMjIyOjpvbjo6bW9kZWwtYWJjMTIz'
persisted file_object.error_file_id  = 'bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZpbGUtYmVkcm9jay1lcnJvci1jY2MzMzM6Om9uOjptb2RlbC1hYmMxMjM'
store_unified_file_id call count     = 2
  store_unified_file_id: file_id=bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZp... mappings={'model-abc123': 'file-bedrock-output-aaa222'} user_id=shin-real-user-id
  store_unified_file_id: file_id=bGl0ZWxsbV9wcm94eTo6bWFuYWdlZF9mb3I6OmZp... mappings={'model-abc123': 'file-bedrock-error-ccc333'} user_id=shin-real-user-id
ensure_batch_response_managed_file_ids invocations = 1
  ensure(): auth.user_id=shin-real-user-id
FLAG_INPUT_IS_RAW=False
FLAG_INPUT_IS_MANAGED=True
FLAG_OUTPUT_IS_RAW=False
FLAG_ERROR_IS_RAW=False
```

Key delta (BEFORE -> AFTER):

| field | BEFORE | AFTER |
|---|---|---|
| `persisted file_object.input_file_id` | `'file-bedrock-input-bbb111'` (raw provider value) -> `FLAG_INPUT_IS_RAW=True` | base64 managed unified id -> `FLAG_INPUT_IS_MANAGED=True` |
| `ensure_batch_response_managed_file_ids invocations` | `0` (legacy partial block ran) | `1` (delegated to central helper) |
| `response.output_file_id` / `error_file_id` | already managed (legacy block) | still managed (helper) — no regression |
| auth context on managed_file write | `user_id=shin-real-user-id` | `user_id=shin-real-user-id` (unchanged) |

### Unit tests

9/9 pass in `tests/proxy_unit_tests/test_check_batch_cost.py` (6 pre-existing kept as-is, 1 updated to drive through the helper, 2 new tests added):

```
$ python3 -m pytest tests/proxy_unit_tests/test_check_batch_cost.py --no-header
============================== 9 passed in 0.36s ==============================
```

Related coverage (`tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py`, 8/8) and broader batch/managed_file tests (`pytest -k "batch or managed_file"` in proxy_unit_tests, 14/14) also pass.

New tests:

- `test_input_file_id_resolved_to_existing_managed_id` — mocks `litellm_managedfiletable.find_first` to return a managed row for the raw input file id; asserts the persisted `file_object.input_file_id` is the managed unified id (was the raw value on `main`).
- `test_existing_output_managed_row_is_reused_not_duplicated` — mocks an existing managed row for the raw output_file_id; asserts `store_unified_file_id` / `get_unified_output_file_id` are NOT called (no duplicate write) and `response.output_file_id` is the existing managed id.

Updated test:

- `test_raw_output_file_id_converted_to_managed_id` — same scope (covers the no-existing-managed-row path) but now drives through the helper instead of the legacy block; uses a real base64-encoded unified_object_id and mocks `find_first -> None`.

## Linear

LIT-3386 — https://linear.app/litellm-ai/issue/LIT-3386/fix-remaining-batch-id-transformation-in-checkbatchcost


---

### Verification (ship-pr)

- [x] **PR base branch**: `litellm_oss_agent_shin_daily_branch` ✓
- [x] **Customer name leak**: none (LIT-3386 has no Linear project/customer)
- [x] **Greptile**: 5/5 on commit `de102db` — *"Safe to merge; the change narrows scope by delegating to an already-tested central helper, and the defensive copy-on-read guards against cross-iteration state bleed."* Two P2 suggestions from Greptile's first pass addressed in `de102db`.
- [x] **Veria AI**: pass — *"No security issues found"*
- [x] **GitHub Actions**: 44/44 green (`pytest`, `lint`, `code-quality`, `semgrep`, `secret-scan`, `validate-model-prices-json`, all proxy-* suites, all-other-providers, vertex, integrations, enterprise-routing, build-ui, docs)
- [x] **Mergeable state**: `clean`
- [x] **Unit tests local**: 9/9 in `tests/proxy_unit_tests/test_check_batch_cost.py`; related `test_batch_update_db_managed_output_file_id.py` 8/8; broader `-k "batch or managed_file"` 14/14
- [x] **Runtime evidence**: BEFORE (clean main `5699a06`) + AFTER terminal output inlined above (`persisted file_object.input_file_id` flips from raw provider value to managed unified id; helper invocation count flips from 0 → 1)
- [x] **Diff scope**: 2 files (`check_batch_cost.py` + the test file)