### PR TITLE
fix(a2a): allow LiteLLMSendMessageResponse.id to be str | int | None (LIT-2818)

### DIFF
--- a/litellm/types/agents.py
+++ b/litellm/types/agents.py
@@ -307,7 +307,16 @@ class LiteLLMSendMessageResponse(LiteLLMPydanticObjectBase):
     """
 
     # A2A response fields
-    id: str
+    #
+    # Per JSON-RPC 2.0, the response ``id`` MAY be a string, a number, or
+    # ``null`` (an error response that could not be correlated to a request
+    # MUST use ``null``). The upstream a2a SDK matches this contract with
+    # ``id: str | int | None = None`` on both ``SendMessageSuccessResponse``
+    # and ``JSONRPCErrorResponse``. Pinning ``id: str`` (required) here
+    # made the proxy raise ``ValidationError`` on legitimate JSON-RPC error
+    # responses (numeric or null id), surfacing as a 500 on the
+    # error-response path. Track the SDK contract instead.
+    id: Optional[Union[str, int]] = None
     jsonrpc: str = "2.0"
     result: Optional[Dict[str, Any]] = None
     error: Optional[Dict[str, Any]] = None

--- a/tests/test_litellm/a2a_protocol/test_send_message_response_id_lit2818.py
+++ b/tests/test_litellm/a2a_protocol/test_send_message_response_id_lit2818.py
@@ -1,0 +1,122 @@
+"""Regression tests for LIT-2818 - LiteLLMSendMessageResponse must accept
+the full JSON-RPC 2.0 id contract: str, int, or None.
+
+Before LIT-2818, LiteLLMSendMessageResponse declared id: str (required).
+Per JSON-RPC 2.0 the response id may be a String, Number, or Null;
+error responses that could not be correlated to a request MUST use null.
+The upstream a2a SDK (a2a-sdk==0.3.24) reflects this on both
+SendMessageSuccessResponse and JSONRPCErrorResponse:
+    id: str | int | None = None
+Pinning id: str (required) here made the proxy raise a Pydantic
+ValidationError whenever an upstream agent returned a legitimate JSON-RPC
+error response with a numeric or null id - surfacing as a 500.
+"""
+
+from typing import Any, Dict
+
+import pytest
+from pydantic import ValidationError
+
+from litellm.types.agents import LiteLLMSendMessageResponse
+
+
+def test_lit2818_constructor_accepts_string_id():
+    r = LiteLLMSendMessageResponse(
+        id="req-abc-123",
+        result={"kind": "task", "id": "task-1"},
+    )
+    assert r.id == "req-abc-123"
+    assert r.jsonrpc == "2.0"
+
+
+def test_lit2818_constructor_accepts_integer_id():
+    # Per JSON-RPC 2.0 id may be a Number. Pre-fix raised:
+    # ValidationError: Input should be a valid string.
+    r = LiteLLMSendMessageResponse(
+        id=42,
+        result={"kind": "message"},
+    )
+    assert r.id == 42
+
+
+def test_lit2818_constructor_accepts_null_id():
+    # JSON-RPC 2.0: error responses that could not be correlated to a
+    # request MUST use null id.
+    r = LiteLLMSendMessageResponse(
+        id=None,
+        error={"code": -32700, "message": "Parse error"},
+    )
+    assert r.id is None
+
+
+def test_lit2818_constructor_accepts_missing_id_defaults_to_none():
+    r = LiteLLMSendMessageResponse(
+        error={"code": -32600, "message": "Invalid Request"},
+    )
+    assert r.id is None
+
+
+def _error_response_dict(rpc_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": rpc_id,
+        "error": {"code": -32603, "message": "Internal error"},
+    }
+
+
+@pytest.mark.parametrize(
+    "rpc_id",
+    [
+        "req-error-1",
+        42,
+        None,
+    ],
+)
+def test_lit2818_from_dict_error_response_accepts_all_jsonrpc_id_shapes(rpc_id):
+    r = LiteLLMSendMessageResponse.from_dict(_error_response_dict(rpc_id))
+    assert r.id == rpc_id
+    assert r.error is not None
+    assert r.error["code"] == -32603
+
+
+def test_lit2818_from_dict_omitted_id_does_not_raise():
+    r = LiteLLMSendMessageResponse.from_dict(
+        {
+            "jsonrpc": "2.0",
+            "error": {"code": -32700, "message": "Parse error"},
+        }
+    )
+    assert r.id is None
+    assert r.error["code"] == -32700
+
+
+def _build_jsonrpc_error_response(rpc_id):
+    from a2a.types import JSONRPCError, JSONRPCErrorResponse, SendMessageResponse
+
+    err = JSONRPCErrorResponse(
+        id=rpc_id,
+        error=JSONRPCError(code=-32603, message="Internal error"),
+    )
+    return SendMessageResponse(root=err)
+
+
+@pytest.mark.parametrize("rpc_id", ["req-1", 7, None])
+def test_lit2818_from_a2a_response_error_path(rpc_id):
+    sdk_response = _build_jsonrpc_error_response(rpc_id)
+    wrapped = LiteLLMSendMessageResponse.from_a2a_response(sdk_response)
+    assert wrapped.id == rpc_id
+    assert wrapped.error is not None
+    assert wrapped.error["code"] == -32603
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        12.34,
+        ["arr"],
+        {"o": "bj"},
+    ],
+)
+def test_lit2818_constructor_still_rejects_invalid_id_shapes(bad_id):
+    with pytest.raises(ValidationError):
+        LiteLLMSendMessageResponse(id=bad_id)


### PR DESCRIPTION
## Summary

Relax `LiteLLMSendMessageResponse.id` from `str` (required) to `Optional[Union[str, int]] = None` to match the JSON-RPC 2.0 spec and the
upstream a2a SDK (`a2a-sdk==0.3.24`).

### Linear
LIT-2818 — "Investigate LiteLLM error-response validation failure for A2A".

## Root cause

`LiteLLMSendMessageResponse` in `litellm/types/agents.py:301` wraps the
upstream a2a SDK’s `SendMessageResponse`. Per JSON-RPC 2.0 §4 / §5, the
response `id` is a `String | Number | Null` value, and error responses that
could not be correlated to a request **MUST** use `null`. The upstream a2a
SDK (`a2a-sdk==0.3.24`) reflects this:

```python
# from a2a/types/__init__.py
class SendMessageSuccessResponse(...):
    id: str | int | None = None

class JSONRPCErrorResponse(...):
    id: str | int | None = None
```

Pre-fix, `LiteLLMSendMessageResponse.id: str` (required) rejected three
shapes the SDK accepts:

1. `id` is a **number** (per spec, `id` MAY be a Number).
2. `id` is **null** (per spec, error responses that could not be correlated
   to a request MUST use `null`).
3. `id` is **missing** — produced by a `model_dump(exclude_none=True)`
   roundtrip on a `null`-id response (this is exactly the path
   `litellm.a2a_protocol.main.asend_message` takes:
   `a2a_response.model_dump(mode="json", exclude_none=True)` →
   `LiteLLMSendMessageResponse.from_a2a_response`).

The success path (`result.kind="task"` / `"message"`) passes because
production agents echo the client’s string `id`. The error-response path
(e.g. upstream JSON parse error or generic `Internal error`) fails Pydantic
validation, which the proxy surfaces as a 500 — matching the report on
LiteLLM `v1.82.0`.

## Fix

Single-field change in `litellm/types/agents.py:LiteLLMSendMessageResponse`:

```python
# before
id: str

# after
id: Optional[Union[str, int]] = None
```

Matches `SendMessageSuccessResponse.id` and `JSONRPCErrorResponse.id` on the
pinned SDK version (`a2a-sdk==0.3.24`). No callers rely on `id` being a
non-None string — grep across `litellm/` shows it is only assigned/round-tripped
through to the response object.

## Evidence

Direct reproduction against the two production code paths
(`LiteLLMSendMessageResponse.from_dict` used by
`_send_message_via_completion_bridge`, and
`LiteLLMSendMessageResponse.from_a2a_response` used by `asend_message`) on
the same checkout (`litellm_oss_agent_shin_daily_branch` HEAD `1fe911d`) —
first without the patch, then with the patch.

### Before (clean `litellm_oss_agent_shin_daily_branch`)

```text
--- from_dict, id=str (success path)
  OK  -> LiteLLMSendMessageResponse(id='req-1', error={'code': -32603, 'message': 'Internal error'})
--- from_dict, id=int (JSON-RPC 2.0 numeric id)
  FAIL -> ValidationError: 1 validation error for LiteLLMSendMessageResponse
--- from_dict, id=None (JSON-RPC 2.0 parse-error)
  FAIL -> ValidationError: 1 validation error for LiteLLMSendMessageResponse
--- from_dict, id omitted (model_dump exclude_none roundtrip)
  FAIL -> ValidationError: 1 validation error for LiteLLMSendMessageResponse
--- from_a2a_response, id=str
  OK  -> LiteLLMSendMessageResponse(id='req-1', error={'code': -32603, 'message': 'Internal error'})
--- from_a2a_response, id=int
  FAIL -> ValidationError: 1 validation error for LiteLLMSendMessageResponse
--- from_a2a_response, id=None
  FAIL -> ValidationError: 1 validation error for LiteLLMSendMessageResponse

SUMMARY: 2/7 cases accepted by LiteLLMSendMessageResponse
```

### After (this PR)

```text
--- from_dict, id=str (success path)
  OK  -> LiteLLMSendMessageResponse(id='req-1', error={'code': -32603, 'message': 'Internal error'})
--- from_dict, id=int (JSON-RPC 2.0 numeric id)
  OK  -> LiteLLMSendMessageResponse(id=42, error={'code': -32603, 'message': 'Internal error'})
--- from_dict, id=None (JSON-RPC 2.0 parse-error)
  OK  -> LiteLLMSendMessageResponse(id=None, error={'code': -32603, 'message': 'Internal error'})
--- from_dict, id omitted (model_dump exclude_none roundtrip)
  OK  -> LiteLLMSendMessageResponse(id=None, error={'code': -32603, 'message': 'Internal error'})
--- from_a2a_response, id=str
  OK  -> LiteLLMSendMessageResponse(id='req-1', error={'code': -32603, 'message': 'Internal error'})
--- from_a2a_response, id=int
  OK  -> LiteLLMSendMessageResponse(id=7, error={'code': -32603, 'message': 'Internal error'})
--- from_a2a_response, id=None
  OK  -> LiteLLMSendMessageResponse(id=None, error={'code': -32603, 'message': 'Internal error'})

SUMMARY: 7/7 cases accepted by LiteLLMSendMessageResponse
```

All five previously-rejected JSON-RPC error-response shapes
(numeric id, null id, omitted id across both code paths) are now accepted.
The success path (string id) is unchanged.

## Tests

Added `tests/test_litellm/a2a_protocol/test_send_message_response_id_lit2818.py`
with 14 cases covering:

- Constructor: `id` is string, int, None, or missing.
- `from_dict(...)`: all three JSON-RPC `id` shapes + omitted-id roundtrip.
- `from_a2a_response(...)`: real `a2a.types.SendMessageResponse(root=
  JSONRPCErrorResponse(...))` payloads for each `id` shape — exercises the
  same `model_dump(exclude_none=True)` roundtrip the proxy takes.
- Negative guards: `float`, `list`, `dict` ids are still rejected (we only
  widened the **allowed** set, did not loosen type-checking).

Full `tests/test_litellm/a2a_protocol/` suite: **41 passed**.

## Notes

Pushed via Git Data API (blobs → tree → commit → ref) against the upstream
base tree, so the merge-base diff should be exactly the two files above.


### Verification (ship-pr)

| Check | Result |
|---|---|
| Base branch is `litellm_oss_agent_shin_daily_branch` | PASS (target: `litellm_oss_agent_shin_daily_branch`) |
| All GitHub Actions green | PASS (44/44 success, 0 failures) |
| Greptile review >= 4/5 | PASS (5/5 — "Safe to merge") |
| Veria AI review | PASS ("No security issues found") |
| Codecov patch coverage | PASS (100% on modified lines) |
| Runtime evidence captured (before + after) | PASS (see Evidence section above) |
| Unit tests added with the fix | PASS (14 tests in `tests/test_litellm/a2a_protocol/test_send_message_response_id_lit2818.py`, full a2a_protocol suite 41 passed) |
| `mergeable_state` clean | PASS |
| No customer name in PR title/body | PASS |
| Diff scope matches task | PASS (2 files: `litellm/types/agents.py` +10/-1, new regression test file) |
