### PR TITLE
fix(redis_cache): pin async client cache TTL to prevent pool churn (LIT-3263)

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -22,6 +22,7 @@ import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import (
     DEFAULT_REDIS_MAJOR_VERSION,
+    REDIS_ASYNC_CLIENT_CACHE_TTL,
     REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
     REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
 )
@@ -345,7 +346,16 @@ class RedisCache(BaseCache):
                 connection_pool=self.async_redis_conn_pool, **self.redis_kwargs
             )
             in_memory_llm_clients_cache.set_cache(
-                key=cache_key, value=redis_async_client
+                key=cache_key,
+                value=redis_async_client,
+                # Pin the cached async client (and its underlying
+                # BlockingConnectionPool) to a long TTL so the pool is not
+                # recycled every InMemoryCache.default_ttl (10 min). Without
+                # this, sustained high-TPS deployments hit a cold pool every
+                # 10 minutes, triggering the pool-wait timeout that surfaces
+                # as "Timeout connecting to server" from
+                # async_increment_pipeline (LIT-3263).
+                ttl=REDIS_ASYNC_CLIENT_CACHE_TTL,
             )
 
         self.redis_async_client = redis_async_client  # type: ignore

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -398,6 +398,20 @@ REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD = int(
 REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT = int(
     os.getenv("REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", 60)
 )
+# How long the in-memory cache holds the async Redis client (and its
+# connection pool). The default LLMClientCache TTL is 600s — short enough
+# that on long-running, high-TPS proxy deployments the Redis async client
+# is evicted while still in heavy use, forcing a fresh BlockingConnectionPool
+# every 10 minutes. The cold pool then triggers a wave of concurrent
+# connect attempts which exhaust the pool wait queue and surface as
+# "Timeout connecting to server" / EVALSHA failures from
+# RedisCache.async_increment_pipeline (LIT-3263). Pinning the client cache
+# to a long TTL (24h by default) preserves the pool across the lifetime of
+# the proxy process; the cache instance does not close evicted clients
+# (see LLMClientCache docstring) so longer TTLs are safe.
+REDIS_ASYNC_CLIENT_CACHE_TTL = int(
+    os.getenv("REDIS_ASYNC_CLIENT_CACHE_TTL", 86400)
+)
 # Default Redis major version to assume when version cannot be determined
 # Using 7 as it's the modern version that supports LPOP with count parameter
 DEFAULT_REDIS_MAJOR_VERSION = int(os.getenv("DEFAULT_REDIS_MAJOR_VERSION", 7))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -409,9 +409,7 @@ REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT = int(
 # to a long TTL (24h by default) preserves the pool across the lifetime of
 # the proxy process; the cache instance does not close evicted clients
 # (see LLMClientCache docstring) so longer TTLs are safe.
-REDIS_ASYNC_CLIENT_CACHE_TTL = int(
-    os.getenv("REDIS_ASYNC_CLIENT_CACHE_TTL", 86400)
-)
+REDIS_ASYNC_CLIENT_CACHE_TTL = int(os.getenv("REDIS_ASYNC_CLIENT_CACHE_TTL", 86400))
 # Default Redis major version to assume when version cannot be determined
 # Using 7 as it's the modern version that supports LPOP with count parameter
 DEFAULT_REDIS_MAJOR_VERSION = int(os.getenv("DEFAULT_REDIS_MAJOR_VERSION", 7))

--- a/tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py
+++ b/tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py
@@ -53,10 +53,20 @@ def redis_cache_instance(redis_no_ping):
         yield RedisCache(host="lit-3263-host", port=6379)
 
 
-def test_redis_async_client_cache_ttl_constant_default():
+def test_redis_async_client_cache_ttl_constant_default(monkeypatch):
     """The TTL constant defaults to 86400 (1 day) — long enough that the
-    pool is never recycled by the default LLMClientCache eviction."""
-    assert REDIS_ASYNC_CLIENT_CACHE_TTL == 86400
+    pool is never recycled by the default LLMClientCache eviction.
+
+    Clears any pre-existing REDIS_ASYNC_CLIENT_CACHE_TTL env var so the
+    assertion pins the in-source default rather than whatever the CI runner
+    happens to have configured.
+    """
+    monkeypatch.delenv("REDIS_ASYNC_CLIENT_CACHE_TTL", raising=False)
+    importlib.reload(litellm_constants)
+    try:
+        assert litellm_constants.REDIS_ASYNC_CLIENT_CACHE_TTL == 86400
+    finally:
+        importlib.reload(litellm_constants)
 
 
 def test_redis_async_client_cache_ttl_env_override(monkeypatch):

--- a/tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py
+++ b/tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py
@@ -1,0 +1,156 @@
+"""
+LIT-3263 — Redis async client cache TTL pinning.
+
+The async Redis client cached in litellm.in_memory_llm_clients_cache must
+not be evicted while the proxy is running. The default LLMClientCache TTL is
+600s, which on sustained high-TPS deployments forces a fresh
+BlockingConnectionPool every 10 minutes — the cold pool then triggers a
+wave of concurrent connect attempts that exhaust the pool wait queue,
+surfacing as Timeout connecting to server errors from
+RedisCache.async_increment_pipeline.
+
+These tests pin behaviour:
+
+  * set_cache is called with an explicit, long TTL (matching the
+    constant).
+  * Cache hits short-circuit — no fresh BlockingConnectionPool is built
+    on subsequent calls.
+  * The constant is configurable via the REDIS_ASYNC_CLIENT_CACHE_TTL
+    env var.
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm.constants as litellm_constants
+from litellm.caching.redis_cache import RedisCache
+from litellm.constants import REDIS_ASYNC_CLIENT_CACHE_TTL
+
+
+@pytest.fixture
+def redis_no_ping():
+    """Suppress the background ping task during construction."""
+    with patch("asyncio.get_running_loop") as mock_get_loop:
+        mock_get_loop.side_effect = RuntimeError("No running event loop")
+        yield
+
+
+@pytest.fixture
+def redis_cache_instance(redis_no_ping):
+    """Build a RedisCache without actually opening a sync connection."""
+    with patch("litellm._redis.get_redis_client") as gc, patch(
+        "litellm._redis.get_redis_connection_pool"
+    ) as gp:
+        gc.return_value = MagicMock(name="sync_redis_client")
+        gp.return_value = MagicMock(name="sync_pool")
+        yield RedisCache(host="lit-3263-host", port=6379)
+
+
+def test_redis_async_client_cache_ttl_constant_default():
+    """The TTL constant defaults to 86400 (1 day) — long enough that the
+    pool is never recycled by the default LLMClientCache eviction."""
+    assert REDIS_ASYNC_CLIENT_CACHE_TTL == 86400
+
+
+def test_redis_async_client_cache_ttl_env_override(monkeypatch):
+    """The TTL constant must be tunable via env var."""
+    monkeypatch.setenv("REDIS_ASYNC_CLIENT_CACHE_TTL", "172800")
+    try:
+        importlib.reload(litellm_constants)
+        assert litellm_constants.REDIS_ASYNC_CLIENT_CACHE_TTL == 172800
+    finally:
+        monkeypatch.delenv("REDIS_ASYNC_CLIENT_CACHE_TTL", raising=False)
+        importlib.reload(litellm_constants)
+
+
+def test_init_async_client_passes_ttl_to_in_memory_cache(redis_cache_instance):
+    """init_async_client must set the cached client with the pinned TTL,
+    not the LLMClientCache default of 600s."""
+    cache = redis_cache_instance
+
+    fake_async_client = MagicMock(name="fake_async_redis_client")
+    fake_pool = MagicMock(name="fake_pool")
+
+    with patch(
+        "litellm._redis.get_redis_connection_pool", return_value=fake_pool
+    ), patch(
+        "litellm._redis.get_redis_async_client", return_value=fake_async_client
+    ), patch(
+        "litellm.in_memory_llm_clients_cache"
+    ) as fake_in_memory:
+        fake_in_memory.get_cache.return_value = None
+
+        result = cache.init_async_client()
+
+    assert result is fake_async_client
+    # Pool was rebuilt for the current event loop and stored on the instance.
+    assert cache.async_redis_conn_pool is fake_pool
+    fake_in_memory.set_cache.assert_called_once()
+    kwargs = fake_in_memory.set_cache.call_args.kwargs
+    assert kwargs["value"] is fake_async_client
+    assert kwargs["ttl"] == REDIS_ASYNC_CLIENT_CACHE_TTL
+    assert kwargs["ttl"] >= 3600, (
+        "TTL must be at least 1 hour — otherwise the connection pool gets "
+        "recycled mid-traffic (LIT-3263)."
+    )
+
+
+def test_init_async_client_reuses_cached_client_no_pool_churn(redis_cache_instance):
+    """Once the cached client is populated, init_async_client must reuse it
+    and must NOT call get_redis_connection_pool again — building a fresh
+    BlockingConnectionPool every call is the exact behaviour LIT-3263 is
+    fixing."""
+    cache = redis_cache_instance
+
+    fake_async_client = MagicMock(name="cached_client")
+
+    with patch(
+        "litellm._redis.get_redis_connection_pool"
+    ) as fake_get_pool, patch(
+        "litellm._redis.get_redis_async_client"
+    ) as fake_get_client, patch(
+        "litellm.in_memory_llm_clients_cache"
+    ) as fake_in_memory:
+        fake_in_memory.get_cache.return_value = fake_async_client
+
+        result = cache.init_async_client()
+
+    assert result is fake_async_client
+    fake_get_pool.assert_not_called()
+    fake_get_client.assert_not_called()
+
+
+def test_init_async_client_creates_fresh_pool_on_cache_miss(redis_cache_instance):
+    """If the cache misses (because TTL did expire, the entry was explicitly
+    evicted, or this is the first call) we still need to construct a fresh
+    pool. Both cache-miss reinits must pin the same long TTL."""
+    cache = redis_cache_instance
+
+    first_client, second_client = MagicMock(name="c1"), MagicMock(name="c2")
+    first_pool, second_pool = MagicMock(name="p1"), MagicMock(name="p2")
+
+    with patch(
+        "litellm._redis.get_redis_connection_pool",
+        side_effect=[first_pool, second_pool],
+    ), patch(
+        "litellm._redis.get_redis_async_client",
+        side_effect=[first_client, second_client],
+    ), patch(
+        "litellm.in_memory_llm_clients_cache"
+    ) as fake_in_memory:
+        fake_in_memory.get_cache.return_value = None
+        c1 = cache.init_async_client()
+        fake_in_memory.get_cache.return_value = None
+        c2 = cache.init_async_client()
+
+    assert c1 is first_client
+    assert c2 is second_client
+    assert fake_in_memory.set_cache.call_count == 2
+    for call in fake_in_memory.set_cache.call_args_list:
+        assert call.kwargs["ttl"] == REDIS_ASYNC_CLIENT_CACHE_TTL

--- a/tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py
+++ b/tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py
@@ -44,9 +44,10 @@ def redis_no_ping():
 @pytest.fixture
 def redis_cache_instance(redis_no_ping):
     """Build a RedisCache without actually opening a sync connection."""
-    with patch("litellm._redis.get_redis_client") as gc, patch(
-        "litellm._redis.get_redis_connection_pool"
-    ) as gp:
+    with (
+        patch("litellm._redis.get_redis_client") as gc,
+        patch("litellm._redis.get_redis_connection_pool") as gp,
+    ):
         gc.return_value = MagicMock(name="sync_redis_client")
         gp.return_value = MagicMock(name="sync_pool")
         yield RedisCache(host="lit-3263-host", port=6379)
@@ -77,13 +78,11 @@ def test_init_async_client_passes_ttl_to_in_memory_cache(redis_cache_instance):
     fake_async_client = MagicMock(name="fake_async_redis_client")
     fake_pool = MagicMock(name="fake_pool")
 
-    with patch(
-        "litellm._redis.get_redis_connection_pool", return_value=fake_pool
-    ), patch(
-        "litellm._redis.get_redis_async_client", return_value=fake_async_client
-    ), patch(
-        "litellm.in_memory_llm_clients_cache"
-    ) as fake_in_memory:
+    with (
+        patch("litellm._redis.get_redis_connection_pool", return_value=fake_pool),
+        patch("litellm._redis.get_redis_async_client", return_value=fake_async_client),
+        patch("litellm.in_memory_llm_clients_cache") as fake_in_memory,
+    ):
         fake_in_memory.get_cache.return_value = None
 
         result = cache.init_async_client()
@@ -110,13 +109,11 @@ def test_init_async_client_reuses_cached_client_no_pool_churn(redis_cache_instan
 
     fake_async_client = MagicMock(name="cached_client")
 
-    with patch(
-        "litellm._redis.get_redis_connection_pool"
-    ) as fake_get_pool, patch(
-        "litellm._redis.get_redis_async_client"
-    ) as fake_get_client, patch(
-        "litellm.in_memory_llm_clients_cache"
-    ) as fake_in_memory:
+    with (
+        patch("litellm._redis.get_redis_connection_pool") as fake_get_pool,
+        patch("litellm._redis.get_redis_async_client") as fake_get_client,
+        patch("litellm.in_memory_llm_clients_cache") as fake_in_memory,
+    ):
         fake_in_memory.get_cache.return_value = fake_async_client
 
         result = cache.init_async_client()
@@ -135,15 +132,17 @@ def test_init_async_client_creates_fresh_pool_on_cache_miss(redis_cache_instance
     first_client, second_client = MagicMock(name="c1"), MagicMock(name="c2")
     first_pool, second_pool = MagicMock(name="p1"), MagicMock(name="p2")
 
-    with patch(
-        "litellm._redis.get_redis_connection_pool",
-        side_effect=[first_pool, second_pool],
-    ), patch(
-        "litellm._redis.get_redis_async_client",
-        side_effect=[first_client, second_client],
-    ), patch(
-        "litellm.in_memory_llm_clients_cache"
-    ) as fake_in_memory:
+    with (
+        patch(
+            "litellm._redis.get_redis_connection_pool",
+            side_effect=[first_pool, second_pool],
+        ),
+        patch(
+            "litellm._redis.get_redis_async_client",
+            side_effect=[first_client, second_client],
+        ),
+        patch("litellm.in_memory_llm_clients_cache") as fake_in_memory,
+    ):
         fake_in_memory.get_cache.return_value = None
         c1 = cache.init_async_client()
         fake_in_memory.get_cache.return_value = None


### PR DESCRIPTION
## Why

LIT-3263 reports that on long-running, high-TPS LiteLLM proxy deployments the Redis circuit breaker keeps opening with the customer-visible error:

```
LiteLLM Redis Caching: async increment_pipeline() - Got exception from REDIS Timeout connecting to server
```

The `Timeout connecting to server` error is raised by `redis.asyncio.BlockingConnectionPool` when a caller waits longer than `REDIS_CONNECTION_POOL_TIMEOUT` (5s) for a free connection. That happens when the pool is briefly cold — every concurrent `async_increment_pipeline` call queues up waiting for connections to be established from scratch.

## Root cause (long-standing, masked at lower QPS)

`RedisCache.init_async_client` caches the async Redis client in `litellm.in_memory_llm_clients_cache`:

```python
in_memory_llm_clients_cache.set_cache(
    key=cache_key, value=redis_async_client
)
```

No `ttl=` is passed. `LLMClientCache` inherits `InMemoryCache.default_ttl = 600s`, so the cached entry — and the underlying `BlockingConnectionPool` it owns — is evicted every 10 minutes. The very next `init_async_client` call rebuilds a brand-new `BlockingConnectionPool`. Under sustained traffic that cold pool gets hit by N concurrent requests immediately; each must wait for `BlockingConnectionPool` to open a fresh TCP/TLS connection. Under enough concurrency the wait queue exceeds `REDIS_CONNECTION_POOL_TIMEOUT`, every queued caller gets `Timeout connecting to server`, the circuit breaker registers `failure_threshold` (5) consecutive failures and trips, fast-failing every other Redis call for 60s.

This was always there. v1.83.x increased the number of pipeline ops per request (added `model_per_project` descriptor + project model TPM lines in `_build_success_event_pipeline_operations`), which is enough to push high-TPS deployments over the edge once the 10-minute pool recycle hits.

The `LLMClientCache` docstring already says it intentionally does NOT close clients on eviction, so leaving the pool pinned for much longer is safe — orphaned pools are garbage-collected when no longer referenced.

## Fix

- New constant `REDIS_ASYNC_CLIENT_CACHE_TTL` (default **86400s = 24h**, env-overridable via `REDIS_ASYNC_CLIENT_CACHE_TTL`).
- `RedisCache.init_async_client` now passes that TTL to `in_memory_llm_clients_cache.set_cache`, so the cached client (and its `BlockingConnectionPool`) is no longer recycled every 10 minutes.

Two-line behavioural change; no API surface changes; same eviction semantics still apply (only the timer is longer).

## Tests

`tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py` — 5 new regression tests:

- `test_redis_async_client_cache_ttl_constant_default` — TTL default is 86400s.
- `test_redis_async_client_cache_ttl_env_override` — `REDIS_ASYNC_CLIENT_CACHE_TTL` env var overrides the constant.
- `test_init_async_client_passes_ttl_to_in_memory_cache` — `set_cache` is called with the pinned `ttl` and the TTL is >= 1h.
- `test_init_async_client_reuses_cached_client_no_pool_churn` — on cache hit, `init_async_client` does NOT rebuild the pool.
- `test_init_async_client_creates_fresh_pool_on_cache_miss` — on cache miss (first call or forced eviction) a fresh pool is built, and the pinned TTL is reapplied.

Existing failures in `tests/test_litellm/caching/test_redis_cache.py::test_redis_cache_async_increment*` and `test_redis_connection_pool.py::test_max_connections_url_config*` are pre-existing on the unchanged base — `monkeypatch.setenv(REDIS_HOST=...)` is not picked up by `get_redis_client(host=...)`-style fixtures; not introduced by this PR.

### Evidence

Reproduction script forces both code paths against a clean `LLMClientCache` instance and reads the `ttl_dict` to observe the recorded eviction deadline:

```
$ python3 /tmp/repro.py
Constants:
  REDIS_ASYNC_CLIENT_CACHE_TTL = 86400 s
  LLMClientCache.default_ttl   = 600s

=== AFTER (this PR) ===
  TTL on cached entry : 86400s (24.0h)

=== BEFORE (v1.83.14 — set_cache without explicit ttl) ===
  TTL on cached entry : 600s (10 min)

CONCLUSION
  BEFORE: pool TTL ~600s   -> pool recycled every 10 min
  AFTER : pool TTL ~86400s -> pool stays warm
```

New tests:

```
$ pytest tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py -v
::test_init_async_client_creates_fresh_pool_on_cache_miss PASSED
::test_init_async_client_passes_ttl_to_in_memory_cache    PASSED
::test_init_async_client_reuses_cached_client_no_pool_churn PASSED
::test_redis_async_client_cache_ttl_constant_default      PASSED
::test_redis_async_client_cache_ttl_env_override          PASSED
5 passed in 0.72s
```

## Notes

- Pushed via the GitHub Contents API (one PUT per file) — Shin token lacks `repo`/`workflow` scopes for `git push`. Diff is exactly the three files listed above; merge-base diff may show three commits instead of one.
- The deeper symptom is multi-causal (cold-pool storms + the modest descriptor expansion in v3 limiter + customer-side concurrency). This PR fixes the most defensible single contributor (the 10-min forced pool recycle). A possible follow-up around bumping the `BlockingConnectionPool.from_url` `max_connections` default for the URL-config path is intentionally out of scope here.

Refs: LIT-3263.

---

### Verification (ship-pr)

- ✅ **Branch base**: `litellm_oss_agent_shin_daily_branch` (per Shin fork policy)
- ✅ **Greptile**: 5/5 — *"Safe to merge — the change is a two-line targeted fix with no API surface changes and the eviction semantics (no client close on eviction) are already safe per the LLMClientCache docstring."*
- ✅ **Veria AI - PR Review**: success
- ⚠️ **GitHub Actions**: **42/44 green**, 2 failing — both are the same `documentation_test_env_keys` step (one under the `documentation` job, one under `code-quality`). They fail because the workflow checks out `BerriAI/litellm-docs@main` and that copy of `config_settings.md` doesn't yet list `REDIS_ASYNC_CLIENT_CACHE_TTL`. The required docs change is filed at https://github.com/BerriAI/litellm-docs/pull/246 — once that merges, both checks pass on a CI re-run; the litellm PR itself does not need additional changes.
- ✅ **Codecov**: 100% patch coverage
- ✅ **Unit tests**: 5/5 new regression tests passing locally (`tests/test_litellm/caching/test_lit_3263_async_client_cache_ttl.py`); adjacent `test_llm_client_cache_e2e.py` (4/4) and `test_redis_connection_pool.py` (6/6, 2 pre-existing failures unrelated) still pass.
- ✅ **Runtime evidence**: `### Evidence` block above shows the 600s→86400s TTL pin against a clean `LLMClientCache` instance — same code path the proxy uses at startup.
- ✅ **Mergeable state**: clean on the substantive checks (only docs check is awaiting cross-repo PR).
