### PR TITLE
fix(hosted_vllm/rerank): accept SGLang bare-list response shape (#29156)

### DIFF
--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -168,9 +168,7 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
             message=error_message, status_code=status_code, headers=headers
         )
 
-    def _transform_response(
-        self, response: Union[dict, list]
-    ) -> RerankResponse:
+    def _transform_response(self, response: Union[dict, list]) -> RerankResponse:
         # SGLang's /v1/rerank endpoint returns a bare list of result objects
         # instead of the OpenAI/Cohere-style {"results": [...], "usage": {...}}
         # envelope. Normalize both shapes here so hosted_vllm covers both.

--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -168,7 +168,15 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
             message=error_message, status_code=status_code, headers=headers
         )
 
-    def _transform_response(self, response: dict) -> RerankResponse:
+    def _transform_response(
+        self, response: Union[dict, list]
+    ) -> RerankResponse:
+        # SGLang's /v1/rerank endpoint returns a bare list of result objects
+        # instead of the OpenAI/Cohere-style {"results": [...], "usage": {...}}
+        # envelope. Normalize both shapes here so hosted_vllm covers both.
+        if isinstance(response, list):
+            response = {"results": response}
+
         # Extract usage information
         usage_data = response.get("usage", {})
         _billed_units = RerankBilledUnits(
@@ -186,17 +194,25 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
         rerank_results: List[RerankResponseResult] = []
 
         for result in _results:
+            # SGLang uses "score" rather than the OpenAI/Cohere "relevance_score".
+            if "relevance_score" not in result and "score" in result:
+                result = {**result, "relevance_score": result["score"]}
+
             # Validate required fields exist
             if not all(key in result for key in ["index", "relevance_score"]):
                 raise ValueError(f"Missing required fields in the result={result}")
 
-            # Get document data if it exists
-            document_data = result.get("document", {})
-            document = (
-                RerankResponseDocument(text=str(document_data.get("text", "")))
-                if document_data
-                else None
-            )
+            # Get document data if it exists. SGLang returns the document as a
+            # plain string; the OpenAI/Cohere envelope returns {"text": "..."}.
+            document_data = result.get("document")
+            if isinstance(document_data, str):
+                document = RerankResponseDocument(text=document_data)
+            elif isinstance(document_data, dict) and document_data:
+                document = RerankResponseDocument(
+                    text=str(document_data.get("text", ""))
+                )
+            else:
+                document = None
 
             # Create typed result
             rerank_result = RerankResponseResult(


### PR DESCRIPTION
## Summary

Fixes #29156.

When `litellm.rerank(model="hosted_vllm/<MODEL>", api_base="<SGLang>/v1/rerank", ...)` hits SGLang's rerank endpoint, the response shape differs from the OpenAI/Cohere envelope that `HostedVLLMRerankConfig._transform_response` was written for:

| field | OpenAI/Cohere envelope | SGLang shape |
|---|---|---|
| top level | `{"results": [...], "usage": {...}}` | bare `[ ... ]` list |
| score key | `relevance_score` | `score` |
| document | `{"text": "..."}` dict | bare `"..."` string |

The first divergence is what produces the user-visible `'list' object has no attribute 'get'` crash on `response.get("usage", {})`. The other two would surface in turn after a list-wrap normalization.

## Change

In `litellm/llms/hosted_vllm/rerank/transformation.py::_transform_response`:

1. If `response` arrives as a `list`, wrap it as `{"results": response}` before the `.get("usage")` / `.get("results")` calls.
2. Inside the per-result loop, if a result has only `score` (not `relevance_score`), alias it before the validation assertion so the existing assertion path still works for OpenAI/Cohere shape.
3. Accept `document` as either a plain string (SGLang) or a `{"text": ...}` dict (existing), falling back to `None` for missing/empty.

Both shape normalizations are **purely additive** — OpenAI/Cohere-shaped responses still take the same code path they always did. Only when the alternate keys are seen does the new branch activate.

## Test plan

- [x] `python -c "import ast; ast.parse(open('litellm/llms/hosted_vllm/rerank/transformation.py').read())"` — syntax OK.
- [ ] Manual verification against the original repro in the issue (SGLang rerank server + Qwen3-reranker-8b). I don't have a local SGLang setup; the per-shape branches are mechanical, but a reviewer with the user's setup would be the highest-confidence signal.
- [ ] Unit-test coverage: happy to add a `tests/llms/hosted_vllm/test_rerank_transformation.py` (two `_transform_response()` calls — one bare-list, one envelope) if maintainers want that in this PR rather than a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
