### PR TITLE
fix(langfuse): hold HTTPHandler reference to prevent closed-client RuntimeError (LIT-3221)

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -154,8 +154,15 @@ class LangFuseLogger:
             self.langfuse_client = create_mock_langfuse_client()
             self.is_mock_mode = True
         else:
-            http_client = _get_httpx_client()
-            self.langfuse_client = http_client.client
+            # Hold a strong reference to the cached HTTPHandler so it (and its
+            # underlying httpx.Client) survives even after the LLM-clients cache
+            # TTL evicts the wrapper. Without this, the HTTPHandler is eligible
+            # for GC after the 1h cache TTL; its __del__ closes the httpx.Client
+            # that the Langfuse SDK background flush thread is still using,
+            # surfacing as RuntimeError("Cannot send a request, as the client
+            # has been closed.") on subsequent traces. See LIT-3221.
+            self._http_handler = _get_httpx_client()
+            self.langfuse_client = self._http_handler.client
             self.is_mock_mode = False
 
         parameters = {

--- a/tests/test_litellm/integrations/test_langfuse_lit_3221.py
+++ b/tests/test_litellm/integrations/test_langfuse_lit_3221.py
@@ -1,0 +1,112 @@
+"""
+Regression tests for LIT-3221: Langfuse trace sending fails with closed client.
+
+Root cause: LangFuseLogger.__init__ extracted only the inner httpx.Client from
+the cached HTTPHandler and discarded the wrapping HTTPHandler reference. When
+the in-memory LLM-clients cache expired (1-hour TTL), the HTTPHandler became
+eligible for GC; its __del__ closed the same httpx.Client that the Langfuse
+SDK background flush thread was still using, surfacing as:
+
+    RuntimeError: Cannot send a request, as the client has been closed.
+
+Fix: store the HTTPHandler on `self._http_handler` so it (and its underlying
+httpx.Client) outlive the cache eviction.
+"""
+
+import gc
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.integrations.langfuse import langfuse as langfuse_module
+from litellm.integrations.langfuse.langfuse import LangFuseLogger
+
+
+@pytest.fixture(autouse=True)
+def _langfuse_env():
+    env = {
+        "LANGFUSE_PUBLIC_KEY": "pk-lf-lit-3221",
+        "LANGFUSE_SECRET_KEY": "sk-lf-lit-3221",
+        "LANGFUSE_HOST": "http://127.0.0.1:9999",
+    }
+    # Track original litellm counter to restore
+    orig = litellm.initialized_langfuse_clients
+    with patch.dict(os.environ, env, clear=False):
+        yield
+    litellm.initialized_langfuse_clients = orig
+
+
+def _safe_init_logger():
+    """Build a LangFuseLogger without contacting Langfuse on init."""
+    mock_lf_client = MagicMock()
+    mock_lf_client.client = MagicMock()
+    mock_lf_client.client.projects.get.return_value.data = [MagicMock(id="proj-1")]
+    with patch.object(
+        LangFuseLogger,
+        "safe_init_langfuse_client",
+        return_value=mock_lf_client,
+    ):
+        return LangFuseLogger()
+
+
+def test_langfuse_logger_holds_http_handler_reference():
+    """
+    Regression for LIT-3221: LangFuseLogger MUST keep a strong reference to the
+    HTTPHandler so the cached httpx.Client cannot be closed by GC after the
+    LLM-clients cache TTL elapses.
+    """
+    lf = _safe_init_logger()
+    assert hasattr(lf, "_http_handler"), (
+        "LangFuseLogger must retain a reference to the HTTPHandler "
+        "(LIT-3221) — without this attribute, the underlying httpx.Client "
+        "is closed by HTTPHandler.__del__ after the cache TTL evicts it."
+    )
+    assert lf._http_handler is not None
+    # The exposed langfuse_client must be the same httpx.Client held by the
+    # HTTPHandler — sharing the connection pool with the rest of the proxy.
+    assert lf.langfuse_client is lf._http_handler.client
+
+
+def test_langfuse_httpx_client_survives_cache_eviction_and_gc():
+    """
+    End-to-end regression: after evicting the HTTPHandler from the in-memory
+    LLM-clients cache AND forcing GC, the httpx.Client held by the LangFuseLogger
+    must still be usable (i.e. not closed).
+    """
+    lf = _safe_init_logger()
+    client = lf.langfuse_client
+    assert client.is_closed is False, "fresh client must not be closed"
+
+    # Evict every cached HTTPHandler entry — same effect as TTL expiry.
+    cache = litellm.in_memory_llm_clients_cache
+    assert hasattr(cache, "cache_dict"), "cache shape changed — update test"
+    for k in list(cache.cache_dict.keys()):
+        cache.cache_dict.pop(k, None)
+    gc.collect()
+    gc.collect()
+
+    assert client.is_closed is False, (
+        "httpx.Client was closed after cache eviction + GC — the "
+        "LangFuseLogger lost its reference to the HTTPHandler (LIT-3221)."
+    )
+
+
+def test_langfuse_mock_mode_does_not_set_http_handler():
+    """
+    The mock-mode path must not call _get_httpx_client. We assert by checking
+    that _http_handler is not set when langfuse-mock mode is active.
+    """
+    with patch.object(langfuse_module, "should_use_langfuse_mock", return_value=True),          patch.object(
+             langfuse_module,
+             "create_mock_langfuse_client",
+             return_value=MagicMock(),
+         ),          patch.object(
+             LangFuseLogger,
+             "safe_init_langfuse_client",
+             return_value=MagicMock(client=MagicMock(projects=MagicMock(get=MagicMock(return_value=MagicMock(data=[MagicMock(id="m")]))))),
+         ):
+        lf = LangFuseLogger()
+    assert lf.is_mock_mode is True
+    assert getattr(lf, "_http_handler", None) is None

--- a/tests/test_litellm/integrations/test_langfuse_lit_3221.py
+++ b/tests/test_litellm/integrations/test_langfuse_lit_3221.py
@@ -13,6 +13,7 @@ Fix: store the HTTPHandler on `self._http_handler` so it (and its underlying
 httpx.Client) outlive the cache eviction.
 """
 
+import copy
 import gc
 import os
 from unittest.mock import MagicMock, patch
@@ -25,29 +26,64 @@ from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
 
 @pytest.fixture(autouse=True)
-def _langfuse_env():
+def _langfuse_env_and_cache_isolation():
+    """
+    Isolate every test from global state:
+      * Set well-known Langfuse env vars.
+      * Snapshot `litellm.in_memory_llm_clients_cache` so test eviction does
+        not leak into other tests in the same worker.
+      * Reset `litellm.initialized_langfuse_clients` afterwards.
+    """
     env = {
         "LANGFUSE_PUBLIC_KEY": "pk-lf-lit-3221",
         "LANGFUSE_SECRET_KEY": "sk-lf-lit-3221",
         "LANGFUSE_HOST": "http://127.0.0.1:9999",
     }
-    # Track original litellm counter to restore
-    orig = litellm.initialized_langfuse_clients
-    with patch.dict(os.environ, env, clear=False):
-        yield
-    litellm.initialized_langfuse_clients = orig
+    orig_counter = litellm.initialized_langfuse_clients
+    cache = litellm.in_memory_llm_clients_cache
+    cache_snapshot = (
+        dict(cache.cache_dict) if hasattr(cache, "cache_dict") else None
+    )
+    try:
+        with patch.dict(os.environ, env, clear=False):
+            yield
+    finally:
+        litellm.initialized_langfuse_clients = orig_counter
+        if cache_snapshot is not None and hasattr(cache, "cache_dict"):
+            cache.cache_dict.clear()
+            cache.cache_dict.update(cache_snapshot)
 
 
-def _safe_init_logger():
-    """Build a LangFuseLogger without contacting Langfuse on init."""
+def _safe_init_logger(mock_mode: bool = False):
+    """
+    Build a LangFuseLogger without contacting Langfuse on init.
+
+    Always patches `should_use_langfuse_mock` so the chosen path is
+    deterministic regardless of any global flag elsewhere in the suite, and
+    also patches the network-touching `safe_init_langfuse_client`.
+    """
     mock_lf_client = MagicMock()
     mock_lf_client.client = MagicMock()
     mock_lf_client.client.projects.get.return_value.data = [MagicMock(id="proj-1")]
-    with patch.object(
-        LangFuseLogger,
-        "safe_init_langfuse_client",
-        return_value=mock_lf_client,
+    with (
+        patch.object(
+            langfuse_module,
+            "should_use_langfuse_mock",
+            return_value=mock_mode,
+        ),
+        patch.object(
+            LangFuseLogger,
+            "safe_init_langfuse_client",
+            return_value=mock_lf_client,
+        ),
     ):
+        if mock_mode:
+            with patch.object(
+                langfuse_module,
+                "create_mock_langfuse_client",
+                return_value=MagicMock(),
+            ):
+                return LangFuseLogger()
         return LangFuseLogger()
 
 
@@ -72,8 +108,8 @@ def test_langfuse_logger_holds_http_handler_reference():
 def test_langfuse_httpx_client_survives_cache_eviction_and_gc():
     """
     End-to-end regression: after evicting the HTTPHandler from the in-memory
-    LLM-clients cache AND forcing GC, the httpx.Client held by the LangFuseLogger
-    must still be usable (i.e. not closed).
+    LLM-clients cache AND forcing GC, the httpx.Client held by the
+    LangFuseLogger must still be usable (i.e. not closed).
     """
     lf = _safe_init_logger()
     client = lf.langfuse_client
@@ -95,18 +131,9 @@ def test_langfuse_httpx_client_survives_cache_eviction_and_gc():
 
 def test_langfuse_mock_mode_does_not_set_http_handler():
     """
-    The mock-mode path must not call _get_httpx_client. We assert by checking
+    The mock-mode path must not call _get_httpx_client. Confirms by asserting
     that _http_handler is not set when langfuse-mock mode is active.
     """
-    with patch.object(langfuse_module, "should_use_langfuse_mock", return_value=True),          patch.object(
-             langfuse_module,
-             "create_mock_langfuse_client",
-             return_value=MagicMock(),
-         ),          patch.object(
-             LangFuseLogger,
-             "safe_init_langfuse_client",
-             return_value=MagicMock(client=MagicMock(projects=MagicMock(get=MagicMock(return_value=MagicMock(data=[MagicMock(id="m")]))))),
-         ):
-        lf = LangFuseLogger()
+    lf = _safe_init_logger(mock_mode=True)
     assert lf.is_mock_mode is True
     assert getattr(lf, "_http_handler", None) is None


### PR DESCRIPTION
## Summary

Fixes **LIT-3221**: Langfuse trace sending fails intermittently with
`RuntimeError: Cannot send a request, as the client has been closed.` after the
proxy has been running for ~1 hour.

## Root cause

`LangFuseLogger.__init__` resolves the cached HTTP client via
`_get_httpx_client()` and then extracts **only** the inner `httpx.Client`,
without storing the wrapping `HTTPHandler` on `self`:

```python
http_client = _get_httpx_client()         # local variable
self.langfuse_client = http_client.client # only httpx.Client is kept
```

The `HTTPHandler` is held in `litellm.in_memory_llm_clients_cache`, which has
a 1-hour TTL (`_DEFAULT_TTL_FOR_HTTPX_CLIENTS`). After eviction the
`HTTPHandler` has **no strong reference** anywhere in the process. As soon as
Python GC runs, `HTTPHandler.__del__` (`litellm/llms/custom_httpx/http_handler.py:1313`)
calls `self.close()` → `self.client.close()` — closing the very `httpx.Client`
that the Langfuse SDK background flush thread is still using. All subsequent
traces from that worker raise
`RuntimeError("Cannot send a request, as the client has been closed.")`.

## Fix

Store the `HTTPHandler` on the logger instance so its lifetime tracks the
logger, not the cache TTL:

```python
self._http_handler = _get_httpx_client()
self.langfuse_client = self._http_handler.client
```

With at least one live strong reference (`self._http_handler`), the
`HTTPHandler` is never GC-eligible while the logger is alive, `__del__` is not
invoked, and the underlying `httpx.Client` remains open for as long as the
SDK needs it.

Single-callsite fix in `litellm/integrations/langfuse/langfuse.py`. Behaviour
is unchanged on the mock-mode path (`should_use_langfuse_mock()` short-circuit
runs before `_get_httpx_client`).

## Files changed

- `litellm/integrations/langfuse/langfuse.py` — store the cached `HTTPHandler`
  on `self._http_handler` (with a code comment pointing at LIT-3221).
- `tests/test_litellm/integrations/test_langfuse_lit_3221.py` — 3 new
  regression tests.

> Pushed via the GitHub **Contents API** (one file per commit) because this
> session\u2019s `GITHUB_TOKEN` lacks the `repo`+`workflow` scopes required by
> `git push`. The merge-base diff is therefore noisier than a `git push` would
> produce; the substantive diff is exactly the two files above.

## Tests

3 new regression cases — all pass with the fix, 2 fail without it
(confirmed by reverting the patch in-place and re-running):

```
tests/test_litellm/integrations/test_langfuse_lit_3221.py::test_langfuse_httpx_client_survives_cache_eviction_and_gc PASSED
tests/test_litellm/integrations/test_langfuse_lit_3221.py::test_langfuse_logger_holds_http_handler_reference PASSED
tests/test_litellm/integrations/test_langfuse_lit_3221.py::test_langfuse_mock_mode_does_not_set_http_handler PASSED
================== 3 passed in 1.13s ==================
```

All 16 pre-existing langfuse tests (`tests/test_litellm/integrations/test_langfuse.py`) still pass:

```
======================= 16 passed, 21 warnings in 0.79s ========================
```

### Evidence

End-to-end runtime evidence on `litellm_oss_agent_shin_daily_branch` HEAD
`1fe911d`. The repro builds a real `LangFuseLogger`, drains every entry from
`litellm.in_memory_llm_clients_cache` (the same effect the 1-hour TTL has in
prod), forces GC, then exercises the cached `httpx.Client` exactly the way the
Langfuse SDK background flush thread does.

**BEFORE fix (clean `litellm_oss_agent_shin_daily_branch` @ 1fe911d):**

```
[init] client.is_closed: False
[init] LangFuseLogger has _http_handler attr? False
[cache] cleared (simulates 1h TTL eviction)
[post-evict+GC] client.is_closed: True
[POST] RuntimeError: Cannot send a request, as the client has been closed.
```

The customer-reported error reproduces exactly: the `httpx.Client` flips from
open → closed as soon as the cache evicts the `HTTPHandler`, and the Langfuse
SDK\u2019s call path (`client.post(\u2026)`) raises
`RuntimeError("Cannot send a request, as the client has been closed.")`.

**AFTER fix:**

```
[init] client.is_closed: False
[init] LangFuseLogger has _http_handler attr? True
[cache] cleared (simulates 1h TTL eviction)
[post-evict+GC] client.is_closed: False
[POST] succeeded \u2014 client is alive
```

`_http_handler` is now retained on the logger, eviction + GC no longer close
the underlying `httpx.Client`, and the same `client.post(\u2026)` call goes
through without error.

## Linear

- LIT-3221 \u2014 Langfuse trace sending fails with closed client


### Verification (ship-pr)

- **PR base branch:** ✅ `litellm_oss_agent_shin_daily_branch` (Verify PR source branch check expected green)
- **GitHub Actions:** ✅ 44/44 green on `4f502b4`
  - includes `Veria AI - PR Review` = success
- **Greptile:** ✅ 4/5 initial (commit `d023616`); P2 nits addressed in `4f502b4`; follow-up Greptile comment: *"Both nits are cleanly handled… LGTM."*
- **Customer name leak check:** ✅ PR title + body contain no customer name (audited)
- **Unit tests:** ✅ 3 LIT-3221 regression cases pass; 16 pre-existing langfuse cases pass; 2 of the 3 LIT-3221 cases FAIL when the fix is reverted in place (proves the assertions are meaningful, not vacuous)
- **Runtime evidence:** ✅ BEFORE/AFTER terminal output included in `### Evidence` above. BEFORE reproduces the exact customer-reported `RuntimeError: Cannot send a request, as the client has been closed.` after simulated 1h-TTL eviction + GC; AFTER shows `client.is_closed=False` and `client.post(…)` going through.
- **Diff scope:** ✅ exactly 2 files, +121/-2 (substantive); pushed via Contents API because `GITHUB_TOKEN` lacks `repo`+`workflow` scopes (noted above).
