### PR TITLE
fix(presidio): incremental SSE streaming for output masking and PII unmasking (LIT-3222)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1202,11 +1202,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
     @staticmethod
     def _split_unmask_safe_prefix(
-        buffer: str, pii_tokens: Dict[str, str], max_token_len: int
+        buffer: str, pii_tokens: Dict[str, str]
     ) -> Tuple[str, str]:
         """Split `buffer` into (safe_prefix, held_tail) for incremental PII unmasking.
 
-        Guarantees: no PII token in `pii_tokens` can span the (safe / tail)
+        Guarantee: no PII token in `pii_tokens` can span the (safe / tail)
         boundary. The held_tail is kept in the buffer for the next iteration
         so a token whose `<` arrived in one upstream chunk and `>` arrived in
         the next still gets rewritten atomically.
@@ -1214,26 +1214,22 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Strategy: PII tokens emitted by `_finalize_presidio_anonymize_numbered_tokens`
         always have the shape `<ENTITY_N>` — they start with `<` and end with `>`.
         We therefore find the rightmost `<` whose matching `>` has NOT yet
-        arrived in `buffer`; everything up to that `<` is safe to emit. As a
-        defensive backstop (e.g. if a token does not match this shape) we also
-        never emit the very last `max_token_len - 1` characters unless the buffer
-        is entirely empty of `<`.
+        arrived in `buffer`; everything up to that `<` is safe to emit. The
+        `pii_tokens` mapping is kept on the signature as a shape-validation
+        extension point but is not consulted by the current `<ENTITY_N>`-shape
+        implementation.
         """
         if not buffer:
             return "", buffer
-
         last_lt = buffer.rfind("<")
         if last_lt < 0:
             # No `<` anywhere — entire buffer is safely emittable.
             return buffer, ""
-
-        # Is the rightmost `<` already closed by a `>` later in the buffer?
+        # If the rightmost `<` is already closed by a `>` later in the buffer,
+        # everything is safe.
         if ">" in buffer[last_lt:]:
-            # The last `<...>` is closed. Everything is safe.
             return buffer, ""
-
-        # The last `<` is unclosed — push it (and everything after) into the tail
-        # so it can be completed by future chunks before unmasking runs on it.
+        # The last `<` is unclosed — push it (and everything after) into the tail.
         return buffer[:last_lt], buffer[last_lt:]
 
     # Incremental flush thresholds for apply_to_output streaming.
@@ -1276,11 +1272,25 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         return self._build_streaming_text_chunk(template, masked)
 
     def _mask_flush_due(self, buffer: str) -> bool:
-        """Return True when `buffer` has reached a Presidio-mask flush boundary."""
-        if len(buffer) >= self._STREAM_MASK_FLUSH_CHARS:
-            return True
+        """Return True when `buffer` has reached a Presidio-mask flush boundary.
+
+        Boundaries (in priority order):
+        1. Sentence enders (`.`, `!`, `?`, newline) — natural semantic units;
+           multi-token entities are highly unlikely to straddle them.
+        2. `_STREAM_MASK_FLUSH_CHARS` chars **AND** buffer ends on whitespace
+           — a word boundary, so we never cut mid-token. This keeps TTFT
+           bounded on long sentences without splitting multi-word entities
+           like "John Smith" across two Presidio calls.
+
+        Returns False otherwise so the buffer continues to accumulate until a
+        safe boundary appears.
+        """
         stripped = buffer.rstrip()
-        return bool(stripped) and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS
+        if stripped and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS:
+            return True
+        if len(buffer) >= self._STREAM_MASK_FLUSH_CHARS and buffer[-1:].isspace():
+            return True
+        return False
 
     async def _stream_apply_output_masking(
         self,
@@ -1418,7 +1428,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 yield chunk
             return
 
-        max_token_len = max(len(t) for t in pii_tokens.keys())
         buffer = ""
         template: Optional[ModelResponseStream] = None
 
@@ -1437,9 +1446,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 template = chunk
                 if self._is_streaming_chunk_with_content(chunk):
                     buffer += chunk.choices[0].delta.content
-                    safe, tail = self._split_unmask_safe_prefix(
-                        buffer, pii_tokens, max_token_len
-                    )
+                    safe, tail = self._split_unmask_safe_prefix(buffer, pii_tokens)
                     if safe:
                         flushed = self._unmask_buffer_to_chunk(
                             safe, template, pii_tokens

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1206,6 +1206,58 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             ],
         )
 
