### PR TITLE
fix(spend_logs): scope team-created virtual keys to their team only (LIT-3301)

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2299,9 +2299,7 @@ async def view_spend_logs(  # noqa: PLR0915
     # legacy /spend/logs endpoint, regardless of the creator's user_role
     # (LIT-3301).
     enforced_team_id: Optional[str] = (
-        user_api_key_dict.team_id
-        if _is_team_scoped_key(user_api_key_dict)
-        else None
+        user_api_key_dict.team_id if _is_team_scoped_key(user_api_key_dict) else None
     )
 
     try:

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1915,7 +1915,23 @@ async def ui_view_spend_logs(  # noqa: PLR0915
                 where_conditions["spend"]["lte"] = max_spend
         is_admin_view = _is_admin_view_safe(user_api_key_dict=user_api_key_dict)
         permitted_team_ids: Optional[List[str]] = None
-        if not is_admin_view:
+        # Team-scoped virtual keys: force-filter to the key's own team_id
+        # so admin-level access cannot leak through (LIT-3301).
+        if _is_team_scoped_key(user_api_key_dict):
+            key_team_id = user_api_key_dict.team_id
+            if team_id is not None and team_id != key_team_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": (
+                            "Team-scoped key cannot query spend logs for "
+                            "team_id={}".format(team_id)
+                        )
+                    },
+                )
+            where_conditions["team_id"] = key_team_id
+            where_conditions.pop("user", None)
+        elif not is_admin_view:
             if team_id is not None:
                 can_view_team = await _can_team_member_view_log(
                     prisma_client=prisma_client,
@@ -2279,6 +2295,15 @@ async def view_spend_logs(  # noqa: PLR0915
     ):
         user_id = user_api_key_dict.user_id
 
+    # Team-scoped virtual keys must see only their team's spend rows on the
+    # legacy /spend/logs endpoint, regardless of the creator's user_role
+    # (LIT-3301).
+    enforced_team_id: Optional[str] = (
+        user_api_key_dict.team_id
+        if _is_team_scoped_key(user_api_key_dict)
+        else None
+    )
+
     try:
         verbose_proxy_logger.debug("inside view_spend_logs")
         if prisma_client is None:
@@ -2310,6 +2335,8 @@ async def view_spend_logs(  # noqa: PLR0915
                     "lte": end_date_iso,  # Less than or equal to End Date
                 }
             }
+            if enforced_team_id is not None:
+                filter_query["team_id"] = enforced_team_id  # type: ignore
 
             if api_key is not None and isinstance(api_key, str):
                 if api_key.startswith("sk-"):
@@ -2395,6 +2422,8 @@ async def view_spend_logs(  # noqa: PLR0915
 
         else:
             scoped_filter: Dict[str, Any] = {}
+            if enforced_team_id is not None:
+                scoped_filter["team_id"] = enforced_team_id
             if api_key is not None and isinstance(api_key, str):
                 if api_key.startswith("sk-"):
                     hashed_token = prisma_client.hash_token(token=api_key)
@@ -3498,8 +3527,15 @@ def _is_admin_view_safe(user_api_key_dict: UserAPIKeyAuth) -> bool:
     """
     Safely determine if the current user has admin view permissions.
     Defaults to False on any exception.
+
+    A team-scoped virtual key (``user_api_key_dict.team_id is not None``)
+    carries only its team's authority -- never admin-view -- even when the
+    creating user holds the ``PROXY_ADMIN`` role. Without this guard, admin
+    powers leak through every team-scoped key (LIT-3301).
     """
     try:
+        if _is_team_scoped_key(user_api_key_dict):
+            return False
         user_role = getattr(user_api_key_dict, "user_role", None)
         if user_role is None:
             return False
@@ -3507,6 +3543,19 @@ def _is_admin_view_safe(user_api_key_dict: UserAPIKeyAuth) -> bool:
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
         )
+    except Exception:
+        return False
+
+
+def _is_team_scoped_key(user_api_key_dict: UserAPIKeyAuth) -> bool:
+    """Return True when the request was authenticated by a team-scoped key.
+
+    A team-scoped key is a virtual key created under a team
+    (``user_api_key_dict.team_id`` is populated). Such a key must only see
+    its own team's data, regardless of the creating user's ``user_role``.
+    """
+    try:
+        return getattr(user_api_key_dict, "team_id", None) is not None
     except Exception:
         return False
 
