### PR TITLE
fix(dashscope): bill qwen3-rerank by token usage

### DIFF
--- a/litellm/llms/dashscope/rerank/transformation.py
+++ b/litellm/llms/dashscope/rerank/transformation.py
@@ -22,7 +22,7 @@ as supported only for gte-rerank-v2 / qwen3-vl-rerank.
 Docs - https://help.aliyun.com/zh/model-studio/text-rerank-api
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import httpx
 
@@ -38,6 +38,7 @@ from litellm.types.rerank import (
     RerankResponseMeta,
     RerankTokens,
 )
+from litellm.types.utils import ModelInfo
 
 from ..common_utils import DashScopeError
 
@@ -239,3 +240,33 @@ class DashScopeRerankConfig(BaseRerankConfig):
             message=error_message,
             headers=headers,
         )
+
+    def calculate_rerank_cost(
+        self,
+        model: str,
+        custom_llm_provider: Optional[str] = None,
+        billed_units: Optional[RerankBilledUnits] = None,
+        model_info: Optional[ModelInfo] = None,
+    ) -> Tuple[float, float]:
+        """
+        qwen3-rerank is billed per token. DashScope reports the count in
+        usage.total_tokens, surfaced here as billed_units["total_tokens"];
+        set the per-token price via `input_cost_per_token` on the model.
+
+        The base BaseRerankConfig prices per query (input_cost_per_query *
+        search_units), which DashScope does not report — hence this override.
+        """
+        if (
+            model_info is None
+            or "input_cost_per_token" not in model_info
+            or model_info["input_cost_per_token"] is None
+            or billed_units is None
+        ):
+            return 0.0, 0.0
+
+        total_tokens = billed_units.get("total_tokens")
+        if total_tokens is None:
+            return 0.0, 0.0
+
+        input_cost = model_info["input_cost_per_token"] * total_tokens
+        return input_cost, 0.0

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10995,6 +10995,12 @@
     "dashscope/qwen3-rerank": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "dashscope",
+        "max_document_chunks_per_query": 500,
+        "max_input_tokens": 120000,
+        "max_output_tokens": 120000,
+        "max_query_tokens": 4000,
+        "max_tokens": 120000,
+        "max_tokens_per_document_chunk": 4000,
         "mode": "rerank",
         "output_cost_per_token": 0.0,
         "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing"

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10992,6 +10992,13 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "dashscope/qwen3-rerank": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "dashscope",
+        "mode": "rerank",
+        "output_cost_per_token": 0.0,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing"
+    },
     "dashscope/qwen3-vl-235b-a22b-instruct": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10995,6 +10995,12 @@
     "dashscope/qwen3-rerank": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "dashscope",
+        "max_document_chunks_per_query": 500,
+        "max_input_tokens": 120000,
+        "max_output_tokens": 120000,
+        "max_query_tokens": 4000,
+        "max_tokens": 120000,
+        "max_tokens_per_document_chunk": 4000,
         "mode": "rerank",
         "output_cost_per_token": 0.0,
         "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10992,6 +10992,13 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "dashscope/qwen3-rerank": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "dashscope",
+        "mode": "rerank",
+        "output_cost_per_token": 0.0,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing"
+    },
     "dashscope/qwen3-vl-235b-a22b-instruct": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",

--- a/tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py
@@ -12,12 +12,14 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
+import litellm
+from litellm.cost_calculator import rerank_cost
 from litellm.llms.dashscope.common_utils import DashScopeError
 from litellm.llms.dashscope.rerank.transformation import (
     DEFAULT_RERANK_URL,
     DashScopeRerankConfig,
 )
-from litellm.types.rerank import RerankResponse
+from litellm.types.rerank import RerankBilledUnits, RerankResponse
 
 
 class TestDashScopeRerankURL:
@@ -312,6 +314,80 @@ class TestDashScopeRerankResponse:
         )
         assert isinstance(err, DashScopeError)
         assert err.status_code == 500