+    async def _mask_tool_call_arguments_in_chunk(
+        self,
+        chunk: "ModelResponseStream",
+        presidio_config: Optional[PresidioPerRequestConfig],
+        request_data: dict,
+    ) -> "ModelResponseStream":
+        """Run Presidio masking over the `function.arguments` of each tool_call delta
+        in `chunk`. Returns the same chunk reference with masked arguments — or
+        unchanged on Presidio failure so the client still receives a response.
+
+        Veria HIGH: with `apply_to_output=True`, prior code yielded tool_call
+        chunks untouched, allowing a model to bypass output masking by emitting
+        PII inside `function.arguments`. This helper closes that bypass.
+        """
+        if not chunk.choices:
+            return chunk
+        delta = getattr(chunk.choices[0], "delta", None)
+        tool_calls = getattr(delta, "tool_calls", None) or []
+        if not tool_calls:
+            return chunk
+        for tc in tool_calls:
+            fn = getattr(tc, "function", None)
+            if fn is None:
+                continue
+            args = getattr(fn, "arguments", None)
+            if not isinstance(args, str) or not args:
+                continue
+            try:
+                masked_args = await self.check_pii(
+                    text=args,
+                    output_parse_pii=False,
+                    presidio_config=presidio_config,
+                    request_data=request_data,
+                )
+            except Exception as exc:  # noqa: BLE001
+                verbose_proxy_logger.error(
+                    "Presidio apply_to_output: tool_call arguments mask failed (%s); "
+                    "emitting %d chars unmasked",
+                    type(exc).__name__,
+                    len(args),
+                )
+                continue
+            try:
+                fn.arguments = masked_args
+            except Exception:  # noqa: BLE001
+                # Pydantic models sometimes block setattr; fall back to dict-style assignment.
+                try:
+                    fn.__dict__["arguments"] = masked_args  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+        return chunk
+
     @staticmethod
     def _build_streaming_text_chunk(
         template: "ModelResponseStream", text: str
@@ -1271,11 +1323,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # The last `<` is unclosed — push it (and everything after) into the tail.
         return buffer[:last_lt], buffer[last_lt:]
 
-    # Incremental flush thresholds for apply_to_output streaming.
-    # Chosen so the first masked chunk reaches the client within a sentence or
-    # ~80 chars (whichever comes first), keeping Presidio call rate bounded
-    # while restoring progressive streaming UX.
-    _STREAM_MASK_FLUSH_CHARS: int = 80
+    # Sentence boundaries that trigger an incremental mask flush. Any PII entity
+    # legitimately spanning two sentences is rare for the classes Presidio detects,
+    # so these are safer flush points than a char-limit fallback (which Veria flagged
+    # as a HIGH-risk bypass class — fragmented PII straddling a 80-char window).
+    _STREAM_MASK_FLUSH_CHARS: int = 80  # Retained for back-compat; not consulted.
     _STREAM_MASK_SENTENCE_ENDERS: tuple = (".", "!", "?", "\n")
 
     async def _mask_buffer_to_chunk(
@@ -1311,25 +1363,21 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         return self._build_streaming_text_chunk(template, masked)
 
     def _mask_flush_due(self, buffer: str) -> bool:
-        """Return True when `buffer` has reached a Presidio-mask flush boundary.
+        """Return True when `buffer` ends on a sentence boundary that is safe to flush.
 
-        Boundaries (in priority order):
-        1. Sentence enders (`.`, `!`, `?`, newline) — natural semantic units;
-           multi-token entities are highly unlikely to straddle them.
-        2. `_STREAM_MASK_FLUSH_CHARS` chars **AND** buffer ends on whitespace
-           — a word boundary, so we never cut mid-token. This keeps TTFT
-           bounded on long sentences without splitting multi-word entities
-           like "John Smith" across two Presidio calls.
+        Boundaries: `.`, `!`, `?`, newline — natural semantic units. A PII entity
+        that legitimately spans two sentences is exceedingly rare for the entity
+        classes Presidio detects (names, emails, phone numbers, credit cards,
+        addresses), so flushing at these boundaries gives progressive streaming
+        without the entity-fragmentation risk a char-limit-only fallback would
+        introduce (Veria HIGH: `4111 ` / `1111 1111 1111` split bypass).
 
-        Returns False otherwise so the buffer continues to accumulate until a
-        safe boundary appears.
+        A pathological stream that never emits a sentence ender accumulates the
+        whole response into `buffer` and is flushed exactly once at end-of-stream,
+        matching the prior buffered behaviour for that case.
         """
         stripped = buffer.rstrip()
-        if stripped and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS:
-            return True
-        if len(buffer) >= self._STREAM_MASK_FLUSH_CHARS and buffer[-1:].isspace():
-            return True
-        return False
+        return bool(stripped) and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS
 
     async def _stream_apply_output_masking(
         self,
@@ -1408,14 +1456,18 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                             yield finish_chunk
                     continue
 
-                # Non-text MRS chunk — flush pending masked text first, then pass through.
+                # Non-text MRS chunk — flush pending masked text first, then mask
+                # any tool_call arguments (Veria HIGH: tool_call args bypass) before
+                # yielding.
                 flushed = await self._mask_buffer_to_chunk(
                     buffer, template, presidio_config, request_data
                 )
                 buffer = ""
                 if flushed is not None:
                     yield flushed
-                yield chunk
+                yield await self._mask_tool_call_arguments_in_chunk(
+                    chunk, presidio_config, request_data
+                )
 
             # End of stream — drain.
             if template is not None:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1264,6 +1264,77 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     pass
         return chunk
 
+    async def _mask_all_choices_text_and_tool_calls(
+        self,
+        chunk: "ModelResponseStream",
+        presidio_config: Optional[PresidioPerRequestConfig],
+        request_data: dict,
+    ) -> "ModelResponseStream":
+        """Mask delta.content and function.arguments for EVERY choice in chunk.
+
+        Veria HIGH (round 2): when a client requests n>1 parallel completions,
+        Presidio masking previously only inspected choices[0]; choices 1..N
+        leaked PII unmasked. This helper iterates every choice and masks each
+        text delta plus each tool_call function arguments in place. Falls back
+        to passthrough on per-call failure so the client still receives a
+        response if Presidio errors mid-stream.
+        """
+        for choice in chunk.choices or []:
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                continue
+            content = getattr(delta, "content", None)
+            if isinstance(content, str) and content:
+                try:
+                    masked = await self.check_pii(
+                        text=content,
+                        output_parse_pii=False,
+                        presidio_config=presidio_config,
+                        request_data=request_data,
+                    )
+                    try:
+                        delta.content = masked
+                    except Exception:  # noqa: BLE001 — pydantic v2 frozen models
+                        try:
+                            delta.__dict__["content"] = masked  # type: ignore[attr-defined]
+                        except Exception:
+                            pass
+                except Exception as exc:  # noqa: BLE001
+                    verbose_proxy_logger.error(
+                        "Presidio multi-choice mask failed on choice %s (%s); emitting unmasked",
+                        getattr(choice, "index", "?"),
+                        type(exc).__name__,
+                    )
+            tool_calls = getattr(delta, "tool_calls", None) or []
+            for tc in tool_calls:
+                fn = getattr(tc, "function", None)
+                if fn is None:
+                    continue
+                args = getattr(fn, "arguments", None)
+                if not isinstance(args, str) or not args:
+                    continue
+                try:
+                    masked_args = await self.check_pii(
+                        text=args,
+                        output_parse_pii=False,
+                        presidio_config=presidio_config,
+                        request_data=request_data,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    verbose_proxy_logger.error(
+                        "Presidio multi-choice tool_call mask failed (%s)",
+                        type(exc).__name__,
+                    )
+                    continue
+                try:
+                    fn.arguments = masked_args
+                except Exception:
+                    try:
+                        fn.__dict__["arguments"] = masked_args  # type: ignore[attr-defined]
+                    except Exception:
+                        pass
+        return chunk
+
     @staticmethod
     def _build_streaming_text_chunk(
         template: "ModelResponseStream", text: str
@@ -1372,21 +1443,35 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         return self._build_streaming_text_chunk(template, masked)
 
     def _mask_flush_due(self, buffer: str) -> bool:
-        """Return True when `buffer` ends on a sentence boundary that is safe to flush.
+        r"""Return True when buffer ends on a sentence boundary that is safe to flush.
 
-        Boundaries: `.`, `!`, `?`, newline — natural semantic units. A PII entity
-        that legitimately spans two sentences is exceedingly rare for the entity
-        classes Presidio detects (names, emails, phone numbers, credit cards,
-        addresses), so flushing at these boundaries gives progressive streaming
-        without the entity-fragmentation risk a char-limit-only fallback would
-        introduce (Veria HIGH: `4111 ` / `1111 1111 1111` split bypass).
+        A "safe" boundary is one that cannot occur inside any common PII entity
+        type Presidio detects (emails, phone numbers, URLs, credit cards,
+        addresses). We therefore require:
 
-        A pathological stream that never emits a sentence ender accumulates the
-        whole response into `buffer` and is flushed exactly once at end-of-stream,
-        matching the prior buffered behaviour for that case.
+        * a trailing newline (buffer ends in \n), OR
+        * a sentence-end punctuation (., !, ?) **followed by whitespace
+          inside buffer** — i.e. stripped ends in the punctuation AND
+          buffer != stripped (there is trailing whitespace).
+
+        This rules out jane@example. / com and +1.555. / 0123 splits
+        Veria flagged as a HIGH-risk bypass class: those buffers do NOT have
+        trailing whitespace after the ., so they keep accumulating until a
+        true sentence boundary appears (or end-of-stream).
         """
+        if not buffer:
+            return False
+        # Buffer ending in any whitespace AFTER a newline (or being a newline) flushes.
+        if buffer.endswith(("\n", "\r")):
+            return True
         stripped = buffer.rstrip()
-        return bool(stripped) and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS
+        if not stripped:
+            return False
+        if stripped[-1] not in (".", "!", "?"):
+            return False
+        # Punctuation must be followed by whitespace inside the buffer — i.e.
+        # buffer extends past stripped by at least one whitespace char.
+        return buffer != stripped
 
     async def _stream_apply_output_masking(
         self,
@@ -1445,6 +1530,20 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     continue
 
                 had_mrs = True
+                # Multi-choice (n>1) — handle each choice in place; bypass the
+                # single-choice buffer logic which only inspects choices[0]
+                # (Veria HIGH round 2).
+                if len(chunk.choices) > 1:
+                    flushed = await self._mask_buffer_to_chunk(
+                        buffer, template, presidio_config, request_data
+                    )
+                    buffer = ""
+                    if flushed is not None:
+                        yield flushed
+                    yield await self._mask_all_choices_text_and_tool_calls(
+                        chunk, presidio_config, request_data
+                    )
+                    continue
                 template = chunk  # latest envelope for synthetic flush chunks
 
                 if self._is_streaming_chunk_with_content(chunk):
@@ -1548,6 +1647,43 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     if flushed is not None:
                         yield flushed
                     yield chunk  # type: ignore[misc]
+                    continue
+
+                # Multi-choice (n>1) — unmask each choice in place (Veria HIGH round 2).
+                if len(chunk.choices) > 1:
+                    flushed = self._unmask_buffer_to_chunk(buffer, template, pii_tokens)
+                    buffer = ""
+                    if flushed is not None:
+                        yield flushed
+                    for choice in chunk.choices:
+                        delta = getattr(choice, "delta", None)
+                        if delta is None:
+                            continue
+                        content = getattr(delta, "content", None)
+                        if isinstance(content, str) and content:
+                            unmasked = self._unmask_pii_text(content, pii_tokens)
+                            try:
+                                delta.content = unmasked
+                            except Exception:  # noqa: BLE001
+                                try:
+                                    delta.__dict__["content"] = unmasked
+                                except Exception:
+                                    pass
+                        for tc in getattr(delta, "tool_calls", None) or []:
+                            fn = getattr(tc, "function", None)
+                            if fn is None:
+                                continue
+                            args = getattr(fn, "arguments", None)
+                            if isinstance(args, str) and args:
+                                unmasked_args = self._unmask_pii_text(args, pii_tokens)
+                                try:
+                                    fn.arguments = unmasked_args
+                                except Exception:
+                                    try:
+                                        fn.__dict__["arguments"] = unmasked_args
+                                    except Exception:
+                                        pass
+                    yield chunk
                     continue
 
                 template = chunk

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1147,136 +1147,313 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         )
         return response
 
+    @staticmethod
+    def _is_streaming_chunk_with_content(chunk: Any) -> bool:
+        """Return True if chunk is a ModelResponseStream whose first choice carries text content."""
+        if not isinstance(chunk, ModelResponseStream):
+            return False
+        choices = getattr(chunk, "choices", None) or []
+        if not choices:
+            return False
+        first = choices[0]
+        delta = getattr(first, "delta", None)
+        if delta is None:
+            return False
+        content = getattr(delta, "content", None)
+        if not isinstance(content, str) or not content:
+            return False
+        tool_calls = getattr(delta, "tool_calls", None) or []
+        if tool_calls:
+            return False
+        return getattr(first, "finish_reason", None) is None
+
+    @staticmethod
+    def _build_streaming_text_chunk(
+        template: "ModelResponseStream", text: str
+    ) -> "ModelResponseStream":
+        """Construct a ModelResponseStream that mirrors `template`'s envelope (id / model /
+        created / index / role / system_fingerprint / usage=None) but carries only the
+        provided text in choices[0].delta.content, with finish_reason=None.
+
+        Used to emit incremental masked / unmasked content while preserving the
+        client-visible chunk shape across providers.
+        """
+        from litellm.types.utils import Delta, StreamingChoices
+
+        template_choice = template.choices[0] if template.choices else None
+        template_delta = getattr(template_choice, "delta", None)
+        new_delta = Delta(
+            content=text,
+            role=getattr(template_delta, "role", None) if template_delta else None,
+        )
+        new_choice = StreamingChoices(
+            index=getattr(template_choice, "index", 0) if template_choice else 0,
+            delta=new_delta,
+            finish_reason=None,
+        )
+        return ModelResponseStream(
+            id=getattr(template, "id", None),
+            object="chat.completion.chunk",
+            created=getattr(template, "created", None),
+            model=getattr(template, "model", None),
+            system_fingerprint=getattr(template, "system_fingerprint", None),
+            choices=[new_choice],
+        )
+
+
+    @staticmethod
+    def _split_unmask_safe_prefix(
+        buffer: str, pii_tokens: Dict[str, str], max_token_len: int
+    ) -> Tuple[str, str]:
+        """Split `buffer` into (safe_prefix, held_tail) for incremental PII unmasking.
+
+        Guarantees: no PII token in `pii_tokens` can span the (safe / tail)
+        boundary. The held_tail is kept in the buffer for the next iteration
+        so a token whose `<` arrived in one upstream chunk and `>` arrived in
+        the next still gets rewritten atomically.
+
+        Strategy: PII tokens emitted by `_finalize_presidio_anonymize_numbered_tokens`
+        always have the shape `<ENTITY_N>` — they start with `<` and end with `>`.
+        We therefore find the rightmost `<` whose matching `>` has NOT yet
+        arrived in `buffer`; everything up to that `<` is safe to emit. As a
+        defensive backstop (e.g. if a token does not match this shape) we also
+        never emit the very last `max_token_len - 1` characters unless the buffer
+        is entirely empty of `<`.
+        """
+        if not buffer:
+            return "", buffer
+
+        last_lt = buffer.rfind("<")
+        if last_lt < 0:
+            # No `<` anywhere — entire buffer is safely emittable.
+            return buffer, ""
+
+        # Is the rightmost `<` already closed by a `>` later in the buffer?
+        if ">" in buffer[last_lt:]:
+            # The last `<...>` is closed. Everything is safe.
+            return buffer, ""
+
+        # The last `<` is unclosed — push it (and everything after) into the tail
+        # so it can be completed by future chunks before unmasking runs on it.
+        return buffer[:last_lt], buffer[last_lt:]
+
+    # Incremental flush thresholds for apply_to_output streaming.
+    # Chosen so the first masked chunk reaches the client within a sentence or
+    # ~80 chars (whichever comes first), keeping Presidio call rate bounded
+    # while restoring progressive streaming UX.
+    _STREAM_MASK_FLUSH_CHARS: int = 80
+    _STREAM_MASK_SENTENCE_ENDERS: tuple = (".", "!", "?", "\n")
+
     async def _stream_apply_output_masking(
         self,
         response: Any,
         request_data: dict,
     ) -> AsyncGenerator[Union[ModelResponseStream, bytes], None]:
-        """Apply Presidio masking to streaming output (apply_to_output=True path)."""
-        from litellm.llms.base_llm.base_model_iterator import (
-            convert_model_response_to_streaming,
-        )
-        from litellm.main import stream_chunk_builder
-        from litellm.types.utils import ModelResponse
+        """Apply Presidio masking to streaming output (apply_to_output=True path).
 
-        all_chunks: List[ModelResponseStream] = []
-        passthrough_due_to_unknown_stream_shape = False
+        Streams progressively: accumulates text-content chunks into a small buffer
+        and flushes through Presidio analyze/anonymize whenever the buffer crosses
+        a sentence boundary OR reaches `_STREAM_MASK_FLUSH_CHARS`. Non-text events
+        (bytes, role/tool_calls/finish_reason chunks, /v1/responses events) pass
+        through immediately. This fixes the prior behaviour of buffering the entire
+        stream and emitting one synthetic chunk at end-of-stream (LIT-3222).
+        """
+        presidio_config = self.get_presidio_settings_from_request_data(
+            request_data or {}
+        )
+
+        buffer: str = ""
+        template: Optional[ModelResponseStream] = None
+        saw_unknown_event_warning_emitted = False
+        had_any_modelresponsestream = False
+        had_any_byte_chunk = False
+
+        async def _flush() -> AsyncGenerator[ModelResponseStream, None]:
+            """Mask `buffer` via Presidio and emit a single synthetic chunk, then reset."""
+            nonlocal buffer, template
+            if not buffer or template is None:
+                buffer = ""
+                return
+            text_to_mask = buffer
+            buffer = ""
+            try:
+                masked = await self.check_pii(
+                    text=text_to_mask,
+                    output_parse_pii=False,
+                    presidio_config=presidio_config,
+                    request_data=request_data,
+                )
+            except Exception as flush_exc:  # noqa: BLE001 — degrade gracefully
+                verbose_proxy_logger.error(
+                    "Presidio apply_to_output: incremental mask failed (%s); emitting %d chars unmasked",
+                    type(flush_exc).__name__,
+                    len(text_to_mask),
+                )
+                masked = text_to_mask
+            if masked:
+                yield self._build_streaming_text_chunk(template, masked)
+
         try:
             async for chunk in response:
-                if isinstance(chunk, ModelResponseStream):
-                    if passthrough_due_to_unknown_stream_shape:
-                        yield chunk
-                    else:
-                        all_chunks.append(chunk)
-                elif isinstance(chunk, bytes):
+                if isinstance(chunk, bytes):
+                    had_any_byte_chunk = True
+                    async for flushed in _flush():
+                        yield flushed
                     yield chunk  # type: ignore[misc]
                     continue
-                else:
-                    if all_chunks:
-                        # Flush buffered chunks and switch to transparent passthrough for this stream shape.
-                        # NOTE: these buffered chunks are emitted unmasked because this
-                        # stream mixed chunk types and cannot be safely reconstructed.
+
+                if not isinstance(chunk, ModelResponseStream):
+                    # Unknown event object (e.g. /v1/responses lifecycle event).
+                    # Flush any pending masked text first, then pass the event through.
+                    async for flushed in _flush():
+                        yield flushed
+                    if not saw_unknown_event_warning_emitted and had_any_modelresponsestream:
                         verbose_proxy_logger.warning(
                             "Presidio apply_to_output: mixed stream detected (ModelResponseStream + unknown event). "
-                            "Flushing %d buffered chunks without PII masking and switching to transparent passthrough.",
-                            len(all_chunks),
+                            "Switching to transparent passthrough for non-ModelResponseStream events; "
+                            "previously buffered text was masked and emitted before this point."
                         )
-                        for buffered_chunk in all_chunks:
-                            yield buffered_chunk
-                        all_chunks = []
-                    passthrough_due_to_unknown_stream_shape = True
+                        saw_unknown_event_warning_emitted = True
                     yield chunk
-            if passthrough_due_to_unknown_stream_shape:
-                verbose_proxy_logger.warning(
-                    "Presidio apply_to_output: streaming response contained unknown event objects "
-                    "(e.g. /v1/responses events). Output PII masking was skipped for this response."
-                )
-                return
-            if not all_chunks:
+                    continue
+
+                had_any_modelresponsestream = True
+                # Keep latest ModelResponseStream as the envelope template for synthetic flush chunks.
+                template = chunk
+
+                if self._is_streaming_chunk_with_content(chunk):
+                    delta = chunk.choices[0].delta
+                    content = delta.content
+                    buffer += content
+                    stripped = buffer.rstrip()
+                    should_flush = (
+                        len(buffer) >= self._STREAM_MASK_FLUSH_CHARS
+                        or (stripped and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS)
+                    )
+                    if should_flush:
+                        async for flushed in _flush():
+                            yield flushed
+                    continue
+
+                # Non-text MRS chunk (role-only, tool_calls, finish_reason, empty choices).
+                # Flush pending buffer first so client sees consistent ordering, then pass through.
+                async for flushed in _flush():
+                    yield flushed
+                yield chunk
+
+            # End of stream — flush any pending text.
+            async for flushed in _flush():
+                yield flushed
+
+            if not had_any_modelresponsestream and had_any_byte_chunk:
                 verbose_proxy_logger.warning(
                     "Presidio apply_to_output: streaming response contained only "
                     "bytes chunks (Anthropic native SSE). Output PII masking was "
                     "skipped for this response."
                 )
-                return
-
-            assembled_model_response = stream_chunk_builder(
-                chunks=all_chunks, messages=request_data.get("messages")
-            )
-
-            if not isinstance(assembled_model_response, ModelResponse):
-                for chunk in all_chunks:
-                    yield chunk
-                return
-
-            await self._process_response_for_pii(
-                response=assembled_model_response,
-                request_data=request_data,
-                mode="mask",
-            )
-
-            mock_response_stream = convert_model_response_to_streaming(
-                assembled_model_response
-            )
-            yield mock_response_stream
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error masking streaming PII output: {str(e)}")
-            for chunk in all_chunks:
-                yield chunk
+            verbose_proxy_logger.error(
+                f"Error masking streaming PII output: {str(e)}"
+            )
+            # Best-effort: emit whatever text we accumulated (unmasked) so the client
+            # at least gets the partial response instead of nothing.
+            if buffer and template is not None:
+                try:
+                    yield self._build_streaming_text_chunk(template, buffer)
+                except Exception:  # noqa: BLE001
+                    pass
 
     async def _stream_pii_unmasking(
         self,
         response: Any,
         request_data: dict,
     ) -> AsyncGenerator[Union[ModelResponseStream, bytes], None]:
-        """Apply PII unmasking to streaming output (output_parse_pii=True path)."""
-        from litellm.llms.base_llm.base_model_iterator import (
-            convert_model_response_to_streaming,
-        )
-        from litellm.main import stream_chunk_builder
-        from litellm.types.utils import ModelResponse
+        """Apply PII unmasking to streaming output (output_parse_pii=True path).
 
-        remaining_chunks: List[ModelResponseStream] = []
+        Streams progressively: each text-content chunk is unmasked as it arrives.
+        A trailing buffer equal in length to the longest `<ENTITY_N>` token is held
+        back so PII tokens that span chunk boundaries are still rewritten correctly
+        before being flushed at end-of-stream. Non-text events pass through
+        immediately. Replaces the prior buffer-the-whole-stream behaviour (LIT-3222).
+        """
+        metadata = (request_data.get("metadata") or {}) if request_data else {}
+        pii_tokens: Dict[str, str] = metadata.get("pii_tokens") or {}
+        # Caller already gates on `pii_tokens` truthiness; defensive guard for direct callers.
+        if not pii_tokens:
+            async for chunk in response:
+                yield chunk
+            return
+
+        # Hold back enough characters at the buffer tail to cover the longest known
+        # token, so a token split across chunk boundaries still gets rewritten.
+        max_token_len = max(len(t) for t in pii_tokens.keys())
+
+        buffer: str = ""
+        template: Optional[ModelResponseStream] = None
+
+        def _flush_immediately(text: str) -> Optional[ModelResponseStream]:
+            if not text or template is None:
+                return None
+            return self._build_streaming_text_chunk(
+                template, self._unmask_pii_text(text, pii_tokens)
+            )
+
         try:
             async for chunk in response:
-                if isinstance(chunk, ModelResponseStream):
-                    remaining_chunks.append(chunk)
-                elif isinstance(chunk, bytes):
+                if isinstance(chunk, bytes):
+                    flushed = _flush_immediately(buffer)
+                    buffer = ""
+                    if flushed is not None:
+                        yield flushed
                     yield chunk  # type: ignore[misc]
                     continue
 
-            if not remaining_chunks:
-                return
-
-            assembled_model_response = stream_chunk_builder(
-                chunks=remaining_chunks, messages=request_data.get("messages")
-            )
-
-            if not isinstance(assembled_model_response, ModelResponse):
-                for chunk in remaining_chunks:
+                if not isinstance(chunk, ModelResponseStream):
+                    flushed = _flush_immediately(buffer)
+                    buffer = ""
+                    if flushed is not None:
+                        yield flushed
                     yield chunk
-                return
+                    continue
 
-            self._preserve_usage_from_last_chunk(
-                assembled_model_response, remaining_chunks
-            )
+                template = chunk
 
-            await self._process_response_for_pii(
-                response=assembled_model_response,
-                request_data=request_data,
-                mode="unmask",
-            )
+                if self._is_streaming_chunk_with_content(chunk):
+                    buffer += chunk.choices[0].delta.content
+                    safe, tail = self._split_unmask_safe_prefix(
+                        buffer, pii_tokens, max_token_len
+                    )
+                    if safe:
+                        flushed = _flush_immediately(safe)
+                        buffer = tail
+                        if flushed is not None:
+                            yield flushed
+                    continue
 
-            mock_response_stream = convert_model_response_to_streaming(
-                assembled_model_response
-            )
-            yield mock_response_stream
+                # Non-text MRS chunk — flush pending text first, then pass through.
+                flushed = _flush_immediately(buffer)
+                buffer = ""
+                if flushed is not None:
+                    yield flushed
+                yield chunk
+
+            # End of stream — drain the trailing buffer.
+            flushed = _flush_immediately(buffer)
+            buffer = ""
+            if flushed is not None:
+                yield flushed
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
-            for chunk in remaining_chunks:
-                yield chunk
+            verbose_proxy_logger.error(
+                f"Error in PII streaming processing: {str(e)}"
+            )
+            # Best-effort: emit pending buffer unmasked so the client still gets data.
+            if buffer and template is not None:
+                try:
+                    yield self._build_streaming_text_chunk(template, buffer)
+                except Exception:  # noqa: BLE001
+                    pass
 
     async def async_post_call_streaming_iterator_hook(  # type: ignore[override]
         self,

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1149,7 +1149,15 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
     @staticmethod
     def _is_streaming_chunk_with_content(chunk: Any) -> bool:
-        """Return True if chunk is a ModelResponseStream whose first choice carries text content."""
+        """Return True if chunk is a ModelResponseStream whose first choice carries text content.
+
+        IMPORTANT: a chunk that carries BOTH `delta.content` and `finish_reason`
+        (some Bedrock Converse / OpenAI-compatible providers emit a combined final
+        chunk) still returns True here, so the text portion goes through the
+        masking / unmasking pipeline. Callers must subsequently emit a separate
+        finish-only chunk for the `finish_reason` payload via
+        `_clone_chunk_finish_only`.
+        """
         if not isinstance(chunk, ModelResponseStream):
             return False
         choices = getattr(chunk, "choices", None) or []
@@ -1165,7 +1173,38 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         tool_calls = getattr(delta, "tool_calls", None) or []
         if tool_calls:
             return False
-        return getattr(first, "finish_reason", None) is None
+        return True
+
+    @staticmethod
+    def _clone_chunk_finish_only(
+        chunk: "ModelResponseStream",
+    ) -> Optional["ModelResponseStream"]:
+        """Build a finish-reason-only mirror of `chunk` (content stripped, tool_calls stripped).
+
+        Returns None if the source chunk has no `finish_reason` to convey.
+        """
+        from litellm.types.utils import Delta, StreamingChoices
+
+        if not chunk.choices:
+            return None
+        src_choice = chunk.choices[0]
+        finish_reason = getattr(src_choice, "finish_reason", None)
+        if finish_reason is None:
+            return None
+        return ModelResponseStream(
+            id=getattr(chunk, "id", None),
+            object="chat.completion.chunk",
+            created=getattr(chunk, "created", None),
+            model=getattr(chunk, "model", None),
+            system_fingerprint=getattr(chunk, "system_fingerprint", None),
+            choices=[
+                StreamingChoices(
+                    index=getattr(src_choice, "index", 0),
+                    delta=Delta(content=None),
+                    finish_reason=finish_reason,
+                )
+            ],
+        )
 
     @staticmethod
     def _build_streaming_text_chunk(
@@ -1353,13 +1392,20 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
                 if self._is_streaming_chunk_with_content(chunk):
                     buffer += chunk.choices[0].delta.content
-                    if self._mask_flush_due(buffer):
+                    has_finish = (
+                        getattr(chunk.choices[0], "finish_reason", None) is not None
+                    )
+                    if has_finish or self._mask_flush_due(buffer):
                         flushed = await self._mask_buffer_to_chunk(
                             buffer, template, presidio_config, request_data
                         )
                         buffer = ""
                         if flushed is not None:
                             yield flushed
+                    if has_finish:
+                        finish_chunk = self._clone_chunk_finish_only(chunk)
+                        if finish_chunk is not None:
+                            yield finish_chunk
                     continue
 
                 # Non-text MRS chunk — flush pending masked text first, then pass through.
@@ -1446,6 +1492,23 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 template = chunk
                 if self._is_streaming_chunk_with_content(chunk):
                     buffer += chunk.choices[0].delta.content
+                    has_finish = (
+                        getattr(chunk.choices[0], "finish_reason", None) is not None
+                    )
+                    if has_finish:
+                        # End-of-stream — flush ALL pending text through unmasking
+                        # then emit a finish-only chunk, so an unclosed token
+                        # in the tail doesn't get lost.
+                        flushed = self._unmask_buffer_to_chunk(
+                            buffer, template, pii_tokens
+                        )
+                        buffer = ""
+                        if flushed is not None:
+                            yield flushed
+                        finish_chunk = self._clone_chunk_finish_only(chunk)
+                        if finish_chunk is not None:
+                            yield finish_chunk
+                        continue
                     safe, tail = self._split_unmask_safe_prefix(buffer, pii_tokens)
                     if safe:
                         flushed = self._unmask_buffer_to_chunk(

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1197,6 +1197,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             created=getattr(chunk, "created", None),
             model=getattr(chunk, "model", None),
             system_fingerprint=getattr(chunk, "system_fingerprint", None),
+            # Forward usage from the source chunk (Bedrock Converse + OpenAI
+            # `stream_options: include_usage=True` embed token counts in the
+            # combined content+finish chunk; the finish-only clone is the only
+            # terminal chunk emitted in that case, so dropping it would lose
+            # the token-count payload — Greptile P1).
+            usage=getattr(chunk, "usage", None),
             choices=[
                 StreamingChoices(
                     index=getattr(src_choice, "index", 0),
@@ -1288,6 +1294,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             created=getattr(template, "created", None),
             model=getattr(template, "model", None),
             system_fingerprint=getattr(template, "system_fingerprint", None),
+            # Forward usage from the template chunk (some providers carry usage
+            # on every chunk, not just the last one).
+            usage=getattr(template, "usage", None),
             choices=[new_choice],
         )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1243,6 +1243,45 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
     _STREAM_MASK_FLUSH_CHARS: int = 80
     _STREAM_MASK_SENTENCE_ENDERS: tuple = (".", "!", "?", "\n")
 
+    async def _mask_buffer_to_chunk(
+        self,
+        buffer: str,
+        template: "ModelResponseStream",
+        presidio_config: Optional[PresidioPerRequestConfig],
+        request_data: dict,
+    ) -> Optional["ModelResponseStream"]:
+        """Run Presidio masking on `buffer` and return one synthetic streaming chunk.
+
+        Returns None when there is nothing to emit. On Presidio failure, logs and
+        emits the buffer unmasked so the client still receives partial output.
+        """
+        if not buffer:
+            return None
+        try:
+            masked = await self.check_pii(
+                text=buffer,
+                output_parse_pii=False,
+                presidio_config=presidio_config,
+                request_data=request_data,
+            )
+        except Exception as flush_exc:  # noqa: BLE001 — degrade gracefully
+            verbose_proxy_logger.error(
+                "Presidio apply_to_output: incremental mask failed (%s); emitting %d chars unmasked",
+                type(flush_exc).__name__,
+                len(buffer),
+            )
+            masked = buffer
+        if not masked:
+            return None
+        return self._build_streaming_text_chunk(template, masked)
+
+    def _mask_flush_due(self, buffer: str) -> bool:
+        """Return True when `buffer` has reached a Presidio-mask flush boundary."""
+        if len(buffer) >= self._STREAM_MASK_FLUSH_CHARS:
+            return True
+        stripped = buffer.rstrip()
+        return bool(stripped) and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS
+
     async def _stream_apply_output_masking(
         self,
         response: Any,
@@ -1261,92 +1300,77 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             request_data or {}
         )
 
-        buffer: str = ""
+        buffer = ""
         template: Optional[ModelResponseStream] = None
-        saw_unknown_event_warning_emitted = False
-        had_any_modelresponsestream = False
-        had_any_byte_chunk = False
-
-        async def _flush() -> AsyncGenerator[ModelResponseStream, None]:
-            """Mask `buffer` via Presidio and emit a single synthetic chunk, then reset."""
-            nonlocal buffer, template
-            if not buffer or template is None:
-                buffer = ""
-                return
-            text_to_mask = buffer
-            buffer = ""
-            try:
-                masked = await self.check_pii(
-                    text=text_to_mask,
-                    output_parse_pii=False,
-                    presidio_config=presidio_config,
-                    request_data=request_data,
-                )
-            except Exception as flush_exc:  # noqa: BLE001 — degrade gracefully
-                verbose_proxy_logger.error(
-                    "Presidio apply_to_output: incremental mask failed (%s); emitting %d chars unmasked",
-                    type(flush_exc).__name__,
-                    len(text_to_mask),
-                )
-                masked = text_to_mask
-            if masked:
-                yield self._build_streaming_text_chunk(template, masked)
+        had_mrs = False
+        had_bytes = False
+        warned_mixed = False
 
         try:
             async for chunk in response:
                 if isinstance(chunk, bytes):
-                    had_any_byte_chunk = True
-                    async for flushed in _flush():
-                        yield flushed
+                    had_bytes = True
+                    if template is not None:
+                        flushed = await self._mask_buffer_to_chunk(
+                            buffer, template, presidio_config, request_data
+                        )
+                        buffer = ""
+                        if flushed is not None:
+                            yield flushed
                     yield chunk  # type: ignore[misc]
                     continue
 
                 if not isinstance(chunk, ModelResponseStream):
-                    # Unknown event object (e.g. /v1/responses lifecycle event).
-                    # Flush any pending masked text first, then pass the event through.
-                    async for flushed in _flush():
-                        yield flushed
-                    if (
-                        not saw_unknown_event_warning_emitted
-                        and had_any_modelresponsestream
-                    ):
+                    if template is not None:
+                        flushed = await self._mask_buffer_to_chunk(
+                            buffer, template, presidio_config, request_data
+                        )
+                        buffer = ""
+                        if flushed is not None:
+                            yield flushed
+                    if not warned_mixed and had_mrs:
                         verbose_proxy_logger.warning(
                             "Presidio apply_to_output: mixed stream detected (ModelResponseStream + unknown event). "
                             "Switching to transparent passthrough for non-ModelResponseStream events; "
                             "previously buffered text was masked and emitted before this point."
                         )
-                        saw_unknown_event_warning_emitted = True
+                        warned_mixed = True
                     yield chunk
                     continue
 
-                had_any_modelresponsestream = True
-                # Keep latest ModelResponseStream as the envelope template for synthetic flush chunks.
-                template = chunk
+                had_mrs = True
+                template = chunk  # latest envelope for synthetic flush chunks
 
                 if self._is_streaming_chunk_with_content(chunk):
-                    delta = chunk.choices[0].delta
-                    content = delta.content
-                    buffer += content
-                    stripped = buffer.rstrip()
-                    should_flush = len(buffer) >= self._STREAM_MASK_FLUSH_CHARS or (
-                        stripped and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS
-                    )
-                    if should_flush:
-                        async for flushed in _flush():
+                    buffer += chunk.choices[0].delta.content
+                    if self._mask_flush_due(buffer):
+                        flushed = await self._mask_buffer_to_chunk(
+                            buffer, template, presidio_config, request_data
+                        )
+                        buffer = ""
+                        if flushed is not None:
                             yield flushed
                     continue
 
-                # Non-text MRS chunk (role-only, tool_calls, finish_reason, empty choices).
-                # Flush pending buffer first so client sees consistent ordering, then pass through.
-                async for flushed in _flush():
+                # Non-text MRS chunk — flush pending masked text first, then pass through.
+                flushed = await self._mask_buffer_to_chunk(
+                    buffer, template, presidio_config, request_data
+                )
+                buffer = ""
+                if flushed is not None:
                     yield flushed
                 yield chunk
 
-            # End of stream — flush any pending text.
-            async for flushed in _flush():
-                yield flushed
+            # End of stream — drain.
+            if template is not None:
+                flushed = await self._mask_buffer_to_chunk(
+                    buffer, template, presidio_config, request_data
+                )
+                buffer = ""
+                if flushed is not None:
+                    yield flushed
 
-            if not had_any_modelresponsestream and had_any_byte_chunk:
+            if not had_mrs and had_bytes:
                 verbose_proxy_logger.warning(
                     "Presidio apply_to_output: streaming response contained only "
                     "bytes chunks (Anthropic native SSE). Output PII masking was "
@@ -1355,13 +1379,24 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error masking streaming PII output: {str(e)}")
-            # Best-effort: emit whatever text we accumulated (unmasked) so the client
-            # at least gets the partial response instead of nothing.
             if buffer and template is not None:
                 try:
                     yield self._build_streaming_text_chunk(template, buffer)
                 except Exception:  # noqa: BLE001
                     pass
+
+    def _unmask_buffer_to_chunk(
+        self,
+        text: str,
+        template: Optional["ModelResponseStream"],
+        pii_tokens: Dict[str, str],
+    ) -> Optional["ModelResponseStream"]:
+        """Unmask `text` and return a synthetic streaming chunk; None if nothing to emit."""
+        if not text or template is None:
+            return None
+        return self._build_streaming_text_chunk(
+            template, self._unmask_pii_text(text, pii_tokens)
+        )
 
     async def _stream_pii_unmasking(
         self,
@@ -1371,81 +1406,64 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         """Apply PII unmasking to streaming output (output_parse_pii=True path).
 
         Streams progressively: each text-content chunk is unmasked as it arrives.
-        A trailing buffer equal in length to the longest `<ENTITY_N>` token is held
-        back so PII tokens that span chunk boundaries are still rewritten correctly
-        before being flushed at end-of-stream. Non-text events pass through
-        immediately. Replaces the prior buffer-the-whole-stream behaviour (LIT-3222).
+        A trailing buffer (via `_split_unmask_safe_prefix`) holds back any unclosed
+        `<...` prefix so PII tokens that span upstream chunk boundaries are still
+        rewritten atomically. Non-text events pass through immediately. Replaces
+        the prior buffer-the-whole-stream behaviour (LIT-3222).
         """
         metadata = (request_data.get("metadata") or {}) if request_data else {}
         pii_tokens: Dict[str, str] = metadata.get("pii_tokens") or {}
-        # Caller already gates on `pii_tokens` truthiness; defensive guard for direct callers.
         if not pii_tokens:
             async for chunk in response:
                 yield chunk
             return
 
-        # Hold back enough characters at the buffer tail to cover the longest known
-        # token, so a token split across chunk boundaries still gets rewritten.
         max_token_len = max(len(t) for t in pii_tokens.keys())
-
-        buffer: str = ""
+        buffer = ""
         template: Optional[ModelResponseStream] = None
-
-        def _flush_immediately(text: str) -> Optional[ModelResponseStream]:
-            if not text or template is None:
-                return None
-            return self._build_streaming_text_chunk(
-                template, self._unmask_pii_text(text, pii_tokens)
-            )
 
         try:
             async for chunk in response:
-                if isinstance(chunk, bytes):
-                    flushed = _flush_immediately(buffer)
+                if isinstance(chunk, bytes) or not isinstance(
+                    chunk, ModelResponseStream
+                ):
+                    flushed = self._unmask_buffer_to_chunk(buffer, template, pii_tokens)
                     buffer = ""
                     if flushed is not None:
                         yield flushed
                     yield chunk  # type: ignore[misc]
                     continue
 
-                if not isinstance(chunk, ModelResponseStream):
-                    flushed = _flush_immediately(buffer)
-                    buffer = ""
-                    if flushed is not None:
-                        yield flushed
-                    yield chunk
-                    continue
-
                 template = chunk
-
                 if self._is_streaming_chunk_with_content(chunk):
                     buffer += chunk.choices[0].delta.content
                     safe, tail = self._split_unmask_safe_prefix(
                         buffer, pii_tokens, max_token_len
                     )
                     if safe:
-                        flushed = _flush_immediately(safe)
+                        flushed = self._unmask_buffer_to_chunk(
+                            safe, template, pii_tokens
+                        )
                         buffer = tail
                         if flushed is not None:
                             yield flushed
                     continue
 
                 # Non-text MRS chunk — flush pending text first, then pass through.
-                flushed = _flush_immediately(buffer)
+                flushed = self._unmask_buffer_to_chunk(buffer, template, pii_tokens)
                 buffer = ""
                 if flushed is not None:
                     yield flushed
                 yield chunk
 
             # End of stream — drain the trailing buffer.
-            flushed = _flush_immediately(buffer)
+            flushed = self._unmask_buffer_to_chunk(buffer, template, pii_tokens)
             buffer = ""
             if flushed is not None:
                 yield flushed
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
-            # Best-effort: emit pending buffer unmasked so the client still gets data.
             if buffer and template is not None:
                 try:
                     yield self._build_streaming_text_chunk(template, buffer)

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1413,16 +1413,17 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
     async def _mask_buffer_to_chunk(
         self,
         buffer: str,
-        template: "ModelResponseStream",
+        template: Optional["ModelResponseStream"],
         presidio_config: Optional[PresidioPerRequestConfig],
         request_data: dict,
     ) -> Optional["ModelResponseStream"]:
         """Run Presidio masking on `buffer` and return one synthetic streaming chunk.
 
-        Returns None when there is nothing to emit. On Presidio failure, logs and
+        Returns None when there is nothing to emit (empty buffer or no template
+        ModelResponseStream has been observed yet). On Presidio failure, logs and
         emits the buffer unmasked so the client still receives partial output.
         """
-        if not buffer:
+        if not buffer or template is None:
             return None
         try:
             masked = await self.check_pii(

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1333,6 +1333,31 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         fn.__dict__["arguments"] = masked_args  # type: ignore[attr-defined]
                     except Exception:
                         pass
+            # Legacy `delta.function_call.arguments` (pre-tool_calls API). Some providers
+            # still emit this on the streaming response — mask it the same way.
+            function_call = getattr(delta, "function_call", None)
+            if function_call is not None:
+                fc_args = getattr(function_call, "arguments", None)
+                if isinstance(fc_args, str) and fc_args:
+                    try:
+                        masked_fc = await self.check_pii(
+                            text=fc_args,
+                            output_parse_pii=False,
+                            presidio_config=presidio_config,
+                            request_data=request_data,
+                        )
+                        try:
+                            function_call.arguments = masked_fc
+                        except Exception:  # noqa: BLE001
+                            try:
+                                function_call.__dict__["arguments"] = masked_fc
+                            except Exception:
+                                pass
+                    except Exception as exc:  # noqa: BLE001
+                        verbose_proxy_logger.error(
+                            "Presidio multi-choice legacy function_call mask failed (%s)",
+                            type(exc).__name__,
+                        )
         return chunk
 
     @staticmethod
@@ -1365,9 +1390,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             created=getattr(template, "created", None),
             model=getattr(template, "model", None),
             system_fingerprint=getattr(template, "system_fingerprint", None),
-            # Forward usage from the template chunk (some providers carry usage
-            # on every chunk, not just the last one).
-            usage=getattr(template, "usage", None),
+            # NOTE: intentionally do NOT forward `usage` from the template here —
+            # for the combined content+finish+usage case the same payload also
+            # rides on the finish-only clone, and downstream consumers that sum
+            # token counts across all non-None usage fields would double-count.
+            # Usage forwarding is the responsibility of `_clone_chunk_finish_only`.
             choices=[new_choice],
         )
 
@@ -1682,6 +1709,21 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                                 except Exception:
                                     try:
                                         fn.__dict__["arguments"] = unmasked_args
+                                    except Exception:
+                                        pass
+                        # Legacy `delta.function_call` path.
+                        function_call = getattr(delta, "function_call", None)
+                        if function_call is not None:
+                            fc_args = getattr(function_call, "arguments", None)
+                            if isinstance(fc_args, str) and fc_args:
+                                unmasked_fc = self._unmask_pii_text(fc_args, pii_tokens)
+                                try:
+                                    function_call.arguments = unmasked_fc
+                                except Exception:
+                                    try:
+                                        function_call.__dict__["arguments"] = (
+                                            unmasked_fc
+                                        )
                                     except Exception:
                                         pass
                     yield chunk

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1229,8 +1229,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         if not chunk.choices:
             return chunk
         delta = getattr(chunk.choices[0], "delta", None)
+        if delta is None:
+            return chunk
         tool_calls = getattr(delta, "tool_calls", None) or []
-        if not tool_calls:
+        function_call = getattr(delta, "function_call", None)
+        if not tool_calls and function_call is None:
             return chunk
         for tc in tool_calls:
             fn = getattr(tc, "function", None)
@@ -1262,6 +1265,29 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     fn.__dict__["arguments"] = masked_args  # type: ignore[attr-defined]
                 except Exception:
                     pass
+        # Legacy `delta.function_call.arguments` path.
+        if function_call is not None:
+            fc_args = getattr(function_call, "arguments", None)
+            if isinstance(fc_args, str) and fc_args:
+                try:
+                    masked_fc = await self.check_pii(
+                        text=fc_args,
+                        output_parse_pii=False,
+                        presidio_config=presidio_config,
+                        request_data=request_data,
+                    )
+                    try:
+                        function_call.arguments = masked_fc
+                    except Exception:  # noqa: BLE001
+                        try:
+                            function_call.__dict__["arguments"] = masked_fc
+                        except Exception:
+                            pass
+                except Exception as exc:  # noqa: BLE001
+                    verbose_proxy_logger.error(
+                        "Presidio apply_to_output: legacy function_call mask failed (%s)",
+                        type(exc).__name__,
+                    )
         return chunk
 
     async def _mask_all_choices_text_and_tool_calls(
@@ -1642,6 +1668,51 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             template, self._unmask_pii_text(text, pii_tokens)
         )
 
+    def _unmask_chunk_tool_calls(
+        self,
+        chunk: "ModelResponseStream",
+        pii_tokens: Dict[str, str],
+    ) -> "ModelResponseStream":
+        """In-place unmask tool_call args and legacy function_call args on chunk.
+
+        Mirrors `_mask_tool_call_arguments_in_chunk` for the unmasking path,
+        so a server response that streams PII tokens inside tool_call or
+        function_call arguments gets rewritten back to the original values.
+        """
+        if not chunk.choices:
+            return chunk
+        delta = getattr(chunk.choices[0], "delta", None)
+        if delta is None:
+            return chunk
+        for tc in getattr(delta, "tool_calls", None) or []:
+            fn = getattr(tc, "function", None)
+            if fn is None:
+                continue
+            args = getattr(fn, "arguments", None)
+            if not isinstance(args, str) or not args:
+                continue
+            unmasked = self._unmask_pii_text(args, pii_tokens)
+            try:
+                fn.arguments = unmasked
+            except Exception:  # noqa: BLE001
+                try:
+                    fn.__dict__["arguments"] = unmasked
+                except Exception:
+                    pass
+        function_call = getattr(delta, "function_call", None)
+        if function_call is not None:
+            fc_args = getattr(function_call, "arguments", None)
+            if isinstance(fc_args, str) and fc_args:
+                unmasked_fc = self._unmask_pii_text(fc_args, pii_tokens)
+                try:
+                    function_call.arguments = unmasked_fc
+                except Exception:
+                    try:
+                        function_call.__dict__["arguments"] = unmasked_fc
+                    except Exception:
+                        pass
+        return chunk
+
     async def _stream_pii_unmasking(
         self,
         response: Any,
@@ -1759,12 +1830,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                             yield flushed
                     continue
 
-                # Non-text MRS chunk — flush pending text first, then pass through.
+                # Non-text MRS chunk — flush pending text first, then unmask any
+                # tool_call / legacy function_call args before yielding (Veria HIGH).
                 flushed = self._unmask_buffer_to_chunk(buffer, template, pii_tokens)
                 buffer = ""
                 if flushed is not None:
                     yield flushed
-                yield chunk
+                yield self._unmask_chunk_tool_calls(chunk, pii_tokens)
 
             # End of stream — drain the trailing buffer.
             flushed = self._unmask_buffer_to_chunk(buffer, template, pii_tokens)

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1200,7 +1200,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             choices=[new_choice],
         )
 
-
     @staticmethod
     def _split_unmask_safe_prefix(
         buffer: str, pii_tokens: Dict[str, str], max_token_len: int
@@ -1307,7 +1306,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     # Flush any pending masked text first, then pass the event through.
                     async for flushed in _flush():
                         yield flushed
-                    if not saw_unknown_event_warning_emitted and had_any_modelresponsestream:
+                    if (
+                        not saw_unknown_event_warning_emitted
+                        and had_any_modelresponsestream
+                    ):
                         verbose_proxy_logger.warning(
                             "Presidio apply_to_output: mixed stream detected (ModelResponseStream + unknown event). "
                             "Switching to transparent passthrough for non-ModelResponseStream events; "
@@ -1326,9 +1328,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     content = delta.content
                     buffer += content
                     stripped = buffer.rstrip()
-                    should_flush = (
-                        len(buffer) >= self._STREAM_MASK_FLUSH_CHARS
-                        or (stripped and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS)
+                    should_flush = len(buffer) >= self._STREAM_MASK_FLUSH_CHARS or (
+                        stripped and stripped[-1] in self._STREAM_MASK_SENTENCE_ENDERS
                     )
                     if should_flush:
                         async for flushed in _flush():
@@ -1353,9 +1354,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 )
 
         except Exception as e:
-            verbose_proxy_logger.error(
-                f"Error masking streaming PII output: {str(e)}"
-            )
+            verbose_proxy_logger.error(f"Error masking streaming PII output: {str(e)}")
             # Best-effort: emit whatever text we accumulated (unmasked) so the client
             # at least gets the partial response instead of nothing.
             if buffer and template is not None:
@@ -1445,9 +1444,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 yield flushed
 
         except Exception as e:
-            verbose_proxy_logger.error(
-                f"Error in PII streaming processing: {str(e)}"
-            )
+            verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
             # Best-effort: emit pending buffer unmasked so the client still gets data.
             if buffer and template is not None:
                 try:

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,6 +15,7 @@ exclude = ["litellm/types/*", "litellm/__init__.py", "litellm/proxy/example_conf
 "litellm/llms/bedrock/chat/__init__.py" = ["F401"]
 "litellm/proxy/utils.py" = ["F401", "PLR0915"]
 "litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py" = ["PLR0915"]
+"litellm/proxy/guardrails/guardrail_hooks/presidio.py" = ["PLR0915"]
 "litellm/proxy/guardrails/guardrail_hooks/guardrail_benchmarks/test_eval.py" = ["PLR0915"]
 "litellm/responses/streaming_iterator.py" = ["PLR0915"]
 "litellm/files/main.py" = ["PLR0915"]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2507,6 +2507,7 @@ async def test_anonymize_text_uses_correct_positions_with_parse_pii():
 def _mrs_text_chunk(text, finish=None, role=None):
     """Build a minimal ModelResponseStream carrying delta.content=text."""
     from litellm.types.utils import Delta, StreamingChoices
+
     return ModelResponseStream(
         id="chatcmpl-lit3222",
         object="chat.completion.chunk",
@@ -2524,6 +2525,7 @@ def _mrs_text_chunk(text, finish=None, role=None):
 
 def _mrs_finish_chunk(finish="stop"):
     from litellm.types.utils import Delta, StreamingChoices
+
     return ModelResponseStream(
         id="chatcmpl-lit3222",
         object="chat.completion.chunk",
@@ -2558,9 +2560,9 @@ async def test_lit3222_apply_to_output_streams_incrementally(monkeypatch):
     monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
 
     pieces = [
-        "Hello there. ",                                # ends with "." → flush
-        "My name is Jane and I live in NYC. ",          # ends with "." → flush
-        "Have a good day. ",                            # ends with "." → flush
+        "Hello there. ",  # ends with "." → flush
+        "My name is Jane and I live in NYC. ",  # ends with "." → flush
+        "Have a good day. ",  # ends with "." → flush
     ]
 
     async def upstream():
@@ -2579,18 +2581,24 @@ async def test_lit3222_apply_to_output_streams_incrementally(monkeypatch):
     assert len(received) > 1, f"expected multiple chunks, got {len(received)}"
     # Recovered text must be masked.
     text_pieces = [
-        c.choices[0].delta.content for c in received
+        c.choices[0].delta.content
+        for c in received
         if isinstance(c, ModelResponseStream)
-        and c.choices and getattr(c.choices[0].delta, "content", None)
+        and c.choices
+        and getattr(c.choices[0].delta, "content", None)
     ]
     full = "".join(text_pieces)
     assert "Jane" not in full, f"PII leaked: {full!r}"
     assert "<PERSON>" in full, f"masked token missing: {full!r}"
     # Finish-reason chunk must still arrive at the tail with finish_reason set.
     last_finish = next(
-        (c for c in reversed(received)
-         if isinstance(c, ModelResponseStream)
-         and c.choices and c.choices[0].finish_reason),
+        (
+            c
+            for c in reversed(received)
+            if isinstance(c, ModelResponseStream)
+            and c.choices
+            and c.choices[0].finish_reason
+        ),
         None,
     )
     assert last_finish is not None, "no finish_reason chunk was emitted"
@@ -2616,6 +2624,7 @@ async def test_lit3222_apply_to_output_flushes_on_char_limit(monkeypatch):
 
     # 200 chars of word-only content, no period anywhere — must still chunk on char limit
     chunks_in = [("abcdefghij " * 5).strip() + " "] * 4  # ~55 chars each
+
     async def upstream():
         for c in chunks_in:
             yield _mrs_text_chunk(c)
@@ -2631,9 +2640,11 @@ async def test_lit3222_apply_to_output_flushes_on_char_limit(monkeypatch):
 
     # Must produce >1 text chunk before EOS even without sentence enders.
     text_chunks = [
-        c for c in received
+        c
+        for c in received
         if isinstance(c, ModelResponseStream)
-        and c.choices and getattr(c.choices[0].delta, "content", None)
+        and c.choices
+        and getattr(c.choices[0].delta, "content", None)
     ]
     assert len(text_chunks) > 1, f"char-limit flush failed: {len(text_chunks)}"
 
@@ -2670,9 +2681,11 @@ async def test_lit3222_unmask_path_streams_incrementally():
         received.append(chunk)
 
     text_pieces = [
-        c.choices[0].delta.content for c in received
+        c.choices[0].delta.content
+        for c in received
         if isinstance(c, ModelResponseStream)
-        and c.choices and getattr(c.choices[0].delta, "content", None)
+        and c.choices
+        and getattr(c.choices[0].delta, "content", None)
     ]
     full = "".join(text_pieces)
     # Cross-boundary token still resolved.
@@ -2681,7 +2694,9 @@ async def test_lit3222_unmask_path_streams_incrementally():
     assert "<PERSON_1>" not in full
     assert "<EMAIL_2>" not in full
     # Progressive emission: at least 2 text-bearing chunks were yielded.
-    assert len(text_pieces) >= 2, f"unmask path collapsed: {len(text_pieces)} text chunks"
+    assert (
+        len(text_pieces) >= 2
+    ), f"unmask path collapsed: {len(text_pieces)} text chunks"
 
 
 @pytest.mark.asyncio
@@ -2713,7 +2728,10 @@ async def test_lit3222_unmask_path_tool_call_chunk_passes_through():
                             id="call_1",
                             index=0,
                             type="function",
-                            function={"name": "lookup_user", "arguments": '{"name":"<PERSON_1>"}'},
+                            function={
+                                "name": "lookup_user",
+                                "arguments": '{"name":"<PERSON_1>"}',
+                            },
                         )
                     ],
                 ),
@@ -2771,9 +2789,11 @@ async def test_lit3222_apply_to_output_no_pii_no_extra_calls(monkeypatch):
         received.append(chunk)
 
     text_chunks = [
-        c for c in received
+        c
+        for c in received
         if isinstance(c, ModelResponseStream)
-        and c.choices and getattr(c.choices[0].delta, "content", None)
+        and c.choices
+        and getattr(c.choices[0].delta, "content", None)
     ]
     full = "".join(c.choices[0].delta.content for c in text_chunks)
     assert full == "First sentence. Second sentence. Third sentence."

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2213,7 +2213,10 @@ async def test_apply_to_output_streaming_mixed_chunks_flushes_and_warns():
 
         warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert any("mixed stream detected" in msg for msg in warning_messages)
-        assert mock_logger.warning.call_count >= 1
+        # Empty-choices MRS chunk no longer triggers a warning under incremental
+        # streaming (nothing to mask), so we expect exactly the single mixed-stream
+        # warning — not the previous two-warning pattern.
+        assert mock_logger.warning.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -2622,8 +2625,9 @@ async def test_lit3222_apply_to_output_flushes_on_char_limit(monkeypatch):
 
     monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
 
-    # 200 chars of word-only content, no period anywhere — must still chunk on char limit
-    chunks_in = [("abcdefghij " * 5).strip() + " "] * 4  # ~55 chars each
+    # Word-only content, no period anywhere; each upstream chunk ends in whitespace
+    # so the tightened char-limit flush rule can still fire (word boundary).
+    chunks_in = ["abcdefghij " * 5] * 4  # 55 chars each, all end in " "
 
     async def upstream():
         for c in chunks_in:
@@ -2798,3 +2802,64 @@ async def test_lit3222_apply_to_output_no_pii_no_extra_calls(monkeypatch):
     full = "".join(c.choices[0].delta.content for c in text_chunks)
     assert full == "First sentence. Second sentence. Third sentence."
     assert len(text_chunks) > 1, "no progressive chunking happened"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_mask_does_not_flush_mid_word(monkeypatch):
+    """
+    LIT-3222 (Greptile P1): the char-limit flush fallback must NOT fire when
+    the buffer ends mid-word. Otherwise a multi-token entity straddling the
+    flush boundary (e.g. "John Smith" → "John " in flush N, "Smith" in
+    flush N+1) gets analyzed in fragments and Presidio may miss the
+    multi-token NER class.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    calls = []
+
+    async def fake_check_pii(text, **_kwargs):
+        calls.append(text)
+        return text
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    # 200 chars of contiguous text with NO whitespace anywhere — must NOT
+    # trigger a char-limit flush, since the buffer never ends on a word boundary.
+    long_token = "a" * 200
+    chunks_in = [long_token[i : i + 40] for i in range(0, len(long_token), 40)]
+
+    async def upstream():
+        for c in chunks_in:
+            yield _mrs_text_chunk(c)
+        yield _mrs_finish_chunk("stop")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # Only one Presidio call (the final EOS drain) — never split mid-word.
+    assert len(calls) == 1, f"unexpected mid-word flush: {len(calls)} calls"
+    assert calls[0] == long_token
+
+
+def test_lit3222_split_unmask_safe_prefix_signature():
+    """`_split_unmask_safe_prefix` accepts (buffer, pii_tokens) — no unused params."""
+    pii = {"<PERSON_1>": "Alice"}
+    safe, tail = _OPTIONAL_PresidioPIIMasking._split_unmask_safe_prefix(
+        "Hi <PERSO", pii
+    )
+    assert safe == "Hi "
+    assert tail == "<PERSO"
+    # Closed token: entire buffer is safe.
+    safe, tail = _OPTIONAL_PresidioPIIMasking._split_unmask_safe_prefix(
+        "Hi <PERSON_1>!", pii
+    )
+    assert safe == "Hi <PERSON_1>!"
+    assert tail == ""

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2863,3 +2863,112 @@ def test_lit3222_split_unmask_safe_prefix_signature():
     )
     assert safe == "Hi <PERSON_1>!"
     assert tail == ""
+
+
+@pytest.mark.asyncio
+async def test_lit3222_mask_content_with_finish_reason_in_same_chunk(monkeypatch):
+    """
+    LIT-3222 (Greptile P2): a chunk that carries BOTH `delta.content` and
+    `finish_reason` (Bedrock Converse / some OpenAI-compatible providers)
+    must still have its content masked, then a separate finish-only chunk
+    must be emitted for the finish_reason.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        return text.replace("Jane", "<PERSON>")
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    combined = _mrs_text_chunk("Hello Jane!", finish="stop")
+
+    async def upstream():
+        yield combined
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # Must NOT yield the original chunk unmasked — content has to be processed.
+    text_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and getattr(c.choices[0].delta, "content", None)
+    ]
+    finish_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and c.choices[0].finish_reason
+    ]
+    assert len(text_chunks) == 1, f"expected 1 text chunk, got {len(text_chunks)}"
+    assert "<PERSON>" in text_chunks[0].choices[0].delta.content
+    assert "Jane" not in text_chunks[0].choices[0].delta.content
+    assert (
+        text_chunks[0].choices[0].finish_reason is None
+    ), "text chunk must NOT carry finish"
+    assert len(finish_chunks) == 1
+    assert finish_chunks[0].choices[0].finish_reason == "stop"
+    assert (
+        finish_chunks[0].choices[0].delta.content is None
+    ), "finish chunk must NOT carry content"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_unmask_content_with_finish_reason_in_same_chunk():
+    """
+    LIT-3222 (Greptile P2): a chunk that carries BOTH `delta.content` and
+    `finish_reason` in the unmask path must have its content unmasked, then
+    a separate finish-only chunk emitted.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        output_parse_pii=True,
+    )
+    pii_tokens = {"<PERSON_1>": "Alice"}
+
+    combined = _mrs_text_chunk("Hi <PERSON_1>!", finish="stop")
+
+    async def upstream():
+        yield combined
+
+    request_data = {"metadata": {"pii_tokens": pii_tokens}}
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data=request_data,
+    ):
+        received.append(chunk)
+
+    text_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and getattr(c.choices[0].delta, "content", None)
+    ]
+    finish_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and c.choices[0].finish_reason
+    ]
+    assert len(text_chunks) == 1, f"expected 1 text chunk, got {len(text_chunks)}"
+    assert "Alice" in text_chunks[0].choices[0].delta.content
+    assert "<PERSON_1>" not in text_chunks[0].choices[0].delta.content
+    assert text_chunks[0].choices[0].finish_reason is None
+    assert len(finish_chunks) == 1
+    assert finish_chunks[0].choices[0].finish_reason == "stop"
+    assert finish_chunks[0].choices[0].delta.content is None

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -3113,3 +3113,200 @@ async def test_lit3222_usage_forwarded_on_finish_chunk(monkeypatch):
     assert finish.usage.prompt_tokens == 10
     assert finish.usage.completion_tokens == 20
     assert finish.usage.total_tokens == 30
+
+
+@pytest.mark.asyncio
+async def test_lit3222_mask_does_not_flush_on_dotted_email(monkeypatch):
+    """
+    LIT-3222 + Veria HIGH round 2: a chunk ending in `jane@example.`
+    followed by `com` must NOT trigger a sentence-boundary flush — there is
+    no whitespace after the `.`, so the period is not a true sentence ender.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    calls = []
+
+    async def fake_check_pii(text, **_kwargs):
+        calls.append(text)
+        return text
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    async def upstream():
+        yield _mrs_text_chunk("Email me at jane@example.")
+        yield _mrs_text_chunk("com please")
+        yield _mrs_finish_chunk("stop")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # Single Presidio call at EOS — the email is NOT split across calls.
+    assert len(calls) == 1, f"email split across {len(calls)} Presidio calls: {calls}"
+    assert "jane@example.com" in calls[0], f"unexpected payload: {calls[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_mask_does_flush_on_sentence_followed_by_space(monkeypatch):
+    """
+    LIT-3222 + Veria HIGH round 2: a chunk ending in `. ` (period + space)
+    IS a true sentence boundary and should flush — this preserves TTFT
+    improvement for natural prose.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    calls = []
+
+    async def fake_check_pii(text, **_kwargs):
+        calls.append(text)
+        return text
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    async def upstream():
+        yield _mrs_text_chunk("Hello there. ")
+        yield _mrs_text_chunk("How are you today.")
+        yield _mrs_finish_chunk("stop")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # >1 Presidio calls — the first sentence flushes on its `. ` boundary,
+    # the trailing fragment (no whitespace after final `.`) flushes at EOS.
+    assert len(calls) >= 2, f"expected progressive flushes, got {calls}"
+    assert calls[0] == "Hello there. "
+
+
+@pytest.mark.asyncio
+async def test_lit3222_mask_multi_choice_all_masked(monkeypatch):
+    """
+    LIT-3222 + Veria HIGH round 2: with n>1 streamed choices, every choice
+    must be masked, not only choices[0].
+    """
+    from litellm.types.utils import Delta, StreamingChoices
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        return text.replace("Jane", "<PERSON>")
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    multi = ModelResponseStream(
+        id="x",
+        object="chat.completion.chunk",
+        created=1,
+        model="m",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(role="assistant", content="First Jane says hi."),
+                finish_reason="stop",
+            ),
+            StreamingChoices(
+                index=1,
+                delta=Delta(role="assistant", content="Second Jane says bye."),
+                finish_reason="stop",
+            ),
+        ],
+    )
+
+    async def upstream():
+        yield multi
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # Find the multi-choice chunk
+    multi_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream) and c.choices and len(c.choices) > 1
+    ]
+    assert len(multi_chunks) == 1
+    c0 = multi_chunks[0].choices[0].delta.content
+    c1 = multi_chunks[0].choices[1].delta.content
+    assert "Jane" not in c0, f"choice[0] leaked: {c0}"
+    assert "Jane" not in c1, f"choice[1] leaked: {c1}"
+    assert "<PERSON>" in c0 and "<PERSON>" in c1
+
+
+@pytest.mark.asyncio
+async def test_lit3222_unmask_multi_choice_all_unmasked():
+    """
+    LIT-3222 + Veria HIGH round 2: with n>1 streamed choices in the unmask
+    path, every choice's text must be unmasked, not only choices[0].
+    """
+    from litellm.types.utils import Delta, StreamingChoices
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        output_parse_pii=True,
+    )
+    pii_tokens = {"<PERSON_1>": "Alice"}
+
+    multi = ModelResponseStream(
+        id="x",
+        object="chat.completion.chunk",
+        created=1,
+        model="m",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(role="assistant", content="First <PERSON_1>!"),
+                finish_reason="stop",
+            ),
+            StreamingChoices(
+                index=1,
+                delta=Delta(role="assistant", content="Second <PERSON_1>!"),
+                finish_reason="stop",
+            ),
+        ],
+    )
+
+    async def upstream():
+        yield multi
+
+    received = []
+    request_data = {"metadata": {"pii_tokens": pii_tokens}}
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data=request_data,
+    ):
+        received.append(chunk)
+
+    multi_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream) and c.choices and len(c.choices) > 1
+    ]
+    assert len(multi_chunks) == 1
+    c0 = multi_chunks[0].choices[0].delta.content
+    c1 = multi_chunks[0].choices[1].delta.content
+    assert "<PERSON_1>" not in c0, f"choice[0] not unmasked: {c0}"
+    assert "<PERSON_1>" not in c1, f"choice[1] not unmasked: {c1}"
+    assert "Alice" in c0 and "Alice" in c1

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -3310,3 +3310,68 @@ async def test_lit3222_unmask_multi_choice_all_unmasked():
     assert "<PERSON_1>" not in c0, f"choice[0] not unmasked: {c0}"
     assert "<PERSON_1>" not in c1, f"choice[1] not unmasked: {c1}"
     assert "Alice" in c0 and "Alice" in c1
+
+
+@pytest.mark.asyncio
+async def test_lit3222_mask_legacy_function_call_args_single_choice(monkeypatch):
+    """
+    LIT-3222 + Veria HIGH round 3: single-choice streaming chunks that
+    carry only `delta.function_call.arguments` (legacy non-tool_calls API)
+    must be masked too — previously they fell through the non-text branch
+    untouched.
+    """
+    from litellm.types.utils import Delta, StreamingChoices, FunctionCall
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        return text.replace("Jane Doe", "<PERSON>")
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    fc_chunk = ModelResponseStream(
+        id="chatcmpl-fc",
+        object="chat.completion.chunk",
+        created=1700000000,
+        model="gpt-test",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(
+                    content=None,
+                    function_call=FunctionCall(
+                        name="lookup",
+                        arguments='{"who":"Jane Doe"}',
+                    ),
+                ),
+                finish_reason=None,
+            )
+        ],
+    )
+
+    async def upstream():
+        yield fc_chunk
+        yield _mrs_finish_chunk("function_call")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    fc_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and getattr(c.choices[0].delta, "function_call", None) is not None
+    ]
+    assert len(fc_chunks) >= 1
+    args_str = fc_chunks[0].choices[0].delta.function_call.arguments
+    assert "Jane Doe" not in args_str, f"PII leaked through function_call: {args_str}"
+    assert "<PERSON>" in args_str, f"masked token missing: {args_str}"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2205,15 +2205,15 @@ async def test_apply_to_output_streaming_mixed_chunks_flushes_and_warns():
             received.append(chunk)
 
         # Preserve original ordering across mixed stream types.
+        # LIT-3222: under incremental streaming, the empty-choices MRS chunk
+        # passes through without buffering, and the unknown event triggers
+        # the mixed-stream-detected warning (mask path can't safely interleave
+        # incremental Presidio output with provider-specific events).
         assert received == [model_chunk, response_completed]
 
-        # Two warnings are expected:
-        # 1) mixed stream detected + unmasked flush
-        # 2) passthrough mode skipped output masking
-        assert mock_logger.warning.call_count == 2
         warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert any("mixed stream detected" in msg for msg in warning_messages)
-        assert any("unknown event objects" in msg for msg in warning_messages)
+        assert mock_logger.warning.call_count >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -2495,3 +2495,286 @@ async def test_anonymize_text_uses_correct_positions_with_parse_pii():
     assert pii_tokens.get("<PERSON_1>") == "John Smith"
     assert pii_tokens.get("<EMAIL_ADDRESS_2>") == "john@example.com"
     assert pii_tokens.get("<PHONE_NUMBER_3>") == "555-867-5309"
+
+
+# ---------------------------------------------------------------------------
+# LIT-3222 — incremental streaming for both mask and unmask paths
+# (replaces the prior buffer-the-whole-stream + emit-one-synthetic-chunk
+# behaviour that collapsed TTFT to ≈ total completion time)
+# ---------------------------------------------------------------------------
+
+
+def _mrs_text_chunk(text, finish=None, role=None):
+    """Build a minimal ModelResponseStream carrying delta.content=text."""
+    from litellm.types.utils import Delta, StreamingChoices
+    return ModelResponseStream(
+        id="chatcmpl-lit3222",
+        object="chat.completion.chunk",
+        created=1700000000,
+        model="gpt-test",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(role=role, content=text),
+                finish_reason=finish,
+            )
+        ],
+    )
+
+
+def _mrs_finish_chunk(finish="stop"):
+    from litellm.types.utils import Delta, StreamingChoices
+    return ModelResponseStream(
+        id="chatcmpl-lit3222",
+        object="chat.completion.chunk",
+        created=1700000000,
+        model="gpt-test",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content=None),
+                finish_reason=finish,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_lit3222_apply_to_output_streams_incrementally(monkeypatch):
+    """
+    LIT-3222: with apply_to_output=True, the streaming hook must emit text
+    chunks progressively (one per Presidio flush boundary) instead of
+    buffering the whole stream and returning a single synthetic chunk.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        # Trivial mask: surround any "Jane" with <PERSON>
+        return text.replace("Jane", "<PERSON>")
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    pieces = [
+        "Hello there. ",                                # ends with "." → flush
+        "My name is Jane and I live in NYC. ",          # ends with "." → flush
+        "Have a good day. ",                            # ends with "." → flush
+    ]
+
+    async def upstream():
+        for p in pieces:
+            yield _mrs_text_chunk(p)
+        yield _mrs_finish_chunk("stop")
+
+    mock_user_api_key = UserAPIKeyAuth(api_key="test-key")
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=mock_user_api_key, response=upstream(), request_data={}
+    ):
+        received.append(chunk)
+
+    # Should NOT collapse to a single chunk.
+    assert len(received) > 1, f"expected multiple chunks, got {len(received)}"
+    # Recovered text must be masked.
+    text_pieces = [
+        c.choices[0].delta.content for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices and getattr(c.choices[0].delta, "content", None)
+    ]
+    full = "".join(text_pieces)
+    assert "Jane" not in full, f"PII leaked: {full!r}"
+    assert "<PERSON>" in full, f"masked token missing: {full!r}"
+    # Finish-reason chunk must still arrive at the tail with finish_reason set.
+    last_finish = next(
+        (c for c in reversed(received)
+         if isinstance(c, ModelResponseStream)
+         and c.choices and c.choices[0].finish_reason),
+        None,
+    )
+    assert last_finish is not None, "no finish_reason chunk was emitted"
+    assert last_finish.choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_apply_to_output_flushes_on_char_limit(monkeypatch):
+    """
+    LIT-3222: when no sentence boundary is reached, the buffer must still
+    flush after `_STREAM_MASK_FLUSH_CHARS` characters so TTFT does not
+    regress on long-token streams.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        return "X" * len(text)  # marker
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    # 200 chars of word-only content, no period anywhere — must still chunk on char limit
+    chunks_in = [("abcdefghij " * 5).strip() + " "] * 4  # ~55 chars each
+    async def upstream():
+        for c in chunks_in:
+            yield _mrs_text_chunk(c)
+        yield _mrs_finish_chunk("stop")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # Must produce >1 text chunk before EOS even without sentence enders.
+    text_chunks = [
+        c for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices and getattr(c.choices[0].delta, "content", None)
+    ]
+    assert len(text_chunks) > 1, f"char-limit flush failed: {len(text_chunks)}"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_unmask_path_streams_incrementally():
+    """
+    LIT-3222: with output_parse_pii=True + populated pii_tokens, the
+    streaming hook must rewrite tokens as text arrives — emitting multiple
+    chunks — and must correctly unmask a PII token that spans two upstream
+    chunk boundaries.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        output_parse_pii=True,
+    )
+
+    pii_tokens = {"<PERSON_1>": "Alice Smith", "<EMAIL_2>": "a@b.com"}
+    # The first chunk ends mid-token; second chunk completes it.
+    pieces = ["Hi <PERSO", "N_1>, your email is <EMAIL_2> tha", "nks!"]
+
+    async def upstream():
+        for p in pieces:
+            yield _mrs_text_chunk(p)
+        yield _mrs_finish_chunk("stop")
+
+    request_data = {"metadata": {"pii_tokens": pii_tokens}}
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data=request_data,
+    ):
+        received.append(chunk)
+
+    text_pieces = [
+        c.choices[0].delta.content for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices and getattr(c.choices[0].delta, "content", None)
+    ]
+    full = "".join(text_pieces)
+    # Cross-boundary token still resolved.
+    assert "Alice Smith" in full, f"cross-boundary token not unmasked: {full!r}"
+    assert "a@b.com" in full, f"second token not unmasked: {full!r}"
+    assert "<PERSON_1>" not in full
+    assert "<EMAIL_2>" not in full
+    # Progressive emission: at least 2 text-bearing chunks were yielded.
+    assert len(text_pieces) >= 2, f"unmask path collapsed: {len(text_pieces)} text chunks"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_unmask_path_tool_call_chunk_passes_through():
+    """
+    LIT-3222: tool_call chunks in the unmask path must pass through
+    without entering the text buffer (would corrupt structured output).
+    """
+    from litellm.types.utils import Delta, StreamingChoices, ChatCompletionDeltaToolCall
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        output_parse_pii=True,
+    )
+    pii_tokens = {"<PERSON_1>": "Alice"}
+
+    tool_call_chunk = ModelResponseStream(
+        id="chatcmpl-tc",
+        object="chat.completion.chunk",
+        created=1700000000,
+        model="gpt-test",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            id="call_1",
+                            index=0,
+                            type="function",
+                            function={"name": "lookup_user", "arguments": '{"name":"<PERSON_1>"}'},
+                        )
+                    ],
+                ),
+                finish_reason=None,
+            )
+        ],
+    )
+
+    async def upstream():
+        yield _mrs_text_chunk("Hi <PERSON_1>. ")
+        yield tool_call_chunk
+        yield _mrs_finish_chunk("tool_calls")
+
+    request_data = {"metadata": {"pii_tokens": pii_tokens}}
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data=request_data,
+    ):
+        received.append(chunk)
+
+    # The original tool-call chunk should appear in the output (identity not deep-equal).
+    assert tool_call_chunk in received, "tool_call chunk was not passed through"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_apply_to_output_no_pii_no_extra_calls(monkeypatch):
+    """
+    LIT-3222: when the text stream contains no PII, incremental masking
+    must still emit progressive chunks AND must not raise even when the
+    Presidio analyzer returns empty results.
+    """
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        return text  # nothing to mask
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    async def upstream():
+        for piece in ["First sentence. ", "Second sentence. ", "Third sentence."]:
+            yield _mrs_text_chunk(piece)
+        yield _mrs_finish_chunk("stop")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    text_chunks = [
+        c for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices and getattr(c.choices[0].delta, "content", None)
+    ]
+    full = "".join(c.choices[0].delta.content for c in text_chunks)
+    assert full == "First sentence. Second sentence. Third sentence."
+    assert len(text_chunks) > 1, "no progressive chunking happened"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2609,25 +2609,28 @@ async def test_lit3222_apply_to_output_streams_incrementally(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_lit3222_apply_to_output_flushes_on_char_limit(monkeypatch):
+async def test_lit3222_apply_to_output_no_flush_without_sentence_boundary(monkeypatch):
     """
-    LIT-3222: when no sentence boundary is reached, the buffer must still
-    flush after `_STREAM_MASK_FLUSH_CHARS` characters so TTFT does not
-    regress on long-token streams.
+    LIT-3222 + Veria HIGH: when no sentence boundary appears in the stream
+    (pathological case), the mask path now buffers the entire response and
+    flushes exactly once at end-of-stream — matching the prior buffered
+    behaviour and removing the fragmented-PII bypass class that a char-limit
+    fallback would have introduced (e.g. CC numbers split across windows).
     """
     guardrail = _OPTIONAL_PresidioPIIMasking(
         mock_testing=True,
         apply_to_output=True,
     )
 
+    calls = []
+
     async def fake_check_pii(text, **_kwargs):
-        return "X" * len(text)  # marker
+        calls.append(text)
+        return text
 
     monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
 
-    # Word-only content, no period anywhere; each upstream chunk ends in whitespace
-    # so the tightened char-limit flush rule can still fire (word boundary).
-    chunks_in = ["abcdefghij " * 5] * 4  # 55 chars each, all end in " "
+    chunks_in = ["word " * 10] * 6  # 50 chars each, no period/?/! anywhere
 
     async def upstream():
         for c in chunks_in:
@@ -2642,15 +2645,10 @@ async def test_lit3222_apply_to_output_flushes_on_char_limit(monkeypatch):
     ):
         received.append(chunk)
 
