### PR TITLE
fix(proxy): enforce budgets for paid fallbacks from free models

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -403,7 +403,7 @@ def get_all_fallbacks(
     try:
         # Use existing function to get fallback model group
         fallback_model_group, _ = get_fallback_model_group(
-            fallbacks=fallbacks_config, model_group=model
+            fallbacks=list(fallbacks_config), model_group=model
         )
 
         if fallback_model_group is None:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -12,7 +12,7 @@ import fnmatch
 import re
 import secrets
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union, cast
 
 import fastapi
 from fastapi import HTTPException, Request, WebSocket, status
@@ -58,6 +58,7 @@ from litellm.proxy.auth.auth_utils import (
     route_in_additonal_public_routes,
 )
 from litellm.proxy.auth.handle_jwt import JWTAuthManager, JWTHandler
+from litellm.proxy.auth.model_checks import get_all_fallbacks
 from litellm.proxy.auth.oauth2_check import Oauth2Handler
 from litellm.proxy.auth.oauth2_proxy_hook import handle_oauth2_proxy_request
 from litellm.proxy.auth.route_checks import RouteChecks
@@ -1018,23 +1019,21 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         else None
                     )
 
-                    # Check if model has zero cost - if so, skip all budget checks
                     model = _get_model_from_request_context(
                         request_data=request_data,
                         route=route,
                         request=request,
                     )
-                    skip_budget_checks = False
-                    if model is not None and llm_router is not None:
-                        from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
-                        skip_budget_checks = _is_model_cost_zero(
-                            model=model, llm_router=llm_router
+                    skip_budget_checks = _should_skip_budget_checks(
+                        request_data=request_data,
+                        route=route,
+                        request=request,
+                        llm_router=llm_router,
+                    )
+                    if skip_budget_checks:
+                        verbose_proxy_logger.info(
+                            f"Skipping all budget checks for zero-cost model: {model}"
                         )
-                        if skip_budget_checks:
-                            verbose_proxy_logger.info(
-                                f"Skipping all budget checks for zero-cost model: {model}"
-                            )
 
                     # Fetch project object for JWT path if project_id is set
                     _jwt_project_obj = None
@@ -1435,23 +1434,21 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         f"User={valid_token.user_id} has been deactivated via SCIM. Keys owned by this user cannot be used."
                     )
 
-            # Check 2a. Check if model has zero cost - if so, skip all budget checks
             model = _get_model_from_request_context(
                 request_data=request_data,
                 route=route,
                 request=request,
             )
