### PR TITLE
test(proxy): defense-in-depth coverage for x-litellm-tags budget enforcement (LIT-2956)

### DIFF
--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4182,6 +4182,256 @@ class TestApplyClientTagPolicyPreAuth:
             assert exc_info.value.max_budget == 0.10
 
 
+    @pytest.mark.asyncio
+    async def test_header_tags_enforced_via_common_checks(self):
+        """Defense-in-depth regression test for the
+        ``apply_client_tag_policy_pre_auth`` -> ``common_checks`` ->
+        ``_tag_max_budget_check`` wiring.
+
+        ``test_header_tags_visible_to_tag_max_budget_check`` covers the helper
+        and ``_tag_max_budget_check`` directly. Production code in
+        ``user_api_key_auth`` calls the helper and then ``common_checks``,
+        which in turn dispatches ``_tag_max_budget_check`` only when
+        ``skip_budget_checks=False``. This test exercises that wrapper path
+        so a refactor that drops the per-tag enforcement out of
+        ``common_checks`` cannot silently bypass header-tagged budget checks.
+        """
+        from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_TagTable
+        from litellm.proxy.auth.auth_checks import common_checks
+        from litellm.proxy.utils import ProxyLogging
+
+        request_mock = _build_request_mock_with_headers(
+            {"x-litellm-tags": "tenant:over-budget"}
+        )
+        data = {"model": "gpt-3.5-turbo"}
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="hashed-key",
+            metadata={},
+            team_metadata={},
+        )
+
+        LiteLLMProxyRequestSetup.apply_client_tag_policy_pre_auth(
+            request=request_mock,
+            request_data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        # Sanity check: the helper merged the header tag into metadata so
+        # ``_tag_max_budget_check`` can see it via ``get_tags_from_request_body``.
+        assert data["metadata"]["tags"] == ["tenant:over-budget"]
+
+        tag_object = LiteLLM_TagTable(
+            tag_name="tenant:over-budget",
+            spend=0.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=0.10),
+        )
+
+        async def mock_get_current_spend(counter_key, fallback_spend):
+            if counter_key == "spend:tag:tenant:over-budget":
+                return 1.00
+            return fallback_spend
+
+        with (
+            patch(
+                "litellm.proxy.proxy_server.get_current_spend",
+                mock_get_current_spend,
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+                new_callable=AsyncMock,
+                return_value={"tenant:over-budget": tag_object},
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks._is_api_route_allowed",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prisma_client",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.proxy_server.user_api_key_cache",
+                MagicMock(),
+            ),
+        ):
+            with pytest.raises(litellm.BudgetExceededError) as exc_info:
+                await common_checks(
+                    request_body=data,
+                    team_object=None,
+                    user_object=None,
+                    end_user_object=None,
+                    global_proxy_spend=None,
+                    general_settings={},
+                    route="/v1/chat/completions",
+                    llm_router=None,
+                    proxy_logging_obj=ProxyLogging(user_api_key_cache=None),
+                    valid_token=UserAPIKeyAuth(token="test-token"),
+                    request=request_mock,
+                    skip_budget_checks=False,
+                )
+
+        assert exc_info.value.current_cost == 1.00
+        assert exc_info.value.max_budget == 0.10
+        assert "tenant:over-budget" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_header_tags_below_budget_pass_via_common_checks(self):
+        """Companion to the test above: header-tagged requests whose tag
+        spend is under budget must pass ``common_checks`` cleanly. Catches
+        the inverse regression where a refactor wires the helper or
+        ``_tag_max_budget_check`` to raise unconditionally on any header tag.
+        """
+        from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_TagTable
+        from litellm.proxy.auth.auth_checks import common_checks
+        from litellm.proxy.utils import ProxyLogging
+
+        request_mock = _build_request_mock_with_headers(
+            {"x-litellm-tags": "tenant:under-budget"}
+        )
+        data = {"model": "gpt-3.5-turbo"}
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="hashed-key",
+            metadata={},
+            team_metadata={},
+        )
+
+        LiteLLMProxyRequestSetup.apply_client_tag_policy_pre_auth(
+            request=request_mock,
+            request_data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        tag_object = LiteLLM_TagTable(
+            tag_name="tenant:under-budget",
+            spend=0.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=1.00),
+        )
+
+        async def mock_get_current_spend(counter_key, fallback_spend):
+            if counter_key == "spend:tag:tenant:under-budget":
+                return 0.05
+            return fallback_spend
+
+        with (
+            patch(
+                "litellm.proxy.proxy_server.get_current_spend",
+                mock_get_current_spend,
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+                new_callable=AsyncMock,
+                return_value={"tenant:under-budget": tag_object},
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks._is_api_route_allowed",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prisma_client",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.proxy_server.user_api_key_cache",
+                MagicMock(),
+            ),
+        ):
+            # Must not raise.
+            await common_checks(
+                request_body=data,
+                team_object=None,
+                user_object=None,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route="/v1/chat/completions",
+                llm_router=None,
+                proxy_logging_obj=ProxyLogging(user_api_key_cache=None),
+                valid_token=UserAPIKeyAuth(token="test-token"),
+                request=request_mock,
+                skip_budget_checks=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_header_tags_skipped_when_budget_checks_disabled(self):
+        """When ``skip_budget_checks=True`` (e.g. free models / certain
+        routes), even an over-budget header tag must not raise. Guards
+        against accidentally promoting the per-tag check above the
+        ``skip_budget_checks`` gate.
+        """
+        from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_TagTable
+        from litellm.proxy.auth.auth_checks import common_checks
+        from litellm.proxy.utils import ProxyLogging
+
+        request_mock = _build_request_mock_with_headers(
+            {"x-litellm-tags": "tenant:over-budget"}
+        )
+        data = {"model": "gpt-3.5-turbo"}
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="hashed-key",
+            metadata={},
+            team_metadata={},
+        )
+
+        LiteLLMProxyRequestSetup.apply_client_tag_policy_pre_auth(
+            request=request_mock,
+            request_data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        tag_object = LiteLLM_TagTable(
+            tag_name="tenant:over-budget",
+            spend=0.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=0.10),
+        )
+
+        async def mock_get_current_spend(counter_key, fallback_spend):
+            if counter_key == "spend:tag:tenant:over-budget":
+                return 1.00
+            return fallback_spend
+
+        with (
+            patch(
+                "litellm.proxy.proxy_server.get_current_spend",
+                mock_get_current_spend,
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+                new_callable=AsyncMock,
+                return_value={"tenant:over-budget": tag_object},
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks._is_api_route_allowed",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prisma_client",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.proxy_server.user_api_key_cache",
+                MagicMock(),
+            ),
+        ):
+            # Must not raise when budget checks are explicitly skipped.
+            await common_checks(
+                request_body=data,
+                team_object=None,
+                user_object=None,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route="/v1/chat/completions",
+                llm_router=None,
+                proxy_logging_obj=ProxyLogging(user_api_key_cache=None),
+                valid_token=UserAPIKeyAuth(token="test-token"),
+                request=request_mock,
+                skip_budget_checks=True,
+            )
+
+
 # ============================================================================
 # Tests for #27516: provider hint resolution from deployment when the
 # user-facing model name has no provider prefix.

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4243,7 +4243,6 @@ class TestApplyClientTagPolicyPreAuth:
             ),
             patch(
                 "litellm.proxy.auth.auth_checks._is_api_route_allowed",
-                new_callable=AsyncMock,
                 return_value=True,
             ),
             patch(
@@ -4325,7 +4324,6 @@ class TestApplyClientTagPolicyPreAuth:
             ),
             patch(
                 "litellm.proxy.auth.auth_checks._is_api_route_allowed",
-                new_callable=AsyncMock,
                 return_value=True,
             ),
             patch(
@@ -4403,7 +4401,6 @@ class TestApplyClientTagPolicyPreAuth:
             ),
             patch(
                 "litellm.proxy.auth.auth_checks._is_api_route_allowed",
-                new_callable=AsyncMock,
                 return_value=True,
             ),
             patch(


### PR DESCRIPTION
## Linear ticket

Resolves LIT-2956.

## Summary

Defense-in-depth regression coverage for the `x-litellm-tags` header tag budget
enforcement landed in commit `36caeb013b`. The original fix added
`LiteLLMProxyRequestSetup.apply_client_tag_policy_pre_auth` so header-supplied
tags are merged into `request_data["metadata"]["tags"]` **before** auth-time
budget gates run.

Production code in `litellm/proxy/auth/user_api_key_auth.py` calls the helper
and then `common_checks`, which only dispatches `_tag_max_budget_check` when
`skip_budget_checks=False`. Existing tests exercise the helper and
`_tag_max_budget_check` directly but never go through `common_checks` — a
refactor that drops `_tag_max_budget_check` out of `common_checks` would
silently bypass header-tagged budget enforcement with no test failure.

This PR adds three tests inside `TestApplyClientTagPolicyPreAuth`:

1. `test_header_tags_enforced_via_common_checks` — over-budget header tag flows
   through helper -> `common_checks` -> `_tag_max_budget_check` and raises
   `BudgetExceededError`.
2. `test_header_tags_below_budget_pass_via_common_checks` — under-budget header
   tag passes `common_checks` cleanly (inverse-regression).
3. `test_header_tags_skipped_when_budget_checks_disabled` — `skip_budget_checks=True`
   correctly suppresses per-tag enforcement even for over-budget header tags.

No source changes; tests-only.

## Regression-coverage verification

The `_tag_max_budget_check` call inside `common_checks` was temporarily
replaced with `pass` and the test suite re-run:

```
FAILED tests/test_litellm/proxy/test_litellm_pre_call_utils.py::TestApplyClientTagPolicyPreAuth::test_header_tags_enforced_via_common_checks
E   Failed: DID NOT RAISE <class litellm.exceptions.BudgetExceededError>
```

After restoring the call, all 11 tests pass:

```
$ python3 -m pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py::TestApplyClientTagPolicyPreAuth -x
collected 11 items
tests/test_litellm/proxy/test_litellm_pre_call_utils.py ...........      [100%]
======================== 11 passed, 1 warning in 10.31s ========================
```

### Evidence

This PR ships only tests — no executable surface in the proxy request path is
modified. Per the testing-only exemption, no HTTP/UI runtime artifact is
captured. The regression-coverage check above demonstrates the tests exercise
the intended code path.

## Notes

Pushed via the GitHub Contents API because the agent token lacks
`repo`+`workflow` scope; the resulting merge-base diff is noisier than a normal
fast-forward but the only changed file is
`tests/test_litellm/proxy/test_litellm_pre_call_utils.py`.

Session: https://litellm-agent-platform.onrender.com/sessions/0c0b71df-7c42-419d-9cd7-0711e7008540


### Verification (ship-pr)

| Check | Result |
|-------|--------|
| Base branch: `litellm_oss_agent_shin_daily_branch` | PASS |
| GitHub Actions | 44/44 green, 0 failed |
| Greptile | 5/5 ("Safe to merge") |
| Veria AI - PR Review | success |
| Codecov | green (all modified lines covered) |
| Unit/regression tests | 11/11 pass on `TestApplyClientTagPolicyPreAuth` |
| Regression-coverage proof | Over-budget test fails (`DID NOT RAISE BudgetExceededError`) when `_tag_max_budget_check` is removed from `common_checks` |
| Source code changed | None (tests-only PR) |
| Customer/Linear leakage in PR body | None |
