### PR TITLE
fix(ui): anchor sidebar hrefs to /ui/ mount (LIT-3063)

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -7,19 +7,28 @@ import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useRouter, useSearchParams } from "next/navigation";
 import { DebugWarningBanner } from "@/components/DebugWarningBanner";
+import { serverRootPath } from "@/components/networking";
 
 /** ---- BASE URL HELPERS ---- */
-function normalizeBasePrefix(raw: string | undefined | null): string {
-  const trimmed = (raw ?? "").trim();
-  if (!trimmed) return "";
-  const core = trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
-  return core ? `/${core}/` : "/";
+/**
+ * Resolve the UI root URL: \`<serverRootPath>/ui/\`.
+ *
+ * The LiteLLM proxy always mounts the static UI at \`/ui\` (see
+ * \`app.mount(\"/ui\", StaticFiles(...))\` in \`litellm/proxy/proxy_server.py\`),
+ * so router targets must always be anchored to that mount. The previous
+ * implementation derived the prefix from \`NEXT_PUBLIC_BASE_URL\` — which is
+ * unset in \`.env.production\` — and produced URLs like \`/?page=logs\` from
+ * dashboard subpaths, leaking the previous route segment in the URL.
+ */
+function uiRootBase(): string {
+  const root = serverRootPath && serverRootPath !== "/" ? serverRootPath.replace(/\/+$/, "") : "";
+  return `${root}/ui/`;
 }
-const BASE_PREFIX = normalizeBasePrefix(process.env.NEXT_PUBLIC_BASE_URL);
 function withBase(path: string): string {
-  const body = path.startsWith("/") ? path.slice(1) : path;
-  const combined = `${BASE_PREFIX}${body}`;
-  return combined.startsWith("/") ? combined : `/${combined}`;
+  const base = uiRootBase();
+  if (path.startsWith("?")) return `${base}${path}`;
+  if (path.startsWith("/")) return `${base}${path.slice(1)}`;
+  return `${base}${path}`;
 }
 /** -------------------------------- */
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -7,23 +7,16 @@ import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useRouter, useSearchParams } from "next/navigation";
 import { DebugWarningBanner } from "@/components/DebugWarningBanner";
-import { serverRootPath } from "@/components/networking";
+import { uiRootBase } from "@/utils/uiRoutes";
 
-/** ---- BASE URL HELPERS ---- */
+/** ---- BASE URL HELPER ---- */
 /**
- * Resolve the UI root URL: \`<serverRootPath>/ui/\`.
+ * Resolve a router target relative to the UI root \`<serverRootPath>/ui/\`.
  *
- * The LiteLLM proxy always mounts the static UI at \`/ui\` (see
- * \`app.mount(\"/ui\", StaticFiles(...))\` in \`litellm/proxy/proxy_server.py\`),
- * so router targets must always be anchored to that mount. The previous
- * implementation derived the prefix from \`NEXT_PUBLIC_BASE_URL\` — which is
- * unset in \`.env.production\` — and produced URLs like \`/?page=logs\` from
- * dashboard subpaths, leaking the previous route segment in the URL.
+ * The proxy always mounts the static UI at \`/ui\` (see \`uiRootBase\` in
+ * \`@/utils/uiRoutes\`); router pushes must therefore be anchored to that
+ * mount regardless of \`NEXT_PUBLIC_BASE_URL\`.
  */
