### PR TITLE
fix(budget): recompute budget_reset_at when budget_duration changes on /budget/update

### DIFF
--- a/litellm/proxy/management_endpoints/budget_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/budget_management_endpoints.py
@@ -182,10 +182,28 @@ async def update_budget(
         except ValueError as e:
             raise HTTPException(status_code=400, detail={"error": str(e)})
 
+    update_data = budget_obj.model_dump(exclude_unset=True)
+
+    # If the caller updates budget_duration without an explicit
+    # budget_reset_at, recompute the reset time. Otherwise, shortening
+    # the duration would leave budget_reset_at pinned to the prior
+    # (longer) schedule, so the budget would not reset until the old
+    # interval fired — even though a new, shorter duration is in effect.
+    # This mirrors /budget/new, /user/update, and the team budget
+    # path, which already recompute budget_reset_at from the new
+    # duration. Fixes LIT-3362.
+    if (
+        update_data.get("budget_duration") is not None
+        and "budget_reset_at" not in update_data
+    ):
+        update_data["budget_reset_at"] = get_budget_reset_time(
+            budget_duration=update_data["budget_duration"]
+        )
+
     response = await prisma_client.db.litellm_budgettable.update(
         where={"budget_id": budget_obj.budget_id},
         data={
-            **budget_obj.model_dump(exclude_unset=True),  # type: ignore
+            **update_data,  # type: ignore
             "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
         },  # type: ignore
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py
@@ -43,11 +43,11 @@ def client_and_table(monkeypatch):
 
     captured = {"create": [], "update": []}
 
-    async def capture_create(*, data):
+    def capture_create(*, data):
         captured["create"].append(data)
         return data
 
-    async def capture_update(*, where, data):
+    def capture_update(*, where, data):
         captured["update"].append({"where": where, "data": data})
         return {**where, **data}
 
@@ -76,8 +76,7 @@ def _last_update_payload(captured):
     return captured["update"][-1]["data"]
 
 
-@pytest.mark.asyncio
-async def test_update_with_duration_only_recomputes_reset_at(client_and_table):
+def test_update_with_duration_only_recomputes_reset_at(client_and_table):
     """budget_duration changes \u2192 reset_at is recomputed forward."""
     client, captured = client_and_table
 
@@ -86,7 +85,6 @@ async def test_update_with_duration_only_recomputes_reset_at(client_and_table):
         "/budget/update",
         json={"budget_id": "b1", "budget_duration": "1d"},
     )
-    after = datetime.now(timezone.utc)
     assert resp.status_code == 200, resp.text
 
     data = _last_update_payload(captured)
@@ -105,8 +103,7 @@ async def test_update_with_duration_only_recomputes_reset_at(client_and_table):
     )
 
 
-@pytest.mark.asyncio
-async def test_update_with_explicit_reset_at_preserves_caller_value(client_and_table):
+def test_update_with_explicit_reset_at_preserves_caller_value(client_and_table):
     """Explicit budget_reset_at wins \u2014 we never silently overwrite it."""
     client, captured = client_and_table
 
@@ -132,8 +129,7 @@ async def test_update_with_explicit_reset_at_preserves_caller_value(client_and_t
     )
 
 
-@pytest.mark.asyncio
-async def test_update_without_budget_duration_does_not_touch_reset_at(client_and_table):
+def test_update_without_budget_duration_does_not_touch_reset_at(client_and_table):
     """Updates that omit budget_duration must not introduce budget_reset_at."""
     client, captured = client_and_table
 
