### PR TITLE
feat(prometheus): emit per-team litellm_team_members_metric on add/remove (LIT-3082)

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -524,6 +524,13 @@ class PrometheusLogger(CustomLogger):
                 labelnames=[],
             )
 
+            # Per-team member count (incremented on add, decremented on remove)
+            self.litellm_team_members_metric = self._gauge_factory(
+                "litellm_team_members_metric",
+                "Net change in team member count since proxy startup, per team. Incremented by 1 on each successful /team/member_add and decremented by 1 on each /team/member_delete. NOTE: this is delta-since-startup, not absolute current membership - the gauge resets to 0 on proxy restart and is never reseeded from the database, so consumers should treat it as a rate-of-change signal rather than a ground-truth count.",
+                labelnames=self.get_labels_for_metric("litellm_team_members_metric"),
+            )
+
             ########################################
             # Managed Batch Metrics
             ########################################
@@ -3408,6 +3415,57 @@ class PrometheusLogger(CustomLogger):
                 self._get_remaining_hours_for_budget_reset(
                     budget_reset_at=team.budget_reset_at
                 )
+            )
+
+    def _team_members_metric_labels(
+        self,
+        team_id: Optional[str],
+        team_alias: Optional[str],
+    ) -> dict:
+        """Build the label dict for litellm_team_members_metric."""
+        enum_values = UserAPIKeyLabelValues(
+            team=team_id or "",
+            team_alias=team_alias or "",
+        )
+        return prometheus_label_factory(
+            supported_enum_labels=self.get_labels_for_metric(
+                metric_name="litellm_team_members_metric"
+            ),
+            enum_values=enum_values,
+        )
+
+    def increment_team_members_metric(
+        self,
+        team_id: Optional[str],
+        team_alias: Optional[str],
+        amount: float = 1.0,
+    ) -> None:
+        """Increment the team-members gauge by ``amount`` (default +1)."""
+        try:
+            labels = self._team_members_metric_labels(
+                team_id=team_id, team_alias=team_alias
+            )
+            self.litellm_team_members_metric.labels(**labels).inc(amount)
+        except Exception as e:
+            verbose_logger.exception(
+                "Error incrementing litellm_team_members_metric: %s", str(e)
+            )
+
+    def decrement_team_members_metric(
+        self,
+        team_id: Optional[str],
+        team_alias: Optional[str],
+        amount: float = 1.0,
+    ) -> None:
+        """Decrement the team-members gauge by ``amount`` (default -1)."""
+        try:
+            labels = self._team_members_metric_labels(
+                team_id=team_id, team_alias=team_alias
+            )
+            self.litellm_team_members_metric.labels(**labels).dec(amount)
+        except Exception as e:
+            verbose_logger.exception(
+                "Error decrementing litellm_team_members_metric: %s", str(e)
             )
 
     async def _set_org_budget_metrics_after_api_request(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2675,6 +2675,16 @@ async def team_member_delete(
         data={"members_with_roles": json.dumps(_db_new_team_members)},  # type: ignore
     )
 
+    # Emit team-members gauge delta (-1) immediately after the authoritative
+    # team-table update, BEFORE any secondary cleanups (user table / team
+    # membership rows / keys) so the gauge stays consistent with the team-
+    # table state even if a downstream cleanup raises.
+    _emit_team_members_metric_delta(
+        team_id=existing_team_row.team_id,
+        team_alias=existing_team_row.team_alias,
+        delta=-1,
+    )
+
     ## DELETE TEAM ID from USER ROW, IF EXISTS ##
     # get user row
     key_val = {}
@@ -2745,16 +2755,6 @@ async def team_member_delete(
                 "team_id": data.team_id,
             }
         )