-            skip_budget_checks = False
-            if model is not None and llm_router is not None:
-                from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
-                skip_budget_checks = _is_model_cost_zero(
-                    model=model, llm_router=llm_router
+            skip_budget_checks = _should_skip_budget_checks(
+                request_data=request_data,
+                route=route,
+                request=request,
+                llm_router=llm_router,
+            )
+            if skip_budget_checks:
+                verbose_proxy_logger.info(
+                    f"Skipping all budget checks for zero-cost model: {model}"
                 )
-                if skip_budget_checks:
-                    verbose_proxy_logger.info(
-                        f"Skipping all budget checks for zero-cost model: {model}"
-                    )
 
             # Check 3. Check if user is in their team budget
             if not skip_budget_checks and valid_token.team_member_spend is not None:
@@ -2149,9 +2146,113 @@ def _should_skip_budget_checks(
         route=route,
         request=request,
     )
-    if model is not None and llm_router is not None:
-        return _is_model_cost_zero(model=model, llm_router=llm_router)
-    return False
+    if model is None or llm_router is None:
+        return False
+
+    if not _is_model_cost_zero(model=model, llm_router=llm_router):
+        return False
+
+    fallback_models = _get_budget_relevant_fallback_models(
+        model=model,
+        request_data=request_data,
+        llm_router=llm_router,
+    )
+    if fallback_models and not _is_model_cost_zero(
+        model=fallback_models,
+        llm_router=llm_router,
+    ):
+        verbose_proxy_logger.debug(
+            "Budget checks will run for zero-cost model %s because one or more "
+            "configured fallback models can incur cost: %s",
+            model,
+            fallback_models,
+        )
+        return False
+
+    return True
+
+
+def _get_budget_relevant_fallback_models(
+    model: Union[str, List[str]],
+    request_data: dict,
+    llm_router: Any,
+) -> List[str]:
+    """Return request/router fallback models that can be reached from ``model``.
+
+    A zero-cost primary model must not skip budget checks if a fallback can
+    route the same request to a paid model.
+    """
+
+    fallback_names: List[str] = []
+    model_names = [model] if isinstance(model, str) else model
+    seen_router_models: Set[str] = set()
+    router_model_queue = list(model_names)
+
+    override_settings = request_data.get("router_settings_override")
+    for fallback_key in ROUTER_FALLBACK_FIELDS:
+        request_fallbacks = list(
+            iter_router_fallback_model_names(request_data.get(fallback_key))
+        )
+        fallback_names.extend(request_fallbacks)
+        router_model_queue.extend(request_fallbacks)
+        if isinstance(override_settings, dict):
+            override_fallbacks = list(
+                iter_router_fallback_model_names(override_settings.get(fallback_key))
+            )
+            fallback_names.extend(override_fallbacks)
+            router_model_queue.extend(override_fallbacks)
+
+    while router_model_queue:
+        model_name = router_model_queue.pop(0)
+        if not isinstance(model_name, str):
+            continue
+        if model_name in seen_router_models:
+            continue
+        seen_router_models.add(model_name)
+
+        for fallback_type in ("general", "context_window", "content_policy"):
+            router_fallbacks = _get_router_configured_fallback_models(
+                model_name=model_name,
+                llm_router=llm_router,
+                fallback_type=fallback_type,
+            )
+            fallback_names.extend(router_fallbacks)
+            router_model_queue.extend(router_fallbacks)
+
+    return list(dict.fromkeys(fallback_names))
+
+
+def _get_router_configured_fallback_models(
+    model_name: str,
+    llm_router: Any,
+    fallback_type: str,
+) -> List[str]:
+    """Return router fallback models for standard and generic fallback shapes."""
+
+    fallback_models = list(
+        iter_router_fallback_model_names(
+            get_all_fallbacks(
+                model=model_name,
+                llm_router=llm_router,
+                fallback_type=fallback_type,
+            )
+        )
+    )
+
+    fallback_attr = {
+        "general": "fallbacks",
+        "context_window": "context_window_fallbacks",
+        "content_policy": "content_policy_fallbacks",
+    }.get(fallback_type)
+    fallbacks_config = getattr(llm_router, fallback_attr, []) if fallback_attr else []
+    if isinstance(fallbacks_config, list):
+        for entry in fallbacks_config:
+            if isinstance(entry, str):
+                fallback_models.append(entry)
+            elif isinstance(entry, dict) and isinstance(entry.get("model"), str):
+                fallback_models.append(entry["model"])
+
+    return list(dict.fromkeys(fallback_models))
 
 
 @tracer.wrap()

--- a/tests/test_litellm/proxy/auth/test_model_checks_fallbacks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks_fallbacks.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import Mock, patch
 
 
@@ -243,3 +242,19 @@ def test_default_fallback_type_is_general():
             fallbacks=fallbacks_config, model_group="claude-4-sonnet"
         )
         assert result == ["bedrock-claude-sonnet-4"]
+
+
+def test_string_fallbacks_do_not_mutate_router_config():
+    """String fallback entries should not be popped from router config."""
+    from litellm.proxy.auth.model_checks import get_all_fallbacks
+
+    fallbacks_config = ["generic-fallback"]
+    router = create_mock_router(fallbacks=fallbacks_config)
+
+    assert get_all_fallbacks("primary-model", llm_router=router) == [
+        "generic-fallback"
+    ]
+    assert router.fallbacks == ["generic-fallback"]
+    assert get_all_fallbacks("primary-model", llm_router=router) == [
+        "generic-fallback"
+    ]

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -11,6 +11,10 @@ import copy
 
 import litellm
 from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+from litellm.proxy.auth.user_api_key_auth import (
+    _get_budget_relevant_fallback_models,
+    _should_skip_budget_checks,
+)
 from litellm.router import Router
 
 
@@ -183,3 +187,400 @@ class TestUnmappedModelBudgetEnforcement:
 
         result = _is_model_cost_zero(model="paid-model", llm_router=mock_router)
         assert result is False