@@ -151,8 +147,7 @@ async def test_update_without_budget_duration_does_not_touch_reset_at(client_and
     assert data["max_budget"] == 50.0
 
 
-@pytest.mark.asyncio
-async def test_update_with_budget_duration_explicit_none_does_not_recompute(client_and_table):
+def test_update_with_budget_duration_explicit_none_does_not_recompute(client_and_table):
     """Setting budget_duration=None (clearing it) must not recompute reset_at."""
     client, captured = client_and_table
 

--- a/tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py
@@ -1,0 +1,169 @@
+"""
+Regression tests for LIT-3362: /budget/update must recompute
+budget_reset_at when budget_duration changes and the caller did
+not pass an explicit budget_reset_at.
+
+Before the fix, callers updating only budget_duration would leave the
+existing budget_reset_at in place. Shortening a budget therefore did
+not bring its reset forward, so the row would not reset until the prior
+(longer) schedule fired \u2014 days or weeks after the new duration was in
+effect.
+
+This module covers four cases via the production FastAPI app + a mocked
+Prisma client (matches the existing test pattern in
+test_budget_endpoints.py):
+
+1. budget_duration in payload, no budget_reset_at \u2192 recompute.
+2. budget_duration AND explicit budget_reset_at \u2192 caller wins.
+3. budget_duration NOT in payload \u2192 budget_reset_at untouched.
+4. budget_duration explicitly None in payload \u2192 do not recompute.
+"""
+
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+
+import litellm.proxy.proxy_server as ps
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.proxy_server import app
+
+sys.path.insert(0, os.path.abspath("../../../"))
+
+
+@pytest.fixture
+def client_and_table(monkeypatch):
+    """Build a TestClient against the real proxy app with a mocked Prisma."""
+    mock_prisma = MagicMock()
+    mock_table = MagicMock()
+
+    captured = {"create": [], "update": []}
+
+    async def capture_create(*, data):
+        captured["create"].append(data)
+        return data
+
+    async def capture_update(*, where, data):
+        captured["update"].append({"where": where, "data": data})
+        return {**where, **data}
+
+    mock_table.create = AsyncMock(side_effect=capture_create)
+    mock_table.update = AsyncMock(side_effect=capture_update)
+
+    mock_prisma.db = types.SimpleNamespace(
+        litellm_budgettable=mock_table,
+        litellm_dailyspend=mock_table,
+    )
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+
+    fake_user = UserAPIKeyAuth(
+        user_id="tester",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: fake_user
+
+    yield TestClient(app), captured
+
+    app.dependency_overrides.clear()
+
+
+def _last_update_payload(captured):
+    assert captured["update"], "expected at least one /budget/update call"
+    return captured["update"][-1]["data"]
+
+
+@pytest.mark.asyncio
+async def test_update_with_duration_only_recomputes_reset_at(client_and_table):
+    """budget_duration changes \u2192 reset_at is recomputed forward."""
+    client, captured = client_and_table
+
+    before = datetime.now(timezone.utc)
+    resp = client.post(
+        "/budget/update",
+        json={"budget_id": "b1", "budget_duration": "1d"},
+    )
+    after = datetime.now(timezone.utc)
+    assert resp.status_code == 200, resp.text
+
+    data = _last_update_payload(captured)
+    assert data["budget_duration"] == "1d"
+    assert "budget_reset_at" in data, "fix must set budget_reset_at"
+
+    reset_at = data["budget_reset_at"]
+    if isinstance(reset_at, str):
+        reset_at = datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
+
+    # New reset must be ~1 day from now (allow generous slack for the
+    # standardized day-boundary timezone logic).
+    delta = reset_at - before
+    assert timedelta(0) < delta <= timedelta(days=2), (
+        f"budget_reset_at={reset_at} not within ~1d of now ({before})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_with_explicit_reset_at_preserves_caller_value(client_and_table):
+    """Explicit budget_reset_at wins \u2014 we never silently overwrite it."""
+    client, captured = client_and_table
+
+    explicit_reset = "2099-01-01T00:00:00+00:00"
+    resp = client.post(
+        "/budget/update",
+        json={
+            "budget_id": "b2",
+            "budget_duration": "1h",
+            "budget_reset_at": explicit_reset,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = _last_update_payload(captured)
+    assert data["budget_duration"] == "1h"
+    # Pydantic may parse the string into a datetime \u2014 normalize either form.
+    stored = data["budget_reset_at"]
+    if hasattr(stored, "isoformat"):
+        stored = stored.isoformat()
+    assert "2099-01-01" in str(stored), (
+        f"explicit budget_reset_at must be preserved, got {stored!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_without_budget_duration_does_not_touch_reset_at(client_and_table):
+    """Updates that omit budget_duration must not introduce budget_reset_at."""
+    client, captured = client_and_table
+
+    resp = client.post(
+        "/budget/update",
+        json={"budget_id": "b3", "max_budget": 50.0},
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = _last_update_payload(captured)
+    assert "budget_reset_at" not in data, (
+        "must not auto-set reset_at when caller did not touch budget_duration"
+    )
+    assert "budget_duration" not in data
+    assert data["max_budget"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_update_with_budget_duration_explicit_none_does_not_recompute(client_and_table):
+    """Setting budget_duration=None (clearing it) must not recompute reset_at."""
+    client, captured = client_and_table
+
+    resp = client.post(
+        "/budget/update",
+        json={"budget_id": "b4", "budget_duration": None},
+    )
+    assert resp.status_code == 200, resp.text
+
+    data = _last_update_payload(captured)
+    # exclude_unset preserves explicitly-set None, so the field IS sent
+    assert "budget_duration" in data and data["budget_duration"] is None
+    # but reset_at must not be auto-computed against a None duration
+    assert "budget_reset_at" not in data


### PR DESCRIPTION
## Summary

`POST /budget/update` did not recompute `budget_reset_at` when `budget_duration` changed and no explicit `budget_reset_at` was supplied. Shortening a budget therefore did not bring its reset forward — the row would not reset until the prior (longer) schedule fired. The same defect affected `POST /team/update` via `team_member_budget_duration` because it delegates to `update_budget`.

Reported behavior: users on a team missed daily resets for ~7 days after `budget_duration` was shortened.

## Fix

In `update_budget` (`litellm/proxy/management_endpoints/budget_management_endpoints.py`), after validation, build the update dict from `model_dump(exclude_unset=True)` and — when the caller updates `budget_duration` without an explicit `budget_reset_at` — compute `budget_reset_at = now + new_duration` via `get_budget_reset_time()`. This mirrors `/budget/new`, `/user/update`, and the team budget path which already do this.

- Explicit `budget_reset_at` is preserved (caller always wins)
- Updates that omit `budget_duration` leave `budget_reset_at` untouched
- `budget_duration` explicitly `None` clears the duration without recomputing `budget_reset_at`

## Evidence

Real proxy in sandbox: `litellm --config /tmp/repro/config.yaml --port 4001 --use_prisma_db_push` with the bundled Postgres. `/health/readiness` returns `{"status":"healthy","db":"connected"}` before each capture. Proxy is restarted between runs.

### Before fix (clean `litellm_oss_agent_shin_daily_branch` HEAD `1fe911d`)

```
=== /budget/new (budget_duration=30d) ===
HTTP 200
{
  "budget_id": "lit3362-before",
  "max_budget": 100.0,
  "budget_duration": "30d",
  "budget_reset_at": "2026-06-01T00:00:00Z",
  ...
}

=== /budget/update — change budget_duration 30d -> 1d (no budget_reset_at) ===
HTTP 200
{
  "budget_id": "lit3362-before",
  "budget_duration": "1d",
  "budget_reset_at": "2026-06-01T00:00:00Z",   <-- BUG: not recomputed
  ...
}

=== /budget/info after /update ===
HTTP 200
[{
  "budget_id": "lit3362-before",
  "budget_duration": "1d",
  "budget_reset_at": "2026-06-01T00:00:00Z"   <-- still 30d-old reset
}]

>> budget_duration after /update = 1d
>> budget_reset_at after /update  = 2026-06-01T00:00:00Z
>> budget_reset_at after /new     = 2026-06-01T00:00:00Z

BUG REPRODUCED: budget_reset_at was NOT recomputed when budget_duration changed.
```

### After fix (this PR)

```
=== /budget/new (budget_duration=30d) ===
HTTP 200
{
  "budget_id": "lit3362-after",
  "budget_duration": "30d",
  "budget_reset_at": "2026-06-01T00:00:00Z",
  ...
}

=== /budget/update — change budget_duration 30d -> 1d (no budget_reset_at) ===
HTTP 200
{
  "budget_id": "lit3362-after",
  "budget_duration": "1d",
  "budget_reset_at": "2026-05-29T00:00:00Z",   <-- FIXED: now ~24h from now
  ...
}

=== /budget/info after /update ===
HTTP 200
[{
  "budget_id": "lit3362-after",
  "budget_duration": "1d",
  "budget_reset_at": "2026-05-29T00:00:00Z"
}]

>> budget_duration after /update = 1d
>> budget_reset_at after /update  = 2026-05-29T00:00:00Z
>> budget_reset_at after /new     = 2026-06-01T00:00:00Z

FIXED: budget_reset_at WAS recomputed when budget_duration changed.

=== Edge: explicit budget_reset_at overrides recompute ===
HTTP 200
  budget_duration = 7d
  budget_reset_at = 2027-01-01T00:00:00Z
PASS: explicit budget_reset_at preserved

=== Edge: update other field, budget_duration NOT in payload ===
  before update: budget_reset_at = 2027-01-01T00:00:00Z
  after update:  budget_reset_at = 2027-01-01T00:00:00Z, max_budget = 200.0
PASS: budget_reset_at NOT touched when budget_duration not in payload
```

## Tests

4 new regression tests in `tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py` (same TestClient+MagicMock pattern as the existing `test_budget_endpoints.py`):

1. `test_update_with_duration_only_recomputes_reset_at` — duration-only update recomputes `budget_reset_at` to within ~1d of now.
2. `test_update_with_explicit_reset_at_preserves_caller_value` — explicit `budget_reset_at` is preserved.
3. `test_update_without_budget_duration_does_not_touch_reset_at` — other-field-only updates do not introduce `budget_reset_at`.
4. `test_update_with_budget_duration_explicit_none_does_not_recompute` — `budget_duration=None` (clear) does not recompute against a `None` duration.

```
tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py
  test_update_with_budget_duration_explicit_none_does_not_recompute PASSED
  test_update_with_duration_only_recomputes_reset_at                PASSED
  test_update_with_explicit_reset_at_preserves_caller_value         PASSED
  test_update_without_budget_duration_does_not_touch_reset_at       PASSED

tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
  11/11 existing tests still pass (no regression).
```

## Files

- `litellm/proxy/management_endpoints/budget_management_endpoints.py` — 1 file, +18/-1
- `tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py` — new, 169 lines

Fixes LIT-3362.


---

### Verification (ship-pr)

- [x] **Base branch** = `litellm_oss_agent_shin_daily_branch` (required for fork PRs).
- [x] **Runtime evidence** captured before/after via real proxy (`litellm --config ... --port 4001 --use_prisma_db_push`, Postgres-backed), `/health/readiness` 200 between runs. Curl/JSON evidence inline in `### Evidence` above; proxy restarted between BEFORE and AFTER.
- [x] **Customer name** scrubbed — no occurrences of the Linear project name anywhere in this PR (title, body, branch, commits, code, tests). Verified by grep.
- [x] **No secrets** in PR or diff (no API keys, tokens, URLs, internal hostnames). Tests use sentinel literals (`"sk-1234"`-style is the documented dummy master key from the docs).
- [x] **Tests pass** locally: 4/4 new regression tests + 11/11 existing `test_budget_endpoints.py` tests.
- [x] **All GitHub Actions green**: 44/44 checks completed, 0 failures (CodeQL/semgrep/secret-scan/proxy-endpoints/proxy-mgmt-behavior/lint/code-quality/build-ui/all proxy + provider suites/test-server-root-path × 2 / Veria AI ✅ / verify-PR-source-branch ✅).
- [x] **Codecov**: ✅ patch — `100.00% of diff hit (target 66.78%)`, "All modified and coverable lines are covered by tests."
- [x] **Greptile**: ✅ **5/5** on commit `b8b1e3e` after the cleanup round — *"The change is a targeted, well-scoped fix with no side effects on callers that omit budget_duration or supply their own budget_reset_at. The fix is a minimal, additive change that delegates to the same get_budget_reset_time helper already used by /budget/new. All three edge cases (explicit override, no-duration-change, explicit-None clear) are handled correctly and covered by tests."*
- [x] **Veria AI - PR Review**: ✅ success
- [x] **mergeable**: clean (`mergeable_state` was `unstable` only while checks were running; resolves to clean once Greptile re-review finalizes).
- [x] **Diff scope**: 2 files changed — `litellm/proxy/management_endpoints/budget_management_endpoints.py` (+18/-1) and `tests/test_litellm/proxy/management_endpoints/test_lit_3362_recompute_budget_reset_at.py` (new, 169 lines). No vendored UI build artifacts, no Prisma migration noise, no unrelated files.
- [x] **Branch contents pushed via Git Data API** (refs/blobs/trees/commits/refs). Standard `git push` over HTTPS fails authentication on this fork in the sandbox; this is the same path documented in the agent runbook. No effect on the merge — base/HEAD/commit-author all normal.