-
-    # Emit team-members gauge delta (-1) for the removed member. The membership
-    # was verified to exist via ``is_member_in_team`` above, so this is always a
-    # real net deletion.
-    _emit_team_members_metric_delta(
-        team_id=existing_team_row.team_id,
-        team_alias=existing_team_row.team_alias,
-        delta=-1,
-    )
-
     return existing_team_row
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -102,6 +102,7 @@ from litellm.proxy.management_helpers.utils import (
 )
 from litellm.proxy.utils import PrismaClient, handle_exception_on_proxy
 from litellm.router import Router
+from litellm.integrations.prometheus import PrometheusLogger
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
@@ -119,6 +120,32 @@ from litellm.types.proxy.management_endpoints.team_endpoints import (
 )
 
 router = APIRouter()
+
+
+def _emit_team_members_metric_delta(
+    team_id: Optional[str],
+    team_alias: Optional[str],
+    delta: int,
+) -> None:
+    """Emit a delta to the per-team Prometheus team-members gauge.
+
+    Positive ``delta`` increments the gauge (member added), negative decrements
+    (member removed). Silently no-ops when the Prometheus callback is not
+    registered or when ``delta`` is zero.
+    """
+    if delta == 0:
+        return
+    prometheus_logger = PrometheusLogger.get_instance()
+    if prometheus_logger is None:
+        return
+    if delta > 0:
+        prometheus_logger.increment_team_members_metric(
+            team_id=team_id, team_alias=team_alias, amount=float(delta)
+        )
+    else:
+        prometheus_logger.decrement_team_members_metric(
+            team_id=team_id, team_alias=team_alias, amount=float(-delta)
+        )
 
 
 def _sanitize_for_log(value: Any) -> str:
@@ -2482,6 +2509,11 @@ async def team_member_add(
                 prisma_client=prisma_client,
             )
 
