### PR TITLE
fix(guardrails): return HTTP 400 (not 403) on content filter violations (LIT-3095)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1202,7 +1202,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "category": category_name,
@@ -1242,7 +1242,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "category": category_name,
@@ -1285,7 +1285,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             error_msg = f"Content blocked: {pattern_name} pattern detected"
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={"error": error_msg, "pattern": pattern_name},
             )
         elif action == ContentFilterAction.MASK:
@@ -1325,7 +1325,7 @@ class ContentFilterGuardrail(CustomGuardrail):
                 error_msg += f" ({description})"
             verbose_proxy_logger.warning(error_msg)
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": error_msg,
                     "keyword": keyword,
@@ -1677,7 +1677,7 @@ class ContentFilterGuardrail(CustomGuardrail):
                 "ContentFilterGuardrail: competitor intent refuse - %s", intent_val
             )
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": msg,
                     "intent": intent_val,

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
@@ -59,7 +59,7 @@ def _run(checker, text: str) -> dict:
         checker.check(text)
         return {"decision": "ALLOW", "score": 0.0, "matched_topic": None}
     except HTTPException as e:
-        if e.status_code == 403:
+        if e.status_code == 400:
             detail: Dict[str, Any] = e.detail if isinstance(e.detail, dict) else {}
             return {
                 "decision": "BLOCK",
@@ -542,7 +542,7 @@ class _LlmJudgeChecker:
 
         if "BLOCK" in decision:
             raise HTTPException(
-                status_code=403,
+                status_code=400,
                 detail={
                     "error": "Content blocked by LLM judge",
                     "topic": "financial_advice",

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_competitor_intent.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_competitor_intent.py
@@ -226,7 +226,7 @@ class TestContentFilterWithCompetitorIntent:
             await guardrail.apply_guardrail(
                 inputs, request_data={}, input_type="request"
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
 
 # Exact config from litellm/proxy/_new_secret_config.yaml (lines 27-53).

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -198,7 +198,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "us_ssn" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -563,7 +563,7 @@ class TestContentFilterGuardrail:
             ):
                 pass
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "us_ssn" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -1010,7 +1010,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "danger_word" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
@@ -1298,7 +1298,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
         if isinstance(detail, dict):
             assert detail.get("category") == "harm_toxic_abuse"
@@ -1327,7 +1327,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
         if isinstance(detail, dict):
             assert detail.get("category") == "harm_toxic_abuse"
@@ -1375,7 +1375,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1443,7 +1443,7 @@ class TestContentFilterGuardrail:
                 input_type="request",
             )
 
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "te*st" in str(exc_info.value.detail)
 
     def test_check_category_keywords_asterisk_pattern_matching(self):
@@ -1510,7 +1510,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1560,7 +1560,7 @@ class TestContentFilterGuardrail:
                     input_type="request",
                 )
 
-            assert exc_info.value.status_code == 403, f"Failed to block: '{test_input}'"
+            assert exc_info.value.status_code == 400, f"Failed to block: '{test_input}'"
             detail = exc_info.value.detail
             if isinstance(detail, dict):
                 assert detail.get("category") == "harm_toxic_abuse"
@@ -1646,7 +1646,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block Spanish: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1683,7 +1683,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block French: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1720,7 +1720,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block German: '{test_input}'"
 
     @pytest.mark.asyncio
@@ -1766,7 +1766,7 @@ class TestContentFilterGuardrail:
                 )
 
             assert (
-                exc_info.value.status_code == 403
+                exc_info.value.status_code == 400
             ), f"Failed to block Australian: '{test_input}'"
 
     async def test_html_tags_in_messages_not_blocked(self):
@@ -1942,7 +1942,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "harmful_child_safety" in str(exc_info.value.detail)
 
         # Test case 2: Should BLOCK - identifier + block word combination
@@ -1956,7 +1956,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 3: Should BLOCK - explicit content + minors
         with pytest.raises(HTTPException) as exc_info:
