### PR TITLE
fix(proxy): bypass no-default-models filter on /v1/models for proxy admins (LIT-3038)

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12394,16 +12394,24 @@ async def model_info_v1(  # noqa: PLR0915
     else:
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
-    key_models = get_key_models(
-        user_api_key_dict=user_api_key_dict,
-        proxy_model_list=proxy_model_list,
-        model_access_groups=model_access_groups,
-    )
-    team_models = get_team_models(
-        team_models=user_api_key_dict.team_models,
-        proxy_model_list=proxy_model_list,
-        model_access_groups=model_access_groups,
-    )
+    # LIT-3038: PROXY_ADMIN sees every model the proxy serves; bypass any
+    # stale `models=["no-default-models"]` restriction inherited from a
+    # prior internal_user role (mirrors the same guard in
+    # `get_available_models_for_user`).
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+        key_models: List[str] = []
+        team_models: List[str] = []
+    else:
+        key_models = get_key_models(
+            user_api_key_dict=user_api_key_dict,
+            proxy_model_list=proxy_model_list,
+            model_access_groups=model_access_groups,
+        )
+        team_models = get_team_models(
+            team_models=user_api_key_dict.team_models,
+            proxy_model_list=proxy_model_list,
+            model_access_groups=model_access_groups,
+        )
     all_models_str = get_complete_model_list(
         key_models=key_models,
         team_models=team_models,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12419,6 +12419,7 @@ async def model_info_v1(  # noqa: PLR0915
         user_model=user_model,
         infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
         llm_router=llm_router,
+        team_id=user_api_key_dict.team_id,
     )
 
     if len(all_models_str) > 0:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6067,9 +6067,7 @@ async def get_available_models_for_user(
             team_models=[],
             proxy_model_list=proxy_model_list,
             user_model=user_model,
-            infer_model_from_keys=general_settings.get(
-                "infer_model_from_keys", False
-            ),
+            infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
             return_wildcard_routes=return_wildcard_routes,
             llm_router=llm_router,
             model_access_groups=model_access_groups,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6057,6 +6057,7 @@ async def get_available_models_for_user(
     # key/team filter and defer to `proxy_model_list` (wildcard / access
     # group expansion still applies downstream).
     from litellm.proxy._types import LitellmUserRoles
+
     if (
         user_api_key_dict is not None
         and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
@@ -6067,9 +6068,7 @@ async def get_available_models_for_user(
             team_models=[],
             proxy_model_list=proxy_model_list,
             user_model=user_model,
-            infer_model_from_keys=general_settings.get(
-                "infer_model_from_keys", False
-            ),
+            infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
             return_wildcard_routes=return_wildcard_routes,
             llm_router=llm_router,
             model_access_groups=model_access_groups,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6047,6 +6047,37 @@ async def get_available_models_for_user(
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
 
+    # LIT-3038: A proxy admin who was previously an internal user (or whose
+    # key/user record predates a role promotion) may still carry a
+    # `models=["no-default-models"]` restriction. Without this guard,
+    # `get_complete_model_list` would echo the literal placeholder string
+    # `"no-default-models"` back to /v1/models, which the UI interprets as
+    # "no models accessible" and uses to force the team-required key-creation
+    # modal. PROXY_ADMIN sees every model the proxy serves, so bypass the
+    # key/team filter and defer to `proxy_model_list` (wildcard / access
+    # group expansion still applies downstream).
+    from litellm.proxy._types import LitellmUserRoles
+    if (
+        user_api_key_dict is not None
+        and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+        and not team_id
+    ):
+        return get_complete_model_list(
+            key_models=[],
+            team_models=[],
+            proxy_model_list=proxy_model_list,
+            user_model=user_model,
+            infer_model_from_keys=general_settings.get(
+                "infer_model_from_keys", False
+            ),
+            return_wildcard_routes=return_wildcard_routes,
+            llm_router=llm_router,
+            model_access_groups=model_access_groups,
+            include_model_access_groups=include_model_access_groups,
+            only_model_access_groups=only_model_access_groups,
+            team_id=user_api_key_dict.team_id,
+        )
+
     # Get key models
     key_models = get_key_models(
         user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -34,6 +34,7 @@ from litellm.constants import DEFAULT_MODEL_CREATED_AT_TIME, MAX_TEAM_LIST_LIMIT
 from litellm.proxy._types import (
     DB_CONNECTION_ERROR_TYPES,
     CommonProxyErrors,
+    LitellmUserRoles,
     ProxyErrorTypes,
     ProxyException,
     SpendLogsMetadata,
@@ -6056,8 +6057,6 @@ async def get_available_models_for_user(
     # modal. PROXY_ADMIN sees every model the proxy serves, so bypass the
     # key/team filter and defer to `proxy_model_list` (wildcard / access
     # group expansion still applies downstream).
-    from litellm.proxy._types import LitellmUserRoles
-
     if (
         user_api_key_dict is not None
         and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
@@ -6068,7 +6067,9 @@ async def get_available_models_for_user(
             team_models=[],
             proxy_model_list=proxy_model_list,
             user_model=user_model,
-            infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
+            infer_model_from_keys=general_settings.get(
+                "infer_model_from_keys", False
+            ),
             return_wildcard_routes=return_wildcard_routes,
             llm_router=llm_router,
             model_access_groups=model_access_groups,

--- a/tests/test_litellm/proxy/test_get_available_models_lit_3038.py
+++ b/tests/test_litellm/proxy/test_get_available_models_lit_3038.py
@@ -1,0 +1,148 @@
+"""LIT-3038 regression: promoted proxy admins should not be locked out of
+the proxy model list when their user/key record still carries the
+``models=["no-default-models"]`` restriction inherited from a prior
+internal_user role.
+
+These tests exercise ``litellm.proxy.utils.get_available_models_for_user``
+directly without spinning up the FastAPI app, by constructing the same
+``UserAPIKeyAuth`` shape that the auth layer produces in the buggy
+scenario.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.utils import get_available_models_for_user
+
+
+def _fake_router(model_names):
+    r = MagicMock()
+    r.get_model_names.return_value = list(model_names)
+    r.get_model_access_groups.return_value = {}
+    r.get_model_list.side_effect = lambda model_name=None: None
+    return r
+
+
+@pytest.mark.asyncio
+async def test_promoted_proxy_admin_with_no_default_models_sees_proxy_model_list():
+    """A user promoted to PROXY_ADMIN whose stale key/user record still
+    carries ``models=["no-default-models"]`` must see the full proxy model
+    list (the previous behaviour returned the literal placeholder string)."""
+    user = UserAPIKeyAuth(
+        api_key="sk-stale",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        models=["no-default-models"],
+        team_models=[],
+    )
+    router = _fake_router(["gpt-3.5-turbo", "gpt-4"])
+
+    models = await get_available_models_for_user(
+        user_api_key_dict=user,
+        llm_router=router,
+        general_settings={},
+        user_model=None,
+    )
+
+    assert "no-default-models" not in models, (
+        "PROXY_ADMIN bypass should hide the placeholder; got "
+        + repr(models)
+    )
+    assert set(models) == {"gpt-3.5-turbo", "gpt-4"}
+
+
+@pytest.mark.asyncio
+async def test_promoted_proxy_admin_with_empty_key_models_still_sees_proxy_models():
+    user = UserAPIKeyAuth(
+        api_key="sk-clean",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        models=[],
+        team_models=[],
+    )
+    router = _fake_router(["gpt-3.5-turbo", "gpt-4"])
+
+    models = await get_available_models_for_user(
+        user_api_key_dict=user,
+        llm_router=router,
+        general_settings={},
+        user_model=None,
+    )
+
+    assert set(models) == {"gpt-3.5-turbo", "gpt-4"}
+
+
+@pytest.mark.asyncio
+async def test_internal_user_with_no_default_models_remains_blocked():
+    """The fix is scoped to PROXY_ADMIN; internal users (and viewer roles)
+    must still be filtered by their key/user model restriction."""
+    user = UserAPIKeyAuth(
+        api_key="sk-intern",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        models=["no-default-models"],
+        team_models=[],
+    )
+    router = _fake_router(["gpt-3.5-turbo", "gpt-4"])
+
+    models = await get_available_models_for_user(
+        user_api_key_dict=user,
+        llm_router=router,
+        general_settings={},
+        user_model=None,
+    )
+
+    # before-the-fix behaviour: the placeholder string flows through; the
+    # fix must NOT change this for non-admin roles.
+    assert "no-default-models" in models
+    assert "gpt-3.5-turbo" not in models
+
+
+@pytest.mark.asyncio
+async def test_proxy_admin_viewer_with_no_default_models_remains_blocked():
+    """``proxy_admin_viewer`` is a read-only role and is NOT the same as
+    PROXY_ADMIN; ensure the bypass does not accidentally cover it."""
+    user = UserAPIKeyAuth(
+        api_key="sk-viewer",
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        models=["no-default-models"],
+        team_models=[],
+    )
+    router = _fake_router(["gpt-3.5-turbo", "gpt-4"])
+
+    models = await get_available_models_for_user(
+        user_api_key_dict=user,
+        llm_router=router,
+        general_settings={},
+        user_model=None,
+    )
+
+    assert "no-default-models" in models
+    assert "gpt-3.5-turbo" not in models
+
+
+@pytest.mark.asyncio
+async def test_proxy_admin_with_explicit_team_id_uses_team_path():
+    """Passing an explicit team_id should still go through the team validation
+    path (not the admin bypass) so that the /v1/models?team_id=... endpoint
+    surfaces team-scoped models even for an admin. The bypass guards on
+    ``team_id`` being falsy."""
+    user = UserAPIKeyAuth(
+        api_key="sk-admin",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        models=["no-default-models"],
+        team_models=[],
+    )
+    router = _fake_router(["gpt-3.5-turbo", "gpt-4"])
+
+    # Without prisma_client/proxy_logging_obj/user_api_key_cache the team_id
+    # branch inside the function is a no-op, so the path falls through to the
+    # legacy key/team filter — and we should see the placeholder. Crucially,
+    # we should NOT see the admin bypass kick in here.
+    models = await get_available_models_for_user(
+        user_api_key_dict=user,
+        llm_router=router,
+        general_settings={},
+        user_model=None,
+        team_id="t-1",
+    )
+
+    assert "no-default-models" in models

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -3749,7 +3749,12 @@ async def test_model_info_v1_oci_secrets_not_leaked():
     mock_user_api_key_dict.user_id = "test-user"
     mock_user_api_key_dict.api_key = "test-key"
     mock_user_api_key_dict.team_models = []
+    mock_user_api_key_dict.team_id = None
     mock_user_api_key_dict.models = ["oci-grok-test"]
+    # LIT-3038: model_info_v1 now branches on user_role; non-admin keeps
+    # the legacy key/team filter path that this test exercises.
+    from litellm.proxy._types import LitellmUserRoles
+    mock_user_api_key_dict.user_role = LitellmUserRoles.INTERNAL_USER
 
     # Mock model data with OCI sensitive information
     mock_model_data = {


### PR DESCRIPTION
## Summary

Fixes LIT-3038: promoted proxy admins still see the internal-user "no models / pick a team" key-creation modal in the UI.

### Root cause

When an internal user (whose user record carries `models=["no-default-models"]` either explicitly or via `default_internal_user_params`) is promoted to `proxy_admin`, the user's `models` field is not rewritten and any pre-promotion virtual key still has the `["no-default-models"]` filter copied from `user_row.models` at key-creation time (see `litellm/proxy/management_endpoints/key_management_endpoints.py:3594`).

After promotion, calls to `/v1/models` and `/model/info` flow through `get_available_models_for_user` (and a duplicate inline copy in `model_info_v1`) which feed `key_models=["no-default-models"]` into `get_complete_model_list`. The placeholder string is non-empty, so it short-circuits the `proxy_model_list` fallback, and the literal token `"no-default-models"` is echoed back to the UI. The UI sees a single non-existent model and falls back to the team-required key-creation modal — exactly the symptom the customer reported.

### Fix

Two narrowly-scoped guards:

1. **`litellm/proxy/utils.py::get_available_models_for_user`** — when `user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN` and no explicit `team_id` is requested, call `get_complete_model_list` with `key_models=[]`/`team_models=[]` so the function defers to `proxy_model_list`. Wildcard / access-group / `only_model_access_groups` expansion still applies downstream.
2. **`litellm/proxy/proxy_server.py::model_info_v1`** — the `/model/info` endpoint duplicates the key/team filtering inline (does not call `get_available_models_for_user`). Apply the same admin-role bypass at the same point so both endpoints stay consistent.

The `team_id` guard on (1) means the `/v1/models?team_id=...` path is unaffected — admins requesting a specific team's models still go through team validation.

Non-admin roles (`internal_user`, `proxy_admin_viewer`, team roles) are explicitly NOT covered by the bypass; their key/team `models` restrictions still apply.

### Evidence

Base commit: `1fe911d89db85bc29f88f4269a78ed63b8f23a00` (`litellm_oss_agent_shin_daily_branch`).

Driving the bug end-to-end through a running proxy in a sandbox (sqlite-backed prisma migrated DB, mock-response models `gpt-3.5-turbo` + `gpt-4`):

**Setup** (creates the stale-state user, retrieves the key whose `models` field was inherited from `user.models`, then promotes the user to `proxy_admin`):

```text
$ curl -s -X POST http://localhost:4000/user/new -H 'Authorization: Bearer sk-master'     -d '{"user_email":"intern@example.com","user_role":"internal_user","models":["no-default-models"]}'
=> user_id=aa089066-..., key=sk-DfTP-..., models=["no-default-models"]

$ curl -s "http://localhost:4000/key/info?key=sk-DfTP-..." -H 'Authorization: Bearer sk-master'
key.models: ['no-default-models']      # key inherited from user_row.models

$ curl -s -X POST http://localhost:4000/user/update -H 'Authorization: Bearer sk-master'     -d '{"user_id":"aa089066-...","user_role":"proxy_admin"}'
=> role: proxy_admin, models: ['no-default-models']
```

**BEFORE FIX** (clean base SHA, proxy restarted, same `sk-DfTP-...` key):

```text
$ curl -s -H 'Authorization: Bearer sk-DfTP-...' http://localhost:4000/v1/models
{"data":[{"id":"no-default-models","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}

$ curl -s -H 'Authorization: Bearer sk-DfTP-...' http://localhost:4000/model/info
{"data":[]}
```

`/v1/models` returns the literal placeholder string `"no-default-models"` as a model id and `/model/info` is empty — the UI interprets both as "this admin has no accessible models" and falls back to the team-required key modal.

**AFTER FIX** (both patches applied, proxy restarted, same `sk-DfTP-...` key):

```text
$ curl -s -H 'Authorization: Bearer sk-DfTP-...' http://localhost:4000/v1/models
{
    "data": [
        {"id": "gpt-3.5-turbo", "object": "model", "created": 1677610602, "owned_by": "openai"},
        {"id": "gpt-4",         "object": "model", "created": 1677610602, "owned_by": "openai"}
    ],
    "object": "list"
}

$ curl -s -H 'Authorization: Bearer sk-DfTP-...' http://localhost:4000/model/info | jq '.data | length'
2
```

**Safety: non-admin roles still blocked** (same proxy, post-fix):

```text
# internal_user with models=["no-default-models"]
$ curl -s -H 'Authorization: Bearer sk-SAjXMLo-...' http://localhost:4000/v1/models
{"data":[{"id":"no-default-models","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}

# proxy_admin_viewer with models=["no-default-models"] (read-only role — NOT the same as PROXY_ADMIN)
$ curl -s -H 'Authorization: Bearer sk-fhZSCyK-...' http://localhost:4000/v1/models
{"data":[{"id":"no-default-models","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

The bypass is scoped to `LitellmUserRoles.PROXY_ADMIN` only.

### Tests

`tests/test_litellm/proxy/test_get_available_models_lit_3038.py` — 5 regression tests, all passing:

```text
$ python -m pytest tests/test_litellm/proxy/test_get_available_models_lit_3038.py -v
tests/test_litellm/proxy/test_get_available_models_lit_3038.py::test_promoted_proxy_admin_with_no_default_models_sees_proxy_model_list PASSED
tests/test_litellm/proxy/test_get_available_models_lit_3038.py::test_promoted_proxy_admin_with_empty_key_models_still_sees_proxy_models PASSED
tests/test_litellm/proxy/test_get_available_models_lit_3038.py::test_internal_user_with_no_default_models_remains_blocked PASSED
tests/test_litellm/proxy/test_get_available_models_lit_3038.py::test_proxy_admin_viewer_with_no_default_models_remains_blocked PASSED
tests/test_litellm/proxy/test_get_available_models_lit_3038.py::test_proxy_admin_with_explicit_team_id_uses_team_path PASSED
============================== 5 passed in 14.03s ==============================
```

### Notes

- Pushed via the GitHub Contents API (one commit per file) because the current `GITHUB_TOKEN` lacks `repo`+`workflow` scopes — reviewers should expect a noisier merge-base diff (3 commits) but the net change is exactly the 3 files listed above.
- Base branch is `litellm_oss_agent_shin_daily_branch` per Shin fork policy.

Session: https://litellm-agent-platform.onrender.com/sessions/d7b8d01c-c02e-41ed-8987-270159b4102f


---

### Verification (ship-pr)

| Check | Status | Notes |
|---|---|---|
| Reproduced on clean main | ✅ | Stale-promoted-admin key returns `[{"id":"no-default-models",...}]` on `/v1/models` and `[]` on `/model/info` at base SHA `1fe911d` |
| Fix applied | ✅ | `litellm/proxy/utils.py::get_available_models_for_user` + `litellm/proxy/proxy_server.py::model_info_v1` |
| AFTER evidence on running proxy | ✅ | Both endpoints return `gpt-3.5-turbo` + `gpt-4`; admin sees all proxy models |
| Safety: non-admin still blocked | ✅ | `internal_user` and `proxy_admin_viewer` keys with same `models=["no-default-models"]` still see the placeholder |
| Unit tests added | ✅ | 5 regression cases in `tests/test_litellm/proxy/test_get_available_models_lit_3038.py` |
| All new + adjacent tests pass | ✅ | 5 new + adjacent `test_model_checks.py` tests pass; `test_model_info_v1_oci_secrets_not_leaked` updated to seed `user_role` on the mock |
| Greptile | ✅ | **5/5** on `ee10660` — "Safe to merge" |
| Veria AI - PR Review | ✅ | success |
| GitHub Actions | ✅ | **44/44 green**, 0 failures |
| Base branch | ✅ | `litellm_oss_agent_shin_daily_branch` per Shin fork policy |
| mergeable_state | ✅ | `clean` |
