### PR TITLE
fix(focus): include organization_id and organization_alias in Vantage Tags (LIT-2895)

### DIFF
--- a/litellm/integrations/focus/database.py
+++ b/litellm/integrations/focus/database.py
@@ -80,10 +80,13 @@ class FocusLiteLLMDatabase:
             vt.team_id,
             vt.key_alias as api_key_alias,
             tt.team_alias,
+            tt.organization_id as organization_id,
+            ot.organization_alias as organization_alias,
             ut.user_email as user_email
         FROM "LiteLLM_DailyUserSpend" dus
         LEFT JOIN "LiteLLM_VerificationToken" vt ON dus.api_key = vt.token
         LEFT JOIN "LiteLLM_TeamTable" tt ON vt.team_id = tt.team_id
+        LEFT JOIN "LiteLLM_OrganizationTable" ot ON tt.organization_id = ot.organization_id
         LEFT JOIN "LiteLLM_UserTable" ut ON dus.user_id = ut.user_id
         {where_clause}
         ORDER BY dus.date DESC, dus.created_at DESC

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -10,6 +10,8 @@ import polars as pl
 from .schema import FOCUS_NORMALIZED_SCHEMA
 
 _TAG_KEYS = (
+    "organization_id",
+    "organization_alias",
     "team_id",
     "team_alias",
     "user_id",

--- a/tests/test_litellm/integrations/focus/test_focus_organization_tags.py
+++ b/tests/test_litellm/integrations/focus/test_focus_organization_tags.py
@@ -1,0 +1,127 @@
+"""Regression tests for LIT-2895 - FOCUS export must include organization_id
+and organization_alias in the Tags JSON so Vantage Token Allocation can route
+on org-level rollups.
+
+Tests the two-file fix:
+  - litellm/integrations/focus/transformer.py - _TAG_KEYS exposes the new keys
+    and the per-row Tags JSON propagates them when present.
+  - litellm/integrations/focus/database.py - the SQL SELECT picks up
+    organization_id (from LiteLLM_TeamTable) and organization_alias (via
+    LEFT JOIN LiteLLM_OrganizationTable).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import json
+import polars as pl
+import pytest
+
+from litellm.integrations.focus.database import FocusLiteLLMDatabase
+from litellm.integrations.focus.transformer import _TAG_KEYS, FocusTransformer
+
+
+def _setup_db(monkeypatch, query_return):
+    query_mock = AsyncMock(return_value=query_return)
+    mock_client = SimpleNamespace(db=SimpleNamespace(query_raw=query_mock))
+    db = FocusLiteLLMDatabase()
+    monkeypatch.setattr(db, "_ensure_prisma_client", lambda: mock_client)
+    return db, query_mock
+
+
+def test_tag_keys_include_organization_fields():
+    assert "organization_id" in _TAG_KEYS
+    assert "organization_alias" in _TAG_KEYS
+
+
+def test_tag_keys_organization_keys_precede_team_keys():
+    keys = list(_TAG_KEYS)
+    assert keys.index("organization_id") < keys.index("team_id")
+    assert keys.index("organization_alias") < keys.index("team_alias")
+
+
+def _make_frame(**overrides):
+    base = {
+        "date": ["2026-01-01"],
+        "user_id": ["u1"],
+        "api_key": ["sk-abc"],
+        "api_key_alias": ["dev-key"],
+        "model": ["gpt-5-mini"],
+        "model_group": ["openai-pool"],
+        "custom_llm_provider": ["openai"],
+        "prompt_tokens": [10],
+        "completion_tokens": [5],
+        "spend": [0.001],
+        "api_requests": [1],
+        "successful_requests": [1],
+        "failed_requests": [0],
+        "cache_creation_input_tokens": [0],
+        "cache_read_input_tokens": [0],
+        "team_id": ["t1"],
+        "team_alias": ["finance-team"],
+        "user_email": ["alice@example.com"],
+    }
+    base.update(overrides)
+    return pl.DataFrame(base)
+
+
+def test_transform_includes_organization_fields_in_tags_when_present():
+    frame = _make_frame(
+        organization_id=["org-1"],
+        organization_alias=["finance-org"],
+    )
+    out = FocusTransformer().transform(frame)
+    tags_row = json.loads(out["Tags"][0])
+    assert tags_row["organization_id"] == "org-1"
+    assert tags_row["organization_alias"] == "finance-org"
+    assert tags_row["team_id"] == "t1"
+    assert tags_row["api_key_alias"] == "dev-key"
+
+
+def test_transform_omits_organization_fields_when_team_has_no_org():
+    frame = _make_frame(
+        organization_id=[None],
+        organization_alias=[None],
+    )
+    out = FocusTransformer().transform(frame)
+    tags_row = json.loads(out["Tags"][0])
+    assert "organization_id" not in tags_row
+    assert "organization_alias" not in tags_row
+    assert tags_row["team_id"] == "t1"
+
+
+def test_transform_works_when_organization_columns_absent_entirely():
+    out = FocusTransformer().transform(_make_frame())
+    tags_row = json.loads(out["Tags"][0])
+    assert "organization_id" not in tags_row
+    assert "organization_alias" not in tags_row
+    assert tags_row["team_id"] == "t1"
+
+
+@pytest.mark.asyncio
+async def test_database_query_selects_organization_columns(monkeypatch):
+    db, query_mock = _setup_db(monkeypatch, [])
+    await db.get_usage_data()
+    query_text, *_ = query_mock.await_args.args
+    assert "tt.organization_id as organization_id" in query_text
+    assert "ot.organization_alias as organization_alias" in query_text
+
+
+@pytest.mark.asyncio
+async def test_database_query_joins_organization_table(monkeypatch):
+    db, query_mock = _setup_db(monkeypatch, [])
+    await db.get_usage_data()
+    query_text, *_ = query_mock.await_args.args
+    join_clause = (
+        'LEFT JOIN "LiteLLM_OrganizationTable" ot '
+        'ON tt.organization_id = ot.organization_id'
+    )
+    assert join_clause in query_text
+
+
+@pytest.mark.asyncio
+async def test_database_query_emits_organization_join_only_once(monkeypatch):
+    db, query_mock = _setup_db(monkeypatch, [])
+    await db.get_usage_data()
+    query_text, *_ = query_mock.await_args.args
+    assert query_text.count('LEFT JOIN "LiteLLM_OrganizationTable"') == 1


### PR DESCRIPTION
## Summary

Plumbs `organization_id` and `organization_alias` through the FOCUS export pipeline so the per-row `Tags` JSON that Vantage Token Allocation reads includes organization-level data, matching the existing pattern for team/user fields. Fixes **LIT-2895**.

## Root cause

The FOCUS export builds a `Tags` column on every cost row (in `litellm/integrations/focus/transformer.py`). Vantage's [custom-provider integration](https://docs.vantage.sh/connecting_custom_providers) routes Token Allocation on those tags, so every key Vantage should see has to be in `_TAG_KEYS` AND fetched by the database query.

On main:
- `_TAG_KEYS` covers `team_id`, `team_alias`, `user_id`, `user_email`, `api_key_alias`, `model`, `model_group`, `custom_llm_provider` — **but not the org fields**.
- `FocusLiteLLMDatabase.get_usage_data` joins `LiteLLM_TeamTable` / `LiteLLM_UserTable` but never touches `LiteLLM_OrganizationTable`, so the columns are not even loaded.

Net effect: even when a team belongs to an organization, the `Tags` JSON drops `organization_id` and `organization_alias` and Vantage cannot surface org-level rollups.

## Fix (3 files, +132 / -0)

1. `litellm/integrations/focus/transformer.py` — add `organization_id` and `organization_alias` to `_TAG_KEYS`, ahead of the team keys (matches the conceptual hierarchy: org > team > user > key > model).
2. `litellm/integrations/focus/database.py` — add `tt.organization_id` and `ot.organization_alias` to the SELECT, with a new `LEFT JOIN "LiteLLM_OrganizationTable" ot ON tt.organization_id = ot.organization_id`. Rows whose team has no org get NULL on those columns — the transformer's existing null-stripping in `_struct_to_json` omits them from the JSON, mirroring how `user_email` already behaves for users without an email.
3. `tests/test_litellm/integrations/focus/test_focus_organization_tags.py` — new file, 8 unit tests covering both files.

## Evidence

**Before fix** — `FocusTransformer.transform()` against a row whose `organization_id`/`organization_alias` are populated upstream still drops them from the Tags JSON (because `_TAG_KEYS` does not list them on `main`):

```
_TAG_KEYS: ('team_id', 'team_alias', 'user_id', 'user_email', 'api_key_alias', 'model', 'model_group', 'custom_llm_provider')
Tags JSON column (Vantage reads this):
{
  "team_id": "t-fin-1",
  "team_alias": "finance-team",
  "user_id": "u-alice",
  "user_email": "alice@example.com",
  "api_key_alias": "finance-dev",
  "model": "azure/gpt-5-mini",
  "model_group": "azure-pool",
  "custom_llm_provider": "azure"
}
>>> BEFORE: organization_id and organization_alias are MISSING
```

**After fix** — same row, this branch:

```
_TAG_KEYS: ('organization_id', 'organization_alias', 'team_id', 'team_alias', 'user_id', 'user_email', 'api_key_alias', 'model', 'model_group', 'custom_llm_provider')
Tags JSON column (Vantage reads this):
{
  "organization_id": "org-fin",
  "organization_alias": "finance-org",
  "team_id": "t-fin-1",
  "team_alias": "finance-team",
  "user_id": "u-alice",
  "user_email": "alice@example.com",
  "api_key_alias": "finance-dev",
  "model": "azure/gpt-5-mini",
  "model_group": "azure-pool",
  "custom_llm_provider": "azure"
}
>>> AFTER: organization_id and organization_alias are PRESENT
```

**SQL emitted by `FocusLiteLLMDatabase.get_usage_data()` after fix**:

```sql
SELECT
    dus.id, dus.date, dus.user_id, dus.api_key, dus.model, dus.model_group,
    dus.custom_llm_provider, dus.prompt_tokens, dus.completion_tokens, dus.spend,
    dus.api_requests, dus.successful_requests, dus.failed_requests,
    dus.cache_creation_input_tokens, dus.cache_read_input_tokens,
    dus.created_at, dus.updated_at,
    vt.team_id,
    vt.key_alias as api_key_alias,
    tt.team_alias,
    tt.organization_id as organization_id,
    ot.organization_alias as organization_alias,
    ut.user_email as user_email
FROM "LiteLLM_DailyUserSpend" dus
LEFT JOIN "LiteLLM_VerificationToken" vt ON dus.api_key = vt.token
LEFT JOIN "LiteLLM_TeamTable" tt ON vt.team_id = tt.team_id
LEFT JOIN "LiteLLM_OrganizationTable" ot ON tt.organization_id = ot.organization_id
LEFT JOIN "LiteLLM_UserTable" ut ON dus.user_id = ut.user_id
ORDER BY dus.date DESC, dus.created_at DESC
```

## Unit tests

```
$ python3 -m pytest tests/test_litellm/integrations/focus/test_focus_organization_tags.py -v
============================== 8 passed in 1.94s ===============================
```

Cases:
- `test_tag_keys_include_organization_fields` — `_TAG_KEYS` lists both new keys
- `test_tag_keys_organization_keys_precede_team_keys` — pins ordering: org > team
- `test_transform_includes_organization_fields_in_tags_when_present` — both org fields flow into Tags JSON
- `test_transform_omits_organization_fields_when_team_has_no_org` — null org row → keys dropped from JSON
- `test_transform_works_when_organization_columns_absent_entirely` — pre-fix frames still transform without raising
- `test_database_query_selects_organization_columns` — SQL SELECTs both new columns
- `test_database_query_joins_organization_table` — `LEFT JOIN LiteLLM_OrganizationTable` clause is present
- `test_database_query_emits_organization_join_only_once` — JOIN clause emitted exactly once

## Push note

Pushed via Git Data API (blobs / tree / commit / refs) because the agent's `GITHUB_TOKEN` lacks the `repo + workflow` scopes git-over-HTTPS requires. PR base, head, and content are unaffected.

## Linear

Resolves LIT-2895.


### Verification (ship-pr)

- [x] Base branch is `litellm_oss_agent_shin_daily_branch` (verified via PR `base.ref`).
- [x] GitHub Actions: **43/43 green**, 0 failures (lint, code-quality, unit-test, semgrep, secret-scan, integrations, proxy-*, validate-model-prices-json, documentation, all `Run tests` shards, etc.).
- [x] Greptile: **5/5** ("Safe to merge; changes are additive, well-tested, and scoped entirely to the non-critical FOCUS export path.").
- [x] Veria AI - PR Review: ✅ success ("No security issues found").
- [x] Runtime evidence: `### Evidence` section above shows before/after of `FocusTransformer.transform()` and the SQL emitted by `FocusLiteLLMDatabase.get_usage_data()`.
- [x] Unit tests: 8 new mock-only tests in `tests/test_litellm/integrations/focus/test_focus_organization_tags.py`; locally `8 passed in 1.94s`.
- [x] Customer-name redaction: PR body does not reference the LiteLLM customer; only the third-party export target (Vantage) is named.
- [x] Diff scope: 3 files (+132/-0), no vendored/generated noise.