+    # Snapshot pre-add member count so we can compute the real ``+N`` delta for
+    # the Prometheus team-members gauge below (independent of any duplicates
+    # silently skipped by ``_update_team_members_list``).
+    members_before_count = len(complete_team_data.members_with_roles or [])
+
     (
         updated_team,
         updated_users,
@@ -2499,6 +2531,23 @@ async def team_member_add(
         raise HTTPException(
             status_code=404, detail={"error": f"Team with id {data.team_id} not found"}
         )
+
+    # Emit team-members gauge delta for *actual* net-new memberships only.
+    # ``team_member_add_duplication_check`` above only raises when *every*
+    # member in a bulk request is already a duplicate; partial-duplicate bulk
+    # adds fall through and ``_update_team_members_list`` silently skips the
+    # already-present ones. We therefore read the real delta off the
+    # team_members list we just persisted (``complete_team_data.members_with_roles``
+    # is mutated in-place by ``_add_team_members_to_team``) rather than
+    # trusting ``len(data.member)``.
+    members_after_count = len(complete_team_data.members_with_roles or [])
+    members_added = max(0, members_after_count - members_before_count)
+    _emit_team_members_metric_delta(
+        team_id=updated_team.team_id,
+        team_alias=updated_team.team_alias,
+        delta=members_added,
+    )
+
     return TeamAddMemberResponse(
         **updated_team.model_dump(),
         updated_users=updated_users,
@@ -2696,6 +2745,15 @@ async def team_member_delete(
                 "team_id": data.team_id,
             }
         )
+
+    # Emit team-members gauge delta (-1) for the removed member. The membership
+    # was verified to exist via ``is_member_in_team`` above, so this is always a
+    # real net deletion.
+    _emit_team_members_metric_delta(
+        team_id=existing_team_row.team_id,
+        team_alias=existing_team_row.team_alias,
+        delta=-1,
+    )
 
     return existing_team_row
 

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -255,6 +255,8 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_check_batch_cost_jobs_processed_total",
     "litellm_check_batch_cost_errors_total",
     "litellm_check_batch_cost_last_run_timestamp",
+    # Team member metrics
+    "litellm_team_members_metric",
 ]
 
 
@@ -709,6 +711,14 @@ class PrometheusMetricLabels:
     litellm_check_batch_cost_errors_total: List[str] = []  # label: error_type (custom)
 
     litellm_check_batch_cost_last_run_timestamp: List[str] = []
+
+    # Team member count metric — incremented when a team member is added,
+    # decremented when one is removed. Labelled by team_id (``team``) and
+    # ``team_alias`` per the dashboards' team-level grouping.
+    litellm_team_members_metric = [
+        UserAPIKeyLabelNames.TEAM.value,
+        UserAPIKeyLabelNames.TEAM_ALIAS.value,
+    ]
 
     @staticmethod
     def get_labels(label_name: DEFINED_PROMETHEUS_METRICS) -> List[str]:

--- a/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
@@ -922,3 +922,85 @@ def test_custom_latency_buckets():
                 REGISTRY.unregister(collector)
             except Exception:
                 pass
+
+
+class TestPrometheusTeamMembersMetric:
+    """Tests for the per-team Prometheus team-members gauge.
+
+    The gauge increments when a member is added to a team and decrements when
+    one is removed. It is labelled by ``team`` (team_id) and ``team_alias``.
+    """
+
+    def _gauge_value(self, prometheus_logger, team_id: str, team_alias: str) -> float:
+        """Read the current value of the team-members gauge for a label combo."""
+        for metric in REGISTRY.collect():
+            for sample in metric.samples:
+                if sample.name != "litellm_team_members_metric":
+                    continue
+                if (
+                    sample.labels.get("team") == team_id
+                    and sample.labels.get("team_alias") == team_alias
+                ):
+                    return sample.value
+        return 0.0
+
+    def test_metric_is_initialized_with_team_labels(self, prometheus_logger):
+        """The gauge should exist and carry the two team-level labels."""
+        assert hasattr(prometheus_logger, "litellm_team_members_metric")
+        assert prometheus_logger.litellm_team_members_metric is not None
+        # Sanity-check the label names by labelling and reading back the sample.
+        prometheus_logger.litellm_team_members_metric.labels(
+            team="t-init", team_alias="t-init-alias"
+        ).set(0)
+        for metric in REGISTRY.collect():
+            for sample in metric.samples:
+                if (
+                    sample.name == "litellm_team_members_metric"
+                    and sample.labels.get("team") == "t-init"
+                ):
+                    assert set(sample.labels.keys()) >= {"team", "team_alias"}
+                    return
+        pytest.fail("litellm_team_members_metric sample not found in registry")
+
+    def test_increment_then_decrement_round_trips_to_zero(self, prometheus_logger):
+        """Add 3 members, then remove 3 — gauge should land back at 0."""
+        team_id, team_alias = "t-rt", "rt-alias"
+        for _ in range(3):
+            prometheus_logger.increment_team_members_metric(
+                team_id=team_id, team_alias=team_alias
+            )
+        assert self._gauge_value(prometheus_logger, team_id, team_alias) == 3.0
+        for _ in range(3):
+            prometheus_logger.decrement_team_members_metric(
+                team_id=team_id, team_alias=team_alias
+            )
+        assert self._gauge_value(prometheus_logger, team_id, team_alias) == 0.0
+
+    def test_increment_with_amount_supports_bulk_add(self, prometheus_logger):
+        """A single bulk add of N members should produce a +N delta."""
+        prometheus_logger.increment_team_members_metric(
+            team_id="t-bulk", team_alias="bulk-alias", amount=5
+        )
+        assert self._gauge_value(prometheus_logger, "t-bulk", "bulk-alias") == 5.0
+
+    def test_independent_teams_track_independently(self, prometheus_logger):
+        """Counts on different teams must not bleed into each other."""
+        prometheus_logger.increment_team_members_metric(
+            team_id="team-a", team_alias="alias-a"
+        )
+        prometheus_logger.increment_team_members_metric(
+            team_id="team-a", team_alias="alias-a"
+        )
+        prometheus_logger.increment_team_members_metric(
+            team_id="team-b", team_alias="alias-b"
+        )
+        assert self._gauge_value(prometheus_logger, "team-a", "alias-a") == 2.0
+        assert self._gauge_value(prometheus_logger, "team-b", "alias-b") == 1.0
+
+    def test_missing_team_alias_falls_back_to_empty_string(self, prometheus_logger):
+        """Teams without an alias must not crash the labels() call."""
+        prometheus_logger.increment_team_members_metric(
+            team_id="t-noalias", team_alias=None
+        )
+        # Empty string is the documented fallback when alias is None.
+        assert self._gauge_value(prometheus_logger, "t-noalias", "") == 1.0

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -8108,3 +8108,154 @@ async def test_update_team_blocks_non_admin_passthrough_routes(mock_db_client):
             )
     assert str(exc.value.code) == "403"
     assert "allowed_passthrough_routes" in str(exc.value.message)
