### PR TITLE
fix(proxy/model-checks): drop wildcard literal from /v1/models when expansion succeeded (LIT-2861)

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -330,6 +330,13 @@ def _get_wildcard_models(
                     model_name=model, team_id=team_id
                 )
                 if model_list:
+                    # LIT-2861: drop the literal wildcard ("openai/*", etc.)
+                    # from the result when expansion succeeded — mirrors the
+                    # fallback branch below and prevents the "<provider>/*"
+                    # token from leaking into /v1/models alongside the
+                    # concrete model IDs. The literal is re-added above when
+                    # the caller passes return_wildcard_routes=True.
+                    expansion_yielded_models = False
                     for router_model in model_list:
                         wildcard_models = get_known_models_from_wildcard(
                             wildcard_model=model,
@@ -337,7 +344,11 @@ def _get_wildcard_models(
                                 **router_model["litellm_params"]  # type: ignore
                             ),
                         )
+                        if wildcard_models:
+                            expansion_yielded_models = True
                         all_wildcard_models.extend(wildcard_models)
+                    if expansion_yielded_models:
+                        models_to_remove.add(model)
                 else:
                     # Router has no deployment for this wildcard (e.g., BYOK team models)
                     # Fall back to expanding from known provider models

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -487,3 +487,90 @@ async def test_get_available_models_for_user_expands_query_team_wildcard(
     )
 
     assert "openai/gpt-4o-mini" in result
+
+
+
+# LIT-2861: wildcard literal must be removed from the result when expansion
+# succeeded against a routed deployment. Previously only the no-deployment
+# fallback removed it, leaving "<provider>/*" leaking into /v1/models and
+# /v1/models?team_id=X for every config-level and team-scoped BYOK wildcard.
+def test_lit_2861_global_wildcard_literal_not_leaked_default():
+    from litellm import Router
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    router = Router(model_list=[{
+        "model_name": "openai/*",
+        "litellm_params": {"model": "openai/*", "api_key": "sk-fake"},
+        "model_info": {"id": "global-1"},
+    }])
+    result = get_complete_model_list(
+        key_models=[], team_models=[],
+        proxy_model_list=router.get_model_names(),
+        user_model=None, infer_model_from_keys=False,
+        return_wildcard_routes=False, llm_router=router,
+    )
+    assert "openai/*" not in result
+    assert any(m.startswith("openai/") for m in result)
+
+
+def test_lit_2861_global_wildcard_literal_included_once_when_requested():
+    from litellm import Router
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    router = Router(model_list=[{
+        "model_name": "openai/*",
+        "litellm_params": {"model": "openai/*", "api_key": "sk-fake"},
+        "model_info": {"id": "global-1"},
+    }])
+    result = get_complete_model_list(
+        key_models=[], team_models=[],
+        proxy_model_list=router.get_model_names(),
+        user_model=None, infer_model_from_keys=False,
+        return_wildcard_routes=True, llm_router=router,
+    )
+    assert result.count("openai/*") == 1
+
+
+def test_lit_2861_team_scoped_wildcard_literal_not_leaked_default():
+    from litellm import Router
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    router = Router(model_list=[{
+        "model_name": "model_name_team-X_abc123",
+        "litellm_params": {"model": "openai/*", "api_key": "sk-fake"},
+        "model_info": {
+            "id": "team-byok-1",
+            "team_id": "team-X",
+            "team_public_model_name": "openai/*",
+        },
+    }])
+    result = get_complete_model_list(
+        key_models=[], team_models=["openai/*"],
+        proxy_model_list=router.get_model_names(),
+        user_model=None, infer_model_from_keys=False,
+        return_wildcard_routes=False, llm_router=router, team_id="team-X",
+    )
+    assert "openai/*" not in result
+    assert any(m.startswith("openai/") for m in result)
+
+
+def test_lit_2861_team_scoped_wildcard_literal_included_once_when_requested():
+    from litellm import Router
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    router = Router(model_list=[{
+        "model_name": "model_name_team-X_abc123",
+        "litellm_params": {"model": "openai/*", "api_key": "sk-fake"},
+        "model_info": {
+            "id": "team-byok-1",
+            "team_id": "team-X",
+            "team_public_model_name": "openai/*",
+        },
+    }])
+    result = get_complete_model_list(
+        key_models=[], team_models=["openai/*"],
+        proxy_model_list=router.get_model_names(),
+        user_model=None, infer_model_from_keys=False,
+        return_wildcard_routes=True, llm_router=router, team_id="team-X",
+    )
+    assert result.count("openai/*") == 1