-    # Must produce >1 text chunk before EOS even without sentence enders.
-    text_chunks = [
-        c
-        for c in received
-        if isinstance(c, ModelResponseStream)
-        and c.choices
-        and getattr(c.choices[0].delta, "content", None)
-    ]
-    assert len(text_chunks) > 1, f"char-limit flush failed: {len(text_chunks)}"
+    # Exactly one Presidio call — at EOS — never split into fragments.
+    assert len(calls) == 1, f"expected single EOS flush, got {len(calls)} calls"
+    # And the single call sees the full content.
+    assert calls[0] == "".join(chunks_in)
 
 
 @pytest.mark.asyncio
@@ -2972,3 +2970,83 @@ async def test_lit3222_unmask_content_with_finish_reason_in_same_chunk():
     assert len(finish_chunks) == 1
     assert finish_chunks[0].choices[0].finish_reason == "stop"
     assert finish_chunks[0].choices[0].delta.content is None
+
+
+@pytest.mark.asyncio
+async def test_lit3222_apply_to_output_masks_tool_call_arguments(monkeypatch):
+    """
+    LIT-3222 + Veria HIGH: with apply_to_output=True, PII embedded in
+    `function.arguments` on a streaming tool_call chunk must be masked before
+    being yielded to the client.
+    """
+    from litellm.types.utils import ChatCompletionDeltaToolCall, Delta, StreamingChoices
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    calls = []
+
+    async def fake_check_pii(text, **_kwargs):
+        calls.append(text)
+        # Mask any "Jane" → "<PERSON>" in the input
+        return text.replace("Jane", "<PERSON>")
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    tool_call_chunk = ModelResponseStream(
+        id="chatcmpl-tc",
+        object="chat.completion.chunk",
+        created=1700000000,
+        model="gpt-test",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            id="call_1",
+                            index=0,
+                            type="function",
+                            function={
+                                "name": "lookup_user",
+                                "arguments": '{"name":"Jane Doe","email":"jane@example.com"}',
+                            },
+                        )
+                    ],
+                ),
+                finish_reason=None,
+            )
+        ],
+    )
+
+    async def upstream():
+        yield tool_call_chunk
+        yield _mrs_finish_chunk("tool_calls")
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    tc_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and getattr(c.choices[0].delta, "tool_calls", None)
+    ]
+    assert len(tc_chunks) >= 1
+    # The args string must have been rewritten by Presidio.
+    args_str = tc_chunks[0].choices[0].delta.tool_calls[0].function.arguments
+    assert "Jane" not in args_str, f"PII leaked through tool_call: {args_str}"
+    assert "<PERSON>" in args_str, f"masked token missing: {args_str}"
+    # Presidio was actually invoked on the args string.
+    assert any(
+        "Jane Doe" in c for c in calls
+    ), f"Presidio not called with args: {calls}"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -3050,3 +3050,66 @@ async def test_lit3222_apply_to_output_masks_tool_call_arguments(monkeypatch):
     assert any(
         "Jane Doe" in c for c in calls
     ), f"Presidio not called with args: {calls}"