+
+
+class TestDashScopeRerankCost:
+    def setup_method(self):
+        self.config = DashScopeRerankConfig()
+
+    def test_cost_is_token_based(self):
+        # qwen3-rerank bills per token: total_tokens * input_cost_per_token.
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=RerankBilledUnits(total_tokens=1000),
+            model_info={"input_cost_per_token": 0.00000005},  # $0.05 / 1M tokens
+        )
+        assert abs(prompt_cost - 0.00005) < 1e-10  # 1000 * 0.00000005
+        assert completion_cost == 0.0
+
+    def test_cost_zero_when_total_tokens_missing(self):
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=RerankBilledUnits(),
+            model_info={"input_cost_per_token": 0.00000005},
+        )
+        assert (prompt_cost, completion_cost) == (0.0, 0.0)
+
+    def test_cost_zero_when_model_info_missing(self):
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=RerankBilledUnits(total_tokens=1000),
+            model_info=None,
+        )
+        assert (prompt_cost, completion_cost) == (0.0, 0.0)
+
+    def test_cost_zero_when_price_unset(self):
+        # Model registered without input_cost_per_token -> no billing.
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=RerankBilledUnits(total_tokens=1000),
+            model_info={},
+        )
+        assert (prompt_cost, completion_cost) == (0.0, 0.0)
+
+
+class TestDashScopeRerankPriceMap:
+    def _load_local_cost_map(self, monkeypatch):
+        # setattr auto-restores litellm.model_cost after the test, so mutating
+        # the global map here can't leak into other tests.
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    def test_qwen3_rerank_price_registered(self, monkeypatch):
+        # Pin the built-in price entry so cost tracking works without per-model
+        # config: $0.1 / 1M tokens == 1e-07 per token.
+        self._load_local_cost_map(monkeypatch)
+
+        info = litellm.get_model_info(
+            model="qwen3-rerank", custom_llm_provider="dashscope"
+        )
+        assert info["input_cost_per_token"] == 1e-07
+        assert info["mode"] == "rerank"
+        assert info["litellm_provider"] == "dashscope"
+
+    def test_qwen3_rerank_billed_end_to_end(self, monkeypatch):
+        # Full production cost path: rerank_cost -> get_model_info ->
+        # DashScopeRerankConfig.calculate_rerank_cost. Guards the seam the
+        # direct unit tests skip.
+        self._load_local_cost_map(monkeypatch)
+
+        prompt_cost, completion_cost = rerank_cost(
+            model="qwen3-rerank",
+            custom_llm_provider="dashscope",
+            billed_units=RerankBilledUnits(total_tokens=1000),
+        )
+        assert abs(prompt_cost - 1e-04) < 1e-12  # 1000 * 1e-07
+        assert completion_cost == 0.0
 
 
 class TestProviderConfigManagerDispatch:


### PR DESCRIPTION
The base `BaseRerankConfig` prices rerank per query (`input_cost_per_query * search_units`), but DashScope reports usage as `total_tokens` and never sets `search_units`, so cost always resolved to $0.

Add a token-based `calculate_rerank_cost` override (`input_cost_per_token * total_tokens`, mirroring `jina_ai`/`voyage`) and register a built-in price for `dashscope/qwen3-rerank` ($0.1 / 1M tokens), so usage is billed out of the box without any per-model pricing config.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

New/updated unit tests for the cost path pass:

```
$ pytest tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py -q
.............................                                            [100%]
29 passed
```

Coverage added for: token-based cost (`total_tokens * input_cost_per_token`), the three zero-cost guard branches (missing `total_tokens`, missing `model_info`, unset price), the built-in `dashscope/qwen3-rerank` price entry resolving through `get_model_info` ($0.1 / 1M = `1e-07`), and the full cost path end-to-end (`rerank_cost` -> `get_model_info` -> `calculate_rerank_cost` = $0.0001 for 1000 tokens).

### `make test-unit`

Full suite: **17977 passed, 114 skipped** (run with `-n 4`). The handful of failures are **unrelated to this change** — they live entirely in `proxy/` (auth, prisma self-heal, health endpoints, premium-license metadata checks), `caching/` (S3), and pass-through (Vertex) modules, none of which this PR touches. Re-running them serially showed most were parallel-execution flakiness (shared global state across xdist workers), and the genuinely-failing ones are pre-existing environment dependencies (real DB, S3 mock, enterprise license, Vertex credentials) that pass in CI. Every test in the changed area is green:

- `tests/test_litellm/llms/dashscope/` — 29 passed
- `tests/test_litellm/test_cost_calculator.py` — 71 passed

## Type

🆕 New Feature
✅ Test

## Changes

- Add `DashScopeRerankConfig.calculate_rerank_cost` in `litellm/llms/dashscope/rerank/transformation.py` — prices per token (`input_cost_per_token * total_tokens`) instead of the base per-query model, since DashScope only reports `total_tokens`.
- Register a built-in price entry for `dashscope/qwen3-rerank` (`input_cost_per_token: 1e-07`, `mode: rerank`) in `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, so cost tracking works with no `litellm_params` pricing overrides.
- Add unit tests in `tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py` covering the cost branches and the price-map wiring.