### PR TITLE
feat(observability): surface AWS Bedrock guardrail request ID in logs + OTEL spans (LIT-3391)

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1753,7 +1753,8 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             # by the provider hook onto StandardLoggingGuardrailInformation,
             # surfaced here so dashboards can pivot from a LiteLLM trace to
             # the corresponding provider-side guardrail execution without
-            # re-running the request.
+            # re-running the request. Skip emitting when the value is missing
+            # so dashboards don't get cluttered with empty attributes.
             guardrail_provider_request_id = guardrail_information.get(
                 "provider_request_id"
             )

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1748,6 +1748,21 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             if guardrail_action:
                 guardrail_span.set_attribute("guardrail_action", guardrail_action)
 
+            # Provider-side per-call request ID (e.g. AWS Bedrock's
+            # ``x-amzn-RequestId`` from the ApplyGuardrail response). Stamped
+            # by the provider hook onto StandardLoggingGuardrailInformation,
+            # surfaced here so dashboards can pivot from a LiteLLM trace to
+            # the corresponding provider-side guardrail execution without
+            # re-running the request.
+            guardrail_provider_request_id = guardrail_information.get(
+                "provider_request_id"
+            )
+            if guardrail_provider_request_id:
+                guardrail_span.set_attribute(
+                    "guardrail_provider_request_id",
+                    guardrail_provider_request_id,
+                )
+
             # The provider hook (e.g. Bedrock) extracts violation_categories
             # from the raw response BEFORE redaction and stamps them onto
             # StandardLoggingGuardrailInformation. Surfacing them here as a

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -664,8 +664,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
     # ``x-amzn-RequestId`` is the canonical header surfaced by the AWS SDK /
     # CloudTrail / Bedrock console; ``x-amz-request-id`` is the legacy S3-style
     # fallback that some Bedrock proxies still emit. Listed in priority order.
+    # ``x-amzn-RequestId`` is the canonical header surfaced by the AWS SDK,
+    # CloudTrail, and the Bedrock console. ``x-amz-request-id`` is the legacy
+    # S3-style fallback some Bedrock proxies still emit. httpx.Headers gives
+    # case-insensitive lookups so listing the canonical capitalisation once
+    # is enough; plain dicts are matched as-is (callers control case).
     _BEDROCK_REQUEST_ID_HEADERS: ClassVar[Tuple[str, ...]] = (
-        "x-amzn-requestid",
         "x-amzn-RequestId",
         "x-amz-request-id",
     )

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -671,9 +671,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
     )
 
     @classmethod
