### PR TITLE
fix(spend-logs): recompute response_cost when stale 0 / empty-string sentinel found in hidden_params (LIT-3057)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1481,6 +1481,8 @@ class Logging(LiteLLMLoggingBaseClass):
                                               (likely a stale early seed).
               - response usage is absent
                 or all zeros                -> authoritative.
+          * Negative numeric                -> not authoritative
+            (negative cost is always a bug upstream).
           * Non-numeric / un-coercible      -> not authoritative.
         """
         if "response_cost" not in hidden_params:
@@ -1494,7 +1496,10 @@ class Logging(LiteLLMLoggingBaseClass):
             return False
         if precomputed_value > 0:
             return True
-        # precomputed_value <= 0 (typically 0.0). Pass-through handlers
+        if precomputed_value < 0:
+            # Negative cost is always a bug upstream; do not silently trust it.
+            return False
+        # precomputed_value == 0.0. Pass-through handlers
         # explicitly set _hidden_params['response_cost'] including 0.0;
         # keep that contract intact.
         if getattr(self, "call_type", None) == "pass_through_endpoint":

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1452,6 +1452,63 @@ class Logging(LiteLLMLoggingBaseClass):
         if margin_total_amount is not None:
             self.cost_breakdown["margin_total_amount"] = margin_total_amount
 
+    def _is_precomputed_response_cost_authoritative(
+        self, hidden_params: dict, response_obj: Any
+    ) -> bool:
+        """
+        Decide whether ``hidden_params['response_cost']`` is a trustworthy
+        pre-computed value or a stale default that should be recomputed.
+
+        LIT-3057: response objects can carry a ``response_cost`` default set
+        earlier in the request flow (e.g. an empty-string sentinel seeded
+        by pre-stream metadata, or a transient ``0.0`` from an early
+        cost lookup that ran before pricing/usage was fully resolved).
+        When such a default is read back later in the logging path it
+        becomes authoritative and the spend log records ``0.0`` even
+        though ``litellm.completion_cost`` would return a non-zero value
+        for the same usage.
+
+        Rules:
+          * Missing key                     -> not authoritative.
+          * ``None`` or empty string        -> not authoritative.
+          * Positive numeric                -> authoritative.
+          * ``0`` for a pass-through call   -> authoritative
+            (pass-through handlers seed the cost intentionally, e.g. a
+            batch-pending response with no cost yet).
+          * ``0`` for any other call type:
+              - response usage has
+                non-zero tokens             -> not authoritative
+                                              (likely a stale early seed).
+              - response usage is absent
+                or all zeros                -> authoritative.
+          * Non-numeric / un-coercible      -> not authoritative.
+        """
+        if "response_cost" not in hidden_params:
+            return False
+        precomputed = hidden_params["response_cost"]
+        if precomputed is None or precomputed == "":
+            return False
+        try:
+            precomputed_value = float(precomputed)
+        except (TypeError, ValueError):
+            return False
+        if precomputed_value > 0:
+            return True
+        # precomputed_value <= 0 (typically 0.0). Pass-through handlers
+        # explicitly set _hidden_params['response_cost'] including 0.0;
+        # keep that contract intact.
+        if getattr(self, "call_type", None) == "pass_through_endpoint":
+            return True
+        usage = getattr(response_obj, "usage", None)
+        if usage is None:
+            return True
+        for field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            value = getattr(usage, field, None)
+            if isinstance(value, (int, float)) and value > 0:
+                # Stale early seed with real usage -> recompute.
+                return False
+        return True
+
     def _response_cost_calculator(
         self,
         result: Union[
@@ -1492,12 +1549,11 @@ class Logging(LiteLLMLoggingBaseClass):
 
         if isinstance(result, BaseModel) and hasattr(result, "_hidden_params"):
             hidden_params = getattr(result, "_hidden_params", {})
-            if (
-                "response_cost" in hidden_params
-                and hidden_params["response_cost"] is not None
-            ):  # use cost if already calculated
+            if self._is_precomputed_response_cost_authoritative(
+                hidden_params, result
+            ):  # use cost if already calculated and trustworthy (LIT-3057)
                 return hidden_params["response_cost"]
-            elif (
+            if (
                 router_model_id is None and "model_id" in hidden_params
             ):  # use model_id if not already set
                 router_model_id = hidden_params["model_id"]
@@ -1761,8 +1817,12 @@ class Logging(LiteLLMLoggingBaseClass):
 
         if self.model_call_details.get("cache_hit") is True:
             self.model_call_details["response_cost"] = 0.0
-        elif "response_cost" in hidden_params:
-            self.model_call_details["response_cost"] = hidden_params["response_cost"]
+        elif self._is_precomputed_response_cost_authoritative(
+            hidden_params, logging_result
+        ):  # trust pre-computed cost only when authoritative (LIT-3057)
+            self.model_call_details["response_cost"] = hidden_params[
+                "response_cost"
+            ]
         elif (
             existing_cost := self.model_call_details.get("response_cost")
         ) is not None and existing_cost != 0:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1820,9 +1820,7 @@ class Logging(LiteLLMLoggingBaseClass):
         elif self._is_precomputed_response_cost_authoritative(
             hidden_params, logging_result
         ):  # trust pre-computed cost only when authoritative (LIT-3057)
-            self.model_call_details["response_cost"] = hidden_params[
-                "response_cost"
-            ]
+            self.model_call_details["response_cost"] = hidden_params["response_cost"]
         elif (
             existing_cost := self.model_call_details.get("response_cost")
         ) is not None and existing_cost != 0:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3062,3 +3062,34 @@ def test_lit3057_is_precomputed_helper_unit():
     helper_pt = lo_pt._is_precomputed_response_cost_authoritative
     assert helper_pt({"response_cost": 0.0}, _FakeResponse(_FakeUsage(10, 5, 15))) is True
 
+
+
+def test_lit3057_helper_rejects_negative_precomputed_cost():
+    """Greptile P2 (PR #29150): negative precomputed cost must never be treated
+    as authoritative. Negative cost is always an upstream bug; recompute."""
+
+    class _FakeUsage:
+        def __init__(self, p=0, c=0, t=0):
+            self.prompt_tokens = p
+            self.completion_tokens = c
+            self.total_tokens = t
+
+    class _FakeResponse:
+        def __init__(self, usage=None):
+            self.usage = usage
+
+    lo = _lit3057_make_logging_obj("acompletion")
+    helper = lo._is_precomputed_response_cost_authoritative
+
+    # Negative with non-zero usage -> not authoritative.
+    assert helper({"response_cost": -0.5}, _FakeResponse(_FakeUsage(10, 5, 15))) is False
+    # Negative with zero usage -> still not authoritative.
+    assert helper({"response_cost": -0.5}, _FakeResponse(_FakeUsage(0, 0, 0))) is False
+    # Negative with no usage attribute -> still not authoritative.
+    assert helper({"response_cost": -0.5}, _FakeResponse(None)) is False
+    # Negative on a pass-through call_type is still not authoritative
+    # — pass-through trust only lifts the zero-with-usage clamp, not the
+    # negative guard.
+    lo_pt = _lit3057_make_logging_obj("pass_through_endpoint")
+    helper_pt = lo_pt._is_precomputed_response_cost_authoritative
+    assert helper_pt({"response_cost": -0.5}, _FakeResponse(_FakeUsage(10, 5, 15))) is False

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2872,3 +2872,193 @@ class TestFirstApiCallStartTimeSetOnce:
         assert obj.model_call_details["api_call_start_time"] > first
         assert obj.model_call_details["first_api_call_start_time"] == first
         assert user_meta == {}
+
+
+# ---------------------------------------------------------------------------
+# LIT-3057: stale `_hidden_params['response_cost']` (0 / '') must not be
+# treated as authoritative for normal completion paths when the response
+# usage has non-zero tokens.
+# ---------------------------------------------------------------------------
+
+
+def _lit3057_make_logging_obj(call_type: str = "acompletion"):
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging as LiteLLMLoggingObj,
+    )
+
+    obj = LiteLLMLoggingObj(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "What's the capital of France?"}],
+        stream=False,
+        call_type=call_type,
+        start_time=datetime.now(),
+        litellm_call_id="test-lit3057",
+        function_id="test-lit3057",
+    )
+    obj.optional_params = {}
+    obj.standard_built_in_tools_params = {}
+    obj.model_call_details["custom_llm_provider"] = "openai"
+    obj.model_call_details["litellm_params"] = {"model": "gpt-4o-mini"}
+    return obj
+
+
+def _lit3057_make_response(precomputed_cost, usage_tuple=(10, 5, 15)):
+    from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+    pt, ct, tt = usage_tuple
+    resp = ModelResponse(
+        id="chatcmpl-test-lit3057",
+        choices=[
+            Choices(
+                message=Message(role="assistant", content="Paris"),
+                index=0,
+                finish_reason="stop",
+            )
+        ],
+        created=1700000000,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=tt),
+    )
+    resp._hidden_params["response_cost"] = precomputed_cost
+    return resp
+
+
+def test_lit3057_response_cost_calculator_recomputes_stale_zero_with_usage():
+    """LIT-3057: a pre-computed 0.0 must be recomputed for a chat completion
+    when the response carries non-zero usage."""
+    lo = _lit3057_make_logging_obj("acompletion")
+    resp = _lit3057_make_response(precomputed_cost=0.0, usage_tuple=(10, 5, 15))
+    cost = lo._response_cost_calculator(result=resp)
+    assert isinstance(cost, float) and cost > 0, (
+        "stale 0 with non-zero usage should be recomputed to >0"
+    )
+
+
+def test_lit3057_response_cost_calculator_recomputes_stale_empty_string():
+    """LIT-3057: an empty-string sentinel must be recomputed."""
+    lo = _lit3057_make_logging_obj("acompletion")
+    resp = _lit3057_make_response(precomputed_cost="", usage_tuple=(10, 5, 15))
+    cost = lo._response_cost_calculator(result=resp)
+    assert isinstance(cost, float) and cost > 0, (
+        "empty-string sentinel should be recomputed to a real cost"
+    )
+
+
+def test_lit3057_response_cost_calculator_preserves_positive_precomputed():
+    """LIT-3057: a positive pre-computed cost is authoritative."""
+    lo = _lit3057_make_logging_obj("acompletion")
+    resp = _lit3057_make_response(precomputed_cost=0.0001234, usage_tuple=(10, 5, 15))
+    cost = lo._response_cost_calculator(result=resp)
+    assert cost == 0.0001234
+
+
+def test_lit3057_response_cost_calculator_zero_usage_keeps_zero():
+    """LIT-3057: precomputed 0.0 with zero usage is genuine (empty response /
+    free tier) — no recompute needed."""
+    lo = _lit3057_make_logging_obj("acompletion")
+    resp = _lit3057_make_response(precomputed_cost=0.0, usage_tuple=(0, 0, 0))
+    cost = lo._response_cost_calculator(result=resp)
+    assert cost == 0.0
+
+
+def test_lit3057_response_cost_calculator_cache_hit_pins_zero():
+    """LIT-3057 must not regress the cache-hit pinning to 0.0."""
+    lo = _lit3057_make_logging_obj("acompletion")
+    lo.model_call_details["cache_hit"] = True
+    resp = _lit3057_make_response(precomputed_cost=0.0, usage_tuple=(10, 5, 15))
+    cost = lo._response_cost_calculator(result=resp)
+    assert cost == 0.0
+
+
+def test_lit3057_response_cost_calculator_passthrough_trusts_zero():
+    """LIT-3057: pass-through handlers set `_hidden_params['response_cost']`
+    intentionally (including 0.0 for batch-pending). Preserve that contract."""
+    lo = _lit3057_make_logging_obj("pass_through_endpoint")
+    resp = _lit3057_make_response(precomputed_cost=0.0, usage_tuple=(100, 10, 110))
+    cost = lo._response_cost_calculator(result=resp)
+    assert cost == 0.0
+
+
+def test_lit3057_process_hidden_params_recomputes_stale_empty_string():
+    """LIT-3057 end-to-end via the spend-log pathway: empty-string sentinel ->
+    recomputed cost lands in StandardLoggingPayload."""
+    from datetime import datetime
+
+    lo = _lit3057_make_logging_obj("acompletion")
+    resp = _lit3057_make_response(precomputed_cost="", usage_tuple=(10, 5, 15))
+    lo._process_hidden_params_and_response_cost(resp, datetime.now(), datetime.now())
+    mcd_cost = lo.model_call_details.get("response_cost")
+    assert isinstance(mcd_cost, float) and mcd_cost > 0
+    slo = lo.model_call_details.get("standard_logging_object") or {}
+    slo_cost = slo.get("response_cost") if isinstance(slo, dict) else None
+    assert isinstance(slo_cost, float) and slo_cost > 0
+
+
+def test_lit3057_process_hidden_params_recomputes_stale_zero_for_acompletion():
+    """LIT-3057 end-to-end: stale 0 on chat completion path -> recomputed."""
+    from datetime import datetime
+
+    lo = _lit3057_make_logging_obj("acompletion")
+    resp = _lit3057_make_response(precomputed_cost=0.0, usage_tuple=(10, 5, 15))
+    lo._process_hidden_params_and_response_cost(resp, datetime.now(), datetime.now())
+    mcd_cost = lo.model_call_details.get("response_cost")
+    assert isinstance(mcd_cost, float) and mcd_cost > 0
+
+
+def test_lit3057_process_hidden_params_preserves_passthrough_zero():
+    """LIT-3057 must keep the existing pass-through contract intact: 0.0 set
+    by a pass-through handler is preserved verbatim, even with non-zero
+    usage on the response."""
+    from datetime import datetime
+
+    lo = _lit3057_make_logging_obj("pass_through_endpoint")
+    resp = _lit3057_make_response(precomputed_cost=0.0, usage_tuple=(100, 10, 110))
+    lo._process_hidden_params_and_response_cost(resp, datetime.now(), datetime.now())
+    assert lo.model_call_details.get("response_cost") == 0.0
+    slo = lo.model_call_details.get("standard_logging_object") or {}
+    assert slo.get("response_cost") == 0.0
+
+
+def test_lit3057_is_precomputed_helper_unit():
+    """Direct exercise of the `_is_precomputed_response_cost_authoritative`
+    helper across all branches."""
+
+    class _FakeUsage:
+        def __init__(self, prompt_tokens=0, completion_tokens=0, total_tokens=0):
+            self.prompt_tokens = prompt_tokens
+            self.completion_tokens = completion_tokens
+            self.total_tokens = total_tokens
+
+    class _FakeResponse:
+        def __init__(self, usage=None):
+            self.usage = usage
+
+    lo = _lit3057_make_logging_obj("acompletion")
+    helper = lo._is_precomputed_response_cost_authoritative
+
+    # Missing key -> not authoritative.
+    assert helper({}, _FakeResponse(_FakeUsage(10, 5, 15))) is False
+    # None / empty -> not authoritative.
+    assert helper({"response_cost": None}, _FakeResponse(_FakeUsage(10, 5, 15))) is False
+    assert helper({"response_cost": ""}, _FakeResponse(_FakeUsage(10, 5, 15))) is False
+    # Positive numeric -> authoritative.
+    assert helper({"response_cost": 0.5}, _FakeResponse(_FakeUsage(10, 5, 15))) is True
+    assert helper({"response_cost": "0.5"}, _FakeResponse(_FakeUsage(10, 5, 15))) is True
+    # Zero with non-zero usage on a chat completion path -> not authoritative.
+    assert helper({"response_cost": 0.0}, _FakeResponse(_FakeUsage(10, 0, 10))) is False
+    assert helper({"response_cost": 0}, _FakeResponse(_FakeUsage(0, 5, 5))) is False
+    # Zero with zero usage -> authoritative.
+    assert helper({"response_cost": 0.0}, _FakeResponse(_FakeUsage(0, 0, 0))) is True
+    # Zero with no usage attribute -> authoritative (defensive default).
+    assert helper({"response_cost": 0.0}, _FakeResponse(None)) is True
+    # Non-numeric / un-coercible -> not authoritative.
+    assert helper({"response_cost": "abc"}, _FakeResponse(_FakeUsage(10, 5, 15))) is False
+
+    # Pass-through call_type trusts zero unconditionally.
+    lo_pt = _lit3057_make_logging_obj("pass_through_endpoint")
+    helper_pt = lo_pt._is_precomputed_response_cost_authoritative
+    assert helper_pt({"response_cost": 0.0}, _FakeResponse(_FakeUsage(10, 5, 15))) is True
+


### PR DESCRIPTION
## Linear ticket

Resolves LIT-3057.

## Problem

Spend logs can record `0.0` for chat completions that actually have non-zero token usage and valid pricing. Reproduced locally on `litellm_oss_agent_shin_daily_branch` with `gpt-4o-mini`: `litellm.completion_cost(...)` returns `4.5e-06` for the same response that the logging path records as `0.0`.

Root cause: response objects can carry a `response_cost` value seeded *early* in the request flow on `_hidden_params`:

* `''` (empty-string sentinel) from streaming pre-stream metadata in `litellm/llms/custom_httpx/llm_http_handler.py:178`.
* `0.0` left over from an early `_response_cost_calculator` call that ran before pricing/usage were fully resolved (via `ResponseMetadata.set_hidden_params` in `litellm/litellm_core_utils/llm_response_utils/response_metadata.py`).

Both `_response_cost_calculator` and `_process_hidden_params_and_response_cost` in `litellm/litellm_core_utils/litellm_logging.py` then read that stale value back and treat it as authoritative, so `StandardLoggingPayload.response_cost` lands as `0.0` (because `raw or 0.0` coerces both `0.0` and `''` to `0.0`).

## Fix

`litellm/litellm_core_utils/litellm_logging.py`:

1. Added `_is_precomputed_response_cost_authoritative(hidden_params, response_obj)`. It returns `True` only when the pre-computed value is *trustworthy*:

   * Missing key / `None` / empty string -> not authoritative.
   * Positive numeric -> authoritative.
   * `0` for `call_type == "pass_through_endpoint"` -> authoritative (pass-through handlers, e.g. Gemini/Vertex/OpenAI passthrough, seed the cost intentionally — sometimes `0.0` for batch-pending — and that contract is preserved).
   * `0` for any other call type, AND the response has non-zero token usage -> NOT authoritative (recompute).
   * `0` with no usage / all-zero usage -> authoritative (genuine zero, e.g. empty/cancelled response or free tier).
   * Non-numeric / un-coercible -> not authoritative.

2. `_response_cost_calculator`: replaced `if "response_cost" in hidden_params and hidden_params["response_cost"] is not None: return hidden_params["response_cost"]` with the helper, so stale sentinels fall through to the existing `litellm.response_cost_calculator(...)` recompute path.

3. `_process_hidden_params_and_response_cost`: same swap — only short-circuit to `hidden_params["response_cost"]` when the helper says it's authoritative.

The cache-hit branch (`self.model_call_details["cache_hit"] is True -> 0.0`) is untouched, as is the `existing_cost != 0` preservation that protects pass-through handlers that drop the cost on `model_call_details["response_cost"]` instead of `_hidden_params`.

## Tests

10 new regression tests in `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` (all prefixed `test_lit3057_*`):

* `_response_cost_calculator` — stale `0.0`, stale `''`, positive precomputed, zero-usage zero, cache-hit pinning, pass-through trust.
* `_process_hidden_params_and_response_cost` — end-to-end via the spend-log pathway: stale `''` recompute, stale `0` recompute on `acompletion`, pass-through `0.0` preservation.
* Direct unit test of `_is_precomputed_response_cost_authoritative` covering every branch (missing/None/empty/positive/zero with usage/zero without usage/non-numeric/pass-through call type).

Existing test `test_process_hidden_params_preserves_zero_cost_in_hidden_params` (pass-through handler intentionally sets `0.0` with non-zero usage) still passes — confirming the pass-through contract is intact.

```
$ python3 -m pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py -k lit3057 -v
============================== 10 passed in 0.94s ==============================
$ python3 -m pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py -q   # (1 unrelated skip: opentelemetry not installed in sandbox)
91 passed, 1 deselected in 5.10s
$ python3 -m pytest tests/test_litellm/test_cost_calculator.py tests/test_litellm/litellm_core_utils/llm_cost_calc/ -q
124 passed in 2.98s
```

## Evidence

Reproducer drives `_response_cost_calculator` and the full `_process_hidden_params_and_response_cost` -> `StandardLoggingPayload.response_cost` path with the same `ModelResponse` (model `gpt-4o-mini`, usage `prompt=10, completion=5, total=15`, real cost `$4.5e-06` per the local cost map). The only knob varied is the value pre-seeded into `_hidden_params["response_cost"]` — `0.0` / `""` / `0.0001` (positive) / cache-hit / zero-usage / no key at all.

### BEFORE (clean `litellm_oss_agent_shin_daily_branch`)

```
=== _response_cost_calculator ===
A: hp[response_cost]=0.0,    usage>0     -> 0.0            ← BUG: stale zero accepted
B: hp[response_cost]='',     usage>0     -> ''             ← BUG: empty string returned, coerced to 0.0 downstream
C: hp[response_cost]=0.0,    usage=0     -> 0.0            ← correct
D: hp[response_cost]=0.0001, usage>0     -> 0.0001         ← correct
E: cache_hit=True                        -> 0.0            ← correct

=== _process_hidden_params_and_response_cost (spend-log payload) ===
A: stale 0.0, usage>0:                mcd=0.0,   std_logging_payload_cost=0.0    ← BUG
B: stale '',  usage>0:                mcd='',    std_logging_payload_cost=0.0    ← BUG
C: 0.0, usage=0 (empty resp):         mcd=0.0,   std_logging_payload_cost=0.0
D: 0.0001, usage>0:                   mcd=0.0001,std_logging_payload_cost=0.0001
E: cache_hit=True:                    mcd=0.0,   std_logging_payload_cost=0.0
F: missing key (no precomp):          mcd=None,  std_logging_payload_cost=0.0    ← BUG (None blocked recompute)
```

### AFTER (with this PR)

```
=== _response_cost_calculator ===
A: hp[response_cost]=0.0,    usage>0     -> 4.5e-06        ← recomputed from real usage
B: hp[response_cost]='',     usage>0     -> 4.5e-06        ← recomputed
C: hp[response_cost]=0.0,    usage=0     -> 0.0            ← unchanged
D: hp[response_cost]=0.0001, usage>0     -> 0.0001         ← unchanged
E: cache_hit=True                        -> 0.0            ← unchanged

=== _process_hidden_params_and_response_cost (spend-log payload) ===
A: stale 0.0, usage>0:                mcd=4.5e-06, std_logging_payload_cost=4.5e-06   ← FIXED
B: stale '',  usage>0:                mcd=4.5e-06, std_logging_payload_cost=4.5e-06   ← FIXED
C: 0.0, usage=0 (empty resp):         mcd=0.0,     std_logging_payload_cost=0.0       ← unchanged
D: 0.0001, usage>0:                   mcd=0.0001,  std_logging_payload_cost=0.0001    ← unchanged
E: cache_hit=True:                    mcd=0.0,     std_logging_payload_cost=0.0       ← unchanged
F: missing key (no precomp):          mcd=4.5e-06, std_logging_payload_cost=4.5e-06   ← FIXED
```

`pass_through_endpoint` preservation, included in the same matrix at the test level:

```
G: pass_through_endpoint + 0.0 + usage>0:    mcd=0.0, std_logging_payload_cost=0.0    ← contract intact
```

(see `test_lit3057_process_hidden_params_preserves_passthrough_zero` + the pre-existing `test_process_hidden_params_preserves_zero_cost_in_hidden_params`)

## Notes

* Branch pushed via the GitHub Git API (blobs -> tree -> commit -> ref) because the agent's token does not have `repo`+`workflow` scopes for raw `git push`. Diff is exactly two files modified, ~257 added / 7 removed.
* No customer-facing behavior change beyond cost values flipping from `0.0` to the actually-computed cost on the affected paths.

## Verification (ship-pr)

| Check | Status | Detail |
|-|-|-|
| Branch base | PASS | `litellm_oss_agent_shin_daily_branch` |
| Customer-name leak | PASS | none — bug found by code-path tracing, no customer in PR body / branch / commit / tests |
| Diff scope | PASS | 2 files: `litellm/litellm_core_utils/litellm_logging.py` + `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` (no generated artifacts, no lockfile, no UI build) |
| `black --check` (target file) | PASS | applied + committed after CI flagged it |
| `ruff check` (target file) | PASS | no new errors |
| Unit tests (target file) | PASS | 92 passed, 1 unrelated skip (`opentelemetry` not in sandbox) |
| Cost-calc-adjacent suites | PASS | `test_cost_calculator.py` 72/72, `llm_cost_calc/` 52/52 |
| New regression tests | PASS | 11/11 `test_lit3057_*` (10 original + 1 added for the Greptile P2 negative-cost guard) |
| Runtime evidence | PASS | before/after table above; same `ModelResponse` exercised through both `_response_cost_calculator` and the full `_process_hidden_params_and_response_cost` → `StandardLoggingPayload.response_cost` path |
| Existing pass-through contract | PASS | pre-existing `test_process_hidden_params_preserves_zero_cost_in_hidden_params` still passes |
| Greptile | PASS | 4/5 (only finding addressed: explicit negative-cost rejection) |
| GitHub Actions | PASS | 44/44 green (post the Greptile P2 fix commit) |
| Veria | PENDING | did not run against this PR in-window; will monitor after merge |