@@ -1967,7 +1967,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 4: Should NOT block - identifier word alone (no block word)
         result = await guardrail.apply_guardrail(
@@ -2009,7 +2009,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_conditional_category_sentence_boundaries(self):
@@ -2093,7 +2093,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
         assert "bias_racial" in str(exc_info.value.detail)
 
         # Test case 2: Should BLOCK - identifier + dehumanizing language
@@ -2107,7 +2107,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 3: Should BLOCK - supremacist content
         with pytest.raises(HTTPException) as exc_info:
@@ -2120,7 +2120,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 4: Should BLOCK - elimination rhetoric
         with pytest.raises(HTTPException) as exc_info:
@@ -2133,7 +2133,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 5: Should NOT block - identifier word alone (no block word)
         result = await guardrail.apply_guardrail(
@@ -2171,7 +2171,7 @@ class TestContentFilterGuardrail:
                 request_data={},
                 input_type="request",
             )
-        assert exc_info.value.status_code == 403
+        assert exc_info.value.status_code == 400
 
         # Test case 9: Should NOT block - block word alone (no identifier)
         result = await guardrail.apply_guardrail(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_lit_3095_status_code_400.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_lit_3095_status_code_400.py
@@ -117,21 +117,50 @@ async def test_lit_3095_pattern_match_returns_400():
 
 def test_lit_3095_no_403_left_in_content_filter_raise_sites():
     """
-    Static guard: there should be zero `raise HTTPException(status_code=403, ...)`
-    sites left in content_filter.py. Any future regression that re-introduces a
-    403 will fail this test immediately, independent of category coverage.
+    Static guard: there should be zero `raise HTTPException(... status_code=403 ...)`
+    sites left in content_filter.py — neither multi-line, single-line, nor reordered.
+    Any future regression that re-introduces a 403 will fail this test immediately,
+    independent of category coverage.
+
+    Uses an AST walk to find every `raise` statement whose value is a Call to
+    `HTTPException` (or `fastapi.HTTPException`) with `status_code=403` passed
+    either as a keyword argument or as the first positional argument. This catches
+    multi-line, single-line, and any future stylistic reordering of the raise.
     """
-    import re
+    import ast
 
     from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter import (
         content_filter as _module,
     )
 
     src = open(_module.__file__).read()
-    matches = re.findall(
-        r"raise HTTPException\(\s*\n\s*status_code=403,", src
-    )
-    assert matches == [], (
-        f"LIT-3095 regression: {len(matches)} `raise HTTPException(status_code=403, ...)` "
-        f"site(s) reintroduced in content_filter.py; expected 400 for content policy violations."
+    tree = ast.parse(src)
+
+    def _is_http_exception(call_func):
+        # Either `HTTPException(...)` or `fastapi.HTTPException(...)`
+        if isinstance(call_func, ast.Name):
+            return call_func.id == "HTTPException"
+        if isinstance(call_func, ast.Attribute):
+            return call_func.attr == "HTTPException"
+        return False
+
+    def _is_403(call):
+        # status_code passed as kw
+        for kw in call.keywords:
+            if kw.arg == "status_code" and isinstance(kw.value, ast.Constant) and kw.value.value == 403:
+                return True
+        # HTTPException(status_code, detail) positional form
+        if call.args and isinstance(call.args[0], ast.Constant) and call.args[0].value == 403:
+            return True
+        return False
+
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+            if _is_http_exception(node.exc.func) and _is_403(node.exc):
+                offenders.append(node.lineno)
+
+    assert offenders == [], (
+        f"LIT-3095 regression: HTTPException(status_code=403) raised at line(s) "
+        f"{offenders} in content_filter.py; expected 400 for content policy violations."
     )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_lit_3095_status_code_400.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_lit_3095_status_code_400.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for LIT-3095:
+litellm_content_filter guardrail must raise HTTPException with status_code=400
+(invalid request — content policy violation), NOT 403 (forbidden / auth failure)
+when content is blocked.
+
+This aligns the built-in `litellm_content_filter` with:
+- `litellm.exceptions.GuardrailRaisedException` (default status_code=400)
+- `litellm.exceptions.BlockedPiiEntityError` (default status_code=400)
+- `litellm.integrations.custom_guardrail.CustomGuardrail._is_guardrail_intervention`
+  which classifies HTTPException(status_code=400) as an intentional block
+  (guardrail_intervened in logs) rather than guardrail_failed_to_respond.
+
+Bug was reported on `nsfw-self-harm-filter-basic` (a basic harmful_self_harm
+content filter) returning HTTP 403 to the client when a pre_call guardrail fired.
+Fix: every `raise HTTPException(status_code=403, ...)` inside content_filter.py
+was changed to `status_code=400`.
+"""
+
+import os
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (  # noqa: E402
+    ContentFilterGuardrail,
+)
+
+
+@pytest.mark.asyncio
+async def test_lit_3095_category_keyword_block_returns_400():
+    """
+    Reproduces the ticket: pre_call content filter on `harmful_self_harm` blocks
+    "I want to kill myself" and the raised HTTPException must be 400 (not 403).
+    """
+    guardrail = ContentFilterGuardrail(
+        guardrail_name="nsfw-self-harm-filter-basic",
+        categories=[
+            {
+                "category": "harmful_self_harm",
+                "enabled": True,
+                "action": "BLOCK",
+                "severity_threshold": "medium",
+            }
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["I want to kill myself"]},
+            request_data={},
+            input_type="request",
+        )
+
+    assert exc_info.value.status_code == 400, (
+        f"LIT-3095: expected 400 (invalid request — content policy violation), "
+        f"got {exc_info.value.status_code}"
+    )
+
+    detail = exc_info.value.detail
+    if isinstance(detail, dict):
+        assert detail.get("category") == "harmful_self_harm"
+        assert "kill myself" in str(detail.get("keyword", "")).lower()
+
+
+@pytest.mark.asyncio
+async def test_lit_3095_blocked_word_returns_400():
+    """Blocked-word match path (blocked_words config) must raise 400."""
+    guardrail = ContentFilterGuardrail(
+        guardrail_name="word-block",
+        blocked_words=[
+            {
+                "keyword": "forbidden-token-xyz",
+                "action": "BLOCK",
+                "description": "test sentinel",
+            }
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["this contains forbidden-token-xyz"]},
+            request_data={},
+            input_type="request",
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_lit_3095_pattern_match_returns_400():
+    """Pattern-match block path must raise 400 (not 403)."""
+    guardrail = ContentFilterGuardrail(
+        guardrail_name="pattern-block",
+        patterns=[
+            {
+                "pattern_type": "regex",
+                "name": "test_pattern",
+                "pattern": r"SECRET-\d{4}",
+                "action": "BLOCK",
+            }
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["please share SECRET-1234"]},
+            request_data={},
+            input_type="request",
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_lit_3095_no_403_left_in_content_filter_raise_sites():
+    """
+    Static guard: there should be zero `raise HTTPException(status_code=403, ...)`
+    sites left in content_filter.py. Any future regression that re-introduces a
+    403 will fail this test immediately, independent of category coverage.
+    """
+    import re
+
+    from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter import (
+        content_filter as _module,
+    )
+
+    src = open(_module.__file__).read()
+    matches = re.findall(
+        r"raise HTTPException\(\s*\n\s*status_code=403,", src
+    )
+    assert matches == [], (
+        f"LIT-3095 regression: {len(matches)} `raise HTTPException(status_code=403, ...)` "
+        f"site(s) reintroduced in content_filter.py; expected 400 for content policy violations."
+    )


### PR DESCRIPTION
## What

Built-in `litellm_content_filter` guardrail raised `HTTPException(status_code=403)` at every content-policy block site. `403 Forbidden` is the auth/RBAC denial code; a content-policy or guardrail violation is an **invalid request** (HTTP 400), which is the convention everything else in the guardrail stack already follows:

- `litellm.exceptions.GuardrailRaisedException` — default `status_code=400`
- `litellm.exceptions.BlockedPiiEntityError` — default `status_code=400`
- `litellm.integrations.custom_guardrail.CustomGuardrail._is_guardrail_intervention` — only classifies `HTTPException(status_code=400)` as an intentional `guardrail_intervened` event; anything else gets logged as `guardrail_failed_to_respond`. So the 403 was *also* mis-classifying every block as a guardrail failure in downstream observability.

This PR changes every `raise HTTPException(status_code=403, ...)` inside `content_filter.py` to `status_code=400` (5 sites: conditional-match, category-keyword, pattern, blocked-word, competitor-intent). Test fixtures and the eval helper that asserted the old 403 are updated to assert 400.

Fixes LIT-3095.

## Files

- `litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py` — 5 raise sites flipped 403 → 400
- `litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py` — eval block raise + downstream check both moved to 400
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py` — 22 assertion updates
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_competitor_intent.py` — 1 assertion update
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_lit_3095_status_code_400.py` — **new** regression file:
  - reproduces the ticket scenario (`harmful_self_harm` category, `"I want to kill myself"` → 400)
  - covers all three remaining block paths (category-keyword, blocked-word, pattern)
  - includes a static AST-style guard (`re.findall` against the module source) that fails immediately if any future commit reintroduces a `raise HTTPException(status_code=403, ...)` site in `content_filter.py`

## How the bug surfaced

The ticket screenshot shows a `pre_call` content filter named `nsfw-self-harm-filter-basic` (a basic `harmful_self_harm` filter) returning HTTP 403 with body `"code":"403"` to the client. Reproduced verbatim on a clean proxy below.

### Evidence

#### BEFORE — clean `litellm_oss_agent_shin_daily_branch` HEAD `1fe911d`

`/health/readiness` 200. Drive the ticket payload through the same `pre_call` guardrail (`harmful_self_harm`, action: BLOCK):

```
$ curl -s -w "\nHTTP_STATUS:%{http_code}\n" \
    -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
    -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini-fake","messages":[{"role":"user","content":"I want to kill myself"}]}'
{"error":{"message":"Content blocked: harmful_self_harm category keyword 'kill myself' detected (severity: high)","type":"None","param":"None","code":"403","provider_specific_fields":{"error":"Content blocked: harmful_self_harm category keyword 'kill myself' detected (severity: high)","category":"harmful_self_harm","keyword":"kill myself","severity":"high","guardrail_name":"nsfw-self-harm-filter-basic","guardrail_mode":"pre_call"}}}
HTTP_STATUS:403
```

`HTTP_STATUS:403` and body `"code":"403"`. Matches the ticket.

#### AFTER — same proxy, same request, same config, this PR applied

```
$ curl -s -w "\nHTTP_STATUS:%{http_code}\n" \
    -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
    -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini-fake","messages":[{"role":"user","content":"I want to kill myself"}]}'
{"error":{"message":"Content blocked: harmful_self_harm category keyword 'kill myself' detected (severity: high)","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: harmful_self_harm category keyword 'kill myself' detected (severity: high)","category":"harmful_self_harm","keyword":"kill myself","severity":"high","guardrail_name":"nsfw-self-harm-filter-basic","guardrail_mode":"pre_call"}}}
HTTP_STATUS:400
```

`HTTP_STATUS:400` and body `"code":"400"`. Detection detail, guardrail name, category and keyword are all preserved — only the status surface changes.

## Tests

```
$ python3 -m pytest \
    tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_lit_3095_status_code_400.py \
    tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py \
    tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_competitor_intent.py \
    -q
77 passed in 38.71s
```

(4 new LIT-3095 regression tests + 73 existing tests updated to assert 400.)

## Notes

- Pushed via the Git Data API (blobs → tree → commit → ref) instead of `git push`; reviewers should see a single clean commit on top of the daily branch's current head.
- No public-facing schema or contract change beyond the HTTP status: error body shape, `category`, `keyword`, `severity`, `guardrail_name`, `guardrail_mode` are all identical between BEFORE and AFTER.

Closes LIT-3095.


### Verification (ship-pr)

- **mergeable_state:** `clean`
- **GitHub Actions:** **44/44 green** at head `885a69a` (every unit-test shard, lint, mypy, semgrep, secret-scan, `test-server-root-path` x2, validate-model-prices-json, build-ui, documentation, Codecov patch ✓ all modified lines covered)
- **Greptile:** **4/5** — "Safe to merge after confirming that no deployed clients are handling content-filter responses by checking for HTTP 403 specifically." The single P2 (static-guard regex coverage gap on single-line raise forms) was addressed in commit `885a69a` by switching the guard from a regex to a full `ast.walk` over `Raise(Call(HTTPException, ..., status_code=403, ...))`, which matches multi-line, single-line, positional and keyword-argument forms.
- **Veria AI - PR Review:** ✅ success (no findings)
- **Base branch:** `litellm_oss_agent_shin_daily_branch` (per fork policy — Verify PR source branch check ✓)
- **Diff:** 5 files changed, 167 insertions, 30 deletions; no generated artifacts.
- **Push method:** Git Data API (blobs → tree → commit → ref). One commit per logical change.
- **Customer-name leakage check:** none — Linear ticket has no project assigned, repro uses generic `gpt-4o-mini-fake` and a public content-policy keyword; PR body, commit messages, and test file mention only `LIT-3095` and the bug class.
