### PR TITLE
Add ModelNotMappedError for unmapped model costs

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1273,6 +1273,7 @@ from .exceptions import (
     InvalidRequestError,
     BadRequestError,
     ImageFetchError,
+    ModelNotMappedError,
     NotFoundError,
     PermissionDeniedError,
     RateLimitError,

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -196,6 +196,19 @@ class ImageFetchError(BadRequestError):
         )
 
 
+class ModelNotMappedError(ValueError):
+    def __init__(
+        self,
+        message: str,
+        model: Optional[str] = None,
+        llm_provider: Optional[str] = None,
+    ):
+        self.message = "litellm.ModelNotMappedError: {}".format(message)
+        self.model = model
+        self.llm_provider = llm_provider
+        super().__init__(self.message)
+
+
 class UnprocessableEntityError(openai.UnprocessableEntityError):  # type: ignore
     def __init__(
         self,
@@ -821,6 +834,7 @@ LITELLM_EXCEPTION_TYPES = [
     AuthenticationError,
     NotFoundError,
     BadRequestError,
+    ModelNotMappedError,
     UnprocessableEntityError,
     UnsupportedParamsError,
     Timeout,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5317,7 +5317,7 @@ def get_max_tokens(model: str) -> Optional[int]:
         int: The maximum number of tokens allowed for the given model.
 
     Raises:
-        Exception: If the model is not mapped yet.
+        ModelNotMappedError: If the model is not mapped yet.
 
     Example:
         >>> get_max_tokens("gpt-4")
@@ -5362,6 +5362,8 @@ def get_max_tokens(model: str) -> Optional[int]:
         else:
             raise Exception()
         return None
+    except ModelNotMappedError:
+        raise
     except Exception:
         raise ModelNotMappedError(
             f"Model {model} isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json",

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -408,6 +408,7 @@ from .exceptions import (
     BudgetExceededError,
     ContentPolicyViolationError,
     ContextWindowExceededError,
+    ModelNotMappedError,
     NotFoundError,
     OpenAIError,
     PermissionDeniedError,
@@ -5362,8 +5363,10 @@ def get_max_tokens(model: str) -> Optional[int]:
             raise Exception()
         return None
     except Exception:
-        raise Exception(
-            f"Model {model} isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+        raise ModelNotMappedError(
+            f"Model {model} isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json",
+            model=model,
+            llm_provider=None,
         )
 
 
@@ -5838,8 +5841,10 @@ def _get_model_info_helper(  # noqa: PLR0915
                         _model_info = None
 
             if _model_info is None or key is None:
-                raise ValueError(
-                    "This model isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+                raise ModelNotMappedError(
+                    "This model isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json",
+                    model=model,
+                    llm_provider=custom_llm_provider,
                 )
 
             _input_cost_per_token: Optional[float] = _model_info.get(
@@ -6052,13 +6057,17 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 uses_embed_content=_model_info.get("uses_embed_content", None),
             )
+    except ModelNotMappedError:
+        raise
     except Exception as e:
         verbose_logger.debug(f"Error getting model info: {e}")
-        raise Exception(
+        raise ModelNotMappedError(
             "This model isn't mapped yet. model={}, custom_llm_provider={}. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.".format(
                 model, custom_llm_provider
-            )
-        )
+            ),
+            model=model,
+            llm_provider=custom_llm_provider,
+        ) from e
 
 
 @lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -19,7 +19,11 @@ from litellm.cost_calculator import (
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
-from litellm.utils import TranscriptionResponse, _invalidate_model_cost_lowercase_map
+from litellm.utils import (
+    TranscriptionResponse,
+    _invalidate_model_cost_lowercase_map,
+    get_max_tokens,
+)
 
 
 def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):
@@ -61,6 +65,29 @@ def test_cost_per_token_unmapped_mistral_raises_model_not_mapped_error(monkeypat
     assert exc_info.value.model == "definitely-unmapped-mistral-model"
     assert exc_info.value.llm_provider == "mistral"
     assert "This model isn't mapped yet" in str(exc_info.value)
+
+
+def test_get_max_tokens_preserves_model_not_mapped_error(monkeypatch):
+    """
+    get_max_tokens should not re-wrap typed mapping errors from inner helpers,
+    so callers can inspect the original provider.
+    """
+
+    def mock_get_llm_provider(*args, **kwargs):
+        raise litellm.ModelNotMappedError(
+            "This model isn't mapped yet.",
+            model="provider/model-name",
+            llm_provider="test-provider",
+        )
+
+    monkeypatch.setattr(litellm, "model_cost", {})
+    monkeypatch.setattr("litellm.utils.get_llm_provider", mock_get_llm_provider)
+
+    with pytest.raises(litellm.ModelNotMappedError) as exc_info:
+        get_max_tokens("provider/model-name")
+
+    assert exc_info.value.model == "provider/model-name"
+    assert exc_info.value.llm_provider == "test-provider"
 
 
 def test_cost_per_token_non_string_model_does_not_hang():

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -19,7 +19,7 @@ from litellm.cost_calculator import (
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
-from litellm.utils import TranscriptionResponse
+from litellm.utils import TranscriptionResponse, _invalidate_model_cost_lowercase_map
 
 
 def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):
@@ -38,6 +38,29 @@ def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):
     )
 
     assert prompt_usd + completion_usd > 0
+
+
+def test_cost_per_token_unmapped_mistral_raises_model_not_mapped_error(monkeypatch):
+    """
+    Users should be able to catch unmapped-model cost lookups without string
+    matching a generic exception.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    _invalidate_model_cost_lowercase_map()
+
+    with pytest.raises(litellm.ModelNotMappedError) as exc_info:
+        cost_per_token(
+            model="definitely-unmapped-mistral-model",
+            prompt_tokens=100,
+            completion_tokens=100,
+            custom_llm_provider="mistral",
+        )
+
+    assert isinstance(exc_info.value, ValueError)
+    assert exc_info.value.model == "definitely-unmapped-mistral-model"
+    assert exc_info.value.llm_provider == "mistral"
+    assert "This model isn't mapped yet" in str(exc_info.value)
 
 
 def test_cost_per_token_non_string_model_does_not_hang():


### PR DESCRIPTION
## What

Adds a public `ModelNotMappedError` for unmapped model cost/model-info lookups so SDK users can catch this case directly instead of string-matching generic exceptions.

Fixes #29146.

## Changes

- Add `litellm.ModelNotMappedError` with model/provider context
- Raise it from unmapped model-info and max-token lookup paths
- Add a focused cost calculator regression test for unmapped Mistral models

## Tests

- `uv run --no-sync black litellm/exceptions.py litellm/__init__.py litellm/utils.py tests/test_litellm/test_cost_calculator.py`
- `uv run --no-sync pytest tests/test_litellm/test_cost_calculator.py::test_cost_per_token_unmapped_mistral_raises_model_not_mapped_error -q`
- `git diff --check`

Note: direct `ruff check` on the full touched files reports pre-existing lint debt in `litellm/__init__.py` and `tests/test_litellm/test_cost_calculator.py`; no unrelated cleanup included.