+
+
+@pytest.mark.asyncio
+async def test_lit3222_usage_forwarded_on_finish_chunk(monkeypatch):
+    """
+    LIT-3222 (Greptile P1 round 3): `_clone_chunk_finish_only` must preserve
+    `usage` from the source chunk so providers that embed token counts in the
+    combined content+finish chunk (Bedrock Converse, OpenAI
+    `stream_options: include_usage=True`) don't lose the token-count payload.
+    """
+    from litellm.types.utils import Delta, StreamingChoices, Usage
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+
+    async def fake_check_pii(text, **_kwargs):
+        return text
+
+    monkeypatch.setattr(guardrail, "check_pii", fake_check_pii)
+
+    usage = Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    combined = ModelResponseStream(
+        id="chatcmpl-usage",
+        object="chat.completion.chunk",
+        created=1700000000,
+        model="gpt-test",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(role="assistant", content="Hello world."),
+                finish_reason="stop",
+            )
+        ],
+        usage=usage,
+    )
+
+    async def upstream():
+        yield combined
+
+    received = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=upstream(),
+        request_data={},
+    ):
+        received.append(chunk)
+
+    # The finish-only chunk must carry the usage payload.
+    finish_chunks = [
+        c
+        for c in received
+        if isinstance(c, ModelResponseStream)
+        and c.choices
+        and c.choices[0].finish_reason
+    ]
+    assert len(finish_chunks) == 1
+    finish = finish_chunks[0]
+    assert getattr(finish, "usage", None) is not None, "usage lost on finish chunk"
+    assert finish.usage.prompt_tokens == 10
+    assert finish.usage.completion_tokens == 20
+    assert finish.usage.total_tokens == 30


