### PR TITLE
feat(otel): surface upstream provider request id as gen_ai.provider.request.id (LIT-3091)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1233,7 +1233,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
     @staticmethod
     def _get_provider_request_id_from_hidden_params(
-        hidden_params: Optional[Dict[str, Any]],
+        hidden_params: Any,
     ) -> Optional[str]:
         """Return the upstream provider's request id from
         ``standard_logging_payload.hidden_params.additional_headers``.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1231,6 +1231,29 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 value=team_alias,
             )
 
+    @staticmethod
+    def _get_provider_request_id_from_hidden_params(
+        hidden_params: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Return the upstream provider's request id from
+        ``standard_logging_payload.hidden_params.additional_headers``.
+
+        Prefers the OpenAI/Azure/Vertex AI ``x-request-id`` (stored as
+        ``llm_provider-x-request-id``); falls back to the Anthropic-style
+        ``request-id`` (stored as ``llm_provider-request-id``).
+        Returns ``None`` if neither is set.
+        """
+        if not isinstance(hidden_params, dict):
+            return None
+        additional_headers = hidden_params.get("additional_headers")
+        if not isinstance(additional_headers, dict):
+            return None
+        for key in ("llm_provider-x-request-id", "llm_provider-request-id"):
+            value = additional_headers.get(key)
+            if value:
+                return str(value)
+        return None
+
     def _set_team_attributes_from_kwargs(self, span: Span, kwargs: dict) -> None:
         """Pull team_id / team_alias from the standard logging metadata in kwargs and stamp them onto span."""
         std_log = kwargs.get("standard_logging_object")
@@ -2187,6 +2210,28 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     span=span,
                     key="litellm.call_id",
                     value=litellm_call_id,
+                )
+
+            # The upstream provider's request identifier (LIT-3091).
+            # `gen_ai.response.id` above is the provider response body id
+            # (e.g. `chatcmpl-...`); providers also return a *request* id in
+            # the response headers (`x-request-id` for OpenAI / Azure /
+            # Vertex AI, `request-id` for Anthropic) which is what their
+            # support teams use to look up a call in provider-side logs.
+            # LiteLLM already captures it into
+            # `standard_logging_payload.hidden_params.additional_headers`,
+            # but it is otherwise only emitted inside the dumped
+            # `hidden_params` JSON blob and is not queryable / filterable in
+            # OTEL backends. Surface it as a dedicated attribute so traces
+            # can be joined with provider-side logs.
+            provider_request_id = self._get_provider_request_id_from_hidden_params(
+                standard_logging_payload.get("hidden_params")
+            )
+            if provider_request_id:
+                self.safe_set_attribute(
+                    span=span,
+                    key="gen_ai.provider.request.id",
+                    value=provider_request_id,
                 )
 
             # The model used to generate the response.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1231,29 +1231,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 value=team_alias,
             )
 
-    @staticmethod
-    def _get_provider_request_id_from_hidden_params(
-        hidden_params: Any,
-    ) -> Optional[str]:
-        """Return the upstream provider's request id from
-        ``standard_logging_payload.hidden_params.additional_headers``.
-
-        Prefers the OpenAI/Azure/Vertex AI ``x-request-id`` (stored as
-        ``llm_provider-x-request-id``); falls back to the Anthropic-style
-        ``request-id`` (stored as ``llm_provider-request-id``).
-        Returns ``None`` if neither is set.
-        """
-        if not isinstance(hidden_params, dict):
-            return None
-        additional_headers = hidden_params.get("additional_headers")
-        if not isinstance(additional_headers, dict):
-            return None
-        for key in ("llm_provider-x-request-id", "llm_provider-request-id"):
-            value = additional_headers.get(key)
-            if value:
-                return str(value)
-        return None
-
     def _set_team_attributes_from_kwargs(self, span: Span, kwargs: dict) -> None:
         """Pull team_id / team_alias from the standard logging metadata in kwargs and stamp them onto span."""
         std_log = kwargs.get("standard_logging_object")
@@ -2210,28 +2187,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     span=span,
                     key="litellm.call_id",
                     value=litellm_call_id,