-    def _extract_bedrock_request_id(
-        cls, headers: Optional[Any]
-    ) -> Optional[str]:
+    def _extract_bedrock_request_id(cls, headers: Optional[Any]) -> Optional[str]:
         """
         Return AWS Bedrock\'s per-call request ID from response headers if
         present, else ``None``. Case-insensitive lookup via ``httpx.Headers``;

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -53,7 +53,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockRequest,
     BedrockTextContent,
 )
-from litellm.types.utils import GenericGuardrailAPIInputs
+from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailTracingDetail
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -475,6 +475,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         status_code,
                         detail_message,
                     ) = self._parse_bedrock_guardrail_error_response(response)
+                    # Surface the AWS request ID on the failure record too so
+                    # operators can correlate a failed/blocked call to the
+                    # provider-side ApplyGuardrail execution without re-running
+                    # the request. Bedrock returns x-amzn-RequestId on error
+                    # responses just like on 2xx.
+                    err_request_id = self._extract_bedrock_request_id(
+                        getattr(response, "headers", None)
+                    )
+                    err_tracing_detail: GuardrailTracingDetail = (
+                        {"provider_request_id": err_request_id}
+                        if err_request_id is not None
+                        else {}
+                    )
                     self.add_standard_logging_guardrail_information_to_request_data(
                         guardrail_provider=self.guardrail_provider,
                         guardrail_json_response={"error": detail_message},
@@ -484,6 +497,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         end_time=datetime.now().timestamp(),
                         duration=(datetime.now() - start_time).total_seconds(),
                         event_type=event_type,
+                        tracing_detail=err_tracing_detail or None,
                     )
                     raise HTTPException(
                         status_code=status_code, detail=detail_message
@@ -510,7 +524,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         # Add guardrail information to request trace
         #########################################################
         _json_response = httpx_response.json()
-        tracing_detail = self._build_tracing_detail(_json_response)
+        tracing_detail = self._build_tracing_detail(
+            _json_response, response_headers=httpx_response.headers
+        )
 
         # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
@@ -644,17 +660,56 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 return (status_code, err)
         return (status_code, message)
 
+    # AWS Bedrock returns the per-call request ID via these response headers.
+    # ``x-amzn-RequestId`` is the canonical header surfaced by the AWS SDK /
+    # CloudTrail / Bedrock console; ``x-amz-request-id`` is the legacy S3-style
+    # fallback that some Bedrock proxies still emit. Listed in priority order.
+    _BEDROCK_REQUEST_ID_HEADERS: ClassVar[Tuple[str, ...]] = (
+        "x-amzn-requestid",
+        "x-amzn-RequestId",
+        "x-amz-request-id",
+    )
+
+    @classmethod
+    def _extract_bedrock_request_id(
+        cls, headers: Optional[Any]
+    ) -> Optional[str]:
+        """
+        Return AWS Bedrock\'s per-call request ID from response headers if
+        present, else ``None``. Case-insensitive lookup via ``httpx.Headers``;
+        also accepts a plain dict. The first non-empty value wins. Never
+        raises - header extraction must not break the guardrail call.
+        """
+        if headers is None:
+            return None
+        try:
+            for name in cls._BEDROCK_REQUEST_ID_HEADERS:
+                value = headers.get(name)
+                if isinstance(value, str) and value:
+                    return value
+        except Exception:
+            return None
+        return None
+
     def _build_tracing_detail(
-        self, response: BedrockGuardrailResponse
+        self,
+        response: BedrockGuardrailResponse,
+        response_headers: Optional[Any] = None,
     ) -> GuardrailTracingDetail:
         """
         Build the tracing detail from the raw Bedrock response, before
         redaction, so downstream loggers (OTEL, Langfuse, ...) get the
         actual category names rather than the "[REDACTED]" sentinel that
-        replaces customWords.match later. Bedrock's top-level ``action``
+        replaces customWords.match later. Bedrock\'s top-level ``action``
         field ("GUARDRAIL_INTERVENED" or "NONE") is also surfaced so the
         OTEL integration can expose it as a queryable span attribute
         without re-parsing the redacted guardrail_response blob.
+
+        When ``response_headers`` is provided, the AWS request ID
+        (``x-amzn-RequestId``) is also stamped onto the tracing detail so
+        that LiteLLM logs, the Logs UI, and downstream observability
+        backends can correlate to the provider-side ApplyGuardrail
+        execution.
         """
         tracing_detail: GuardrailTracingDetail = {}
         violation_categories = self._extract_violation_category_names(response)
@@ -663,6 +718,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         bedrock_action = response.get("action")
         if isinstance(bedrock_action, str):
             tracing_detail["guardrail_action"] = bedrock_action
+        bedrock_request_id = self._extract_bedrock_request_id(response_headers)
+        if bedrock_request_id is not None:
+            tracing_detail["provider_request_id"] = bedrock_request_id
         return tracing_detail
 
     def _extract_violation_category_names(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -53,7 +53,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockRequest,
     BedrockTextContent,
 )
-from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailTracingDetail
+from litellm.types.utils import GenericGuardrailAPIInputs
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2782,6 +2782,15 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     surface it as a queryable span attribute without parsing the raw
     guardrail_response blob."""
 
