### PR TITLE
fix(rate-limiter): key model RPM/TPM override takes precedence over team (LIT-2792)

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1309,9 +1309,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         key_metadata = user_api_key_dict.metadata or {}
         key_model_rpm = key_metadata.get("model_rpm_limit") or {}
         key_model_tpm = key_metadata.get("model_tpm_limit") or {}
-        if (
-            isinstance(key_model_rpm, dict) and requested_model in key_model_rpm
-        ) or (
+        if (isinstance(key_model_rpm, dict) and requested_model in key_model_rpm) or (
             isinstance(key_model_tpm, dict) and requested_model in key_model_tpm
         ):
             return True
@@ -1320,8 +1318,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         if isinstance(key_model_max_budget, dict):
             entry = key_model_max_budget.get(requested_model)
             if isinstance(entry, dict) and (
-                entry.get("rpm_limit") is not None
-                or entry.get("tpm_limit") is not None
+                entry.get("rpm_limit") is not None or entry.get("tpm_limit") is not None
             ):
                 return True
 

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1281,6 +1281,52 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
         return descriptors
 
+    def _key_has_model_specific_override(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        requested_model: Optional[str],
+    ) -> bool:
+        """
+        Return True if the API key has its own model-specific rate-limit override
+        for requested_model.
+
+        A key override is recognised when requested_model is present as a key
+        in any of:
+
+        * user_api_key_dict.metadata[model_rpm_limit]
+        * user_api_key_dict.metadata[model_tpm_limit]
+        * user_api_key_dict.model_max_budget (with rpm_limit or
+          tpm_limit set in the per-model budget dict)
+
+        When this is True, the key-level override is treated as authoritative
+        for the requested model and the team-level model_rpm_limit /
+        model_tpm_limit value for the same model is intentionally skipped so
+        the team value cannot clamp below the key override (LIT-2792).
+        """
+        if not requested_model:
+            return False
+
+        key_metadata = user_api_key_dict.metadata or {}
+        key_model_rpm = key_metadata.get("model_rpm_limit") or {}
+        key_model_tpm = key_metadata.get("model_tpm_limit") or {}
+        if (
+            isinstance(key_model_rpm, dict) and requested_model in key_model_rpm
+        ) or (
+            isinstance(key_model_tpm, dict) and requested_model in key_model_tpm
+        ):
+            return True
+
+        key_model_max_budget = user_api_key_dict.model_max_budget or {}
+        if isinstance(key_model_max_budget, dict):
+            entry = key_model_max_budget.get(requested_model)
+            if isinstance(entry, dict) and (
+                entry.get("rpm_limit") is not None
+                or entry.get("tpm_limit") is not None
+            ):
+                return True
+
+        return False
+
     def _add_model_per_key_rate_limit_descriptor(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -1623,44 +1669,11 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             descriptors=descriptors,
         )
 
-        if (
-            get_team_model_rpm_limit(user_api_key_dict) is not None
-            or get_team_model_tpm_limit(user_api_key_dict) is not None
-        ):
-            _tpm_limit_for_team_model = (
-                get_team_model_tpm_limit(user_api_key_dict) or {}
-            )
-            _rpm_limit_for_team_model = (
-                get_team_model_rpm_limit(user_api_key_dict) or {}
-            )
-            should_check_rate_limit = False
-            if requested_model in _tpm_limit_for_team_model:
-                should_check_rate_limit = True
-            elif requested_model in _rpm_limit_for_team_model:
-                should_check_rate_limit = True
-
-            if should_check_rate_limit:
-                model_specific_tpm_limit = None
-                model_specific_rpm_limit = None
-                if requested_model in _tpm_limit_for_team_model:
-                    model_specific_tpm_limit = _tpm_limit_for_team_model[
-                        requested_model
-                    ]
-                if requested_model in _rpm_limit_for_team_model:
-                    model_specific_rpm_limit = _rpm_limit_for_team_model[
-                        requested_model
-                    ]
-                descriptors.append(
-                    RateLimitDescriptor(
-                        key="model_per_team",
-                        value=f"{user_api_key_dict.team_id}:{requested_model}",
-                        rate_limit={
-                            "requests_per_unit": model_specific_rpm_limit,
-                            "tokens_per_unit": model_specific_tpm_limit,
-                            "window_size": self.window_size,
-                        },
-                    )
-                )
+        # NB: the team-level model_per_team descriptor is appended later by
+        # _add_team_model_rate_limit_descriptor_from_metadata, which is called
+        # from async_pre_call_hook after this function returns. It also honours
+        # the LIT-2792 key-override precedence rule via
+        # _key_has_model_specific_override.
 
         # Agent-level and session-level rate limits
         resolved_agent_id = self._get_resolved_agent_id(user_api_key_dict, data)
@@ -1744,7 +1757,20 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         requested_model: Optional[str],
         descriptors: List[RateLimitDescriptor],
     ) -> None:
