### PR TITLE
fix(guardrails): team kill-switch + opted-out list must not be overridden by key metadata (LIT-1825)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -7,6 +7,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Tuple,
     Type,
     Union,
     get_args,
@@ -237,18 +238,43 @@ class CustomGuardrail(CustomLogger):
         ``litellm_metadata`` depending on endpoint. Check both so a caller
         cannot shadow admin config by pre-populating the other key.
         Key-level settings override team-level.
+
+        NOTE: this last-write-wins merge is the wrong semantic for
+        kill-switch style settings (``disable_global_guardrails``) and
+        union-style settings (``opted_out_global_guardrails``) where a
+        permissive key value should never override a restrictive team
+        value. See LIT-1825 — the dedicated getters
+        ``get_disable_global_guardrail`` and
+        ``get_opted_out_global_guardrails_from_metadata`` read team and key
+        independently via ``_get_admin_metadata_team_and_key`` instead of
+        calling this method. Continue using this only for settings where
+        last-write-wins is the intended behavior.
+        """
+        team_meta, key_meta = CustomGuardrail._get_admin_metadata_team_and_key(data)
+        return {**team_meta, **key_meta}
+
+    @staticmethod
+    def _get_admin_metadata_team_and_key(data: dict) -> Tuple[dict, dict]:
+        """Return ``(team_admin_metadata, key_admin_metadata)`` without merging.
+
+        Same source-of-truth as ``_get_admin_metadata`` (proxy-injected
+        ``user_api_key_team_metadata`` / ``user_api_key_metadata`` under
+        either ``metadata`` or ``litellm_metadata``), but returns the two
+        dicts separately so callers can apply the merge semantic that
+        fits their setting (boolean OR, list UNION, last-write-wins,
+        etc.).
         """
         team_meta: dict = {}
         key_meta: dict = {}
         for key in ("metadata", "litellm_metadata"):
-            # Defensive: an unparsed JSON-string metadata could leak past the
-            # proxy's normal parse path; don't AttributeError on .get().
+            # Defensive: an unparsed JSON-string metadata could leak past
+            # the proxy's normal parse path; don't AttributeError on .get().
             meta = data.get(key)
             if not isinstance(meta, dict):
                 continue
             team_meta = meta.get("user_api_key_team_metadata") or team_meta
             key_meta = meta.get("user_api_key_metadata") or key_meta
-        return {**team_meta, **key_meta}
+        return team_meta, key_meta
 
     def get_disable_global_guardrail(self, data: dict) -> Optional[bool]:
         """
@@ -256,17 +282,53 @@ class CustomGuardrail(CustomLogger):
 
         Reads from admin-configured key/team metadata only, not from
         the request body, to prevent callers from disabling guardrails.
+
+        Team and key are treated as **independent kill-switches**: if
+        either admin-configured ``disable_global_guardrails`` is True the
+        guardrail is skipped. A key cannot un-disable a guardrail that
+        the team has disabled — necessary because the UI form
+        (``ui/litellm-dashboard/src/components/templates/key_edit_view.tsx``)
+        always submits ``disable_global_guardrails: false`` on key edit
+        unless the operator explicitly checks the box, which would
+        otherwise silently shadow the team kill-switch on every key edit.
+        See LIT-1825.
         """
-        return self._get_admin_metadata(data).get("disable_global_guardrails", False)
+        team_meta, key_meta = self._get_admin_metadata_team_and_key(data)
+        if team_meta.get("disable_global_guardrails") is True:
+            return True
+        if key_meta.get("disable_global_guardrails") is True:
+            return True
+        return False
 
     def get_opted_out_global_guardrails_from_metadata(self, data: dict) -> List[str]:
         """
-        Returns the list of global guardrail names the team/key has opted out of.
+        Returns the list of global guardrail names the team/key has opted
+        out of.
 
         Reads from admin-configured key/team metadata only.