+
+
+class TestEmitTeamMembersMetricDelta:
+    """Tests for the ``_emit_team_members_metric_delta`` helper.
+
+    The helper is the seam between the team management endpoints and the
+    Prometheus team-members gauge — it should call the right
+    ``PrometheusLogger`` method (inc or dec) based on sign, and silently
+    no-op when Prometheus is not configured.
+    """
+
+    def test_no_op_when_prometheus_logger_not_registered(self):
+        """Without a PrometheusLogger in callbacks the helper must not raise."""
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            _emit_team_members_metric_delta,
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.team_endpoints.PrometheusLogger.get_instance",
+            return_value=None,
+        ):
+            # Should not raise, and there's nothing to assert on the call — the
+            # absence of an exception is the contract being tested.
+            _emit_team_members_metric_delta(
+                team_id="t-1", team_alias="alias-1", delta=3
+            )
+
+    def test_zero_delta_short_circuits_before_lookup(self):
+        """delta=0 must not even touch get_instance — no work to do."""
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            _emit_team_members_metric_delta,
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.team_endpoints.PrometheusLogger.get_instance"
+        ) as mock_get:
+            _emit_team_members_metric_delta(
+                team_id="t-1", team_alias="alias-1", delta=0
+            )
+            mock_get.assert_not_called()
+
+    def test_positive_delta_calls_increment(self):
+        """A +N delta routes to ``increment_team_members_metric(amount=N)``."""
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            _emit_team_members_metric_delta,
+        )
+
+        mock_logger = MagicMock()
+        with patch(
+            "litellm.proxy.management_endpoints.team_endpoints.PrometheusLogger.get_instance",
+            return_value=mock_logger,
+        ):
+            _emit_team_members_metric_delta(
+                team_id="t-1", team_alias="alias-1", delta=3
+            )
+
+        mock_logger.increment_team_members_metric.assert_called_once_with(
+            team_id="t-1", team_alias="alias-1", amount=3.0
+        )
+        mock_logger.decrement_team_members_metric.assert_not_called()
+
+    def test_negative_delta_calls_decrement_with_absolute_amount(self):
+        """A -N delta routes to ``decrement_team_members_metric(amount=N)``."""
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            _emit_team_members_metric_delta,
+        )
+
+        mock_logger = MagicMock()
+        with patch(
+            "litellm.proxy.management_endpoints.team_endpoints.PrometheusLogger.get_instance",
+            return_value=mock_logger,
+        ):
+            _emit_team_members_metric_delta(
+                team_id="t-1", team_alias="alias-1", delta=-1
+            )
+
+        mock_logger.decrement_team_members_metric.assert_called_once_with(
+            team_id="t-1", team_alias="alias-1", amount=1.0
+        )
+        mock_logger.increment_team_members_metric.assert_not_called()
+
+
+
+class TestTeamMembersMetricBulkAddDeltaCalculation:
+    """Verify the math used by ``team_member_add`` to compute the gauge delta.
+
+    The endpoint emits ``members_after - members_before`` to the Prometheus
+    team-members gauge so a bulk add with mixed (some duplicate, some new)
+    members increments the gauge only by the count of actually-added members.
+    """
+
+    @pytest.mark.asyncio
+    async def test_partial_duplicate_bulk_add_does_not_overcount(self):
+        """3 requested + 1 already-present member => delta is +2, never +3."""
+        from litellm.proxy._types import (
+            LiteLLM_TeamTable, Member, TeamMemberAddRequest,
+        )
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            _update_team_members_list,
+        )
+
+        existing_member = Member(
+            user_id="u-existing", user_email="existing@x.com", role="user"
+        )
+        complete_team_data = LiteLLM_TeamTable(
+            team_id="t-partial-dup", team_alias="partial-dup-alias",
+            members_with_roles=[existing_member],
+        )
+        data = TeamMemberAddRequest(
+            team_id="t-partial-dup",
+            member=[
+                Member(user_id="u-existing", user_email="existing@x.com", role="user"),
+                Member(user_id="u-new-a", user_email="new-a@x.com", role="user"),
+                Member(user_id="u-new-b", user_email="new-b@x.com", role="user"),
+            ],
+        )
+        members_before_count = len(complete_team_data.members_with_roles or [])
+        await _update_team_members_list(
+            data=data, complete_team_data=complete_team_data, updated_users=[],
+        )
+        members_after_count = len(complete_team_data.members_with_roles or [])
+        delta = max(0, members_after_count - members_before_count)
+        assert members_before_count == 1
+        assert members_after_count == 3
+        assert delta == 2, (
+            f"Expected gauge delta of +2 (only the two new members), "
+            f"got +{delta}. ``len(data.member)`` would have wrongly given +3."
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_member_add_delta_is_one(self):
+        """The single-member (non-bulk) path emits exactly +1."""
+        from litellm.proxy._types import (
+            LiteLLM_TeamTable, Member, TeamMemberAddRequest,
+        )
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            _update_team_members_list,
+        )
+        complete_team_data = LiteLLM_TeamTable(
+            team_id="t-single", team_alias="single-alias", members_with_roles=[],
+        )
+        data = TeamMemberAddRequest(
+            team_id="t-single",
+            member=Member(user_id="u-only", user_email="only@x.com", role="user"),
+        )
+        members_before_count = len(complete_team_data.members_with_roles or [])
+        await _update_team_members_list(
+            data=data, complete_team_data=complete_team_data, updated_users=[],
+        )
+        members_after_count = len(complete_team_data.members_with_roles or [])
+        assert max(0, members_after_count - members_before_count) == 1