+
+    def test_zero_cost_model_with_paid_router_fallback_enforces_budget(self):
+        """A free primary must not bypass budgets when router fallback is paid."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ],
+            fallbacks=[{"free-primary": ["paid-fallback"]}],
+        )
+
+        assert (
+            _is_model_cost_zero(model="free-primary", llm_router=router) is True
+        )
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_budget_checks_run_without_router_context(self):
+        """Missing router context must not skip budget checks."""
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=None,
+            )
+            is False
+        )
+
+    def test_paid_primary_model_enforces_budget_without_checking_fallbacks(self):
+        """Paid primary models keep budget checks enabled regardless of fallbacks."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "paid-primary",
+                    "litellm_params": {
+                        "model": "openai/paid-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                }
+            ]
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "paid-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_zero_cost_model_with_zero_cost_router_fallback_skips_budget(self):
+        """All-zero primary/fallback chain keeps the existing skip behavior."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "free-fallback",
+                    "litellm_params": {
+                        "model": "openai/free-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+            ],
+            fallbacks=[{"free-primary": ["free-fallback"]}],
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is True
+        )
+
+    def test_zero_cost_model_with_transitive_paid_fallback_enforces_budget(self):
+        """A paid fallback later in the router chain keeps budget checks enabled."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "free-fallback",
+                    "litellm_params": {
+                        "model": "openai/free-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ],
+            fallbacks=[
+                {"free-primary": ["free-fallback"]},
+                {"free-fallback": ["paid-fallback"]},
+            ],
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_zero_cost_model_with_paid_request_fallback_enforces_budget(self):
+        """Client-provided paid fallbacks also keep budget checks enabled."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ]
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={
+                    "model": "free-primary",
+                    "fallbacks": [{"free-primary": ["paid-fallback"]}],
+                },
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_request_fallback_with_transitive_paid_router_fallback_enforces_budget(
+        self,
+    ):
+        """Request fallback models are also checked through router fallback chains."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "free-request-fallback",
+                    "litellm_params": {
+                        "model": "openai/free-request-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-router-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-router-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ],
+            fallbacks=[
+                {"free-request-fallback": ["paid-router-fallback"]},
+            ],
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={
+                    "model": "free-primary",
+                    "fallbacks": [{"free-primary": ["free-request-fallback"]}],
+                },
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_zero_cost_model_with_paid_generic_router_fallback_enforces_budget(self):
+        """Generic router fallback lists are checked beyond the first entry."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "free-generic-fallback",
+                    "litellm_params": {
+                        "model": "openai/free-generic-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-generic-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-generic-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ],
+        )
+        router.fallbacks = ["free-generic-fallback", "paid-generic-fallback"]
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_zero_cost_model_with_paid_generic_dict_fallback_enforces_budget(self):
+        """Generic router fallback dict entries are included in budget checks."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-dict-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-dict-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ],
+            fallbacks=[{"model": "paid-dict-fallback"}],
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-primary"},
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_zero_cost_model_with_paid_override_fallback_enforces_budget(self):
+        """Per-request router overrides are included in budget checks."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+                {
+                    "model_name": "paid-override-fallback",
+                    "litellm_params": {
+                        "model": "openai/paid-override-fallback",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.000001,
+                        "output_cost_per_token": 0.000002,
+                    },
+                },
+            ]
+        )
+
+        assert (
+            _should_skip_budget_checks(
+                request_data={
+                    "model": "free-primary",
+                    "router_settings_override": {
+                        "fallbacks": [{"free-primary": ["paid-override-fallback"]}]
+                    },
+                },
+                route="/chat/completions",
+                request=None,
+                llm_router=router,
+            )
+            is False
+        )
+
+    def test_budget_fallback_discovery_ignores_non_string_model_entries(self):
+        """Defensive fallback traversal tolerates malformed model lists."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-primary",
+                    "litellm_params": {
+                        "model": "openai/free-primary",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                }
+            ]
+        )
+
+        assert (
+            _get_budget_relevant_fallback_models(
+                model=["free-primary", {"bad": "shape"}],
+                request_data={},
+                llm_router=router,
+            )
+            == []
+        )

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -1549,6 +1549,72 @@ class TestJWTOAuth2Coexistence:
             assert result.user_id == "jwt-human-user"
 
     @pytest.mark.asyncio