-                )
-
-            # The upstream provider's request identifier (LIT-3091).
-            # `gen_ai.response.id` above is the provider response body id
-            # (e.g. `chatcmpl-...`); providers also return a *request* id in
-            # the response headers (`x-request-id` for OpenAI / Azure /
-            # Vertex AI, `request-id` for Anthropic) which is what their
-            # support teams use to look up a call in provider-side logs.
-            # LiteLLM already captures it into
-            # `standard_logging_payload.hidden_params.additional_headers`,
-            # but it is otherwise only emitted inside the dumped
-            # `hidden_params` JSON blob and is not queryable / filterable in
-            # OTEL backends. Surface it as a dedicated attribute so traces
-            # can be joined with provider-side logs.
-            provider_request_id = self._get_provider_request_id_from_hidden_params(
-                standard_logging_payload.get("hidden_params")
-            )
-            if provider_request_id:
-                self.safe_set_attribute(
-                    span=span,
-                    key="gen_ai.provider.request.id",
-                    value=provider_request_id,
                 )
 
             # The model used to generate the response.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1231,6 +1231,32 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 value=team_alias,
             )
 
+    @staticmethod
+    def _get_provider_request_id_from_hidden_params(
+        hidden_params: Any,
+    ) -> Optional[str]:
+        """Return the upstream providers request id from
+        standard_logging_payload.hidden_params.additional_headers.
+
+        Prefers the OpenAI / Azure / Vertex AI x-request-id (stored as
+        llm_provider-x-request-id); falls back to the Anthropic-style
+        request-id (stored as llm_provider-request-id). Returns
+        None if neither header is present, the value is empty, or the
+        input is not a mapping. Used by set_attributes (LIT-3091) to
+        surface the value as a dedicated, queryable
+        gen_ai.provider.request.id span attribute.
+        """
+        if not isinstance(hidden_params, dict):
+            return None
+        additional_headers = hidden_params.get("additional_headers")
+        if not isinstance(additional_headers, dict):
+            return None
+        for key in ("llm_provider-x-request-id", "llm_provider-request-id"):
+            value = additional_headers.get(key)
+            if value:
+                return str(value)
+        return None
+
     def _set_team_attributes_from_kwargs(self, span: Span, kwargs: dict) -> None:
         """Pull team_id / team_alias from the standard logging metadata in kwargs and stamp them onto span."""
         std_log = kwargs.get("standard_logging_object")
@@ -2187,6 +2213,28 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     span=span,
                     key="litellm.call_id",
                     value=litellm_call_id,
+                )
+
+            # The upstream providers request identifier (LIT-3091).
+            #  above is the provider response body id
+            # (e.g. ); providers also return a *request* id in
+            # the response headers ( for OpenAI / Azure /
+            # Vertex AI,  for Anthropic) which is what their
+            # support teams use to look up a call in provider-side logs.
+            # LiteLLM already captures it into
+            # ,
+            # but it is otherwise only emitted inside the dumped
+            #  JSON blob and is not queryable / filterable in
+            # OTEL backends. Surface it as a dedicated attribute so traces
+            # can be joined with provider-side logs.
+            provider_request_id = self._get_provider_request_id_from_hidden_params(
+                standard_logging_payload.get("hidden_params")
+            )
+            if provider_request_id:
+                self.safe_set_attribute(
+                    span=span,
+                    key="gen_ai.provider.request.id",
+                    value=provider_request_id,
                 )
 
             # The model used to generate the response.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1235,7 +1235,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     def _get_provider_request_id_from_hidden_params(
         hidden_params: Any,
     ) -> Optional[str]:
-        """Return the upstream providers request id from
+        """Return the upstream provider's request id from
         standard_logging_payload.hidden_params.additional_headers.
 
         Prefers the OpenAI / Azure / Vertex AI x-request-id (stored as
@@ -2215,18 +2215,18 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                     value=litellm_call_id,
                 )
 
-            # The upstream providers request identifier (LIT-3091).
-            #  above is the provider response body id
-            # (e.g. ); providers also return a *request* id in
-            # the response headers ( for OpenAI / Azure /
-            # Vertex AI,  for Anthropic) which is what their
+            # The upstream provider's request identifier (LIT-3091).
+            # `gen_ai.response.id` above is the provider response body id
+            # (e.g. `chatcmpl-...`); providers also return a *request* id
+            # in the response headers (`x-request-id` for OpenAI / Azure /
+            # Vertex AI, `request-id` for Anthropic) which is what their
             # support teams use to look up a call in provider-side logs.
             # LiteLLM already captures it into
-            # ,
+            # `standard_logging_payload.hidden_params.additional_headers`
             # but it is otherwise only emitted inside the dumped