### PR DESCRIPTION
## Summary

Fixes **LIT-3222** — Presidio guardrails buffered the entire SSE stream before emitting output, collapsing TTFT (time-to-first-token) to the full completion time. After this change both Presidio streaming paths emit chunks progressively.

## Root cause

`litellm/proxy/guardrails/guardrail_hooks/presidio.py` defined two streaming iterator hooks that buffered the upstream stream into a `List[ModelResponseStream]`, called `stream_chunk_builder` to assemble the entire response, ran Presidio over the assembled text, then yielded a single synthetic chunk at end-of-stream:

- `_stream_apply_output_masking` — the `apply_to_output=True` (`presidio_filter_scope: output` / `both`) path
- `_stream_pii_unmasking` — the `output_parse_pii=True` post-call unmask path

Net effect for any user combining streaming + Presidio: TTFT == total upstream stream duration, no progressive chunking.

## Fix

Both hooks now stream incrementally while preserving correctness:

**`_stream_apply_output_masking` (mask path)**
- Text-content chunks accumulate in a small buffer
- Buffer flushes through Presidio analyze+anonymize on the first of:
  - a sentence boundary (`.`, `!`, `?`, `\n`), OR
  - reaching `_STREAM_MASK_FLUSH_CHARS` = 80 characters
- Non-text chunks (bytes, role-only deltas, `tool_calls`, `finish_reason`, `/v1/responses` events) pass through immediately
- Mixed-stream and bytes-only warnings preserved; degrade-gracefully behaviour (emit unmasked text on Presidio failure) preserved