-        """Add team model rate limit descriptor from team_metadata if applicable."""
+        """Add team model rate limit descriptor from team_metadata if applicable.
+
+        LIT-2792: when the API key has its own model-specific override for the
+        requested model (see _key_has_model_specific_override), the team-level
+        model_rpm_limit / model_tpm_limit value for the same model is
+        intentionally skipped so the team value cannot clamp below the key
+        override.
+        """
+        if self._key_has_model_specific_override(
+            user_api_key_dict=user_api_key_dict,
+            requested_model=requested_model,
+        ):
+            return
+
         if (
             get_model_rate_limit_from_metadata(
                 user_api_key_dict, "team_metadata", "model_rpm_limit"

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1555,11 +1555,6 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         Returns list of descriptors for API key, user, team, team member, end user,
         model-specific, agent, and agent-session limits.
         """
-        from litellm.proxy.auth.auth_utils import (
-            get_team_model_rpm_limit,
-            get_team_model_tpm_limit,
-        )
-
         descriptors = []
 
         # API Key rate limits

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1285,44 +1285,46 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         self,
         user_api_key_dict: UserAPIKeyAuth,
         requested_model: Optional[str],
-    ) -> bool:
+    ) -> Tuple[bool, bool]:
         """
-        Return True if the API key has its own model-specific rate-limit override
-        for requested_model.
+        Return ``(rpm_override, tpm_override)`` — whether the API key has its
+        own model-specific RPM / TPM override for ``requested_model``.
 
-        A key override is recognised when requested_model is present as a key
-        in any of:
+        A dimension override is recognised when ``requested_model`` is present in:
 
-        * user_api_key_dict.metadata[model_rpm_limit]
-        * user_api_key_dict.metadata[model_tpm_limit]
-        * user_api_key_dict.model_max_budget (with rpm_limit or
-          tpm_limit set in the per-model budget dict)
+        * ``user_api_key_dict.metadata["model_rpm_limit"]`` (RPM)
+        * ``user_api_key_dict.metadata["model_tpm_limit"]`` (TPM)
+        * ``user_api_key_dict.model_max_budget[requested_model]`` — ``rpm_limit``
+          contributes to RPM, ``tpm_limit`` to TPM.
 
-        When this is True, the key-level override is treated as authoritative
-        for the requested model and the team-level model_rpm_limit /
-        model_tpm_limit value for the same model is intentionally skipped so
-        the team value cannot clamp below the key override (LIT-2792).
+        The two dimensions are tracked independently so the team-level
+        model-specific value for the OTHER dimension is not silently dropped
+        when the key overrides only one of RPM / TPM (LIT-2792).
         """
         if not requested_model:
-            return False
+            return False, False
+
+        rpm_override = False
+        tpm_override = False
 
         key_metadata = user_api_key_dict.metadata or {}
         key_model_rpm = key_metadata.get("model_rpm_limit") or {}
         key_model_tpm = key_metadata.get("model_tpm_limit") or {}
-        if (isinstance(key_model_rpm, dict) and requested_model in key_model_rpm) or (
-            isinstance(key_model_tpm, dict) and requested_model in key_model_tpm
-        ):
-            return True
+        if isinstance(key_model_rpm, dict) and requested_model in key_model_rpm:
+            rpm_override = True
+        if isinstance(key_model_tpm, dict) and requested_model in key_model_tpm:
+            tpm_override = True
 
         key_model_max_budget = user_api_key_dict.model_max_budget or {}
         if isinstance(key_model_max_budget, dict):
             entry = key_model_max_budget.get(requested_model)
-            if isinstance(entry, dict) and (
-                entry.get("rpm_limit") is not None or entry.get("tpm_limit") is not None
-            ):
-                return True
+            if isinstance(entry, dict):
+                if entry.get("rpm_limit") is not None:
+                    rpm_override = True
+                if entry.get("tpm_limit") is not None:
+                    tpm_override = True
 
-        return False
+        return rpm_override, tpm_override
 
     def _add_model_per_key_rate_limit_descriptor(
         self,
@@ -1757,15 +1759,20 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         """Add team model rate limit descriptor from team_metadata if applicable.
 
         LIT-2792: when the API key has its own model-specific override for the
-        requested model (see _key_has_model_specific_override), the team-level
-        model_rpm_limit / model_tpm_limit value for the same model is
-        intentionally skipped so the team value cannot clamp below the key
-        override.
+        requested model on a given dimension (RPM / TPM), only THAT dimension
+        of the team-level descriptor is suppressed so the team value cannot
+        clamp below the key override. The other dimension of the team-level
+        descriptor is preserved so partial key overrides (e.g. key sets only
+        RPM, team sets only TPM) do not silently drop the team's TPM cap.
+
+        If both dimensions are overridden by the key, no team descriptor is
+        appended.
         """
-        if self._key_has_model_specific_override(
+        key_rpm_override, key_tpm_override = self._key_has_model_specific_override(
             user_api_key_dict=user_api_key_dict,
             requested_model=requested_model,
-        ):
+        )
+        if key_rpm_override and key_tpm_override:
             return
 
         if (
@@ -1802,6 +1809,23 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 model_specific_rpm_limit = _rpm_limit_for_team_model.get(
                     requested_model
                 )
+
+                # Per-dimension key precedence: blank out only the team
+                # dimensions that the key already owns. The remaining
+                # dimension(s) still apply to the team budget.
+                if key_rpm_override:
+                    model_specific_rpm_limit = None
+                if key_tpm_override:
+                    model_specific_tpm_limit = None
+
+                # After per-dimension suppression there may be nothing left
+                # for the team to enforce on this descriptor.
+                if (
+                    model_specific_rpm_limit is None
+                    and model_specific_tpm_limit is None
+                ):
+                    return
+
                 descriptors.append(
                     RateLimitDescriptor(
                         key="model_per_team",

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -3119,3 +3119,122 @@ async def test_lit_2792_key_model_max_budget_override_suppresses_team_v3():
         "Key model_max_budget override must suppress team model_per_team, "
         f"got: {descriptor_keys}"
     )
+
+
+# --------------------------------------------------------------------------
+# LIT-2792 — Greptile follow-up: partial key override must not silently drop
+# the other dimension of the team-level model descriptor.
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_lit_2792_partial_key_override_preserves_team_other_dimension_v3():
+    """
+    LIT-2792 partial override:
+
+    - Key overrides only RPM for gpt-4 (model_rpm_limit).
+    - Team configures BOTH RPM and TPM for gpt-4.
+
+    The team's RPM dimension for gpt-4 must be suppressed (key wins per
+    LIT-2792), but the team's TPM cap for gpt-4 must still apply — otherwise
+    a key with a partial override would silently bypass the team's TPM
+    budget.
+    """
+    _api_key = hash_token("sk-lit-2792-partial-rpm-only")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors: List[Dict[str, Any]] = []
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        captured_descriptors.extend(descriptors)
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id="team-lit-2792-partial",
+        metadata={
+            "model_rpm_limit": {"gpt-4": 50},
+        },
+        team_metadata={
+            "model_rpm_limit": {"gpt-4": 10},
+            "model_tpm_limit": {"gpt-4": 1000},
+        },
+    )
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"model": "gpt-4"},
+        call_type="",
+    )
+
+    descriptor_keys = [d["key"] for d in captured_descriptors]
+    assert (
+        "model_per_team" in descriptor_keys
+    ), (
+        "Team's TPM dimension must still produce a model_per_team descriptor "
+        f"under a partial key override, got: {descriptor_keys}"
+    )
+
+    model_per_team = next(
+        d for d in captured_descriptors if d["key"] == "model_per_team"
+    )
+    # The team's RPM dimension is suppressed by the key override.
+    assert model_per_team["rate_limit"]["requests_per_unit"] is None, (
+        "Team RPM must be suppressed when key overrides RPM for gpt-4, got "
+        f"{model_per_team['rate_limit']}"
+    )
+    # The team's TPM dimension is preserved.
+    assert (
+        model_per_team["rate_limit"]["tokens_per_unit"] == 1000
+    ), f"Team TPM must remain enforced, got {model_per_team['rate_limit']}"
+
+
+@pytest.mark.asyncio
+async def test_lit_2792_partial_key_override_tpm_only_preserves_team_rpm_v3():
+    """
+    Mirror of the partial-RPM case: key overrides only TPM, team configures
+    only RPM. The team's RPM cap must remain enforced.
+    """
+    _api_key = hash_token("sk-lit-2792-partial-tpm-only")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors: List[Dict[str, Any]] = []
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        captured_descriptors.extend(descriptors)
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id="team-lit-2792-partial-tpm",
+        metadata={
+            "model_tpm_limit": {"gpt-4": 5000},
+        },
+        team_metadata={
+            "model_rpm_limit": {"gpt-4": 7},
+        },
+    )
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"model": "gpt-4"},
+        call_type="",
+    )
+
+    descriptor_keys = [d["key"] for d in captured_descriptors]
+    assert "model_per_team" in descriptor_keys, descriptor_keys
+    model_per_team = next(
+        d for d in captured_descriptors if d["key"] == "model_per_team"
+    )
+    assert model_per_team["rate_limit"]["requests_per_unit"] == 7
+    assert model_per_team["rate_limit"]["tokens_per_unit"] is None

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -2893,3 +2893,229 @@ async def test_pre_call_hook_rejects_caller_supplied_stash_values():
     ):
         leaked = [k for k in _LITELLM_STASH_KEYS if k in channel]
         assert not leaked, f"caller-supplied stash survived in {channel!r}: {leaked}"
+
+
+# --------------------------------------------------------------------------
+# LIT-2792: Key model-specific RPM/TPM override must take precedence over
+# team model-specific RPM/TPM override
+# --------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_lit_2792_key_model_override_takes_precedence_over_team_v3():
+    """
+    LIT-2792: when both a key-level metadata.model_rpm_limit override and a
+    team-level team_metadata.model_rpm_limit override exist for the same
+    model, the team descriptor must be skipped so the key override is
+    authoritative for that model.
+    """
+    _api_key = hash_token("sk-lit-2792-key-precedence")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors: List[Dict[str, Any]] = []
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        captured_descriptors.extend(descriptors)
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    # Key override: 50 RPM / 5000 TPM on gpt-4
+    # Team override: 10 RPM / 1000 TPM on gpt-4  (stricter; would clamp below key)
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id="team-lit-2792",
+        metadata={
+            "model_rpm_limit": {"gpt-4": 50},
+            "model_tpm_limit": {"gpt-4": 5000},
+        },
+        team_metadata={
+            "model_rpm_limit": {"gpt-4": 10},
+            "model_tpm_limit": {"gpt-4": 1000},
+        },
+    )
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"model": "gpt-4"},
+        call_type="",
+    )
+
+    descriptor_keys = [d["key"] for d in captured_descriptors]
+    assert (
+        "model_per_key" in descriptor_keys
+    ), f"model_per_key must still be added, got: {descriptor_keys}"
+    assert (
+        "model_per_team" not in descriptor_keys
+    ), (
+        "LIT-2792 regression: model_per_team must be SKIPPED for gpt-4 when "
+        f"the key has its own override, got: {descriptor_keys}"
+    )
+
+    # The key override values must be the ones forwarded to the rate-limit script.
+    model_per_key = next(
+        d for d in captured_descriptors if d["key"] == "model_per_key"
+    )
+    assert model_per_key["rate_limit"]["requests_per_unit"] == 50
+    assert model_per_key["rate_limit"]["tokens_per_unit"] == 5000
+
+
+@pytest.mark.asyncio
+async def test_lit_2792_team_model_limit_still_applied_for_unconstrained_model_v3():
+    """
+    LIT-2792 guardrail: the key override only suppresses the team descriptor
+    for the SAME model. If the request is for a different model that the key
+    does not constrain, the team-level model_rpm_limit/model_tpm_limit must
+    still be enforced.
+    """
+    _api_key = hash_token("sk-lit-2792-other-model")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors: List[Dict[str, Any]] = []
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        captured_descriptors.extend(descriptors)
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id="team-lit-2792-other",
+        metadata={
+            # Key only overrides gpt-4; the request below is for gpt-3.5-turbo.
+            "model_rpm_limit": {"gpt-4": 50},
+        },
+        team_metadata={
+            # Team has limits for the actually-requested model.
+            "model_rpm_limit": {"gpt-3.5-turbo": 7},
+            "model_tpm_limit": {"gpt-3.5-turbo": 700},
+        },
+    )
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"model": "gpt-3.5-turbo"},
+        call_type="",
+    )
+
+    descriptor_keys = [d["key"] for d in captured_descriptors]
+    assert (
+        "model_per_team" in descriptor_keys
+    ), (
+        "Team model limit must still apply when the key does not override the "
+        f"requested model, got: {descriptor_keys}"
+    )
+    model_per_team = next(
+        d for d in captured_descriptors if d["key"] == "model_per_team"
+    )
+    assert model_per_team["value"] == "team-lit-2792-other:gpt-3.5-turbo"
+    assert model_per_team["rate_limit"]["requests_per_unit"] == 7
+    assert model_per_team["rate_limit"]["tokens_per_unit"] == 700
+
+
+@pytest.mark.asyncio
+async def test_lit_2792_no_key_override_team_model_limit_applied_v3():
+    """
+    LIT-2792 baseline: when the key has no metadata.model_rpm_limit override
+    at all, the team-level model_rpm_limit must continue to apply (existing
+    behaviour preserved).
+    """
+    _api_key = hash_token("sk-lit-2792-no-key-override")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors: List[Dict[str, Any]] = []
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        captured_descriptors.extend(descriptors)
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id="team-lit-2792-baseline",
+        metadata={},  # no key-level model override
+        team_metadata={
+            "model_rpm_limit": {"gpt-4": 10},
+            "model_tpm_limit": {"gpt-4": 1000},
+        },
+    )
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"model": "gpt-4"},
+        call_type="",
+    )
+
+    descriptor_keys = [d["key"] for d in captured_descriptors]
+    assert (
+        "model_per_team" in descriptor_keys
+    ), (
+        "Team model_per_team must be enforced when the key does not override, "
+        f"got: {descriptor_keys}"
+    )
+    model_per_team = next(
+        d for d in captured_descriptors if d["key"] == "model_per_team"
+    )
+    assert model_per_team["rate_limit"]["requests_per_unit"] == 10
+    assert model_per_team["rate_limit"]["tokens_per_unit"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_lit_2792_key_model_max_budget_override_suppresses_team_v3():
+    """
+    LIT-2792: a key-level model_max_budget entry with rpm_limit/tpm_limit also
+    counts as a key override and suppresses the team-level model descriptor.
+    """
+    _api_key = hash_token("sk-lit-2792-budget-override")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors: List[Dict[str, Any]] = []
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        captured_descriptors.extend(descriptors)
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id="team-lit-2792-budget",
+        metadata={},  # no metadata.model_rpm_limit, but model_max_budget below
+        model_max_budget={
+            "gpt-4": {"rpm_limit": 25, "tpm_limit": 2500},
+        },
+        team_metadata={
+            "model_rpm_limit": {"gpt-4": 5},
+            "model_tpm_limit": {"gpt-4": 500},
+        },
+    )
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"model": "gpt-4"},
+        call_type="",
+    )
+
+    descriptor_keys = [d["key"] for d in captured_descriptors]
+    assert (
+        "model_per_team" not in descriptor_keys
+    ), (
+        "Key model_max_budget override must suppress team model_per_team, "
+        f"got: {descriptor_keys}"
+    )

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -2947,17 +2947,13 @@ async def test_lit_2792_key_model_override_takes_precedence_over_team_v3():
     assert (
         "model_per_key" in descriptor_keys
     ), f"model_per_key must still be added, got: {descriptor_keys}"
-    assert (
-        "model_per_team" not in descriptor_keys
-    ), (
+    assert "model_per_team" not in descriptor_keys, (
         "LIT-2792 regression: model_per_team must be SKIPPED for gpt-4 when "
         f"the key has its own override, got: {descriptor_keys}"
     )
 
     # The key override values must be the ones forwarded to the rate-limit script.
-    model_per_key = next(
-        d for d in captured_descriptors if d["key"] == "model_per_key"
-    )
+    model_per_key = next(d for d in captured_descriptors if d["key"] == "model_per_key")
     assert model_per_key["rate_limit"]["requests_per_unit"] == 50
     assert model_per_key["rate_limit"]["tokens_per_unit"] == 5000
 
@@ -3006,9 +3002,7 @@ async def test_lit_2792_team_model_limit_still_applied_for_unconstrained_model_v
     )
 
     descriptor_keys = [d["key"] for d in captured_descriptors]
-    assert (
-        "model_per_team" in descriptor_keys
-    ), (
+    assert "model_per_team" in descriptor_keys, (
         "Team model limit must still apply when the key does not override the "
         f"requested model, got: {descriptor_keys}"
     )
@@ -3059,9 +3053,7 @@ async def test_lit_2792_no_key_override_team_model_limit_applied_v3():
     )
 
     descriptor_keys = [d["key"] for d in captured_descriptors]
-    assert (
-        "model_per_team" in descriptor_keys
-    ), (
+    assert "model_per_team" in descriptor_keys, (
         "Team model_per_team must be enforced when the key does not override, "
         f"got: {descriptor_keys}"
     )
@@ -3113,9 +3105,7 @@ async def test_lit_2792_key_model_max_budget_override_suppresses_team_v3():
     )
 
     descriptor_keys = [d["key"] for d in captured_descriptors]
-    assert (
-        "model_per_team" not in descriptor_keys
-    ), (
+    assert "model_per_team" not in descriptor_keys, (
         "Key model_max_budget override must suppress team model_per_team, "
         f"got: {descriptor_keys}"
     )
@@ -3172,9 +3162,7 @@ async def test_lit_2792_partial_key_override_preserves_team_other_dimension_v3()
     )
 
     descriptor_keys = [d["key"] for d in captured_descriptors]
-    assert (
-        "model_per_team" in descriptor_keys
-    ), (
+    assert "model_per_team" in descriptor_keys, (
         "Team's TPM dimension must still produce a model_per_team descriptor "
         f"under a partial key override, got: {descriptor_keys}"
     )


### PR DESCRIPTION
## Summary

Fixes **LIT-2792**: when a model has an RPM/TPM override on both a key (`metadata.model_rpm_limit` / `metadata.model_tpm_limit`) and the team that owns the key (`team_metadata.model_rpm_limit` / `team_metadata.model_tpm_limit`), the team value clamped below the key override because both descriptors were enforced in Redis and the strictest one wins. Ticket ask: *make the key override take precedence.*

## Root cause

`litellm/proxy/hooks/parallel_request_limiter_v3.py::async_pre_call_hook` builds a list of rate-limit descriptors and forwards them all to the rate-limit script. For a key+team scenario it ended up appending **both** `model_per_key` (with the key value) **and** `model_per_team` (with the team value) — and the team descriptor was added **twice** (once inline in `_create_rate_limit_descriptors`, once via the helper `_add_team_model_rate_limit_descriptor_from_metadata`). The duplicate had been latent; it halved the effective team RPM budget on every request.

## Fix (per-dimension)

1. New helper `_key_has_model_specific_override(user_api_key_dict, requested_model) -> Tuple[bool, bool]` returns `(rpm_override, tpm_override)` — independent flags for RPM and TPM. A dimension is "overridden by the key" if `requested_model` appears in:
   - `metadata["model_rpm_limit"]` → sets `rpm_override`
   - `metadata["model_tpm_limit"]` → sets `tpm_override`
   - `model_max_budget[model].rpm_limit` (not None) → sets `rpm_override`
   - `model_max_budget[model].tpm_limit` (not None) → sets `tpm_override`
2. `_add_team_model_rate_limit_descriptor_from_metadata` now consults both flags:
   - If **both** dimensions are overridden by the key → no `model_per_team` descriptor (team fully suppressed for this model).
   - If **only RPM** is overridden → team descriptor is still appended with `requests_per_unit=None` (team RPM suppressed) and `tokens_per_unit=team_tpm` (team TPM preserved).
   - If **only TPM** is overridden → inverse: team RPM preserved, team TPM suppressed.
   - If after suppression neither dimension has a value → no descriptor (skip the noop).
3. Removed the duplicate inline team-model block in `_create_rate_limit_descriptors`. The helper invoked from `async_pre_call_hook` is now the single source of truth.

When the key does NOT override the requested model, the team-level descriptor is appended exactly as before (no regression in baseline behaviour).

Greptile-flagged edge case "key sets only RPM, team sets only TPM" is covered by the per-dimension flags + new test `test_lit_2792_partial_key_override_preserves_team_other_dimension_v3`.

## Evidence

Scenario (verbatim from LIT-2792): Key `metadata.model_rpm_limit={gpt-4: 50}`, `model_tpm_limit={gpt-4: 5000}`. Team `team_metadata.model_rpm_limit={gpt-4: 10}`, `model_tpm_limit={gpt-4: 1000}`.

**BEFORE** (clean `litellm_oss_agent_shin_daily_branch` @ `1fe911d8`):

```
Descriptors forwarded to the rate-limit script:
  - key=model_per_key   value=<key_hash>:gpt-4   rpm=50  tpm=5000
  - key=model_per_team  value=team-acme:gpt-4    rpm=10  tpm=1000
  - key=model_per_team  value=team-acme:gpt-4    rpm=10  tpm=1000   <-- duplicate

=> BUG: team descriptor present; strictest (10) wins; key override (50) has no effect.
```

End-to-end drain (60 attempts, local DualCache):

```
requests attempted: 60
allowed before 429: 5
first 429 at attempt #: 6
```

5 allowed because the duplicate `model_per_team` descriptor halved the team budget of 10.

**AFTER** (this PR):

```
Descriptors forwarded to the rate-limit script:
  - key=model_per_key   value=<key_hash>:gpt-4   rpm=50  tpm=5000

=> FIXED: team descriptor suppressed; key override (50 RPM, 5000 TPM) is authoritative.
```

End-to-end drain (same script, same scenario):

```
requests attempted: 60
allowed before 429: 50
first 429 at attempt #: 51
```

50/60 allowed before 429 — exactly matches the key override.

## Tests

Added in `tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py`:

- `test_lit_2792_key_model_override_takes_precedence_over_team_v3` — full override on RPM+TPM → team descriptor suppressed.
- `test_lit_2792_team_model_limit_still_applied_for_unconstrained_model_v3` — key overrides gpt-4 but request is for gpt-3.5-turbo → team limit on gpt-3.5-turbo still enforced.
- `test_lit_2792_no_key_override_team_model_limit_applied_v3` — key has no override → team limit enforced as before.
- `test_lit_2792_key_model_max_budget_override_suppresses_team_v3` — `model_max_budget[model].{rpm_limit, tpm_limit}` also counts as a key override.
- `test_lit_2792_partial_key_override_preserves_team_other_dimension_v3` — key sets only RPM, team sets RPM+TPM → team's RPM dimension is suppressed (None), TPM cap is preserved.
- `test_lit_2792_partial_key_override_tpm_only_preserves_team_rpm_v3` — key sets only TPM, team sets only RPM → team's RPM cap is preserved.

```
$ PYTHONPATH=. python3 -m pytest tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
================== 55 passed, 1 skipped, 13 warnings in 8.24s ==================
```

## Notes

- This PR was pushed via the GitHub Contents API (the agent git-push path was rejected as "Password authentication is not supported"). The PR is a single squashed commit containing both files; the merge-base diff is identical to what a git push would have produced.
- Base branch: `litellm_oss_agent_shin_daily_branch` per Shin fork policy.

### Verification (ship-pr)

- Base branch: `litellm_oss_agent_shin_daily_branch` ✅
- Black: `python3 -m black --check` clean on both touched files ✅
- Ruff: cleaned up unused `get_team_model_rpm_limit` / `get_team_model_tpm_limit` imports after the inline-block removal ✅
- Targeted unit tests: 6/6 new + 49/49 existing pass (1 unrelated skip) ✅
- Runtime evidence: BEFORE 5/60 → 429, AFTER 50/60 → 429 (in-process drain of `_PROXY_MaxParallelRequestsHandler_v3.async_pre_call_hook` against the verbatim ticket scenario) ✅
- Descriptor capture: BEFORE shows duplicate `model_per_team` and team value clamping; AFTER shows single `model_per_key` only ✅
- Greptile: 5/5 ("Safe to merge — the change is additive, well-scoped to the rate-limit descriptor building path, and backed by six targeted regression tests.") ✅
- GitHub Actions: all `Run tests` jobs green; lint + black + ruff green; the only red checks are 3 `Upload coverage to Codecov` sub-steps and `codecov/patch` (informational; tests themselves passed).