-            #  JSON blob and is not queryable / filterable in
-            # OTEL backends. Surface it as a dedicated attribute so traces
-            # can be joined with provider-side logs.
+            # `hidden_params` JSON blob and is not queryable / filterable
+            # in OTEL backends. Surface it as a dedicated attribute so
+            # traces can be joined with provider-side logs.
             provider_request_id = self._get_provider_request_id_from_hidden_params(
                 standard_logging_payload.get("hidden_params")
             )

--- a/tests/test_litellm/integrations/open_telemetry/test_otel_provider_request_id.py
+++ b/tests/test_litellm/integrations/open_telemetry/test_otel_provider_request_id.py
@@ -1,0 +1,223 @@
+"""LIT-3091: provider request id surfaced as a dedicated OTEL span attribute.
+
+The upstream provider's request identifier (the value of the response header
+``x-request-id`` for OpenAI / Azure / Vertex AI, or ``request-id`` for
+Anthropic) is captured by LiteLLM into
+``standard_logging_payload.hidden_params.additional_headers`` as
+``llm_provider-x-request-id`` / ``llm_provider-request-id``. Previously it was
+only emitted as part of the dumped ``hidden_params`` JSON blob, which is not
+queryable in OTEL backends. These tests pin that it is now emitted as a
+dedicated, queryable attribute ``gen_ai.provider.request.id`` on the request
+span, while still preserving the existing ``gen_ai.response.id`` (provider
+response body id) and ``litellm.call_id`` (internal id) so all three
+identifiers can be correlated.
+"""
+from datetime import datetime, timezone
+from typing import Optional, Tuple
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from litellm.integrations.opentelemetry import OpenTelemetry
+
+
+@pytest.fixture
+def otel_with_exporter() -> Tuple[OpenTelemetry, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    otel = OpenTelemetry()
+    otel.OTEL_TRACER_PROVIDER = provider
+    otel.tracer = provider.get_tracer("lit-3091-tests")
+    return otel, exporter
+
+
+def _build_kwargs(
+    additional_headers: Optional[dict],
+    *,
+    response_id: str = "chatcmpl-AbCdEf123456",
+    litellm_call_id: str = "litellm-call-1234abcd",
+):
+    hidden_params = {"model_id": "deploy-id-1", "api_base": "https://api.openai.com/v1"}
+    if additional_headers is not None:
+        hidden_params["additional_headers"] = additional_headers
+
+    slp = {
+        "id": response_id,
+        "call_type": "completion",
+        "litellm_call_id": litellm_call_id,
+        "trace_id": "trace-zzzz",
+        "metadata": {
+            "user_api_key_alias": "alice-key",
+            "user_api_key_user_id": "user-7",
+            "user_api_key_team_id": "team-42",
+            "user_api_key_team_alias": "team-alpha",
+            "user_api_key_user_email": "alice@example.com",
+            "user_api_key_hash": "hashed-thingy",
+        },
+        "hidden_params": hidden_params,
+    }
+    kwargs = {
+        "model": "openai/gpt-4o-mini",
+        "litellm_params": {"custom_llm_provider": "openai", "metadata": {}},
+        "optional_params": {"max_tokens": 50, "temperature": 0.0},
+        "standard_logging_object": slp,
+    }
+    response_obj = {
+        "id": response_id,
+        "model": "gpt-4o-mini-2024-07-18",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    return kwargs, response_obj
+
+
+# ---------------------------------------------------------------------------
+# Helper: _get_provider_request_id_from_hidden_params
+# ---------------------------------------------------------------------------
+class TestGetProviderRequestIdHelper:
+    """Exercises the static extraction helper in isolation."""
+
+    def test_prefers_x_request_id(self):
+        hp = {
+            "additional_headers": {
+                "llm_provider-x-request-id": "req_x",
+                "llm_provider-request-id": "req_anthropic",
+            }
+        }
+        assert (
+            OpenTelemetry._get_provider_request_id_from_hidden_params(hp) == "req_x"
+        )
+
+    def test_falls_back_to_request_id(self):
+        """Anthropic-style: only `request-id` header is returned."""
+        hp = {"additional_headers": {"llm_provider-request-id": "msg_01F6"}}
+        assert (
+            OpenTelemetry._get_provider_request_id_from_hidden_params(hp) == "msg_01F6"
+        )
+
+    def test_returns_none_when_no_additional_headers(self):
+        assert (
+            OpenTelemetry._get_provider_request_id_from_hidden_params(
+                {"model_id": "deploy-1"}
+            )
+            is None
+        )
+
+    def test_returns_none_when_additional_headers_empty(self):
+        assert (
+            OpenTelemetry._get_provider_request_id_from_hidden_params(
+                {"additional_headers": {}}
+            )
+            is None
+        )
+
+    def test_returns_none_when_additional_headers_is_not_a_mapping(self):
+        # Defensive: do not crash on malformed payloads from upstream callers.
+        assert (
+            OpenTelemetry._get_provider_request_id_from_hidden_params(
+                {"additional_headers": ["x-request-id"]}
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize("bad", [None, "string-not-dict", 42, []])
+    def test_returns_none_when_hidden_params_is_not_a_mapping(self, bad):
+        assert OpenTelemetry._get_provider_request_id_from_hidden_params(bad) is None
+
+    def test_returns_none_when_value_is_empty_string(self):
+        # Empty header value should not produce an attribute (falsy guard).
+        hp = {"additional_headers": {"llm_provider-x-request-id": ""}}
+        assert OpenTelemetry._get_provider_request_id_from_hidden_params(hp) is None
+
+    def test_coerces_to_string(self):
+        # Defensive: if a stray non-str value sneaks in, we coerce to str so
+        # safe_set_attribute does not blow up on the otel side.
+        hp = {"additional_headers": {"llm_provider-x-request-id": 12345}}
+        assert (
+            OpenTelemetry._get_provider_request_id_from_hidden_params(hp) == "12345"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: span attribute emission
+# ---------------------------------------------------------------------------
+class TestSpanAttributeEmission:
+    """Drives log_success_event end-to-end and inspects the emitted span."""
+
+    @staticmethod
+    def _collect_request_span(exporter: InMemorySpanExporter):
+        spans = exporter.get_finished_spans()
+        for s in spans:
+            if s.name == "litellm_request":
+                return s
+        raise AssertionError(
+            f"litellm_request span not found; got: {[s.name for s in spans]}"
+        )
+
+    def test_provider_request_id_surfaced_as_dedicated_attribute(
+        self, otel_with_exporter
+    ):
+        otel, exporter = otel_with_exporter
+        kwargs, response_obj = _build_kwargs(
+            {
+                "llm_provider-x-request-id": "req_85f49b546c7b4d3180755621f36631a1",
+                "llm_provider-request-id": "msg_01F6CycZZPSHKRCCctcS1Vto",
+                "x_ratelimit_remaining_requests": 9999,
+            }
+        )
+        now = datetime.now(timezone.utc)
+        otel.log_success_event(kwargs=kwargs, response_obj=response_obj, start_time=now, end_time=now)
+
+        span = self._collect_request_span(exporter)
+        # NEW attribute from LIT-3091:
+        assert (
+            span.attributes["gen_ai.provider.request.id"]
+            == "req_85f49b546c7b4d3180755621f36631a1"
+        )
+        # Existing identifiers preserved so all three can be correlated:
+        assert span.attributes["gen_ai.response.id"] == "chatcmpl-AbCdEf123456"
+        assert span.attributes["litellm.call_id"] == "litellm-call-1234abcd"
+
+    def test_anthropic_style_request_id_fallback(self, otel_with_exporter):
+        otel, exporter = otel_with_exporter
+        kwargs, response_obj = _build_kwargs(
+            {"llm_provider-request-id": "msg_01F6CycZZPSHKRCCctcS1Vto"}
+        )
+        now = datetime.now(timezone.utc)
+        otel.log_success_event(kwargs=kwargs, response_obj=response_obj, start_time=now, end_time=now)
+
+        span = self._collect_request_span(exporter)
+        assert (
+            span.attributes["gen_ai.provider.request.id"]
+            == "msg_01F6CycZZPSHKRCCctcS1Vto"
+        )
+
+    def test_attribute_omitted_when_no_additional_headers(self, otel_with_exporter):
+        """When the upstream call did not return a request-id header (e.g.
+        embedding routes or a custom provider that omits it), the attribute
+        is omitted rather than emitted as None / empty string."""
+        otel, exporter = otel_with_exporter
+        kwargs, response_obj = _build_kwargs(None)  # no additional_headers at all
+        now = datetime.now(timezone.utc)
+        otel.log_success_event(kwargs=kwargs, response_obj=response_obj, start_time=now, end_time=now)
+
+        span = self._collect_request_span(exporter)
+        assert "gen_ai.provider.request.id" not in span.attributes
+        # The existing identifiers are still emitted.
+        assert span.attributes["gen_ai.response.id"] == "chatcmpl-AbCdEf123456"
+        assert span.attributes["litellm.call_id"] == "litellm-call-1234abcd"
+
+    def test_attribute_omitted_when_header_value_empty(self, otel_with_exporter):
+        otel, exporter = otel_with_exporter
+        kwargs, response_obj = _build_kwargs(
+            {"llm_provider-x-request-id": "", "llm_provider-request-id": ""}
+        )
+        now = datetime.now(timezone.utc)
+        otel.log_success_event(kwargs=kwargs, response_obj=response_obj, start_time=now, end_time=now)
+
+        span = self._collect_request_span(exporter)
+        assert "gen_ai.provider.request.id" not in span.attributes


### PR DESCRIPTION
## What

Surface the upstream provider's request id as a dedicated, queryable OpenTelemetry span attribute (`gen_ai.provider.request.id`) so LiteLLM traces can be joined with provider-side logs by the provider's own request id.

Closes LIT-3091.

## Why

LiteLLM already records the upstream provider's request identifier — the value of the response header `x-request-id` for OpenAI / Azure / Vertex AI, or `request-id` for Anthropic — into `standard_logging_payload.hidden_params.additional_headers` as `llm_provider-x-request-id` / `llm_provider-request-id`.

But on the OTEL side it was only emitted as part of the dumped `hidden_params` JSON blob attribute. That blob is opaque to OTEL backends (Datadog, Honeycomb, Tempo, Grafana, ...) and is not queryable or filterable, so users could not search traces by the provider's own request id or join LiteLLM traces with provider-side support logs.

The three identifiers that should be present on every LLM request span:

| Identifier | Source | Existing attribute | Status |
|---|---|---|---|
| LiteLLM internal id | LiteLLM-generated UUID | `litellm.call_id` | ✅ already emitted |
| Provider response body id | upstream JSON body `id` (e.g. `chatcmpl-...`) | `gen_ai.response.id` | ✅ already emitted |
| **Provider request id** | upstream response header `x-request-id` / `request-id` | **`gen_ai.provider.request.id`** | ✅ **new in this PR** |

Per-key / user / team metadata (`metadata.user_api_key_*`) is already on every span via `set_attributes` and `_record_metrics`, so the "associated user, service, or API key" portion of the ticket is already satisfied.

## How

1. New static helper `OpenTelemetry._get_provider_request_id_from_hidden_params(hidden_params)`:
   - prefers `additional_headers["llm_provider-x-request-id"]` (OpenAI / Azure / Vertex AI),
   - falls back to `additional_headers["llm_provider-request-id"]` (Anthropic),
   - returns `None` on any non-mapping input, empty string, or missing header,
   - coerces to `str` defensively before returning.
2. In `OpenTelemetry.set_attributes`, after the existing `gen_ai.response.id` + `litellm.call_id` block, emit `gen_ai.provider.request.id` from the helper. Attribute is omitted entirely when no value is available (so embedding routes / custom providers that don't return a request-id header are unaffected).
3. Deliberately **not** added to `_record_metrics` histogram attributes — request id is per-call, high-cardinality, and would explode metric cardinality on histograms like `gen_ai.client.operation.duration` / `gen_ai.client.token.usage`. Span attribute only.

`langfuse_otel.py` and `weave_otel.py` have their own attribute setters and are out of scope for this PR; they can be updated in a follow-up if/when the same correlation gap is reported there.

## Evidence

The repro drives the real `OpenTelemetry.log_success_event` callback against a `TracerProvider` whose `SimpleSpanProcessor` feeds an `InMemorySpanExporter`, with a synthesized but realistic `standard_logging_object` that includes both `llm_provider-x-request-id` and `llm_provider-request-id` inside `hidden_params.additional_headers`. Then it dumps the captured span attributes.

### Before (clean `litellm_oss_agent_shin_daily_branch` @ `1fe911d`):

```
SPAN name='litellm_request'
  gen_ai.operation.name = 'chat'
  gen_ai.request.max_tokens = 50
  gen_ai.request.model = 'openai/gpt-4o-mini'
  gen_ai.response.id = 'chatcmpl-AbCdEf123456'
  gen_ai.response.model = 'gpt-4o-mini-2024-07-18'
  gen_ai.system = 'openai'
  gen_ai.usage.input_tokens = 10
  gen_ai.usage.output_tokens = 5
  gen_ai.usage.total_tokens = 15
  hidden_params = '{"model_id": "deploy-id-1", "api_base": "https://api.openai.com/v1", "additional_headers": {"llm_provider-x-request-id": "req_85f49b546c7b4d3180755621f36631a1", "llm_provider-request-id": "msg_01F6Cyc...<truncated>'
  litellm.call_id = 'litellm-call-1234abcd'
  ...

=== ASSERTIONS ===
gen_ai.response.id present:         True
gen_ai.provider.request.id present: False  ← buried inside hidden_params JSON blob, not queryable
litellm.call_id present:            True
```

### After (this PR):

```
SPAN name='litellm_request'
  gen_ai.operation.name = 'chat'
  gen_ai.provider.request.id = 'req_85f49b546c7b4d3180755621f36631a1'   ← NEW, dedicated, queryable
  gen_ai.request.max_tokens = 50
  gen_ai.request.model = 'openai/gpt-4o-mini'
  gen_ai.response.id = 'chatcmpl-AbCdEf123456'
  gen_ai.response.model = 'gpt-4o-mini-2024-07-18'
  gen_ai.system = 'openai'
  gen_ai.usage.input_tokens = 10
  gen_ai.usage.output_tokens = 5
  gen_ai.usage.total_tokens = 15
  hidden_params = '{"model_id": "deploy-id-1", ...}'
  litellm.call_id = 'litellm-call-1234abcd'
  ...

=== ASSERTIONS ===
gen_ai.response.id present:         True
gen_ai.provider.request.id present: True   ← now top-level attribute
litellm.call_id present:            True
```

### Tests

- 15 new tests in `tests/test_litellm/integrations/open_telemetry/test_otel_provider_request_id.py` covering the helper (prefer / fallback / empty / non-dict / parametric bad inputs / coercion) and the end-to-end span path (OpenAI-style header / Anthropic-style fallback / attribute omitted when no header / attribute omitted when header value empty).
- Full OTEL test directory: **124/124 passed** locally (`tests/test_litellm/integrations/open_telemetry/`).
- Adjacent `litellm_logging` hidden-params tests: **12/12 passed**.

## Notes for reviewers

- Branch was created on the fork via GitHub Contents API (one PUT per file). Direct git push from the sandbox failed because the current `GITHUB_TOKEN` lacks `repo` + `workflow` scopes — this is the documented Shin fork limit and produces a slightly noisier merge-base diff but identical file contents to a normal commit.

---

---

### Verification (ship-pr)

| Check | Status | Notes |
|---|---|---|
| Linear ticket linked | ✅ | LIT-3091 in title + commit + body; PR link cross-posted to Linear |
| Base branch | ✅ | `litellm_oss_agent_shin_daily_branch` (fork policy) |
| Branch / push method | ✅ | Pushed via GitHub Contents API (one PUT per file). Documented above in PR body. |
| Before/after runtime evidence | ✅ | Real `OpenTelemetry.log_success_event` driven against `InMemorySpanExporter`; before shows `gen_ai.provider.request.id` absent (value buried in dumped `hidden_params` JSON blob), after shows it surfaced as a dedicated queryable attribute. Inline in PR body. |
| Unit tests | ✅ | 15 new tests in `tests/test_litellm/integrations/open_telemetry/test_otel_provider_request_id.py`; full `tests/test_litellm/integrations/open_telemetry/` suite **124/124 passed** locally. |
| Regression sweep | ✅ | Related `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` `additional_headers` / `hidden_params` subset **12/12 passed** locally. |
| GitHub Actions | ✅ | **44/44 green** on head `6b91f9f` (lint / mypy / proxy / OTEL / responses / unit / integrations / Codecov / Veria AI - PR Review / ...). |
| Greptile | ✅ | **5/5** — "Safe to merge — the change is purely additive, emitting a new optional span attribute only when provider header data is available, with no modifications to existing logic." Second review at commit `6b91f9f` after the only finding from the first 4/5 review (garbled backtick-quoted code identifiers in the inline comment block) was resolved. |
| Veria AI | ✅ | `Veria AI - PR Review` check `success`. |
| Codecov | ✅ | "All modified and coverable lines are covered by tests." |
| Cardinality / metric impact | ✅ | Attribute is span-only by design; deliberately NOT added to histogram metric labels (per-request id is high cardinality and would balloon metric series on histograms like `gen_ai.client.operation.duration` / `gen_ai.client.token.usage`). |
| Customer name leak | ✅ | No customer name in PR title, body, commits, or test fixtures. |
| Secrets in PR | ✅ | No tokens / keys / PEMs in PR or evidence. Synthesized request id values in fixtures (`req_85f49b...`, `msg_01F6...`) are non-real. |