+    provider_request_id: Optional[str]
+    """Provider-side request ID for the guardrail execution. AWS Bedrock
+    returns this as the ``x-amzn-RequestId`` response header on every
+    ApplyGuardrail call; populated by the provider hook so operators can
+    correlate a LiteLLM request to the corresponding provider-side
+    guardrail execution in compliance logs, vendor dashboards, and support
+    tickets. ``None`` when the provider does not expose a request ID or the
+    header was missing on the response."""
+
 
 class EvalVerdict(TypedDict, total=False):
     criterion_name: str
@@ -2825,6 +2834,7 @@ class GuardrailTracingDetail(TypedDict, total=False):
     risk_score: Optional[float]
     violation_categories: Optional[List[str]]
     guardrail_action: Optional[str]
+    provider_request_id: Optional[str]
 
 
 StandardLoggingPayloadStatus = Literal["success", "failure"]

--- a/tests/test_litellm/integrations/test_otel_guardrail_provider_request_id.py
+++ b/tests/test_litellm/integrations/test_otel_guardrail_provider_request_id.py
@@ -8,6 +8,7 @@ This is the "dashboard" half of LIT-3391 - once it's a span attribute, every
 OTEL backend (Langfuse, Honeycomb, Datadog APM, Tempo, Grafana Cloud, etc.)
 can filter / pivot on it without re-parsing the redacted guardrail_response.
 """
+
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
 
@@ -62,11 +63,13 @@ def _capture_attrs(otel_handler, kwargs):
 
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = _SpanCapture()
-    with patch.object(
-        otel_handler, "get_tracer_to_use_for_request", return_value=fake_tracer
-    ), patch.object(otel_handler, "_emit_once", return_value=True), patch.object(
-        otel_handler, "safe_set_attribute"
-    ) as safe_set:
+    with (
+        patch.object(
+            otel_handler, "get_tracer_to_use_for_request", return_value=fake_tracer
+        ),
+        patch.object(otel_handler, "_emit_once", return_value=True),
+        patch.object(otel_handler, "safe_set_attribute") as safe_set,
+    ):
         safe_set.side_effect = lambda span, key, value: span.set_attribute(key, value)
         otel_handler._create_guardrail_span(kwargs=kwargs, context=None)
     return attrs

--- a/tests/test_litellm/integrations/test_otel_guardrail_provider_request_id.py
+++ b/tests/test_litellm/integrations/test_otel_guardrail_provider_request_id.py
@@ -1,0 +1,96 @@
+"""
+LIT-3391: OTEL surface - assert that when StandardLoggingGuardrailInformation
+carries ``provider_request_id`` (e.g. AWS Bedrock's x-amzn-RequestId), the
+OpenTelemetry integration emits it as the queryable span attribute
+``guardrail_provider_request_id`` on the per-guardrail span.
+
+This is the "dashboard" half of LIT-3391 - once it's a span attribute, every
+OTEL backend (Langfuse, Honeycomb, Datadog APM, Tempo, Grafana Cloud, etc.)
+can filter / pivot on it without re-parsing the redacted guardrail_response.
+"""
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def otel_handler():
+    from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
+
+    cfg = OpenTelemetryConfig(exporter="console")
+    return OpenTelemetry(config=cfg)
+
+
+def _make_kwargs(provider_request_id: Any) -> Dict[str, Any]:
+    return {
+        "standard_logging_object": {
+            "trace_id": "trace-test",
+            "metadata": {
+                "user_api_key": "test-key",
+                "user_api_key_team_id": None,
+                "user_api_key_team_alias": None,
+            },
+            "guardrail_information": [
+                {
+                    "guardrail_name": "test_bedrock_guardrail",
+                    "guardrail_mode": "pre_call",
+                    "guardrail_status": "success",
+                    "guardrail_provider": "bedrock",
+                    "guardrail_response": {"action": "NONE"},
+                    "guardrail_action": "NONE",
+                    "provider_request_id": provider_request_id,
+                    "start_time": 1.0,
+                    "end_time": 2.0,
+                }
+            ],
+        },
+        "litellm_params": {"metadata": {}},
+        "model": "gpt-4o",
+    }
+
+
+def _capture_attrs(otel_handler, kwargs):
+    attrs: List[Any] = []
+
+    class _SpanCapture:
+        def set_attribute(self, key, value):
+            attrs.append((key, value))
+
+        def end(self, end_time=None):
+            pass
+
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = _SpanCapture()
+    with patch.object(
+        otel_handler, "get_tracer_to_use_for_request", return_value=fake_tracer
+    ), patch.object(otel_handler, "_emit_once", return_value=True), patch.object(
+        otel_handler, "safe_set_attribute"
+    ) as safe_set:
+        safe_set.side_effect = lambda span, key, value: span.set_attribute(key, value)
+        otel_handler._create_guardrail_span(kwargs=kwargs, context=None)
+    return attrs
+
+
+def test_otel_emits_provider_request_id_when_present(otel_handler):
+    attrs = _capture_attrs(
+        otel_handler,
+        _make_kwargs(provider_request_id="7c1f8a4d-4b8a-4f9a-9d1c-0c2e1a8b3f47"),
+    )
+    flat = dict(attrs)
+    assert (
+        flat.get("guardrail_provider_request_id")
+        == "7c1f8a4d-4b8a-4f9a-9d1c-0c2e1a8b3f47"
+    ), f"missing guardrail_provider_request_id. Got: {attrs}"
+
+
+def test_otel_omits_provider_request_id_when_absent(otel_handler):
+    attrs = _capture_attrs(otel_handler, _make_kwargs(provider_request_id=None))
+    keys = {k for k, _ in attrs}
+    assert "guardrail_provider_request_id" not in keys
+
+
+def test_otel_omits_provider_request_id_when_empty_string(otel_handler):
+    attrs = _capture_attrs(otel_handler, _make_kwargs(provider_request_id=""))
+    keys = {k for k, _ in attrs}
+    assert "guardrail_provider_request_id" not in keys

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_request_id.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_request_id.py
@@ -92,7 +92,9 @@ class _IntegrationGuardrail:
                 return_value=(MagicMock(), "us-east-1"),
             )
         )
-        prep = self._stack.enter_context(patch.object(BedrockGuardrail, "_prepare_request"))
+        prep = self._stack.enter_context(
+            patch.object(BedrockGuardrail, "_prepare_request")
+        )
         p = MagicMock()
         p.url = "https://bedrock-runtime.us-east-1.amazonaws.com/guardrail/test/version/1/apply"
         p.body = b"{}"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_request_id.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_request_id.py
@@ -1,0 +1,187 @@
+"""
+Regression tests for LIT-3391.
+
+Bedrock returns ``x-amzn-RequestId`` on every ApplyGuardrail response. Prior to
+this fix the response headers were discarded; downstream loggers (Langfuse,
+Datadog, OTEL, the Logs UI) had no way to correlate a LiteLLM request to the
+provider-side guardrail execution.
+"""
+
+from contextlib import ExitStack
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
+    BedrockGuardrail,
+)
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        ({"x-amzn-RequestId": "abc-123"}, "abc-123"),
+        ({"X-AMZN-REQUESTID": "abc-123"}, "abc-123"),
+        ({"x-amz-request-id": "legacy-99"}, "legacy-99"),
+        ({"x-amzn-RequestId": "canonical", "x-amz-request-id": "legacy"}, "canonical"),
+        ({"content-type": "application/json"}, None),
+        ({}, None),
+    ],
+)
+def test_extract_request_id_dict(headers, expected):
+    h = httpx.Headers(headers)
+    assert BedrockGuardrail._extract_bedrock_request_id(h) == expected
+
+
+def test_extract_request_id_none_input():
+    assert BedrockGuardrail._extract_bedrock_request_id(None) is None
+
+
+def test_extract_request_id_empty_string_skipped():
+    h = httpx.Headers({"x-amzn-RequestId": ""})
+    assert BedrockGuardrail._extract_bedrock_request_id(h) is None
+
+
+def test_extract_request_id_never_raises():
+    class Boom:
+        def get(self, *a, **k):
+            raise RuntimeError("simulated httpx malfunction")
+
+    assert BedrockGuardrail._extract_bedrock_request_id(Boom()) is None
+
+
+def _bare_guardrail():
+    return BedrockGuardrail.__new__(BedrockGuardrail)
+
+
+def test_build_tracing_detail_includes_request_id():
+    g = _bare_guardrail()
+    response = {"action": "GUARDRAIL_INTERVENED", "assessments": []}
+    headers = httpx.Headers({"x-amzn-RequestId": "req-xyz"})
+    td = g._build_tracing_detail(response, response_headers=headers)
+    assert td.get("provider_request_id") == "req-xyz"
+    assert td.get("guardrail_action") == "GUARDRAIL_INTERVENED"
+
+
+def test_build_tracing_detail_omits_request_id_when_headers_absent():
+    g = _bare_guardrail()
+    response = {"action": "NONE", "assessments": []}
+    td = g._build_tracing_detail(response)
+    assert "provider_request_id" not in td
+
+
+def test_build_tracing_detail_omits_request_id_when_header_missing():
+    g = _bare_guardrail()
+    response = {"action": "NONE", "assessments": []}
+    td = g._build_tracing_detail(
+        response,
+        response_headers=httpx.Headers({"content-type": "application/json"}),
+    )
+    assert "provider_request_id" not in td
+
+
+class _IntegrationGuardrail:
+    def __enter__(self):
+        self._stack = ExitStack()
+        self._stack.enter_context(
+            patch.object(
+                BedrockGuardrail,
+                "_load_credentials",
+                return_value=(MagicMock(), "us-east-1"),
+            )
+        )
+        prep = self._stack.enter_context(patch.object(BedrockGuardrail, "_prepare_request"))
+        p = MagicMock()
+        p.url = "https://bedrock-runtime.us-east-1.amazonaws.com/guardrail/test/version/1/apply"
+        p.body = b"{}"
+        p.headers = {"Content-Type": "application/json"}
+        prep.return_value = p
+        self.g = BedrockGuardrail(
+            guardrailIdentifier="test-id",
+            guardrailVersion="1",
+            aws_region_name="us-east-1",
+            guardrail_name="test_guardrail",
+            event_hook="pre_call",
+        )
+        return self.g
+
+    def __exit__(self, *exc):
+        self._stack.close()
+
+
+def _fake_response(status, headers, body):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.headers = httpx.Headers(headers)
+    r.json = MagicMock(return_value=body)
+    r.text = str(body)
+    return r
+
+
+@pytest.mark.asyncio
+async def test_make_bedrock_api_request_success_records_request_id():
+    with _IntegrationGuardrail() as g:
+        fake = _fake_response(
+            200,
+            {"x-amzn-RequestId": "success-request-id-001"},
+            {"action": "NONE", "assessments": []},
+        )
+        g.async_handler = MagicMock()
+        g.async_handler.post = AsyncMock(return_value=fake)
+        rd: Dict[str, Any] = {"metadata": {}}
+        await g.make_bedrock_api_request(
+            source="INPUT",
+            messages=[{"role": "user", "content": "hello"}],
+            request_data=rd,
+        )
+        slg = rd["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg) == 1
+        assert slg[0].get("provider_request_id") == "success-request-id-001"
+        assert slg[0].get("guardrail_action") == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_make_bedrock_api_request_http_error_records_request_id():
+    with _IntegrationGuardrail() as g:
+        err = _fake_response(
+            400,
+            {"x-amzn-RequestId": "err-request-id-042"},
+            {"message": "ValidationException: bad input"},
+        )
+        raised = httpx.HTTPStatusError("400", request=MagicMock(), response=err)
+        g.async_handler = MagicMock()
+        g.async_handler.post = AsyncMock(side_effect=raised)
+        rd: Dict[str, Any] = {"metadata": {}}
+        with pytest.raises(Exception):
+            await g.make_bedrock_api_request(
+                source="INPUT",
+                messages=[{"role": "user", "content": "hello"}],
+                request_data=rd,
+            )
+        slg = rd["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg) == 1
+        assert slg[0].get("guardrail_status") == "guardrail_failed_to_respond"
+        assert slg[0].get("provider_request_id") == "err-request-id-042"
+
+
+@pytest.mark.asyncio
+async def test_make_bedrock_api_request_success_omits_request_id_when_header_missing():
+    with _IntegrationGuardrail() as g:
+        fake = _fake_response(
+            200,
+            {"content-type": "application/json"},
+            {"action": "NONE", "assessments": []},
+        )
+        g.async_handler = MagicMock()
+        g.async_handler.post = AsyncMock(return_value=fake)
+        rd: Dict[str, Any] = {"metadata": {}}
+        await g.make_bedrock_api_request(
+            source="INPUT",
+            messages=[{"role": "user", "content": "hello"}],
+            request_data=rd,
+        )
+        slg = rd["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg) == 1
+        assert not slg[0].get("provider_request_id")


### PR DESCRIPTION
## Summary — LIT-3391

AWS Bedrock returns a per-call request ID on every `ApplyGuardrail` response via the
`x-amzn-RequestId` HTTP header. Until this PR, LiteLLM discarded that header — so
once a guardrail decision landed in the LiteLLM logs, the Logs UI, Langfuse, Datadog,
or an OTEL collector, operators had no way to pivot from a LiteLLM request to the
corresponding Bedrock-side execution for debugging, false-positive analysis, or
compliance / cost investigation.

This PR plumbs the AWS request ID through the existing `StandardLoggingGuardrailInformation`
contract so it lands everywhere standard guardrail metadata already does, and surfaces it
as a queryable OTEL span attribute so dashboards can filter on it.

## Changes

1. **`litellm/types/utils.py`** — add `provider_request_id: Optional[str]` to
   `StandardLoggingGuardrailInformation` (the contract every guardrail integration writes
   into) and to `GuardrailTracingDetail` (the typed dict providers fill in).
2. **`litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py`** —
   - New `BedrockGuardrail._extract_bedrock_request_id(headers)` helper that
     case-insensitively reads `x-amzn-RequestId` (canonical) then `x-amz-request-id`
     (legacy fallback), returns `None` cleanly when absent, and never raises.
   - `_build_tracing_detail(response, response_headers=…)` gains an optional
     `response_headers` arg and stamps `provider_request_id` onto the tracing detail
     when present.
   - Wires `httpx_response.headers` into `_build_tracing_detail` at the **success path**
     and stamps the same value onto the failure record on the **HTTP error path** (so
     operators can correlate even blocked / 4xx responses back to the AWS execution).
3. **`litellm/integrations/opentelemetry.py`** — when
   `guardrail_information["provider_request_id"]` is set, emit it as the OTEL span
   attribute `guardrail_provider_request_id` next to the existing `guardrail_action`
   attribute. Empty / missing values are skipped.
4. **Regression tests** — 18 new tests across two files:
   - `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_request_id.py` (15 tests):
     header extraction (canonical / case-insensitive / legacy / absent / empty / never-raises),
     `_build_tracing_detail` include/omit, and end-to-end `make_bedrock_api_request` on
     success + 4xx error + header-missing paths.
   - `tests/test_litellm/integrations/test_otel_guardrail_provider_request_id.py` (3 tests):
     OTEL span attribute is emitted when set, omitted when `None`, omitted when empty string.

## Scope guardrails

- No API surface change. The new field is `total=False` on a TypedDict so existing
  callers/consumers that don't know about it ignore it cleanly.
- No schema / DB migration.
- Helper is total (never raises) and falls back to "no field" when extraction fails —
  if the AWS SDK ever stops returning the header, the existing log payload is unchanged.
- OTEL change only emits the attribute when the value is truthy, so existing dashboards
  built on guardrail spans are unaffected.

### Evidence

Driving `BedrockGuardrail.make_bedrock_api_request` against a captured Bedrock
ApplyGuardrail response (200 with `x-amzn-RequestId: 7c1f8a4d-…`), then dumping the
`StandardLoggingGuardrailInformation` payload LiteLLM forwards to Langfuse / Datadog /
OTEL / spend-logs.

**BEFORE** (clean `litellm_oss_agent_shin_daily_branch` @ `1fe911d`):
```
[repro] guardrail intervened (expected): HTTPException
{
  "guardrail_provider": "bedrock",
  "guardrail_status": "guardrail_intervened",
  "guardrail_action": "GUARDRAIL_INTERVENED",
  "violation_categories": ["Financial Advice"],
  "provider_request_id": null
}
```

**AFTER** (this branch):
```
[repro] guardrail intervened (expected): HTTPException
{
  "guardrail_provider": "bedrock",
  "guardrail_status": "guardrail_intervened",
  "guardrail_action": "GUARDRAIL_INTERVENED",
  "violation_categories": ["Financial Advice"],
  "provider_request_id": "7c1f8a4d-4b8a-4f9a-9d1c-0c2e1a8b3f47"
}
```

Test results (local):
```
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_request_id.py
.............15 passed in 7.94s

tests/test_litellm/integrations/test_otel_guardrail_provider_request_id.py
...3 passed in 7.93s

tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py  (regression)
........................................................56 passed in 8.34s

tests/test_litellm/integrations/test_otel_guardrail_violation_spans.py  (regression)
..............14 passed in 8.59s
```

### Notes for reviewers

- PR was pushed via the GitHub Contents API (one PUT per file) because this agent's
  `GITHUB_TOKEN` lacks `repo` + `workflow` scopes. The merge-base diff may therefore
  look noisier than a fast-forward; the actual change is 5 files (3 source + 2 test).
- Targets `litellm_oss_agent_shin_daily_branch` per fork policy.

Linear: LIT-3391


### Verification (ship-pr)

- ✅ Base branch: `litellm_oss_agent_shin_daily_branch` (per fork policy)
- ✅ GitHub Actions: **44/44 green** at head `2bb915c3ccff2220d2e12990d51157620d25e095` (lint, code-quality, ruff, every unit-test shard, build-ui, semgrep, secret-scan, both `test-server-root-path` variants, Verify PR source branch, etc.)
- ✅ Greptile: **5/5** — "Safe to merge — all changes are additive and backward-compatible; the previously flagged unreachable tuple entry has been cleanly removed."
- ✅ Veria AI - PR Review: success — "No security issues found"
- ✅ Codecov: patch coverage passing after second push
- ✅ Mergeable: yes
- ✅ Customer-name check: no customer name anywhere in the PR title, body, branch name, commit messages, or new code/tests
- ✅ Unit tests: 18 new (15 bedrock + 3 OTEL) + 70 existing regression tests (56 bedrock + 14 OTEL) all green locally
- ✅ Runtime evidence: BEFORE / AFTER captured against a real `make_bedrock_api_request` call with a mocked Bedrock response carrying `x-amzn-RequestId`; the `StandardLoggingGuardrailInformation` payload changes from `provider_request_id: null` -> `provider_request_id: "7c1f8a4d-…"`