+
+        Returns the **union** of team-level and key-level opt-out lists,
+        with team entries appearing first and duplicates removed in
+        stable order. A key-level empty list never erases the team's
+        opt-outs — necessary because the UI form persists
+        ``opted_out_global_guardrails: []`` on every key edit where the
+        operator hasn't picked any per-key opt-outs, which would
+        otherwise silently shadow the team-level opt-out list. See
+        LIT-1825.
         """
-        value = self._get_admin_metadata(data).get("opted_out_global_guardrails")
-        return value if isinstance(value, list) else []
+        team_meta, key_meta = self._get_admin_metadata_team_and_key(data)
+        team_list = team_meta.get("opted_out_global_guardrails")
+        key_list = key_meta.get("opted_out_global_guardrails")
+        out: List[str] = []
+        seen: set = set()
+        for src_list in (team_list, key_list):
+            if not isinstance(src_list, list):
+                continue
+            for name in src_list:
+                if isinstance(name, str) and name not in seen:
+                    seen.add(name)
+                    out.append(name)
+        return out
 
     def _is_valid_response_type(self, result: Any) -> bool:
         """

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -276,7 +276,7 @@ class CustomGuardrail(CustomLogger):
             key_meta = meta.get("user_api_key_metadata") or key_meta
         return team_meta, key_meta
 