-function uiRootBase(): string {
-  const root = serverRootPath && serverRootPath !== "/" ? serverRootPath.replace(/\/+$/, "") : "";
-  return `${root}/ui/`;
-}
 function withBase(path: string): string {
   const base = uiRootBase();
   if (path.startsWith("?")) return `${base}${path}`;

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -3,6 +3,19 @@ import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../tests/test-utils";
 import Sidebar from "./leftnav";
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/ui/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 vi.mock("../utils/roles", () => {
   return {
     all_admin_roles: ["admin", "admin_viewer"],
@@ -220,5 +233,57 @@ describe("Sidebar (leftnav)", () => {
     renderWithProviders(<Sidebar {...defaultProps} />);
 
     expect(screen.getByText("Organizations")).toBeInTheDocument();
+  });
+});
+
+// -------------------------------------------------------------------------
+// LIT-3063 — Sidebar nav broken in v1.83.14
+//
+// Two regressions covered by the helpers introduced in leftnav.tsx:
+//   1. The API Reference sidebar entry was rendering with href
+//      "/api-reference" instead of "/ui/api-reference", so Ctrl/Cmd+click
+//      (or double-click) navigated outside the UI mount and 404ed.
+//   2. The legacy (query-param) entries rendered with relative
+//      hrefs like "?page=logs" — so on /ui/api-reference the browser
+//      resolved them to "/ui/api-reference?page=logs" instead of
+//      "/ui/?page=logs", leaving the previous route segment in the URL.
+//
+// The hrefs are now anchored to the UI root ("<serverRootPath>/ui/")
+// regardless of NEXT_PUBLIC_BASE_URL, matching the proxys static
+// mount in litellm/proxy/proxy_server.py.
+// -------------------------------------------------------------------------
+describe("Sidebar (leftnav) — LIT-3063 absolute /ui/ href anchoring", () => {
+  const defaultProps = {
+    setPage: vi.fn(),
+    defaultSelectedKey: "api-keys",
+    collapsed: false,
+  };
+
+  it("renders the API Reference link with an absolute /ui/api-reference href", () => {
+    const { container } = renderWithProviders(<Sidebar {...defaultProps} />);
+    const apiRef = Array.from(container.querySelectorAll("a")).find(
+      (a) => a.textContent?.trim() === "API Reference",
+    );
+    expect(apiRef).toBeTruthy();
+    // The raw attribute (what Ctrl/Cmd+click follows) must already be /ui/...
+    expect(apiRef!.getAttribute("href")).toBe("/ui/api-reference");
+  });
+
+  it("renders every legacy (query-param) link anchored to /ui/", () => {
+    const { container } = renderWithProviders(<Sidebar {...defaultProps} />);
+    const anchors = Array.from(container.querySelectorAll("a"));
+    const cases: Record<string, string> = {
+      Logs: "page=logs",
+      Teams: "page=teams",
+      "Virtual Keys": "page=api-keys",
+    };
+    for (const [label, expected] of Object.entries(cases)) {
+      const a = anchors.find((x) => x.textContent?.trim() === label);
+      expect(a, `missing link for ${label}`).toBeTruthy();
+      const href = a!.getAttribute("href") ?? "";
+      // Anchored to /ui/, not relative ?page=...
+      expect(href.startsWith("/ui/?"), `${label} href \`${href}\` must start with /ui/?`).toBe(true);
+      expect(href).toContain(expected);
+    }
   });
 });

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -32,6 +32,7 @@ import {
 import type { MenuProps } from "antd";
 import { ConfigProvider, Layout, Menu } from "antd";
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
 import {
   all_admin_roles,
   internalUserRoles,
@@ -56,19 +57,32 @@ const MIGRATED_PAGES: Record<string, string> = {
   "api-reference": "api-reference",
 };
 
-/** Build an absolute href for a migrated page, respecting base URL + serverRootPath. */
+/**
+ * Resolve the UI root URL: \`<serverRootPath>/ui/\`.
+ *
+ * The LiteLLM proxy always mounts the static UI at \`/ui\` (see
+ * \`app.mount(\"/ui\", StaticFiles(...))\` in \`litellm/proxy/proxy_server.py\`),
+ * so sidebar links must always be anchored to that mount. The previous
+ * implementation derived the prefix from \`NEXT_PUBLIC_BASE_URL\` — which is
+ * unset in \`.env.production\` — and ended up producing hrefs like
+ * \`/api-reference\` that hit the proxy 404 handler instead of the UI.
+ */
+function uiRootBase(): string {
+  const root = serverRootPath && serverRootPath !== "/" ? serverRootPath.replace(/\/+$/, "") : "";
+  return `${root}/ui/`;
+}
+
+/** Build an absolute href for a migrated (path-based) page. */
 function migratedHref(routeSegment: string): string {
-  const raw = process.env.NEXT_PUBLIC_BASE_URL ?? "";
-  const trimmed = raw.replace(/^\/+|\/+$/g, "");
-  let base = trimmed ? `/${trimmed}/` : "/";
+  return `${uiRootBase()}${routeSegment.replace(/^\/+/, "")}`;
+}
 
-  if (serverRootPath && serverRootPath !== "/") {
-    const cleanRoot = serverRootPath.replace(/\/+$/, "");
-    const cleanBase = base.replace(/^\/+/, "");
-    base = `${cleanRoot}/${cleanBase}`;
-  }
-
-  return `${base}${routeSegment}`;
+/** Build an absolute href for a legacy (query-param) page. */
+function legacyHref(page: string): string {
+  const search = typeof window !== "undefined" ? window.location.search : "";
+  const params = new URLSearchParams(search);
+  params.set("page", page);
+  return `${uiRootBase()}?${params.toString()}`;
 }
 
 // Define the props type
@@ -422,6 +436,7 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
   const { userId, accessToken, userRole } = useAuthorized();
   const { data: organizations } = useOrganizations();
   const { data: teams } = useTeams();
+  const router = useRouter();
 
   // Check if user is an org_admin
   const isOrgAdmin = useMemo(() => {
@@ -436,14 +451,26 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
 
   // Navigate to page helper
   const navigateToPage = (page: string) => {
-    // For migrated pages, just call setPage — the parent layout handles routing
+    // Migrated (path-based) pages are routed by the parent layout (full
+    // router.push to the matching segment under (dashboard)/).
     if (MIGRATED_PAGES[page]) {
       setPage(page);
       return;
     }
-    const newSearchParams = new URLSearchParams(window.location.search);
-    newSearchParams.set("page", page);
-    window.history.pushState(null, "", `?${newSearchParams.toString()}`);
+    // Legacy (query-param) pages live at the UI root \`<serverRootPath>/ui/\`.
+    // When the user is currently on a migrated path such as \`/ui/api-reference\`,
+    // a relative \`pushState(\"?page=...\")\` would produce \`/ui/api-reference?page=...\`
+    // and leave the previous route segment in the URL. Build the absolute
+    // target and hand off to the Next.js router so the root SPA re-mounts.
+    const target = legacyHref(page);
+    const currentPath = window.location.pathname.replace(/\/+$/, "");
+    const rootPath = uiRootBase().replace(/\/+$/, "");
+    if (currentPath === rootPath) {
+      // Already at the UI root — pushState avoids a full re-render.
+      window.history.pushState(null, "", target);
+    } else {
+      router.push(target);
+    }
     setPage(page);
   };
 
@@ -467,11 +494,10 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
         </a>
       );
     }
-    // For migrated pages, generate a path-based href for right-click "Open in new tab"
+    // Resolve to an absolute href so that right-click "Open in new tab" and
+    // Ctrl/Cmd+click work consistently regardless of the current path.
     const migratedRoute = MIGRATED_PAGES[page];
-    const href = migratedRoute
-      ? migratedHref(migratedRoute)
-      : (() => { const params = new URLSearchParams(window.location.search); params.set("page", page); return `?${params.toString()}`; })();
+    const href = migratedRoute ? migratedHref(migratedRoute) : legacyHref(page);
     return (
       <a
         href={href}

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -44,7 +44,7 @@ import {
 import NewBadge from "./common_components/NewBadge";
 import type { Organization } from "./networking";
 import UsageIndicator from "./UsageIndicator";
-import { serverRootPath } from "./networking";
+import { legacyHref, migratedHref, uiRootBase } from "@/utils/uiRoutes";
 const { Sider } = Layout;
 
 /**
@@ -56,34 +56,6 @@ const { Sider } = Layout;
 const MIGRATED_PAGES: Record<string, string> = {
   "api-reference": "api-reference",
 };
-
-/**
- * Resolve the UI root URL: \`<serverRootPath>/ui/\`.
- *
- * The LiteLLM proxy always mounts the static UI at \`/ui\` (see
- * \`app.mount(\"/ui\", StaticFiles(...))\` in \`litellm/proxy/proxy_server.py\`),
- * so sidebar links must always be anchored to that mount. The previous
- * implementation derived the prefix from \`NEXT_PUBLIC_BASE_URL\` — which is
- * unset in \`.env.production\` — and ended up producing hrefs like
- * \`/api-reference\` that hit the proxy 404 handler instead of the UI.
- */
-function uiRootBase(): string {
-  const root = serverRootPath && serverRootPath !== "/" ? serverRootPath.replace(/\/+$/, "") : "";
-  return `${root}/ui/`;
-}
-
-/** Build an absolute href for a migrated (path-based) page. */
-function migratedHref(routeSegment: string): string {
-  return `${uiRootBase()}${routeSegment.replace(/^\/+/, "")}`;
-}
-
-/** Build an absolute href for a legacy (query-param) page. */
-function legacyHref(page: string): string {
-  const search = typeof window !== "undefined" ? window.location.search : "";
-  const params = new URLSearchParams(search);
-  params.set("page", page);
-  return `${uiRootBase()}?${params.toString()}`;
-}
 
 // Define the props type
 interface SidebarProps {

--- a/ui/litellm-dashboard/src/utils/uiRoutes.ts
+++ b/ui/litellm-dashboard/src/utils/uiRoutes.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers for resolving sidebar / dashboard navigation hrefs.
+ *
+ * The LiteLLM proxy always mounts the static UI at \`/ui\` (see
+ * \`app.mount("/ui", StaticFiles(...))\` in
+ * \`litellm/proxy/proxy_server.py\`). All sidebar links must therefore
+ * be anchored to that mount regardless of \`NEXT_PUBLIC_BASE_URL\`.
+ *
+ * Keep this module dependency-light — both \`leftnav.tsx\` and
+ * \`(dashboard)/layout.tsx\` import from it.
+ */
+import { serverRootPath } from "@/components/networking";
+
+/** Resolve the UI root URL: \`<serverRootPath>/ui/\`. */
+export function uiRootBase(): string {
+  const root = serverRootPath && serverRootPath !== "/" ? serverRootPath.replace(/\/+$/, "") : "";
+  return `${root}/ui/`;
+}
+
+/** Build an absolute href for a migrated (path-based) page. */
+export function migratedHref(routeSegment: string): string {
+  return `${uiRootBase()}${routeSegment.replace(/^\/+/, "")}`;
+}
+
+/**
+ * Build an absolute href for a legacy (query-param) page.
+ *
+ * Only emits \`?page=<page>\`; we intentionally do not carry over any
+ * other query parameters from \`window.location.search\` because each
+ * legacy page renders its own panel and reusing a stale filter (e.g.
+ * \`someFilter=value\` from a previous panel) silently leaks state.
+ */
+export function legacyHref(page: string): string {
+  return `${uiRootBase()}?page=${encodeURIComponent(page)}`;
+}


### PR DESCRIPTION
## Summary

Resolves **LIT-3063**.

In v1.83.14 the admin UI shipped a regression that breaks two sidebar navigation paths:

1. Clicking (or Ctrl/Cmd+clicking) **API Reference** navigates to `/api-reference` — outside the `/ui` mount — which the proxy returns 404 for, instead of `/ui/api-reference`.
2. After visiting `/ui/api-reference`, every other sidebar entry produces a malformed URL such as `/ui/api-reference?page=logs` instead of `/ui/?page=logs`, leaving the previous route segment in the URL.

Root cause: both `migratedHref()` (in `leftnav.tsx`) and `withBase()` (in `(dashboard)/layout.tsx`) derived their UI base prefix from `NEXT_PUBLIC_BASE_URL`. `.env.production` does not set that variable, so the helpers fell back to `/` and emitted hrefs/router targets without the `/ui/` segment that the proxy mounts the static UI at (`app.mount("/ui", StaticFiles(...))` in `litellm/proxy/proxy_server.py`). The legacy-page navigation also performed a `window.history.pushState` with a relative `?page=…` query, so the URL inherited the previous path when the user clicked from a migrated route.

## Fix

* New `ui/litellm-dashboard/src/utils/uiRoutes.ts` exports shared `uiRootBase()`, `migratedHref()`, and `legacyHref()` helpers that anchor on `<serverRootPath>/ui/`, independent of `NEXT_PUBLIC_BASE_URL`.
* `leftnav.tsx` imports from the shared module. `renderNavLink` uses `legacyHref(page)` for query-param entries so the raw `<a href>` attribute is always an absolute `/ui/?page=<page>` (right-click "Open in new tab" works from any path; `legacyHref` does not carry over unrelated query parameters from the current page).
* `navigateToPage` hands off to `next/navigation` `router.push` with an absolute URL when the user is on a migrated path (e.g. `/ui/api-reference`) so the root SPA re-mounts and the URL no longer carries the previous segment.
* `(dashboard)/layout.tsx#withBase` imports the same `uiRootBase()` helper so `router.push(withBase("?page=…"))` lands on `/ui/?page=…`.

Net `+102 / -45` across 4 files; no behaviour change for deployments that previously relied on `NEXT_PUBLIC_BASE_URL` because the proxy mount path is hard-coded.

## Evidence

Reproduced against the prebuilt UI shipped at the base SHA (`1fe911d` on `litellm_oss_agent_shin_daily_branch`) and again against the fixed build from this branch. The capture script renders the real `Sidebar` component in headless Chromium with a mocked `/litellm/.well-known/litellm-ui-config` payload and a signed JWT cookie, then inspects every sidebar `<a>` element. The overlay banner at the top of each shot is injected by the test harness — the sidebar underneath is unmodified.

#### Before — sidebar rendered on `/ui/`

`API Reference` href is `/api-reference` (404 path), `Logs` href is a bare relative `?page=logs`:

![before sidebar on /ui/](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3063/before_root.png)

#### Before — sidebar rendered on `/ui/api-reference`

`Logs` href is still relative `?page=logs`, so the browser resolves it to `/ui/api-reference?page=logs`:

![before sidebar on /ui/api-reference](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3063/before_apiref.png)

#### After — sidebar rendered on `/ui/`

`API Reference` href is the absolute `/ui/api-reference`, `Logs` is the absolute `/ui/?page=logs`:

![after sidebar on /ui/](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3063/after_root.png)

#### After — sidebar rendered on `/ui/api-reference`

Both stay anchored to `/ui/`, no carry-over of the previous segment:

![after sidebar on /ui/api-reference](https://raw.githubusercontent.com/oss-agent-shin/litellm/pr-assets-lit-3063/after_apiref.png)

#### Console summary from the harness

Same playwright script, both builds. Each line is `browser-resolved href` for the matching sidebar entry.

```
=== BEFORE (out_before) ===
/ui/                 → API Reference: http://localhost:8765/api-reference
/ui/                 → Logs:          http://localhost:8765/ui/?page=logs
/ui/api-reference    → API Reference: http://localhost:8765/api-reference
/ui/api-reference    → Logs:          http://localhost:8765/ui/api-reference?page=logs

=== AFTER (out from this branch) ===
/ui/                 → API Reference: http://localhost:8765/ui/api-reference
/ui/                 → Logs:          http://localhost:8765/ui/?page=logs
/ui/api-reference    → API Reference: http://localhost:8765/ui/api-reference
/ui/api-reference    → Logs:          http://localhost:8765/ui/?page=logs
```

## Tests

Two new regression tests in `leftnav.test.tsx` cover the failure modes:

* `renders the API Reference link with an absolute /ui/api-reference href`
* `renders every legacy (query-param) link anchored to /ui/`

```
$ npx vitest run src/components/leftnav.test.tsx
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

## Notes

* Files were uploaded via the GitHub Contents API because the agent token lacks `repo` scope for `git push`; the merge-base diff may look noisier to reviewers but functionally only the four listed files changed (`leftnav.tsx`, `leftnav.test.tsx`, `(dashboard)/layout.tsx`, new `utils/uiRoutes.ts`).
* The capture script is in `ui/litellm-dashboard/__shin_run_test.mjs` in the local working tree; it is intentionally not committed (test harness only).
* The unused `Sidebar2.tsx` component is not imported anywhere in the tree (`grep -r "from.*Sidebar2" src/` returns no matches), so it is intentionally left untouched in this PR to keep the scope tight.

### Verification (ship-pr)

- **Target branch**: `litellm_oss_agent_shin_daily_branch` ✓ (`Verify PR source branch` check green).
- **Greptile**: **4/5** on the initial commit. Two P2 nits flagged on first review:
  - *Duplicate `uiRootBase()` between leftnav and dashboard layout* → addressed in commit `48d0aa17` by extracting to `ui/litellm-dashboard/src/utils/uiRoutes.ts`.
  - *`legacyHref` leaks unrelated query parameters from current page* → addressed in the same commit; `legacyHref(page)` now emits only `?page=<page>`.
- **GitHub Actions**: 43/44 green at head `48d0aa17`. Only `Veria AI - PR Review` is still pending (started `2026-05-28T12:11Z` — over an hour with every other check green; matches the known Veria queue-time flake noted on prior Shin PRs).
- **Codecov**: ✅ all modified and coverable lines covered by tests.
- **Unit tests**: `npx vitest run src/components/leftnav.test.tsx` — 10/10 passing (the 2 new LIT-3063 tests plus 8 pre-existing).
- **Runtime evidence**: Real before/after Playwright screenshots showing the actual rendered `<a href>` attribute of every sidebar entry on both `/ui/` and `/ui/api-reference`. Hosted on the orphan `pr-assets-lit-3063` branch; all four `raw.githubusercontent.com` URLs return `200 image/png`.
- **Customer leak check**: no customer name referenced anywhere in the PR title, body, branch name, or test names.
- **CLA**: `oss-agent-shin` signatures pre-accepted on this repo (CLAassistant banner is the standard fork-bot notice; matches every prior Shin PR that merged on this base branch).

