### PR TITLE
fix(jwt-auth): propagate team_alias on JWT-driven team_id_upsert (LIT-3087)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1820,8 +1820,19 @@ async def _delete_cache_key_object(
 
 @log_db_metrics
 async def _get_team_db_check(
-    team_id: str, prisma_client: PrismaClient, team_id_upsert: Optional[bool] = None
+    team_id: str,
+    prisma_client: PrismaClient,
+    team_id_upsert: Optional[bool] = None,
+    upsert_team_alias: Optional[str] = None,
 ):
+    """Look up a team by id, optionally upserting if missing.
+
+    ``upsert_team_alias`` is only consulted when ``team_id_upsert`` triggers
+    the auto-create branch. Callers driven by an IdP (e.g. a JWT carrying
+    ``team_alias_jwt_field`` alongside ``team_id_jwt_field``) pass the
+    resolved alias here so the freshly created team has a human-readable
+    name in the UI / spend tooling instead of an empty alias.
+    """
     response = await prisma_client.db.litellm_teamtable.find_unique(
         where={"team_id": team_id}
     )
@@ -1829,7 +1840,10 @@ async def _get_team_db_check(
     if response is None and team_id_upsert:
         from litellm.proxy.management_endpoints.team_endpoints import new_team
 
-        new_team_data = NewTeamRequest(team_id=team_id)
+        new_team_kwargs: Dict[str, Any] = {"team_id": team_id}
+        if upsert_team_alias:
+            new_team_kwargs["team_alias"] = upsert_team_alias
+        new_team_data = NewTeamRequest(**new_team_kwargs)
 
         mock_request = Request(scope={"type": "http"})
         system_admin_user = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN)
@@ -1858,6 +1872,7 @@ async def _get_team_object_from_user_api_key_cache(
     proxy_logging_obj: Optional[ProxyLogging],
     key: str,
     team_id_upsert: Optional[bool] = None,
+    upsert_team_alias: Optional[str] = None,
 ) -> LiteLLM_TeamTableCachedObj:
     db_access_time_key = key
     should_check_db = _should_check_db(
@@ -1867,7 +1882,10 @@ async def _get_team_object_from_user_api_key_cache(
     )
     if should_check_db:
         response = await _get_team_db_check(
-            team_id=team_id, prisma_client=prisma_client, team_id_upsert=team_id_upsert
+            team_id=team_id,
+            prisma_client=prisma_client,
+            team_id_upsert=team_id_upsert,
+            upsert_team_alias=upsert_team_alias,
         )
     else:
         response = None
@@ -1950,6 +1968,7 @@ async def get_team_object(
     check_cache_only: Optional[bool] = None,
     check_db_only: Optional[bool] = None,
     team_id_upsert: Optional[bool] = None,
+    upsert_team_alias: Optional[str] = None,
 ) -> LiteLLM_TeamTableCachedObj:
     """
     - Check if team id in proxy Team Table
@@ -1997,6 +2016,7 @@ async def get_team_object(
             db_cache_expiry=db_cache_expiry,
             key=key,
             team_id_upsert=team_id_upsert,
+            upsert_team_alias=upsert_team_alias,
         )
     except Exception:
         raise HTTPException(

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -1037,6 +1037,16 @@ class JWTAuthManager:
 
         # First try to get team by team_id
         if individual_team_id:
+            # When upserting a new team from the JWT, propagate the
+            # ``team_alias_jwt_field`` value (if configured + present) so the
+            # auto-created team has a human-readable name in the UI / spend
+            # tooling instead of an empty alias.
+            upsert_alias_from_jwt: Optional[str] = None
+            if jwt_handler.litellm_jwtauth.team_id_upsert:
+                upsert_alias_from_jwt = jwt_handler.get_team_alias(
+                    token=jwt_valid_token, default_value=None
+                )
+
             team_object = await get_team_object(
                 team_id=individual_team_id,
                 prisma_client=prisma_client,
@@ -1044,6 +1054,7 @@ class JWTAuthManager:
                 parent_otel_span=parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,
                 team_id_upsert=jwt_handler.litellm_jwtauth.team_id_upsert,
+                upsert_team_alias=upsert_alias_from_jwt,
             )
             return individual_team_id, team_object
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -608,9 +608,7 @@ async def test_get_team_db_check_does_not_call_new_team_if_exists(
 @patch(
     "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
 )
-async def test_get_team_db_check_upsert_propagates_team_alias(
-    mock_new_team, monkeypatch
-):
+async def test_get_team_db_check_upsert_propagates_team_alias(mock_new_team):
     """LIT-3087: when ``upsert_team_alias`` is passed alongside
     ``team_id_upsert``, the auto-create call sends the alias into
     ``NewTeamRequest`` so the freshly created team has a human-readable name.
@@ -644,9 +642,7 @@ async def test_get_team_db_check_upsert_propagates_team_alias(
 @patch(
     "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
 )
-async def test_get_team_db_check_upsert_without_alias_preserved_behavior(
-    mock_new_team, monkeypatch
-):
+async def test_get_team_db_check_upsert_without_alias_preserved_behavior(mock_new_team):
     """LIT-3087: when ``upsert_team_alias`` is None (default), the upsert
     request must not stamp an alias — pre-fix behavior is preserved for
     deployments that do not configure ``team_alias_jwt_field``.
@@ -675,9 +671,7 @@ async def test_get_team_db_check_upsert_without_alias_preserved_behavior(
 @patch(
     "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
 )
-async def test_get_team_db_check_upsert_empty_alias_treated_as_unset(
-    mock_new_team, monkeypatch
-):
+async def test_get_team_db_check_upsert_empty_alias_treated_as_unset(mock_new_team):
     """LIT-3087: an empty string alias from the JWT must not be stamped as
     the team's ``team_alias`` — empty alias is indistinguishable from "no
     alias claim" and would produce a confusing blank-name team in the UI.
@@ -706,9 +700,7 @@ async def test_get_team_db_check_upsert_empty_alias_treated_as_unset(
 @patch(
     "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
 )
-async def test_get_team_db_check_alias_ignored_when_team_exists(
-    mock_new_team, monkeypatch
-):
+async def test_get_team_db_check_alias_ignored_when_team_exists(mock_new_team):
     """LIT-3087: alias backfill is intentionally NOT performed — existing
     teams keep their alias on every JWT auth. The fix only affects newly
     created (upserted) teams.

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -599,6 +599,140 @@ async def test_get_team_db_check_does_not_call_new_team_if_exists(
     mock_new_team.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# LIT-3087: team_alias propagation when JWT triggers team_id_upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
+)
+async def test_get_team_db_check_upsert_propagates_team_alias(
+    mock_new_team, monkeypatch
+):
+    """LIT-3087: when ``upsert_team_alias`` is passed alongside
+    ``team_id_upsert``, the auto-create call sends the alias into
+    ``NewTeamRequest`` so the freshly created team has a human-readable name.
+    """
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db = AsyncMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique.return_value = None
+
+    team_id_to_create = "jwt-upsert-team-with-alias"
+    expected_alias = "Platform Engineering"
+    mock_new_team.return_value = {
+        "team_id": team_id_to_create,
+        "team_alias": expected_alias,
+        "max_budget": None,
+    }
+
+    await _get_team_db_check(
+        team_id=team_id_to_create,
+        prisma_client=mock_prisma_client,
+        team_id_upsert=True,
+        upsert_team_alias=expected_alias,
+    )
+
+    mock_new_team.assert_called_once()
+    data_arg = mock_new_team.call_args[1]["data"]
+    assert data_arg.team_id == team_id_to_create
+    assert data_arg.team_alias == expected_alias
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
+)
+async def test_get_team_db_check_upsert_without_alias_preserved_behavior(
+    mock_new_team, monkeypatch
+):
+    """LIT-3087: when ``upsert_team_alias`` is None (default), the upsert
+    request must not stamp an alias — pre-fix behavior is preserved for
+    deployments that do not configure ``team_alias_jwt_field``.
+    """
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db = AsyncMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique.return_value = None
+
+    team_id_to_create = "jwt-upsert-team-no-alias"
+    mock_new_team.return_value = {"team_id": team_id_to_create, "max_budget": None}
+
+    await _get_team_db_check(
+        team_id=team_id_to_create,
+        prisma_client=mock_prisma_client,
+        team_id_upsert=True,
+        # upsert_team_alias intentionally omitted
+    )
+
+    mock_new_team.assert_called_once()
+    data_arg = mock_new_team.call_args[1]["data"]
+    assert data_arg.team_id == team_id_to_create
+    assert data_arg.team_alias is None
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
+)
+async def test_get_team_db_check_upsert_empty_alias_treated_as_unset(
+    mock_new_team, monkeypatch
+):
+    """LIT-3087: an empty string alias from the JWT must not be stamped as
+    the team's ``team_alias`` — empty alias is indistinguishable from "no
+    alias claim" and would produce a confusing blank-name team in the UI.
+    """
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db = AsyncMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique.return_value = None
+
+    team_id_to_create = "jwt-upsert-team-empty-alias"
+    mock_new_team.return_value = {"team_id": team_id_to_create, "max_budget": None}
+
+    await _get_team_db_check(
+        team_id=team_id_to_create,
+        prisma_client=mock_prisma_client,
+        team_id_upsert=True,
+        upsert_team_alias="",
+    )
+
+    mock_new_team.assert_called_once()
+    data_arg = mock_new_team.call_args[1]["data"]
+    assert data_arg.team_id == team_id_to_create
+    assert data_arg.team_alias is None
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
+)
+async def test_get_team_db_check_alias_ignored_when_team_exists(
+    mock_new_team, monkeypatch
+):
+    """LIT-3087: alias backfill is intentionally NOT performed — existing
+    teams keep their alias on every JWT auth. The fix only affects newly
+    created (upserted) teams.
+    """
+    existing_row = MagicMock()
+    existing_row.team_alias = None  # legacy upsert without alias
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db = AsyncMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique.return_value = existing_row
+
+    result = await _get_team_db_check(
+        team_id="legacy-team",
+        prisma_client=mock_prisma_client,
+        team_id_upsert=True,
+        upsert_team_alias="A New Alias From JWT",
+    )
+
+    # new_team must NOT be called when the team already exists
+    mock_new_team.assert_not_called()
+    # The returned row is the legacy row, unchanged
+    assert result is existing_row
+    assert result.team_alias is None
+
+
 # Vector Store Auth Check Tests
 
 

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1811,6 +1811,156 @@ async def test_is_required_team_id_with_team_alias_field():
 
 
 @pytest.mark.asyncio
+async def test_find_and_validate_specific_team_id_upsert_propagates_jwt_alias():
+    """LIT-3087: when a JWT presents both ``team_id`` and ``team_name`` claims
+    and ``team_id_upsert: True`` is configured, the value resolved from
+    ``team_alias_jwt_field`` must flow into ``get_team_object`` as
+    ``upsert_team_alias`` so the auto-created team gets a human-readable
+    name in the UI / spend tooling. The pre-fix path dropped the alias and
+    the team was created with ``team_alias=None``.
+    """
+    from litellm.caching import DualCache
+    from litellm.proxy._types import LiteLLM_JWTAuth, LiteLLM_TeamTable
+    from litellm.proxy.auth.handle_jwt import JWTAuthManager, JWTHandler
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=user_api_key_cache)
+
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_id_jwt_field="team_id",
+            team_alias_jwt_field="team_name",
+            team_id_upsert=True,
+        ),
+    )
+
+    jwt_token = {
+        "sub": "user-okta-1",
+        "team_id": "okta-eng-platform",
+        "team_name": "Engineering Platform",
+    }
+    expected_team = LiteLLM_TeamTable(
+        team_id="okta-eng-platform", team_alias="Engineering Platform"
+    )
+
+    with patch(
+        "litellm.proxy.auth.handle_jwt.get_team_object", new_callable=AsyncMock
+    ) as mock_get_team:
+        mock_get_team.return_value = expected_team
+
+        team_id, team_obj = await JWTAuthManager.find_and_validate_specific_team_id(
+            jwt_handler=jwt_handler,
+            jwt_valid_token=jwt_token,
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+        assert team_id == "okta-eng-platform"
+        assert team_obj is expected_team
+        mock_get_team.assert_called_once()
+        kwargs = mock_get_team.call_args.kwargs
+        assert kwargs["team_id"] == "okta-eng-platform"
+        assert kwargs["team_id_upsert"] is True
+        assert kwargs["upsert_team_alias"] == "Engineering Platform"
+
+
+@pytest.mark.asyncio
+async def test_find_and_validate_specific_team_id_no_alias_passes_none():
+    """LIT-3087: when ``team_alias_jwt_field`` is configured but the JWT does
+    not carry that claim, ``upsert_team_alias`` is propagated as ``None`` —
+    behavior matches pre-fix when no alias was available.
+    """
+    from litellm.caching import DualCache
+    from litellm.proxy._types import LiteLLM_JWTAuth, LiteLLM_TeamTable
+    from litellm.proxy.auth.handle_jwt import JWTAuthManager, JWTHandler
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=user_api_key_cache)
+
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_id_jwt_field="team_id",
+            team_alias_jwt_field="team_name",
+            team_id_upsert=True,
+        ),
+    )
+
+    jwt_token = {"sub": "u", "team_id": "no-alias-team"}  # team_name absent
+
+    with patch(
+        "litellm.proxy.auth.handle_jwt.get_team_object", new_callable=AsyncMock
+    ) as mock_get_team:
+        mock_get_team.return_value = LiteLLM_TeamTable(team_id="no-alias-team")
+
+        await JWTAuthManager.find_and_validate_specific_team_id(
+            jwt_handler=jwt_handler,
+            jwt_valid_token=jwt_token,
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+        assert mock_get_team.call_args.kwargs["upsert_team_alias"] is None
+
+
+@pytest.mark.asyncio
+async def test_find_and_validate_specific_team_id_does_not_resolve_alias_when_upsert_disabled():
+    """LIT-3087: ``get_team_alias`` is a no-op call but we still skip it
+    entirely when ``team_id_upsert`` is False — the alias has no upsert
+    purpose and we should not eagerly do dict lookups on the token for it.
+    """
+    from litellm.caching import DualCache
+    from litellm.proxy._types import LiteLLM_JWTAuth, LiteLLM_TeamTable
+    from litellm.proxy.auth.handle_jwt import JWTAuthManager, JWTHandler
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=user_api_key_cache)
+
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_id_jwt_field="team_id",
+            team_alias_jwt_field="team_name",
+            team_id_upsert=False,
+        ),
+    )
+    jwt_token = {"sub": "u", "team_id": "tid", "team_name": "Should Not Be Sent"}
+
+    with (
+        patch(
+            "litellm.proxy.auth.handle_jwt.get_team_object", new_callable=AsyncMock
+        ) as mock_get_team,
+        patch.object(jwt_handler, "get_team_alias") as mock_get_alias,
+    ):
+        mock_get_team.return_value = LiteLLM_TeamTable(team_id="tid")
+        await JWTAuthManager.find_and_validate_specific_team_id(
+            jwt_handler=jwt_handler,
+            jwt_valid_token=jwt_token,
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        # No alias resolution should occur when upsert is disabled
+        mock_get_alias.assert_not_called()
+        assert mock_get_team.call_args.kwargs["upsert_team_alias"] is None
+
+
+@pytest.mark.asyncio
 async def test_find_and_validate_specific_team_id_with_team_alias():
     """
     Test that find_and_validate_specific_team_id resolves team by name when team_id is not found


### PR DESCRIPTION
## Summary

When the proxy auto-creates a team via `team_id_upsert` from a JWT, the value resolved from `team_alias_jwt_field` was silently dropped. `_get_team_db_check` called `NewTeamRequest(team_id=team_id)` with no alias, so the auto-created team had `team_alias=None` in the database — leaving an unnamed team in the UI and spend tooling even though the IdP token already carried a human-readable name.

This patch plumbs a new optional `upsert_team_alias` kwarg through:

`JWTAuthManager.find_and_validate_specific_team_id`
→ `get_team_object`
→ `_get_team_object_from_user_api_key_cache`
→ `_get_team_db_check`
→ `NewTeamRequest`

The JWT dispatcher resolves the alias from `team_alias_jwt_field` (only when `team_id_upsert` is True; no-op otherwise) and passes it through. Empty-string aliases are treated as unset, and existing teams are never backfilled — the fix only affects teams that this auth call actually creates.

Other call sites that pass `team_id_upsert` (header-driven `x-litellm-team-id`, single-team fallback) intentionally keep the previous behavior because they have no JWT alias to forward.

## Files touched

- `litellm/proxy/auth/auth_checks.py` — signature additions + propagation
- `litellm/proxy/auth/handle_jwt.py` — resolve + forward JWT alias on upsert
- `tests/test_litellm/proxy/auth/test_auth_checks.py` — 4 new tests
- `tests/test_litellm/proxy/auth/test_handle_jwt.py` — 3 new tests

## Branch / push note

Branch contents pushed via the GitHub Contents API (one PUT per file), as the current `GITHUB_TOKEN` lacks the `repo`+`workflow` scopes required for plain `git push`. Reviewers may see a noisier merge-base diff than a normal squashed branch — the underlying 4-file delta is exactly the one in the commit listing.

### Evidence

Reproduced against a fresh sandbox proxy with `enable_jwt_auth: True`, `team_id_jwt_field: "team_id"`, `team_alias_jwt_field: "team_name"`, `team_id_upsert: true`, real Postgres. The JWT-auth dispatcher (`JWTAuthManager.find_and_validate_specific_team_id`) was driven with a decoded token carrying both claims.

**BEFORE — unpatched `_get_team_db_check` (no `upsert_team_alias` kwarg):**
```
REPRO_BEFORE:{"team_id": "lit3087-repro-before-fix",
              "team_alias": null,
              "expected_alias_from_jwt": "Engineering Auto-Created",
              "alias_was_dropped": true}
```

**AFTER — same path with new kwarg threaded by the JWT dispatcher:**
```
REPRO_AFTER:{"team_id": "lit3087-repro-after-fix",
             "team_alias": "Engineering Auto-Created",
             "expected_alias_from_jwt": "Engineering Auto-Created"}
```

**End-to-end through `JWTAuthManager.find_and_validate_specific_team_id` (the exact function `user_api_key_auth` invokes on every JWT request), reading the row directly from Postgres after the call:**
```
REPRO_E2E:{"auth_returned_team_id": "lit3087-e2e-team-id-1",
           "auth_returned_team_alias": "Platform Engineering (JWT auto-upsert)",
           "db_team_id": "lit3087-e2e-team-id-1",
           "db_team_alias": "Platform Engineering (JWT auto-upsert)",
           "expected_alias": "Platform Engineering (JWT auto-upsert)"}
```

**Negative case — JWT does not carry the `team_name` claim (no regression):**
```
REPRO_NO_ALIAS:{"team_alias_after": null, "expected": null}
```

## Tests

```
$ python3 -m pytest tests/test_litellm/proxy/auth/test_handle_jwt.py tests/test_litellm/proxy/auth/test_auth_checks.py -q
........................................................................ [ 36%]
........................................................................ [ 73%]
....................................................                     [100%]
196 passed in 45.35s
```

New regression tests:
- `test_get_team_db_check_upsert_propagates_team_alias`
- `test_get_team_db_check_upsert_without_alias_preserved_behavior`
- `test_get_team_db_check_upsert_empty_alias_treated_as_unset`
- `test_get_team_db_check_alias_ignored_when_team_exists`
- `test_find_and_validate_specific_team_id_upsert_propagates_jwt_alias`
- `test_find_and_validate_specific_team_id_no_alias_passes_none`
- `test_find_and_validate_specific_team_id_does_not_resolve_alias_when_upsert_disabled`

## Linear

LIT-3087


### Verification (ship-pr)

- [x] **PR base branch:** `litellm_oss_agent_shin_daily_branch` ✅
- [x] **Mergeable state:** `clean` ✅
- [x] **GitHub Actions:** 44/44 green, 0 failed, 0 pending ✅
- [x] **Codecov:** patch coverage check passing ✅
- [x] **Veria AI - PR Review:** ✅ "No security issues found"
- [x] **Greptile:** 4/5 — "Safe to merge — the change only affects team creation during JWT-driven upsert; no existing teams are mutated, and all other auth paths are unchanged."
- [x] **Customer name leak check:** PR title/body contain no customer names ✅
- [x] **Runtime evidence:** before/after JSON captured against a real Postgres through `JWTAuthManager.find_and_validate_specific_team_id` (the actual JWT auth dispatcher) — included under `### Evidence` above
- [x] **Unit tests:** 7 new regression tests; both auth suites combined `196 passed`
- [x] **No binary commits, no external image hosts:** terminal output inline in fenced blocks; nothing added to a `pr-assets-*` branch (no UI screenshots needed for this fix)

Greptile P2 nit (unused `monkeypatch` fixture parameter in 4 new tests) addressed in follow-up commit `644e6a2` — no functional change, test-only style cleanup.

Head SHA: `644e6a20`