### PR DESCRIPTION
## Summary

Adds a new per-team Prometheus gauge `litellm_team_members_metric` that tracks net change in team membership since proxy startup, labelled by `team` (team_id) and `team_alias`.

- **Increments by +1** on each successful `/team/member_add` (and the real net-new delta on `/team/bulk_member_add` — partial-duplicate adds only count actually-new members).
- **Decrements by 1** on each successful `/team/member_delete`.
- **Silently no-ops** when the Prometheus callback is not registered, so this is zero-cost for proxies that have not enabled Prometheus.
- **Treats `team_alias=None` as `""`** to keep the labels() call safe.

### Files touched

| Path | What |
| --- | --- |
| `litellm/integrations/prometheus.py` | New `litellm_team_members_metric` gauge + `increment_team_members_metric` / `decrement_team_members_metric` helpers (+ `_team_members_metric_labels` builder). |
| `litellm/types/integrations/prometheus.py` | Adds `litellm_team_members_metric` to `DEFINED_PROMETHEUS_METRICS` and `PrometheusMetricLabels` with `[team, team_alias]`. |
| `litellm/proxy/management_endpoints/team_endpoints.py` | `_emit_team_members_metric_delta` seam between handlers and the gauge; called from `team_member_add` (+N net delta) and `team_member_delete` (-1). |
| `tests/test_litellm/integrations/test_prometheus_user_team_metrics.py` | 5 unit tests covering label set, round-trip to zero, bulk amount, label isolation, `None` alias fallback. |
| `tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py` | 4 helper unit tests + 2 bulk-delta math tests (partial-duplicate bulk add must not overcount; single-member add is +1). |