### PR DESCRIPTION
## Summary

Fixes [LIT-2861](https://linear.app/litellm-ai/issue/LIT-2861). In litellm/proxy/auth/model_checks.py, _get_wildcard_models only added the literal wildcard (e.g. openai/*) to models_to_remove in the no-deployment fallback branch. When the router *did* have a deployment for the wildcard — true for every config-level wildcard and for team-scoped BYOK wildcards via model_info.team_public_model_name — the literal stayed in unique_models and leaked into /v1/models and /v1/models?team_id=X alongside the concrete expansions. With return_wildcard_routes=true it ended up in the list twice.

This PR mirrors the fallback branch in the routed-deployment path: track whether get_known_models_from_wildcard produced any concrete models and, if so, drop the literal from unique_models. The literal is still re-added exactly once by the existing return_wildcard_routes=True branch above. Unknown-provider wildcards (no expansion possible) keep the literal so the response is not empty.

## Reproduction (HEAD 1fe911d)

Before the fix:
```
Scenario 1 (global config wildcard):
  RW=False -> total=207, literal-wildcard count=1
  RW=True  -> total=208, literal-wildcard count=2
Scenario 2 (team-scoped BYOK wildcard, /v1/models?team_id=team-X):
  RW=False -> total=207, literal-wildcard count=1
  RW=True  -> total=208, literal-wildcard count=2
```

After the fix (this PR):
```
Scenario 1 (global config wildcard):
  RW=False -> total=206, literal-wildcard count=0
  RW=True  -> total=207, literal-wildcard count=1
Scenario 2 (team-scoped BYOK wildcard, /v1/models?team_id=team-X):
  RW=False -> total=206, literal-wildcard count=0
  RW=True  -> total=207, literal-wildcard count=1
```

Repro driver (run against a fresh clone of the daily branch / this branch, no DB or live proxy required):

```python
from litellm import Router
from litellm.proxy.auth.model_checks import get_complete_model_list

needle = "openai/*"

# Scenario 1 — global config wildcard
r = Router(model_list=[{
    "model_name": needle,
    "litellm_params": {"model": needle, "api_key": "sk-fake"},
    "model_info": {"id": "global-1"},
}])
for rw in (False, True):
    out = get_complete_model_list(
        key_models=[], team_models=[],
        proxy_model_list=r.get_model_names(),
        user_model=None, infer_model_from_keys=False,
        return_wildcard_routes=rw, llm_router=r,
    )
    print(f"global RW={rw}: total={len(out)} literal={out.count(needle)}")

# Scenario 2 — team-scoped BYOK wildcard
r2 = Router(model_list=[{
    "model_name": "model_name_team-X_abc123",
    "litellm_params": {"model": needle, "api_key": "sk-fake"},
    "model_info": {
        "id": "team-byok-1",
        "team_id": "team-X",
        "team_public_model_name": needle,
    },
}])
for rw in (False, True):
    out = get_complete_model_list(
        key_models=[], team_models=[needle],
        proxy_model_list=r2.get_model_names(),
        user_model=None, infer_model_from_keys=False,
        return_wildcard_routes=rw, llm_router=r2, team_id="team-X",
    )
    print(f"team   RW={rw}: total={len(out)} literal={out.count(needle)}")
```

### Evidence

This is a pure backend code-path change driving the /v1/models response, captured as before/after function output above (no DB or HTTP layer in the loop — model_list callers feed straight through get_complete_model_list). The proxy endpoint at litellm/proxy/proxy_server.py::model_list calls get_available_models_for_user → get_complete_model_list, so the function-level output above is the same payload that lands in the JSON response. UI screenshots add no signal here — the team admin pane reads the same data.

### Tests

Four new regression tests in tests/test_litellm/proxy/auth/test_model_checks.py, each pinned to a concrete (proxy_model_list, team_models, team_id, return_wildcard_routes) tuple:

* test_lit_2861_global_wildcard_literal_not_leaked_default — RW=False, global wildcard, asserts "openai/*" not in result and expansion happened.
* test_lit_2861_global_wildcard_literal_included_once_when_requested — RW=True, asserts result.count("openai/*") == 1.
* test_lit_2861_team_scoped_wildcard_literal_not_leaked_default — team-scoped BYOK wildcard via team_public_model_name, RW=False, asserts literal absent + expansion happened.
* test_lit_2861_team_scoped_wildcard_literal_included_once_when_requested — team-scoped, RW=True, asserts result.count("openai/*") == 1.

All 18 tests in the file pass:

```
tests/test_litellm/proxy/auth/test_model_checks.py::test_get_available_models_for_user_expands_query_team_wildcard PASSED
tests/test_litellm/proxy/auth/test_model_checks.py::test_get_complete_model_list_byok_wildcard_expansion PASSED
tests/test_litellm/proxy/auth/test_model_checks.py::test_get_complete_model_list_expands_team_scoped_wildcard_with_stored_credential PASSED
... (14 others) ...
tests/test_litellm/proxy/auth/test_model_checks.py::test_lit_2861_global_wildcard_literal_included_once_when_requested PASSED
tests/test_litellm/proxy/auth/test_model_checks.py::test_lit_2861_global_wildcard_literal_not_leaked_default PASSED
tests/test_litellm/proxy/auth/test_model_checks.py::test_lit_2861_team_scoped_wildcard_literal_included_once_when_requested PASSED
tests/test_litellm/proxy/auth/test_model_checks.py::test_lit_2861_team_scoped_wildcard_literal_not_leaked_default PASSED
============================== 18 passed in 9.74s ==============================
```

### Notes

Pushed via the GitHub Contents API (one PUT per file): the agent token currently lacks the repo + workflow scopes needed for git push and PATCH /git/refs, so the merge-base diff will be slightly noisier than a normal force-push. The commits land cleanly on top of litellm_oss_agent_shin_daily_branch.

Linear: LIT-2861
Agent session: https://litellm-agent-platform.onrender.com/sessions/75246fbc-562e-44c4-8fb8-032ac0cb2bda


### Verification (ship-pr)

- [x] **Bug reproduced on daily branch BEFORE fix** — captured in the "Reproduction" block above; same Router instances driving the production get_complete_model_list path, no mocks.
- [x] **Fix verified runtime behaviour** — after the patch, the same two scenarios drop from total=207→206 (RW=False) and the literal count goes from 1→0; with RW=True from 2→1.
- [x] **Regression tests added** — four test_lit_2861_* tests covering global vs team-scoped wildcards × RW=False/True. pytest tests/test_litellm/proxy/auth/test_model_checks.py → 18 passed.
- [x] **Customer name redacted** — LIT-2861 has no project / customer in Linear; no customer reference appears in the PR title, body, commit message, or test data.
- [x] **Base branch** — BerriAI/litellm:litellm_oss_agent_shin_daily_branch (fork-PR policy).
- [x] **All GitHub Actions green** — 44/44 checks completed success on commit 410f008: unit-test, code-quality, lint, semgrep, secret-scan, every per-area pytest workflow, build-ui, validate-model-prices-json, both test-server-root-path matrices, codecov upload, Veria AI - PR Review.
- [x] **Greptile ≥ 4/5** — 4/5 "Safe to merge — narrowly scoped … guarded by four new regression tests" on commit 410f008.
- [x] **Veria AI - PR Review** — success on commit 410f008.
- [x] **Linear ticket linked** — comment on LIT-2861 with PR link + before/after evidence.