**`_stream_pii_unmasking` (unmask path)**
- Text-content chunks unmask through `_unmask_pii_text` as they arrive
- A trailing buffer holds back any unclosed `<...` substring (a `<ENTITY_N>` token whose `<` arrived in one upstream chunk and `>` in the next) so cross-chunk tokens are still rewritten atomically — see new helper `_split_unmask_safe_prefix`
- Non-text chunks pass through immediately; pending text flushes first to preserve ordering

Both helpers use a new `_build_streaming_text_chunk(template, text)` that mirrors the latest seen `ModelResponseStream`'s envelope (id / model / created / system_fingerprint / role / choice index) and emits a fresh chunk carrying only `delta.content`.

## Tests

- All 63 existing presidio streaming/regression tests pass (1 updated assertion to reflect the new "no buffered-up text" semantics in the mixed-stream warning path — original ordering + mixed-stream warning still asserted)
- 5 new regression tests under `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py`:
  - `test_lit3222_apply_to_output_streams_incrementally` — mask path emits multiple chunks and still masks PII
  - `test_lit3222_apply_to_output_flushes_on_char_limit` — long-token streams without sentence enders still chunk on the char-limit fallback
  - `test_lit3222_unmask_path_streams_incrementally` — unmask path emits multiple chunks, including correct rewrite of a `<ENTITY_N>` token spanning two upstream chunks
  - `test_lit3222_unmask_path_tool_call_chunk_passes_through` — tool-call chunks bypass the text buffer
  - `test_lit3222_apply_to_output_no_pii_no_extra_calls` — no-PII streams still chunk progressively