## Test plan

- **11 new tests** all pass locally:
  - `tests/test_litellm/integrations/test_prometheus_user_team_metrics.py::TestPrometheusTeamMembersMetric` — 5 tests
  - `tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py::TestEmitTeamMembersMetricDelta` — 4 tests
  - `tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py::TestTeamMembersMetricBulkAddDeltaCalculation` — 2 tests
- Pre-existing suites still pass with the changes:
  - `test_prometheus_user_team_metrics.py` — **43/43 PASS**
  - `test_team_endpoints.py` — **146/146 PASS**

### Evidence

In-process `/metrics` registry scrape against the real `PrometheusLogger` callback + the real `_emit_team_members_metric_delta` seam used by the endpoint handlers. Sequence: 3 single-member adds, one bulk add of 5 to a different team, 2 deletes, a zero-delta no-op, an add to a team with no alias, then unregister the callback and confirm the helper silently no-ops.

```
=== baseline (before any add/delete) ===
(no litellm_team_members_metric samples)

=== after add #1 (alice) ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  1.0

=== after add #2 (bob) ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  2.0

=== after add #3 (carol) ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  3.0

=== after bulk add of 5 to team-other ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  3.0
litellm_team_members_metric{team="team-other",team_alias="Other Team"}  5.0

=== after delete #1 (alice) ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  2.0
litellm_team_members_metric{team="team-other",team_alias="Other Team"}  5.0

=== after delete #2 (bob) ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  1.0
litellm_team_members_metric{team="team-other",team_alias="Other Team"}  5.0

=== after zero-delta no-op ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  1.0
litellm_team_members_metric{team="team-other",team_alias="Other Team"}  5.0

=== after add to team-noalias ===
litellm_team_members_metric{team="team-acme-prod",team_alias="Acme Production"}  1.0
litellm_team_members_metric{team="team-other",team_alias="Other Team"}  5.0
litellm_team_members_metric{team="team-noalias",team_alias=""}  1.0

=== Verification: no-op when PrometheusLogger not registered ===
PASS: helper silently no-ops when PrometheusLogger is not in callbacks
```

## Notes

- This refiles closed PR #28300 against `litellm_oss_agent_shin_daily_branch` (the required base branch for fork PRs). Same fix conceptually, fresh repro evidence on the daily branch.
- The metric is delta-since-startup, not absolute current membership. Consumers should treat it as a rate-of-change signal — it resets to 0 on proxy restart and is never reseeded from the database.
- Pushed via the Git Data API (blobs → tree → commit → ref) because the current `GITHUB_TOKEN` lacks `repo`+`workflow` scopes for direct git push. The diff is still scoped to the 5 listed files only.

Session: https://litellm-agent-platform.onrender.com/sessions/5ce7932b-02ab-4247-be92-049e2b978118

---

### Verification (ship-pr)

| Gate | Status |
| --- | --- |
| Base branch is `litellm_oss_agent_shin_daily_branch` | ✅ |
| GitHub Actions — all checks passing | ✅ 44/44 green |
| Greptile review ≥ 4/5 | ✅ 4/5 ("Safe to merge") |
| Veria AI - PR Review | ✅ pass (12m45s) |
| Greptile findings resolved | ✅ Delete-path placement P2 fixed in `d371674`; custom-label folding is shared with all existing team-level metrics (`litellm_remaining_team_budget_metric`, etc.) and intentionally left unchanged for consistency |
| Runtime evidence in PR body | ✅ Before/after `/metrics` registry scrape inline |
| Pre-existing unit tests still passing | ✅ 43/43 prometheus + 146/146 team_endpoints |
| Diff scoped to intended files | ✅ 5 files only (3 source, 2 tests) |
