### PR TITLE
fix(guardrails): redact full PEM private key block in hide_secrets (LIT-3292)

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -422,7 +422,7 @@ _default_detect_secrets_config = {
 }
 
 
-# Regex helpers for PEM-armored private key redaction (LIT-3292).
+# Regex for PEM-armored private key redaction (LIT-3292).
 #
 # ``detect-secrets`` is line-based: ``PrivateKeyDetector`` returns only the
 # ``BEGIN ... PRIVATE KEY`` header line as ``secret_value``. A plain
@@ -430,18 +430,15 @@ _default_detect_secrets_config = {
 # body and ``-----END ... PRIVATE KEY-----`` footer in the forwarded payload,
 # which is the bug this guardrail is supposed to prevent.
 #
-# To redact the *entire* armored block we expand any "Private Key" match to
-# the full ``BEGIN ... END`` span before substituting. A fallback regex covers
-# malformed/truncated PEMs where the END footer is missing so residual key
-# material still does not leak downstream.
-# A single non-greedy span that matches:
-#   - BEGIN ... END  (closed armored block, normal case), or
-#   - BEGIN ... \Z   (truncated PEM with no END footer in the message — the
-#                     fallback consumes everything from BEGIN to end-of-string,
-#                     so partial encrypted keys with header lines and blank
-#                     separator lines can not leak past the BEGIN marker).
-# Using a single ``re.DOTALL`` span avoids the encrypted-PEM blank-line gap
-# that an earlier two-regex pass-and-fallback formulation missed.
+# A single non-greedy span matches:
+#   - BEGIN ... END   — closed armored block (RSA, EC, OpenSSH, generic,
+#                       encrypted-with-Proc-Type-headers); the trailing END
+#                       footer wins because of the non-greedy ``*?``.
+#   - BEGIN ... \Z    — truncated paste with no END footer in the message;
+#                       consume everything from BEGIN to end-of-string so the
+#                       base64 key body (including any blank-line separator
+#                       that follows the encrypted-PEM Proc-Type / DEK-Info
+#                       headers) cannot leak.
 _PEM_PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"
     r"[\s\S]*?"

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -434,13 +434,18 @@ _default_detect_secrets_config = {
 # the full ``BEGIN ... END`` span before substituting. A fallback regex covers
 # malformed/truncated PEMs where the END footer is missing so residual key
 # material still does not leak downstream.
-_PEM_PRIVATE_KEY_BLOCK_RE = re.compile(
-    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
-    re.DOTALL,
-)
-_PEM_PRIVATE_KEY_FALLBACK_RE = re.compile(
+# A single non-greedy span that matches:
+#   - BEGIN ... END  (closed armored block, normal case), or
+#   - BEGIN ... \Z   (truncated PEM with no END footer in the message — the
+#                     fallback consumes everything from BEGIN to end-of-string,
+#                     so partial encrypted keys with header lines and blank
+#                     separator lines can not leak past the BEGIN marker).
+# Using a single ``re.DOTALL`` span avoids the encrypted-PEM blank-line gap
+# that an earlier two-regex pass-and-fallback formulation missed.
+_PEM_PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"
-    r"(?:\r?\n[A-Za-z0-9+/=:.\- _,]+)*",
+    r"[\s\S]*?"
+    r"(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|\Z)",
 )
 
 
@@ -455,8 +460,7 @@ def _redact_text_with_detected_secrets(text: str, detected_secrets) -> str:
         return text
     has_pem = any(s.get("type") == "Private Key" for s in detected_secrets)
     if has_pem:
-        text = _PEM_PRIVATE_KEY_BLOCK_RE.sub("[REDACTED]", text)
-        text = _PEM_PRIVATE_KEY_FALLBACK_RE.sub("[REDACTED]", text)
+        text = _PEM_PRIVATE_KEY_RE.sub("[REDACTED]", text)
     for secret in detected_secrets:
         if secret.get("type") == "Private Key":
             continue

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -6,6 +6,7 @@
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
 
 import os
+import re
 import sys
 
 sys.path.insert(
@@ -421,6 +422,50 @@ _default_detect_secrets_config = {
 }
 
 
+# Regex helpers for PEM-armored private key redaction (LIT-3292).
+#
+# ``detect-secrets`` is line-based: ``PrivateKeyDetector`` returns only the
+# ``BEGIN ... PRIVATE KEY`` header line as ``secret_value``. A plain
+# ``str.replace(secret_value, "[REDACTED]")`` therefore leaves the base64 key
+# body and ``-----END ... PRIVATE KEY-----`` footer in the forwarded payload,
+# which is the bug this guardrail is supposed to prevent.
+#
+# To redact the *entire* armored block we expand any "Private Key" match to
+# the full ``BEGIN ... END`` span before substituting. A fallback regex covers
+# malformed/truncated PEMs where the END footer is missing so residual key
+# material still does not leak downstream.
+_PEM_PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_PEM_PRIVATE_KEY_FALLBACK_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"
+    r"(?:\r?\n[A-Za-z0-9+/=:.\- _,]+)*",
+)
+
+
+def _redact_text_with_detected_secrets(text: str, detected_secrets) -> str:
+    """Redact every detected secret in ``text`` with ``[REDACTED]``.
+
+    For ``"Private Key"`` matches the entire ``BEGIN ... END`` PEM block is
+    replaced (not just the single-line header that ``detect-secrets`` returns).
+    All other secret types fall back to the existing ``str.replace`` behavior.
+    """
+    if not detected_secrets:
+        return text
+    has_pem = any(s.get("type") == "Private Key" for s in detected_secrets)
+    if has_pem:
+        text = _PEM_PRIVATE_KEY_BLOCK_RE.sub("[REDACTED]", text)
+        text = _PEM_PRIVATE_KEY_FALLBACK_RE.sub("[REDACTED]", text)
+    for secret in detected_secrets:
+        if secret.get("type") == "Private Key":
+            continue
+        value = secret.get("value")
+        if value:
+            text = text.replace(value, "[REDACTED]")
+    return text
+
+
 class _ENTERPRISE_SecretDetection(CustomGuardrail):
     def __init__(self, detect_secrets_config: Optional[dict] = None, **kwargs):
         self.user_defined_detect_secrets_config = detect_secrets_config
@@ -477,8 +522,7 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
         # Covers multimodal list content + Responses-API input.
         def _redact_message_text(text: str) -> str:
             detected_secrets = self.scan_message_for_secrets(text)
-            for secret in detected_secrets:
-                text = text.replace(secret["value"], "[REDACTED]")
+            text = _redact_text_with_detected_secrets(text, detected_secrets)
             if detected_secrets:
                 secret_types = [secret["type"] for secret in detected_secrets]
                 verbose_proxy_logger.warning(
@@ -491,10 +535,9 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
         if "prompt" in data:
             if isinstance(data["prompt"], str):
                 detected_secrets = self.scan_message_for_secrets(data["prompt"])
-                for secret in detected_secrets:
-                    data["prompt"] = data["prompt"].replace(
-                        secret["value"], "[REDACTED]"
-                    )
+                data["prompt"] = _redact_text_with_detected_secrets(
+                    data["prompt"], detected_secrets
+                )
                 if len(detected_secrets) > 0:
                     secret_types = [secret["type"] for secret in detected_secrets]
                     verbose_proxy_logger.warning(
@@ -507,8 +550,7 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
                 for idx, item in enumerate(data["prompt"]):
                     if isinstance(item, str):
                         detected_secrets = self.scan_message_for_secrets(item)
-                        for secret in detected_secrets:
-                            item = item.replace(secret["value"], "[REDACTED]")
+                        item = _redact_text_with_detected_secrets(item, detected_secrets)
                         data["prompt"][idx] = item
                         if len(detected_secrets) > 0:
                             secret_types = [

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_secret_detection_pem.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_secret_detection_pem.py
@@ -1,0 +1,221 @@
+"""
+Regression tests for LIT-3292: hide_secrets only redacts PEM header line.
+
+The ``hide_secrets`` guardrail wraps ``detect-secrets`` which is line-based:
+``PrivateKeyDetector`` returns just the ``BEGIN ... PRIVATE KEY`` header line
+as ``secret_value``. The pre-fix code did
+``text.replace(secret["value"], "[REDACTED]")`` which only replaced that single
+line — leaving the base64 key body and ``-----END ... PRIVATE KEY-----`` footer
+in the payload forwarded to the upstream LLM.
+
+These tests pin the fixed behaviour: a private key embedded in a chat /
+completion request must be redacted in its entirety, regardless of PEM
+variant (RSA, EC, OpenSSH, generic, encrypted-with-headers, truncated).
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "enterprise")))
+
+from litellm.caching.caching import DualCache  # noqa: E402
+from litellm.proxy._types import UserAPIKeyAuth  # noqa: E402
+from litellm_enterprise.enterprise_callbacks.secret_detection import (  # noqa: E402
+    _ENTERPRISE_SecretDetection,
+    _redact_text_with_detected_secrets,
+)
+
+
+# Synthetic PEM material used in tests; not a real key.
+_RSA_PEM = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAabcdEF1234567890+/abcdef0123456789ABCDEF
+ABCDabcdEF1234567890+/abcdef0123456789ABCDEF==
+-----END RSA PRIVATE KEY-----"""
+
+_EC_PEM = """-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIPbGm5d/abcDEF+1234567890==
+oAoGCCqGSM49AwEHoUQDQgAEabcdef
+-----END EC PRIVATE KEY-----"""
+
+_OPENSSH_PEM = """-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABCsalkdjflkajsdflkj
+KSjwZmpsfnsm1234567890==
+-----END OPENSSH PRIVATE KEY-----"""
+
+_ENCRYPTED_PEM = """-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-EDE3-CBC,FEEDFACECAFEBEEF
+
+abc123XYZ+++/ab1234567890ABCDEFabcdef0123456789
+-----END RSA PRIVATE KEY-----"""
+
+_TRUNCATED_PEM = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAabcdEF1234567890+/abcdef0123456789ABCDEF=="""
+
+_BODY_MARKERS = {
+    "_RSA_PEM": "MIIEpAIBAAKCAQEAabcdEF",
+    "_EC_PEM": "MHcCAQEEIPbGm5d",
+    "_OPENSSH_PEM": "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYm",
+    "_ENCRYPTED_PEM": "abc123XYZ+++",
+    "_TRUNCATED_PEM": "MIIEpAIBAAKCAQEAabcdEF",
+}
+
+
+def _hook():
+    return _ENTERPRISE_SecretDetection()
+
+
+def _user_auth():
+    return UserAPIKeyAuth(api_key="sk-test", permissions={})
+
+
+@pytest.mark.parametrize(
+    "name,pem,body_marker,expect_end",
+    [
+        ("rsa", _RSA_PEM, _BODY_MARKERS["_RSA_PEM"], True),
+        ("ec", _EC_PEM, _BODY_MARKERS["_EC_PEM"], True),
+        ("openssh", _OPENSSH_PEM, _BODY_MARKERS["_OPENSSH_PEM"], True),
+        ("encrypted", _ENCRYPTED_PEM, _BODY_MARKERS["_ENCRYPTED_PEM"], True),
+        ("truncated", _TRUNCATED_PEM, _BODY_MARKERS["_TRUNCATED_PEM"], False),
+    ],
+)
+def test_full_pem_block_redacted_in_chat_messages(name, pem, body_marker, expect_end):
+    """End-to-end: pre_call_hook on chat messages strips body + END footer."""
+    data = {
+        "model": "echo-model",
+        "messages": [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "secret follows:\n" + pem + "\nplease parse."},
+        ],
+    }
+    asyncio.run(
+        _hook().async_pre_call_hook(
+            user_api_key_dict=_user_auth(),
+            cache=DualCache(),
+            data=data,
+            call_type="completion",
+        )
+    )
+    forwarded = data["messages"][1]["content"]
+    assert body_marker not in forwarded, f"PEM body leaked for {name}: {forwarded!r}"
+    if expect_end:
+        assert "-----END" not in forwarded, f"PEM END footer leaked for {name}: {forwarded!r}"
+    assert "[REDACTED]" in forwarded
+
+
+def test_full_pem_block_redacted_in_completion_prompt_str():
+    """Pre-fix the `data['prompt']` string branch had the same line-only bug."""
+    data = {
+        "model": "echo-model",
+        "prompt": "look at this:\n" + _RSA_PEM + "\nthanks",
+    }
+    asyncio.run(
+        _hook().async_pre_call_hook(
+            user_api_key_dict=_user_auth(),
+            cache=DualCache(),
+            data=data,
+            call_type="text_completion",
+        )
+    )
+    assert _BODY_MARKERS["_RSA_PEM"] not in data["prompt"]
+    assert "-----END" not in data["prompt"]
+    assert "[REDACTED]" in data["prompt"]
+
+
+def test_full_pem_block_redacted_in_completion_prompt_list():
+    """Same for the `data['prompt']` list-of-strings branch."""
+    data = {
+        "model": "echo-model",
+        "prompt": [
+            "plain question",
+            "leaked here:\n" + _RSA_PEM,
+            "another one " + _EC_PEM,
+        ],
+    }
+    asyncio.run(
+        _hook().async_pre_call_hook(
+            user_api_key_dict=_user_auth(),
+            cache=DualCache(),
+            data=data,
+            call_type="text_completion",
+        )
+    )
+    joined = "\n".join(data["prompt"])
+    assert _BODY_MARKERS["_RSA_PEM"] not in joined
+    assert _BODY_MARKERS["_EC_PEM"] not in joined
+    assert "-----END" not in joined
+    assert joined.count("[REDACTED]") >= 2
+
+
+def test_pem_plus_non_pem_secret_both_redacted():
+    """A request containing an AWS access key alongside a PEM block should
+    redact both — non-PEM secrets must keep working after the fix."""
+    aws = "AKIAIOSFODNN7EXAMPLE"
+    data = {
+        "model": "echo-model",
+        "messages": [
+            {"role": "user", "content": f"creds {aws} and key:\n{_RSA_PEM}"},
+        ],
+    }
+    asyncio.run(
+        _hook().async_pre_call_hook(
+            user_api_key_dict=_user_auth(),
+            cache=DualCache(),
+            data=data,
+            call_type="completion",
+        )
+    )
+    content = data["messages"][0]["content"]
+    assert aws not in content
+    assert _BODY_MARKERS["_RSA_PEM"] not in content
+    assert "-----END" not in content
+
+
+def test_no_secret_no_change():
+    """Negative case: a plain message must not be mangled by the new helper."""
+    data = {
+        "model": "echo-model",
+        "messages": [
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    }
+    asyncio.run(
+        _hook().async_pre_call_hook(
+            user_api_key_dict=_user_auth(),
+            cache=DualCache(),
+            data=data,
+            call_type="completion",
+        )
+    )
+    assert data["messages"][0]["content"] == "What is the capital of France?"
+
+
+def test_helper_handles_empty_detected_secrets():
+    """Direct unit test: helper with empty `detected_secrets` is identity."""
+    text = "hello world"
+    assert _redact_text_with_detected_secrets(text, []) == text
+
+
+def test_helper_handles_non_pem_only():
+    """Direct unit test: helper falls back to `str.replace` for non-PEM types."""
+    text = "key=sk-abc-123 here"
+    out = _redact_text_with_detected_secrets(text, [{"type": "OpenAI Token", "value": "sk-abc-123"}])
+    assert "sk-abc-123" not in out
+    assert "[REDACTED]" in out
+
+
+def test_helper_skips_private_key_str_value_match():
+    """Direct unit test: ``"Private Key"`` entries are *not* used for plain
+    str.replace (they only drive the PEM-block regex expansion). This makes
+    the helper robust against fake/header-only `secret_value`s that detect-
+    secrets might emit and ensures we never accidentally fall back to the
+    line-only behaviour for the PEM case."""
+    text = "no key here"
+    out = _redact_text_with_detected_secrets(text, [{"type": "Private Key", "value": "BEGIN RSA PRIVATE KEY"}])
+    # Helper should not crash and should not substitute when no BEGIN..END
+    # spans match (and we deliberately don't substitute the literal header).
+    assert out == "no key here"

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_secret_detection_pem.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_secret_detection_pem.py
@@ -219,3 +219,41 @@ def test_helper_skips_private_key_str_value_match():
     # Helper should not crash and should not substitute when no BEGIN..END
     # spans match (and we deliberately don't substitute the literal header).
     assert out == "no key here"
+
+
+_TRUNCATED_ENCRYPTED_PEM = """-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-EDE3-CBC,FEEDFACECAFEBEEF
+
+abc123XYZ+++/ab1234567890ABCDEFabcdef0123456789"""
+
+
+def test_truncated_encrypted_pem_blank_line_separator_does_not_leak_body():
+    """LIT-3292 / Veria PR review #29149: encrypted PEM blocks have a blank
+    line between the ``Proc-Type``/``DEK-Info`` headers and the base64 body.
+    If the END footer is missing (truncated paste), an earlier two-regex
+    formulation stopped consuming at the blank line and let the body through.
+    The consolidated single-span fallback must consume from BEGIN through
+    end-of-string so the body cannot leak."""
+    data = {
+        "model": "echo-model",
+        "messages": [
+            {"role": "user", "content": "partial:\n" + _TRUNCATED_ENCRYPTED_PEM},
+        ],
+    }
+    asyncio.run(
+        _hook().async_pre_call_hook(
+            user_api_key_dict=_user_auth(),
+            cache=DualCache(),
+            data=data,
+            call_type="completion",
+        )
+    )
+    content = data["messages"][0]["content"]
+    # Body marker (after the blank line) MUST be gone.
+    assert "abc123XYZ+++" not in content, content
+    # And nothing of the encrypted-headers section either.
+    assert "Proc-Type:" not in content
+    assert "DEK-Info:" not in content
+    assert "[REDACTED]" in content
+


### PR DESCRIPTION
## Summary

The enterprise `hide_secrets` guardrail detects PEM private keys but only redacts the `-----BEGIN … PRIVATE KEY-----` header line. The base64 key body and `-----END …` footer are still forwarded to the upstream LLM, while the proxy logs incorrectly report that the secret was redacted.

**Root cause** — `detect-secrets` is line-based. For PEM blocks, `PrivateKeyDetector` records only the `BEGIN ... PRIVATE KEY` header line as `secret_value`. The previous redaction in `_ENTERPRISE_SecretDetection.async_pre_call_hook` did:

```python
for secret in detected_secrets:
    text = text.replace(secret["value"], "[REDACTED]")
```

which leaves the key body + `END` footer intact verbatim.

## Fix

`enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py`

1. New module-level helper `_redact_text_with_detected_secrets(text, detected_secrets)`:
   - Whenever any detection has `type == "Private Key"`, run `_PEM_PRIVATE_KEY_BLOCK_RE.sub("[REDACTED]", text)` first — a `re.DOTALL` match across `-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----` replaces the entire armored block (RSA / EC / OpenSSH / generic / encrypted-with-Proc-Type-headers).
   - `_PEM_PRIVATE_KEY_FALLBACK_RE` catches *truncated* PEMs (BEGIN with no matching END) by consuming the header line and any directly-following base64-ish lines, so a partially-pasted key still cannot leak downstream.
   - All non-PEM detections keep using `str.replace(secret_value, "[REDACTED]")` — behaviour unchanged for AWS keys, OpenAI tokens, GitHub tokens, etc.
2. The three existing redaction call sites in `async_pre_call_hook` now route through the helper:
   - `_redact_message_text` (chat messages / responses-API input via `walk_user_text`)
   - `data["prompt"]` string branch (text completions)
   - `data["prompt"]` list branch (batched text completions)

Existing `_ENTERPRISE_SecretDetection.scan_message_for_secrets` is untouched.

## Tests

`tests/enterprise/litellm_enterprise/enterprise_callbacks/test_secret_detection_pem.py` — 12 new tests, all passing:

- `test_full_pem_block_redacted_in_chat_messages[rsa|ec|openssh|encrypted|truncated]` — 5 parametrized end-to-end runs of `async_pre_call_hook` against chat messages containing each PEM variant; asserts the base64 body marker AND the `-----END` footer are absent post-hook (truncated variant skips END assertion).
- `test_full_pem_block_redacted_in_completion_prompt_str` — exercises the `data["prompt"]` string branch.
- `test_full_pem_block_redacted_in_completion_prompt_list` — exercises the `data["prompt"]` list branch with two PEM entries.
- `test_pem_plus_non_pem_secret_both_redacted` — guards against regression on non-PEM detections (AWS access key alongside a PEM block).
- `test_no_secret_no_change` — negative case (plain-text message must pass through unchanged).
- `test_helper_handles_empty_detected_secrets` / `test_helper_handles_non_pem_only` / `test_helper_skips_private_key_str_value_match` — direct unit tests on the helper.

```
$ python3 -m pytest tests/enterprise/litellm_enterprise/enterprise_callbacks/test_secret_detection_pem.py -v
============================================== 12 passed in 7.48s ==============================================
```

## Evidence

Runtime evidence captured by driving the exact proxy code path — `_ENTERPRISE_SecretDetection.async_pre_call_hook(...)` — against a realistic chat-completion `data` dict containing an RSA PEM block AND an AWS access key. This is the same function the proxy invokes for every request; the only thing skipped vs an HTTP request is the FastAPI/uvicorn transport layer, which is unrelated to this bug.

> Note: full proxy startup in the inline-harness sandbox is blocked by the enterprise license gate (the `hide_secrets` callback requires `premium_user is True` to even load). I exercised the actual hook in-process instead; see verbose log line below showing `Detected and redacted secrets in message: ['AWS Access Key', 'Private Key']` firing exactly as it would behind the proxy.

### Before (current `litellm_oss_agent_shin_daily_branch`, no patch)

```
12:11 - LiteLLM Proxy:WARNING: secret_detection.py - Detected and redacted secrets in message: ['AWS Access Key', 'Private Key']

AFTER pre_call_hook (what main currently forwards to the upstream LLM):
{
  "model": "echo-model",
  "messages": [
    {"role": "system", "content": "You are helpful."},
    {"role": "user",
     "content": "Hi! Here's my private key for context:\n-----[REDACTED]-----\nMIIEpAIBAAKCAQEAabcdEF1234567890+/abcdef0123456789ABCDEF\nABCDabcdEF1234567890+/abcdef0123456789ABCDEF==\n-----END RSA PRIVATE KEY-----\nAlso AWS=[REDACTED]. What can you do?"}
  ]
}

LEAK CHECK (main, no PR):
PEM base64 body 'MIIEpAIB' leaked?   True
PEM END footer leaked?               True
AWS key 'AKIAIOSFODNN7EXAMPLE' leak? False
Replacement '[REDACTED]' present?   True
```

### After (this PR)

```
12:11 - LiteLLM Proxy:WARNING: secret_detection.py - Detected and redacted secrets in message: ['AWS Access Key', 'Private Key']

AFTER pre_call_hook (what the proxy now forwards to the upstream LLM):
{
  "model": "echo-model",
  "messages": [
    {"role": "system", "content": "You are helpful."},
    {"role": "user",
     "content": "Hi! Here's my private key for context:\n[REDACTED]\nAlso AWS=[REDACTED]. What can you do?"}
  ]
}

LEAK CHECK:
PEM base64 body 'MIIEpAIB' leaked?   False
PEM END footer leaked?               False
AWS key 'AKIAIOSFODNN7EXAMPLE' leak? False
Replacement '[REDACTED]' present?   True
```

The base64 body and `-----END` footer are both gone post-fix while the warning log fires exactly the same.

## Risk

Low. Behaviour change is limited to inputs that contain a PEM-armored private key — those previously leaked the key body + footer and now redact the whole block. Non-PEM secret types take exactly the same code path as before (`str.replace`). No public API surface change.

## Refile

This is a refile of the previously-closed-without-merge PR #28614 (which targeted the wrong base branch). This PR targets `litellm_oss_agent_shin_daily_branch` per fork policy.

Closes LIT-3292.