-    def get_disable_global_guardrail(self, data: dict) -> Optional[bool]:
+    def get_disable_global_guardrail(self, data: dict) -> bool:
         """
         Returns True if the global guardrail should be disabled.
 

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -257,6 +257,202 @@ class TestCustomGuardrailShouldRunGuardrail:
             result is False
         ), "Admin config in metadata must be respected when other metadata key is empty"
 
+    def test_disable_global_guardrail_team_kill_switch_not_overridden_by_key_false(
+        self,
+    ):
+        """LIT-1825 regression: a team's ``disable_global_guardrails=True``
+        must remain a kill-switch even when a key was edited via the UI
+        and ended up with the form's default
+        ``disable_global_guardrails=False`` stored in
+        ``user_api_key_metadata``. Without this guarantee, every key edit
+        silently re-enables global guardrails for that key."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="global_guardrail",
+            default_on=True,
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+
+        # Team kill-switch ON, key form-default OFF.
+        data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "test"}],
+            "metadata": {
+                "user_api_key_team_metadata": {
+                    "disable_global_guardrails": True,
+                },
+                "user_api_key_metadata": {
+                    "disable_global_guardrails": False,
+                },
+            },
+        }
+        assert custom_guardrail.get_disable_global_guardrail(data) is True, (
+            "team-level kill-switch must not be overridden by key-level False"
+        )
+        assert (
+            custom_guardrail.should_run_guardrail(
+                data=data, event_type=GuardrailEventHooks.pre_call
+            )
+            is False
+        ), "team-level kill-switch must skip the guardrail"
+
+    def test_disable_global_guardrail_key_kill_switch_when_team_false(self):
+        """A key can still independently disable a global guardrail when
+        the team has not set the kill-switch."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="global_guardrail",
+            default_on=True,
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+
+        data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "test"}],
+            "metadata": {
+                "user_api_key_team_metadata": {
+                    "disable_global_guardrails": False,
+                },
+                "user_api_key_metadata": {
+                    "disable_global_guardrails": True,
+                },
+            },
+        }
+        assert custom_guardrail.get_disable_global_guardrail(data) is True
+        assert (
+            custom_guardrail.should_run_guardrail(
+                data=data, event_type=GuardrailEventHooks.pre_call
+            )
+            is False
+        )
+
+    def test_disable_global_guardrail_neither_set_runs_guardrail(self):
+        """Baseline: neither team nor key set ``disable_global_guardrails``,
+        guardrail must run because ``default_on=True``."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="global_guardrail",
+            default_on=True,
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+
+        data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "test"}],
+            "metadata": {
+                "user_api_key_team_metadata": {},
+                "user_api_key_metadata": {},
+            },
+        }
+        assert custom_guardrail.get_disable_global_guardrail(data) is False
+        assert (
+            custom_guardrail.should_run_guardrail(
+                data=data, event_type=GuardrailEventHooks.pre_call
+            )
+            is True
+        )
+
+    def test_opted_out_global_guardrails_team_union_key(self):
+        """LIT-1825 regression: opted_out lists must union across team
+        and key. A key opting out of one guardrail must not erase the
+        team's opt-out list (which is what last-write-wins did)."""
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="g_a",
+            default_on=True,
+        )
+        data = {
+            "metadata": {
+                "user_api_key_team_metadata": {
+                    "opted_out_global_guardrails": ["g_a", "g_b"],
+                },
+                "user_api_key_metadata": {
+                    "opted_out_global_guardrails": ["g_c"],
+                },
+            },
+        }
+        assert custom_guardrail.get_opted_out_global_guardrails_from_metadata(
+            data
+        ) == ["g_a", "g_b", "g_c"]
+
+    def test_opted_out_global_guardrails_key_empty_does_not_erase_team(self):
+        """LIT-1825 regression: a key submitted with
+        ``opted_out_global_guardrails: []`` (the UI form's default for
+        any key edited without per-key opt-outs) must not erase
+        team-level opt-outs."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="g_a",
+            default_on=True,
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+        data = {
+            "metadata": {
+                "user_api_key_team_metadata": {
+                    "opted_out_global_guardrails": ["g_a", "g_b"],
+                },
+                "user_api_key_metadata": {
+                    "opted_out_global_guardrails": [],
+                },
+            },
+        }
+        assert custom_guardrail.get_opted_out_global_guardrails_from_metadata(
+            data
+        ) == ["g_a", "g_b"]
+        # And the guardrail itself, named g_a, should still be skipped.
+        assert (
+            custom_guardrail.should_run_guardrail(
+                data=data, event_type=GuardrailEventHooks.pre_call
+            )
+            is False
+        )
+
+    def test_opted_out_global_guardrails_dedup_with_stable_order(self):
+        """Team entries appear first; duplicates removed without
+        re-ordering."""
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="anything",
+            default_on=True,
+        )
+        data = {
+            "metadata": {
+                "user_api_key_team_metadata": {
+                    "opted_out_global_guardrails": ["g_a", "g_b"],
+                },
+                "user_api_key_metadata": {
+                    "opted_out_global_guardrails": ["g_b", "g_c"],
+                },
+            },
+        }
+        assert custom_guardrail.get_opted_out_global_guardrails_from_metadata(
+            data
+        ) == ["g_a", "g_b", "g_c"]
+
+    def test_opted_out_global_guardrails_non_string_entries_ignored(self):
+        """Non-string entries (e.g. a future-typed value or malformed JSON
+        leaking into metadata) are silently dropped instead of poisoning
+        the result."""
+        custom_guardrail = CustomGuardrail(
+            guardrail_name="anything",
+            default_on=True,
+        )
+        data = {
+            "metadata": {
+                "user_api_key_team_metadata": {
+                    "opted_out_global_guardrails": ["g_a", 5, None],
+                },
+                "user_api_key_metadata": {
+                    "opted_out_global_guardrails": [{"name": "g_b"}, "g_c"],
+                },
+            },
+        }
+        assert custom_guardrail.get_opted_out_global_guardrails_from_metadata(
+            data
+        ) == ["g_a", "g_c"]
+
     def test_should_run_guardrail_with_opted_out_global_guardrails(self):
         """Test that per-guardrail opt-out only works from admin metadata"""
         from litellm.types.guardrails import GuardrailEventHooks


### PR DESCRIPTION
## Linear ticket

Resolves LIT-1825

## Problem

`CustomGuardrail._get_admin_metadata()` returns `{**team_meta, **key_meta}` (dict merge — **key wins on conflict**). Two callers depend on this:

- `get_disable_global_guardrail()` reads `disable_global_guardrails` from the merged dict, so a key with `disable_global_guardrails=False` shadows a team with `disable_global_guardrails=True`.
- `get_opted_out_global_guardrails_from_metadata()` reads `opted_out_global_guardrails` from the merged dict, so a key's list (including the empty list `[]`) replaces the team's list entirely.

This breaks the documented team-level kill-switch contract: setting `disable_global_guardrails=true` on a team must reliably disable global guardrails for **all** keys in that team. In practice, the LiteLLM UI form (`ui/litellm-dashboard/src/components/templates/key_edit_view.tsx:178`) always submits

```ts
disable_global_guardrails: keyData.metadata?.disable_global_guardrails || false,
```

so every key edited through the UI ends up with `metadata.disable_global_guardrails = false` stored on the key, which then shadows the team-level kill-switch. The same UI default pattern erases the team-level `opted_out_global_guardrails` list when an operator edits a key without per-key opt-outs.

## Fix

Split the metadata read in two:

- `_get_admin_metadata_team_and_key()` returns `(team_meta, key_meta)` unmerged, so each caller can apply the merge semantic that fits its setting.
- `_get_admin_metadata()` is kept as the same last-write-wins merge for backward compatibility (no remaining in-tree callers depend on this semantic for kill-switches, but other downstream callers may exist).
- `get_disable_global_guardrail()` now returns `True` if **either** team's or key's `disable_global_guardrails` is `True` (boolean OR — team is an authoritative kill-switch that a key cannot un-set).
- `get_opted_out_global_guardrails_from_metadata()` now returns the **union** of team's and key's opt-out lists, team entries first, duplicates removed in stable order, non-string entries silently dropped.

User-injected `disable_global_guardrails` (request-body / `metadata` / `litellm_metadata`) is still ignored — only proxy-injected `user_api_key_team_metadata` and `user_api_key_metadata` are read. Existing security tests still pass.

## Evidence

Runtime evidence for this transformation/auth-layer fix is the same data driven through the unit-level entry point with both behaviors observable. There is no HTTP/UI surface introduced or changed by this patch.

**BEFORE (unpatched HEAD `1fe911d`):**

```
--- LIT-1825 cases ---
  team=True + key=False -> should_run_guardrail=True  (want False)
  team[gg,other] + key[] -> opted_out=[]  (want [global_guardrail, other])
```

**AFTER (this PR):**

```
--- LIT-1825 cases ---
  team=True + key=False -> should_run_guardrail=False  (want False)
  team[gg,other] + key[] -> opted_out=['global_guardrail', 'other']  (want [global_guardrail, other])
```

**Regression suite (7 new tests + 36 existing in this file):**

```
$ pytest tests/test_litellm/integrations/test_custom_guardrail.py -q
...........................................                              [100%]
43 passed in 1.35s
```

Adjacent paths also clean:

```
$ pytest tests/test_litellm/integrations/test_custom_guardrail.py          tests/test_litellm/proxy/auth/test_auth_checks.py
167 passed in 33.40s

$ pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py
135 passed in 14.28s
```

## Notes

- Files were pushed via the contents API (`PUT /repos/{owner}/{repo}/contents/{path}`) because the agent's GitHub token lacks the `repo` + `workflow` scopes needed for `git push` / `git refs` writes. Two commits land on the branch — one per file — instead of a single merge commit; the resulting diff vs `litellm_oss_agent_shin_daily_branch` is exactly the two files listed above.
- Pre-Submission checklist:
  - [x] Tests added in `tests/test_litellm/` (7 new regression tests covering both the kill-switch and opted-out cases plus dedup and non-string defensiveness).
  - [x] Verified `tests/test_litellm/proxy/auth/test_auth_checks.py` security tests for `disable_global_guardrails` still pass (167 passed).


### Verification (ship-pr)

- [x] **Greptile**: 5/5 — "Safe to merge — the change is a targeted correctness fix to two metadata-read methods with no new external dependencies, and is covered by 43 passing tests including 7 new regression cases."
- [x] **Veria AI - PR Review**: success — "No security issues found"
- [x] **GitHub Actions**: 44/44 checks green, 0 failures
- [x] **Base branch**: `litellm_oss_agent_shin_daily_branch` (Shin base-branch rule)
- [x] **Linear ticket**: `LIT-1825` linked in title + body
- [x] **Runtime evidence**: before/after of the same call site captured in the Evidence section (this is an auth-layer transformation fix with no HTTP/UI surface — terminal output of the call path against unpatched HEAD vs patched HEAD is the runtime evidence)
- [x] **Regression coverage**: 7 new tests in `tests/test_litellm/integrations/test_custom_guardrail.py`, all passing
- [x] **Existing tests still pass**: `tests/test_litellm/integrations/test_custom_guardrail.py` 43 passed; `tests/test_litellm/proxy/auth/test_auth_checks.py` (incl. existing `disable_global_guardrails` security tests) 167 passed combined; `tests/test_litellm/proxy/test_litellm_pre_call_utils.py` 135 passed
- [x] **No customer / tenant name leak** in PR title or body
- [x] **No secrets** in PR or commits
- [x] **Diff is scoped**: 2 files changed only (the impl + its tests)
- [x] **Session linked**: https://litellm-agent-platform.onrender.com/sessions/5ce7932b-02ab-4247-be92-049e2b978118