+    async def test_jwt_auth_builder_uses_budget_skip_helper_result(self):
+        """Non-admin JWT auth should also defer budget skipping to one helper."""
+        from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+        jwt_token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMSJ9.signature"
+        general_settings = {
+            "enable_oauth2_auth": True,
+            "enable_jwt_auth": True,
+        }
+
+        mock_jwt_result = {
+            "is_proxy_admin": False,
+            "team_object": None,
+            "user_object": None,
+            "end_user_object": None,
+            "org_object": None,
+            "token": jwt_token,
+            "team_id": "jwt-team",
+            "user_id": "jwt-human-user",
+            "end_user_id": None,
+            "org_id": None,
+            "team_membership": None,
+            "jwt_claims": {"sub": "user1"},
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/chat/completions"
+        mock_request.headers = {"authorization": f"Bearer {jwt_token}"}
+        mock_request.query_params = {}
+
+        with (
+            patch("litellm.proxy.proxy_server.general_settings", general_settings),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+            patch("litellm.proxy.proxy_server.prisma_client", None),
+            patch("litellm.proxy.proxy_server.llm_router", None),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.JWTAuthManager.auth_builder",
+                new_callable=AsyncMock,
+                return_value=mock_jwt_result,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._should_skip_budget_checks",
+                return_value=True,
+            ) as mock_should_skip,
+        ):
+            litellm.proxy.proxy_server.jwt_handler.update_environment(
+                prisma_client=None,
+                user_api_key_cache=DualCache(),
+                litellm_jwtauth=LiteLLM_JWTAuth(),
+            )
+
+            result = await _user_api_key_auth_builder(
+                request=mock_request,
+                api_key=f"Bearer {jwt_token}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={"model": "free-primary"},
+            )
+
+        mock_should_skip.assert_called_once()
+        assert result.user_id == "jwt-human-user"
+
+    @pytest.mark.asyncio
     async def test_routing_override_routes_matching_jwt_to_oauth2(self):
         """
         When routing_overrides match JWT claims, route JWT-shaped token to OAuth2.
@@ -2360,6 +2426,88 @@ async def test_user_api_key_auth_builder_no_blocking_calls():
                 f"on the async hot path — use async_{_m}() instead"
             )
 
+    finally:
+        for k, v in _originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_standard_auth_builder_uses_budget_skip_helper_result():
+    """Standard key auth should defer zero-cost budget skipping to one helper."""
+    from starlette.datastructures import URL
+    from starlette.requests import Request
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    api_key = "sk-test-budget-skip-helper"
+    valid_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=api_key,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=valid_token)
+    mock_cache.async_set_cache = AsyncMock(return_value=None)
+    mock_cache.delete_cache = MagicMock()
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = (
+        AsyncMock()
+    )
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _originals = {k: getattr(_proxy_server_mod, k, None) for k in _attrs}
+
+    try:
+        for k, v in _attrs.items():
+            setattr(_proxy_server_mod, k, v)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_key_object",
+                new_callable=AsyncMock,
+                return_value=valid_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._should_skip_budget_checks",
+                return_value=True,
+            ) as mock_should_skip,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={"model": "free-primary"},
+            )
+
+        mock_should_skip.assert_called_once()
+        assert result.user_role == LitellmUserRoles.INTERNAL_USER
     finally:
         for k, v in _originals.items():
             setattr(_proxy_server_mod, k, v)


### PR DESCRIPTION
## Summary
- keep budget checks enabled when a zero-cost requested model can route to paid or unknown fallback models
- inspect router-level fallbacks recursively across general, context-window, and content-policy fallback chains
- inspect request-level fallback overrides before allowing the zero-cost budget-check bypass

Fixes #26672

## Tests
- `uv run ruff check litellm/proxy/auth/user_api_key_auth.py tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py`
- `uv run --extra proxy pytest tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py -q`
- `uv run --extra proxy pytest tests/test_litellm/proxy/auth/test_model_checks_fallbacks.py tests/test_litellm/proxy/auth/test_router_override_fallback_auth.py -q`
- `uv run --extra proxy pytest tests/test_litellm/proxy/auth/test_auth_checks.py::test_virtual_key_budget_check_reads_from_spend_counter tests/test_litellm/proxy/auth/test_auth_checks.py::test_virtual_key_budget_check_fallback_no_counter tests/test_litellm/proxy/auth/test_user_api_key_auth.py::test_centralized_common_checks_runs_for_standard_auth -q`