@@ -3576,6 +3625,21 @@ async def _assert_user_can_view_request_id(
     )
     if row is None:
         return
+
+    # Team-scoped key: only rows belonging to the key's own team are visible
+    # (LIT-3301). Any cross-team row falls through to a 403.
+    if _is_team_scoped_key(user_api_key_dict):
+        if row.team_id is not None and row.team_id == user_api_key_dict.team_id:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": (
+                    "Team-scoped key cannot view spend log for "
+                    "request_id={}".format(request_id)
+                )
+            },
+        )
 
     if row.user is not None and row.user == user_api_key_dict.user_id:
         return

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3624,20 +3624,24 @@ async def _assert_user_can_view_request_id(
     if row is None:
         return
 
-    # Team-scoped key: only rows belonging to the key's own team are visible
-    # (LIT-3301). Any cross-team row falls through to a 403.
+    # Team-scoped key: rows that belong to a *different* team are denied
+    # (LIT-3301). Rows with no team_id ("orphan" historical rows that pre-date
+    # team attribution, or rows from non-team requests) fall through to the
+    # regular user-based check below so a key whose owning user posted the row
+    # can still see it.
     if _is_team_scoped_key(user_api_key_dict):
-        if row.team_id is not None and row.team_id == user_api_key_dict.team_id:
-            return
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={
-                "error": (
-                    "Team-scoped key cannot view spend log for "
-                    "request_id={}".format(request_id)
-                )
-            },
-        )
+        if row.team_id is not None:
+            if row.team_id == user_api_key_dict.team_id:
+                return
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": (
+                        "Team-scoped key cannot view spend log for "
+                        "request_id={}".format(request_id)
+                    )
+                },
+            )
 
     if row.user is not None and row.user == user_api_key_dict.user_id:
         return

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3185,3 +3185,280 @@ async def test_view_spend_logs_date_range_hashes_sk_api_key(client, monkeypatch)
         assert where["api_key"] == "hashed::sk-raw-admin-token"
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+# ---------- LIT-3301: team-scoped key spend-logs scoping ----------
+
+
+@pytest.mark.asyncio
+async def test_is_admin_view_safe_team_scoped_admin_key_is_not_admin():
+    """A PROXY_ADMIN key that also carries a team_id is a team-scoped key
+    and must NOT be treated as admin-view (LIT-3301)."""
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+    assert spend_management_endpoints._is_admin_view_safe(auth) is False
+    assert spend_management_endpoints._is_team_scoped_key(auth) is True
+
+
+@pytest.mark.asyncio
+async def test_is_admin_view_safe_personal_admin_key_is_admin():
+    """A PROXY_ADMIN personal (non-team) key is still admin-view."""
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+    )
+    assert spend_management_endpoints._is_admin_view_safe(auth) is True
+    assert spend_management_endpoints._is_team_scoped_key(auth) is False
+
+
+@pytest.mark.asyncio
+async def test_view_spend_logs_team_key_date_range_forces_team_filter(
+    client, monkeypatch
+):
+    """Legacy /spend/logs date-range path must force team_id filter for a
+    team-scoped admin-created key (LIT-3301)."""
+    mock_client = _CapturePrismaClient()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+    try:
+        response = client.get(
+            "/spend/logs",
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+                "summarize": "false",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200
+        where = mock_client.db.captured_where
+        assert where is not None
+        assert where["team_id"] == "team-A"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_view_spend_logs_team_key_non_date_range_forces_team_filter(
+    client, monkeypatch
+):
+    """Legacy /spend/logs non-date-range path must force team_id filter for a
+    team-scoped admin-created key (LIT-3301)."""
+    mock_client = _CapturePrismaClient()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+    try:
+        response = client.get(
+            "/spend/logs",
+            params={"api_key": "sk-leaked-key"},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200
+        where = mock_client.db.captured_where
+        assert where is not None
+        assert where["team_id"] == "team-A"
+        # api_key filter still applied alongside team scoping
+        assert where["api_key"] == "hashed::sk-leaked-key"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_view_spend_logs_personal_admin_key_no_team_filter(
+    client, monkeypatch
+):
+    """A personal (non-team) PROXY_ADMIN key must still see global logs."""
+    mock_client = _CapturePrismaClient()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+    )
+    try:
+        response = client.get(
+            "/spend/logs",
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+                "summarize": "false",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200
+        where = mock_client.db.captured_where
+        assert where is not None
+        assert "team_id" not in where
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_team_key_forces_team_filter(client, monkeypatch):
+    """/spend/logs/ui must force team_id=key.team_id for a team-scoped
+    PROXY_ADMIN-created key, even if no team_id was provided in the query (LIT-3301)."""
+    start_date, end_date = _default_date_range()
+
+    captured = {}
+
+    def filter_fn(where):
+        captured["where"] = dict(where)
+        return []
+
+    mock_client = make_ui_spend_logs_mock_prisma(
+        mock_spend_logs=[], filter_fn=filter_fn
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+    try:
+        response = client.get(
+            "/spend/logs/ui",
+            params={"start_date": start_date, "end_date": end_date},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200, response.text
+        assert captured.get("where", {}).get("team_id") == "team-A"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_team_key_rejects_cross_team_query(client, monkeypatch):
+    """A team-scoped key requesting team_id != its own must 403 (LIT-3301)."""
+    start_date, end_date = _default_date_range()
+
+    mock_client = make_ui_spend_logs_mock_prisma(
+        mock_spend_logs=[], filter_fn=lambda w: []
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+    try:
+        response = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "team_id": "team-B",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 403, response.text
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_team_key_same_team_allowed(client, monkeypatch):
+    """A team-scoped key requesting team_id == its own is allowed (LIT-3301)."""
+    start_date, end_date = _default_date_range()
+
+    captured = {}
+
+    def filter_fn(where):
+        captured["where"] = dict(where)
+        return []
+
+    mock_client = make_ui_spend_logs_mock_prisma(
+        mock_spend_logs=[], filter_fn=filter_fn
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+    try:
+        response = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "team_id": "team-A",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200, response.text
+        assert captured.get("where", {}).get("team_id") == "team-A"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_assert_user_can_view_request_id_team_key_same_team_allowed():
+    """A team-scoped key viewing a spend-log row from its OWN team passes."""
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+
+    row = MagicMock()
+    row.team_id = "team-A"
+    row.user = "some_other_user"
+
+    class _DB:
+        litellm_spendlogs = MagicMock()
+    _DB.litellm_spendlogs.find_unique = AsyncMock(return_value=row)
+
+    class _Client:
+        db = _DB
+
+    # Should not raise
+    await spend_management_endpoints._assert_user_can_view_request_id(
+        prisma_client=_Client(),
+        user_api_key_dict=auth,
+        request_id="r1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_assert_user_can_view_request_id_team_key_other_team_denied():
+    """A team-scoped key viewing a spend-log row from a DIFFERENT team is 403."""
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+
+    row = MagicMock()
+    row.team_id = "team-B"
+    row.user = "admin_user_1"  # even matching user_id must not leak
+
+    class _DB:
+        litellm_spendlogs = MagicMock()
+    _DB.litellm_spendlogs.find_unique = AsyncMock(return_value=row)
+
+    class _Client:
+        db = _DB
+
+    with pytest.raises(HTTPException) as exc_info:
+        await spend_management_endpoints._assert_user_can_view_request_id(
+            prisma_client=_Client(),
+            user_api_key_dict=auth,
+            request_id="r1",
+        )
+    assert exc_info.value.status_code == 403

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3464,3 +3464,65 @@ async def test_assert_user_can_view_request_id_team_key_other_team_denied():
             request_id="r1",
         )
     assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_assert_user_can_view_request_id_team_key_orphan_row_falls_through():
+    """A team-scoped key viewing an orphan row (team_id=None) falls through to
+    the user-based check. The row's user matches the key's owning user_id so
+    access is allowed (LIT-3301 — backward compatibility for pre-team rows)."""
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+
+    row = MagicMock()
+    row.team_id = None  # orphan row
+    row.user = "admin_user_1"  # owned by key's user
+
+    class _DB:
+        litellm_spendlogs = MagicMock()
+
+    _DB.litellm_spendlogs.find_unique = AsyncMock(return_value=row)
+
+    class _Client:
+        db = _DB
+
+    # Should not raise — row.user matches user_api_key_dict.user_id
+    await spend_management_endpoints._assert_user_can_view_request_id(
+        prisma_client=_Client(),
+        user_api_key_dict=auth,
+        request_id="r-orphan",
+    )
+
+
+@pytest.mark.asyncio
+async def test_assert_user_can_view_request_id_team_key_orphan_row_other_user_denied():
+    """A team-scoped key viewing an orphan row owned by a different user is
+    denied (no team match, no user match)."""
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_1",
+        team_id="team-A",
+    )
+
+    row = MagicMock()
+    row.team_id = None
+    row.user = "someone_else"
+
+    class _DB:
+        litellm_spendlogs = MagicMock()
+
+    _DB.litellm_spendlogs.find_unique = AsyncMock(return_value=row)
+
+    class _Client:
+        db = _DB
+
+    with pytest.raises(HTTPException) as exc_info:
+        await spend_management_endpoints._assert_user_can_view_request_id(
+            prisma_client=_Client(),
+            user_api_key_dict=auth,
+            request_id="r-orphan",
+        )
+    assert exc_info.value.status_code == 403

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3277,9 +3277,7 @@ async def test_view_spend_logs_team_key_non_date_range_forces_team_filter(
 
 
 @pytest.mark.asyncio
-async def test_view_spend_logs_personal_admin_key_no_team_filter(
-    client, monkeypatch
-):
+async def test_view_spend_logs_personal_admin_key_no_team_filter(client, monkeypatch):
     """A personal (non-team) PROXY_ADMIN key must still see global logs."""
     mock_client = _CapturePrismaClient()
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_client)
@@ -3341,7 +3339,9 @@ async def test_ui_view_spend_logs_team_key_forces_team_filter(client, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_ui_view_spend_logs_team_key_rejects_cross_team_query(client, monkeypatch):
+async def test_ui_view_spend_logs_team_key_rejects_cross_team_query(
+    client, monkeypatch
+):
     """A team-scoped key requesting team_id != its own must 403 (LIT-3301)."""
     start_date, end_date = _default_date_range()
 
@@ -3422,6 +3422,7 @@ async def test_assert_user_can_view_request_id_team_key_same_team_allowed():
 
     class _DB:
         litellm_spendlogs = MagicMock()
+
     _DB.litellm_spendlogs.find_unique = AsyncMock(return_value=row)
 
     class _Client:
@@ -3450,6 +3451,7 @@ async def test_assert_user_can_view_request_id_team_key_other_team_denied():
 
     class _DB:
         litellm_spendlogs = MagicMock()
+
     _DB.litellm_spendlogs.find_unique = AsyncMock(return_value=row)
 
     class _Client:


### PR DESCRIPTION
## Summary

A virtual key created under a team currently leaks every other team's spend rows when the creator has the `PROXY_ADMIN` role.

`_is_admin_view_safe` only checks `user_role`, so any request authenticated through a team-scoped admin-created key satisfies `is_admin_view=True` and skips the team-scoping branch. This patch treats every team-scoped key (`user_api_key_dict.team_id is not None`) as non-admin and force-filters spend-logs queries to the key's own team.

Closes LIT-3301.

## Surface area

- `_is_admin_view_safe(...)` — returns `False` when the key is team-scoped, even with `user_role=PROXY_ADMIN`.
- New helper `_is_team_scoped_key(...)`.
- `ui_view_spend_logs` (`/spend/logs/v2`, `/spend/logs/ui`) — force-filters `team_id` to the key's team and 403s any explicit cross-team `team_id` query param.
- `view_spend_logs` (legacy `/spend/logs`) — force-filters `team_id` on both the date-range and non-date-range code paths.
- `_assert_user_can_view_request_id` (`/spend/logs/ui/{request_id}`) — 403s rows that belong to a *different* team. Rows with `team_id=NULL` (orphan/historical) fall through to the existing user-ownership check so a team-scoped key whose owning user posted the row can still see it.

Out of scope (admin-only at the auth layer, not in the leak path the ticket reports): `/global/spend/*`, `/spend/keys`, `/spend/users`. These keep their existing role-based gating.

Non-team-scoped admin keys are unchanged.

### Evidence

Reproduced on a fresh proxy started from `litellm_oss_agent_shin_daily_branch`, with two teams (A, B), four seeded spend-log rows (2 per team), and a `team_id=team-A` virtual key created by a `PROXY_ADMIN` user.

**BEFORE (baseline, bug present):**

```
## Test 1: GET /spend/logs with team-A key
rows returned: 4
  request_id=req-A-1  team_id=team-A  user=alice@example.com   spend=0.01
  request_id=req-B-1  team_id=team-B  user=carol@example.com   spend=0.05    <-- LEAK
  request_id=req-A-2  team_id=team-A  user=bob@example.com     spend=0.02
  request_id=req-B-2  team_id=team-B  user=dave@example.com    spend=0.1     <-- LEAK

## Test 2: GET /spend/logs/v2 with team-A key
total: 4 rows returned: 4
  request_id=req-B-1  team_id=team-B    <-- LEAK
  request_id=req-A-1  team_id=team-A
  request_id=req-B-2  team_id=team-B    <-- LEAK
  request_id=req-A-2  team_id=team-A

## Test 3: GET /spend/logs/ui/req-B-1 with team-A key
HTTP 200
{"messages":{},"response":{},"proxy_server_request":{}}                       <-- LEAK

## Test 4: GET /spend/logs/v2?team_id=team-B with team-A key (cross-team)
HTTP 200
total: 2 rows returned: 2
  request_id=req-B-1  team_id=team-B                                          <-- LEAK
  request_id=req-B-2  team_id=team-B                                          <-- LEAK
```

**AFTER fix:**

```
## Test 1: GET /spend/logs with team-A key
rows returned: 2
  request_id=req-A-1  team_id=team-A  user=alice@example.com   spend=0.01    OK
  request_id=req-A-2  team_id=team-A  user=bob@example.com     spend=0.02    OK

## Test 2: GET /spend/logs/v2 with team-A key
total: 2 rows returned: 2
  request_id=req-A-1  team_id=team-A    OK
  request_id=req-A-2  team_id=team-A    OK

## Test 3: GET /spend/logs/ui/req-B-1 with team-A key
HTTP 403                                                                      OK
{"detail":{"error":"Team-scoped key cannot view spend log for request_id=req-B-1"}}

## Test 4: GET /spend/logs/v2?team_id=team-B with team-A key (cross-team)
HTTP 403                                                                      OK
{"error":{"message":"Team-scoped key cannot query spend logs for team_id=..."}}
```

**Regression check — personal (non-team-scoped) admin master key (`sk-1234`):**

```
## GET /spend/logs                  -> 4 rows (both teams)  OK (unchanged)
## GET /spend/logs/v2               -> total: 4, 4 rows     OK (unchanged)
```

### Tests

11 new unit tests appended to `tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py`:

```
test_is_admin_view_safe_team_scoped_admin_key_is_not_admin
test_is_admin_view_safe_personal_admin_key_is_admin
test_view_spend_logs_team_key_date_range_forces_team_filter
test_view_spend_logs_team_key_non_date_range_forces_team_filter
test_view_spend_logs_personal_admin_key_no_team_filter
test_ui_view_spend_logs_team_key_forces_team_filter
test_ui_view_spend_logs_team_key_rejects_cross_team_query
test_ui_view_spend_logs_team_key_same_team_allowed
test_assert_user_can_view_request_id_team_key_same_team_allowed
test_assert_user_can_view_request_id_team_key_other_team_denied
test_assert_user_can_view_request_id_team_key_orphan_row_falls_through
test_assert_user_can_view_request_id_team_key_orphan_row_other_user_denied
```

Local run: **76 passed**, 1 unrelated warning.

### Notes for reviewers

- This PR was pushed via the GitHub contents API (one commit per file) because the current bot token lacks `repo`+`workflow` scopes for `git push`. The merge-base diff is the same as the squashed change; please use the "Files changed" tab.

---

### Verification (ship-pr)

- Reproduced bug on `litellm_oss_agent_shin_daily_branch` with real proxy + Postgres
- Captured BEFORE evidence (team-A key returned 4 rows incl. team-B; `/spend/logs/v2?team_id=team-B` returned 200; `/spend/logs/ui/req-B-1` returned 200)
- Applied fix; re-ran SAME requests and captured AFTER evidence (team-A key returns 2 team-A rows; cross-team queries return 403)
- Regression check: personal admin master key still sees all 4 rows on both endpoints (no behavior change for non-team-scoped admin keys)
- Unit tests: 76/76 in `test_spend_management_endpoints.py` pass locally
- No customer name in PR body, commit messages, code, or tests
- Targets `litellm_oss_agent_shin_daily_branch` (required for fork PRs)
- Greptile: **4/5** (orphan-row concern resolved in follow-up commit c0022f0; new tests cover team-only allow + orphan + cross-team 403)
- GitHub Actions: 43/44 green at posting time (Veria still running; all proxy/lint/test/security checks pass)