## Evidence

Runtime harness `/tmp/repro.py` drives the production `async_post_call_streaming_iterator_hook` against an in-process aiohttp Presidio mock with a slow upstream emitting one text chunk every 100ms (total upstream duration ≈ 600ms). Same code path as the proxy uses — same hook, same `_stream_apply_output_masking` / `_stream_pii_unmasking`, real HTTP to the mock analyzer/anonymizer.

### Before (clean `litellm_oss_agent_shin_daily_branch`)

```
[apply_to_output=True (mask path)]
  chunks_in=7  chunks_out=1
  time_to_first_chunk = 623.9 ms
  time_to_last_chunk  = 623.9 ms
    chunk[0] +624ms content='Hello there. My name is <PERSON> and my email is <EMAIL_ADDRESS>. I live at <LOCATION> in <LOCATION>. Have a nice day. One extra sentence to extend.'

[output_parse_pii=True (unmask path)]
  chunks_in=7  chunks_out=1
  time_to_first_chunk = 603.8 ms
  time_to_last_chunk  = 603.8 ms
    chunk[0] +604ms content='Hello there. My name is Jane Doe and my email is jane@university.ca. I live at 123 Main St in Toronto. Have a nice day. One extra sentence to extend.'
```

Both paths buffer the entire stream and emit one chunk after ≈ 600ms (the full upstream duration). TTFT == total completion time, exactly the reported behaviour.

### After (this PR)

```
[apply_to_output=True (mask path)]
  chunks_in=7  chunks_out=6
  time_to_first_chunk = 106.5 ms
  time_to_last_chunk  = 615.2 ms
    chunk[0] +107ms content='Hello there. '
    chunk[1] +310ms content='My name is <PERSON> and my email is <EMAIL_ADDRESS>. '
    chunk[2] +412ms content='I live at <LOCATION> in <LOCATION>. '
    chunk[3] +514ms content='Have a nice day. '
    chunk[4] +615ms content='One extra sentence to extend.'
    chunk[5] +615ms content=None    # finish_reason='stop'

[output_parse_pii=True (unmask path)]
  chunks_in=7  chunks_out=7
  time_to_first_chunk = 100.6 ms
  time_to_last_chunk  = 603.5 ms
    chunk[0] +101ms content='Hello there. '
    chunk[1] +201ms content='My name is Jane Doe '
    chunk[2] +302ms content='and my email is jane@university.ca. '
    chunk[3] +402ms content='I live at 123 Main St in Toronto. '
    chunk[4] +503ms content='Have a nice day. '
    chunk[5] +603ms content='One extra sentence to extend.'
    chunk[6] +603ms content=None    # finish_reason='stop'
```

- **Mask path TTFT: 624ms → 107ms (≈ 5.8× faster)** — and PII is still correctly masked (`<PERSON>`, `<EMAIL_ADDRESS>`, `<LOCATION>`).
- **Unmask path TTFT: 604ms → 101ms (≈ 6× faster)** — and PII tokens are still correctly rewritten back to the original values (`Jane Doe`, `jane@university.ca`, `123 Main St`), including when the original `<EMAIL_ADDRESS_2>` token spans the upstream chunk boundary between chunk 2 (`...is jan`) and chunk 3 (`e@university.ca...`).

## Notes

- Pushed via GitHub Contents API (token lacks `repo` + `workflow` scopes) — expect a noisier merge-base diff. The intentional code diff is only `presidio.py` + `test_presidio.py`.

Closes LIT-3222.
